### PR TITLE
[breadboard] 'beforehandler', 'afterhandler' -> 'nodestart', 'nodeend'.

### DIFF
--- a/packages/breadboard-ui/src/history-entry.ts
+++ b/packages/breadboard-ui/src/history-entry.ts
@@ -52,7 +52,7 @@ export class HistoryEntry extends LitElement {
       pointer-events: none;
     }
 
-    #container.beforehandler summary::before {
+    #container.nodestart summary::before {
       background: radial-gradient(
           var(--bb-progress-color) 0%,
           var(--bb-progress-color) 30%,
@@ -188,8 +188,7 @@ export class HistoryEntry extends LitElement {
 
   #isOpen(type: HistoryEventType) {
     return (
-      type === HistoryEventType.BEFOREHANDLER ||
-      type === HistoryEventType.OUTPUT
+      type === HistoryEventType.NODESTART || type === HistoryEventType.OUTPUT
     );
   }
 

--- a/packages/breadboard-ui/src/history-entry.ts
+++ b/packages/breadboard-ui/src/history-entry.ts
@@ -71,7 +71,7 @@ export class HistoryEntry extends LitElement {
       animation: rotate 0.5s linear infinite;
     }
 
-    #container.afterhandler summary::before {
+    #container.nodeend summary::before {
       background: var(--bb-progress-color);
       border: 1px solid rgb(90, 64, 119);
     }

