### PR TITLE
[breadboard] Introduce `PortDispatcher` to handle multiple worker client/servers."

### DIFF
--- a/packages/breadboard-web/src/worker.ts
+++ b/packages/breadboard-web/src/worker.ts
@@ -11,12 +11,15 @@ import {
 } from "@google-labs/breadboard/worker";
 import { Board } from "@google-labs/breadboard";
 import {
+  PortDispatcher,
   ProxyClient,
   WorkerClientTransport,
 } from "@google-labs/breadboard/remote";
 import { proxyConfig } from "./config";
 
 const worker = self as unknown as Worker;
+
+const dispatcher = new PortDispatcher(worker);
 
 const controller = new MessageController(new WorkerTransport(worker));
 const runtime = new WorkerRuntime(controller);
@@ -25,7 +28,9 @@ const url = await runtime.onload();
 
 const runner = await Board.load(url);
 
-const proxyClient = new ProxyClient(new WorkerClientTransport(worker));
+const proxyClient = new ProxyClient(
+  new WorkerClientTransport(dispatcher.send("proxy"))
+);
 const proxyKit = proxyClient.createProxyKit(proxyConfig.proxy);
 
 await runtime.run(runner, [proxyKit, ...proxyConfig.kits]);

--- a/packages/breadboard/src/harness/worker-harness.ts
+++ b/packages/breadboard/src/harness/worker-harness.ts
@@ -21,7 +21,7 @@ import { asyncGen } from "../index.js";
 import { createSecretAskingKit } from "./secrets.js";
 import { WorkerResult } from "./result.js";
 import { ProxyServer } from "../remote/proxy.js";
