### PR TITLE
[breadboard/new] Return $state after each round

### DIFF
--- a/packages/breadboard/src/new/recipe-grammar/node.ts
+++ b/packages/breadboard/src/new/recipe-grammar/node.ts
@@ -239,7 +239,7 @@ export class BuilderNode<
           const graphs = handler.graph.getPinnedNodes();
           if (graphs.length !== 1)
             throw new Error("Expected exactly one graph");
-          result = (await scope.invokeOnce(inputs, graphs[0])) as O;
+          result = (await scope.invokeToNextOutput(inputs, graphs[0])) as O;
         } else {
           throw new Error(`Can't find handler for ${this.id}`);
         }

--- a/packages/breadboard/src/new/recipe-grammar/node.ts
+++ b/packages/breadboard/src/new/recipe-grammar/node.ts
@@ -239,7 +239,7 @@ export class BuilderNode<
           const graphs = handler.graph.getPinnedNodes();
           if (graphs.length !== 1)
             throw new Error("Expected exactly one graph");
-          result = (await scope.invokeToNextOutput(inputs, graphs[0])) as O;
+          result = (await scope.invokeOneRound(inputs, graphs[0])) as O;
         } else {
           throw new Error(`Can't find handler for ${this.id}`);
         }

--- a/packages/breadboard/src/new/runner/node.ts
+++ b/packages/breadboard/src/new/runner/node.ts
@@ -129,7 +129,7 @@ export class BaseNode<
       // scope. This requires moving state management into the dyanmic scope.
       const graphs = handler.graph.getPinnedNodes();
       if (graphs.length !== 1) throw new Error("Expected exactly one graph");
-      result = (await scope.invokeOnce(inputs, graphs[0])) as O;
+      result = (await scope.invokeToNextOutput(inputs, graphs[0])) as O;
     } else {
       throw new Error(`Can't find handler for ${this.id}`);
     }

--- a/packages/breadboard/src/new/runner/node.ts
+++ b/packages/breadboard/src/new/runner/node.ts
@@ -129,7 +129,7 @@ export class BaseNode<
       // scope. This requires moving state management into the dyanmic scope.
       const graphs = handler.graph.getPinnedNodes();
       if (graphs.length !== 1) throw new Error("Expected exactly one graph");
-      result = (await scope.invokeToNextOutput(inputs, graphs[0])) as O;
+      result = (await scope.invokeOneRound(inputs, graphs[0])) as O;
     } else {
       throw new Error(`Can't find handler for ${this.id}`);
     }

