### PR TITLE
[breadboard-cli] Adding --verbose logging to the run command

### DIFF
--- a/packages/breadboard-cli/src/commands/lib/verbose-logging-probe.ts
+++ b/packages/breadboard-cli/src/commands/lib/verbose-logging-probe.ts
@@ -1,0 +1,16 @@
+import { Probe, ProbeMessage } from "@google-labs/breadboard";
+
+export type VerboseLoggingCallback = (message: ProbeMessage) => Promise<void>;
+
+export class VerboseLoggingProbe extends EventTarget implements Probe {
+  #callback: VerboseLoggingCallback;
+
+  constructor(callback: VerboseLoggingCallback) {
+    super();
+    this.#callback = callback;
+  }
+
+  async report(message: ProbeMessage): Promise<void> {
+    return this.#callback(message);
+  }
+}

--- a/packages/breadboard-cli/src/commands/mermaid.ts
+++ b/packages/breadboard-cli/src/commands/mermaid.ts
@@ -6,7 +6,6 @@
 
 import { BoardRunner } from "@google-labs/breadboard";
 import { loadBoard, parseStdin, resolveFilePath, watch } from "./lib/utils.js";
-import path from "path";
 
 export const mermaid = async (
   file: string,

--- a/packages/breadboard-cli/src/index.ts
+++ b/packages/breadboard-cli/src/index.ts
@@ -57,6 +57,7 @@ program
   .command("run [file]")
   .description("Run a graph.")
   .option("-w, --watch", "Watch the file for changes.")
+  .option("-v, --verbose", "Output events and processing information.")
   .option(
     "-o, --output <path>",
     "If compiling a graph in Typescript (.ts), you MUST specific a location to output the compiled graph."


### PR DESCRIPTION
Adds a simple Probe to the CLI.
Adds a command `-v` or `--verbose` and it will output all of the log events to `STDOUT`

This should also work well with `--watch` so as you edit the board you will see your fixes process.