### PR TITLE
[breadboard-ui] Include last event time in updates

### DIFF
--- a/packages/breadboard-ui/src/history-tree.ts
+++ b/packages/breadboard-ui/src/history-tree.ts
@@ -8,6 +8,7 @@ import { LitElement, html, css, HTMLTemplateResult, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { HistoryEntry, HistoryEventType } from "./types.js";
 import { classMap } from "lit/directives/class-map.js";
+import { keyed } from "lit/directives/keyed.js";
 
 const enum STATE {
   COLLAPSED = "collapsed",
@@ -574,10 +575,13 @@ export class HistoryTree extends LitElement {
     } else if (entry.graphNodeData === undefined) {
       dataOutput = html`<span class="empty">(none)</span>`;
     } else {
-      dataOutput = html`<bb-json-tree
-        .json=${entry.graphNodeData}
-        autoExpand="true"
-      ></bb-json-tree>`;
+      dataOutput = html`${keyed(
+        this.lastUpdate,
+        html`<bb-json-tree
+          .json=${entry.graphNodeData}
+          autoExpand="true"
+        ></bb-json-tree>`
+      )}`;
     }
 
     const typeLabel = this.#getTypeLabel(entry);

--- a/packages/breadboard-ui/src/ui.ts
+++ b/packages/breadboard-ui/src/ui.ts
@@ -650,6 +650,10 @@ export class UI extends LitElement {
   }
 
   #updateHistoryEntry(event: NodeEndResult) {
+    if (Number.isNaN(this.#lastHistoryEventTime)) {
+      this.#lastHistoryEventTime = globalThis.performance.now();
+    }
+
     const id = pathToId(event.data.path, event.type);
     const entryList = this.#findParentHistoryEntry(event.data.path, event.type);
     const existingEntry = entryList.find((item) => item.id === id);
@@ -680,6 +684,7 @@ export class UI extends LitElement {
       existingEntry.graphNodeData = undefined;
     }
 
+    this.#lastHistoryEventTime = globalThis.performance.now();
     this.requestUpdate();
   }
 

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -209,25 +209,21 @@ export class Main {
       }
 
       case "graphstart": {
-        console.log("graphstart", message.data.path, message);
         this.#ui.graphstart(message);
         break;
       }
 
       case "graphend": {
-        console.log("graphend", message.data.path, message);
         this.#ui.graphend(message);
         break;
       }
 
       case "nodestart": {
-        console.log("nodestart", message.data.path, message);
         this.#ui.nodestart(message);
         break;
       }
 
       case "nodeend": {
-        console.log("nodeend", message.data.path, message);
         this.#ui.nodeend(message);
         break;
       }


### PR DESCRIPTION
I noticed that we don't update the last event time in the `#updateHistoryEntry` function, which we should. This means that we don't get live updates to the history in every case. We also need to key the JSON view off the last updated time so that Lit knows to re-render.