### PR TITLE
[breadboard-cli] Refactoring the Loaders.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "breadboard",
+  "name": "labs-prototypes",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
@@ -16221,6 +16221,14 @@
       "version": "4.0.0",
       "license": "ISC"
     },
+    "node_modules/yaml": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
+      "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "license": "MIT",
@@ -16344,7 +16352,8 @@
         "@google-labs/breadboard": "*",
         "commander": "^11.1.0",
         "esbuild": "^0.19.9",
-        "serve": "^14.2.1"
+        "serve": "^14.2.1",
+        "yaml": "^2.3.4"
       },
       "bin": {
         "breadboard": "dist/src/index.js"

--- a/seeds/breadboard-cli/boards/echo.yaml
+++ b/seeds/breadboard-cli/boards/echo.yaml
@@ -1,0 +1,28 @@
+title: Echo
+description: "Echo cho cho cho ho o"
+version: "0.0.3"
+
+edges:
+  - input.text->output-1.text
+nodes:
+  - {
+      id: input,
+      type: input,
+      configuration:
+        {
+          schema:
+            {
+              type: object,
+              properties:
+                {
+                  text:
+                    {
+                      type: string,
+                      title: Echo,
+                      description: What shall I say back to you?,
+                    },
+                },
+            },
+        },
+    }
+  - { id: output-1, type: output }

--- a/seeds/breadboard-cli/package.json
+++ b/seeds/breadboard-cli/package.json
@@ -124,6 +124,7 @@
     "@google-labs/breadboard": "*",
     "commander": "^11.1.0",
     "esbuild": "^0.19.9",
-    "serve": "^14.2.1"
+    "serve": "^14.2.1",
+    "yaml": "^2.3.4"
   }
 }

--- a/seeds/breadboard-cli/src/commands/lib/loader.ts
+++ b/seeds/breadboard-cli/src/commands/lib/loader.ts
@@ -1,0 +1,101 @@
+import { Board, BoardRunner, GraphDescriptor } from "@google-labs/breadboard";
+import { readFile, stat, unlink, writeFile } from "fs/promises";
+import path, { basename, join } from "path";
+
+export type Options = {
+  output?: string;
+  watch?: boolean;
+};
+
+const boardLike = (
+  board: Record<string, unknown>
+): board is GraphDescriptor => {
+  return board && "edges" in board && "nodes" in board;
+};
+
+export abstract class Loader {
+  async makeFromSource(filename: string, source: string, options?: Options) {
+    const board = await this.loadBoardFromSource(filename, source, options);
+    const boardJson = JSON.stringify(board, null, 2);
+    return { boardJson, board };
+  }
+
+  async makeFromFile(filePath: string) {
+    const board = await this.loadBoardFromModule(
+      path.resolve(process.cwd(), filePath)
+    );
+    const boardJson = JSON.stringify(board, null, 2);
+    return { boardJson, board };
+  }
+
+  async loadBoardFromModule(file: string) {
+    // This will leak. Look for other hot reloading solutions.
+    let board = (await import(`${file}?${Date.now()}`)).default;
+
+    if (board == undefined)
+      throw new Error(`Board ${file} does not have a default export`);
+
+    if (boardLike(board)) {
+      // A graph descriptor has been exported.. Possibly a lambda.
+      board = await Board.fromGraphDescriptor(board);
+    }
+    if (
+      board instanceof Board == false &&
+      board instanceof BoardRunner == false
+    )
+      throw new Error(
+        `Board ${file} does not have a default export of type Board, Lambda or something that looks like a board.`
+      );
+
+    return board;
+  }
+
+  /* 
+  If we are loading from Source (TS) then we need to compile it and output it to a place where there are unlikely to be any collisions.
+*/
+  async loadBoardFromSource(
+    filename: string,
+    source: string,
+    options?: Options
+  ) {
+    const tmpDir = options?.output ?? process.cwd();
+    const filePath = join(tmpDir, `~${basename(filename, "ts")}tmp.mjs`);
+
+    let tmpFileStat;
+    try {
+      tmpFileStat = await stat(filePath);
+    } catch (e) {
+      // Don't care if the file doesn't exist. It's fine. It's what we want.
+      ("Nothing to see here. Just don't want to have to re-throw.");
+    }
+
+    if (tmpFileStat && tmpFileStat.isFile()) {
+      // Don't write to a file.
+      throw new Error(
+        `The temporary file ${filePath} already exists. We can't write to it.`
+      );
+    }
+
+    if (tmpFileStat && tmpFileStat.isSymbolicLink()) {
+      // Don't write to a symbolic link.
+      throw new Error(
+        `The file ${filePath} is a symbolic link. We can't write to it.`
+      );
+    }
+
+    // I heard it might be possible to do a symlink hijack. double check.
+    await writeFile(filePath, source);
+
+    // For the import to work it has to be relative to the current working directory.
+    const board = await this.loadBoardFromModule(
+      path.resolve(process.cwd(), filePath)
+    );
+
+    // remove the file
+    await unlink(filePath);
+
+    return board;
+  }
+
+  abstract load(filePath: string, options: Options): Promise<BoardRunner>;
+}

