### PR TITLE
[breadboard/new] don't use lambda nodes for non-closures

### DIFF
--- a/packages/breadboard-web/docs/graphs/openai-gpt-35-turbo.md
+++ b/packages/breadboard-web/docs/graphs/openai-gpt-35-turbo.md
@@ -4,12 +4,11 @@
 %%{init: 'themeVariables': { 'fontFamily': 'Fira Code, monospace' }}%%
 graph TD;
 streamTransform["transformStream <br> id='streamTransform'"] -- all --> streamOutput{{"output <br> id='streamOutput'"}}:::output
-lambda5["lambda <br> id='lambda-5'"] -- "board->board" --> streamTransform["transformStream <br> id='streamTransform'"]
-subgraph sg_lambda5 [lambda-5]
-lambda5_transformCompletion["jsonata <br> id='transformCompletion'"] -- "result->chunk" --> lambda5_result{{"output <br> id='result'"}}:::output
-lambda5_chunk[/"input <br> id='chunk'"/]:::input -- "chunk->json" --> lambda5_transformCompletion["jsonata <br> id='transformCompletion'"]
+subgraph sg_streamTransform [streamTransform]
+streamTransform_transformCompletion["jsonata <br> id='transformCompletion'"] -- "result->chunk" --> streamTransform_result{{"output <br> id='result'"}}:::output
+streamTransform_chunk[/"input <br> id='chunk'"/]:::input -- "chunk->json" --> streamTransform_transformCompletion["jsonata <br> id='transformCompletion'"]
 end
-sg_lambda5:::slotted -- "lamdba->lamdba" --o lambda5
+sg_streamTransform:::slotted -- "lamdba->lamdba" --o streamTransform
 
 callOpenAI["fetch <br> id='callOpenAI'"] -- "response->json" --> getResponse["jsonata <br> id='getResponse'"]
 callOpenAI["fetch <br> id='callOpenAI'"] -- "stream->stream" --> streamTransform["transformStream <br> id='streamTransform'"]

--- a/packages/breadboard-web/docs/graphs/openai-gpt-4-vision.md
+++ b/packages/breadboard-web/docs/graphs/openai-gpt-4-vision.md
@@ -4,12 +4,11 @@
 %%{init: 'themeVariables': { 'fontFamily': 'Fira Code, monospace' }}%%
 graph TD;
 streamTransform["transformStream <br> id='streamTransform'"] -- all --> streamOutput{{"output <br> id='streamOutput'"}}:::output
-lambda5["lambda <br> id='lambda-5'"] -- "board->board" --> streamTransform["transformStream <br> id='streamTransform'"]
-subgraph sg_lambda5 [lambda-5]
-lambda5_transformCompletion["jsonata <br> id='transformCompletion'"] -- "result->chunk" --> lambda5_result{{"output <br> id='result'"}}:::output
-lambda5_chunk[/"input <br> id='chunk'"/]:::input -- "chunk->json" --> lambda5_transformCompletion["jsonata <br> id='transformCompletion'"]
+subgraph sg_streamTransform [streamTransform]
+streamTransform_transformCompletion["jsonata <br> id='transformCompletion'"] -- "result->chunk" --> streamTransform_result{{"output <br> id='result'"}}:::output
+streamTransform_chunk[/"input <br> id='chunk'"/]:::input -- "chunk->json" --> streamTransform_transformCompletion["jsonata <br> id='transformCompletion'"]
 end
-sg_lambda5:::slotted -- "lamdba->lamdba" --o lambda5
+sg_streamTransform:::slotted -- "lamdba->lamdba" --o streamTransform
 
 openai["fetch <br> id='openai'"] -- "response->json" --> getResponse["jsonata <br> id='getResponse'"]
 openai["fetch <br> id='openai'"] -- "stream->stream" --> streamTransform["transformStream <br> id='streamTransform'"]

