### PR TITLE
[breadboard/new] Add .is<String|Number|...> to wires, use to infer schemas

### DIFF
--- a/packages/breadboard/src/new/recipe-grammar/types.ts
+++ b/packages/breadboard/src/new/recipe-grammar/types.ts
@@ -219,7 +219,8 @@ export interface BuilderNodeInterface<
   addInputsFromNode(
     from: AbstractNode,
     keymap: KeyMap,
-    constant?: boolean
+    constant?: boolean,
+    schema?: Schema
   ): void;
 
   asProxy(): NodeProxy<I, O>;

--- a/packages/breadboard/src/new/recipe-grammar/types.ts
+++ b/packages/breadboard/src/new/recipe-grammar/types.ts
@@ -10,6 +10,7 @@ import {
   BreadboardCapability,
   NodeDescriberFunction,
   GraphMetadata,
+  Schema,
 } from "../../types.js";
 
 import {
@@ -252,7 +253,12 @@ export abstract class AbstractValue<T extends NodeValue = NodeValue>
     onrejected?: ((reason: unknown) => TResult2 | PromiseLike<TResult2>) | null
   ): PromiseLike<TResult1 | TResult2>;
 
-  abstract asNodeInput(): [AbstractNode, { [key: string]: string }, boolean];
+  abstract asNodeInput(): [
+    AbstractNode,
+    { [key: string]: string },
+    boolean,
+    Schema
+  ];
 
   abstract to<
     ToO extends OutputValues = OutputValues,

--- a/packages/breadboard/src/new/recipe-grammar/types.ts
+++ b/packages/breadboard/src/new/recipe-grammar/types.ts
@@ -242,7 +242,7 @@ export type ClosureNodeInterface<
       | Promise<BreadboardCapability>;
   };
 