--- a/seeds/breadboard-cli/src/commands/lib/loaders/index.ts
+++ b/seeds/breadboard-cli/src/commands/lib/loaders/index.ts
@@ -1,0 +1,38 @@
+import { BoardRunner } from "@google-labs/breadboard";
+import { JSLoader } from "./javascript.js";
+import { Loader, Options } from "../loader.js";
+import { YAMLLoader } from "./yaml.js";
+import { TypeScriptLoader } from "./typescript.js";
+import { JSONLoader } from "./json.js";
+
+const supportedFileTypes = ["yaml", "js", "ts", "json"] as const;
+type LoaderTuple = typeof supportedFileTypes;
+type LoaderType = LoaderTuple[number];
+
+export class Loaders {
+  #loaderInstance: any;
+
+  static get supportedFileTypes(): LoaderTuple {
+    return supportedFileTypes;
+  }
+
+  constructor(loader: LoaderType) {
+    if (loader === "yaml") {
+      this.#loaderInstance = new YAMLLoader();
+    } else if (loader === "js") {
+      this.#loaderInstance = new JSLoader();
+    } else if (loader === "ts") {
+      this.#loaderInstance = new TypeScriptLoader();
+    } else if (loader === "json") {
+      this.#loaderInstance = new JSONLoader();
+    } else {
+      throw new Error(`Unsupported file type ${loader}`);
+    }
+  }
+
+  async load(filePath: string, options: Options): Promise<BoardRunner> {
+    return this.#loaderInstance.load(filePath, options);
+  }
+}
+
+export { Loader };

--- a/seeds/breadboard-cli/src/commands/lib/loaders/javascript.ts
+++ b/seeds/breadboard-cli/src/commands/lib/loaders/javascript.ts
@@ -1,0 +1,9 @@
+import { BoardRunner } from "@google-labs/breadboard";
+import { Loader } from "../loader.js";
+
+export class JSLoader extends Loader {
+  async load(filePath: string): Promise<BoardRunner> {
+    const { board } = await this.makeFromFile(filePath);
+    return board;
+  }
+}

--- a/seeds/breadboard-cli/src/commands/lib/loaders/json.ts
+++ b/seeds/breadboard-cli/src/commands/lib/loaders/json.ts
@@ -1,0 +1,12 @@
+import { Board, BoardRunner } from "@google-labs/breadboard";
+import { readFile } from "fs/promises";
+import { Loader } from "../loader.js";
+
+export class JSONLoader extends Loader {
+  async load(filePath: string): Promise<BoardRunner> {
+    const fileContents = await readFile(filePath, "utf-8");
+    const board = await Board.fromGraphDescriptor(JSON.parse(fileContents));
+
+    return board;
+  }
+}

