### PR TITLE
[breadboard-ui] More type simplification

### DIFF
--- a/packages/breadboard-ui/src/types.ts
+++ b/packages/breadboard-ui/src/types.ts
@@ -48,13 +48,10 @@ export interface CanvasData {
   };
 }
 
-export type HistoryEntry = {
+export type HistoryEntry = AnyRunResult & {
   id: string;
   guid: string;
-  type: AnyRunResult["type"];
-  graphNodeId: string;
-  graphNodeType: string;
-  data:
+  graphNodeData:
     | { inputs: Record<string, unknown>; outputs: Record<string, unknown> }
     | null
     | undefined;


### PR DESCRIPTION
This PR makes the `HistoryEvent` an augmented version of the `AnyRunResult` from Breadboard proper. This means we will automatically propagate any new additional data surfaced through `AnyRunResult`, which I think is pretty handy.