-export abstract class AbstractValue<T extends NodeValue | unknown = NodeValue>
+export abstract class AbstractValue<T extends NodeValue = NodeValue>
   implements PromiseLike<T | undefined>
 {
   abstract then<TResult1 = T | undefined, TResult2 = never>(
@@ -277,6 +277,13 @@ export abstract class AbstractValue<T extends NodeValue | unknown = NodeValue>
   abstract memoize(): AbstractValue<T>;
 
   abstract invoke(config?: BuilderNodeConfig): NodeProxy;
+
+  abstract isUnknown(): AbstractValue<unknown>;
+  abstract isString(): AbstractValue<string>;
+  abstract isNumber(): AbstractValue<number>;
+  abstract isBoolean(): AbstractValue<boolean>;
+  abstract isArray(): AbstractValue<NodeValue[]>;
+  abstract isObject(): AbstractValue<{ [key: string]: NodeValue }>;
 }
 
 /**

--- a/packages/breadboard/src/new/recipe-grammar/value.ts
+++ b/packages/breadboard/src/new/recipe-grammar/value.ts
@@ -172,6 +172,44 @@ export class Value<T extends NodeValue = NodeValue>
     }).asProxy();
   }
 
+  /**
+   * The following are type-casting methods that are useful when a node type
+   * returns generic types but we want to narrow the types to what we know they
+   * are, e.g. a parser node returning the result as raw wires.
+   *
+   * This is also a way to define the schema of a recipe, e.g. by casting input
+   * wires and what is returned.
+   *
+   * Use as `foo.asString()` or `foo.asNumber()`. `isArray` and `isObject` cast
+   * to generic arrays and objects.
+   */
+
+  isUnknown(): AbstractValue<unknown> {
+    return this as unknown as AbstractValue<unknown>;
+  }
+
+  isString(): AbstractValue<string> {
+    return this as unknown as AbstractValue<string>;
+  }
+
+  isNumber(): AbstractValue<number> {
+    return this as unknown as AbstractValue<number>;
+  }
+
+  isBoolean(): AbstractValue<boolean> {
+    return this as unknown as AbstractValue<boolean>;
+  }
+
+  isArray(): AbstractValue<NodeValue[]> {
+    return this as unknown as AbstractValue<NodeValue[]>;
+  }
+
+  isObject(): AbstractValue<{ [key: string]: NodeValue }> {
+    return this as unknown as AbstractValue<{
+      [key: string]: NodeValue;
+    }>;
+  }
+
   #remapKeys(newKeys: KeyMap) {
     const newMap = { ...this.#keymap };
     Object.entries(newKeys).forEach(([fromKey, toKey]) => {

--- a/packages/breadboard/src/new/recipe-grammar/value.ts
+++ b/packages/breadboard/src/new/recipe-grammar/value.ts
@@ -20,6 +20,7 @@ import {
   NodeTypeIdentifier,
   KeyMap,
 } from "../runner/types.js";
+import { Schema } from "../../types.js";
 
 import { BuilderNode, isBuilderNodeProxy } from "./node.js";
 import { BuilderScope } from "./scope.js";
@@ -45,6 +46,7 @@ export class Value<T extends NodeValue = NodeValue>
   #scope: BuilderScope;
   #keymap: KeyMap;
   #constant: boolean;
+  #schema: Schema = {};
 
   constructor(
     node: BuilderNode<InputValues, OutputValue<T>>,
@@ -80,9 +82,10 @@ export class Value<T extends NodeValue = NodeValue>
   asNodeInput(): [
     BuilderNodeInterface<InputValues, OutputValue<T>>,
     { [key: string]: string },
-    boolean
+    boolean,
+    Schema
   ] {
-    return [this.#node.unProxy(), this.#keymap, this.#constant];
+    return [this.#node.unProxy(), this.#keymap, this.#constant, this.#schema];
   }
 
   to<
@@ -185,26 +188,32 @@ export class Value<T extends NodeValue = NodeValue>
    */
 
   isUnknown(): AbstractValue<unknown> {
+    delete this.#schema.type;
     return this as unknown as AbstractValue<unknown>;
   }
 
   isString(): AbstractValue<string> {
+    this.#schema.type = "string";
     return this as unknown as AbstractValue<string>;
   }
 
   isNumber(): AbstractValue<number> {
+    this.#schema.type = "number";
     return this as unknown as AbstractValue<number>;
   }
 
   isBoolean(): AbstractValue<boolean> {
+    this.#schema.type = "boolean";
     return this as unknown as AbstractValue<boolean>;
   }
 
   isArray(): AbstractValue<NodeValue[]> {
+    this.#schema.type = "array";
     return this as unknown as AbstractValue<NodeValue[]>;
   }
 
   isObject(): AbstractValue<{ [key: string]: NodeValue }> {
+    this.#schema.type = "object";
     return this as unknown as AbstractValue<{
       [key: string]: NodeValue;
     }>;

--- a/packages/breadboard/src/new/runner/node.ts
+++ b/packages/breadboard/src/new/runner/node.ts
@@ -87,7 +87,8 @@ export class BaseNode<
     from: AbstractNode,
     out: string,
     in_: string,
-    constant?: boolean
+    constant?: boolean,
+    schema?: Schema
   ) {
     if ((from as BaseNode).#scope !== this.#scope)
       throw new Error("Can't connect nodes from different scopes");
@@ -97,6 +98,7 @@ export class BaseNode<
       from: from,
       out,
       in: in_,
+      schema,
     };
     if (constant) edge.constant = true;
 

--- a/packages/breadboard/src/new/runner/types.ts
+++ b/packages/breadboard/src/new/runner/types.ts
@@ -70,6 +70,7 @@ export interface EdgeInterface<
   out: string;
   in: string;
   constant?: boolean;
+  schema?: Schema;
 }
 
 export type OptionalIdConfiguration = { $id?: string };
@@ -89,7 +90,8 @@ export abstract class AbstractNode<
     from: AbstractNode,
     out: string,
     in_: string,
-    constant?: boolean
+    constant?: boolean,
+    schema?: Schema
   ): void;
   abstract receiveInputs(edge: EdgeInterface, inputs: InputValues): string[];
   abstract missingInputs(): string[] | false;

--- a/packages/breadboard/tests/new/recipe-grammar/serialize-and-run-with-old-runner.ts
+++ b/packages/breadboard/tests/new/recipe-grammar/serialize-and-run-with-old-runner.ts
@@ -84,6 +84,37 @@ test("simple inline code", async (t) => {
   t.deepEqual(result, { result: 3 });
 });
 
+test("simple inline code, declare and cast types w/o contradiction", async (t) => {
+  const graph = recipe<{ a: number; b: number }, { result: number }>(
+    (inputs) => {
+      return {
+        result: code<{ a: number; b: number }, { result: number }>(
+          ({ a, b }) => {
+            return { result: a + b };
+          }
+        )({ a: inputs.a.isNumber(), b: inputs.b.isNumber() }).result.isNumber(),
+      };
+    }
+  );
+
+  const result = await serializeAndRunGraph(graph, { a: 1, b: 2 });
+  t.like(result, { result: 3 });
+});
+
+test("simple inline code, cast types and infer in TypeScript", async (t) => {
+  const graph = recipe((inputs) => {
+    return {
+      result: code(({ a, b }) => {
+        // TODO: Get rid of this extra cast, it shouldn't be necessary
+        return { result: (a as number) + (b as number) };
+      })({ a: inputs.a.isNumber(), b: inputs.b.isNumber() }).result.isNumber(),
+    };
+  });
+
+  const result = await serializeAndRunGraph(graph, { a: 1, b: 2 });
+  t.like(result, { result: 3 });
+});
+
 test("simple inline code, single parameter", async (t) => {
   const graph = recipe<{ number: number }, { result: number }>((inputs) => {
     return code<{ number: number }>((inputs) => {
@@ -96,10 +127,10 @@ test("simple inline code, single parameter", async (t) => {
 });
 
 test("simple inline code, single parameter, pick", async (t) => {
-  const graph = recipe<{ number: number }, { result: number }>((inputs) => {
+  const graph = recipe<{ number: number }, { result: number }>(({ number }) => {
     return code<{ number: number }>((inputs) => {
       return { result: -inputs.number };
-    })(inputs.number);
+    })(number);
   });
 
   const result = await serializeAndRunGraph(graph, { number: 3 });
@@ -145,12 +176,10 @@ test("simple inline code, explicit input and output, single parameter, pick", as
 });
 
 test("code recipe called from another recipe", async (t) => {
-  const add = code<{ a: number; b: number }, { result: number }>(
-    async (inputs) => {
-      const { a, b } = await inputs;
-      return { result: a + b };
-    }
-  );
+  const add = code<{ a: number; b: number }, { result: number }>((inputs) => {
+    const { a, b } = inputs;
+    return { result: a + b };
+  });
 
   const graph = recipe<{ a: number; b: number }, { result: number }>(
     (inputs) => {

--- a/packages/breadboard/tests/new/recipe-grammar/serialize-and-run-with-old-runner.ts
+++ b/packages/breadboard/tests/new/recipe-grammar/serialize-and-run-with-old-runner.ts
@@ -99,6 +99,7 @@ test("simple inline code, declare and cast types w/o contradiction", async (t) =
 
   const result = await serializeAndRunGraph(graph, { a: 1, b: 2 });
   t.like(result, { result: 3 });
+  t.like(result, { schema: { properties: { result: { type: "number" } } } });
 });
 
 test("simple inline code, cast types and infer in TypeScript", async (t) => {
@@ -113,6 +114,7 @@ test("simple inline code, cast types and infer in TypeScript", async (t) => {
 
   const result = await serializeAndRunGraph(graph, { a: 1, b: 2 });
   t.like(result, { result: 3 });
+  t.like(result, { schema: { properties: { result: { type: "number" } } } });
 });
 
 test("simple inline code, single parameter", async (t) => {

--- a/packages/breadboard/tests/new/runner/default-schemas.ts
+++ b/packages/breadboard/tests/new/runner/default-schemas.ts
@@ -68,3 +68,32 @@ test("schema derived from noop (no describe)", async (t) => {
     required: ["bar"],
   });
 });
+
+test("schema derived from noop, with type casts", async (t) => {
+  const graph = recipe(({ foo }) => ({
+    bar: testKit.noop({ foo: foo.isNumber() }).foo.isNumber(),
+  }));
+
+  const serialized = await graph.serialize();
+
+  const inputSchema = serialized.nodes.find((node) => node.type === "input")
+    ?.configuration?.schema;
+  const outputSchema = serialized.nodes.find((node) => node.type === "output")
+    ?.configuration?.schema;
+
+  t.deepEqual(inputSchema, {
+    type: "object",
+    properties: {
+      foo: { type: "number", title: "foo" },
+    },
+    required: ["foo"],
+  });
+
+  t.deepEqual(outputSchema, {
+    type: "object",
+    properties: {
+      bar: { type: "number", title: "bar" },
+    },
+    required: ["bar"],
+  });
+});


### PR DESCRIPTION
Example:

```
recipe(({ a, b }) => {
  const { c, d } = core.passthrough({ c: a.isNumber(), d: b.isString() });
  return { c: c.isNumber(), d: d.isString() };
});
```

Adds a type annotation on the `a` and `b` inputs and `c` and `d` outputs, which will be reflected in the inferred schema.

(Next up is inferring c, d automatically)