--- a/packages/breadboard/src/new/runner/runner.ts
+++ b/packages/breadboard/src/new/runner/runner.ts
@@ -214,7 +214,7 @@ export class Runner implements BreadboardRunner {
     // TODO: One big difference to before: This will keep running forever, even
     // after the first output is encountered. We need to add a way to abort the
     // run.
-    return scope.invokeToNextOutput(
+    return scope.invokeOneRound(
       args,
       this.#anyNode
     ) as Promise<OriginalOutputValues>;

--- a/packages/breadboard/src/new/runner/runner.ts
+++ b/packages/breadboard/src/new/runner/runner.ts
@@ -194,43 +194,10 @@ export class Runner implements BreadboardRunner {
     }
   }
 
-  // This is mostly copy & pasted from the original
-  async runOnce(
-    inputs: OriginalInputValues,
-    context?: NodeHandlerContext
-  ): Promise<OriginalOutputValues> {
-    const args = { ...inputs, ...this.args };
-
-    try {
-      let outputs: OriginalOutputValues = {};
-
-      for await (const result of this.run(context ?? {})) {
-        if (result.type === "input") {
-          // Pass the inputs to the board. If there are inputs bound to the board
-          // (e.g. from a lambda node that had incoming wires), they will
-          // overwrite supplied inputs.
-          result.inputs = args;
-        } else if (result.type === "output") {
-          outputs = result.outputs;
-          // Exit once we receive the first output.
-          break;
-        }
-      }
-      return outputs;
-    } catch (e) {
-      // Unwrap unhandled error (handled errors are just outputs of the board!)
-      if ((e as { cause: string }).cause)
-        return Promise.resolve({
-          $error: (e as { cause: string }).cause,
-        } as OriginalOutputValues);
-      else throw e;
-    }
-  }
-
   // To discuss: This is the same as runOnce() above, but implemented in
   // parallel to run(), using different (and very simple) proxied input and
   // output nodes.
-  async runOnce2(
+  async runOnce(
     inputs: OriginalInputValues,
     context?: NodeHandlerContext
   ): Promise<OriginalOutputValues> {
@@ -242,30 +209,15 @@ export class Runner implements BreadboardRunner {
     const scope = new Scope({ lexicalScope: this.#scope });
 
     context?.kits?.forEach((kit) => scope.addHandlers(handlersFromKit(kit)));
-
-    let resolver: (outputs: OriginalOutputValues) => void;
-    const promise = new Promise<OriginalOutputValues>((resolve) => {
-      resolver = resolve;
-    });
-
-    scope.addHandlers({
-      input: async () => {
-        return args as InputValues;
-      },
-      output: async (inputs: InputValues | PromiseLike<InputValues>) => {
-        resolver((await inputs) as OriginalOutputValues);
-        return {};
-      },
-    });
-
     if (context?.probe) scope.addCallbacks(createProbeCallbacks(context.probe));
 
     // TODO: One big difference to before: This will keep running forever, even
     // after the first output is encountered. We need to add a way to abort the
     // run.
-    scope.invoke(this.#anyNode);
-
-    return promise;
+    return scope.invokeToNextOutput(
+      args,
+      this.#anyNode
+    ) as Promise<OriginalOutputValues>;
   }
 
   addValidator(_: BreadboardValidator): void {

--- a/packages/breadboard/src/new/runner/scope.ts
+++ b/packages/breadboard/src/new/runner/scope.ts
@@ -99,23 +99,24 @@ export class Scope implements ScopeInterface {
   }
 
   async invoke(
-    node?: AbstractNode | AbstractNode[],
+    node?: AbstractNode | AbstractNode[] | false,
     state: StateInterface = new State()
   ): Promise<void> {
     try {
-      (node ? (node instanceof Array ? node : [node]) : this.#pinnedNodes)
-        .flatMap((node) =>
-          this.#findAllConnectedNodes(node).filter(
-            (node) => state?.missingInputs(node) === false
+      if (node !== false)
+        (node ? (node instanceof Array ? node : [node]) : this.#pinnedNodes)
+          .flatMap((node) =>
+            this.#findAllConnectedNodes(node).filter(
+              (node) => state?.missingInputs(node) === false
+            )
           )
-        )
-        .forEach((node) => state?.queueUp(node));
+          .forEach((node) => state?.queueUp(node));
 
       const callbacks = this.#getAllCallbacks();
 
       while (!state.done()) {
         for (const callback of callbacks)
-          if (await callback.stop?.(this)) return;
+          if (await callback.stop?.(this, state)) return;
 
         const node = state.next();
 
@@ -159,9 +160,10 @@ export class Scope implements ScopeInterface {
     }
   }
 
-  invokeOnce(
+  invokeToNextOutput(
     inputs: InputValues = {},
-    node?: AbstractNode
+    node: AbstractNode | false | undefined = undefined,
+    state?: StateInterface
   ): Promise<OutputValues> {
     let resolver: undefined | ((outputs: OutputValues) => void) = undefined;
     const promise = new Promise<OutputValues>((resolve) => {
@@ -184,9 +186,12 @@ export class Scope implements ScopeInterface {
     let lastNode: AbstractNode | undefined = undefined;
     const lastMissingInputs = new Map<string, string>();
 
+    let stopState: StateInterface | undefined = undefined;
+
     scope.addCallbacks({
-      stop: () => {
+      stop: (_scope, state) => {
         // Once output node was executed, stop execution.
+        if (!resolver) stopState = state;
         return !resolver;
       },
       after: (_scope, node, _inputs, _outputs, distribution) => {
@@ -220,10 +225,16 @@ export class Scope implements ScopeInterface {
       },
     });
 
-    const runner = scope.invoke(node ?? this.#pinnedNodes);
+    const runner = scope.invoke(
+      node !== undefined ? node : this.#pinnedNodes,
+      state
+    );
 
-    // Wait for both, return output values
-    return Promise.all([promise, runner]).then(([outputs]) => outputs);
+    // Wait for both, return output values, and last state if stopped.
+    return Promise.all([promise, runner]).then(([outputs]) => ({
+      ...outputs,
+      ...(stopState ? { $state: stopState } : {}),
+    }));
   }
 
   async serialize(

--- a/packages/breadboard/src/new/runner/scope.ts
+++ b/packages/breadboard/src/new/runner/scope.ts
@@ -160,7 +160,7 @@ export class Scope implements ScopeInterface {
     }
   }
 
-  invokeToNextOutput(
+  invokeOneRound(
     inputs: InputValues = {},
     node: AbstractNode | false | undefined = undefined,
     state?: StateInterface

--- a/packages/breadboard/src/new/runner/scope.ts
+++ b/packages/breadboard/src/new/runner/scope.ts
@@ -30,7 +30,6 @@ export class Scope implements ScopeInterface {
 
   #handlers: NodeHandlers = {};
   #pinnedNodes: AbstractNode[] = [];
-  #state?: State;
 
   #callbacks: InvokeCallbacks[] = [];
 

--- a/packages/breadboard/src/new/runner/scope.ts
+++ b/packages/breadboard/src/new/runner/scope.ts
@@ -30,6 +30,7 @@ export class Scope implements ScopeInterface {
 
   #handlers: NodeHandlers = {};
   #pinnedNodes: AbstractNode[] = [];
+  #state?: State;
 
   #callbacks: InvokeCallbacks[] = [];
 

--- a/packages/breadboard/src/new/runner/scope.ts
+++ b/packages/breadboard/src/new/runner/scope.ts
@@ -165,6 +165,11 @@ export class Scope implements ScopeInterface {
     node: AbstractNode | false | undefined = undefined,
     state?: StateInterface
   ): Promise<OutputValues> {
+    if ("$state" in inputs) {
+      state = inputs["$state"] as StateInterface;
+      delete inputs["$state"];
+    }
+
     let resolver: undefined | ((outputs: OutputValues) => void) = undefined;
     const promise = new Promise<OutputValues>((resolve) => {
       resolver = resolve;

--- a/packages/breadboard/src/new/runner/types.ts
+++ b/packages/breadboard/src/new/runner/types.ts
@@ -128,7 +128,11 @@ export interface OutputDistribution {
 export interface InvokeCallbacks {
   // Called at the top of any iteration.
   // Return true to abort execution.
-  stop?: (scope: ScopeInterface) => boolean | Promise<boolean>;
+  // Use `state` to continue later.
+  stop?: (
+    scope: ScopeInterface,
+    state: StateInterface
+  ) => boolean | Promise<boolean>;
 
   // Called before a node is invoked.
   // Waits for execution until promise is resolved. (Useful to pause execution)
@@ -248,7 +252,11 @@ export interface ScopeInterface {
    *
    * @throws If no output node was called before graph terminates
    */
-  invokeOnce(inputs: InputValues, node?: AbstractNode): Promise<OutputValues>;
+  invokeToNextOutput(
+    inputs: InputValues,
+    node?: AbstractNode,
+    state?: StateInterface
+  ): Promise<OutputValues>;
 
   /**
    * Adds callbacks that are being called before and after each node invocation

--- a/packages/breadboard/src/new/runner/types.ts
+++ b/packages/breadboard/src/new/runner/types.ts
@@ -252,7 +252,7 @@ export interface ScopeInterface {
    *
    * @throws If no output node was called before graph terminates
    */
-  invokeToNextOutput(
+  invokeOneRound(
     inputs: InputValues,
     node?: AbstractNode,
     state?: StateInterface

--- a/packages/breadboard/tests/new/runner/abort-early-in-invokeOnce.ts
+++ b/packages/breadboard/tests/new/runner/abort-early-in-invokeOnce.ts
@@ -34,7 +34,7 @@ test("abort once the first output is called", async (t) => {
 
   scope.addHandlers(handlers);
 
-  const result = await scope.invokeToNextOutput({ foo: "success" });
+  const result = await scope.invokeOneRound({ foo: "success" });
 
   t.like(result, { bar: "success" });
   t.like(result, { $state: { queue: [noop2] } });

--- a/packages/breadboard/tests/new/runner/abort-early-in-invokeOnce.ts
+++ b/packages/breadboard/tests/new/runner/abort-early-in-invokeOnce.ts
@@ -34,8 +34,9 @@ test("abort once the first output is called", async (t) => {
 
   scope.addHandlers(handlers);
 
-  const result = await scope.invokeOnce({ foo: "success" });
+  const result = await scope.invokeToNextOutput({ foo: "success" });
 
-  t.deepEqual(result, { bar: "success" });
+  t.like(result, { bar: "success" });
+  t.like(result, { $state: { queue: [noop2] } });
   t.is(noopCalls, 1);
 });

--- a/packages/breadboard/tests/new/runner/pinning-scopes.ts
+++ b/packages/breadboard/tests/new/runner/pinning-scopes.ts
@@ -77,7 +77,7 @@ test("pin node and invokeOnce scope", async (t) => {
 
   scope.addHandlers(handlers);
 
-  const result = await scope.invokeToNextOutput({ foo: "success" });
+  const result = await scope.invokeOneRound({ foo: "success" });
 
   t.deepEqual(result, { bar: "success" });
 });

--- a/packages/breadboard/tests/new/runner/pinning-scopes.ts
+++ b/packages/breadboard/tests/new/runner/pinning-scopes.ts
@@ -77,7 +77,7 @@ test("pin node and invokeOnce scope", async (t) => {
 
   scope.addHandlers(handlers);
 
-  const result = await scope.invokeOnce({ foo: "success" });
+  const result = await scope.invokeToNextOutput({ foo: "success" });
 
   t.deepEqual(result, { bar: "success" });
 });


### PR DESCRIPTION
`invokeOneRound` (formerly `invokeOnce`) accepts and returns `$state` to enable calling a recipe over multiple rounds.

Currently returns after the first output, next up is
- switch that to returning `$state` when hitting an input after hitting any output (i.e. a complete round), or nothing when done
- (much later, once parallel running works well): Change invoking of graphs so that any output's node data will be immediately distributed, not just when they are all combined