### PR TITLE
[breadboard-cli-tools] watch and debug server

### DIFF
--- a/seeds/breadboard-cli-tools/README.md
+++ b/seeds/breadboard-cli-tools/README.md
@@ -6,15 +6,12 @@
 
 ### Debug
 
-If it's not installed:
+`npx breadboard debug` - Brings up the web debug server
+`npx breadboard debug ./tests/echo.json` - Brings up the local board hosted in the UI
 
-`npm run run-debug debug` - Brings up the web debug server
-`npm run run-debug debug ./tests/echo.json` - Brings up the local board hosted in the UI
+`npx breadboard debug ./tests/` - Brings up the local board hosted in the UI and show all the boards in the folder.
 
-If it is installed:
-
-`breadboard debug` - Brings up the web debug server
-`breadboard debug ./tests/echo.json` - Brings up the local board hosted in the UI
+`npx breadboard debug ./tests/ --watch` - Brings up the local board hosted in the UI and show all the boards in the folder. If new boards added to the folder then they will be added to the UI.
 
 ### Mermaid
 

--- a/seeds/breadboard-cli-tools/src/commands/debug.ts
+++ b/seeds/breadboard-cli-tools/src/commands/debug.ts
@@ -4,38 +4,106 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { fileURLToPath, pathToFileURL } from 'url'
-import { stat } from 'fs/promises';
-import { Stats, createReadStream } from 'fs';
-import { join, dirname } from 'path';
-import handler from 'serve-handler';
-import http from 'http';
+import { fileURLToPath, pathToFileURL } from "url";
+import { stat, opendir, readFile } from "fs/promises";
+import { createReadStream } from "fs";
+import { join, dirname, relative } from "path";
+import { watch } from "./lib/utils.js";
+import handler from "serve-handler";
+import http from "http";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-export const debug = async (file: string) => {
-  let fileStat: Stats;
-  let fileUrl: URL;
+type LocalBoard = { title: string; url: string };
 
-  if (file != undefined) {
-    fileStat = await stat(file);
-    fileUrl = pathToFileURL(file);
+const getBoards = async (path: string): Promise<Array<LocalBoard>> => {
+  const fileStat = await stat(path);
+  const fileUrl = pathToFileURL(path);
+
+  if (fileStat && fileStat.isFile() && path.endsWith(".json")) {
+    const data = await readFile(path, { encoding: "utf-8" });
+    const board = JSON.parse(data);
+
+    if ("title" in board == false) return [];
+
+    return [
+      {
+        title: board.title,
+        url: join("/", relative(process.cwd(), path)),
+      },
+    ];
   }
 
+  if (fileStat && fileStat.isDirectory()) {
+    const dir = await opendir(fileUrl);
+    const boards: Array<LocalBoard> = [];
+    for await (const dirent of dir) {
+      if (dirent.isFile() && dirent.name.endsWith(".json")) {
+        const data = await readFile(dirent.path, { encoding: "utf-8" });
+        const board = JSON.parse(data);
+        boards.push({
+          title: board.title ?? join("/", path, dirent.name),
+          url: join("/", path, dirent.name),
+        });
+      }
+    }
+    return boards;
+  }
+
+  return [];
+};
+
+export const debug = async (file: string) => {
+  if (file == undefined) {
+    file = process.cwd();
+  }
+
+  const fileUrl = pathToFileURL(file);
+
+  let boards: Array<LocalBoard> = [];
+
   const distDir = join(__dirname, "..", "..", "ui");
-  //const distDir = dirname(fileURLToPath(distPath));
-  const server = http.createServer((request, response) => {
+
+  watch(file, {
+    onChange: async (filename: string) => {
+      // Refresh the list of boards that are passed in at the start of the server.
+      console.log(`${filename} changed. Refreshing boards...`);
+      boards = await getBoards(file);
+    },
+    onRename: async () => {
+      // Refresh the list of boards that are passed in at the start of the server.
+      console.log(`Refreshing boards...`);
+      boards = await getBoards(file);
+    },
+  });
+
+  const server = http.createServer(async (request, response) => {
     // You pass two more arguments for config and middleware
     // More details here: https://github.com/vercel/serve-handler#options
-    const requestURL = new URL(request.url ?? '', 'http://localhost:3000');
-    const boardUrl = new URL(fileUrl.pathname ?? '', 'http://localhost:3000');
+    const requestURL = new URL(request.url ?? "", "http://localhost:3000");
+
+    if (requestURL.pathname === "/local-boards.json") {
+      // Generate a list of boards that are valid at runtime.
+      // Cache until things change.
+      boards = await getBoards(file);
+
+      const boardsData = JSON.stringify(boards);
+      response.writeHead(200, {
+        "Content-Type": "application/json",
+        "Content-Length": boardsData.length,
+      });
+
+      return response.end(boardsData);
+    }
+
+    const board = boards.find((board) => board.url == requestURL.pathname);
 
     // We only want to serve the file that is being debugged... nothing else.
-    if (fileStat != undefined && requestURL.pathname === boardUrl.pathname) {
-
+    if (board) {
+      const boardData = JSON.stringify(board);
       response.writeHead(200, {
-        'Content-Type': 'application/json',
-        'Content-Length': fileStat.size
+        "Content-Type": "application/json",
+        "Content-Length": boardData.length,
       });
 
       const readStream = createReadStream(file);
@@ -47,6 +115,12 @@ export const debug = async (file: string) => {
   });
 
   server.listen(3000, () => {
-    console.log(`Running at http://localhost:3000/${(fileUrl != undefined ? `?board=${fileUrl.pathname}` : '')}`);
+    console.log(
+      `Running at http://localhost:3000/${
+        fileUrl != undefined
+          ? `?board=/${relative(process.cwd(), fileUrl.pathname)}`
+          : ""
+      }`
+    );
   });
 };

--- a/seeds/breadboard-cli-tools/src/commands/lib/utils.ts
+++ b/seeds/breadboard-cli-tools/src/commands/lib/utils.ts
@@ -11,13 +11,18 @@ import { join } from "node:path";
 import { stdin as input } from "node:process";
 import * as readline from "node:readline/promises";
 import path, { basename } from "path";
+import { watch as fsWatch } from "fs";
 
 export type Options = {
   output?: string;
   watch?: boolean;
 };
 
-export async function makeFromSource(filename: string, source: string, options?: Options) {
+export async function makeFromSource(
+  filename: string,
+  source: string,
+  options?: Options
+) {
   const board = await loadBoardFromSource(filename, source, options);
   const boardJson = JSON.stringify(board, null, 2);
   return { boardJson, board };
@@ -30,7 +35,7 @@ export async function makeFromFile(filePath: string, options?: Options) {
 }
 
 export const loadBoardFromModule = async (file: string) => {
-  console.log(file)
+  console.log(file);
 
   // This will leak. Look for other hot reloading solutions.
   const board = (await import(`${file}?${Date.now()}`)).default;
@@ -49,8 +54,11 @@ export const loadBoardFromModule = async (file: string) => {
 /* 
   If we are loading from Source (TS) then we need to compile it and output it to a place where there are unlikely to be any collisions.
 */
-export const loadBoardFromSource = async (filename: string, source: string, options?: Options) => {
-
+export const loadBoardFromSource = async (
+  filename: string,
+  source: string,
+  options?: Options
+) => {
   const tmpDir = options?.output ?? process.cwd();
   const filePath = join(tmpDir, `~${basename(filename, "ts")}tmp.mjs`);
 
@@ -58,26 +66,65 @@ export const loadBoardFromSource = async (filename: string, source: string, opti
   try {
     tmpFileStat = await stat(filePath);
   } catch (e) {
-    "Nothing to see here. Just don't want to have to re-throw."
+    ("Nothing to see here. Just don't want to have to re-throw.");
   }
 
   if (tmpFileStat && tmpFileStat.isSymbolicLink()) {
     // Don't write to a symbolic link.
-    throw new Error(`The file ${filePath} is a symbolic link. We can't write to it.`);
+    throw new Error(
+      `The file ${filePath} is a symbolic link. We can't write to it.`
+    );
   }
 
   // I heard it might be possible to do a symlink hijack. double check.
   await writeFile(filePath, source);
 
   // For the import to work it has to be relative to the current working directory.
-  const board = await loadBoardFromModule(path.resolve(process.cwd(), filePath));
+  const board = await loadBoardFromModule(
+    path.resolve(process.cwd(), filePath)
+  );
 
   // remove the file
   await unlink(filePath);
 
   return board;
-}
+};
 
+type WatchOptions = {
+  onChange: (filename: string) => void;
+  onRename?: (filename: string) => void;
+  controller?: AbortController;
+};
+
+export const watch = (file: string, options: WatchOptions) => {
+  let { controller, onChange, onRename } = options;
+
+  onChange = onChange ?? (() => "");
+  onRename =
+    onRename ??
+    ((filename) =>
+      console.error(
+        `File ${filename} has been renamed. We can't manage this yet. Sorry!`
+      ));
+
+  controller = controller ?? new AbortController();
+
+  fsWatch(
+    file,
+    { signal: controller.signal, recursive: true },
+    async (eventType: string, filename: string | Buffer | null) => {
+      if (typeof filename != "string") return;
+
+      if (eventType === "change") {
+        onChange(filename);
+      } else if (eventType === "rename") {
+        if (onRename != undefined) {
+          onRename(filename);
+        }
+      }
+    }
+  );
+};
 
 export const resolveFilePath = (file: string) => {
   return path.resolve(
@@ -86,7 +133,10 @@ export const resolveFilePath = (file: string) => {
   );
 };
 
-export const loadBoard = async (file: string, options: Options): Promise<BoardRunner> => {
+export const loadBoard = async (
+  file: string,
+  options: Options
+): Promise<BoardRunner> => {
   if (file.endsWith(".ts")) {
     const fileContents = await readFile(file, "utf-8");
     const result = await esbuild.transform(fileContents, { loader: "ts" });

--- a/seeds/breadboard-cli-tools/src/commands/mermaid.ts
+++ b/seeds/breadboard-cli-tools/src/commands/mermaid.ts
@@ -5,15 +5,13 @@
  */
 
 import { BoardRunner } from "@google-labs/breadboard";
-import { watch } from "fs";
-import { loadBoard, parseStdin, resolveFilePath } from "./lib/utils.js";
+import { loadBoard, parseStdin, resolveFilePath, watch } from "./lib/utils.js";
 import path from "path";
 
 export const mermaid = async (
   file: string,
   options: Record<string, string>
 ) => {
-
   if (
     file != undefined &&
     path.extname(file) == ".ts" &&
@@ -31,25 +29,12 @@ export const mermaid = async (
     console.log(board.mermaid());
 
     if ("watch" in options) {
-      const controller = new AbortController();
-
-      watch(
-        file,
-        { signal: controller.signal },
-        async (eventType: string, filename: string | Buffer | null) => {
-          if (typeof filename != "string") return;
-
-          if (eventType === "change") {
-            board = await loadBoard(filePath, options);
-            console.log(board.mermaid());
-          } else if (eventType === "rename") {
-            console.error(
-              `File ${filename} has been renamed. We can't manage this yet. Sorry!`
-            );
-            controller.abort();
-          }
-        }
-      );
+      watch(file, {
+        onChange: async () => {
+          board = await loadBoard(filePath, options);
+          console.log(board.mermaid());
+        },
+      });
     }
   } else {
     const stdin = await parseStdin();

--- a/seeds/breadboard-cli-tools/src/index.ts
+++ b/seeds/breadboard-cli-tools/src/index.ts
@@ -18,8 +18,9 @@ program
 
 program
   .command("debug [file]")
-  .option("-o, --output <path>", "If compiling a graph in Typescript (.ts), you MUST specific a location to output the compiled graph.")
   .description("Starts a simple HTTP server that serves the breadboard-web app, and outputs a URL that contains a link to a breadboard file that the user provided.")
+  .option("-o, --output <path>", "If compiling a graph in Typescript (.ts), you MUST specific a location to output the compiled graph.")
+  .option("-w, --watch", "Watch the file for changes.")
   .action(debug);
 
 program


### PR DESCRIPTION
+ Debug server can now accept a list of boards from a directory
+ Debug server can watch for changes in the inputted file or boards and refresh the dropdown (on-reload)
+ Debug should also convert TS on the fly

Other
====

+ Refactored fs.watch to be shared across commands
+ Reformatted code.