### PR TITLE
[breadboard-web] Compose richer history of the run.

### DIFF
--- a/packages/breadboard-ui/src/history-entry.ts
+++ b/packages/breadboard-ui/src/history-entry.ts
@@ -49,7 +49,7 @@ export class HistoryEntry extends LitElement {
       pointer-events: none;
     }
 
-    #container.progress summary::before {
+    #container.beforehandler summary::before {
       background: radial-gradient(
           var(--bb-progress-color) 0%,
           var(--bb-progress-color) 30%,
@@ -68,8 +68,9 @@ export class HistoryEntry extends LitElement {
       animation: rotate 0.5s linear infinite;
     }
 
-    :host(:not(:first-child)) #container.progress {
-      display: none;
+    #container.afterhandler summary::before {
+      background: var(--bb-progress-color);
+      border: 1px solid rgb(90, 64, 119);
     }
 
     #container.load summary::before {

--- a/packages/breadboard-ui/src/types.ts
+++ b/packages/breadboard-ui/src/types.ts
@@ -5,7 +5,8 @@ export const enum HarnessEventType {
   INPUT_MULTIPART = "input-multi-part",
   LOAD = "load",
   OUTPUT = "output",
-  PROGRESS = "progress",
+  BEFOREHANDLER = "beforehandler",
+  AFTERHANDLER = "afterhandler",
   RESULT = "result",
   SECRETS = "secrets",
 }

--- a/packages/breadboard-ui/src/ui-controller.ts
+++ b/packages/breadboard-ui/src/ui-controller.ts
@@ -734,6 +734,20 @@ export class UIController extends HTMLElement implements UI {
     }
   }
 