--- a/seeds/breadboard-cli/src/commands/lib/loaders/typescript.ts
+++ b/seeds/breadboard-cli/src/commands/lib/loaders/typescript.ts
@@ -1,4 +1,4 @@
-import { Board, BoardRunner, GraphDescriptor } from "@google-labs/breadboard";
+import { BoardRunner } from "@google-labs/breadboard";
 import esbuild from "esbuild";
 import { readFile } from "fs/promises";
 import { Loader, Options } from "../loader.js";

--- a/seeds/breadboard-cli/src/commands/lib/loaders/typescript.ts
+++ b/seeds/breadboard-cli/src/commands/lib/loaders/typescript.ts
@@ -1,0 +1,13 @@
+import { Board, BoardRunner, GraphDescriptor } from "@google-labs/breadboard";
+import esbuild from "esbuild";
+import { readFile } from "fs/promises";
+import { Loader, Options } from "../loader.js";
+
+export class TypeScriptLoader extends Loader {
+  async load(filePath: string, options: Options): Promise<BoardRunner> {
+    const fileContents = await readFile(filePath, "utf-8");
+    const result = await esbuild.transform(fileContents, { loader: "ts" });
+    const { board } = await this.makeFromSource(filePath, result.code, options);
+    return board;
+  }
+}

--- a/seeds/breadboard-cli/src/commands/lib/loaders/yaml.ts
+++ b/seeds/breadboard-cli/src/commands/lib/loaders/yaml.ts
@@ -1,0 +1,83 @@
+import { Board, BoardRunner, GraphDescriptor } from "@google-labs/breadboard";
+import { readFile } from "fs/promises";
+import yaml from "yaml";
+
+export class YAMLLoader {
+  async load(filePath: string): Promise<BoardRunner> {
+    const fileContents = await readFile(filePath, "utf-8");
+
+    const yamlInstance = yaml.parse(fileContents);
+
+    if (yamlInstance == undefined) {
+      throw new Error(`There is an error with your YAML file`);
+    }
+
+    if (yamlInstance.edges == undefined) {
+      throw new Error(`There is no edges property in your YAML file`);
+    }
+
+    if (yamlInstance.nodes == undefined) {
+      throw new Error(`There is no nodes property in your YAML file`);
+    }
+
+    const edges = yamlInstance.edges.map((edgeYaml: string) => {
+      // Parse the edge syntax
+      const edgeSyntax = edgeYaml.match(/(.+)\.(.+){0,1}->(.+)\.(.+){0,1}/);
+
+      if (edgeSyntax == null || edgeSyntax.length == 0) {
+        return null;
+      }
+
+      const edge = {
+        from: edgeSyntax[1],
+        out: edgeSyntax[2],
+        to: edgeSyntax[3],
+        in: edgeSyntax[4],
+      };
+
+      return {
+        ...edge,
+      };
+    });
+
+    const nodeCounter: Record<string, number> = {};
+    const nodes = yamlInstance.nodes.map(
+      (nodeYaml: Record<string, unknown>) => {
+        if (nodeYaml.type == undefined) {
+          throw new Error(
+            `'type' is missing from a node definition in YAML file`
+          );
+        }
+
+        const type: string = nodeYaml.type as string;
+        let id = nodeYaml.id;
+
+        // If the id is not defined then we need to generate one. we can only have one node of each type without an id
+        if (id == undefined) {
+          if (type in nodeCounter) {
+            throw new Error(
+              `There is more than one node of type ${type} without an id. Please add an id to one of them.`
+            );
+          }
+
+          nodeCounter[type] = nodeCounter[type]++ ?? 0;
+          id = `${type}`;
+        }
+
+        return {
+          ...nodeYaml,
+          type,
+          id,
+        };
+      }
+    );
+
+    const board: GraphDescriptor = {
+      ...yamlInstance,
+      edges,
+      nodes,
+    };
+
+    return Board.fromGraphDescriptor(board);
+  }
+}

