### PR TITLE
[breadboard] Emit `nodestart` and `nodeend` results for inputs and outputs.

### DIFF
--- a/packages/breadboard-server/tests/writer.ts
+++ b/packages/breadboard-server/tests/writer.ts
@@ -61,7 +61,8 @@ test("writes input", async (t) => {
       newOpportunities: [],
       pendingOutputs: new Map(),
     },
-    "input"
+    "input",
+    0
   );
   await writer.writeInput(stop);
   t.is(
@@ -88,7 +89,8 @@ test("writes output", async (t) => {
       newOpportunities: [],
       pendingOutputs: new Map(),
     },
-    "output"
+    "output",
+    0
   );
   await writer.writeOutput(stop);
   t.is(
@@ -129,7 +131,8 @@ test("transforms state", async (t) => {
       newOpportunities: [],
       pendingOutputs: new Map(),
     },
-    "output"
+    "output",
+    0
   );
   await writer.writeOutput(stop);
   t.is(

--- a/packages/breadboard-ui/src/input.ts
+++ b/packages/breadboard-ui/src/input.ts
@@ -396,7 +396,9 @@ export class Input extends LitElement {
             input = html`<select name="${key}" id="${key}">
               ${options.map((option) => {
                 const isSelected = option === property.default;
-                return html`<option ?selected=${isSelected} value=${option}">${option}</option>`;
+                return html`<option ?selected=${isSelected} value=${option}>
+                  ${option}
+                </option>`;
               })}
             </select>`;
           } else if (isBoolean(property)) {

--- a/packages/breadboard/src/bubble.ts
+++ b/packages/breadboard/src/bubble.ts
@@ -126,7 +126,7 @@ export class RequestedInputsManager {
           schema: { type: "object", properties: { [name]: schema } },
         },
       };
-      await next(new InputStageResult(requestInputResult));
+      await next(new InputStageResult(requestInputResult, -1));
       const outputs = await requestInputResult.outputsPromise;
       let value = outputs && outputs[name];
       if (value === undefined) {

--- a/packages/breadboard/src/remote/run.ts
+++ b/packages/breadboard/src/remote/run.ts
@@ -88,6 +88,7 @@ type Writer = WritableStreamDefaultWriter<AnyRunRequestMessage>;
 class ClientRunResult implements BreadboardRunResult {
   type: RunResultType;
   node: NodeDescriptor;
+  invocationId = 0;
 
   #state?: string;
   #inputArguments: InputValues = {};

--- a/packages/breadboard/src/run.ts
+++ b/packages/breadboard/src/run.ts
@@ -40,10 +40,20 @@ export const reviver = (
 export class RunResult implements BreadboardRunResult {
   #type: RunResultType;
   #state: TraversalResult;
+  #invocationId;
 
-  constructor(state: TraversalResult, type: RunResultType) {
+  constructor(
+    state: TraversalResult,
+    type: RunResultType,
+    invocationId: number
+  ) {
     this.#state = state;
     this.#type = type;
+    this.#invocationId = invocationId;
+  }
+
+  get invocationId(): number {
+    return this.#invocationId;
   }
 
   get type(): RunResultType {
@@ -91,13 +101,13 @@ export class RunResult implements BreadboardRunResult {
   static load(stringifiedResult: string): RunResult {
     const { state, type } = JSON.parse(stringifiedResult, reviver);
     const machineResult = MachineResult.fromObject(state);
-    return new RunResult(machineResult, type);
+    return new RunResult(machineResult, type, 0);
   }
 }
 
 export class InputStageResult extends RunResult {
-  constructor(state: TraversalResult) {
-    super(state, "input");
+  constructor(state: TraversalResult, invocationId: number) {
+    super(state, "input", invocationId);
   }
 
   get outputs(): OutputValues {
@@ -106,8 +116,8 @@ export class InputStageResult extends RunResult {
 }
 
 export class OutputStageResult extends RunResult {
-  constructor(state: TraversalResult) {
-    super(state, "output");
+  constructor(state: TraversalResult, invocationId: number) {
+    super(state, "output", invocationId);
   }
 
   get inputArguments(): InputValues {

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -380,6 +380,11 @@ export interface BreadboardRunResult {
    * graph traversal.
    */
   get state(): TraversalResult;
+  /**
+   * The invocation id of the current node. This is useful for tracking
+   * the node within the run, similar to an "index" property in map/forEach.
+   */
+  get invocationId(): number;
 }
 
 export interface NodeFactory {


### PR DESCRIPTION
- Start emitting 'nodestart' and 'nodeend' for input/output nodes.
- Fix a typo in Breadboard UI 'input' element.
