### PR TITLE
[breadboard/remote] Add Worker transports.

### DIFF
--- a/packages/breadboard/src/remote/index.ts
+++ b/packages/breadboard/src/remote/index.ts
@@ -5,6 +5,7 @@
  */
 
 export { HTTPServerTransport, HTTPClientTransport } from "./http.js";
+export { WorkerServerTransport, WorkerClientTransport } from "./worker.js";
 export { ProxyServer, ProxyClient } from "./proxy.js";
 export { RunServer, RunClient } from "./run.js";
 export { defineConfig, hasOrigin, type ProxyServerConfig } from "./config.js";

--- a/packages/breadboard/src/remote/worker.ts
+++ b/packages/breadboard/src/remote/worker.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  PatchedReadableStream,
+  PortStreams,
+  portToStreams,
+} from "../stream.js";
+import {
+  ClientTransport,
+  ServerBidirectionalStream,
+  ServerTransport,
+} from "./protocol.js";
+
+export const sendStartTransportMessage = (
+  worker: Worker,
+  port: MessagePort
+) => {
+  worker.postMessage(
+    {
+      type: "starttransport",
+      port,
+    },
+    [port]
+  );
+};
+
+export const receiveStartTransportMessage = (
+  worker: Worker,
+  callback: (port: MessagePort) => void
+) => {
+  worker.addEventListener("message", (event) => {
+    if (event.data.type === "starttransport") {
+      callback(event.data.port);
+    }
+  });
+};
+
+export class WorkerClientTransport<Request, Response>
+  implements ClientTransport<Request, Response>
+{
+  #serverStreams: PortStreams<Response, Request>;
+
+  constructor(worker: Worker) {
+    const channel = new MessageChannel();
+    worker.postMessage(sendStartTransportMessage(worker, channel.port1));
+    this.#serverStreams = portToStreams(channel.port2);
+  }
+
+  createClientStream() {
+    return {
+      writableRequests: this.#serverStreams.writable,
+      readableResponses: this.#serverStreams
+        .readable as PatchedReadableStream<Response>,
+    };
+  }
+}
+
+export class WorkerServerTransport<Request, Response>
+  implements ServerTransport<Request, Response>
+{
+  #clientStreams?: PortStreams<Request, Response>;
+  #ready: Promise<void>;
+
+  private constructor(worker: Worker) {
+    this.#ready = new Promise((resolve) => {
+      receiveStartTransportMessage(worker, (port) => {
+        this.#clientStreams = portToStreams(port);
+        resolve();
+      });
+    });
+  }
+
+  async #waitForClient() {
+    await this.#ready;
+  }
+
+  createServerStream(): ServerBidirectionalStream<Request, Response> {
+    if (!this.#clientStreams) {
+      throw new Error("The client has not connected yet");
+    }
+    return {
+      readableRequests: this.#clientStreams
+        .readable as PatchedReadableStream<Request>,
+      writableResponses: this.#clientStreams.writable,
+    };
+  }
+
+  static async create<Request, Response>(
+    worker: Worker
+  ): Promise<WorkerServerTransport<Request, Response>> {
+    const transport = new WorkerServerTransport<Request, Response>(worker);
+    await transport.#waitForClient();
+    return transport;
+  }
+}

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -559,43 +559,6 @@ export interface NodeHandlerContext {
   readonly invocationPath?: number[];
 }
 
-type Common<To, From> = {
-  [P in keyof (From | To) as From[P] extends To[P] ? P : never]?:
-    | To[P]
-    | undefined;
-};
-
-type LongOutSpec<From, To> =
-  | `${string & keyof From}->${string & keyof To}`
-  | `${string & keyof From}->${string & keyof To}.`
-  | `${string & keyof From}->${string & keyof To}?`;
-
-type LongInSpec<From, To> =
-  | `${string & keyof From}<-${string & keyof To}`
-  | `${string & keyof From}<-${string & keyof To}.`
-  | `${string & keyof From}<-${string & keyof To}?`;
-
-type ShortOutSpec<From, To> =
-  | `${string & keyof Common<From, To>}`
-  | `${string & keyof Common<From, To>}->`
-  | `${string & keyof Common<From, To>}->.`
-  | `${string & keyof Common<From, To>}->?`;
-
-type ShortInSpec<From, To> =
-  | `<-${string & keyof Common<From, To>}`
-  | `<-${string & keyof Common<From, To>}.`
-  | `<-${string & keyof Common<From, To>}?`;
-
-export type WireOutSpec<From, To> =
-  | LongOutSpec<From, To>
-  | ShortOutSpec<From, To>;
-
-export type WireInSpec<From, To> = LongInSpec<From, To> | ShortInSpec<From, To>;
-
-export type WireSpec<FromIn, FromOut, ToIn, ToOut> =
-  | WireOutSpec<FromOut, ToIn>
-  | WireInSpec<ToOut, FromIn>;
-
 export interface BreadboardNode<Inputs, Outputs> {
   /**
    * Wires the current node to another node.

--- a/packages/breadboard/src/worker/controller.ts
+++ b/packages/breadboard/src/worker/controller.ts
@@ -53,6 +53,10 @@ export class WorkerTransport implements MessageControllerTransport {
 
   #onMessage(e: MessageEvent) {
     const message = e.data as ControllerMessage;
+    if (!message) {
+      console.debug(`[${this.#direction}]`, "unknown message", e);
+      return;
+    }
     console.debug(`[${this.#direction}]`, message.type, message.data);
     this.#messageHandler && this.#messageHandler(message);
   }
@@ -78,6 +82,9 @@ export class MessageController {
 
   #onMessage(message: ControllerMessage) {
     if (!message.type || !VALID_MESSAGE_TYPES.includes(message.type)) {
+      // This is only used in transition from worker machinery to
+      // remote machinery.
+      if ((message.type as string) === "starttransport") return;
       throw new Error(`Invalid message type "${message.type}"`);
     }
     if (message.id) {


### PR DESCRIPTION
- Rip out some never-realized early ideas about syntax.
- Sketch out WorkerClientTransport and WorkerServerTransport.
- Patch up MessageController to work with new transports.
- Introduce 'streamsToAsyncIterable' helper.