--- a/seeds/breadboard-cli/src/commands/lib/utils.ts
+++ b/seeds/breadboard-cli/src/commands/lib/utils.ts
@@ -4,18 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Board, BoardRunner, GraphDescriptor } from "@google-labs/breadboard";
-import * as esbuild from "esbuild";
+import { BoardRunner, GraphDescriptor } from "@google-labs/breadboard";
 import { watch as fsWatch } from "fs";
-import { opendir, readFile, stat, unlink, writeFile } from "fs/promises";
+import { opendir, readFile, stat } from "fs/promises";
 import { join } from "node:path";
 import { stdin as input } from "node:process";
 import * as readline from "node:readline/promises";
-import path, { basename, extname } from "path";
+import path, { extname } from "path";
 import { relative } from "path/posix";
 import { pathToFileURL } from "url";
-import { Loaders } from "./loaders/index.js";
 import { Options } from "./loader.js";
+import { Loaders } from "./loaders/index.js";
 
 export type BoardMetaData = {
   title: string;
@@ -73,8 +72,6 @@ export const loadBoard = async (
   file: string,
   options: Options
 ): Promise<BoardRunner> => {
-  let board: BoardRunner;
-
   const loaderType = extname(file).slice(1) as "js" | "ts" | "yaml" | "json";
 
   const loader = new Loaders(loaderType);

--- a/seeds/breadboard-cli/src/commands/make-graph.ts
+++ b/seeds/breadboard-cli/src/commands/make-graph.ts
@@ -48,9 +48,8 @@ export const makeGraph = async (
     const loader = new Loaders(loaderType);
 
     let board = await loader.load(filePath, options);
-    const boardJson = JSON.stringify(board, null, 2);
 
-    console.log(boardJson, null, 2);
+    console.log(JSON.stringify(board, null, 2));
 
     if ("watch" in options) {
       watch(file, {

--- a/seeds/breadboard-cli/src/commands/make-graph.ts
+++ b/seeds/breadboard-cli/src/commands/make-graph.ts
@@ -6,9 +6,8 @@
 
 import { stat } from "fs/promises";
 import path, { extname } from "path";
-import { resolveFilePath, watch } from "./lib/utils.js";
-import { Loader } from "./lib/loader.js";
 import { Loaders } from "./lib/loaders/index.js";
+import { resolveFilePath, watch } from "./lib/utils.js";
 
 export const makeGraph = async (
   file: string,

--- a/seeds/breadboard-cli/src/commands/make-graph.ts
+++ b/seeds/breadboard-cli/src/commands/make-graph.ts
@@ -5,8 +5,10 @@
  */
 
 import { stat } from "fs/promises";
-import path from "path";
-import { makeFromFile, resolveFilePath, watch } from "./lib/utils.js";
+import path, { extname } from "path";
+import { resolveFilePath, watch } from "./lib/utils.js";
+import { Loader } from "./lib/loader.js";
+import { Loaders } from "./lib/loaders/index.js";
 
 export const makeGraph = async (
   file: string,
@@ -43,16 +45,20 @@ export const makeGraph = async (
   }
 
   if (file != undefined) {
-    let { boardJson } = await makeFromFile(filePath);
+    const loaderType = extname(file).slice(1) as "js" | "ts" | "yaml" | "json";
+    const loader = new Loaders(loaderType);
+
+    let board = await loader.load(filePath, options);
+    const boardJson = JSON.stringify(board, null, 2);
 
     console.log(boardJson, null, 2);
 
     if ("watch" in options) {
       watch(file, {
         onChange: async () => {
-          ({ boardJson } = await makeFromFile(filePath));
+          board = await loader.load(filePath, options);
 
-          console.log(JSON.stringify(boardJson, null, 2));
+          console.log(JSON.stringify(board, null, 2));
         },
       });
     }


### PR DESCRIPTION
The utils file was getting messy.

We can now quickly load new types of formats that store board information.  In this PR we also had in a YAML loader (as mentioned in #219) as an experiment.