### PR TITLE
[breadboard/new] automatically wire closure wires

### DIFF
--- a/packages/breadboard/src/new/recipe-grammar/scope.ts
+++ b/packages/breadboard/src/new/recipe-grammar/scope.ts
@@ -5,26 +5,36 @@
  */
 
 import { GraphDescriptor, GraphMetadata } from "@google-labs/breadboard";
-import { BuilderScopeInterface, BuilderNodeInterface } from "./types.js";
+import {
+  BuilderScopeInterface,
+  BuilderNodeInterface,
+  ClosureEdge,
+} from "./types.js";
 import { AbstractNode, ScopeConfig } from "../runner/types.js";
 
 import { Scope } from "../runner/scope.js";
 import { swapCurrentContextScope } from "./default-scope.js";
+import { BuilderNode } from "./node.js";
 
 /**
  * Adds syntactic sugar to support unproxying and serialization of nodes/graphs.
  */
 export class BuilderScope extends Scope implements BuilderScopeInterface {
   #isSerializing: boolean;
+  #closureEdges: ClosureEdge[] = [];
+
+  parentLambdaNode?: BuilderNode;
 
   // TODO:BASE, config of subclasses can have more fields
   constructor(
     config: ScopeConfig & {
       serialize?: boolean;
+      parentLambda?: BuilderNode;
     } = {}
   ) {
     super(config);
     this.#isSerializing = config.serialize ?? false;
+    this.parentLambdaNode = config.parentLambda;
   }
 
   async serialize(
@@ -53,5 +63,13 @@ export class BuilderScope extends Scope implements BuilderScopeInterface {
         swapCurrentContextScope(oldScope);
       }
     }) as T;
+  }
+
+  addClosureEdge(edge: ClosureEdge) {
+    this.#closureEdges.push(edge);
+  }
+
+  getClosureEdges() {
+    return this.#closureEdges;
   }
 }

--- a/packages/breadboard/src/new/recipe-grammar/types.ts
+++ b/packages/breadboard/src/new/recipe-grammar/types.ts
@@ -294,6 +294,14 @@ export type NodeProxy<
   [key in string]: AbstractValue<NodeValue> & ((...args: unknown[]) => unknown);
 } & NodeProxyMethods<I, O>;
 
+export interface ClosureEdge {
+  scope: BuilderScopeInterface;
+  from: BuilderNodeInterface;
+  to: BuilderNodeInterface;
+  out: string;
+  in: string;
+}
+
 export interface BuilderScopeInterface {
   /**
    * Swap global scope with this one, run the function, then restore
@@ -305,4 +313,10 @@ export interface BuilderScopeInterface {
    * Helpers to detect handlers that construct graphs but don't invoke them.
    */
   serializing(): boolean;
+
+  /**
+   * used by recipe() and node.addIncomingEdges() to auto-wire closures
+   */
+  addClosureEdge(edge: ClosureEdge): void;
+  getClosureEdges(): ClosureEdge[];
 }

--- a/packages/breadboard/src/new/runner/node.ts
+++ b/packages/breadboard/src/new/runner/node.ts
@@ -28,7 +28,11 @@ import { Scope } from "./scope.js";
 
 import { IdVendor } from "../../id.js";
 
-export const nodeIdVendor = new IdVendor();
+const nodeIdVendor = new IdVendor();
+
+export function nextNodeId(scope: ScopeInterface, type: string) {
+  return nodeIdVendor.vendId(scope, type);
+}
 
 // TODO:BASE Extract base class that isn't opinionated about the syntax. Marking
 // methods that should be base as "TODO:BASE" below, including complications.
@@ -75,7 +79,7 @@ export class BaseNode<
 
     const { $id, ...rest } = config;
 
-    this.id = $id ?? nodeIdVendor.vendId(scope, this.type);
+    this.id = $id ?? nextNodeId(scope, this.type);
 
     this.configuration = rest as Partial<I>;
 

--- a/packages/breadboard/src/new/runner/types.ts
+++ b/packages/breadboard/src/new/runner/types.ts
@@ -85,6 +85,12 @@ export abstract class AbstractNode<
   abstract incoming: EdgeInterface[];
   abstract configuration: Partial<I>;
 
+  abstract addIncomingEdge(
+    from: AbstractNode,
+    out: string,
+    in_: string,
+    constant?: boolean
+  ): void;
   abstract receiveInputs(edge: EdgeInterface, inputs: InputValues): string[];
   abstract missingInputs(): string[] | false;
 
@@ -148,6 +154,14 @@ export interface ScopeConfig {
 }
 
 export interface ScopeInterface {
+  parentLexicalScope?: ScopeInterface;
+  parentDynamicScope?: ScopeInterface;
+
+  /**
+   * Add handlers to this scope. See `getHandler` for resolution order.
+   *
+   * @param handlers handlers to add
+   */
   addHandlers(handlers: NodeHandlers): void;
 
   /**

--- a/packages/breadboard/tests/new/recipe-grammar/recipe-as-code.ts
+++ b/packages/breadboard/tests/new/recipe-grammar/recipe-as-code.ts
@@ -7,18 +7,18 @@
 import test from "ava";
 import { code } from "../../../src/index.js";
 
-test("recipeAsCode works with sync arrow functions", async (t) => {
+test("`code` works with sync arrow functions", async (t) => {
   const fn = await code(() => {
     return { value: 1 };
-  })({}).serialize();
+  })({ $id: "fn" }).serialize();
   t.like(fn, {
     graphs: {
-      "fn-1": {
+      fn: {
         nodes: [
           { type: "input" },
           {
             configuration: {
-              code: `function fn_1() {
+              code: `function fn() {
         return { value: 1 };
     }`,
             },
@@ -29,18 +29,18 @@ test("recipeAsCode works with sync arrow functions", async (t) => {
   });
 });
 
-test("recipeAsCode works with async arrow functions", async (t) => {
+test("`code` works with async arrow functions", async (t) => {
   const fn = await code(async () => {
     return { value: 1 };
-  })({}).serialize();
+  })({ $id: "fn" }).serialize();
   t.like(fn, {
     graphs: {
-      "fn-2": {
+      fn: {
         nodes: [
           { type: "input" },
           {
             configuration: {
-              code: `async function fn_2() {
+              code: `async function fn() {
         return { value: 1 };
     }`,
             },


### PR DESCRIPTION
Nested `recipe()` calls can now refer to nodes from upper scopes and
the framework will automatically wire the underlying lambdas together.

E.g. see how `bar` is defined at the top, but not passed through the caller,
which calls the lambda? That is now happening under the hood:

```ts
  const graph = recipe(({ foo, bar }) => {
    const lambda = recipe(({ foo }) => testKit.noop({ foo, bar }));
    const caller = recipe(({ lambda, foo }) => {
      return lambda({ foo });
    });
    return caller({ lambda, foo });
  });
```
