### PR TITLE
Add a Breadboard JSON schema

### DIFF
--- a/seeds/breadboard/breadboard.schema.json
+++ b/seeds/breadboard/breadboard.schema.json
@@ -1,0 +1,145 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/breadboard-ai/breadboard/main/seeds/breadboard/breadboard.schema.json",
+  "title": "Breadboard",
+  "description": "An executable program graph",
+  "$defs": {
+    "identifier": {
+      "type": "string",
+      "pattern": "^[a-zA-Z_][a-zA-Z0-9_-]*$"
+    }
+  },
+  "type": "object",
+  "required": ["nodes", "edges"],
+  "additionalProperties": false,
+  "properties": {
+    "nodes": {
+      "description": "All of the nodes in the graph",
+      "type": "array",
+      "items": {
+        "description": "A \"step\" or \"function\" in the program which performs computation",
+        "type": "object",
+        "required": ["id", "type"],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "description": "Identifier for this node that is unique to this graph",
+            "$ref": "#/$defs/identifier"
+          },
+          "type": {
+            "description": "The type of the node. Must be either a built-in type or a type provided by a kit.",
+            "$ref": "#/$defs/identifier"
+          },
+          "configuration": {
+            "description": "Type-specific configuration of the node",
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      }
+    },
+    "edges": {
+      "description": "All of the edges in the graph",
+      "type": "array",
+      "items": {
+        "description": "A connection between two nodes through which data flows",
+        "type": "object",
+        "required": ["from", "to"],
+        "additionalProperties": false,
+        "properties": {
+          "from": {
+            "description": "The ID of the source node",
+            "$ref": "#/$defs/identifier"
+          },
+          "to": {
+            "description": "The ID of the destination node",
+            "$ref": "#/$defs/identifier"
+          },
+          "out": {
+            "description": "The output port of the `from` node.\nIf \"*\", then all outputs of the `from` node are passed to the `to` node. In this case `in` must be empty string or undefined.\nIf undefined or empty string, then no data is passed, and the nodes are instead connected purely for yielding control flow. In this case `in` must be empty string or undefined.",
+            "type": "string"
+          },
+          "in": {
+            "description": "The input port of the `to` node.\nMust be empty string or undefined if and only if `out` is either \"*\" or itself empty string or undefined.",
+            "type": "string"
+          },
+          "optional": {
+            "description": "If true, nodes connected to this edge won't wait for data to appear before proceding with execution.",
+            "type": "boolean"
+          },
+          "constant": {
+            "description": "If true, the most recent data that passed through this edge will remain available indefinitely, instead of being destructively consumed.",
+            "type": "boolean"
+          }
+        },
+        "oneOf": [
+          {
+            "required": [],
+            "properties": {
+              "out": {
+                "const": ""
+              },
+              "in": {
+                "const": ""
+              }
+            }
+          },
+          {
+            "required": ["out"],
+            "properties": {
+              "out": {
+                "const": "*"
+              },
+              "in": {
+                "const": ""
+              }
+            }
+          },
+          {
+            "required": ["out", "in"],
+            "properties": {
+              "out": {
+                "$ref": "#/$defs/identifier"
+              },
+              "in": {
+                "$ref": "#/$defs/identifier"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "kits": {
+      "description": "All of the kits this graph depends on",
+      "type": "array",
+      "items": {
+        "description": "A library that will be imported prior to execution for providing handlers for non built-in node types.",
+        "type": "object",
+        "required": ["url"],
+        "additionalProperties": false,
+        "properties": {
+          "url": {
+            "description": "Address of the kit",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "graphs": {
+      "description": "Sub-graphs that can be referred to by nodes in the parent graph.",
+      "type": "object",
+      "additionalProperties": false,
+      "patternProperties": {
+        "^[a-zA-Z_][a-zA-Z0-9_-]*$": {
+          "$ref": "#"
+        }
+      }
+    },
+    "args": {
+      "description": "Arguments that are passed to the graph, useful to bind values to lambdas.",
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}

--- a/seeds/breadboard/package.json
+++ b/seeds/breadboard/package.json
@@ -112,7 +112,8 @@
   "files": [
     "dist/src",
     "dist/*.js",
-    "dist/*.js.map"
+    "dist/*.js.map",
+    "breadboard.schema.json"
   ],
   "ava": {
     "timeout": "30s",


### PR DESCRIPTION
Adds `breadboard.schema.json`, a JSON schema that describes breadboard graph JSON files.

A few things to note:

- Identifiers must match the pattern `^[a-zA-Z_][a-zA-Z0-9_-]*$`. This applies to node IDs, node types, input/output ports, and graph IDs. This is similar to valid JS identifiers, but adds `-` because we're already using `-` in our auto-generated node IDs.

- It's strict about what are valid `in` and `out` arrangements. Either both are identifiers, both are empty/undefined, or `in` is `*` and `out` is empty/undefined.

- I'm using the word "port" to refer to node inputs/outputs, as in "I wired the foo port of X to the bar port of Y".

- I'm using the GitHub raw endpoint as the ID. If we get a domain we might want to publish it there as `<our-domain>/schema.json` or something to make it easier to remember.

Fixes https://github.com/breadboard-ai/breadboard/issues/5
