### PR TITLE
Pass wire schemas to describe

### DIFF
--- a/packages/breadboard/src/new/runner/scope.ts
+++ b/packages/breadboard/src/new/runner/scope.ts
@@ -302,12 +302,12 @@ export class Scope implements ScopeInterface {
     const incomingPorts = Object.fromEntries(
       node.incoming
         .filter((edge) => edge.out !== "" && edge.out !== "*")
-        .map((edge) => [edge.out, {}])
+        .map((edge) => [edge.out, edge.schema ?? {}])
     );
     const outgoingPorts = Object.fromEntries(
       node.outgoing
         .filter((edge) => edge.out !== "" && edge.out !== "*")
-        .map((edge) => [edge.out, {}])
+        .map((edge) => [edge.out, edge.schema ?? {}])
     );
 
     return await node.describe(

--- a/packages/breadboard/tests/helpers/_test-kit.ts
+++ b/packages/breadboard/tests/helpers/_test-kit.ts
@@ -160,7 +160,10 @@ export const TestKit = new KitBuilder({
               type: "string",
               title: inputSchema?.properties?.[port]?.title ?? port,
               description:
-                op + (inputSchema?.properties?.[port]?.description ?? port),
+                op +
+                (inputSchema?.properties?.[port]?.description ??
+                  inputSchema?.properties?.[port]?.title ??
+                  port),
             },
           ])
         ),

--- a/packages/breadboard/tests/helpers/_test-kit.ts
+++ b/packages/breadboard/tests/helpers/_test-kit.ts
@@ -149,22 +149,27 @@ export const TestKit = new KitBuilder({
         ...Object.keys(inputSchema?.properties ?? {}),
       ];
 
-      const schema = (description: string) => ({
+      const schema = (op: string) => ({
         title: "Reverser",
         description: "Reverses the provided string inputs",
         type: "object",
         properties: Object.fromEntries(
           ports.map((port) => [
             port,
-            { type: "string", title: port, description },
+            {
+              type: "string",
+              title: inputSchema?.properties?.[port]?.title ?? port,
+              description:
+                op + (inputSchema?.properties?.[port]?.description ?? port),
+            },
           ])
         ),
         additonalProperties: Object.entries(inputs ?? {}).length === 0,
       });
 
       return {
-        inputSchema: schema("String to reverse"),
-        outputSchema: schema("Reversed string"),
+        inputSchema: schema("Reverse: "),
+        outputSchema: schema("Reversed: "),
       };
     },
   },

--- a/packages/breadboard/tests/new/runner/default-schemas.ts
+++ b/packages/breadboard/tests/new/runner/default-schemas.ts
@@ -25,7 +25,7 @@ test("schema derived from reverser (has describe)", async (t) => {
   t.deepEqual(inputSchema, {
     type: "object",
     properties: {
-      foo: { type: "string", title: "foo", description: "String to reverse" },
+      foo: { type: "string", title: "foo", description: "Reverse: foo" },
     },
     required: ["foo"],
   });
@@ -34,7 +34,7 @@ test("schema derived from reverser (has describe)", async (t) => {
   t.deepEqual(outputSchema, {
     type: "object",
     properties: {
-      bar: { type: "string", title: "foo", description: "Reversed string" },
+      bar: { type: "string", title: "foo", description: "Reversed: foo" },
     },
     required: ["bar"],
   });
@@ -102,6 +102,39 @@ test("schema derived from noop, with type casts", async (t) => {
     type: "object",
     properties: {
       bar: { type: "number", title: "bar", description: "A bar-ish number" },
+    },
+    required: ["bar"],
+  });
+});
+
+test("schema derived from reverser, with type annotations", async (t) => {
+  const graph = recipe<{ foo: string }>(({ foo }) => ({
+    bar: testKit
+      .reverser({ foo: foo.title("A foo") })
+      .foo.description("Reversed bar"),
+  }));
+
+  const serialized = await graph.serialize();
+
+  const inputSchema = serialized.nodes.find((node) => node.type === "input")
+    ?.configuration?.schema;
+  const outputSchema = serialized.nodes.find((node) => node.type === "output")
+    ?.configuration?.schema;
+
+  t.deepEqual(inputSchema, {
+    type: "object",
+    properties: {
+      foo: { type: "string", title: "A foo", description: "Reverse: A foo" },
+    },
+    required: ["foo"],
+  });
+
+  // Note "foo" as title, as this is determined by the reverse node,
+  // while description is overriden.
+  t.deepEqual(outputSchema, {
+    type: "object",
+    properties: {
+      bar: { type: "string", title: "foo", description: "Reversed bar" },
     },
     required: ["bar"],
   });

--- a/packages/breadboard/tests/new/runner/default-schemas.ts
+++ b/packages/breadboard/tests/new/runner/default-schemas.ts
@@ -129,12 +129,12 @@ test("schema derived from reverser, with type annotations", async (t) => {
     required: ["foo"],
   });
 
-  // Note "foo" as title, as this is determined by the reverse node,
+  // Note "A foo" as title, as this is determined by the reverse node,
   // while description is overriden.
   t.deepEqual(outputSchema, {
     type: "object",
     properties: {
-      bar: { type: "string", title: "foo", description: "Reversed bar" },
+      bar: { type: "string", title: "A foo", description: "Reversed bar" },
     },
     required: ["bar"],
   });


### PR DESCRIPTION
`describe` functions on handlers now receive schemas placed via `.isString()`, `.title()`, etc. on their incoming and outgoing wires.