### PR TITLE
[breadboard-web] Nicer types and diagnostics.

### DIFF
--- a/packages/breadboard-ui/src/input.ts
+++ b/packages/breadboard-ui/src/input.ts
@@ -26,7 +26,7 @@ import { WebcamInput } from "./webcam.js";
 import { DrawableInput } from "./drawable.js";
 
 export type InputArgs = {
-  schema: Schema;
+  schema?: Schema;
 };
 
 export type InputData = Record<string, unknown>;

--- a/packages/breadboard-ui/src/load.ts
+++ b/packages/breadboard-ui/src/load.ts
@@ -11,7 +11,7 @@ import { LitElement, html, css } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 export type LoadArgs = {
-  title: string;
+  title?: string;
   description?: string;
   version?: string;
   diagram?: string;

--- a/packages/breadboard-ui/src/output.ts
+++ b/packages/breadboard-ui/src/output.ts
@@ -14,10 +14,10 @@ export type OutputArgs = {
   node: {
     id: string;
     type: string;
-    configuration: unknown;
+    configuration?: unknown;
   };
   outputs: {
-    schema: Schema;
+    schema?: Schema;
   } & Record<string, unknown>;
 };
 

--- a/packages/breadboard-ui/src/ui-controller.ts
+++ b/packages/breadboard-ui/src/ui-controller.ts
@@ -758,7 +758,7 @@ export class UIController extends HTMLElement implements UI {
     const { title, description = "", version = "", url = "" } = info;
     const load = new Load();
 
-    load.title = title;
+    load.title = title || "Untitled";
     load.description = description;
     load.version = version;
     load.url = url;

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -311,6 +311,7 @@ export class Main {
       type: "worker",
       url: WORKER_URL,
     };
-    return createHarness({ kits, remote, proxy });
+    const diagnostics = true;
+    return createHarness({ kits, remote, proxy, diagnostics });
   }
 }

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -229,11 +229,6 @@ export class Main {
   async #handleEvent(result: HarnessRunResult) {
     const { data, type } = result.message;
 
-    if (type === "load") {
-      const loadData = data as BreadboardUI.LoadArgs;
-      this.#ui.load(loadData);
-    }
-
     // Update the graph to the latest.
     if (this.#hasNodeInfo(data)) {
       await this.#ui.renderDiagram(data.node.id);
@@ -242,25 +237,22 @@ export class Main {
     }
 
     switch (type) {
+      case "load": {
+        this.#ui.load(data);
+        break;
+      }
       case "output": {
-        const outputData = data as BreadboardUI.OutputArgs;
-        await this.#ui.output(outputData);
+        await this.#ui.output(data);
         break;
       }
 
       case "input": {
-        const inputData = data as {
-          node: { id: string };
-          inputArguments: BreadboardUI.InputArgs;
-        };
-        result.reply(
-          await this.#ui.input(inputData.node.id, inputData.inputArguments)
-        );
+        result.reply(await this.#ui.input(data.node.id, data.inputArguments));
         break;
       }
 
       case "secret": {
-        const keys = (data as { keys: string[] }).keys;
+        const keys = data.keys;
         result.reply(
           Object.fromEntries(
             await Promise.all(
@@ -272,21 +264,13 @@ export class Main {
       }
 
       case "beforehandler": {
-        const progressData = data as {
-          node: {
-            id: string;
-            type: string;
-            configuration: Record<string, unknown> | null;
-          };
-        };
-        this.#ui.progress(progressData.node.id, progressData.node.type);
-        this.#pending.set(progressData.node.id, progressData.node.type);
+        this.#ui.progress(data.node.id, data.node.type);
+        this.#pending.set(data.node.id, data.node.type);
         break;
       }
 
       case "error": {
-        const errorData = data as { error: Error };
-        this.#ui.error(errorData.error.message);
+        this.#ui.error(data.error.message);
         break;
       }
 

--- a/packages/breadboard/src/harness/diagnostics.ts
+++ b/packages/breadboard/src/harness/diagnostics.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ProbeEvent } from "../types.js";
+import { AfterhandlerResult, BeforehandlerResult } from "./types.js";
+
+export type DiagnosticMesageType = "beforehandler" | "afterhandler";
+
+export type DiagnosticsCallback = (
+  message: BeforehandlerResult | AfterhandlerResult
+) => void;
+
+export class Diagnostics extends EventTarget {
+  #callback: DiagnosticsCallback;
+
+  constructor(callback: DiagnosticsCallback) {
+    super();
+    this.#callback = callback;
+    const eventHandler = this.#eventHandler.bind(this);
+    this.addEventListener("beforehandler", eventHandler);
+    this.addEventListener("node", eventHandler);
+  }
+
+  #eventHandler = (event: Event) => {
+    const e = event as ProbeEvent;
+    const message =
+      e.type === "beforehandler"
+        ? ({
+            type: "beforehandler",
+            data: {
+              node: e.detail.descriptor,
+              inputs: e.detail.inputs,
+            },
+          } as BeforehandlerResult)
+        : ({
+            type: "afterhandler",
+            data: {
+              node: e.detail.descriptor,
+              outputs: e.detail.outputs,
+            },
+          } as AfterhandlerResult);
+    this.#callback(message);
+  };
+}

--- a/packages/breadboard/src/harness/local-harness.ts
+++ b/packages/breadboard/src/harness/local-harness.ts
@@ -20,6 +20,7 @@ import { HTTPClientTransport } from "../remote/http.js";
 import { asyncGen } from "../utils/async-gen.js";
 import { Board } from "../board.js";
 import { Diagnostics } from "./diagnostics.js";
+import { LogProbe } from "../log.js";
 
 export class LocalHarness implements Harness {
   #config: HarnessConfig;
@@ -85,7 +86,7 @@ export class LocalHarness implements Harness {
         );
 
         const probe = new Diagnostics(async (message) => {
-          await next(new LocalRunResult(message));
+          next(new LocalRunResult(message));
         });
 
         for await (const data of runner.run({ probe, kits })) {

--- a/packages/breadboard/src/harness/local-harness.ts
+++ b/packages/breadboard/src/harness/local-harness.ts
@@ -98,10 +98,6 @@ export class LocalHarness implements Harness {
             data.inputs = inputResult.response as InputValues;
           } else if (type === "output") {
             await next(new LocalRunResult({ type, data }));
-          } else if (type === "beforehandler") {
-            await next(new LocalRunResult({ type, data }));
-          } else if (type === "afterhandler") {
-            await next(new LocalRunResult({ type, data }));
           }
         }
         await next(new LocalRunResult({ type: "end", data: {} }));

--- a/packages/breadboard/src/harness/local-harness.ts
+++ b/packages/breadboard/src/harness/local-harness.ts
@@ -20,7 +20,6 @@ import { HTTPClientTransport } from "../remote/http.js";
 import { asyncGen } from "../utils/async-gen.js";
 import { Board } from "../board.js";
 import { Diagnostics } from "./diagnostics.js";
-import { LogProbe } from "../log.js";
 
 export class LocalHarness implements Harness {
   #config: HarnessConfig;
@@ -85,9 +84,11 @@ export class LocalHarness implements Harness {
           })
         );
 
-        const probe = new Diagnostics(async (message) => {
-          next(new LocalRunResult(message));
-        });
+        const probe = this.#config.diagnostics
+          ? new Diagnostics(async (message) => {
+              next(new LocalRunResult(message));
+            })
+          : undefined;
 
         for await (const data of runner.run({ probe, kits })) {
           const { type } = data;

--- a/packages/breadboard/src/harness/secrets.ts
+++ b/packages/breadboard/src/harness/secrets.ts
@@ -85,6 +85,7 @@ export const createOnSecret = (
   next: (result: HarnessRunResult) => Promise<void>
 ): SecretHandler => {
   return async ({ keys }) => {
+    if (!keys) return {};
     const result = new LocalRunResult({ type: "secret", data: { keys } });
     await next(result);
     return result.response as OutputValues;

--- a/packages/breadboard/src/harness/types.ts
+++ b/packages/breadboard/src/harness/types.ts
@@ -168,4 +168,9 @@ export type HarnessConfig = {
    * server and a list of nodes that will be proxied to it.
    */
   proxy?: HarnessProxyConfig[];
+  /**
+   * Specifies whether to output diagnostics information.
+   * Defaults to `false`.
+   */
+  diagnostics?: boolean;
 };

--- a/packages/breadboard/src/harness/types.ts
+++ b/packages/breadboard/src/harness/types.ts
@@ -11,7 +11,12 @@ import {
   LoadResponse,
   OutputResponse,
 } from "../remote/protocol.js";
-import { Kit, OutputValues } from "../types.js";
+import { Kit, NodeDescriptor, OutputValues } from "../types.js";
+
+export type AfterhandlerResponse = {
+  node: NodeDescriptor;
+  outputs: OutputValues;
+};
 
 export type ResultType =
   /**
@@ -27,9 +32,13 @@ export type ResultType =
    */
   | "output"
   /**
-   * Sent before a handler for a particular node is handled
+   * Sent before a handler for a particular node is invoked
    */
   | "beforehandler"
+  /**
+   * Sent after a handler for a particular node is invoked
+   */
+  | "afterhandler"
   /**
    * Sent when the harness is asking for secret
    */
@@ -72,6 +81,11 @@ export type BeforehandlerResult = {
   data: BeforehandlerResponse;
 };
 
+export type AfterhandlerResult = {
+  type: "afterhandler";
+  data: AfterhandlerResponse;
+};
+
 export type ErrorResult = {
   type: "error";
   data: { error: Error };
@@ -93,6 +107,7 @@ export type AnyResult = (
   | OutputResult
   | SecretResult
   | BeforehandlerResult
+  | AfterhandlerResult
   | ErrorResult
   | EndResult
   | ShutdownResult

--- a/packages/breadboard/src/harness/types.ts
+++ b/packages/breadboard/src/harness/types.ts
@@ -11,7 +11,7 @@ import {
   LoadResponse,
   OutputResponse,
 } from "../remote/protocol.js";
-import { InputValues, Kit, OutputValues } from "../types.js";
+import { Kit, OutputValues } from "../types.js";
 
 export type ResultType =
   /**
@@ -64,7 +64,7 @@ export type OutputResult = {
 
 export type SecretResult = {
   type: "secret";
-  data: InputValues;
+  data: { keys: string[] };
 };
 
 export type BeforehandlerResult = {

--- a/packages/breadboard/src/harness/worker-harness.ts
+++ b/packages/breadboard/src/harness/worker-harness.ts
@@ -79,10 +79,8 @@ export class WorkerHarness implements Harness {
         }
 
         const message = await this.controller.listen();
-        console.log("message", message);
         const { data, type, id } = message;
         if (type === "proxy") {
-          console.log("proxy message", data);
           try {
             const result = await receiver.handle(data as ProxyPromiseResponse);
             id && this.controller.reply(id, result.value, type);

--- a/packages/breadboard/src/harness/worker-harness.ts
+++ b/packages/breadboard/src/harness/worker-harness.ts
@@ -96,9 +96,7 @@ export class WorkerHarness implements Harness {
             break;
           }
         }
-        await next(
-          new WorkerRunResult(this.controller, message as unknown as AnyResult)
-        );
+        await next(new WorkerRunResult(this.controller, message as AnyResult));
         if (data && type === "end") {
           break;
         }

--- a/packages/breadboard/src/harness/worker-harness.ts
+++ b/packages/breadboard/src/harness/worker-harness.ts
@@ -5,6 +5,7 @@
  */
 
 import type {
+  ControllerMessageType,
   LoadRequestMessage,
   LoadResponseMessage,
   StartMesssage,
@@ -43,6 +44,13 @@ export class WorkerHarness implements Harness {
     }
     const absoluteURL = new URL(workerURL, location.href);
     this.workerURL = prepareBlobUrl(absoluteURL.href);
+  }
+
+  #skipDiagnosticMessages(type: ControllerMessageType) {
+    return (
+      !this.#config.diagnostics &&
+      (type === "beforehandler" || type === "afterhandler")
+    );
   }
 
   async *run(url: string) {
@@ -95,6 +103,9 @@ export class WorkerHarness implements Harness {
             );
             break;
           }
+        }
+        if (this.#skipDiagnosticMessages(type)) {
+          continue;
         }
         await next(new WorkerRunResult(this.controller, message as AnyResult));
         if (data && type === "end") {

--- a/packages/breadboard/src/runner.ts
+++ b/packages/breadboard/src/runner.ts
@@ -121,7 +121,7 @@ export class BoardRunner implements BreadboardRunner {
     context: NodeHandlerContext = {},
     result?: RunResult
   ): AsyncGenerator<RunResult> {
-    yield* asyncGen(async (next) => {
+    yield* asyncGen<RunResult>(async (next) => {
       const handlers = await BoardRunner.handlersFromBoard(this, context.kits);
       const slots = { ...this.#slots, ...context.slots };
       this.#validators.forEach((validator) => validator.addGraph(this));

--- a/packages/breadboard/src/utils/async-gen.ts
+++ b/packages/breadboard/src/utils/async-gen.ts
@@ -7,41 +7,9 @@
 type AsyncGenNext<T> = (value: T) => Promise<void>;
 type AsyncGenCallback<T> = (next: AsyncGenNext<T>) => Promise<void>;
 
-/**
- * Converts async/await style code into an async generator.
- * Useful when you need to combine arrow-style functions and yield.
- *
- * Example:
- *
- * ```ts
- * async function* foo() {
- *   yield 1;
- *   yield* asyncGen(async (next) => {
- *     await next(2);
- *     await next(3);
- *   });
- *   yield 4;
- * }
- *
- * for await (const val of foo()) {
- *   console.log(val);
- * }
- * ```
- *
- * This code will print:
- *
- * ```
- * 1
- * 2
- * 3
- * 4
- * ```
- *
- * @param callback A callback that will be called with a `next` function.
- * The callback should call `next` with the next value to yield.
- * @returns An async generator.
- */
-export const asyncGen = <T>(callback: AsyncGenCallback<T>) => {
+// only here for historical purposes. Use asyncGen instead.
+// Remove this when we're sure we don't need it anymore.
+export const asyncGenOld = <T>(callback: AsyncGenCallback<T>) => {
   type MaybeT = T | undefined;
   let proceedToNext: (() => void) | undefined;
   let nextCalled: (value: MaybeT) => void;
@@ -85,6 +53,150 @@ export const asyncGen = <T>(callback: AsyncGenCallback<T>) => {
           return { done, value };
         },
       } as AsyncIterator<T, void, unknown>;
+    },
+  };
+};
+
+type QueuEntry<T> = {
+  value: T | undefined;
+  receipt: () => void;
+};
+
+const noop = () => {
+  /* noop */
+};
+
+class AsyncGenQueue<T> {
+  #queue: QueuEntry<T>[] = [];
+  #wroteIntoQueue = noop;
+  #whenQueuedUp: Promise<void> | undefined;
+  #lastReceipt: (() => void) | undefined;
+  abort: (err: Error) => void = noop;
+
+  constructor() {
+    this.#setQueuePromise();
+  }
+
+  #setQueuePromise() {
+    this.#whenQueuedUp = new Promise<void>((resolve, reject) => {
+      this.#wroteIntoQueue = resolve;
+      this.abort = reject;
+    });
+  }
+
+  #addToQueue(entry: QueuEntry<T>) {
+    this.#queue.push(entry);
+    if (this.#queue.length == 1) {
+      this.#wroteIntoQueue();
+      this.#setQueuePromise();
+    }
+  }
+
+  async write(value: T): Promise<void> {
+    return new Promise((receipt) => {
+      this.#addToQueue({ value, receipt });
+    });
+  }
+
+  async read(): Promise<IteratorResult<T, void>> {
+    this.#lastReceipt && this.#lastReceipt();
+    if (this.#queue.length === 0) {
+      await this.#whenQueuedUp;
+    }
+    const entry = this.#queue.shift();
+    if (!entry) {
+      throw new Error("asyncGen queue should never be empty.");
+    }
+    this.#lastReceipt = entry.receipt;
+    if (!entry.value) {
+      return { done: true, value: undefined };
+    }
+    return { done: false, value: entry.value };
+  }
+
+  close(): void {
+    this.#addToQueue({ value: undefined, receipt: noop });
+  }
+}
+
+class AsyncGenIterator<T> implements AsyncIterator<T, void, unknown> {
+  #callback: AsyncGenCallback<T>;
+  #firstTime = true;
+  #queue = new AsyncGenQueue<T>();
+
+  constructor(callback: AsyncGenCallback<T>) {
+    this.#callback = callback;
+  }
+
+  /**
+   * Called by the callback to advance to the next value.
+   * Roughly equivalent to "yield":
+   * ```ts
+   * yield value;
+   * ```
+   * same as
+   * ```ts
+   * await next(value);
+   * ```
+   * @param value
+   */
+  async #next(value: T): Promise<void> {
+    return this.#queue.write(value);
+  }
+
+  async next(): Promise<IteratorResult<T, void>> {
+    if (this.#firstTime) {
+      this.#firstTime = false;
+      this.#callback(this.#next.bind(this))
+        .then(() => {
+          this.#queue.close();
+        })
+        .catch((err) => {
+          this.#queue.abort(err);
+        });
+    }
+    return this.#queue.read();
+  }
+}
+
+/**
+ * Converts async/await style code into an async generator.
+ * Useful when you need to combine arrow-style functions and yield.
+ *
+ * Example:
+ *
+ * ```ts
+ * async function* foo() {
+ *   yield 1;
+ *   yield* asyncGen(async (next) => {
+ *     await next(2);
+ *     await next(3);
+ *   });
+ *   yield 4;
+ * }
+ *
+ * for await (const val of foo()) {
+ *   console.log(val);
+ * }
+ * ```
+ *
+ * This code will print:
+ *
+ * ```
+ * 1
+ * 2
+ * 3
+ * 4
+ * ```
+ *
+ * @param callback A callback that will be called with a `next` function.
+ * The callback should call `next` with the next value to yield.
+ * @returns An async generator.
+ */
+export const asyncGen = <T>(callback: AsyncGenCallback<T>) => {
+  return {
+    [Symbol.asyncIterator]() {
+      return new AsyncGenIterator<T>(callback);
     },
   };
 };

--- a/packages/breadboard/src/worker/protocol.ts
+++ b/packages/breadboard/src/worker/protocol.ts
@@ -21,6 +21,7 @@ export const VALID_MESSAGE_TYPES = [
   "input",
   "output",
   "beforehandler",
+  "afterhandler",
   "proxy",
   "end",
   "error",

--- a/packages/breadboard/src/worker/worker-runtime.ts
+++ b/packages/breadboard/src/worker/worker-runtime.ts
@@ -91,12 +91,11 @@ export class WorkerRuntime {
         asRuntimeKit(kitConstructor)
       );
 
-      for await (const stop of board.run({
-        probe: new Diagnostics(({ type, data }) => {
-          this.#controller.inform(data, type);
-        }),
-        kits,
-      })) {
+      const probe = new Diagnostics(({ type, data }) => {
+        this.#controller.inform(data, type);
+      });
+
+      for await (const stop of board.run({ probe, kits })) {
         if (stop.type === "input") {
           const inputMessage = (await this.#controller.ask<
             InputRequestMessage,

--- a/packages/breadboard/src/worker/worker-runtime.ts
+++ b/packages/breadboard/src/worker/worker-runtime.ts
@@ -8,7 +8,6 @@ import { BoardRunner } from "../runner.js";
 import type { InputValues, Kit, KitConstructor } from "../types.js";
 import {
   type LoadResponseMessage,
-  type BeforehandlerMessage,
   type EndMessage,
   type ErrorMessage,
   type InputRequestMessage,
@@ -20,7 +19,7 @@ import {
 import { MessageController } from "./controller.js";
 import { makeProxyKit } from "./proxy.js";
 import { asRuntimeKit } from "../kits/ctors.js";
-import { LogProbe } from "../log.js";
+import { Diagnostics } from "../harness/diagnostics.js";
 
 export class WorkerRuntime {
   #controller: MessageController;
@@ -92,7 +91,12 @@ export class WorkerRuntime {
         asRuntimeKit(kitConstructor)
       );
 
-      for await (const stop of board.run({ probe: new LogProbe(), kits })) {
+      for await (const stop of board.run({
+        probe: new Diagnostics(({ type, data }) => {
+          this.#controller.inform(data, type);
+        }),
+        kits,
+      })) {
         if (stop.type === "input") {
           const inputMessage = (await this.#controller.ask<
             InputRequestMessage,
@@ -110,13 +114,6 @@ export class WorkerRuntime {
             {
               node: stop.node,
               outputs: stop.outputs,
-            },
-            stop.type
-          );
-        } else if (stop.type === "beforehandler") {
-          this.#controller.inform<BeforehandlerMessage>(
-            {
-              node: stop.node,
             },
             stop.type
           );

--- a/packages/breadboard/tests/board.ts
+++ b/packages/breadboard/tests/board.ts
@@ -155,6 +155,7 @@ test("allows pausing and resuming the board", async (t) => {
     for await (const stop of firstBoard.run({ kits: [kit] })) {
       t.is(stop.type, "beforehandler");
       result = stop;
+      console.log(await result.save());
       break;
     }
   }


### PR DESCRIPTION
- Nicer types. So nice.
- Remove spurious logging.
- Introduce Diagnostics probe and start using it.
- Teach asyncGen to handle non-awaited 'next' invocations.
- Wire up 'diagnostics' config value.
- Don't listen to diagnostic results in LocalHarness.
