### PR TITLE
[breadboard-ui] Deprecate old UI controller

### DIFF
--- a/packages/breadboard-ui/src/deprecated-ui-controller.ts
+++ b/packages/breadboard-ui/src/deprecated-ui-controller.ts
@@ -67,6 +67,9 @@ const hasPath = (
 
 const pathToId = (path: number[]) => `path-${path.join("-")}`;
 
+/**
+ * @deprecated This has been replaced by the UI element in ./ui.ts
+ */
 export class UIController extends HTMLElement implements UI {
   #inputContainer = new InputContainer();
   #nodeInformation: HTMLElement;

--- a/packages/breadboard-ui/src/index.ts
+++ b/packages/breadboard-ui/src/index.ts
@@ -19,7 +19,7 @@ export { UI } from "./ui.js";
 export { BoardList } from "./board-list.js";
 
 import { Output } from "./output.js";
-import { UIController } from "./ui-controller.js";
+import { UIController as DeprecatedUIController } from "./deprecated-ui-controller.js";
 import {
   MultipartInput,
   MultipartInputImage,
@@ -29,15 +29,11 @@ import { Diagram } from "./diagram.js";
 
 export const register = () => {
   customElements.define("bb-diagram", Diagram);
-  customElements.define("bb-ui", UIController);
+  customElements.define("bb-ui", DeprecatedUIController);
   customElements.define("bb-output", Output);
   customElements.define("bb-multipart-input", MultipartInput);
   customElements.define("bb-multipart-input-image", MultipartInputImage);
   customElements.define("bb-multipart-input-text", MultipartInputText);
-};
-
-export const get = () => {
-  return document.querySelector("bb-ui") as UIController;
 };
 
 export type { LoadArgs } from "./load.js";


### PR DESCRIPTION
This deprecates the old UI controller because it's not needed. I didn't remove it because I want to give it a once over tomorrow and just check that all the functionality has been brought over to the new UI controller.