### PR TITLE
[breadboard/new] renamed `recipeForCode` to `code`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -948,6 +948,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -1883,7 +1884,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
-      "devOptional": true
+      "optional": true
     },
     "node_modules/@google-cloud/firestore": {
       "version": "6.8.0",
@@ -3182,7 +3183,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz",
       "integrity": "sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "@gar/promisify": "^1.0.1",
         "semver": "^7.3.5"
@@ -3193,7 +3194,7 @@
       "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz",
       "integrity": "sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==",
       "deprecated": "This functionality has been moved to @npmcli/fs",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "mkdirp": "^1.0.4",
         "rimraf": "^3.0.2"
@@ -3206,7 +3207,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3226,7 +3227,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -4719,7 +4720,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
       "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "humanize-ms": "^1.2.1"
       },
@@ -5702,7 +5703,7 @@
       "version": "15.3.0",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz",
       "integrity": "sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "@npmcli/fs": "^1.0.0",
         "@npmcli/move-file": "^1.0.1",
@@ -5731,7 +5732,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
       "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "clean-stack": "^2.0.0",
         "indent-string": "^4.0.0"
@@ -5744,7 +5745,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "devOptional": true,
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -5753,7 +5754,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -5773,7 +5774,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "devOptional": true,
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -5782,7 +5783,7 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -5794,7 +5795,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
       "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "aggregate-error": "^3.0.0"
       },
@@ -5809,7 +5810,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -7743,7 +7744,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "devOptional": true,
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -7752,7 +7753,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
       "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
-      "devOptional": true
+      "optional": true
     },
     "node_modules/errno": {
       "version": "0.1.8",
@@ -9472,7 +9473,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
       "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
-      "devOptional": true
+      "optional": true
     },
     "node_modules/http-equiv-refresh": {
       "version": "1.0.0",
@@ -9541,7 +9542,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
       "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "ms": "^2.0.0"
       }
@@ -9646,7 +9647,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
       "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
-      "devOptional": true
+      "optional": true
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -9918,7 +9919,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
       "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
-      "devOptional": true
+      "optional": true
     },
     "node_modules/is-module": {
       "version": "1.0.0",
@@ -10029,6 +10030,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
       "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -12599,7 +12601,7 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz",
       "integrity": "sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "agentkeepalive": "^4.1.3",
         "cacache": "^15.2.0",
@@ -12626,7 +12628,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
-      "devOptional": true,
+      "optional": true,
       "engines": {
         "node": ">= 6"
       }
@@ -12635,7 +12637,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
       "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "@tootallnate/once": "1",
         "agent-base": "6",
@@ -12649,7 +12651,7 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -13406,7 +13408,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
       "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -13418,7 +13420,7 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -13430,7 +13432,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz",
       "integrity": "sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "minipass": "^3.1.0",
         "minipass-sized": "^1.0.3",
@@ -13447,7 +13449,7 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -13459,7 +13461,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
       "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -13471,7 +13473,7 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -13483,7 +13485,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
       "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -13495,7 +13497,7 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -13507,7 +13509,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
       "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -13519,7 +13521,7 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -13760,7 +13762,7 @@
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
       "integrity": "sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "env-paths": "^2.2.0",
         "glob": "^7.1.4",
@@ -13784,7 +13786,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "devOptional": true,
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -13793,7 +13795,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
       "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^3.6.0"
@@ -13806,13 +13808,13 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "devOptional": true
+      "optional": true
     },
     "node_modules/node-gyp/node_modules/gauge": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
       "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "aproba": "^1.0.3 || ^2.0.0",
         "color-support": "^1.1.3",
@@ -13831,7 +13833,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -13851,7 +13853,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "devOptional": true,
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -13860,7 +13862,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
       "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "are-we-there-yet": "^3.0.0",
         "console-control-strings": "^1.1.0",
@@ -13875,7 +13877,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
       "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -13890,7 +13892,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -13904,7 +13906,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -17851,13 +17853,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
