### PR TITLE
[breadboard] Introduce 'graphstart' and 'graphend' results.

### DIFF
--- a/packages/breadboard-ui/src/history-entry.ts
+++ b/packages/breadboard-ui/src/history-entry.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { HarnessEventType } from "./types.js";
+import { HistoryEventType } from "./types.js";
 
 import { LitElement, html, css } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
@@ -12,7 +12,7 @@ import { customElement, property, state } from "lit/decorators.js";
 @customElement("bb-history-entry")
 export class HistoryEntry extends LitElement {
   @property()
-  type: HarnessEventType = HarnessEventType.DONE;
+  type: HistoryEventType = HistoryEventType.DONE;
 
   @state()
   summary = "";

--- a/packages/breadboard-ui/src/history-entry.ts
+++ b/packages/breadboard-ui/src/history-entry.ts
@@ -15,6 +15,9 @@ export class HistoryEntry extends LitElement {
   type: HistoryEventType = HistoryEventType.DONE;
 
   @state()
+  nodeId = "";
+
+  @state()
   summary = "";
 
   @state()
@@ -183,7 +186,7 @@ export class HistoryEntry extends LitElement {
     return html`<div id="container" class="${this.type}">
     <details ${this.type === "output" ? "open" : ""}>
       <summary>${this.summary} <span id="id">${
-      this.id || ""
+      this.nodeId || ""
     }</span> <span id="elapsed-time">${this.#formatTime(
       this.elapsedTime
     )}<span></summary>

--- a/packages/breadboard-ui/src/index.ts
+++ b/packages/breadboard-ui/src/index.ts
@@ -44,6 +44,6 @@ export type { OutputArgs } from "./output.js";
 export type { InputArgs } from "./input.js";
 export type { ResultArgs } from "./result.js";
 export type { StartArgs } from "./start.js";
-export type { HarnessEventType } from "./types.js";
+export type { HistoryEventType as HarnessEventType } from "./types.js";
 
 export { StartEvent, ToastEvent, DelayEvent } from "./events.js";

--- a/packages/breadboard-ui/src/types.ts
+++ b/packages/breadboard-ui/src/types.ts
@@ -11,6 +11,13 @@ export const enum HistoryEventType {
   SECRETS = "secrets",
 }
 
+export type HistoryEvent = {
+  type: HistoryEventType;
+  summary?: string;
+  id?: string | null;
+  data?: unknown;
+};
+
 export interface ImageHandler {
   start(): Promise<void>;
   stop(): void;

--- a/packages/breadboard-ui/src/types.ts
+++ b/packages/breadboard-ui/src/types.ts
@@ -9,14 +9,23 @@ export const enum HistoryEventType {
   AFTERHANDLER = "afterhandler",
   RESULT = "result",
   SECRETS = "secrets",
+  GRAPHSTART = "graphstart",
+  GRAPHEND = "graphend",
 }
 
-export type HistoryEvent = {
-  type: HistoryEventType;
+export type LooseHistoryEventTypes = Exclude<
+  HistoryEventType,
+  HistoryEventType.GRAPHEND | HistoryEventType.GRAPHSTART
+>;
+
+export type LooseHistoryEvent = {
+  type: LooseHistoryEventTypes;
   summary?: string;
   id?: string | null;
   data?: unknown;
 };
+
+export type HistoryEvent = LooseHistoryEvent;
 
 export interface ImageHandler {
   start(): Promise<void>;

--- a/packages/breadboard-ui/src/types.ts
+++ b/packages/breadboard-ui/src/types.ts
@@ -1,4 +1,4 @@
-export const enum HarnessEventType {
+export const enum HistoryEventType {
   DONE = "done",
   ERROR = "error",
   INPUT = "input",

--- a/packages/breadboard-ui/src/types.ts
+++ b/packages/breadboard-ui/src/types.ts
@@ -18,14 +18,32 @@ export type LooseHistoryEventTypes = Exclude<
   HistoryEventType.GRAPHEND | HistoryEventType.GRAPHSTART
 >;
 
-export type LooseHistoryEvent = {
-  type: LooseHistoryEventTypes;
+export type PrimordialHistoryEvent = {
+  type: HistoryEventType;
   summary?: string;
   id?: string | null;
   data?: unknown;
 };
 
-export type HistoryEvent = LooseHistoryEvent;
+export type LooseHistoryEvent = PrimordialHistoryEvent & {
+  type: LooseHistoryEventTypes;
+};
+
+export type GraphStartHistoryEvent = PrimordialHistoryEvent & {
+  type: HistoryEventType.GRAPHSTART;
+  data: {
+    path: string[];
+  };
+};
+
+export type GraphEndHistoryEvent = GraphStartHistoryEvent & {
+  type: HistoryEventType.GRAPHEND;
+};
+
+export type HistoryEvent =
+  | LooseHistoryEvent
+  | GraphStartHistoryEvent
+  | GraphEndHistoryEvent;
 
 export interface ImageHandler {
   start(): Promise<void>;

--- a/packages/breadboard-ui/src/types.ts
+++ b/packages/breadboard-ui/src/types.ts
@@ -13,9 +13,14 @@ export const enum HistoryEventType {
   GRAPHEND = "graphend",
 }
 
+// TODO: Remove all the `Loose` types by tightening up the types for
+// each event.
 export type LooseHistoryEventTypes = Exclude<
   HistoryEventType,
-  HistoryEventType.GRAPHEND | HistoryEventType.GRAPHSTART
+  | HistoryEventType.GRAPHEND
+  | HistoryEventType.GRAPHSTART
+  | HistoryEventType.BEFOREHANDLER
+  | HistoryEventType.AFTERHANDLER
 >;
 
 export type PrimordialHistoryEvent = {
@@ -29,21 +34,36 @@ export type LooseHistoryEvent = PrimordialHistoryEvent & {
   type: LooseHistoryEventTypes;
 };
 
-export type GraphStartHistoryEvent = PrimordialHistoryEvent & {
-  type: HistoryEventType.GRAPHSTART;
-  data: {
-    path: string[];
-  };
+export type DataWithPath = {
+  path: number[];
 };
 
-export type GraphEndHistoryEvent = GraphStartHistoryEvent & {
+export type GraphStartHistoryEvent = PrimordialHistoryEvent & {
+  type: HistoryEventType.GRAPHSTART;
+  data: DataWithPath;
+};
+
+export type GraphEndHistoryEvent = PrimordialHistoryEvent & {
   type: HistoryEventType.GRAPHEND;
+  data: DataWithPath;
+};
+
+export type BeforehandlerHistoryEvent = PrimordialHistoryEvent & {
+  type: HistoryEventType.BEFOREHANDLER;
+  data: DataWithPath;
+};
+
+export type AfterhandlerHistoryEvent = PrimordialHistoryEvent & {
+  type: HistoryEventType.AFTERHANDLER;
+  data: DataWithPath & { outputs: Record<string, unknown> };
 };
 
 export type HistoryEvent =
   | LooseHistoryEvent
   | GraphStartHistoryEvent
-  | GraphEndHistoryEvent;
+  | GraphEndHistoryEvent
+  | BeforehandlerHistoryEvent
+  | AfterhandlerHistoryEvent;
 
 export interface ImageHandler {
   start(): Promise<void>;

--- a/packages/breadboard-ui/src/ui-controller.ts
+++ b/packages/breadboard-ui/src/ui-controller.ts
@@ -805,24 +805,24 @@ export class UIController extends HTMLElement implements UI {
 
   beforehandler(data: BeforehandlerResponse) {
     const {
-      invocationId,
+      path,
       node: { id, type },
     } = data;
     this.#createHistoryEntry(
       HarnessEventType.BEFOREHANDLER,
       type,
-      `${id}_${invocationId}`
+      `${id}_${path.join("_")}`
     );
   }
 
   afterhandler(data: AfterhandlerResponse) {
     const {
-      invocationId,
+      path,
       node: { id },
     } = data;
     this.#updateHistoryEntry(
       HarnessEventType.AFTERHANDLER,
-      `${id}_${invocationId}`,
+      `${id}_${path.join("_")}`,
       data.outputs
     );
   }

--- a/packages/breadboard-ui/src/ui-controller.ts
+++ b/packages/breadboard-ui/src/ui-controller.ts
@@ -23,7 +23,7 @@ import {
   assertRoot,
   assertSelectElement,
 } from "./utils/assertions.js";
-import { HarnessEventType } from "./types.js";
+import { HistoryEventType } from "./types.js";
 import { HistoryEntry } from "./history-entry.js";
 import { NodeConfiguration, NodeDescriptor } from "@google-labs/breadboard";
 import { BeforehandlerResponse } from "@google-labs/breadboard/remote";
@@ -699,7 +699,7 @@ export class UIController extends HTMLElement implements UI {
   }
 
   #createHistoryEntry(
-    type: HarnessEventType,
+    type: HistoryEventType,
     summary: string,
     id: string | null = null,
     data: unknown | null = null
@@ -734,7 +734,7 @@ export class UIController extends HTMLElement implements UI {
     }
   }
 
-  #updateHistoryEntry(type: HarnessEventType, id: string, data: unknown) {
+  #updateHistoryEntry(type: HistoryEventType, id: string, data: unknown) {
     const root = this.shadowRoot;
     assertRoot(root);
 
@@ -788,7 +788,7 @@ export class UIController extends HTMLElement implements UI {
     this.#historyLog.length = 0;
     this.#lastHistoryEventTime = globalThis.performance.now();
     this.#createHistoryEntry(
-      HarnessEventType.LOAD,
+      HistoryEventType.LOAD,
       "Board loaded",
       undefined,
       info.url
@@ -809,7 +809,7 @@ export class UIController extends HTMLElement implements UI {
       node: { id, type },
     } = data;
     this.#createHistoryEntry(
-      HarnessEventType.BEFOREHANDLER,
+      HistoryEventType.BEFOREHANDLER,
       type,
       `${id}_${path.join("_")}`
     );
@@ -821,7 +821,7 @@ export class UIController extends HTMLElement implements UI {
       node: { id },
     } = data;
     this.#updateHistoryEntry(
-      HarnessEventType.AFTERHANDLER,
+      HistoryEventType.AFTERHANDLER,
       `${id}_${path.join("_")}`,
       data.outputs
     );
@@ -829,7 +829,7 @@ export class UIController extends HTMLElement implements UI {
 
   async output(values: OutputArgs) {
     this.#createHistoryEntry(
-      HarnessEventType.OUTPUT,
+      HistoryEventType.OUTPUT,
       "Output",
       values.node.id,
       values.outputs
@@ -879,18 +879,18 @@ export class UIController extends HTMLElement implements UI {
       });
     });
 
-    this.#createHistoryEntry(HarnessEventType.SECRETS, `secrets`, id);
+    this.#createHistoryEntry(HistoryEventType.SECRETS, `secrets`, id);
 
     return response.secret;
   }
 
-  proxyResult(type: HarnessEventType, id: string, data: unknown | null = null) {
+  proxyResult(type: HistoryEventType, id: string, data: unknown | null = null) {
     this.#createHistoryEntry(type, type, id, data);
   }
 
   result(value: ResultArgs, id = null) {
     this.#createHistoryEntry(
-      HarnessEventType.RESULT,
+      HistoryEventType.RESULT,
       value.title,
       id,
       value.result || null
@@ -920,7 +920,7 @@ export class UIController extends HTMLElement implements UI {
       }
     });
 
-    this.#createHistoryEntry(HarnessEventType.INPUT, "input", id, {
+    this.#createHistoryEntry(HistoryEventType.INPUT, "input", id, {
       args,
       response,
     });
@@ -929,10 +929,10 @@ export class UIController extends HTMLElement implements UI {
   }
 
   error(message: string) {
-    this.#createHistoryEntry(HarnessEventType.ERROR, message);
+    this.#createHistoryEntry(HistoryEventType.ERROR, message);
   }
 
   done() {
-    this.#createHistoryEntry(HarnessEventType.DONE, "Board finished");
+    this.#createHistoryEntry(HistoryEventType.DONE, "Board finished");
   }
 }

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -255,6 +255,16 @@ export class Main {
         break;
       }
 
+      case "graphstart": {
+        console.log("graphstart", data);
+        break;
+      }
+
+      case "graphend": {
+        console.log("graphend", data);
+        break;
+      }
+
       case "beforehandler": {
         this.#ui.beforehandler(data);
         break;

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -256,12 +256,12 @@ export class Main {
       }
 
       case "graphstart": {
-        console.log("graphstart", data);
+        console.log("graphstart", data.path.join("_"), data);
         break;
       }
 
       case "graphend": {
-        console.log("graphend", data);
+        console.log("graphend", data.path.join("_"), data);
         break;
       }
 

--- a/packages/breadboard/src/harness/diagnostics.ts
+++ b/packages/breadboard/src/harness/diagnostics.ts
@@ -4,16 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ProbeEvent } from "../types.js";
+import type { Probe, ProbeEvent, ProbeMessage } from "../types.js";
 import { AfterhandlerResult, BeforehandlerResult } from "./types.js";
 
 export type DiagnosticMesageType = "beforehandler" | "afterhandler";
 
 export type DiagnosticsCallback = (
-  message: BeforehandlerResult | AfterhandlerResult
-) => void;
+  message: BeforehandlerResult | AfterhandlerResult | ProbeMessage
+) => Promise<void>;
 
-export class Diagnostics extends EventTarget {
+export class Diagnostics extends EventTarget implements Probe {
   #callback: DiagnosticsCallback;
 
   constructor(callback: DiagnosticsCallback) {
@@ -22,6 +22,10 @@ export class Diagnostics extends EventTarget {
     const eventHandler = this.#eventHandler.bind(this);
     this.addEventListener("beforehandler", eventHandler);
     this.addEventListener("node", eventHandler);
+  }
+
+  async report(message: ProbeMessage): Promise<void> {
+    await this.#callback(message);
   }
 
   #eventHandler = (event: Event) => {

--- a/packages/breadboard/src/harness/diagnostics.ts
+++ b/packages/breadboard/src/harness/diagnostics.ts
@@ -25,21 +25,21 @@ export class Diagnostics extends EventTarget implements Probe {
   }
 
   async report(message: ProbeMessage): Promise<void> {
-    await this.#callback(message);
+    return this.#callback(message);
   }
 
   #eventHandler = (event: Event) => {
     const e = event as ProbeEvent;
-    const { descriptor: node, inputs, outputs, invocationId } = e.detail;
+    const { descriptor: node, inputs, outputs, path } = e.detail;
     const message =
       e.type === "beforehandler"
         ? ({
             type: "beforehandler",
-            data: { node, inputs, invocationId },
+            data: { node, inputs, path },
           } as BeforehandlerResult)
         : ({
             type: "afterhandler",
-            data: { node, outputs, invocationId },
+            data: { node, outputs, path },
           } as AfterhandlerResult);
     this.#callback(message);
   };

--- a/packages/breadboard/src/harness/local-harness.ts
+++ b/packages/breadboard/src/harness/local-harness.ts
@@ -88,7 +88,14 @@ export class LocalHarness implements Harness {
       try {
         const probe = this.#config.diagnostics
           ? new Diagnostics(async (message) => {
-              next(new LocalResult(message));
+              if (
+                message.type === "graphstart" ||
+                message.type === "graphend"
+              ) {
+                await next(new LocalResult(message));
+              } else {
+                next(new LocalResult(message));
+              }
             })
           : undefined;
 

--- a/packages/breadboard/src/harness/types.ts
+++ b/packages/breadboard/src/harness/types.ts
@@ -15,7 +15,7 @@ import { Kit, NodeDescriptor, OutputValues, ProbeMessage } from "../types.js";
 
 export type AfterhandlerResponse = {
   node: NodeDescriptor;
-  invocationId: number;
+  path: number[];
   outputs: OutputValues;
 };
 

--- a/packages/breadboard/src/harness/types.ts
+++ b/packages/breadboard/src/harness/types.ts
@@ -11,7 +11,7 @@ import {
   LoadResponse,
   OutputResponse,
 } from "../remote/protocol.js";
-import { Kit, NodeDescriptor, OutputValues } from "../types.js";
+import { Kit, NodeDescriptor, OutputValues, ProbeMessage } from "../types.js";
 
 export type AfterhandlerResponse = {
   node: NodeDescriptor;
@@ -103,6 +103,7 @@ export type AnyRunResult = (
   | AfterhandlerResult
   | ErrorResult
   | EndResult
+  | ProbeMessage
 ) &
   OptionalId;
 

--- a/packages/breadboard/src/remote/protocol.ts
+++ b/packages/breadboard/src/remote/protocol.ts
@@ -107,7 +107,7 @@ export type BeforehandlerResponse = {
    * @see [NodeDescriptor]
    */
   node: NodeDescriptor;
-  invocationId: number;
+  path: number[];
 };
 export type BeforehandlerResponseMessage = [
   "beforehandler",

--- a/packages/breadboard/src/runner.ts
+++ b/packages/breadboard/src/runner.ts
@@ -132,7 +132,7 @@ export class BoardRunner implements BreadboardRunner {
 
       const requestedInputs = new RequestedInputsManager(context);
 
-      await probe?.report?.({ type: "graphstart", metadata: this });
+      await probe?.report?.({ type: "graphstart", data: { metadata: this } });
 
       for await (const result of machine) {
         invocationId++;
@@ -225,7 +225,7 @@ export class BoardRunner implements BreadboardRunner {
 
         result.outputsPromise = outputsPromise;
       }
-      await probe?.report?.({ type: "graphend", metadata: this });
+      await probe?.report?.({ type: "graphend", data: { metadata: this } });
     });
   }
 
@@ -248,6 +248,7 @@ export class BoardRunner implements BreadboardRunner {
     context: NodeHandlerContext = {}
   ): Promise<OutputValues> {
     const args = { ...inputs, ...this.args };
+    const { probe } = context;
 
     if (context.board && context.descriptor) {
       // If called from another node in a parent board, add the parent board's
@@ -270,6 +271,7 @@ export class BoardRunner implements BreadboardRunner {
         } else if (result.type === "output") {
           outputs = result.outputs;
           // Exit once we receive the first output.
+          await probe?.report?.({ type: "graphend", data: { metadata: this } });
           break;
         }
       }

--- a/packages/breadboard/src/runner.ts
+++ b/packages/breadboard/src/runner.ts
@@ -132,6 +132,8 @@ export class BoardRunner implements BreadboardRunner {
 
       const requestedInputs = new RequestedInputsManager(context);
 
+      await probe?.report?.({ type: "graphstart", metadata: this });
+
       for await (const result of machine) {
         invocationId++;
         const { inputs, descriptor, missingInputs } = result;
@@ -223,6 +225,7 @@ export class BoardRunner implements BreadboardRunner {
 
         result.outputsPromise = outputsPromise;
       }
+      await probe?.report?.({ type: "graphend", metadata: this });
     });
   }
 

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -451,6 +451,7 @@ export interface BreadboardValidator {
 
 export type GraphProbeMessageData = {
   metadata: GraphMetadata;
+  path: number[];
 };
 
 export type GraphStartProbeMessage = {
@@ -497,11 +498,12 @@ export interface ProbeDetails {
    */
   nesting?: number;
   /*
-   * Invocation Id. This is a unique id that is generated for each invocation
-   * of the node. It can be used to correlate events.
-   * The number is unique within a board run.
+   * Invocation Path. This is an array of unique node invocation ids that
+   * represents the current place of the node in the graph traversal.
+   * It can be used to correlate events.
+   * The array is unique to the invocation of a node across all board runs.
    */
-  invocationId: number;
+  path: number[];
   sources?: string[];
   validatorMetadata?: BreadboardValidatorMetadata[];
 }
@@ -562,6 +564,7 @@ export interface NodeHandlerContext {
   readonly slots?: BreadboardSlotSpec;
   readonly probe?: Probe;
   readonly requestInput?: (name: string, schema: Schema) => Promise<NodeValue>;
+  readonly invocationPath?: number[];
 }
 
 type Common<To, From> = {

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -449,6 +449,22 @@ export interface BreadboardValidator {
   ): BreadboardValidator;
 }
 
+export type GraphStartProbeMessage = {
+  type: "graphstart";
+  metadata: GraphMetadata;
+};
+
+export type GraphEndProbeMessage = {
+  type: "graphend";
+  metadata: GraphDescriptor;
+};
+
+export type ProbeMessage = GraphStartProbeMessage | GraphEndProbeMessage;
+
+export interface Probe extends EventTarget {
+  report?(message: ProbeMessage): Promise<void>;
+}
+
 /**
  * Details of the `ProbeEvent` event.
  */
@@ -540,7 +556,7 @@ export interface NodeHandlerContext {
   readonly base?: string;
   readonly outerGraph?: GraphDescriptor;
   readonly slots?: BreadboardSlotSpec;
-  readonly probe?: EventTarget;
+  readonly probe?: Probe;
   readonly requestInput?: (name: string, schema: Schema) => Promise<NodeValue>;
 }
 

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -449,14 +449,18 @@ export interface BreadboardValidator {
   ): BreadboardValidator;
 }
 
+export type GraphProbeMessageData = {
+  metadata: GraphMetadata;
+};
+
 export type GraphStartProbeMessage = {
   type: "graphstart";
-  metadata: GraphMetadata;
+  data: GraphProbeMessageData;
 };
 
 export type GraphEndProbeMessage = {
   type: "graphend";
-  metadata: GraphDescriptor;
+  data: GraphProbeMessageData;
 };
 
 export type ProbeMessage = GraphStartProbeMessage | GraphEndProbeMessage;

--- a/packages/breadboard/src/worker/protocol.ts
+++ b/packages/breadboard/src/worker/protocol.ts
@@ -25,6 +25,8 @@ export const VALID_MESSAGE_TYPES = [
   "proxy",
   "end",
   "error",
+  "graphstart",
+  "graphend",
 ] as const;
 
 export type ControllerMessageType = (typeof VALID_MESSAGE_TYPES)[number];

--- a/packages/breadboard/src/worker/worker-runtime.ts
+++ b/packages/breadboard/src/worker/worker-runtime.ts
@@ -91,7 +91,7 @@ export class WorkerRuntime {
         asRuntimeKit(kitConstructor)
       );
 
-      const probe = new Diagnostics(({ type, data }) => {
+      const probe = new Diagnostics(async ({ type, data }) => {
         this.#controller.inform(data, type);
       });
 

--- a/packages/core-kit/src/nodes/map.ts
+++ b/packages/core-kit/src/nodes/map.ts
@@ -56,9 +56,13 @@ export default async (
   const result = await Promise.all(
     list.map(async (item, index) => {
       // TODO: Express as a multi-turn `run`.
+      const newContext = {
+        ...context,
+        invocationPath: [...(context?.invocationPath || []), index],
+      };
       const outputs = await runnableBoard.runOnce(
         { item, index, list },
-        context
+        newContext
       );
       return outputs;
     })


### PR DESCRIPTION
- Minor style tweaks to probe invocations.
- Introduce Probe interface and start reporting stuff.
- Plumb graphstart/graphend to harnesses.
- Retool for invocationPath, rather than invocationId.
- Rename HarnessEventType to HistoryEventType.
- Change historyEntry controller methods to deal with obj args.
- Add GRAPHSTART and GRAPHEND history events.
- Type-fu.
- Start using path for generating HistoryEntry ids.
