### PR TITLE
[breadboard/harness] Separate 'load' and 'run' calls.

### DIFF
--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -127,11 +127,7 @@ export class Main {
         }
 
         for await (const result of harness.run()) {
-          if (
-            result.message.type !== "load" &&
-            result.message.type !== "beforehandler" &&
-            result.message.type !== "shutdown"
-          ) {
+          if (result.message.type !== "beforehandler") {
             const currentBoardId = this.#boardId;
             await this.#suspendIfPaused();
             if (currentBoardId !== this.#boardId) {

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -9,7 +9,6 @@ import {
   type HarnessProxyConfig,
   type HarnessRemoteConfig,
   createHarness,
-  HarnessLoadResult,
   HarnessRunResult,
 } from "@google-labs/breadboard/harness";
 import { asRuntimeKit } from "@google-labs/breadboard";
@@ -123,9 +122,7 @@ export class Main {
 
         const harness = this.#getHarness(startEvent.url);
 
-        for await (const result of harness.load()) {
-          await this.#handleEvent(result);
-        }
+        this.#ui.load(await harness.load());
 
         for await (const result of harness.run()) {
           if (result.message.type !== "beforehandler") {
@@ -226,7 +223,7 @@ export class Main {
     });
   }
 
-  async #handleEvent(result: HarnessRunResult | HarnessLoadResult) {
+  async #handleEvent(result: HarnessRunResult) {
     const { data, type } = result.message;
 
     // Update the graph to the latest.
@@ -237,10 +234,6 @@ export class Main {
     }
 
     switch (type) {
-      case "load": {
-        this.#ui.load(data);
-        break;
-      }
       case "output": {
         await this.#ui.output(data);
         break;

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -6,7 +6,6 @@
 
 import * as BreadboardUI from "@google-labs/breadboard-ui";
 import {
-  type Harness,
   type HarnessProxyConfig,
   type HarnessRemoteConfig,
   type HarnessRunResult,
@@ -79,7 +78,6 @@ const sleep = (time: number) =>
 
 export class Main {
   #ui = BreadboardUI.get();
-  #harness: Harness;
   #hasActiveBoard = false;
   #boardId = 0;
   #delay = 0;
@@ -96,7 +94,6 @@ export class Main {
     }
     config.boards.sort((a, b) => a.title.localeCompare(b.title));
 
-    this.#harness = this.#getHarness();
     BreadboardUI.register();
 
     document.body.addEventListener(
@@ -123,7 +120,9 @@ export class Main {
         const startEvent = evt as BreadboardUI.StartEvent;
         this.setActiveBreadboard(startEvent.url);
 
-        for await (const result of this.#harness.run(startEvent.url)) {
+        const harness = this.#getHarness(startEvent.url);
+
+        for await (const result of harness.run()) {
           if (
             result.message.type !== "load" &&
             result.message.type !== "beforehandler" &&
@@ -284,7 +283,7 @@ export class Main {
     }
   }
 
-  #getHarness() {
+  #getHarness(url: string) {
     const harness =
       globalThis.localStorage.getItem(HARNESS_SWITCH_KEY) ?? DEFAULT_HARNESS;
 
@@ -312,6 +311,6 @@ export class Main {
       url: WORKER_URL,
     };
     const diagnostics = true;
-    return createHarness({ kits, remote, proxy, diagnostics });
+    return createHarness({ url, kits, remote, proxy, diagnostics });
   }
 }

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -278,9 +278,6 @@ export class Main {
         this.#ui.done();
         this.#hasActiveBoard = false;
         break;
-
-      case "shutdown":
-        break;
     }
   }
 

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -8,8 +8,9 @@ import * as BreadboardUI from "@google-labs/breadboard-ui";
 import {
   type HarnessProxyConfig,
   type HarnessRemoteConfig,
-  type HarnessRunResult,
   createHarness,
+  HarnessLoadResult,
+  HarnessRunResult,
 } from "@google-labs/breadboard/harness";
 import { asRuntimeKit } from "@google-labs/breadboard";
 import Starter from "@google-labs/llm-starter";
@@ -225,7 +226,7 @@ export class Main {
     });
   }
 
-  async #handleEvent(result: HarnessRunResult) {
+  async #handleEvent(result: HarnessRunResult | HarnessLoadResult) {
     const { data, type } = result.message;
 
     // Update the graph to the latest.

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -122,6 +122,10 @@ export class Main {
 
         const harness = this.#getHarness(startEvent.url);
 
+        for await (const result of harness.load()) {
+          await this.#handleEvent(result);
+        }
+
         for await (const result of harness.run()) {
           if (
             result.message.type !== "load" &&

--- a/packages/breadboard/src/harness/local-harness.ts
+++ b/packages/breadboard/src/harness/local-harness.ts
@@ -68,10 +68,6 @@ export class LocalHarness implements Harness {
 
   async *load() {
     yield* asyncGen<HarnessLoadResult>(async (next) => {
-      if (this.#runner) {
-        await next(new LocalResult({ type: "shutdown", data: null }));
-      }
-
       const url = this.#config.url;
       const runner = await Board.load(url);
 

--- a/packages/breadboard/src/harness/local-harness.ts
+++ b/packages/breadboard/src/harness/local-harness.ts
@@ -66,10 +66,11 @@ export class LocalHarness implements Harness {
   }
 
   async *load() {
-    if (this.#runner) {
-      throw new Error("Harness already loaded and is ready to run.");
-    }
     yield* asyncGen<HarnessRunResult>(async (next) => {
+      if (this.#runner) {
+        await next(new LocalRunResult({ type: "shutdown", data: null }));
+      }
+
       const url = this.#config.url;
       const runner = await Board.load(url);
 
@@ -89,10 +90,11 @@ export class LocalHarness implements Harness {
 
   async *run() {
     yield* asyncGen<HarnessRunResult>(async (next) => {
-      const kits = this.#configureKits(createOnSecret(next));
       if (!this.#runner) {
         throw new Error("Harness not loaded. Please call 'load' first.");
       }
+
+      const kits = this.#configureKits(createOnSecret(next));
 
       try {
         const probe = this.#config.diagnostics

--- a/packages/breadboard/src/harness/local-harness.ts
+++ b/packages/breadboard/src/harness/local-harness.ts
@@ -63,24 +63,22 @@ export class LocalHarness implements Harness {
     return kits;
   }
 
-  async *run(url: string) {
+  async *run() {
     yield* asyncGen<HarnessRunResult>(async (next) => {
       const kits = this.#configureKits(createOnSecret(next));
 
       try {
+        const url = this.#config.url;
         const runner = await Board.load(url);
+
+        const { title, description, version } = runner;
+        const diagram = runner.mermaid("TD", true);
+        const nodes = runner.nodes;
 
         await next(
           new LocalRunResult({
             type: "load",
-            data: {
-              title: runner.title,
-              description: runner.description,
-              version: runner.version,
-              diagram: runner.mermaid("TD", true),
-              url: url,
-              nodes: runner.nodes,
-            },
+            data: { title, description, version, diagram, url, nodes },
           })
         );
 

--- a/packages/breadboard/src/harness/local-harness.ts
+++ b/packages/breadboard/src/harness/local-harness.ts
@@ -7,7 +7,6 @@
 import type {
   Harness,
   HarnessConfig,
-  HarnessLoadResult,
   HarnessRunResult,
   SecretHandler,
 } from "./types.js";
@@ -66,23 +65,16 @@ export class LocalHarness implements Harness {
     return kits;
   }
 
-  async *load() {
-    yield* asyncGen<HarnessLoadResult>(async (next) => {
-      const url = this.#config.url;
-      const runner = await Board.load(url);
+  async load() {
+    const url = this.#config.url;
+    const runner = await Board.load(url);
 
-      const { title, description, version } = runner;
-      const diagram = runner.mermaid("TD", true);
-      const nodes = runner.nodes;
+    const { title, description, version } = runner;
+    const diagram = runner.mermaid("TD", true);
+    const nodes = runner.nodes;
 
-      this.#runner = runner;
-      await next(
-        new LocalResult({
-          type: "load",
-          data: { title, description, version, diagram, url, nodes },
-        })
-      );
-    });
+    this.#runner = runner;
+    return { title, description, version, diagram, url, nodes };
   }
 
   async *run() {

--- a/packages/breadboard/src/harness/local-harness.ts
+++ b/packages/breadboard/src/harness/local-harness.ts
@@ -20,9 +20,11 @@ import { HTTPClientTransport } from "../remote/http.js";
 import { asyncGen } from "../utils/async-gen.js";
 import { Board } from "../board.js";
 import { Diagnostics } from "./diagnostics.js";
+import { BoardRunner } from "../runner.js";
 
 export class LocalHarness implements Harness {
   #config: HarnessConfig;
+  #runner: BoardRunner | undefined;
 
   constructor(config: HarnessConfig) {
     this.#config = config;
@@ -63,32 +65,43 @@ export class LocalHarness implements Harness {
     return kits;
   }
 
+  async *load() {
+    if (this.#runner) {
+      throw new Error("Harness already loaded and is ready to run.");
+    }
+    yield* asyncGen<HarnessRunResult>(async (next) => {
+      const url = this.#config.url;
+      const runner = await Board.load(url);
+
+      const { title, description, version } = runner;
+      const diagram = runner.mermaid("TD", true);
+      const nodes = runner.nodes;
+
+      this.#runner = runner;
+      await next(
+        new LocalRunResult({
+          type: "load",
+          data: { title, description, version, diagram, url, nodes },
+        })
+      );
+    });
+  }
+
   async *run() {
     yield* asyncGen<HarnessRunResult>(async (next) => {
       const kits = this.#configureKits(createOnSecret(next));
+      if (!this.#runner) {
+        throw new Error("Harness not loaded. Please call 'load' first.");
+      }
 
       try {
-        const url = this.#config.url;
-        const runner = await Board.load(url);
-
-        const { title, description, version } = runner;
-        const diagram = runner.mermaid("TD", true);
-        const nodes = runner.nodes;
-
-        await next(
-          new LocalRunResult({
-            type: "load",
-            data: { title, description, version, diagram, url, nodes },
-          })
-        );
-
         const probe = this.#config.diagnostics
           ? new Diagnostics(async (message) => {
               next(new LocalRunResult(message));
             })
           : undefined;
 
-        for await (const data of runner.run({ probe, kits })) {
+        for await (const data of this.#runner.run({ probe, kits })) {
           const { type } = data;
           if (type === "input") {
             const inputResult = new LocalRunResult({ type, data });

--- a/packages/breadboard/src/harness/result.ts
+++ b/packages/breadboard/src/harness/result.ts
@@ -7,11 +7,9 @@
 import { OutputValues } from "../types.js";
 import { MessageController } from "../worker/controller.js";
 import { ControllerMessageType } from "../worker/protocol.js";
-import { AnyLoadResult, AnyRunResult, HarnessResult } from "./types.js";
+import { AnyRunResult, HarnessResult } from "./types.js";
 
-export class LocalResult<R extends AnyRunResult | AnyLoadResult>
-  implements HarnessResult<R>
-{
+export class LocalResult<R extends AnyRunResult> implements HarnessResult<R> {
   message: R;
   response?: unknown;
 
@@ -24,9 +22,7 @@ export class LocalResult<R extends AnyRunResult | AnyLoadResult>
   }
 }
 
-export class WorkerResult<R extends AnyRunResult | AnyLoadResult>
-  implements HarnessResult<R>
-{
+export class WorkerResult<R extends AnyRunResult> implements HarnessResult<R> {
   #controller: MessageController;
   message: R;
 

--- a/packages/breadboard/src/harness/result.ts
+++ b/packages/breadboard/src/harness/result.ts
@@ -7,13 +7,15 @@
 import { OutputValues } from "../types.js";
 import { MessageController } from "../worker/controller.js";
 import { ControllerMessageType } from "../worker/protocol.js";
-import { AnyResult, HarnessRunResult } from "./types.js";
+import { AnyLoadResult, AnyRunResult, HarnessResult } from "./types.js";
 
-export class LocalRunResult implements HarnessRunResult {
-  message: AnyResult;
+export class LocalResult<R extends AnyRunResult | AnyLoadResult>
+  implements HarnessResult<R>
+{
+  message: R;
   response?: unknown;
 
-  constructor(message: AnyResult) {
+  constructor(message: R) {
     this.message = message;
   }
 
@@ -22,11 +24,13 @@ export class LocalRunResult implements HarnessRunResult {
   }
 }
 
-export class WorkerRunResult implements HarnessRunResult {
+export class WorkerResult<R extends AnyRunResult | AnyLoadResult>
+  implements HarnessResult<R>
+{
   #controller: MessageController;
-  message: AnyResult;
+  message: R;
 
-  constructor(controller: MessageController, message: AnyResult) {
+  constructor(controller: MessageController, message: R) {
     this.#controller = controller;
     this.message = message;
   }

--- a/packages/breadboard/src/harness/secrets.ts
+++ b/packages/breadboard/src/harness/secrets.ts
@@ -6,7 +6,7 @@
 
 import type { NodeValue, OutputValues } from "@google-labs/breadboard";
 import { HarnessRunResult, SecretHandler } from "./types.js";
-import { LocalRunResult } from "./result.js";
+import { LocalResult } from "./result.js";
 
 const PROXIED_PREFIX = "PROXIED_";
 
@@ -86,7 +86,7 @@ export const createOnSecret = (
 ): SecretHandler => {
   return async ({ keys }) => {
     if (!keys) return {};
-    const result = new LocalRunResult({ type: "secret", data: { keys } });
+    const result = new LocalResult({ type: "secret", data: { keys } });
     await next(result);
     return result.response as OutputValues;
   };

--- a/packages/breadboard/src/harness/types.ts
+++ b/packages/breadboard/src/harness/types.ts
@@ -119,6 +119,7 @@ export interface HarnessRunResult {
 }
 
 export interface Harness {
+  load(): AsyncGenerator<HarnessRunResult, void>;
   run(): AsyncGenerator<HarnessRunResult, void>;
 }
 

--- a/packages/breadboard/src/harness/types.ts
+++ b/packages/breadboard/src/harness/types.ts
@@ -105,18 +105,15 @@ export type AnyRunResult = (
 ) &
   OptionalId;
 
-export type AnyLoadResult = LoadResult & OptionalId;
-
-export interface HarnessResult<R extends AnyRunResult | AnyLoadResult> {
+export interface HarnessResult<R extends AnyRunResult> {
   reply(reply: unknown): void;
   message: R;
 }
 
 export type HarnessRunResult = HarnessResult<AnyRunResult>;
-export type HarnessLoadResult = HarnessResult<AnyLoadResult>;
 
 export interface Harness {
-  load(): AsyncGenerator<HarnessLoadResult, void>;
+  load(): Promise<LoadResponse>;
   run(): AsyncGenerator<HarnessRunResult, void>;
 }
 

--- a/packages/breadboard/src/harness/types.ts
+++ b/packages/breadboard/src/harness/types.ts
@@ -101,8 +101,9 @@ export type ShutdownResult = {
   data: null;
 };
 
-export type AnyResult = (
-  | LoadResult
+export type OptionalId = { id?: string };
+
+export type AnyRunResult = (
   | InputResult
   | OutputResult
   | SecretResult
@@ -110,16 +111,21 @@ export type AnyResult = (
   | AfterhandlerResult
   | ErrorResult
   | EndResult
-  | ShutdownResult
-) & { id?: string };
+) &
+  OptionalId;
 
-export interface HarnessRunResult {
+export type AnyLoadResult = (LoadResult | ShutdownResult) & OptionalId;
+
+export interface HarnessResult<R extends AnyRunResult | AnyLoadResult> {
   reply(reply: unknown): void;
-  message: AnyResult;
+  message: R;
 }
 
+export type HarnessRunResult = HarnessResult<AnyRunResult>;
+export type HarnessLoadResult = HarnessResult<AnyLoadResult>;
+
 export interface Harness {
-  load(): AsyncGenerator<HarnessRunResult, void>;
+  load(): AsyncGenerator<HarnessLoadResult, void>;
   run(): AsyncGenerator<HarnessRunResult, void>;
 }
 

--- a/packages/breadboard/src/harness/types.ts
+++ b/packages/breadboard/src/harness/types.ts
@@ -50,11 +50,7 @@ export type ResultType =
   /**
    * Sent when the board run finished
    */
-  | "end"
-  /**
-   * Sent when the harness is shutting down
-   */
-  | "shutdown";
+  | "end";
 
 export type LoadResult = {
   type: "load";
@@ -96,11 +92,6 @@ export type EndResult = {
   data: Record<string, never>;
 };
 
-export type ShutdownResult = {
-  type: "shutdown";
-  data: null;
-};
-
 export type OptionalId = { id?: string };
 
 export type AnyRunResult = (
@@ -114,7 +105,7 @@ export type AnyRunResult = (
 ) &
   OptionalId;
 
-export type AnyLoadResult = (LoadResult | ShutdownResult) & OptionalId;
+export type AnyLoadResult = LoadResult & OptionalId;
 
 export interface HarnessResult<R extends AnyRunResult | AnyLoadResult> {
   reply(reply: unknown): void;

--- a/packages/breadboard/src/harness/types.ts
+++ b/packages/breadboard/src/harness/types.ts
@@ -119,7 +119,7 @@ export interface HarnessRunResult {
 }
 
 export interface Harness {
-  run(url: string): AsyncGenerator<HarnessRunResult, void>;
+  run(): AsyncGenerator<HarnessRunResult, void>;
 }
 
 export type SecretHandler = (keys: {
@@ -151,6 +151,10 @@ export type HarnessRemoteConfig =
   | false;
 
 export type HarnessConfig = {
+  /**
+   * The URL of the board to run.
+   */
+  url: string;
   /**
    * The kits to use by the runtime.
    */

--- a/packages/breadboard/src/harness/worker-harness.ts
+++ b/packages/breadboard/src/harness/worker-harness.ts
@@ -74,12 +74,6 @@ export class WorkerHarness implements Harness {
     yield* asyncGen<HarnessLoadResult>(async (next) => {
       if (this.#run) {
         this.#stop();
-        await next(
-          new WorkerResult(this.#run.controller, {
-            type: "shutdown",
-            data: null,
-          })
-        );
       }
 
       const proxyNodes = (this.#config.proxy?.[0]?.nodes ?? []).map((node) => {

--- a/packages/breadboard/src/harness/worker-harness.ts
+++ b/packages/breadboard/src/harness/worker-harness.ts
@@ -53,7 +53,9 @@ export class WorkerHarness implements Harness {
     );
   }
 
-  async *run(url: string) {
+  async *run() {
+    const url = this.#config.url;
+
     yield* asyncGen<HarnessRunResult>(async (next) => {
       if (this.worker && this.transport && this.controller) {
         this.#stop();

--- a/packages/breadboard/src/worker/protocol.ts
+++ b/packages/breadboard/src/worker/protocol.ts
@@ -25,7 +25,6 @@ export const VALID_MESSAGE_TYPES = [
   "proxy",
   "end",
   "error",
-  "shutdown",
 ] as const;
 
 export type ControllerMessageType = (typeof VALID_MESSAGE_TYPES)[number];


### PR DESCRIPTION
- Fold 'url' into HarnessConfig.
- Separate load and run in Harness.
- Teach LocalHarness about 'shutdown' result.
- Tighten up types.
- Remove 'shutdown' message, since it's not useful anymore.
- Turn 'load' method into a simple async call.
