### PR TITLE
[breadboard-ui] Remove node info when board changes

### DIFF
--- a/seeds/breadboard-ui/src/ui-controller.ts
+++ b/seeds/breadboard-ui/src/ui-controller.ts
@@ -744,6 +744,7 @@ export class UIController extends HTMLElement implements UI {
     this.#hideIntroContent();
     this.#clearBoardContents();
     this.#showBoardContainer();
+    this.#clearNodeInformation();
 
     const load = new Load(info);
     load.slot = "load";


### PR DESCRIPTION
Fixes a little oopsie where the node info was being retained when the board changed.