### PR TITLE
[breadboard] Tech up Worker transports and Proxy machinery.

### DIFF
--- a/packages/breadboard/src/remote/protocol.ts
+++ b/packages/breadboard/src/remote/protocol.ts
@@ -190,8 +190,9 @@ export type ProxyResolveRequestMessage = [
  * Indicates that the board is done running.
  * Can only be the last message in the response stream.
  */
-export type EndResponse = Record<string, never>;
-export type EndResponseMessage = ["end", EndResponse];
+export type End = Record<string, never>;
+export type EndResponseMessage = ["end", End];
+export type EndRequestMessage = ["end", End];
 
 /**
  * Sent by the server when an error occurs.
@@ -235,7 +236,7 @@ export type ProxyChunkResponse = {
 
 export type ProxyChunkResponseMessage = ["chunk", ProxyChunkResponse];
 
-export type AnyProxyRequestMessage = ProxyRequestMessage;
+export type AnyProxyRequestMessage = ProxyRequestMessage | EndRequestMessage;
 export type AnyProxyResponseMessage =
   | ProxyResponseMessage
   | ErrorResponseMessage

--- a/packages/breadboard/src/remote/proxy.ts
+++ b/packages/breadboard/src/remote/proxy.ts
@@ -10,6 +10,7 @@ import {
   StreamCapability,
   StreamCapabilityType,
   isStreamCapability,
+  streamsToAsyncIterable,
 } from "../stream.js";
 import { asRuntimeKit } from "../kits/ctors.js";
 import { KitBuilder } from "../kits/builder.js";
@@ -63,80 +64,73 @@ export class ProxyServer {
   async serve(config: ProxyServerConfig) {
     const { board } = config;
     const stream = this.#transport.createServerStream();
-    const reader = stream.readableRequests.getReader();
-    const request = await reader.read();
-    if (request.done) return;
 
-    const writer = stream.writableResponses.getWriter();
+    for await (const request of streamsToAsyncIterable(
+      stream.writableResponses,
+      stream.readableRequests
+    )) {
+      const [type] = request.data;
 
-    const [type] = request.value;
-
-    if (type !== "proxy") {
-      writer.write(["error", { error: "Expected proxy request." }]);
-      writer.close();
-      return;
-    }
-
-    const [, { node, inputs }] = request.value;
-
-    const handlerConfig = getHandlerConfig(node.type, config.proxy);
-
-    const tunnelKit = createTunnelKit(
-      readConfig(config),
-      await Board.handlersFromBoard(board)
-    );
-    const handlers = tunnelKit.handlers;
-
-    const handler = handlerConfig ? handlers[node.type] : undefined;
-    if (!handler) {
-      writer.write([
-        "error",
-        { error: "Can't proxy a node of this node type." },
-      ]);
-      writer.close();
-      return;
-    }
-
-    try {
-      const result = await callHandler(handler, inputs, {
-        outerGraph: board,
-        board,
-        descriptor: node,
-      });
-
-      if (!result) {
-        writer.write(["error", { error: "Handler returned nothing." }]);
-        writer.close();
-        return;
+      if (type !== "proxy") {
+        request.reply(["error", { error: "Expected proxy request." }]);
+        continue;
       }
 
-      // Look for StreamCapability in the result. If it's there, we need to
-      // pipe it to the response.
-      // For now, we'll only support one stream per response, and only
-      // when the stream is at the top level of the response.
-      const streams = Object.values(result).filter((value) =>
-        isStreamCapability(value)
+      const [, { node, inputs }] = request.data;
+
+      const handlerConfig = getHandlerConfig(node.type, config.proxy);
+
+      const tunnelKit = createTunnelKit(
+        readConfig(config),
+        await Board.handlersFromBoard(board)
       );
-      writer.write(["proxy", { outputs: result }]);
-      if (streams.length > 0) {
-        const stream = (streams[0] as StreamCapability<unknown>).stream;
-        await stream.pipeTo(
-          new WritableStream({
-            write(chunk) {
-              writer.write(["chunk", { chunk }]);
-            },
-            close() {
-              writer.write(["end", {}]);
-              writer.close();
-            },
-          })
-        );
-      } else {
-        writer.close();
+      const handlers = tunnelKit.handlers;
+
+      const handler = handlerConfig ? handlers[node.type] : undefined;
+      if (!handler) {
+        request.reply([
+          "error",
+          { error: "Can't proxy a node of this node type." },
+        ]);
+        continue;
       }
-    } catch (e) {
-      writer.write(["error", { error: (e as Error).message }]);
-      writer.close();
+
+      try {
+        const result = await callHandler(handler, inputs, {
+          outerGraph: board,
+          board,
+          descriptor: node,
+        });
+
+        if (!result) {
+          request.reply(["error", { error: "Handler returned nothing." }]);
+          continue;
+        }
+
+        // Look for StreamCapability in the result. If it's there, we need to
+        // pipe it to the response.
+        // For now, we'll only support one stream per response, and only
+        // when the stream is at the top level of the response.
+        const streams = Object.values(result).filter((value) =>
+          isStreamCapability(value)
+        );
+        request.reply(["proxy", { outputs: result }]);
+        if (streams.length > 0) {
+          const stream = (streams[0] as StreamCapability<unknown>).stream;
+          await stream.pipeTo(
+            new WritableStream({
+              write(chunk) {
+                request.reply(["chunk", { chunk }]);
+              },
+              close() {
+                request.reply(["end", {}]);
+              },
+            })
+          );
+        }
+      } catch (e) {
+        request.reply(["error", { error: (e as Error).message }]);
+      }
     }
   }
 }

--- a/packages/breadboard/src/remote/proxy.ts
+++ b/packages/breadboard/src/remote/proxy.ts
@@ -71,6 +71,10 @@ export class ProxyServer {
     )) {
       const [type] = request.data;
 
+      if (type === "end") {
+        break;
+      }
+
       if (type !== "proxy") {
         request.reply(["error", { error: "Expected proxy request." }]);
         continue;
@@ -151,6 +155,13 @@ export class ProxyClient {
 
   constructor(transport: ProxyClientTransport) {
     this.#transport = transport;
+  }
+
+  shutdownServer() {
+    const stream = this.#transport.createClientStream();
+    const writer = stream.writableRequests.getWriter();
+    writer.write(["end", {}]);
+    writer.close();
   }
 
   async proxy(

--- a/packages/breadboard/src/remote/worker.ts
+++ b/packages/breadboard/src/remote/worker.ts
@@ -78,9 +78,6 @@ export class WorkerServerTransport<Request, Response>
   }
 
   createServerStream(): ServerBidirectionalStream<Request, Response> {
-    if (!this.#clientStreams) {
-      throw new Error("The client has not connected yet");
-    }
     return {
       readableRequests: this.#clientStreams
         .readable as PatchedReadableStream<Request>,

--- a/packages/breadboard/src/remote/worker.ts
+++ b/packages/breadboard/src/remote/worker.ts
@@ -35,7 +35,7 @@ export const receiveStartTransportMessage = (
   callback: (port: MessagePort) => void
 ) => {
   worker.addEventListener("message", (event) => {
-    if (event.data.type === "starttransport") {
+    if (event.data?.type === "starttransport") {
       callback(event.data.port);
     }
   });

--- a/packages/breadboard/src/stream.ts
+++ b/packages/breadboard/src/stream.ts
@@ -217,3 +217,22 @@ export const streamFromAsyncGen = <T>(
     },
   }) as PatchedReadableStream<T>;
 };
+
+export const streamFromReader = <Read>(
+  reader: ReadableStreamDefaultReader<Read>
+) => {
+  return new ReadableStream(
+    {
+      async pull(controller) {
+        const { value, done } = await reader.read();
+
+        if (done) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(value);
+      },
+    },
+    { highWaterMark: 0 }
+  ) as PatchedReadableStream<Read>;
+};

--- a/packages/breadboard/src/stream.ts
+++ b/packages/breadboard/src/stream.ts
@@ -236,3 +236,16 @@ export const streamFromReader = <Read>(
     { highWaterMark: 0 }
   ) as PatchedReadableStream<Read>;
 };
+
+export const streamFromWriter = <Write>(
+  writer: WritableStreamDefaultWriter<Write>
+) => {
+  return new WritableStream<Write>(
+    {
+      async write(chunk) {
+        return writer.write(chunk);
+      },
+    },
+    { highWaterMark: 0 }
+  );
+};

--- a/packages/breadboard/src/stream.ts
+++ b/packages/breadboard/src/stream.ts
@@ -102,6 +102,55 @@ export const portToStreams = <Read, Write>(
   };
 };
 
+export const portFactoryToStreams = <Read, Write>(
+  portFactory: () => Promise<MessagePortLike>
+): PortStreams<Read, Write> => {
+  let streams: PortStreams<Read, Write>;
+  const streamsAvailable = new Promise<void>((resolve) => {
+    portFactory().then((port) => {
+      streams = portToStreams(port);
+      resolve();
+    });
+  });
+  const readable = new ReadableStream<Read>({
+    async start() {
+      await streamsAvailable;
+    },
+    pull(controller) {
+      return streams.readable.pipeTo(
+        new WritableStream({
+          write(chunk) {
+            controller.enqueue(chunk);
+          },
+        })
+      );
+    },
+    cancel() {
+      streams.readable.cancel();
+    },
+  });
+  const writable = new WritableStream<Write>({
+    async start() {
+      await streamsAvailable;
+    },
+    async write(chunk) {
+      const writer = streams.writable.getWriter();
+      await writer.write(chunk);
+      writer.releaseLock();
+    },
+    async close() {
+      await streams.writable.close();
+    },
+    async abort(reason) {
+      await streams.writable.abort(reason);
+    },
+  });
+  return {
+    readable,
+    writable,
+  };
+};
+
 class WritableResult<Read, Write> {
   #writer: WritableStreamDefaultWriter<Write>;
   data: Read;

--- a/packages/breadboard/tests/remote/transport.ts
+++ b/packages/breadboard/tests/remote/transport.ts
@@ -14,9 +14,13 @@ import { Board } from "../../src/board.js";
 import { TestKit } from "../helpers/_test-kit.js";
 import {
   IdentityTransport,
-  MockWorkerTransport,
+  createMockWorkers,
 } from "../helpers/_test-transport.js";
 import { RunClient, RunServer } from "../../src/remote/run.js";
+import {
+  WorkerClientTransport,
+  WorkerServerTransport,
+} from "../../src/remote/worker.js";
 
 test("Interruptible streaming", async (t) => {
   const board = new Board();
@@ -72,14 +76,22 @@ test("Continuous streaming", async (t) => {
   const kit = board.addKit(TestKit);
   board.input({ foo: "bar" }).wire("*", kit.noop().wire("*", board.output()));
 
-  const transport = new MockWorkerTransport<
+  // Set up the transports.
+  const mockWorkers = createMockWorkers();
+  const clientTransport = new WorkerClientTransport<
     AnyRunRequestMessage,
     AnyRunResponseMessage
-  >();
-  const server = new RunServer(transport);
+  >(mockWorkers.host);
+  const server = new RunServer(
+    await WorkerServerTransport.create(mockWorkers.worker)
+  );
+
+  // Serve the board.
   server.serve(board);
+
+  // Hand-craft running the board
   const { writableRequests: requests, readableResponses: responses } =
-    transport.createClientStream();
+    clientTransport.createClientStream();
   const writer = requests.getWriter();
   const reader = responses.getReader();
 
@@ -108,14 +120,14 @@ test("runOnce client can run once", async (t) => {
   const kit = board.addKit(TestKit);
   board.input({ foo: "bar" }).wire("*", kit.noop().wire("*", board.output()));
 
-  const transport = new MockWorkerTransport<
-    AnyRunRequestMessage,
-    AnyRunResponseMessage
-  >();
-  const server = new RunServer(transport);
-  const client = new RunClient(transport);
+  const mockWorkers = createMockWorkers();
+  const client = new RunClient(new WorkerClientTransport(mockWorkers.host));
+  const server = new RunServer(
+    await WorkerServerTransport.create(mockWorkers.worker)
+  );
 
   server.serve(board);
+  console.log("HERE");
   const outputs = await client.runOnce({ hello: "world" });
 
   t.deepEqual(outputs, { hello: "world" });

--- a/packages/breadboard/tests/remote/worker.ts
+++ b/packages/breadboard/tests/remote/worker.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import test from "ava";
+import { createMockWorkers } from "../helpers/_test-transport.js";
+import { MirrorUniverseKit, TestKit } from "../helpers/_test-kit.js";
+import { ProxyClient, ProxyServer } from "../../src/remote/proxy.js";
+import {
+  WorkerClientTransport,
+  WorkerServerTransport,
+} from "../../src/remote/worker.js";
+import { Board } from "../../src/board.js";
+
+test("Worker transports can handle ProxyServer and ProxyClient", async (t) => {
+  const workers = createMockWorkers();
+
+  const serverBoard = new Board();
+  serverBoard.addKit(MirrorUniverseKit);
+  const server = new ProxyServer(new WorkerServerTransport(workers.host));
+  server.serve({ board: serverBoard, proxy: ["reverser"] });
+
+  const client = new ProxyClient(new WorkerClientTransport(workers.worker));
+  const board = new Board();
+  const kit = board.addKit(TestKit);
+  board
+    .input({ hello: "world" })
+    .wire("*", kit.reverser().wire("*", board.output()));
+  const kits = [client.createProxyKit(["reverser"]), kit];
+  const outputs = await board.runOnce({ hello: "world" }, { kits });
+  t.deepEqual(outputs, { hello: "dlorw" });
+});
+
+test("Worker transports can handle proxy tunnels", async (t) => {
+  {
+    const workers = createMockWorkers();
+    const serverBoard = new Board();
+    serverBoard.addKit(TestKit);
+    const server = new ProxyServer(new WorkerServerTransport(workers.host));
+
+    server.serve({
+      board: serverBoard,
+      proxy: [
+        {
+          node: "test",
+          tunnel: {
+            hello: "reverser",
+          },
+        },
+        "reverser",
+      ],
+    });
+    const client = new ProxyClient(new WorkerClientTransport(workers.worker));
+    const board = new Board();
+    const kit = board.addKit(TestKit);
+    board
+      .input({ hello: "world" })
+      .wire(
+        "*",
+        kit.test().wire("*", kit.reverser().wire("*", board.output()))
+      );
+    const kits = [client.createProxyKit(["test", "reverser"]), kit];
+    const outputs = await board.runOnce({ hello: "world" }, { kits });
+    t.deepEqual(outputs, { hello: "dlrow" });
+  }
+  {
+    const workers = createMockWorkers();
+    const serverBoard = new Board();
+    serverBoard.addKit(TestKit);
+    const server = new ProxyServer(new WorkerServerTransport(workers.host));
+    server.serve({
+      board: serverBoard,
+      proxy: [
+        {
+          node: "test",
+          tunnel: {
+            hello: {
+              to: "reverser",
+              when: {
+                hello: "bye",
+              },
+            },
+          },
+        },
+        "reverser",
+      ],
+    });
+    const client = new ProxyClient(new WorkerClientTransport(workers.worker));
+    const board = new Board();
+    const kit = board.addKit(TestKit);
+    board
+      .input({ hello: "world" })
+      .wire(
+        "*",
+        kit.test().wire("*", kit.reverser().wire("*", board.output()))
+      );
+    const kits = [client.createProxyKit(["test", "reverser"]), kit];
+    const outputs = await board.runOnce({ hello: "world" }, { kits });
+    t.deepEqual(outputs, { hello: "DEKCOLB_EULAV" });
+  }
+});


### PR DESCRIPTION
- Introduce 'streamFromReader'.
- Introduce 'streamFromWriter'.
- Switch WorkerClientTransport to retain readers/writers.
- Introduce 'createMockWorkers' and replace 'MockWorkerTransport' with it.
- Introduce 'portFactoryToStreams'.
- Teach WorkerServerTransport to use portFactoryToStreams.
- Teach Worker transports to work with proxy.
- Add ability to shutdown ProxyServer from ProxyClient.
