### PR TITLE
[breadboard-cli] Removing the requirement for `-o` when compiling TS

### DIFF
--- a/seeds/breadboard-cli/src/commands/lib/loader.ts
+++ b/seeds/breadboard-cli/src/commands/lib/loader.ts
@@ -61,7 +61,7 @@ export abstract class Loader {
     const tmpDir = options?.output ?? process.cwd();
     const randomName = Buffer.from(
       crypto.getRandomValues(new Uint32Array(16))
-    ).toString("base64");
+    ).toString("hex");
     const filePath = join(
       tmpDir,
       `~${basename(filename, "ts")}${randomName}tmp.mjs`

--- a/seeds/breadboard-cli/src/commands/lib/loader.ts
+++ b/seeds/breadboard-cli/src/commands/lib/loader.ts
@@ -59,7 +59,13 @@ export abstract class Loader {
     options?: Options
   ) {
     const tmpDir = options?.output ?? process.cwd();
-    const filePath = join(tmpDir, `~${basename(filename, "ts")}tmp.mjs`);
+    const randomName = Buffer.from(
+      crypto.getRandomValues(new Uint32Array(16))
+    ).toString("base64");
+    const filePath = join(
+      tmpDir,
+      `~${basename(filename, "ts")}${randomName}tmp.mjs`
+    );
 
     let tmpFileStat;
     try {
@@ -80,6 +86,13 @@ export abstract class Loader {
       // Don't write to a symbolic link.
       throw new Error(
         `The file ${filePath} is a symbolic link. We can't write to it.`
+      );
+    }
+
+    if (tmpFileStat && tmpFileStat.isDirectory() == false) {
+      // Don't write to a directory.
+      throw new Error(
+        `The file ${filePath} is a directory. We can't write to it.`
       );
     }
 

--- a/seeds/breadboard-cli/src/commands/make-graph.ts
+++ b/seeds/breadboard-cli/src/commands/make-graph.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { stat } from "fs/promises";
 import path, { extname } from "path";
 import { Loaders } from "./lib/loaders/index.js";
 import { resolveFilePath, watch } from "./lib/utils.js";
@@ -17,30 +16,13 @@ export const makeGraph = async (
 
   if (
     file != undefined &&
-    path.extname(file) == ".ts" &&
-    "output" in options == false
+    path.extname(file) != ".js" &&
+    path.extname(file) != ".ts" &&
+    path.extname(file) != ".yaml"
   ) {
     throw new Error(
-      `File ${file} is not a TypeScript file. You must specify the output directory with --output.`
+      `File ${file} must be JavaScript, TypeScript or YAML file.`
     );
-  }
-
-  if (file != undefined && path.extname(file) == ".ts" && options["output"]) {
-    const fullDirPath = path.resolve(process.cwd(), options["output"]);
-    const dirStat = await stat(fullDirPath);
-    if (dirStat.isDirectory() == false) {
-      throw new Error(
-        `The path specified by ${options["output"]} is not a directory.`
-      );
-    }
-  }
-
-  if (
-    file != undefined &&
-    path.extname(file) != ".js" &&
-    path.extname(file) != ".ts"
-  ) {
-    throw new Error(`File ${file} must be JavaScript or a TypeScript file.`);
   }
 
   if (file != undefined) {

--- a/seeds/breadboard-cli/src/commands/mermaid.ts
+++ b/seeds/breadboard-cli/src/commands/mermaid.ts
@@ -12,16 +12,6 @@ export const mermaid = async (
   file: string,
   options: Record<string, string>
 ) => {
-  if (
-    file != undefined &&
-    path.extname(file) == ".ts" &&
-    "output" in options == false
-  ) {
-    throw new Error(
-      `File ${file} is a TypeScript file. You must specify the output directory with --output.`
-    );
-  }
-
   if (file != undefined) {
     const filePath = resolveFilePath(file);
     let board = await loadBoard(filePath, options);

--- a/seeds/breadboard-cli/src/commands/run.ts
+++ b/seeds/breadboard-cli/src/commands/run.ts
@@ -14,7 +14,6 @@ import {
 import { loadBoard, parseStdin, resolveFilePath, watch } from "./lib/utils.js";
 import * as readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
-import path from "path";
 
 async function runBoard(
   board: BoardRunner,
@@ -73,16 +72,6 @@ export const run = async (file: string, options: Record<string, any>) => {
   const kitDeclarations = options.kit as string[] | undefined;
   const input =
     "input" in options ? (JSON.parse(options.input) as InputValues) : {};
-
-  if (
-    file != undefined &&
-    path.extname(file) == ".ts" &&
-    "output" in options == false
-  ) {
-    throw new Error(
-      `File ${file} is a TypeScript file. You must specify the output directory with --output.`
-    );
-  }
 
   if (file != undefined) {
     const filePath = resolveFilePath(file);


### PR DESCRIPTION
+ removing requirement for `-o` when compiling to TS.
+ make graph can input YAML
+ ensure that the temp file being created isn't already a directory.