### PR TITLE
allow .title() and .description() on values, use in schema inference

### DIFF
--- a/packages/breadboard/src/new/recipe-grammar/types.ts
+++ b/packages/breadboard/src/new/recipe-grammar/types.ts
@@ -291,6 +291,9 @@ export abstract class AbstractValue<T extends NodeValue = NodeValue>
   abstract isBoolean(): AbstractValue<boolean>;
   abstract isArray(): AbstractValue<NodeValue[]>;
   abstract isObject(): AbstractValue<{ [key: string]: NodeValue }>;
+
+  abstract title(title: string): AbstractValue<T>;
+  abstract description(description: string): AbstractValue<T>;
 }
 
 /**

--- a/packages/breadboard/src/new/recipe-grammar/value.ts
+++ b/packages/breadboard/src/new/recipe-grammar/value.ts
@@ -233,6 +233,16 @@ export class Value<T extends NodeValue = NodeValue>
     }>;
   }
 
+  title(title: string): AbstractValue<T> {
+    this.#schema.title = title;
+    return this;
+  }
+
+  description(description: string): AbstractValue<T> {
+    this.#schema.description = description;
+    return this;
+  }
+
   #remapKeys(newKeys: KeyMap) {
     const newMap = { ...this.#keymap };
     Object.entries(newKeys).forEach(([fromKey, toKey]) => {

--- a/packages/breadboard/tests/new/runner/default-schemas.ts
+++ b/packages/breadboard/tests/new/runner/default-schemas.ts
@@ -71,7 +71,12 @@ test("schema derived from noop (no describe)", async (t) => {
 
 test("schema derived from noop, with type casts", async (t) => {
   const graph = recipe(({ foo }) => ({
-    bar: testKit.noop({ foo: foo.isNumber() }).foo.isNumber(),
+    bar: testKit
+      .noop({
+        foo: foo.isNumber().title("The foo").description("A foo-lish number"),
+      })
+      .foo.isNumber()
+      .description("A bar-ish number"),
   }));
 
   const serialized = await graph.serialize();
@@ -84,7 +89,11 @@ test("schema derived from noop, with type casts", async (t) => {
   t.deepEqual(inputSchema, {
     type: "object",
     properties: {
-      foo: { type: "number", title: "foo" },
+      foo: {
+        type: "number",
+        title: "The foo",
+        description: "A foo-lish number",
+      },
     },
     required: ["foo"],
   });
@@ -92,7 +101,7 @@ test("schema derived from noop, with type casts", async (t) => {
   t.deepEqual(outputSchema, {
     type: "object",
     properties: {
-      bar: { type: "number", title: "bar" },
+      bar: { type: "number", title: "bar", description: "A bar-ish number" },
     },
     required: ["bar"],
   });


### PR DESCRIPTION
In addition to .isString(), etc. this allows setting title and descriptions of the schema.

This should now be enough to no longer need to pass a whole `schema` to `input` and `output` and instead derive the schema from the connected wires. Types are still quite basic, but it should be easy to add the next set of needed features.