### PR TITLE
[breadboard-ui] Dedupe input/output/secret log entries

### DIFF
--- a/packages/breadboard-ui/src/history-tree.ts
+++ b/packages/breadboard-ui/src/history-tree.ts
@@ -194,9 +194,9 @@ export class HistoryTree extends LitElement {
       box-sizing: border-box;
     }
 
-    tr .marker.load::after {
-      background: rgb(110, 84, 139);
-      border: 1px solid rgb(90, 64, 119);
+    tr .marker.nodeend::after {
+      border: 1px solid hsl(33.6, 100%, 52.5%);
+      background: hsl(44.7, 100%, 80%);
     }
 
     tr .marker.graphstart::after,
@@ -230,6 +230,7 @@ export class HistoryTree extends LitElement {
       border: 1px solid #38761d;
     }
 
+    tr .marker.load::after,
     tr .marker.done::after {
       background: var(--bb-done-color);
       border: 1px solid var(--bb-done-color);
@@ -250,11 +251,6 @@ export class HistoryTree extends LitElement {
 
       border: none;
       animation: rotate 0.5s linear infinite;
-    }
-
-    tr .marker.nodeend::after {
-      border: 1px solid hsl(33.6, 100%, 52.5%);
-      background: hsl(44.7, 100%, 80%);
     }
 
     tr .marker::before {
@@ -423,15 +419,9 @@ export class HistoryTree extends LitElement {
       dataOutput = html`${JSON.stringify(entry.data)}`;
     }
 
-    if (
-      entry.type === HistoryEventType.NODESTART ||
-      entry.type === HistoryEventType.GRAPHSTART
-    ) {
+    if (entry.type === HistoryEventType.NODESTART) {
       this.#autoExpand.add(entry.id);
-    } else if (
-      entry.type === HistoryEventType.NODEEND ||
-      entry.type === HistoryEventType.GRAPHEND
-    ) {
+    } else if (entry.type === HistoryEventType.NODEEND) {
       this.#autoExpand.delete(entry.id);
     }
 
@@ -443,6 +433,10 @@ export class HistoryTree extends LitElement {
     const expanded = this.expandCollapseState.has(entry.id)
       ? this.expandCollapseState.get(entry.id) === STATE.EXPANDED
       : this.#autoExpand.has(entry.id);
+
+    const entryClass = entry.summary
+      .replaceAll(/\s/gim, "-")
+      .toLocaleLowerCase();
 
     return html`<tr
         class="${classMap({
@@ -470,7 +464,11 @@ export class HistoryTree extends LitElement {
               : nothing}</span
           >
           <span
-            class="${classMap({ marker: true, [entry.type]: true })}"
+            class="${classMap({
+              marker: true,
+              [entry.type]: true,
+              [entryClass]: true,
+            })}"
           ></span>
           ${entry.summary}
         </td>

--- a/packages/breadboard-ui/src/types.ts
+++ b/packages/breadboard-ui/src/types.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Schema } from "@google-labs/breadboard";
+import { Schema, TraversalResult } from "@google-labs/breadboard";
 
 export type InputArgs = {
   schema?: Schema;
@@ -67,6 +67,11 @@ export type DataWithPath = {
   path: number[];
 };
 
+export type DataWithPathAndState = {
+  path: number[];
+  state?: string | TraversalResult;
+};
+
 export type GraphStartHistoryEvent = HistoryEvent & {
   type: HistoryEventType.GRAPHSTART;
   data: DataWithPath;
@@ -79,14 +84,14 @@ export type GraphEndHistoryEvent = HistoryEvent & {
 
 export type NodeStartHistoryEvent = HistoryEvent & {
   type: HistoryEventType.NODESTART;
-  data: DataWithPath;
+  data: DataWithPathAndState;
 };
 
 export type NodeEndHistoryEvent = HistoryEvent & {
   type: HistoryEventType.NODEEND;
-  data: DataWithPath & {
+  data: {
+    path: number[];
     outputs: Record<string, unknown>;
-    inputs: Record<string, unknown>;
   };
 };
 
@@ -120,7 +125,10 @@ export type HistoryEntry = {
   type: HistoryEventType;
   nodeId: string;
   summary: string;
-  data: unknown;
+  data:
+    | { inputs: Record<string, unknown>; outputs: Record<string, unknown> }
+    | null
+    | undefined;
   elapsedTime: number;
   children: HistoryEntry[];
 };

--- a/packages/breadboard-ui/src/types.ts
+++ b/packages/breadboard-ui/src/types.ts
@@ -84,7 +84,10 @@ export type NodeStartHistoryEvent = HistoryEvent & {
 
 export type NodeEndHistoryEvent = HistoryEvent & {
   type: HistoryEventType.NODEEND;
-  data: DataWithPath & { outputs: Record<string, unknown> };
+  data: DataWithPath & {
+    outputs: Record<string, unknown>;
+    inputs: Record<string, unknown>;
+  };
 };
 
 export type AnyHistoryEvent =

--- a/packages/breadboard-ui/src/ui.ts
+++ b/packages/breadboard-ui/src/ui.ts
@@ -619,7 +619,9 @@ export class UI extends LitElement {
       if (type === HistoryEventType.GRAPHSTART) {
         // If this is a graph start and there is a corresponding nodestart with
         // the same path we will adjust the positions so that the graphstart
-        // appears just before the nodestart. This has a nicer semantic meaning.
+        // appears just before the nodestart. This tends to match the mental
+        // model a bit closer, where we think of a board starting before the
+        // nodes it contains.
         const existingNodeStartEntryIdx = entryList.findIndex(
           (sibling) => sibling.id === pathToId(event.data.path)
         );

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -186,7 +186,7 @@ export class Main {
 
     switch (type) {
       case "output": {
-        await this.#ui.output(data);
+        await this.#ui.output(data.node.id, data);
         break;
       }
 

--- a/packages/breadboard/src/index.ts
+++ b/packages/breadboard/src/index.ts
@@ -53,6 +53,8 @@ export type {
   KitConstructor,
   GenericKit,
   LambdaNodeOutputs,
+  QueuedNodeValuesState,
+  NodeValuesQueuesMap,
 } from "./types.js";
 export { TraversalMachine } from "./traversal/machine.js";
 export { MachineResult } from "./traversal/result.js";

--- a/packages/breadboard/src/remote/protocol.ts
+++ b/packages/breadboard/src/remote/protocol.ts
@@ -13,6 +13,7 @@ import {
   OutputValues,
   Schema,
   SkipProbeMessage,
+  TraversalResult,
 } from "../types.js";
 
 /**
@@ -112,6 +113,7 @@ export type NodeStartResponse = {
    */
   node: NodeDescriptor;
   path: number[];
+  state?: string | TraversalResult;
 };
 export type NodeStartResponseMessage = [
   "nodestart",

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -485,7 +485,7 @@ export type NodeStartProbeMessage = {
     node: NodeDescriptor;
     inputs: InputValues;
     path: number[];
-    state: string;
+    state: string | TraversalResult;
   };
 };
 


### PR DESCRIPTION
Having spoken with @dglazkov I realised that `nodestart` is the "key" event through which we can drive the history log. In other words the `input`, `output`, and `secret` events that were being created as a side effect of the other UI work can be removed.

This PR makes a few changes:

1. It removes the any entry that isn't `nodestart|end` or `graphstart|end`.
2. It uses the state object from the `nodestart` to populate an "input" area in the entry's value field. (There isn't any corresponding state in the `nodeend` for us to update the "output" side as yet.
3. It moves each `graphstart` event before its neighboring `nodestart` event. Right now we emit the `graphstart` after the `nodestart` for a subgraph, and that makes things look a bit peculiar; intuitively I think you want to see `graphstart` and `graphend` "containing" the relevant nodes.

Number 3 is a little hacky, therefore, as I feel like we'd be better placed doing that work in the harness rather than the UI.