### PR TITLE
[breadboard/new] automatically derive missing input/output schemas

### DIFF
--- a/packages/breadboard/src/new/runner/kits.ts
+++ b/packages/breadboard/src/new/runner/kits.ts
@@ -16,6 +16,10 @@ export function handlersFromKit(kit: Kit): NodeHandlers {
     Object.entries(kit.handlers).map(([name, handler]) => {
       const handlerFunction =
         handler instanceof Function ? handler : handler.invoke;
+      const describeFunction =
+        handler instanceof Function ? undefined : handler.describe;
+      const describe = describeFunction ? { describe: describeFunction } : {};
+
       return [
         name,
         {
@@ -25,6 +29,7 @@ export function handlersFromKit(kit: Kit): NodeHandlers {
               {}
             ) as Promise<OutputValues>;
           },
+          ...describe,
         },
       ];
     })

--- a/packages/breadboard/src/new/runner/node.ts
+++ b/packages/breadboard/src/new/runner/node.ts
@@ -169,8 +169,9 @@ export class BaseNode<
 
   #getHandlerDescribe(scope: ScopeInterface) {
     const handler = this.#handler ?? scope.getHandler(this.type);
-    if (!handler) throw new Error(`Handler ${this.type} not found`);
-    return typeof handler === "function" ? undefined : handler.describe;
+    return handler && typeof handler !== "function"
+      ? handler.describe
+      : undefined;
   }
 
   #getHandlerFunction(scope: Scope) {

--- a/packages/breadboard/src/new/runner/types.ts
+++ b/packages/breadboard/src/new/runner/types.ts
@@ -9,7 +9,9 @@ import {
   GraphDescriptor,
   GraphMetadata,
   NodeDescriberFunction,
+  NodeDescriberResult,
   NodeValue as OriginalNodeValue,
+  Schema,
 } from "../../types.js";
 
 // TODO:BASE: Same as before, but I added NodeFactory as base type, which is a
@@ -88,6 +90,12 @@ export abstract class AbstractNode<
   abstract getInputs(): I;
 
   abstract invoke(dynamicScope?: ScopeInterface): Promise<O>;
+  abstract describe(
+    scope?: ScopeInterface,
+    inputs?: InputValues,
+    inputSchema?: Schema,
+    outputSchema?: Schema
+  ): Promise<NodeDescriberResult | undefined>;
 
   abstract serialize(metadata?: GraphMetadata): Promise<GraphDescriptor>;
 

