### PR TITLE
Extract state from node

### DIFF
--- a/packages/breadboard/src/new/runner/node.ts
+++ b/packages/breadboard/src/new/runner/node.ts
@@ -47,11 +47,6 @@ export class BaseNode<
 
   #handler?: NodeHandler<InputValues, OutputValues>;
 
-  #inputs: Partial<I>;
-  #constants: Partial<I> = {};
-  #incomingControlWires: AbstractNode[] = [];
-  #outputs?: O;
-
   #scope: ScopeInterface;
 
   constructor(
@@ -78,9 +73,6 @@ export class BaseNode<
     this.id = $id ?? nodeIdVendor.vendId(scope, this.type);
 
     this.configuration = rest as Partial<I>;
-
-    this.#inputs = {};
-    this.#constants = {};
   }
 
   addIncomingEdge(
@@ -106,68 +98,6 @@ export class BaseNode<
     from.outgoing.push(edge);
   }
 
-  receiveInputs(edge: EdgeInterface, inputs: InputValues) {
-    const data =
-      edge.out === "*"
-        ? inputs
-        : edge.out === ""
-        ? {}
-        : inputs[edge.out] !== undefined
-        ? { [edge.in]: inputs[edge.out] }
-        : {};
-    if (edge.constant) this.#constants = { ...this.#constants, ...data };
-    this.#inputs = { ...this.#inputs, ...data };
-
-    if (edge.in === "") this.#incomingControlWires.push(edge.from);
-
-    // return which wires were used
-    return Object.keys(data);
-  }
-
-  /**
-   * Compute required inputs from edges and compare with present inputs
-   *
-   * Required inputs are
-   *  - for all named incoming edges, the presence of any data, irrespective of
-   *    which node they come from
-   *  - at least one of the incoming empty or * wires, if present (TODO: Is that
-   *    correct?)
-   *  - data from at least one node if it already ran (#this.outputs not empty)
-   *
-   * @returns false if none are missing, otherwise string[] of missing inputs.
-   * NOTE: A node with no incoming wires returns an empty array after  first
-   * run.
-   */
-  missingInputs(): string[] | false {
-    if (this.incoming.length === 0 && this.#outputs) return [];
-
-    const requiredKeys = new Set(this.incoming.map((edge) => edge.in));
-
-    const presentKeys = new Set([
-      ...Object.keys(this.configuration),
-      ...Object.keys(this.#inputs),
-      ...Object.keys(this.#constants),
-    ]);
-    if (this.#incomingControlWires.length) presentKeys.add("");
-
-    const missingInputs = [...requiredKeys].filter(
-      (key) => !presentKeys.has(key)
-    );
-    return missingInputs.length ? missingInputs : false;
-  }
-
-  getInputs(): I {
-    return { ...this.configuration, ...(this.#inputs as I) };
-  }
-
-  setOutputs(outputs: O) {
-    this.#outputs = outputs;
-
-    // Clear inputs, reset with constants
-    this.#inputs = { ...this.#constants };
-    this.#incomingControlWires = [];
-  }
-
   #getHandlerDescribe(scope: ScopeInterface) {
     const handler = this.#handler ?? scope.getHandler(this.type);
     return handler && typeof handler !== "function"
@@ -181,7 +111,7 @@ export class BaseNode<
   //
   // The logic from BuilderNode.invoke should be somehow called from here, for
   // deserialized nodes that require the Builder environment.
-  async invoke(dynamicScope?: Scope): Promise<O> {
+  async invoke(inputs: I, dynamicScope?: Scope): Promise<O> {
     const scope = dynamicScope ?? (this.#scope as Scope);
 
     const handler: NodeHandler | undefined =
@@ -192,22 +122,17 @@ export class BaseNode<
     const handlerFn = typeof handler === "function" ? handler : handler?.invoke;
 
     if (handlerFn) {
-      result = (await handlerFn(
-        this.getInputs() as I & PromiseLike<I>,
-        this
-      )) as O;
+      result = (await handlerFn(inputs, this)) as O;
     } else if (handler && typeof handler !== "function" && handler.graph) {
       // TODO: This isn't quite right, but good enough for now. Instead what
       // this should be in invoking a graph from a lexical scope in a dynamic
       // scope. This requires moving state management into the dyanmic scope.
       const graphs = handler.graph.getPinnedNodes();
       if (graphs.length !== 1) throw new Error("Expected exactly one graph");
-      result = (await scope.invokeOnce(this.getInputs(), graphs[0])) as O;
+      result = (await scope.invokeOnce(inputs, graphs[0])) as O;
     } else {
       throw new Error(`Can't find handler for ${this.id}`);
     }
-
-    this.setOutputs(result);
 
     return result;
   }

--- a/packages/breadboard/src/new/runner/node.ts
+++ b/packages/breadboard/src/new/runner/node.ts
@@ -124,11 +124,6 @@ export class BaseNode<
     return Object.keys(data);
   }
 
-  receiveConstants(constants: InputValues) {
-    this.#constants = { ...this.#constants, ...constants };
-    this.#inputs = { ...this.#inputs, ...constants };
-  }
-
   /**
    * Compute required inputs from edges and compare with present inputs
    *

--- a/packages/breadboard/src/new/runner/runner.ts
+++ b/packages/breadboard/src/new/runner/runner.ts
@@ -6,7 +6,6 @@
 
 import {
   GraphDescriptor,
-  GraphMetadata,
   NodeDescriptor,
   Edge,
   Kit,

--- a/packages/breadboard/src/new/runner/runner.ts
+++ b/packages/breadboard/src/new/runner/runner.ts
@@ -134,7 +134,7 @@ export class Runner implements BreadboardRunner {
     });
 
     scope.addHandlers({
-      input: async (inputs: InputValues | PromiseLike<InputValues>, node) => {
+      input: async (inputs: InputValues, node: AbstractNode) => {
         let resolver: (outputs: OutputValues) => void;
         const outputsPromise = new Promise<OutputValues>((resolve) => {
           resolver = resolve;

--- a/packages/breadboard/src/new/runner/runner.ts
+++ b/packages/breadboard/src/new/runner/runner.ts
@@ -273,16 +273,6 @@ export class Runner implements BreadboardRunner {
     // TODO: Implement
   }
 
-  static async fromNode(
-    node: AbstractNode,
-    metadata?: GraphMetadata
-  ): Promise<Runner> {
-    const board = new Runner();
-    Object.assign(board, await node.serialize(metadata));
-    board.#anyNode = node;
-    return board;
-  }
-
   static async fromGraphDescriptor(graph: GraphDescriptor): Promise<Runner> {
     const board = new Runner();
     board.nodes = graph.nodes;

--- a/packages/breadboard/src/new/runner/scope.ts
+++ b/packages/breadboard/src/new/runner/scope.ts
@@ -30,7 +30,6 @@ export class Scope implements ScopeInterface {
 
   #handlers: NodeHandlers = {};
   #pinnedNodes: AbstractNode[] = [];
-  #state?: State;
 
   #callbacks: InvokeCallbacks[] = [];
 
@@ -101,7 +100,7 @@ export class Scope implements ScopeInterface {
 
   async invoke(node?: AbstractNode | AbstractNode[]): Promise<void> {
     try {
-      const state = (this.#state ??= new State());
+      const state = new State();
 
       state.queue = (
         node ? (node instanceof Array ? node : [node]) : this.#pinnedNodes

--- a/packages/breadboard/src/new/runner/scope.ts
+++ b/packages/breadboard/src/new/runner/scope.ts
@@ -119,7 +119,7 @@ export class Scope implements ScopeInterface {
 
         const node = state.queue.shift() as AbstractNode;
 
-        const inputs = state.getInputs(node);
+        const inputs = state.shiftInputs(node);
 
         let callbackResult: OutputValues | undefined = undefined;
         for (const callback of callbacks)
@@ -136,8 +136,6 @@ export class Scope implements ScopeInterface {
               },
             };
           }));
-
-        state.hasRun(node);
 
         // Distribute data to outgoing edges
         const unusedPorts = new Set<string>(Object.keys(result));

--- a/packages/breadboard/src/new/runner/scope.ts
+++ b/packages/breadboard/src/new/runner/scope.ts
@@ -106,8 +106,8 @@ export class Scope implements ScopeInterface {
       state.queue = (
         node ? (node instanceof Array ? node : [node]) : this.#pinnedNodes
       ).flatMap((node) =>
-        this.#findAllConnectedNodes(node).filter((node) =>
-          state.missingInputs(node)
+        this.#findAllConnectedNodes(node).filter(
+          (node) => state.missingInputs(node) === false
         )
       );
 

--- a/packages/breadboard/src/new/runner/state.ts
+++ b/packages/breadboard/src/new/runner/state.ts
@@ -18,7 +18,7 @@ export class State implements StateInterface {
   controlWires: Map<AbstractNode, AbstractNode[]> = new Map();
   haveRun: Set<AbstractNode> = new Set();
 
-  receiveInputs(edge: EdgeInterface, inputs: InputValues) {
+  distributeResults(edge: EdgeInterface, inputs: InputValues) {
     const data =
       edge.out === "*"
         ? inputs

--- a/packages/breadboard/src/new/runner/state.ts
+++ b/packages/breadboard/src/new/runner/state.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AbstractNode, InputValues, EdgeInterface } from "./types.js";
+
+class State {
+  queue: AbstractNode[] = [];
+  inputs: Map<AbstractNode, Partial<InputValues>> = new Map();
+  constants: Map<AbstractNode, Partial<InputValues>> = new Map();
+  controlWires: Map<AbstractNode, AbstractNode[]> = new Map();
+  haveRun: Set<AbstractNode> = new Set();
+
+  receiveInputs(node: AbstractNode, edge: EdgeInterface, inputs: InputValues) {
+    const data =
+      edge.out === "*"
+        ? inputs
+        : edge.out === ""
+        ? {}
+        : inputs[edge.out] !== undefined
+        ? { [edge.in]: inputs[edge.out] }
+        : {};
+    if (edge.constant)
+      this.constants.set(node, { ...this.constants.get(node), ...data });
+    this.inputs.set(node, { ...this.inputs.get(node), ...data });
+
+    if (edge.in === "")
+      this.controlWires.set(node, [
+        ...(this.controlWires.get(node) ?? []),
+        edge.from,
+      ]);
+
+    // return which wires were used
+    return Object.keys(data);
+  }
+
+  /**
+   * Compute required inputs from edges and compare with present inputs
+   *
+   * Required inputs are
+   *  - for all named incoming edges, the presence of any data, irrespective of
+   *    which node they come from
+   *  - at least one of the incoming empty or * wires, if present (TODO: Is that
+   *    correct?)
+   *  - data from at least one node if it already ran
+   *
+   * @returns false if none are missing, otherwise string[] of missing inputs.
+   * NOTE: A node with no incoming wires returns an empty array after  first
+   * run.
+   */
+  missingInputs(node: AbstractNode): string[] | false {
+    if (node.incoming.length === 0 && this.haveRun.has(node)) return [];
+
+    const requiredKeys = new Set(node.incoming.map((edge) => edge.in));
+
+    const presentKeys = new Set([
+      ...Object.keys(node.configuration),
+      ...Object.keys(this.inputs.get(node) ?? {}),
+      ...Object.keys(this.constants.get(node) ?? {}),
+    ]);
+    if (this.controlWires.get(node)?.length) presentKeys.add("");
+
+    const missingInputs = [...requiredKeys].filter(
+      (key) => !presentKeys.has(key)
+    );
+    return missingInputs.length ? missingInputs : false;
+  }
+
+  getInputs<I extends InputValues>(node: AbstractNode<I>): I {
+    return { ...node.configuration, ...(this.inputs.get(node) as I) };
+  }
+
+  hasRun(node: AbstractNode) {
+    // Mark as run, clear inputs, reset with constants
+    this.haveRun.add(node);
+    this.inputs.set(node, this.constants.get(node) ?? {});
+    this.controlWires.delete(node);
+  }
+
+  reset() {
+    this.queue = [];
+    this.inputs = new Map();
+    this.constants = new Map();
+    this.controlWires = new Map();
+    this.haveRun = new Set();
+  }
+}

--- a/packages/breadboard/src/new/runner/state.ts
+++ b/packages/breadboard/src/new/runner/state.ts
@@ -73,15 +73,15 @@ export class State implements StateInterface {
     return missingInputs.length ? missingInputs : false;
   }
 
-  getInputs<I extends InputValues>(node: AbstractNode<I>): I {
-    return { ...node.configuration, ...(this.inputs.get(node) as I) };
-  }
+  shiftInputs<I extends InputValues>(node: AbstractNode<I>): I {
+    const inputs = { ...node.configuration, ...(this.inputs.get(node) as I) };
 
-  hasRun(node: AbstractNode) {
     // Mark as run, clear inputs, reset with constants
     this.haveRun.add(node);
     this.inputs.set(node, this.constants.get(node) ?? {});
     this.controlWires.delete(node);
+
+    return inputs;
   }
 
   reset() {

--- a/packages/breadboard/src/new/runner/state.ts
+++ b/packages/breadboard/src/new/runner/state.ts
@@ -4,16 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AbstractNode, InputValues, EdgeInterface } from "./types.js";
+import {
+  AbstractNode,
+  InputValues,
+  EdgeInterface,
+  StateInterface,
+} from "./types.js";
 
-class State {
+export class State implements StateInterface {
   queue: AbstractNode[] = [];
   inputs: Map<AbstractNode, Partial<InputValues>> = new Map();
   constants: Map<AbstractNode, Partial<InputValues>> = new Map();
   controlWires: Map<AbstractNode, AbstractNode[]> = new Map();
   haveRun: Set<AbstractNode> = new Set();
 
-  receiveInputs(node: AbstractNode, edge: EdgeInterface, inputs: InputValues) {
+  receiveInputs(edge: EdgeInterface, inputs: InputValues) {
     const data =
       edge.out === "*"
         ? inputs
@@ -23,12 +28,12 @@ class State {
         ? { [edge.in]: inputs[edge.out] }
         : {};
     if (edge.constant)
-      this.constants.set(node, { ...this.constants.get(node), ...data });
-    this.inputs.set(node, { ...this.inputs.get(node), ...data });
+      this.constants.set(edge.to, { ...this.constants.get(edge.to), ...data });
+    this.inputs.set(edge.to, { ...this.inputs.get(edge.to), ...data });
 
     if (edge.in === "")
-      this.controlWires.set(node, [
-        ...(this.controlWires.get(node) ?? []),
+      this.controlWires.set(edge.to, [
+        ...(this.controlWires.get(edge.to) ?? []),
         edge.from,
       ]);
 

--- a/packages/breadboard/src/new/runner/types.ts
+++ b/packages/breadboard/src/new/runner/types.ts
@@ -108,7 +108,7 @@ export interface StateInterface {
   distributeResults(edge: EdgeInterface, inputs: InputValues): string[];
   missingInputs(node: AbstractNode): string[] | false;
 
-  getInputs<I extends InputValues>(node: AbstractNode<I>): I;
+  shiftInputs<I extends InputValues>(node: AbstractNode<I>): I;
 }
 
 export interface OutputDistribution {

--- a/packages/breadboard/src/new/runner/types.ts
+++ b/packages/breadboard/src/new/runner/types.ts
@@ -105,7 +105,7 @@ export abstract class AbstractNode<
 }
 
 export interface StateInterface {
-  receiveInputs(edge: EdgeInterface, inputs: InputValues): string[];
+  distributeResults(edge: EdgeInterface, inputs: InputValues): string[];
   missingInputs(node: AbstractNode): string[] | false;
 
   getInputs<I extends InputValues>(node: AbstractNode<I>): I;
@@ -123,7 +123,7 @@ export interface OutputDistribution {
 export interface InvokeCallbacks {
   // Called at the top of any iteration.
   // Return true to abort execution.
-  abort?: (scope: ScopeInterface) => boolean | Promise<boolean>;
+  stop?: (scope: ScopeInterface) => boolean | Promise<boolean>;
 
   // Called before a node is invoked.
   // Waits for execution until promise is resolved. (Useful to pause execution)

--- a/packages/breadboard/src/new/runner/types.ts
+++ b/packages/breadboard/src/new/runner/types.ts
@@ -105,10 +105,15 @@ export abstract class AbstractNode<
 }
 
 export interface StateInterface {
-  distributeResults(edge: EdgeInterface, inputs: InputValues): string[];
-  missingInputs(node: AbstractNode): string[] | false;
+  queueUp(node: AbstractNode): void;
+  next(): AbstractNode;
+  done(): boolean;
 
+  processResult(node: AbstractNode, result: OutputValues): OutputDistribution;
+
+  missingInputs(node: AbstractNode): string[] | false;
   shiftInputs<I extends InputValues>(node: AbstractNode<I>): I;
+  distributeResults(edge: EdgeInterface, inputs: InputValues): string[];
 }
 
 export interface OutputDistribution {
@@ -232,7 +237,7 @@ export interface ScopeInterface {
    * @param node Node to invoke, or undefined to invoke all pinned nodes
    * @returns Promise that resolves when all nodes have been invoked
    */
-  invoke(node?: AbstractNode): Promise<void>;
+  invoke(node?: AbstractNode, state?: StateInterface): Promise<void>;
 
   /**
    * Helper to invoke a graph and return the values of the first `output` node

--- a/packages/breadboard/tests/new/runner/state.ts
+++ b/packages/breadboard/tests/new/runner/state.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import test from "ava";
+
+import { BaseNode } from "../../../src/new/runner/node.js";
+import { Scope } from "../../../src/new/runner/scope.js";
+import { State } from "../../../src/new/runner/state.js";
+
+test("transfer data across wires", async (t) => {
+  const scope = new Scope();
+  const node1 = new BaseNode("noop", scope);
+  const node2 = new BaseNode("noop", scope);
+
+  node2.addIncomingEdge(node1, "foo", "foo");
+
+  const state = new State();
+
+  t.false(state.missingInputs(node1));
+  t.like(state.missingInputs(node2), ["foo"]);
+
+  state.distributeResults(
+    { from: node1, to: node2, out: "foo", in: "foo" },
+    { foo: "bar" }
+  );
+
+  t.false(state.missingInputs(node2));
+
+  const inputs = state.shiftInputs(node2);
+  t.deepEqual(inputs, { foo: "bar" });
+
+  t.like(state.missingInputs(node2), ["foo"]);
+});
+
+test("build and empty queue", async (t) => {
+  const scope = new Scope();
+  const node = new BaseNode("noop", scope);
+
+  const state = new State();
+
+  state.distributeResults(
+    { from: node, to: node, out: "foo", in: "foo" },
+    { foo: "1" }
+  );
+
+  state.distributeResults(
+    { from: node, to: node, out: "foo", in: "foo" },
+    { foo: "2" }
+  );
+
+  t.deepEqual(state.shiftInputs(node), { foo: "1" });
+  t.deepEqual(state.shiftInputs(node), { foo: "2" });
+  t.deepEqual(state.shiftInputs(node), {});
+});


### PR DESCRIPTION
Refactored state out of `Node` classes, which is cleaner, but also necessary because the same node instance could appear in different concurrent dynamic scopes down the road.

Now all the logic about triggering nodes, moving data between nodes, etc. are all in one place.