--- a/packages/breadboard-ui/src/types.ts
+++ b/packages/breadboard-ui/src/types.ts
@@ -17,7 +17,7 @@ export const enum HistoryEventType {
   LOAD = "load",
   OUTPUT = "output",
   NODESTART = "nodestart",
-  AFTERHANDLER = "afterhandler",
+  NODEEND = "nodeend",
   SECRETS = "secrets",
   GRAPHSTART = "graphstart",
   GRAPHEND = "graphend",
@@ -76,8 +76,8 @@ export type NodeStartHistoryEvent = HistoryEvent & {
   data: DataWithPath;
 };
 
-export type AfterhandlerHistoryEvent = HistoryEvent & {
-  type: HistoryEventType.AFTERHANDLER;
+export type NodeEndHistoryEvent = HistoryEvent & {
+  type: HistoryEventType.NODEEND;
   data: DataWithPath & { outputs: Record<string, unknown> };
 };
 
@@ -90,7 +90,7 @@ export type AnyHistoryEvent =
   | GraphStartHistoryEvent
   | GraphEndHistoryEvent
   | NodeStartHistoryEvent
-  | AfterhandlerHistoryEvent
+  | NodeEndHistoryEvent
   | LoadHistoryEvent;
 
 export interface ImageHandler {

--- a/packages/breadboard-ui/src/types.ts
+++ b/packages/breadboard-ui/src/types.ts
@@ -16,7 +16,7 @@ export const enum HistoryEventType {
   INPUT = "input",
   LOAD = "load",
   OUTPUT = "output",
-  BEFOREHANDLER = "beforehandler",
+  NODESTART = "nodestart",
   AFTERHANDLER = "afterhandler",
   SECRETS = "secrets",
   GRAPHSTART = "graphstart",
@@ -71,8 +71,8 @@ export type GraphEndHistoryEvent = HistoryEvent & {
   data: DataWithPath;
 };
 
-export type BeforehandlerHistoryEvent = HistoryEvent & {
-  type: HistoryEventType.BEFOREHANDLER;
+export type NodeStartHistoryEvent = HistoryEvent & {
+  type: HistoryEventType.NODESTART;
   data: DataWithPath;
 };
 
@@ -89,7 +89,7 @@ export type AnyHistoryEvent =
   | SecretsHistoryEvent
   | GraphStartHistoryEvent
   | GraphEndHistoryEvent
-  | BeforehandlerHistoryEvent
+  | NodeStartHistoryEvent
   | AfterhandlerHistoryEvent
   | LoadHistoryEvent;
 

--- a/packages/breadboard-ui/src/ui-controller.ts
+++ b/packages/breadboard-ui/src/ui-controller.ts
@@ -27,17 +27,17 @@ import {
   AnyHistoryEvent,
   GraphEndHistoryEvent,
   GraphStartHistoryEvent,
-  BeforehandlerHistoryEvent,
+  NodeStartHistoryEvent,
   AfterhandlerHistoryEvent,
   InputArgs,
 } from "./types.js";
 import { HistoryEntry } from "./history-entry.js";
 import { NodeConfiguration, NodeDescriptor } from "@google-labs/breadboard";
-import { BeforehandlerResponse } from "@google-labs/breadboard/remote";
+import { NodeStartResponse } from "@google-labs/breadboard/remote";
 import { AfterhandlerResponse } from "@google-labs/breadboard/harness";
 
 export interface UI {
-  beforehandler(data: BeforehandlerResponse): void;
+  nodestart(data: NodeStartResponse): void;
   afterhandler(data: AfterhandlerResponse): void;
   output(values: OutputArgs): void;
   input(id: string, args: InputArgs): Promise<Record<string, unknown>>;
@@ -58,9 +58,9 @@ const hasPath = (
 ): event is
   | GraphEndHistoryEvent
   | GraphStartHistoryEvent
-  | BeforehandlerHistoryEvent
+  | NodeStartHistoryEvent
   | AfterhandlerHistoryEvent =>
-  event.type === HistoryEventType.BEFOREHANDLER ||
+  event.type === HistoryEventType.NODESTART ||
   event.type === HistoryEventType.AFTERHANDLER ||
   event.type === HistoryEventType.GRAPHSTART ||
   event.type === HistoryEventType.GRAPHEND;
@@ -838,13 +838,13 @@ export class UIController extends HTMLElement implements UI {
     return this.#diagram.render(this.#currentBoardDiagram, highlightNode);
   }
 
-  beforehandler(data: BeforehandlerResponse) {
+  nodestart(data: NodeStartResponse) {
     const {
       path,
       node: { id, type },
     } = data;
     this.#createHistoryEntry({
-      type: HistoryEventType.BEFOREHANDLER,
+      type: HistoryEventType.NODESTART,
       summary: type,
       id,
       data: { path },

--- a/packages/breadboard-ui/src/ui-controller.ts
+++ b/packages/breadboard-ui/src/ui-controller.ts
@@ -28,17 +28,17 @@ import {
   GraphEndHistoryEvent,
   GraphStartHistoryEvent,
   NodeStartHistoryEvent,
-  AfterhandlerHistoryEvent,
+  NodeEndHistoryEvent,
   InputArgs,
 } from "./types.js";
 import { HistoryEntry } from "./history-entry.js";
 import { NodeConfiguration, NodeDescriptor } from "@google-labs/breadboard";
 import { NodeStartResponse } from "@google-labs/breadboard/remote";
-import { AfterhandlerResponse } from "@google-labs/breadboard/harness";
+import { NodeEndResponse } from "@google-labs/breadboard/harness";
 
 export interface UI {
   nodestart(data: NodeStartResponse): void;
-  afterhandler(data: AfterhandlerResponse): void;
+  nodeend(data: NodeEndResponse): void;
   output(values: OutputArgs): void;
   input(id: string, args: InputArgs): Promise<Record<string, unknown>>;
   error(message: string): void;
@@ -59,9 +59,9 @@ const hasPath = (
   | GraphEndHistoryEvent
   | GraphStartHistoryEvent
   | NodeStartHistoryEvent
-  | AfterhandlerHistoryEvent =>
+  | NodeEndHistoryEvent =>
   event.type === HistoryEventType.NODESTART ||
-  event.type === HistoryEventType.AFTERHANDLER ||
+  event.type === HistoryEventType.NODEEND ||
   event.type === HistoryEventType.GRAPHSTART ||
   event.type === HistoryEventType.GRAPHEND;
 
@@ -769,7 +769,7 @@ export class UIController extends HTMLElement implements UI {
     }
   }
 
-  #updateHistoryEntry({ type, data }: AfterhandlerHistoryEvent) {
+  #updateHistoryEntry({ type, data }: NodeEndHistoryEvent) {
     const root = this.shadowRoot;
     assertRoot(root);
 
@@ -851,14 +851,14 @@ export class UIController extends HTMLElement implements UI {
     });
   }
 
-  afterhandler(data: AfterhandlerResponse) {
+  nodeend(data: NodeEndResponse) {
     const {
       path,
       node: { id },
       outputs,
     } = data;
     this.#updateHistoryEntry({
-      type: HistoryEventType.AFTERHANDLER,
+      type: HistoryEventType.NODEEND,
       id,
       data: { path, outputs },
     });

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -124,7 +124,7 @@ export class Main {
         this.#ui.load(await harness.load());
 
         for await (const result of harness.run()) {
-          if (result.message.type !== "beforehandler") {
+          if (result.message.type !== "nodestart") {
             const currentBoardId = this.#boardId;
             await this.#suspendIfPaused();
             if (currentBoardId !== this.#boardId) {
@@ -265,8 +265,8 @@ export class Main {
         break;
       }
 
-      case "beforehandler": {
-        this.#ui.beforehandler(data);
+      case "nodestart": {
+        this.#ui.nodestart(data);
         break;
       }
 

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -270,8 +270,8 @@ export class Main {
         break;
       }
 
-      case "afterhandler": {
-        this.#ui.afterhandler(data);
+      case "nodeend": {
+        this.#ui.nodeend(data);
         break;
       }
 

--- a/packages/breadboard/src/harness/diagnostics.ts
+++ b/packages/breadboard/src/harness/diagnostics.ts
@@ -5,13 +5,8 @@
  */
 
 import type { Probe, ProbeMessage } from "../types.js";
-import { BeforehandlerResult } from "./types.js";
 
-export type DiagnosticMesageType = "beforehandler";
-
-export type DiagnosticsCallback = (
-  message: BeforehandlerResult | ProbeMessage
-) => Promise<void>;
+export type DiagnosticsCallback = (message: ProbeMessage) => Promise<void>;
 
 export class Diagnostics extends EventTarget implements Probe {
   #callback: DiagnosticsCallback;

--- a/packages/breadboard/src/harness/types.ts
+++ b/packages/breadboard/src/harness/types.ts
@@ -13,7 +13,7 @@ import {
 } from "../remote/protocol.js";
 import { Kit, NodeDescriptor, OutputValues, ProbeMessage } from "../types.js";
 
-export type AfterhandlerResponse = {
+export type NodeEndResponse = {
   node: NodeDescriptor;
   path: number[];
   outputs: OutputValues;
@@ -39,7 +39,7 @@ export type ResultType =
   /**
    * Sent after a handler for a particular node is invoked
    */
-  | "afterhandler"
+  | "nodeend"
   /**
    * Sent when the harness is asking for secret
    */
@@ -78,9 +78,9 @@ export type NodeStartResult = {
   data: NodeStartResponse;
 };
 
-export type AfterhandlerResult = {
-  type: "afterhandler";
-  data: AfterhandlerResponse;
+export type NodeEndResult = {
+  type: "nodeend";
+  data: NodeEndResponse;
 };
 
 export type ErrorResult = {
@@ -100,7 +100,7 @@ export type AnyRunResult = (
   | OutputResult
   | SecretResult
   | NodeStartResult
-  | AfterhandlerResult
+  | NodeEndResult
   | ErrorResult
   | EndResult
   | ProbeMessage

--- a/packages/breadboard/src/harness/types.ts
+++ b/packages/breadboard/src/harness/types.ts
@@ -6,7 +6,7 @@
 
 import { NodeProxyConfig } from "../remote/config.js";
 import {
-  BeforehandlerResponse,
+  NodeStartResponse,
   InputPromiseResponse,
   LoadResponse,
   OutputResponse,
@@ -35,7 +35,7 @@ export type ResultType =
   /**
    * Sent before a handler for a particular node is invoked
    */
-  | "beforehandler"
+  | "nodestart"
   /**
    * Sent after a handler for a particular node is invoked
    */
@@ -73,9 +73,9 @@ export type SecretResult = {
   data: { keys: string[] };
 };
 
-export type BeforehandlerResult = {
-  type: "beforehandler";
-  data: BeforehandlerResponse;
+export type NodeStartResult = {
+  type: "nodestart";
+  data: NodeStartResponse;
 };
 
 export type AfterhandlerResult = {
@@ -99,7 +99,7 @@ export type AnyRunResult = (
   | InputResult
   | OutputResult
   | SecretResult
-  | BeforehandlerResult
+  | NodeStartResult
   | AfterhandlerResult
   | ErrorResult
   | EndResult

--- a/packages/breadboard/src/harness/worker-harness.ts
+++ b/packages/breadboard/src/harness/worker-harness.ts
@@ -63,7 +63,10 @@ export class WorkerHarness implements Harness {
   #skipDiagnosticMessages(type: ControllerMessageType) {
     return (
       !this.#config.diagnostics &&
-      (type === "nodestart" || type === "afterhandler")
+      (type === "nodestart" ||
+        type === "nodeend" ||
+        type === "graphstart" ||
+        type === "graphend")
     );
   }
 

--- a/packages/breadboard/src/harness/worker-harness.ts
+++ b/packages/breadboard/src/harness/worker-harness.ts
@@ -63,7 +63,7 @@ export class WorkerHarness implements Harness {
   #skipDiagnosticMessages(type: ControllerMessageType) {
     return (
       !this.#config.diagnostics &&
-      (type === "beforehandler" || type === "afterhandler")
+      (type === "nodestart" || type === "afterhandler")
     );
   }
 

--- a/packages/breadboard/src/new/runner/runner.ts
+++ b/packages/breadboard/src/new/runner/runner.ts
@@ -46,7 +46,7 @@ function createProbeCallbacks(probe: EventTarget): InvokeCallbacks {
         outputs: Promise.resolve({}),
       };
       const shouldInvokeHandler = probe.dispatchEvent(
-        new CustomEvent("beforehandler", {
+        new CustomEvent("nodestart", {
           detail,
           cancelable: true,
         })

--- a/packages/breadboard/src/remote/protocol.ts
+++ b/packages/breadboard/src/remote/protocol.ts
@@ -70,7 +70,7 @@ export type RunRequestType = "run" | "input" | "proxy";
  * These are markers for individual messages within the response,
  * so that the client can identify which message is which.
  */
-export type RunResponseType = "output" | "beforehandler" | "input" | "proxy";
+export type RunResponseType = "output" | "input" | "proxy";
 
 export type RunState = string;
 
@@ -101,7 +101,7 @@ export type OutputResponseMessage = ["output", OutputResponse];
 /**
  * Sent by a server just before a node is about to run.
  */
-export type BeforehandlerResponse = {
+export type NodeStartResponse = {
   /**
    * The description of the node that is about to run.
    * @see [NodeDescriptor]
@@ -109,10 +109,7 @@ export type BeforehandlerResponse = {
   node: NodeDescriptor;
   path: number[];
 };
-export type BeforehandlerResponseMessage = [
-  "beforehandler",
-  BeforehandlerResponse
-];
+export type NodeStartResponseMessage = ["nodestart", NodeStartResponse];
 
 /**
  * Sent by a server to request input.
@@ -252,7 +249,7 @@ export type AnyRunRequestMessage =
 
 export type AnyRunResponseMessage =
   | OutputResponseMessage
-  | BeforehandlerResponseMessage
+  | NodeStartResponseMessage
   | InputPromiseResponseMessage
   | ProxyPromiseResponseMessage
   | EndResponseMessage

--- a/packages/breadboard/src/runner.ts
+++ b/packages/breadboard/src/runner.ts
@@ -162,7 +162,7 @@ export class BoardRunner implements BreadboardRunner {
           throw new Error(`No handler for node type "${descriptor.type}"`);
 
         await probe?.report?.({
-          type: "beforehandler",
+          type: "nodestart",
           data: {
             node: descriptor,
             inputs,

--- a/packages/breadboard/src/runner.ts
+++ b/packages/breadboard/src/runner.ts
@@ -189,7 +189,7 @@ export class BoardRunner implements BreadboardRunner {
         ) as Promise<OutputValues>;
 
         await probe?.report?.({
-          type: "afterhandler",
+          type: "nodeend",
           data: {
             node: descriptor,
             inputs,

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -483,8 +483,8 @@ export type NodeStartProbeMessage = {
   };
 };
 
-export type AfterhandlerProbeMessage = {
-  type: "afterhandler";
+export type NodeEndProbeMessage = {
+  type: "nodeend";
   data: {
     node: NodeDescriptor;
     inputs: InputValues;
@@ -499,7 +499,7 @@ export type ProbeMessage =
   | GraphEndProbeMessage
   | SkipProbeMessage
   | NodeStartProbeMessage
-  | AfterhandlerProbeMessage;
+  | NodeEndProbeMessage;
 
 // TODO: Remove extending EventTarget once new runner is converted to use
 // reporting.

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -474,8 +474,8 @@ export type SkipProbeMessage = {
   };
 };
 
-export type BeforehandlerProbeMessage = {
-  type: "beforehandler";
+export type NodeStartProbeMessage = {
+  type: "nodestart";
   data: {
     node: NodeDescriptor;
     inputs: InputValues;
@@ -498,7 +498,7 @@ export type ProbeMessage =
   | GraphStartProbeMessage
   | GraphEndProbeMessage
   | SkipProbeMessage
-  | BeforehandlerProbeMessage
+  | NodeStartProbeMessage
   | AfterhandlerProbeMessage;
 
 // TODO: Remove extending EventTarget once new runner is converted to use

--- a/packages/breadboard/src/worker/index.ts
+++ b/packages/breadboard/src/worker/index.ts
@@ -8,7 +8,7 @@ export { MessageController, WorkerTransport } from "./controller.js";
 export { WorkerRuntime } from "./worker-runtime.js";
 export type {
   ControllerMessage,
-  BeforehandlerMessage,
+  NodeStartMessage,
   EndMessage,
   ErrorMessage,
   InputRequestMessage,

--- a/packages/breadboard/src/worker/protocol.ts
+++ b/packages/breadboard/src/worker/protocol.ts
@@ -5,7 +5,7 @@
  */
 
 import {
-  BeforehandlerResponse,
+  NodeStartResponse,
   ErrorResponse,
   InputPromiseResponse,
   LoadRequest,
@@ -20,7 +20,7 @@ export const VALID_MESSAGE_TYPES = [
   "start",
   "input",
   "output",
-  "beforehandler",
+  "nodestart",
   "afterhandler",
   "proxy",
   "end",
@@ -135,13 +135,13 @@ export type InputResponseMessage = {
 /**
  * The message that is sent by the worker to the host before it runs a node.
  */
-export type BeforehandlerMessage = {
+export type NodeStartMessage = {
   /**
-   * The "beforehandler" type signals to the host that the board is about to
+   * The "nodestart" type signals to the host that the board is about to
    * run a node.
    */
-  type: "beforehandler";
-  data: BeforehandlerResponse;
+  type: "nodestart";
+  data: NodeStartResponse;
 };
 
 /**

--- a/packages/breadboard/src/worker/protocol.ts
+++ b/packages/breadboard/src/worker/protocol.ts
@@ -21,7 +21,7 @@ export const VALID_MESSAGE_TYPES = [
   "input",
   "output",
   "nodestart",
-  "afterhandler",
+  "nodeend",
   "proxy",
   "end",
   "error",

--- a/packages/breadboard/tests/remote/transport.ts
+++ b/packages/breadboard/tests/remote/transport.ts
@@ -91,8 +91,8 @@ test("Continuous streaming", async (t) => {
     { node: { type: "input" }, inputArguments: { foo: "bar" } },
   ]);
   writer.write(["input", { inputs: { hello: "world" } }, ""]);
-  // second result was "beforehandler", but I removed it because of the
-  // refactoring to use diagnostics.
+  // second result was "beforehandler" (now "nodestart"), but I removed it
+  // because of the refactoring to use diagnostics.
   const thirdResult = await reader.read();
   t.assert(!thirdResult.done);
   t.like(thirdResult.value, ["output", { outputs: { hello: "world" } }]);

--- a/packages/graph-playground/src/index.ts
+++ b/packages/graph-playground/src/index.ts
@@ -135,7 +135,7 @@ async function main(args: string[], use_input_handler = false) {
   const probe = {
     report(message: ProbeMessage) {
       const { type, data } = message;
-      if (type === "afterhandler") {
+      if (type === "nodeend") {
         if (logIntegrityLabels && data.validatorMetadata?.length) {
           const label = data.validatorMetadata
             .map((m) => m.description)


### PR DESCRIPTION
- Rename 'beforehandler' to 'nodestart'.
- Rename 'afterhandler' to 'nodeend'.
