### PR TITLE
[breadboard/new] add useful debug information when not reaching an output node.

### DIFF
--- a/packages/breadboard/src/new/recipe-grammar/node.ts
+++ b/packages/breadboard/src/new/recipe-grammar/node.ts
@@ -464,7 +464,11 @@ export class BuilderNode<
     try {
       // It's ok to call this multiple times: If it already run it'll only do
       // something if new nodes or inputs were added (e.g. between await calls)
-      this.#scope.invoke(this as unknown as BaseNode);
+      this.#scope.invoke(this as unknown as BaseNode).catch((e) => {
+        if (onrejected)
+          return Promise.reject(e).catch(this.#scope.asScopeFor(onrejected));
+        else throw e;
+      });
 
       return this.#promise.then(
         onfulfilled && this.#scope.asScopeFor(onfulfilled),

--- a/packages/breadboard/tests/new/recipe-grammar/invoke-by-await.ts
+++ b/packages/breadboard/tests/new/recipe-grammar/invoke-by-await.ts
@@ -111,7 +111,6 @@ test("directly await declarative recipe, passing full inputs as spread, twice", 
     const reverser = testKit.reverser({ ...inputs });
     return testKit.noop({ ...reverser });
   });
-  t.log(await graph.serialize());
   const baz = await graph({ baz: "bar" }).baz;
   t.is(baz as unknown as string, "rab");
 });

--- a/packages/breadboard/tests/new/runner/no-infinite-runs.ts
+++ b/packages/breadboard/tests/new/runner/no-infinite-runs.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import test from "ava";
+
+import { recipe } from "../../../src/new/recipe-grammar/recipe.js";
+
+import { testKit } from "../../helpers/_test-kit.js";
+
+test("broken graph should return an error", async (t) => {
+  const brokenGraph = recipe<{ foo: string }>(({ foo }) => ({
+    bar: testKit.reverser({ foo }).bar, // Note: should be .foo
+  }));
+
+  let result;
+
+  try {
+    result = await brokenGraph({ foo: "bar" });
+  } catch (e) {
+    t.is(
+      (e as Error).message,
+      "Output node never reach. Last node was reverser-3.\n\n" +
+        "These nodes had inputs missing:\n" +
+        "  output-2: bar"
+    );
+  }
+  t.deepEqual(result, {
+    $error: {
+      type: "error",
+      error: new Error(
+        "Output node never reach. Last node was reverser-3.\n\n" +
+          "These nodes had inputs missing:\n" +
+          "  output-2: bar"
+      ),
+    },
+  });
+});


### PR DESCRIPTION
(Instead of just never returning!)

Returns $error noting
 - the last node actually ran,
 - nodes that were adjacent to invoked nodes with their missing inputs

Fixed missing error handling as well.