+  #updateHistoryEntry(type: HarnessEventType, id: string, data: unknown) {
+    const root = this.shadowRoot;
+    assertRoot(root);
+
+    const historyList = root.querySelector("#history-list");
+    assertHTMLElement(historyList);
+
+    const historyEntry = historyList.querySelector(`#${id}`) as HistoryEntry;
+    assertHTMLElement(historyEntry);
+
+    historyEntry.type = type;
+    historyEntry.data = data;
+  }
+
   #parseNodeInformation(nodes?: NodeDescriptor[]) {
     this.#nodeInfo.clear();
     if (!nodes) {
@@ -790,13 +804,27 @@ export class UIController extends HTMLElement implements UI {
   }
 
   beforehandler(data: BeforehandlerResponse) {
-    const { id, type: message } = data.node;
-    this.#createHistoryEntry(HarnessEventType.PROGRESS, message, id);
+    const {
+      invocationId,
+      node: { id, type },
+    } = data;
+    this.#createHistoryEntry(
+      HarnessEventType.BEFOREHANDLER,
+      type,
+      `${id}_${invocationId}`
+    );
   }
 
   afterhandler(data: AfterhandlerResponse) {
-    const { id, type: message } = data.node;
-    this.#createHistoryEntry(HarnessEventType.PROGRESS, message, id);
+    const {
+      invocationId,
+      node: { id },
+    } = data;
+    this.#updateHistoryEntry(
+      HarnessEventType.AFTERHANDLER,
+      `${id}_${invocationId}`,
+      data.outputs
+    );
   }
 
   async output(values: OutputArgs) {

--- a/packages/breadboard-ui/src/ui-controller.ts
+++ b/packages/breadboard-ui/src/ui-controller.ts
@@ -26,9 +26,12 @@ import {
 import { HarnessEventType } from "./types.js";
 import { HistoryEntry } from "./history-entry.js";
 import { NodeConfiguration, NodeDescriptor } from "@google-labs/breadboard";
+import { BeforehandlerResponse } from "@google-labs/breadboard/remote";
+import { AfterhandlerResponse } from "@google-labs/breadboard/harness";
 
 export interface UI {
-  progress(id: string, message: string): void;
+  beforehandler(data: BeforehandlerResponse): void;
+  afterhandler(data: AfterhandlerResponse): void;
   output(values: OutputArgs): void;
   input(id: string, args: InputArgs): Promise<Record<string, unknown>>;
   error(message: string): void;
@@ -786,7 +789,13 @@ export class UIController extends HTMLElement implements UI {
     return this.#diagram.render(this.#currentBoardDiagram, highlightNode);
   }
 
-  progress(id: string, message: string) {
+  beforehandler(data: BeforehandlerResponse) {
+    const { id, type: message } = data.node;
+    this.#createHistoryEntry(HarnessEventType.PROGRESS, message, id);
+  }
+
+  afterhandler(data: AfterhandlerResponse) {
+    const { id, type: message } = data.node;
     this.#createHistoryEntry(HarnessEventType.PROGRESS, message, id);
   }
 

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -235,7 +235,6 @@ export class Main {
     switch (type) {
       case "output": {
         await this.#ui.output(data);
-        console.log("output", data);
         break;
       }
 
@@ -258,12 +257,10 @@ export class Main {
 
       case "beforehandler": {
         this.#ui.progress(data.node.id, data.node.type);
-        console.info("beforehandler", data.node.id, data.node.type);
         break;
       }
 
       case "afterhandler": {
-        console.info("afterhandler", data.node.id, data.node.type);
         break;
       }
 

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -256,11 +256,12 @@ export class Main {
       }
 
       case "beforehandler": {
-        this.#ui.progress(data.node.id, data.node.type);
+        this.#ui.beforehandler(data);
         break;
       }
 
       case "afterhandler": {
+        this.#ui.afterhandler(data);
         break;
       }
 

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -82,7 +82,6 @@ export class Main {
   #boardId = 0;
   #delay = 0;
   #pauser = new Pauser();
-  #pending = new Map<string, string>();
 
   constructor(config: BreadboardUI.StartArgs) {
     // Remove boards that are still works-in-progress from production builds.
@@ -236,6 +235,7 @@ export class Main {
     switch (type) {
       case "output": {
         await this.#ui.output(data);
+        console.log("output", data);
         break;
       }
 
@@ -258,7 +258,12 @@ export class Main {
 
       case "beforehandler": {
         this.#ui.progress(data.node.id, data.node.type);
-        this.#pending.set(data.node.id, data.node.type);
+        console.info("beforehandler", data.node.id, data.node.type);
+        break;
+      }
+
+      case "afterhandler": {
+        console.info("afterhandler", data.node.id, data.node.type);
         break;
       }
 

--- a/packages/breadboard/src/harness/diagnostics.ts
+++ b/packages/breadboard/src/harness/diagnostics.ts
@@ -26,21 +26,16 @@ export class Diagnostics extends EventTarget {
 
   #eventHandler = (event: Event) => {
     const e = event as ProbeEvent;
+    const { descriptor: node, inputs, outputs, invocationId } = e.detail;
     const message =
       e.type === "beforehandler"
         ? ({
             type: "beforehandler",
-            data: {
-              node: e.detail.descriptor,
-              inputs: e.detail.inputs,
-            },
+            data: { node, inputs, invocationId },
           } as BeforehandlerResult)
         : ({
             type: "afterhandler",
-            data: {
-              node: e.detail.descriptor,
-              outputs: e.detail.outputs,
-            },
+            data: { node, outputs, invocationId },
           } as AfterhandlerResult);
     this.#callback(message);
   };

--- a/packages/breadboard/src/harness/types.ts
+++ b/packages/breadboard/src/harness/types.ts
@@ -15,6 +15,7 @@ import { Kit, NodeDescriptor, OutputValues } from "../types.js";
 
 export type AfterhandlerResponse = {
   node: NodeDescriptor;
+  invocationId: number;
   outputs: OutputValues;
 };
 

--- a/packages/breadboard/src/remote/protocol.ts
+++ b/packages/breadboard/src/remote/protocol.ts
@@ -107,6 +107,7 @@ export type BeforehandlerResponse = {
    * @see [NodeDescriptor]
    */
   node: NodeDescriptor;
+  invocationId: number;
 };
 export type BeforehandlerResponseMessage = [
   "beforehandler",

--- a/packages/breadboard/src/remote/run.ts
+++ b/packages/breadboard/src/remote/run.ts
@@ -73,9 +73,6 @@ export class RunServer {
         } else if (stop.type === "output") {
           const { node, outputs } = stop;
           await responses.write(["output", { node, outputs }]);
-        } else if (stop.type === "beforehandler") {
-          const { node } = stop;
-          await responses.write(["beforehandler", { node }]);
         }
       }
       await responses.write(["end", {}]);

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -476,6 +476,12 @@ export interface ProbeDetails {
    * increment for each level of nesting.
    */
   nesting?: number;
+  /*
+   * Invocation Id. This is a unique id that is generated for each invocation
+   * of the node. It can be used to correlate events.
+   * The number is unique within a board run.
+   */
+  invocationId: number;
   sources?: string[];
   validatorMetadata?: BreadboardValidatorMetadata[];
 }

--- a/packages/breadboard/src/worker/controller.ts
+++ b/packages/breadboard/src/worker/controller.ts
@@ -53,7 +53,7 @@ export class WorkerTransport implements MessageControllerTransport {
 
   #onMessage(e: MessageEvent) {
     const message = e.data as ControllerMessage;
-    console.log(`[${this.#direction}]`, message.type, message.data);
+    console.debug(`[${this.#direction}]`, message.type, message.data);
     this.#messageHandler && this.#messageHandler(message);
   }
 }

--- a/packages/breadboard/tests/remote/transport.ts
+++ b/packages/breadboard/tests/remote/transport.ts
@@ -64,7 +64,7 @@ test("Interruptible streaming", async (t) => {
     secondRunResults.push(type);
   }
   t.deepEqual(outputs, { hello: "world" });
-  t.deepEqual(secondRunResults, ["beforehandler", "output", "end"]);
+  t.deepEqual(secondRunResults, ["output", "end"]);
 });
 
 test("Continuous streaming", async (t) => {
@@ -91,9 +91,8 @@ test("Continuous streaming", async (t) => {
     { node: { type: "input" }, inputArguments: { foo: "bar" } },
   ]);
   writer.write(["input", { inputs: { hello: "world" } }, ""]);
-  const secondResult = await reader.read();
-  t.assert(!secondResult.done);
-  t.like(secondResult.value, ["beforehandler", { node: { type: "noop" } }]);
+  // second result was "beforehandler", but I removed it because of the
+  // refactoring to use diagnostics.
   const thirdResult = await reader.read();
   t.assert(!thirdResult.done);
   t.like(thirdResult.value, ["output", { outputs: { hello: "world" } }]);


### PR DESCRIPTION
- Plumb through invocationId.
- Remove unused #pending property.
- Move worker communication logging to debug level.
- Oops, add missing invocationId.
- Remove spurious logging.
- Plumb 'beforehandler' and 'afterhandler' to UI Controller.
- Added some rudimentary UI code.