-      "devOptional": true
+      "optional": true
     },
     "node_modules/promise-retry": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
       "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "err-code": "^2.0.2",
         "retry": "^0.12.0"
@@ -17870,7 +17872,7 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "devOptional": true,
+      "optional": true,
       "engines": {
         "node": ">= 4"
       }
@@ -19191,7 +19193,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "devOptional": true,
+      "optional": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -19207,7 +19209,7 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
       "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "ip": "^2.0.0",
         "smart-buffer": "^4.2.0"
@@ -19221,7 +19223,7 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz",
       "integrity": "sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "agent-base": "^6.0.2",
         "debug": "^4.3.3",
@@ -19235,7 +19237,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
       "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==",
-      "devOptional": true
+      "optional": true
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -20626,7 +20628,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
       "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "unique-slug": "^2.0.0"
       }
@@ -20635,7 +20637,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
       "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "imurmurhash": "^0.1.4"
       }

--- a/packages/breadboard-web/src/boards/gemini-pro-vision.ts
+++ b/packages/breadboard-web/src/boards/gemini-pro-vision.ts
@@ -9,7 +9,7 @@ import {
   Schema,
   base,
   recipe,
-  recipeAsCode,
+  code,
 } from "@google-labs/breadboard";
 import { starter } from "@google-labs/llm-starter";
 import { nursery } from "@google-labs/node-nursery-web";