--- a/packages/breadboard/tests/helpers/_test-kit.ts
+++ b/packages/breadboard/tests/helpers/_test-kit.ts
@@ -102,7 +102,10 @@ export const TestKit = new KitBuilder({
       // Bare subset of describe() for invoke: Find the first input and output
       // nodes of inline supplied graphs (no loading), and use their schemas.
       let graph: GraphDescriptor | undefined = undefined;
-      if ((inputs?.$recipe as BreadboardCapability).kind === "board") {
+      if (
+        inputs?.$recipe &&
+        (inputs?.$recipe as BreadboardCapability).kind === "board"
+      ) {
         graph = (inputs?.$recipe as BreadboardCapability).board;
       } else if (
         inputs?.board &&

--- a/packages/breadboard/tests/helpers/_test-kit.ts
+++ b/packages/breadboard/tests/helpers/_test-kit.ts
@@ -11,7 +11,9 @@ import {
   BreadboardCapability,
   GraphDescriptor,
   InputValues,
+  NodeDescriberResult,
   NodeHandlerContext,
+  Schema,
 } from "../../src/types.js";
 
 type IncludeInputValues = InputValues & {
@@ -58,53 +60,110 @@ export const TestKit = new KitBuilder({
    * This is a primitive implementation of the `invoke` node in Core Kit,
    * just enough for testing.
    */
-  invoke: async (inputs: InvokeInputValues, context: NodeHandlerContext) => {
-    const { $recipe, ...args } = inputs;
+  invoke: {
+    invoke: async (inputs: InvokeInputValues, context: NodeHandlerContext) => {
+      const { $recipe, ...args } = inputs;
 
-    if ($recipe) {
-      const board =
-        ($recipe as BreadboardCapability).kind === "board"
-          ? await Board.fromBreadboardCapability(
-              $recipe as BreadboardCapability
-            )
-          : typeof $recipe === "string"
-          ? await Board.load($recipe, {
+      if ($recipe) {
+        const board =
+          ($recipe as BreadboardCapability).kind === "board"
+            ? await Board.fromBreadboardCapability(
+                $recipe as BreadboardCapability
+              )
+            : typeof $recipe === "string"
+            ? await Board.load($recipe, {
+                base: context.base,
+                outerGraph: context.outerGraph,
+              })
+            : undefined;
+
+        if (!board) throw new Error("Must provide valid $recipe to invoke");
+
+        return await board.runOnce(args, context);
+      } else {
+        const { board, path, ...args } = inputs;
+
+        const runnableBoard = board
+          ? await Board.fromBreadboardCapability(board)
+          : path
+          ? await Board.load(path, {
               base: context.base,
               outerGraph: context.outerGraph,
             })
           : undefined;
 
-      if (!board) throw new Error("Must provide valid $recipe to invoke");
+        if (!runnableBoard)
+          throw new Error("Must provide valid board to invoke");
 
-      return await board.runOnce(args, context);
-    } else {
-      const { board, path, ...args } = inputs;
+        return await runnableBoard.runOnce(args, context);
+      }
+    },
+    describe: async (inputs?: InputValues): Promise<NodeDescriberResult> => {
+      // Bare subset of describe() for invoke: Find the first input and output
+      // nodes of inline supplied graphs (no loading), and use their schemas.
+      let graph: GraphDescriptor | undefined = undefined;
+      if ((inputs?.$recipe as BreadboardCapability).kind === "board") {
+        graph = (inputs?.$recipe as BreadboardCapability).board;
+      } else if (
+        inputs?.board &&
+        (inputs.board as BreadboardCapability).kind === "board"
+      ) {
+        graph = (inputs.board as BreadboardCapability).board;
+      } else if (inputs?.graph) {
+        graph = inputs.graph as GraphDescriptor;
+      }
 
-      const runnableBoard = board
-        ? await Board.fromBreadboardCapability(board)
-        : path
-        ? await Board.load(path, {
-            base: context.base,
-            outerGraph: context.outerGraph,
-          })
-        : undefined;
+      const inputSchema =
+        (graph?.nodes.find((n) => n.type === "input" && n.configuration?.schema)
+          ?.configuration?.schema as Schema) ?? {};
+      const outputSchema =
+        (graph?.nodes.find(
+          (n) => n.type === "output" && n.configuration?.schema
+        )?.configuration?.schema as Schema) ?? {};
 
-      if (!runnableBoard) throw new Error("Must provide valid board to invoke");
-
-      return await runnableBoard.runOnce(args, context);
-    }
+      return { inputSchema, outputSchema };
+    },
   },
   /**
    * Reverses provided string inputs. Will crash if provided non-string inputs.
    * @param inputs InputValues
    */
-  reverser: async (inputs) => {
-    return Object.fromEntries(
-      Object.entries(inputs).map(([key, value]) => [
-        key,
-        (inputs[key] = [...(value as string)].reverse().join("")),
-      ])
-    );
+  reverser: {
+    invoke: async (inputs) => {
+      return Object.fromEntries(
+        Object.entries(inputs).map(([key, value]) => [
+          key,
+          (inputs[key] = [...(value as string)].reverse().join("")),
+        ])
+      );
+    },
+    describe: async (
+      inputs?: InputValues,
+      inputSchema?: Schema
+    ): Promise<NodeDescriberResult> => {
+      const ports = [
+        ...Object.keys(inputs ?? {}),
+        ...Object.keys(inputSchema?.properties ?? {}),
+      ];
+
+      const schema = (description: string) => ({
+        title: "Reverser",
+        description: "Reverses the provided string inputs",
+        type: "object",
+        properties: Object.fromEntries(
+          ports.map((port) => [
+            port,
+            { type: "string", title: port, description },
+          ])
+        ),
+        additonalProperties: Object.entries(inputs ?? {}).length === 0,
+      });
+
+      return {
+        inputSchema: schema("String to reverse"),
+        outputSchema: schema("Reversed string"),
+      };
+    },
   },
   /**
    * Supplies a simple stream output that can be used to test interactions with

--- a/packages/breadboard/tests/new/recipe-grammar/serialize-and-run-with-old-runner.ts
+++ b/packages/breadboard/tests/new/recipe-grammar/serialize-and-run-with-old-runner.ts
@@ -56,7 +56,7 @@ test("simplest graph, pick input and output", async (t) => {
     return { foo };
   });
   const result = await serializeAndRunGraph(graph, { foo: "bar" });
-  t.deepEqual(result, { foo: "bar" });
+  t.like(result, { foo: "bar" });
 });
 
 test("two nodes, spread", async (t) => {

--- a/packages/breadboard/tests/new/runner/default-schemas.ts
+++ b/packages/breadboard/tests/new/runner/default-schemas.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import test from "ava";
+
+import { z } from "zod";
+
+import { recipe } from "../../../src/new/recipe-grammar/recipe.js";
+
+import { testKit } from "../../helpers/_test-kit.js";
+
+test("schema derived from reverser (has describe)", async (t) => {
+  const graph = recipe<{ foo: string }>(({ foo }) => ({
+    bar: testKit.reverser({ foo }).foo,
+  }));
+
+  const serialized = await graph.serialize();
+
+  const inputSchema = serialized.nodes.find((node) => node.type === "input")
+    ?.configuration?.schema;
+  const outputSchema = serialized.nodes.find((node) => node.type === "output")
+    ?.configuration?.schema;
+
+  t.deepEqual(inputSchema, {
+    type: "object",
+    properties: {
+      foo: { type: "string", title: "foo", description: "String to reverse" },
+    },
+    required: ["foo"],
+  });
+
+  // Note "foo" as title, as this is determined by the reverse node.
+  t.deepEqual(outputSchema, {
+    type: "object",
+    properties: {
+      bar: { type: "string", title: "foo", description: "Reversed string" },
+    },
+    required: ["bar"],
+  });
+});
+
+test("schema derived from noop (no describe)", async (t) => {
+  const graph = recipe(({ foo }) => ({
+    bar: testKit.noop({ foo }).foo,
+  }));
+
+  const serialized = await graph.serialize();
+
+  const inputSchema = serialized.nodes.find((node) => node.type === "input")
+    ?.configuration?.schema;
+  const outputSchema = serialized.nodes.find((node) => node.type === "output")
+    ?.configuration?.schema;
+
+  t.deepEqual(inputSchema, {
+    type: "object",
+    properties: {
+      foo: { type: "string", title: "foo" },
+    },
+    required: ["foo"],
+  });
+
+  t.deepEqual(outputSchema, {
+    type: "object",
+    properties: {
+      bar: { type: "string", title: "bar" },
+    },
+    required: ["bar"],
+  });
+});


### PR DESCRIPTION
When the input and output nodes don't have schemas, derive them from the graph, calling its neighboring nodes' describe functions.

Implements #155.