### PR TITLE
[breadboard/new] allow recipe construction without return value

### DIFF
--- a/packages/breadboard/src/new/recipe-grammar/types.ts
+++ b/packages/breadboard/src/new/recipe-grammar/types.ts
@@ -97,7 +97,8 @@ export type OutputsForGraphDeclaration<
         | AbstractValue<NodeValue>
         | NodeProxy<NI, Partial<InputValues>>;
     })
-  | PromiseLike<OutputsMaybeAsValues<T>>; // = returning a node
+  | PromiseLike<OutputsMaybeAsValues<T>> // = returning a node
+  | void; // = returning nothing, i.e. expect nodes to be pinned instead
 
 export type NodeProxyHandlerFunction<
   I extends InputValues = InputValues,
@@ -114,7 +115,10 @@ export type NodeProxyHandlerFunction<
 export type GraphDeclarationFunction<
   I extends InputValues = InputValues,
   O extends OutputValuesOrUnknown = OutputValuesOrUnknown
-> = (inputs: InputsForGraphDeclaration<I>) => OutputsForGraphDeclaration<O>;
+> = (
+  inputs: InputsForGraphDeclaration<I>,
+  base: { [key: string]: NodeFactory<InputValues, OutputValues> }
+) => OutputsForGraphDeclaration<O>;
 
 export type Lambda<
   I extends InputValues = InputValues,

--- a/packages/breadboard/src/new/runner/node.ts
+++ b/packages/breadboard/src/new/runner/node.ts
@@ -200,7 +200,12 @@ export class BaseNode<
         this
       )) as O;
     } else if (handler && typeof handler !== "function" && handler.graph) {
-      result = (await scope.invokeOnce(this.getInputs(), handler.graph)) as O;
+      // TODO: This isn't quite right, but good enough for now. Instead what
+      // this should be in invoking a graph from a lexical scope in a dynamic
+      // scope. This requires moving state management into the dyanmic scope.
+      const graphs = handler.graph.getPinnedNodes();
+      if (graphs.length !== 1) throw new Error("Expected exactly one graph");
+      result = (await scope.invokeOnce(this.getInputs(), graphs[0])) as O;
     } else {
       throw new Error(`Can't find handler for ${this.id}`);
     }

--- a/packages/breadboard/src/new/runner/scope.ts
+++ b/packages/breadboard/src/new/runner/scope.ts
@@ -56,6 +56,24 @@ export class Scope implements ScopeInterface {
     this.#pinnedNodes.push(node);
   }
 
+  compactPins() {
+    const visited = new Set<AbstractNode>();
+    const disjointPins = [];
+
+    for (const node of this.#pinnedNodes) {
+      if (visited.has(node)) continue;
+      disjointPins.push(node);
+      const connected = this.#findAllConnectedNodes(node);
+      connected.forEach((node) => visited.add(node));
+    }
+
+    this.#pinnedNodes = disjointPins;
+  }
+
+  getPinnedNodes(): AbstractNode[] {
+    return this.#pinnedNodes;
+  }
+
   addCallbacks(callbacks: InvokeCallbacks) {
     this.#callbacks.push(callbacks);
   }
@@ -94,7 +112,7 @@ export class Scope implements ScopeInterface {
         let callbackResult: OutputValues | undefined = undefined;
         for (const callback of callbacks)
           callbackResult ??= await callback.before?.(this, node, inputs);
-        console.log("called", node.id);
+
         // Invoke node, unless before callback already provided a result.
         const result =
           callbackResult ??

--- a/packages/breadboard/src/new/runner/types.ts
+++ b/packages/breadboard/src/new/runner/types.ts
@@ -41,7 +41,7 @@ export type NodeHandler<
   | {
       invoke?: NodeHandlerFunction<I, O>;
       describe?: NodeDescriberFunction;
-      graph?: AbstractNode; // Graphs can be node handlers, too
+      graph?: ScopeInterface; // Pinned graph is the node
     }
   | NodeHandlerFunction<I, O>;
 
@@ -190,6 +190,20 @@ export interface ScopeInterface {
    * @param node node to pin to this scope
    */
   pin(node: AbstractNode): void;
+
+  /**
+   * Reduces set of pinned pins to one per disjoint graph. Call this after
+   * constructing a graph that might have pinned several nodes.
+   */
+  compactPins(): void;
+
+  /**
+   * Returns all pinned nodes in this scope. After calling compactPins(), this
+   * will return one node representing each disjoint graph.
+   *
+   * @returns Array of pinned nodes
+   */
+  getPinnedNodes(): AbstractNode[];
 
   /**
    * Invokes a node, or all pinned nodes if none is specified.

--- a/packages/breadboard/tests/new/recipe-grammar/recipe-overloads.ts
+++ b/packages/breadboard/tests/new/recipe-grammar/recipe-overloads.ts
@@ -24,3 +24,18 @@ test("zod + graph, w/ nested code recipe", async (t) => {
   const result = await graph({ foo: "bar" });
   t.like(result, { foo: "bar!" });
 });
+
+test("recipe with its own inputs and outputs", async (t) => {
+  const graph = recipe((_, base) => {
+    base.input().foo.as("bar").to(base.output());
+  });
+
+  const serialized = await graph.serialize();
+
+  t.like(serialized, {
+    nodes: [{ type: "input" }, { type: "output" }],
+  });
+
+  const result = await graph({ foo: "success" });
+  t.like(result, { bar: "success" });
+});

--- a/packages/breadboard/tests/new/runner/pinning-scopes.ts
+++ b/packages/breadboard/tests/new/runner/pinning-scopes.ts
@@ -81,3 +81,32 @@ test("pin node and invokeOnce scope", async (t) => {
 
   t.deepEqual(result, { bar: "success" });
 });
+
+test("multiple connected pins result in only pinning once", async (t) => {
+  const scope = new Scope();
+
+  t.is(scope.getPinnedNodes().length, 0);
+
+  const input = new BaseNode("input", scope);
+  const noop = new BaseNode("noop", scope);
+  const output = new BaseNode("output", scope);
+  noop.addIncomingEdge(input, "foo", "foo");
+  output.addIncomingEdge(noop, "foo", "bar");
+
+  scope.pin(input);
+  t.is(scope.getPinnedNodes().length, 1);
+
+  scope.pin(output);
+  t.is(scope.getPinnedNodes().length, 2);
+
+  scope.compactPins();
+  t.is(scope.getPinnedNodes().length, 1);
+
+  const noop2 = new BaseNode("noop", scope);
+  scope.pin(noop2);
+
+  t.is(scope.getPinnedNodes().length, 2);
+
+  scope.compactPins();
+  t.is(scope.getPinnedNodes().length, 2);
+});


### PR DESCRIPTION
the function passed to recipe() can now accept a second parameter `base` that is a base kit.

if using that to create a graph, then there is no longer any need to return something.
