### PR TITLE
[breadboard-ui] Tweak sidebar

### DIFF
--- a/seeds/breadboard-ui/src/input.ts
+++ b/seeds/breadboard-ui/src/input.ts
@@ -107,7 +107,7 @@ export class Input extends HTMLElement {
         }
 
         * {
-          box-sizing: border-box; 
+          box-sizing: border-box;
           font-size: var(--bb-text-medium);
         }
 
@@ -118,13 +118,18 @@ export class Input extends HTMLElement {
           grid-template-columns: 1fr 1fr 1fr 1fr;
           row-gap: calc(var(--bb-grid-size) * 2);
           flex: 1;
-          margin: calc(var(--bb-grid-size) * 3) 0;
+          margin: calc(var(--bb-grid-size) * 2) 0;
+        }
+
+        #choice-container {
+          border-top: 1px solid rgb(244, 244, 244);
         }
 
         label {
+          grid-column: 1/3;
           font-family: var(--bb-font-family);
           font-size: var(--bb-text-small);
-          padding: 0 calc(var(--bb-grid-size) * 2) 0 calc(var(--bb-grid-size) * 8);
+          padding: calc(var(--bb-grid-size) * 2) calc(var(--bb-grid-size) * 2) 0 0;
         }
 
         #choice-container label:not(:first-of-type) {
@@ -145,7 +150,7 @@ export class Input extends HTMLElement {
           flex: 1;
           width: 100%;
           overflow: hidden;
-          border-radius: calc(var(--bb-grid-size) * 10);
+          border-radius: calc(var(--bb-grid-size) * 3);
           border: 1px solid rgb(209, 209, 209);
           min-height: calc(var(--bb-grid-size) * 50);
         }
