### PR TITLE
[breadboard] Massage and align types a bit.

### DIFF
--- a/packages/breadboard-ui/src/types.ts
+++ b/packages/breadboard-ui/src/types.ts
@@ -4,9 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GraphProbeMessageData, Schema } from "@google-labs/breadboard";
-import { AnyRunResult, NodeEndResponse } from "@google-labs/breadboard/harness";
-import { NodeStartResponse } from "@google-labs/breadboard/remote";
+import {
+  GraphProbeData,
+  NodeEndResponse,
+  NodeStartResponse,
+  Schema,
+} from "@google-labs/breadboard";
+import { AnyRunResult } from "@google-labs/breadboard/harness";
 
 export type InputArgs = {
   schema?: Schema;
@@ -32,7 +36,7 @@ export type Board = {
 };
 
 export type AnyHistoryEvent =
-  | GraphProbeMessageData
+  | GraphProbeData
   | NodeStartResponse
   | NodeEndResponse;
 

--- a/packages/breadboard/src/harness/types.ts
+++ b/packages/breadboard/src/harness/types.ts
@@ -7,7 +7,7 @@
 import { NodeProxyConfig } from "../remote/config.js";
 import {
   NodeStartResponse,
-  InputPromiseResponse,
+  InputResponse,
   LoadResponse,
   OutputResponse,
 } from "../remote/protocol.js";
@@ -60,7 +60,7 @@ export type LoadResult = {
 
 export type InputResult = {
   type: "input";
-  data: InputPromiseResponse;
+  data: InputResponse;
 };
 
 export type OutputResult = {

--- a/packages/breadboard/src/harness/types.ts
+++ b/packages/breadboard/src/harness/types.ts
@@ -5,13 +5,16 @@
  */
 
 import { NodeProxyConfig } from "../remote/config.js";
+import { LoadResponse } from "../remote/protocol.js";
 import {
-  NodeStartResponse,
   InputResponse,
-  LoadResponse,
+  Kit,
+  NodeDescriptor,
+  NodeStartResponse,
   OutputResponse,
-} from "../remote/protocol.js";
-import { Kit, NodeDescriptor, OutputValues, ProbeMessage } from "../types.js";
+  OutputValues,
+  ProbeMessage,
+} from "../types.js";
 
 export type NodeEndResponse = {
   node: NodeDescriptor;

--- a/packages/breadboard/src/harness/types.ts
+++ b/packages/breadboard/src/harness/types.ts
@@ -7,20 +7,15 @@
 import { NodeProxyConfig } from "../remote/config.js";
 import { LoadResponse } from "../remote/protocol.js";
 import {
+  ErrorResponse,
   InputResponse,
   Kit,
-  NodeDescriptor,
+  NodeEndResponse,
   NodeStartResponse,
   OutputResponse,
   OutputValues,
   ProbeMessage,
 } from "../types.js";
-
-export type NodeEndResponse = {
-  node: NodeDescriptor;
-  path: number[];
-  outputs: OutputValues;
-};
 
 export type ResultType =
   /**
@@ -88,7 +83,7 @@ export type NodeEndResult = {
 
 export type ErrorResult = {
   type: "error";
-  data: { error: string };
+  data: ErrorResponse;
 };
 
 export type EndResult = {

--- a/packages/breadboard/src/index.ts
+++ b/packages/breadboard/src/index.ts
@@ -24,7 +24,7 @@ export type {
   GenericKit,
   GraphDescriptor,
   GraphMetadata,
-  GraphProbeMessageData,
+  GraphProbeData as GraphProbeMessageData,
   InputValues,
   Kit,
   KitConstructor,

--- a/packages/breadboard/src/index.ts
+++ b/packages/breadboard/src/index.ts
@@ -4,59 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+export type * from "./types.js";
+
 export { Board } from "./board.js";
 export { BoardRunner } from "./runner.js";
 export { Node } from "./node.js";
 export { SchemaBuilder } from "./schema.js";
 export { RunResult } from "./run.js";
-export type {
-  BreadboardCapability,
-  BreadboardNode,
-  BreadboardRunner,
-  BreadboardRunResult,
-  BreadboardSlotSpec,
-  BreadboardValidator,
-  BreadboardValidatorMetadata,
-  Capability,
-  ConfigOrLambda,
-  Edge,
-  ErrorCapability,
-  GenericKit,
-  GraphDescriptor,
-  GraphMetadata,
-  GraphProbeData as GraphProbeMessageData,
-  InputValues,
-  Kit,
-  KitConstructor,
-  KitDescriptor,
-  KitReference,
-  LambdaFunction,
-  LambdaNodeInputs,
-  LambdaNodeOutputs,
-  NodeConfiguration,
-  NodeConfigurationConstructor,
-  NodeDescriberFunction,
-  NodeDescriberResult,
-  NodeDescriptor,
-  NodeFactory,
-  NodeHandler,
-  NodeHandlerContext,
-  NodeHandlerFunction,
-  NodeHandlers,
-  NodeIdentifier,
-  NodeTypeIdentifier,
-  NodeValue,
-  NodeValuesQueuesMap,
-  OptionalIdConfiguration,
-  OutputValues,
-  Probe,
-  ProbeMessage,
-  QueuedNodeValuesState,
-  RunResultType,
-  Schema,
-  SubGraphs,
-  TraversalResult,
-} from "./types.js";
 export { TraversalMachine } from "./traversal/machine.js";
 export { MachineResult } from "./traversal/result.js";
 export { toMermaid } from "./mermaid.js";

--- a/packages/breadboard/src/remote/protocol.ts
+++ b/packages/breadboard/src/remote/protocol.ts
@@ -17,13 +17,6 @@ import {
 } from "../types.js";
 
 /**
- * Valid request names: "load", "run", "proxy". A good way to think of
- * these is as a roughly equivalent to the paths in the url.
- * For example, "/load" is a "load" request.
- */
-export type RequestName = "load" | "run" | "proxy";
-
-/**
  * Sent by the client to request loading a board. This is an optional request
  * that may not be implemented in some environments (for example, a cloud
  * function that can only run one board).
@@ -65,17 +58,6 @@ export type LoadResponse = {
    */
   nodes?: NodeDescriptor[];
 };
-
-/**
- * These are markers for individual messages within the request,
- * so that the server can identify which message is which.
- */
-export type RunRequestType = "run" | "input" | "proxy";
-/**
- * These are markers for individual messages within the response,
- * so that the client can identify which message is which.
- */
-export type RunResponseType = "output" | "input" | "proxy";
 
 export type RunState = string;
 

--- a/packages/breadboard/src/remote/protocol.ts
+++ b/packages/breadboard/src/remote/protocol.ts
@@ -6,6 +6,7 @@
 
 import { PatchedReadableStream } from "../stream.js";
 import {
+  ErrorResponse,
   GraphProbeData,
   InputResponse,
   InputValues,
@@ -146,17 +147,6 @@ export type End = Record<string, never>;
 export type EndResponseMessage = ["end", End];
 export type EndRequestMessage = ["end", End];
 
-/**
- * Sent by the server when an error occurs.
- * Error response also indicates that the board is done running.
- * Can only be the last message in the response stream.
- */
-export type ErrorResponse = {
-  /**
-   * The error message.
-   */
-  error: string;
-};
 export type ErrorResponseMessage = ["error", ErrorResponse];
 
 /**

--- a/packages/breadboard/src/remote/protocol.ts
+++ b/packages/breadboard/src/remote/protocol.ts
@@ -6,14 +6,15 @@
 
 import { PatchedReadableStream } from "../stream.js";
 import {
-  GraphProbeMessageData,
+  GraphProbeData,
+  InputResponse,
   InputValues,
   NodeDescriptor,
   NodeEndProbeMessage,
+  NodeStartResponse,
+  OutputResponse,
   OutputValues,
-  Schema,
   SkipProbeMessage,
-  TraversalResult,
 } from "../types.js";
 
 /**
@@ -68,35 +69,8 @@ export type RunState = string;
 export type RunRequest = Record<string, never>;
 export type RunRequestMessage = ["run", RunRequest, RunState?];
 
-/**
- * Sent by a server to supply outputs.
- */
-export type OutputResponse = {
-  /**
-   * The description of the node that is providing output.
-   * @see [NodeDescriptor]
-   */
-  node: NodeDescriptor;
-  /**
-   * The output values that the node is providing.
-   * @see [OutputValues]
-   */
-  outputs: OutputValues;
-};
 export type OutputResponseMessage = ["output", OutputResponse];
 
-/**
- * Sent by a server just before a node is about to run.
- */
-export type NodeStartResponse = {
-  /**
-   * The description of the node that is about to run.
-   * @see [NodeDescriptor]
-   */
-  node: NodeDescriptor;
-  path: number[];
-  state?: string | TraversalResult;
-};
 export type NodeStartResponseMessage = [
   "nodestart",
   NodeStartResponse,
@@ -105,30 +79,12 @@ export type NodeStartResponseMessage = [
 
 export type NodeEndResponseMessage = ["nodeend", NodeEndProbeMessage["data"]];
 
-export type GraphStartResponseMessage = ["graphstart", GraphProbeMessageData];
+export type GraphStartResponseMessage = ["graphstart", GraphProbeData];
 
-export type GraphEndResponseMessage = ["graphend", GraphProbeMessageData];
+export type GraphEndResponseMessage = ["graphend", GraphProbeData];
 
 export type SkipResponseMessage = ["skip", SkipProbeMessage["data"]];
 
-/**
- * Sent by a server to request input.
- * Can only be the last message in the response stream.
- */
-export type InputResponse = {
-  /**
-   * The description of the node that is requesting input.
-   * @see [NodeDescriptor]
-   */
-  node: NodeDescriptor;
-  /**
-   * The input arguments that were given to the node that is requesting input.
-   * These arguments typically contain the schema of the inputs that are
-   * expected.
-   * @see [InputValues]
-   */
-  inputArguments: InputValues & { schema?: Schema };
-};
 export type InputResponseMessage = ["input", InputResponse, RunState];
 
 /**
@@ -255,11 +211,6 @@ export type AnyRunResponseMessage =
   | ProxyPromiseResponseMessage
   | EndResponseMessage
   | ErrorResponseMessage;
-
-// export type RunResponseStream = PatchedReadableStream<AnyRunResponseMessage>;
-// export type RunRequestStream = PatchedReadableStream<AnyRunRequestMessage>;
-// export type WritableRunRequestStream = WritableStream<AnyRunRequestMessage>;
-// export type WritableRunResponseStream = WritableStream<AnyRunResponseMessage>;
 
 export interface ClientBidirectionalStream<Request, Response> {
   writableRequests: WritableStream<Request>;

--- a/packages/breadboard/src/remote/protocol.ts
+++ b/packages/breadboard/src/remote/protocol.ts
@@ -133,7 +133,7 @@ export type SkipResponseMessage = ["skip", SkipProbeMessage["data"]];
  * Sent by a server to request input.
  * Can only be the last message in the response stream.
  */
-export type InputPromiseResponse = {
+export type InputResponse = {
   /**
    * The description of the node that is requesting input.
    * @see [NodeDescriptor]
@@ -147,11 +147,7 @@ export type InputPromiseResponse = {
    */
   inputArguments: InputValues & { schema?: Schema };
 };
-export type InputPromiseResponseMessage = [
-  "input",
-  InputPromiseResponse,
-  RunState
-];
+export type InputResponseMessage = ["input", InputResponse, RunState];
 
 /**
  * Sent by the client to provide inputs, requested by the server.
@@ -273,7 +269,7 @@ export type AnyRunResponseMessage =
   | GraphStartResponseMessage
   | GraphEndResponseMessage
   | SkipResponseMessage
-  | InputPromiseResponseMessage
+  | InputResponseMessage
   | ProxyPromiseResponseMessage
   | EndResponseMessage
   | ErrorResponseMessage;

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -454,19 +454,19 @@ export interface BreadboardValidator {
   ): BreadboardValidator;
 }
 
-export type GraphProbeMessageData = {
+export type GraphProbeData = {
   metadata: GraphMetadata;
   path: number[];
 };
 
 export type GraphStartProbeMessage = {
   type: "graphstart";
-  data: GraphProbeMessageData;
+  data: GraphProbeData;
 };
 
 export type GraphEndProbeMessage = {
   type: "graphend";
-  data: GraphProbeMessageData;
+  data: GraphProbeData;
 };
 
 export type SkipProbeMessage = {
@@ -481,12 +481,7 @@ export type SkipProbeMessage = {
 
 export type NodeStartProbeMessage = {
   type: "nodestart";
-  data: {
-    node: NodeDescriptor;
-    inputs: InputValues;
-    path: number[];
-    state: string | TraversalResult;
-  };
+  data: NodeStartResponse;
 };
 
 export type NodeEndProbeMessage = {
@@ -506,6 +501,54 @@ export type ProbeMessage =
   | SkipProbeMessage
   | NodeStartProbeMessage
   | NodeEndProbeMessage;
+
+/**
+ * Sent by the runner to supply outputs.
+ */
+export type OutputResponse = {
+  /**
+   * The description of the node that is providing output.
+   * @see [NodeDescriptor]
+   */
+  node: NodeDescriptor;
+  /**
+   * The output values that the node is providing.
+   * @see [OutputValues]
+   */
+  outputs: OutputValues;
+};
+
+/**
+ * Sent by the runner just before a node is about to run.
+ */
+export type NodeStartResponse = {
+  /**
+   * The description of the node that is about to run.
+   * @see [NodeDescriptor]
+   */
+  node: NodeDescriptor;
+  inputs: InputValues;
+  path: number[];
+  state?: string | TraversalResult;
+};
+
+/**
+ * Sent by the runner to request input.
+ */
+export type InputResponse = {
+  /**
+   * The description of the node that is requesting input.
+   * @see [NodeDescriptor]
+   */
+  node: NodeDescriptor;
+  /**
+   * The input arguments that were given to the node that is requesting input.
+   * These arguments typically contain the schema of the inputs that are
+   * expected.
+   * @see [InputValues]
+   */
+  inputArguments: InputValues & { schema?: Schema };
+};
 
 // TODO: Remove extending EventTarget once new runner is converted to use
 // reporting.

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -486,13 +486,7 @@ export type NodeStartProbeMessage = {
 
 export type NodeEndProbeMessage = {
   type: "nodeend";
-  data: {
-    node: NodeDescriptor;
-    inputs: InputValues;
-    outputs: OutputValues;
-    validatorMetadata?: BreadboardValidatorMetadata[];
-    path: number[];
-  };
+  data: NodeEndResponse;
 };
 
 export type ProbeMessage =
@@ -501,6 +495,14 @@ export type ProbeMessage =
   | SkipProbeMessage
   | NodeStartProbeMessage
   | NodeEndProbeMessage;
+
+export type NodeEndResponse = {
+  node: NodeDescriptor;
+  inputs: InputValues;
+  outputs: OutputValues;
+  validatorMetadata?: BreadboardValidatorMetadata[];
+  path: number[];
+};
 
 /**
  * Sent by the runner to supply outputs.
@@ -548,6 +550,17 @@ export type InputResponse = {
    * @see [InputValues]
    */
   inputArguments: InputValues & { schema?: Schema };
+};
+
+/**
+ * Sent by the runner when an error occurs.
+ * Error response also indicates that the board is done running.
+ */
+export type ErrorResponse = {
+  /**
+   * The error message.
+   */
+  error: string;
 };
 
 // TODO: Remove extending EventTarget once new runner is converted to use

--- a/packages/breadboard/src/worker/controller.ts
+++ b/packages/breadboard/src/worker/controller.ts
@@ -4,17 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  getStreams,
-  parseWithStreams,
-  stringifyWithStreams,
-} from "../stream.js";
 import { InputValues } from "../types.js";
-import {
-  type ControllerMessage,
-  type RoundTripControllerMessage,
-  VALID_MESSAGE_TYPES,
-} from "./protocol.js";
+import { type ControllerMessage, VALID_MESSAGE_TYPES } from "./protocol.js";
 
 type ResolveFunction<T extends ControllerMessage = ControllerMessage> = (
   value: T
@@ -22,15 +13,9 @@ type ResolveFunction<T extends ControllerMessage = ControllerMessage> = (
 
 type MessageHandler = (e: ControllerMessage) => void;
 
-const replaceStreams = (data: InputValues): InputValues => {
-  const stringified = stringifyWithStreams(data).value;
-  return parseWithStreams(stringified, () => new ReadableStream());
-};
-
 export interface MessageControllerTransport {
   setMessageHandler(messageHandler: MessageHandler): void;
   sendMessage<T extends ControllerMessage>(message: T): void;
-  sendRoundTripMessage<T extends RoundTripControllerMessage>(message: T): void;
 }
 
 export class WorkerTransport implements MessageControllerTransport {
@@ -50,21 +35,8 @@ export class WorkerTransport implements MessageControllerTransport {
     this.#messageHandler = messageHandler;
   }
 
-  sendRoundTripMessage<T extends RoundTripControllerMessage>(message: T) {
-    const streams = getStreams(message.data as InputValues);
-    this.worker.postMessage(message, streams);
-  }
-
   sendMessage<T extends ControllerMessage>(message: T) {
-    const { type } = message;
-    // This is necessary because a stream can only be transferred once,
-    // and both nodeend and nodestart messages need to transfer the same stream,
-    // along with the "output" message
-    if (type === "nodestart" || type === "nodeend") {
-      message.data = replaceStreams(message.data as InputValues);
-    }
-    const streams = getStreams(message.data as InputValues);
-    this.worker.postMessage(message, streams);
+    this.worker.postMessage(message, message.data as InputValues);
   }
 
   #onMessage(e: MessageEvent) {

--- a/packages/breadboard/src/worker/controller.ts
+++ b/packages/breadboard/src/worker/controller.ts
@@ -69,10 +69,7 @@ export class MessageController {
 
   #onMessage(message: ControllerMessage) {
     if (!message.type || !VALID_MESSAGE_TYPES.includes(message.type)) {
-      // This is only used in transition from worker machinery to
-      // remote machinery.
-      if ((message.type as string) === "port-dispatcher-sendport") return;
-      throw new Error(`Invalid message type "${message.type}"`);
+      return;
     }
     if (this.#listener) {
       this.#listener(message);

--- a/packages/breadboard/src/worker/index.ts
+++ b/packages/breadboard/src/worker/index.ts
@@ -8,15 +8,6 @@ export { MessageController, WorkerTransport } from "./controller.js";
 export { WorkerRuntime } from "./worker-runtime.js";
 export type {
   ControllerMessage,
-  NodeStartMessage,
-  EndMessage,
   ErrorMessage,
-  InputRequestMessage,
-  InputResponseMessage,
   LoadRequestMessage,
-  LoadResponseMessage,
-  ProxyRequestMessage,
-  ProxyResponseMessage,
-  OutputMessage,
-  StartMesssage,
 } from "./protocol.js";

--- a/packages/breadboard/src/worker/protocol.ts
+++ b/packages/breadboard/src/worker/protocol.ts
@@ -4,53 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  NodeStartResponse,
-  ErrorResponse,
-  InputPromiseResponse,
-  LoadRequest,
-  LoadResponse,
-  OutputResponse,
-  ProxyPromiseResponse,
-} from "../remote/protocol.js";
-import type { NodeValue, OutputValues } from "../types.js";
+import { ErrorResponse, LoadRequest } from "../remote/protocol.js";
 
-export const VALID_MESSAGE_TYPES = [
-  "load",
-  "start",
-  "input",
-  "output",
-  "nodestart",
-  "nodeend",
-  "proxy",
-  "end",
-  "error",
-  "graphstart",
-  "graphend",
-  "skip",
-] as const;
+export const VALID_MESSAGE_TYPES = ["load", "error"] as const;
 
 export type ControllerMessageType = (typeof VALID_MESSAGE_TYPES)[number];
-
-export type RoundTrip = {
-  id: string;
-};
 
 export type ControllerMessage = {
   id?: string;
   type: ControllerMessageType;
   data: unknown;
-};
-
-export type RoundTripControllerMessage = ControllerMessage & RoundTrip;
-
-export type ControllerMessageBase<
-  Type extends ControllerMessageType,
-  Payload,
-  HasId extends RoundTrip | unknown = unknown
-> = HasId & {
-  type: `${Type}`;
-  data: Payload;
 };
 
 /**
@@ -59,152 +22,10 @@ export type ControllerMessageBase<
  */
 export type LoadRequestMessage = {
   /**
-   * id of the message.
-   */
-  id: string;
-  /**
    * The "load" type signals to the worker that it should load the board.
    */
   type: "load";
   data: LoadRequest;
-};
-
-/**
- * The message that is sent by the worker to the host after it loaded the board.
- */
-export type LoadResponseMessage = {
-  /**
-   * The id of the message.
-   */
-  id: string;
-  /**
-   * The "load" type signals to the host that the worker is responding to a
-   * load request.
-   */
-  type: "load";
-  data: LoadResponse;
-};
-
-/**
- * The message that sent by the host to the worker to start the board.
- */
-export type StartMesssage = {
-  /**
-   * The "start" type signals to the worker that it should start the board.
-   */
-  type: "start";
-  data: unknown;
-};
-
-/**
- * The message that is sent by the worker to the host when the board
- * requests input.
- */
-export type InputRequestMessage = {
-  /**
-   * The id of the message.
-   */
-  id: string;
-  /**
-   * The "input" type signals to the host that the board is requesting input.
-   */
-  type: "input";
-  data: InputPromiseResponse;
-};
-
-/**
- * The message that is sent by the host to the worker after it requested input.
- */
-export type InputResponseMessage = {
-  /**
-   * The id of the message.
-   */
-  id: string;
-  /**
-   * The "input" type signals to the worker that the host is responding to an
-   * input request.
-   */
-  type: "input";
-  /**
-   * The input values that the host is providing to the worker.
-   * @see [NodeValue]
-   */
-  data: NodeValue;
-};
-
-/**
- * The message that is sent by the worker to the host before it runs a node.
- */
-export type NodeStartMessage = {
-  /**
-   * The "nodestart" type signals to the host that the board is about to
-   * run a node.
-   */
-  type: "nodestart";
-  data: NodeStartResponse;
-};
-
-/**
- * The message that is sent by the worker to the host when the board is
- * providing outputs.
- */
-export type OutputMessage = {
-  /**
-   * The "output" type signals to the host that the board is providing outputs.
-   */
-  type: "output";
-  data: OutputResponse;
-};
-
-/**
- * The message that is sent by the worker to the host when the board is
- * requesting to proxy the node.
- */
-export type ProxyRequestMessage = {
-  /**
-   * The id of the message.
-   */
-  id: string;
-  /**
-   * The "proxy" type signals to the host that the board is requesting to proxy
-   * a node.
-   */
-  type: "proxy";
-  data: ProxyPromiseResponse;
-};
-
-/**
- * The message that is sent by the host to the worker after it requested to
- * proxy the node.
- */
-export type ProxyResponseMessage = {
-  /**
-   * The id of the message.
-   */
-  id: string;
-  /**
-   * The "proxy" type signals to the worker that the host is responding to a
-   * proxy request.
-   */
-  type: "proxy";
-  /**
-   * The output values that the host is providing to the board in lieu of
-   * the proxied node.
-   * @see [OutputValues]
-   */
-  data: OutputValues;
-};
-
-/**
- * The message that is sent by the worker to the host when the board is
- * finished running.
- */
-export type EndMessage = {
-  /**
-   * The "end" type signals to the host that the board is finished running.
-   */
-  type: "end";
-  data: unknown;
 };
 
 /**

--- a/packages/breadboard/src/worker/protocol.ts
+++ b/packages/breadboard/src/worker/protocol.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ErrorResponse, LoadRequest } from "../remote/protocol.js";
+import { LoadRequest } from "../remote/protocol.js";
+import { ErrorResponse } from "../types.js";
 
 export const VALID_MESSAGE_TYPES = ["load", "error"] as const;
 

--- a/packages/breadboard/tests/remote/transport.ts
+++ b/packages/breadboard/tests/remote/transport.ts
@@ -8,7 +8,7 @@ import test from "ava";
 import {
   AnyRunRequestMessage,
   AnyRunResponseMessage,
-  InputPromiseResponseMessage,
+  InputResponseMessage,
 } from "../../src/remote/protocol.js";
 import { Board } from "../../src/board.js";
 import { TestKit } from "../helpers/_test-kit.js";
@@ -44,7 +44,7 @@ test("Interruptible streaming", async (t) => {
 
   let intermediateState;
   for await (const result of await run(["run", {}])) {
-    const [type, response, state] = result as InputPromiseResponseMessage;
+    const [type, response, state] = result as InputResponseMessage;
     t.is(type, "input");
     t.is(response.node.type, "input");
     t.deepEqual(response.inputArguments, { foo: "bar" });


### PR DESCRIPTION
- Trim `MessageController` to size.
- Make `MessageController` more forgiving.
- Rename `InputPromiseResponse*` to `InputResponse*`.
- Clean up unused types.
- Move data types from `remote` to `types`.
- Continue massaging response types.
- Just export all types in `breadboard/src/types.ts`.