--- a/packages/breadboard-web/public/graphs/openai-gpt-35-turbo.json
+++ b/packages/breadboard-web/public/graphs/openai-gpt-35-turbo.json
@@ -10,12 +10,6 @@
       "in": ""
     },
     {
-      "from": "lambda-5",
-      "to": "streamTransform",
-      "out": "board",
-      "in": "board"
-    },
-    {
       "from": "callOpenAI",
       "to": "getResponse",
       "out": "response",
@@ -97,11 +91,6 @@
     {
       "id": "streamTransform",
       "type": "transformStream",
-      "configuration": {}
-    },
-    {
-      "id": "lambda-5",
-      "type": "lambda",
       "configuration": {
         "board": {
           "kind": "board",

--- a/packages/breadboard-web/public/graphs/openai-gpt-4-vision.json
+++ b/packages/breadboard-web/public/graphs/openai-gpt-4-vision.json
@@ -10,12 +10,6 @@
       "in": ""
     },
     {
-      "from": "lambda-5",
-      "to": "streamTransform",
-      "out": "board",
-      "in": "board"
-    },
-    {
       "from": "openai",
       "to": "getResponse",
       "out": "response",
@@ -85,11 +79,6 @@
     {
       "id": "streamTransform",
       "type": "transformStream",
-      "configuration": {}
-    },
-    {
-      "id": "lambda-5",
-      "type": "lambda",
       "configuration": {
         "board": {
           "kind": "board",

--- a/packages/breadboard-web/src/boards/openai-chunk-transformer.ts
+++ b/packages/breadboard-web/src/boards/openai-chunk-transformer.ts
@@ -10,17 +10,15 @@ import { starter } from "@google-labs/llm-starter";
 /**
  * A recipe for chunking OpenaAI output streams into text chunks.
  */
-export const chunkTransformer = () => {
-  return recipe(async () => {
-    const input = base.input({ $id: "chunk" });
-    const transformCompletion = starter.jsonata({
-      $id: "transformCompletion",
-      expression: 'choices[0].delta.content ? choices[0].delta.content : ""',
-      json: input.chunk as V<string>,
-    });
-
-    return transformCompletion.result
-      .as("chunk")
-      .to(base.output({ $id: "result" }));
+export const chunkTransformer = recipe(async () => {
+  const input = base.input({ $id: "chunk" });
+  const transformCompletion = starter.jsonata({
+    $id: "transformCompletion",
+    expression: 'choices[0].delta.content ? choices[0].delta.content : ""',
+    json: input.chunk as V<string>,
   });
-};
+
+  return transformCompletion.result
+    .as("chunk")
+    .to(base.output({ $id: "result" }));
+});

--- a/packages/breadboard-web/src/boards/openai-gpt-35-turbo.ts
+++ b/packages/breadboard-web/src/boards/openai-gpt-35-turbo.ts
@@ -227,7 +227,7 @@ export default await recipe(async () => {
   return nursery
     .transformStream({
       $id: "streamTransform",
-      board: chunkTransformer(),
+      board: chunkTransformer,
       stream: fetch,
     })
     .to(streamOutput);

--- a/packages/breadboard-web/src/boards/openai-gpt-4-vision.ts
+++ b/packages/breadboard-web/src/boards/openai-gpt-4-vision.ts
@@ -119,7 +119,7 @@ export default await recipe(async () => {
 
   return nursery
     .transformStream({
-      board: chunkTransformer(),
+      board: chunkTransformer,
       $id: "streamTransform",
       stream: fetch,
     })

--- a/packages/breadboard/src/new/recipe-grammar/recipe.ts
+++ b/packages/breadboard/src/new/recipe-grammar/recipe.ts
@@ -280,7 +280,13 @@ function recipeImpl(
   }
 
   // Return wire from lambdaNode that will generate a BoardCapability
-  factory.getBoardCapabilityAsValue = () => getLambdaNode().asProxy().board;
+  factory.getBoardCapabilityAsValue = () =>
+    lambdaNode !== undefined
+      ? lambdaNode.asProxy().board
+      : ((async () => ({
+          kind: "board",
+          board: { kits: [], ...(await factory.serialize()) },
+        }))() as Promise<BreadboardCapability>);
 
   // Access to factory as if it was a node means accessing the closure node.
   // This makes otherNode.to(factory) work.

--- a/packages/breadboard/src/new/recipe-grammar/types.ts
+++ b/packages/breadboard/src/new/recipe-grammar/types.ts
@@ -237,7 +237,9 @@ export type ClosureNodeInterface<
 > = Pick<BuilderNodeInterface<I, O>, "unProxy"> &
   Pick<NodeProxyMethods<I, O>, "in"> &
   Pick<AbstractValue<NodeValue>, "invoke"> & {
-    getBoardCapabilityAsValue(): AbstractValue<BreadboardCapability>;
+    getBoardCapabilityAsValue():
+      | AbstractValue<BreadboardCapability>
+      | Promise<BreadboardCapability>;
   };
 
 export abstract class AbstractValue<T extends NodeValue | unknown = NodeValue>

--- a/packages/breadboard/tests/new/recipe-grammar/lambdas.ts
+++ b/packages/breadboard/tests/new/recipe-grammar/lambdas.ts
@@ -30,7 +30,7 @@ async function serializeAndRunGraph(
 test("simplest lambda", async (t) => {
   const graph = recipe(async ({ foo }) => {
     const lambda = recipe(async (inputs) => testKit.noop(inputs));
-    t.assert(isLambda(lambda));
+    t.true(isLambda(lambda));
     t.false(isLambda(testKit.noop({})));
     const caller = recipe(async ({ lambda, foo }) => {
       return lambda.invoke({ foo });
@@ -88,9 +88,10 @@ test("serialize simple lambda", async (t) => {
   const lambda = recipe(async (inputs) => testKit.noop(inputs));
   t.assert(isLambda(lambda));
 
-  // This turns a simple recipe into a lambda
+  // This is no closure, so there should be no lambda node
   const boardValue = lambda.getBoardCapabilityAsValue();
-  t.assert(isValue(boardValue));
+  t.false(isValue(boardValue));
+  t.like(await boardValue, { kind: "board" });
 
   const serialized = await lambda.serialize();
 


### PR DESCRIPTION
When passing a lambda that is a self-contained recipe, then no longer add extra lambda nodes.

This allows `import { aRecipe } from "elsewhere"` and then using that recipe, either as is or as lambda in a new board.

Note that if one imports an actual closure like this, then you are creating a closure by using it and right now it'll serialize everything that is connected. In practice there should be no need to include closures like this (instead the entire closure should be wrapped in a recipe), so this should probably produce an error on serialize. That is, we allow serializing self-contained recipes that are defined outside of the scope of the serialized recipe, but we don't allow including _nodes_ that are outside a serialized recipe. Note that the regular way to serialize a closure is to run it and return it.