@@ -157,10 +162,9 @@ export class Input extends HTMLElement {
         textarea,
         .parsed-value {
           grid-column: 1 / 5;
-          border-radius: calc(var(--bb-grid-size) * 10);
+          border-radius: calc(var(--bb-grid-size) * 3);
           background: rgb(255, 255, 255);
-          min-height: calc(var(--bb-grid-size) * 12);
-          padding: 0 calc(var(--bb-grid-size) * 10) 0 calc(var(--bb-grid-size) * 8);
+          padding: calc(var(--bb-grid-size) * 2);
           width: 100%;
           border: 1px solid rgb(209, 209, 209);
         }
@@ -171,8 +175,9 @@ export class Input extends HTMLElement {
 
         textarea {
           resize: none;
-          padding-top: calc(var(--bb-grid-size) * 4);
-          padding-bottom: calc(var(--bb-grid-size) * 4);
+          font-size: var(--bb-text-small);
+          padding-top: calc(var(--bb-grid-size) * 2);
+          padding-bottom: calc(var(--bb-grid-size) * 2);
           line-height: 1.4;
           border: none;
           height: 100%;
@@ -211,9 +216,9 @@ export class Input extends HTMLElement {
           height: calc(var(--bb-grid-size) * 8);
           position: absolute;
           right: calc(var(--bb-grid-size) * 2);
-          top: calc(var(--bb-grid-size) * 0);
+          top: calc(var(--bb-grid-size) * 1.5);
           border-radius: 50%;
-          background: #FFF var(--bb-icon-start) center center no-repeat;
+          background: var(--bb-icon-start) center center no-repeat;
           border: none;
         }
 

--- a/seeds/breadboard-ui/src/input.ts
+++ b/seeds/breadboard-ui/src/input.ts
@@ -215,7 +215,7 @@ export class Input extends HTMLElement {
           width: calc(var(--bb-grid-size) * 8);
           height: calc(var(--bb-grid-size) * 8);
           position: absolute;
-          right: calc(var(--bb-grid-size) * 2);
+          right: 0;
           top: calc(var(--bb-grid-size) * 1.5);
           border-radius: 50%;
           background: var(--bb-icon-start) center center no-repeat;

--- a/seeds/breadboard-ui/src/ui-controller.ts
+++ b/seeds/breadboard-ui/src/ui-controller.ts
@@ -47,6 +47,13 @@ export class UIController extends HTMLElement implements UI {
   constructor() {
     super();
 
+    const toggleMapping = ["history", "output", "input"];
+    const isExpanded = new Map(
+      toggleMapping.map((id) => {
+        return [id, this.#getRememberedValue(`ui-${id}-active`, true)];
+      })
+    );
+
     const root = this.attachShadow({ mode: "open" });
     root.innerHTML = `
       <style>
@@ -130,13 +137,15 @@ export class UIController extends HTMLElement implements UI {
         }
 
         #sidebar.active {
-          display: grid;
-          grid-template-rows: calc(var(--bb-grid-size) * 14) auto;
+          display: flex;
+          flex-direction: column;
           height: 100%;
           overflow: hidden;
         }
 
         #controls {
+          height: calc(var(--bb-grid-size) * 14);
+          flex: 0 0 auto;
           display: flex;
           flex-direction: row;
           align-items: center;
@@ -153,8 +162,14 @@ export class UIController extends HTMLElement implements UI {
           overflow: hidden;
         }
 
-        #history, #input {
-          border-bottom: 1px solid rgb(227, 231, 237);
+        #history.active,
+        #output.active,
+        #input.active {
+          flex: 1;
+        }
+
+        #history, #output {
+          border-top: 1px solid rgb(227, 231, 237);
         }
 
         #history h1,
@@ -165,6 +180,17 @@ export class UIController extends HTMLElement implements UI {
           font-weight: 400;
           padding: 0 0 0 calc(var(--bb-grid-size) * 8);
           line-height: calc(var(--bb-grid-size) * 6);
+          cursor: pointer;
+          opacity: 0.6;
+        }
+
+        #history.active h1,
+        #history h1:hover,
+        #output.active h1,
+        #output h1:hover,
+        #input.active h1,
+        #input h1:hover {
+          opacity: 1;
         }
 
         #history h1 {
@@ -187,9 +213,16 @@ export class UIController extends HTMLElement implements UI {
         #history-list,
         #output-list,
         #input-list {
+          display: none;
           scrollbar-gutter: stable;
           overflow-y: auto;
           flex: 1;
+        }
+
+        #history.active #history-list,
+        #output.active #output-list,
+        #input.active #input-list {
+          display: block;
         }
 
         #input-list {
@@ -342,22 +375,24 @@ export class UIController extends HTMLElement implements UI {
               <option>1500ms delay</option>
             </select>
           </div>
-          <div id="history">
+          <div id="input" class="${isExpanded.get("input") ? "active" : ""}">
+            <h1>Inputs</h1>
+            <div id="input-list" class="active">
+              <slot></slot>
+            </div>
+          </div>
+          <div id="output" class="${isExpanded.get("output") ? "active" : ""}">
+            <h1>Outputs</h1>
+            <div id="output-list" class="active"></div>
+          </div>
+          <div id="history" class="${
+            isExpanded.get("history") ? "active" : ""
+          }">
             <h1>
               <span>History</span>
               <a href="#" id="download-history-log" download="history-log.json">Download log</a>
             </h1>
-            <div id="history-list"></div>
-          </div>
-          <div id="input">
-            <h1>Input</h1>
-            <div id="input-list">
-              <slot></slot>
-            </div>
-          </div>
-          <div id="output">
-            <h1>Outputs</h1>
-            <div id="output-list"></div>
+            <div id="history-list" class="active"></div>
           </div>
         </div>
       </div>
@@ -392,6 +427,21 @@ export class UIController extends HTMLElement implements UI {
       downloadLog.setAttribute("download", `history-log-${Date.now()}.json`);
       downloadLog.setAttribute("href", URL.createObjectURL(file));
     });
+
+    for (const target of toggleMapping) {
+      const element = root.querySelector(`#${target} > h1`);
+      const targetElement = root.querySelector(`#${target}`);
+      assertHTMLElement(element);
+      assertHTMLElement(targetElement);
+
+      element.addEventListener("click", () => {
+        targetElement.classList.toggle("active");
+        this.#rememberValue(
+          `ui-${target}-active`,
+          targetElement.classList.contains("active")
+        );
+      });
+    }
   }
 
   toast(message: string, type: ToastType) {
@@ -405,6 +455,28 @@ export class UIController extends HTMLElement implements UI {
 
   hidePaused() {
     this.classList.remove("paused");
+  }
+
+  #getLocalStorageKey(id: string) {
+    return `bb-remember-${id}`;
+  }
+
+  #getRememberedValue<T>(id: string, defaultValue: T): T {
+    const key = this.#getLocalStorageKey(id);
+    const data = localStorage.getItem(key);
+    if (!data) {
+      this.#rememberValue(id, defaultValue);
+      return defaultValue;
+    }
+
+    return JSON.parse(data) as T;
+  }
+
+  #rememberValue(id: string, data: unknown) {
+    const key = this.#getLocalStorageKey(id);
+    const json = JSON.stringify(data);
+    localStorage.setItem(key, json);
+    return;
   }
 
   #clearBoardContents() {
@@ -468,6 +540,17 @@ export class UIController extends HTMLElement implements UI {
 
     root.querySelector("#sidebar")?.classList.add("active");
     root.querySelector("#diagram")?.classList.add("active");
+  }
+
+  #autoShowInput() {
+    const root = this.shadowRoot;
+    assertRoot(root);
+
+    const input = root.querySelector("#input");
+    assertHTMLElement(input);
+
+    input.classList.add("active");
+    this.#rememberValue(`ui-input-active`, true);
   }
 
   #createHistoryEntry(
@@ -579,6 +662,7 @@ export class UIController extends HTMLElement implements UI {
     } else {
       this.#inputContainer.appendChild(input);
     }
+    this.#autoShowInput();
 
     const data = (await input.ask()) as Record<string, string>;
     input.remove();
@@ -610,6 +694,8 @@ export class UIController extends HTMLElement implements UI {
     } else {
       this.#inputContainer.appendChild(input);
     }
+
+    this.#autoShowInput();
 
     const response = (await input.ask()) as Record<string, unknown>;
     this.#createHistoryEntry(HarnessEventType.INPUT, "input", id, {

--- a/seeds/breadboard-ui/src/ui-controller.ts
+++ b/seeds/breadboard-ui/src/ui-controller.ts
@@ -416,7 +416,9 @@ export class UIController extends HTMLElement implements UI {
 
     const downloadLog = root.querySelector("#download-history-log");
     assertHTMLElement(downloadLog);
-    downloadLog.addEventListener("click", () => {
+    downloadLog.addEventListener("click", (evt: Event) => {
+      evt.stopImmediatePropagation();
+
       const currentLink = downloadLog.getAttribute("href");
       if (currentLink) {
         URL.revokeObjectURL(currentLink);


### PR DESCRIPTION
Working on #160 a bit. This PR adds expand-collapse behaviors for the sidebar so that you can toggle the visibility of inputs, outputs, and history. I also reordered them so it's inputs, outputs, and history in that order. Feels a little more intuitive.