-import { WorkerServerTransport } from "../remote/worker.js";
+import { PortDispatcher, WorkerServerTransport } from "../remote/worker.js";
 
 export const createWorker = (url: string) => {
   const workerURL = new URL(url, location.href);
@@ -39,9 +39,12 @@ class HarnessRun {
 
   constructor(workerURL: string) {
     this.worker = createWorker(workerURL);
+    const dispatcher = new PortDispatcher(this.worker);
     this.transport = new WorkerTransport(this.worker);
     this.controller = new MessageController(this.transport);
-    this.proxyServer = new ProxyServer(new WorkerServerTransport(this.worker));
+    this.proxyServer = new ProxyServer(
+      new WorkerServerTransport(dispatcher.receive("proxy"))
+    );
   }
 
   terminate() {

--- a/packages/breadboard/src/remote/index.ts
+++ b/packages/breadboard/src/remote/index.ts
@@ -5,7 +5,11 @@
  */
 
 export { HTTPServerTransport, HTTPClientTransport } from "./http.js";
-export { WorkerServerTransport, WorkerClientTransport } from "./worker.js";
+export {
+  PortDispatcher,
+  WorkerServerTransport,
+  WorkerClientTransport,
+} from "./worker.js";
 export { ProxyServer, ProxyClient } from "./proxy.js";
 export { RunServer, RunClient } from "./run.js";
 export { defineConfig, hasOrigin, type ProxyServerConfig } from "./config.js";

--- a/packages/breadboard/src/remote/run.ts
+++ b/packages/breadboard/src/remote/run.ts
@@ -161,10 +161,7 @@ export class RunClient implements RunnerLike {
     try {
       for await (const response of responses) {
         const [type] = response;
-        if (type === "proxy") {
-          // TODO: Implement proxying.
-          throw new Error("Proxying is not yet implemented.");
-        } else if (type === "end") {
+        if (type === "end" || type === "error") {
           break;
         }
         yield new ClientRunResult(requests, response);

--- a/packages/breadboard/src/remote/worker.ts
+++ b/packages/breadboard/src/remote/worker.ts
@@ -38,6 +38,50 @@ export const receiveStartTransportMessage = (
   worker.addEventListener("message", listener);
 };
 
+const DISPATCHER_SEND = "port-dispatcher-sendport";
+
+export class PortDispatcher {
+  #worker: Worker;
+  #waitForSender: Map<string, (port: MessagePort) => void> = new Map();
+  #pool: Map<string, MessagePort> = new Map();
+
+  constructor(worker: Worker) {
+    this.#worker = worker;
+    this.#worker.addEventListener("message", (event) => {
+      const { type, id, port } = event.data;
+      if (type !== DISPATCHER_SEND) return;
+      const waiting = this.#waitForSender.get(id);
+      if (waiting) {
+        waiting(port);
+        this.#waitForSender.delete(id);
+      } else {
+        this.#pool.set(id, port);
+      }
+    });
+  }
+
+  receive<Request, Response>(id: string): PortStreams<Request, Response> {
+    const pooledPort = this.#pool.get(id);
+    if (pooledPort) {
+      this.#pool.delete(id);
+      return portToStreams(pooledPort);
+    }
+    return portFactoryToStreams<Request, Response>(() => {
+      return new Promise((resolve) => {
+        this.#waitForSender.set(id, resolve);
+      });
+    });
+  }
+
+  send<Request, Response>(id: string): PortStreams<Request, Response> {
+    const { port1, port2 } = new MessageChannel();
+    this.#worker.postMessage({ type: DISPATCHER_SEND, id, port: port2 }, [
+      port2,
+    ]);
+    return portToStreams(port1);
+  }
+}
+
 export class WorkerClientTransport<Request, Response>
   implements ClientTransport<Request, Response>
 {

--- a/packages/breadboard/src/worker/controller.ts
+++ b/packages/breadboard/src/worker/controller.ts
@@ -100,7 +100,7 @@ export class MessageController {
     if (!message.type || !VALID_MESSAGE_TYPES.includes(message.type)) {
       // This is only used in transition from worker machinery to
       // remote machinery.
-      if ((message.type as string) === "starttransport") return;
+      if ((message.type as string) === "port-dispatcher-sendport") return;
       throw new Error(`Invalid message type "${message.type}"`);
     }
     if (message.id) {

--- a/packages/breadboard/tests/remote/http.ts
+++ b/packages/breadboard/tests/remote/http.ts
@@ -49,7 +49,6 @@ test("parseWithStreamsTransform works as expected", async (t) => {
   t.truthy(result3.value.value);
   t.true(isStreamCapability(result3.value.value));
   const result4 = await reader.read();
-  console.log(result4);
   t.true(result4.done);
   const dataReader = result3.value.value.stream.getReader();
   const dataResult = await dataReader.read();

--- a/packages/breadboard/tests/remote/worker.ts
+++ b/packages/breadboard/tests/remote/worker.ts
@@ -18,14 +18,20 @@ import { asRuntimeKit } from "../../src/index.js";
 
 test("Worker transports can handle ProxyServer and ProxyClient", async (t) => {
   const workers = createMockWorkers();
+  const hostDispatcher = new PortDispatcher(workers.host);
+  const workerDispatcher = new PortDispatcher(workers.worker);
 
-  const server = new ProxyServer(new WorkerServerTransport(workers.host));
+  const server = new ProxyServer(
+    new WorkerServerTransport(hostDispatcher.receive("test"))
+  );
   server.serve({
     kits: [asRuntimeKit(MirrorUniverseKit)],
     proxy: ["reverser"],
   });
 
-  const client = new ProxyClient(new WorkerClientTransport(workers.worker));
+  const client = new ProxyClient(
+    new WorkerClientTransport(workerDispatcher.send("test"))
+  );
   const board = new Board();
   const kit = board.addKit(TestKit);
   board
@@ -39,7 +45,12 @@ test("Worker transports can handle ProxyServer and ProxyClient", async (t) => {
 test("Worker transports can handle proxy tunnels", async (t) => {
   {
     const workers = createMockWorkers();
-    const server = new ProxyServer(new WorkerServerTransport(workers.host));
+    const hostDispatcher = new PortDispatcher(workers.host);
+    const workerDispatcher = new PortDispatcher(workers.worker);
+
+    const server = new ProxyServer(
+      new WorkerServerTransport(hostDispatcher.receive("test"))
+    );
 
     server.serve({
       kits: [asRuntimeKit(TestKit)],
@@ -53,7 +64,9 @@ test("Worker transports can handle proxy tunnels", async (t) => {
         "reverser",
       ],
     });
-    const client = new ProxyClient(new WorkerClientTransport(workers.worker));
+    const client = new ProxyClient(
+      new WorkerClientTransport(workerDispatcher.send("test"))
+    );
     const board = new Board();
     const kit = board.addKit(TestKit);
     board
@@ -68,7 +81,12 @@ test("Worker transports can handle proxy tunnels", async (t) => {
   }
   {
     const workers = createMockWorkers();
-    const server = new ProxyServer(new WorkerServerTransport(workers.host));
+    const hostDispatcher = new PortDispatcher(workers.host);
+    const workerDispatcher = new PortDispatcher(workers.worker);
+
+    const server = new ProxyServer(
+      new WorkerServerTransport(hostDispatcher.receive("test"))
+    );
     server.serve({
       kits: [asRuntimeKit(TestKit)],
       proxy: [
@@ -86,7 +104,9 @@ test("Worker transports can handle proxy tunnels", async (t) => {
         "reverser",
       ],
     });
-    const client = new ProxyClient(new WorkerClientTransport(workers.worker));
+    const client = new ProxyClient(
+      new WorkerClientTransport(workerDispatcher.send("test"))
+    );
     const board = new Board();
     const kit = board.addKit(TestKit);
     board


### PR DESCRIPTION
- Introduce PortDispatcher.
- Switch to use PortDispatcher.
- Remove 'proxy' TODO from RunClient.