@@ -153,7 +153,7 @@ export default await recipe(() => {
       return base
         .input({})
         .chunk.to(
-          recipeAsCode(({ chunk }: Chunky) => {
+          code(({ chunk }: Chunky) => {
             return {
               chunk: chunk.candidates[0].content.parts[0].text,
             };

--- a/packages/breadboard-web/src/boards/mock-text-generator.ts
+++ b/packages/breadboard-web/src/boards/mock-text-generator.ts
@@ -10,7 +10,7 @@ import {
   V,
   base,
   recipe,
-  recipeAsCode,
+  code,
 } from "@google-labs/breadboard";
 import { nursery } from "@google-labs/node-nursery-web";
 
@@ -82,7 +82,7 @@ const mockGenerator = recipe<MockGeneratorInputs, MockGeneratorOutputs>(() => {
 
   type GeneratorOutputs = MockGeneratorTextOutput | { list: string[] };
 
-  const generator = recipeAsCode<MockGeneratorInputs, GeneratorOutputs>(
+  const generator = code<MockGeneratorInputs, GeneratorOutputs>(
     ({ text, useStreaming }) => {
       text = `Mock model with streaming off echoes back: ${text}`;
       if (useStreaming) {

--- a/packages/breadboard-web/src/boards/palm-text-generator.ts
+++ b/packages/breadboard-web/src/boards/palm-text-generator.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Schema, V, base, recipe, recipeAsCode } from "@google-labs/breadboard";
+import { Schema, V, base, recipe, code } from "@google-labs/breadboard";
 import { starter } from "@google-labs/llm-starter";
 import { palm } from "@google-labs/palm-kit";
 
@@ -47,7 +47,7 @@ const textOutputSchema = {
 export default await recipe(() => {
   const parameters = base.input({ $id: "parameters", schema: inputSchema });
 
-  recipeAsCode(({ useStreaming }) => {
+  code(({ useStreaming }) => {
     if (useStreaming)
       throw new Error("Streaming is not supported by PaLM model");
     return {};

--- a/packages/breadboard-web/src/boards/text-generator.ts
+++ b/packages/breadboard-web/src/boards/text-generator.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Schema, base, recipe, recipeAsCode } from "@google-labs/breadboard";
+import { Schema, base, recipe, code } from "@google-labs/breadboard";
 import { core } from "@google-labs/core-kit";
 
 const metadata = {
@@ -75,7 +75,7 @@ export default await recipe(() => {
     schema: streamOutputSchema,
   });
 
-  const switchModel = recipeAsCode(({ MODEL }: { MODEL: string }) => {
+  const switchModel = code(({ MODEL }: { MODEL: string }) => {
     const models: Record<string, string> = {
       "Gemini Pro": "gemini-generator.json",
       PaLM: "palm-text-generator.json",

--- a/packages/breadboard-web/src/boards/tour-guide-writer.ts
+++ b/packages/breadboard-web/src/boards/tour-guide-writer.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Schema, V, base, recipe, recipeAsCode } from "@google-labs/breadboard";
+import { Schema, V, base, recipe, code } from "@google-labs/breadboard";
 import { core } from "@google-labs/core-kit";
 import { starter } from "@google-labs/llm-starter";
 
@@ -109,15 +109,13 @@ const graph = recipe(() => {
   type Itinerary = { itinerary: string };
   type SplitItinerary = { list: string[] };
 
-  const splitItinerary = recipeAsCode<Itinerary, SplitItinerary>(
-    ({ itinerary }) => {
-      const list = itinerary
-        .split(/[0-9]{1,2}\)/)
-        .map((e) => e.trim())
-        .filter((e) => e !== "");
-      return { list };
-    }
-  )({ itinerary: travelItineraryGenerator.text as V<string> });
+  const splitItinerary = code<Itinerary, SplitItinerary>(({ itinerary }) => {
+    const list = itinerary
+      .split(/[0-9]{1,2}\)/)
+      .map((e) => e.trim())
+      .filter((e) => e !== "");
+    return { list };
+  })({ itinerary: travelItineraryGenerator.text as V<string> });
 
   travelItinerary.prompt.as("text").to(travelItineraryGenerator);
 
@@ -170,7 +168,7 @@ const graph = recipe(() => {
 
   type Guide = { guide: string };
 
-  const combineGuides = recipeAsCode<GuideMaterials, Guide>(
+  const combineGuides = code<GuideMaterials, Guide>(
     ({ location, activities, guides }) => {
       const guideList = guides.map((item) => item.guide);
       return {

--- a/packages/breadboard/src/index.ts
+++ b/packages/breadboard/src/index.ts
@@ -71,13 +71,7 @@ export {
 
 // New Syntax:
 export { Runner } from "./new/runner/runner.js";
-export {
-  recipe,
-  recipeAsGraph,
-  recipeAsCode,
-  recipeAsGraphWithZod,
-  recipeAsCodeWithZod,
-} from "./new/recipe-grammar/recipe.js";
+export { recipe, code } from "./new/recipe-grammar/recipe.js";
 export { addKit } from "./new/recipe-grammar/kits.js";
 export { base } from "./new/recipe-grammar/base.js";
 export type {

--- a/packages/breadboard/src/new/recipe-grammar/recipe.ts
+++ b/packages/breadboard/src/new/recipe-grammar/recipe.ts
@@ -51,69 +51,28 @@ export const recipe: RecipeFactory = (
   const options = typeof optionsOrFn === "object" ? optionsOrFn : {};
   options.graph ??= typeof optionsOrFn === "function" ? optionsOrFn : maybeFn;
 
-  return recipeImpl(options);
+  return lambdaFactory(options);
 };
 
 /**
  * Explicit implementations of the overloaded variants, also splitting
  * graph generation and code recipes.
  */
-export const recipeAsGraph = <
-  I extends InputValues = InputValues,
-  O extends OutputValues = OutputValues
->(
-  fn: GraphDeclarationFunction<I, O>
-): Lambda<I, Required<O>> => {
-  return recipeImpl({
-    graph: fn as GraphDeclarationFunction,
-  }) as Lambda<I, Required<O>>;
-};
-
-export const recipeAsCode = <
+export const code = <
   I extends InputValues = InputValues,
   O extends OutputValues = OutputValues
 >(
   fn: (inputs: I) => O | PromiseLike<O>
 ): Lambda<I, Required<O>> => {
-  return recipeImpl({
+  return lambdaFactory({
     invoke: fn as unknown as NodeProxyHandlerFunction,
   }) as Lambda<I, Required<O>>;
-};
-
-export const recipeAsGraphWithZod = <
-  IT extends z.ZodType,
-  OT extends z.ZodType
->(
-  options: {
-    input: IT;
-    output: OT;
-    describe?: NodeDescriberFunction;
-    name?: string;
-  } & GraphMetadata,
-  fn: GraphDeclarationFunction<z.infer<IT>, z.infer<OT>>
-): Lambda<z.infer<IT>, Required<z.infer<OT>>> => {
-  return recipeImpl({
-    ...options,
-    graph: fn as GraphDeclarationFunction,
-  }) as Lambda<z.infer<IT>, Required<z.infer<OT>>>;
-};
-
-export const recipeAsCodeWithZod = <IT extends z.ZodType, OT extends z.ZodType>(
-  options: {
-    input: IT;
-    output: OT;
-    invoke: (inputs: z.infer<IT>) => z.infer<OT> | PromiseLike<z.infer<OT>>;
-    describe?: NodeDescriberFunction;
-    name?: string;
-  } & GraphMetadata
-): Lambda<z.infer<IT>, Required<z.infer<OT>>> => {
-  return recipeImpl(options) as Lambda<z.infer<IT>, Required<z.infer<OT>>>;
 };
 
 /**
  * Actual implementation of all the above
  */
-function recipeImpl(
+function lambdaFactory(
   options: {
     input?: z.ZodType | Schema;
     output?: z.ZodType | Schema;

--- a/packages/breadboard/tests/new/recipe-grammar/invoke-by-await.ts
+++ b/packages/breadboard/tests/new/recipe-grammar/invoke-by-await.ts
@@ -7,11 +7,7 @@
 import { z } from "zod";
 import test from "ava";
 
-import {
-  recipe,
-  recipeAsCode,
-  recipeAsGraph,
-} from "../../../src/new/recipe-grammar/recipe.js";
+import { recipe, code } from "../../../src/new/recipe-grammar/recipe.js";
 import { V } from "../../../src/index.js";
 import { testKit } from "../../helpers/_test-kit.js";
 
@@ -74,7 +70,7 @@ test("directly await declarative recipe, deconstruct", async (t) => {
 });
 
 test("directly await declarative recipe, deconstruct, 'in' and 'to'", async (t) => {
-  const graph = recipeAsGraph((inputs) => {
+  const graph = recipe((inputs) => {
     const { to } = testKit.noop({ to: inputs.in });
     return { to: to as unknown as V<string> };
   });
@@ -116,7 +112,7 @@ test("directly await declarative recipe, passing full inputs as spread, twice", 
 });
 
 test("directly await imperative recipe, value assignment", async (t) => {
-  const graph = recipeAsCode(async (inputs) => {
+  const graph = code(async (inputs) => {
     const { foo } = await testKit.noop({ foo: inputs.foo });
     return { foo };
   });
@@ -125,7 +121,7 @@ test("directly await imperative recipe, value assignment", async (t) => {
 });
 
 test("directly await imperative recipe, deconstruct", async (t) => {
-  const graph = recipeAsCode(async (inputs) => {
+  const graph = code(async (inputs) => {
     const { foo } = await testKit.noop({ foo: inputs.foo });
     return { foo };
   });
@@ -134,10 +130,10 @@ test("directly await imperative recipe, deconstruct", async (t) => {
 });
 
 test("if-else, imperative execution", async (t) => {
-  const math = recipeAsCode(async () => {
+  const math = code(async () => {
     return { result: "math result" };
   });
-  const search = recipeAsCode(async () => {
+  const search = code(async () => {
     return { text: "search result" };
   });
 
@@ -186,10 +182,10 @@ test("if-else, imperative execution", async (t) => {
 });
 
 test.skip("if-else, serializable", async (t) => {
-  const math = recipeAsCode(async () => {
+  const math = code(async () => {
     return { result: "math result" };
   });
-  const search = recipeAsCode(async () => {
+  const search = code(async () => {
     return { text: "search result" };
   });
 

--- a/packages/breadboard/tests/new/recipe-grammar/recipe-as-code.ts
+++ b/packages/breadboard/tests/new/recipe-grammar/recipe-as-code.ts
@@ -5,13 +5,13 @@
  */
 
 import test from "ava";
-import { recipeAsCode } from "../../../src/index.js";
+import { code } from "../../../src/index.js";
 
 test("recipeAsCode works with sync arrow functions", async (t) => {
-  const code = await recipeAsCode(() => {
+  const fn = await code(() => {
     return { value: 1 };
   })({}).serialize();
-  t.like(code, {
+  t.like(fn, {
     graphs: {
       "fn-1": {
         nodes: [
@@ -30,10 +30,10 @@ test("recipeAsCode works with sync arrow functions", async (t) => {
 });
 
 test("recipeAsCode works with async arrow functions", async (t) => {
-  const code = await recipeAsCode(async () => {
+  const fn = await code(async () => {
     return { value: 1 };
   })({}).serialize();
-  t.like(code, {
+  t.like(fn, {
     graphs: {
       "fn-2": {
         nodes: [

--- a/packages/breadboard/tests/new/recipe-grammar/recipe-overloads.ts
+++ b/packages/breadboard/tests/new/recipe-grammar/recipe-overloads.ts
@@ -8,10 +8,7 @@ import test from "ava";
 
 import { z } from "zod";
 
-import {
-  recipe,
-  recipeAsCode,
-} from "../../../src/new/recipe-grammar/recipe.js";
+import { recipe, code } from "../../../src/new/recipe-grammar/recipe.js";
 
 test("zod + graph, w/ nested code recipe", async (t) => {
   const graph = recipe(
@@ -20,7 +17,7 @@ test("zod + graph, w/ nested code recipe", async (t) => {
       output: z.object({ foo: z.string() }),
     },
     (inputs) => {
-      return recipeAsCode(({ foo }) => ({ foo: `${foo}!` }))(inputs);
+      return code(({ foo }) => ({ foo: `${foo}!` }))(inputs);
     }
   );
 

--- a/packages/breadboard/tests/new/recipe-grammar/serialize-and-run-with-old-runner.ts
+++ b/packages/breadboard/tests/new/recipe-grammar/serialize-and-run-with-old-runner.ts
@@ -7,10 +7,7 @@
 import { z } from "zod";
 import test from "ava";
 
-import {
-  recipe,
-  recipeAsCode,
-} from "../../../src/new/recipe-grammar/recipe.js";
+import { recipe, code } from "../../../src/new/recipe-grammar/recipe.js";
 import { Serializeable } from "../../../src/new/runner/types.js";
 import {
   InputValues,
@@ -74,7 +71,7 @@ test("two nodes, spread", async (t) => {
 test("simple inline action", async (t) => {
   const graph = recipe<{ a: number; b: number }, { result: number }>(
     (inputs) => {
-      return recipeAsCode<{ a: number; b: number }, { result: number }>(
+      return code<{ a: number; b: number }, { result: number }>(
         async (inputs) => {
           const { a, b } = await inputs;
           return { result: a + b };
@@ -88,7 +85,7 @@ test("simple inline action", async (t) => {
 });
 
 test("code recipe called from another recipe", async (t) => {
-  const add = recipeAsCode<{ a: number; b: number }, { result: number }>(
+  const add = code<{ a: number; b: number }, { result: number }>(
     async (inputs) => {
       const { a, b } = await inputs;
       return { result: a + b };
@@ -117,7 +114,7 @@ test("nested inline action, with schema", async (t) => {
       }),
     },
     (inputs) => {
-      return recipeAsCode<{ a: number; b: number }, { result: number }>(
+      return code<{ a: number; b: number }, { result: number }>(
         async (inputs) => {
           const { a, b } = await inputs;
           return { result: a + b };


### PR DESCRIPTION
removed all other variants, now it's just `recipe` and `code`:
Use `recipe` for graphs (runs at serialization time), `code` for anything else (runs only at runtime).