### PR TITLE
[breadboard] Refactor to remove LocalResult abstraction.

### DIFF
--- a/packages/breadboard-ui/src/ui.ts
+++ b/packages/breadboard-ui/src/ui.ts
@@ -26,6 +26,7 @@ import { Input } from "./input.js";
 import { Output, OutputArgs } from "./output.js";
 import {
   AnyRunResult,
+  HarnessRunResult,
   InputResult,
   OutputResult,
 } from "@google-labs/breadboard/harness";
@@ -522,16 +523,16 @@ export class UI extends LitElement {
     globalThis.sessionStorage.setItem("grid-row-bottom", rowBottom);
   }
 
-  #createHistoryEntry(event: AnyRunResult): void {
+  #createHistoryEntry(event: HarnessRunResult): void {
     if (Number.isNaN(this.#lastHistoryEventTime)) {
       this.#lastHistoryEventTime = globalThis.performance.now();
     }
 
     const getNodeData = (): HistoryEntry["graphNodeData"] => {
       if (hasPath(event)) {
-        if (hasStateInfo(event) && typeof event.data.state === "object") {
+        if (hasStateInfo(event) && typeof event.state === "object") {
           const id = hasPath(event) ? event.data.node.id : "";
-          const nodeValues = event.data.state.state.state.get(id);
+          const nodeValues = event.state.state.state.get(id);
           if (!nodeValues) {
             return null;
           }
@@ -695,7 +696,7 @@ export class UI extends LitElement {
   }
 
   async handleStateChange(
-    message: AnyRunResult
+    message: HarnessRunResult
   ): Promise<Record<string, unknown> | void> {
     const nodeId = hasNodeInfo(message) ? message.data.node.id : "";
     await this.renderDiagram(nodeId);

--- a/packages/breadboard-ui/src/ui.ts
+++ b/packages/breadboard-ui/src/ui.ts
@@ -27,13 +27,13 @@ import { Output, OutputArgs } from "./output.js";
 import {
   AnyRunResult,
   InputResult,
-  NodeEndResult,
-  NodeStartResult,
   OutputResult,
 } from "@google-labs/breadboard/harness";
 import {
   NodeConfiguration,
   NodeDescriptor,
+  NodeEndProbeMessage,
+  NodeStartProbeMessage,
   NodeValue,
   ProbeMessage,
 } from "@google-labs/breadboard";
@@ -48,22 +48,25 @@ type ExtendedNodeInformation = {
 type RunResultWithNodeInfo =
   | InputResult
   | OutputResult
-  | NodeStartResult
-  | NodeEndResult;
+  | NodeStartProbeMessage
+  | NodeEndProbeMessage;
 const hasNodeInfo = (event: AnyRunResult): event is RunResultWithNodeInfo =>
   event.type === "input" ||
   event.type === "output" ||
   event.type === "nodestart" ||
   event.type === "nodeend";
 
-type RunResultWithPath = ProbeMessage | NodeStartResult | NodeEndResult;
+type RunResultWithPath =
+  | ProbeMessage
+  | NodeStartProbeMessage
+  | NodeEndProbeMessage;
 const hasPath = (event: AnyRunResult): event is RunResultWithPath =>
   event.type === "nodestart" ||
   event.type === "nodeend" ||
   event.type === "graphstart" ||
   event.type === "graphend";
 
-type RunResultWithState = NodeStartResult;
+type RunResultWithState = NodeStartProbeMessage;
 const hasStateInfo = (event: AnyRunResult): event is RunResultWithState =>
   event.type === "nodestart";
 
@@ -596,7 +599,7 @@ export class UI extends LitElement {
     return entryList;
   }
 
-  #updateHistoryEntry(event: NodeEndResult) {
+  #updateHistoryEntry(event: NodeStartProbeMessage | NodeEndProbeMessage) {
     if (Number.isNaN(this.#lastHistoryEventTime)) {
       this.#lastHistoryEventTime = globalThis.performance.now();
     }
@@ -620,7 +623,7 @@ export class UI extends LitElement {
       return;
     }
 
-    (existingEntry as unknown as NodeEndResult).type = event.type;
+    (existingEntry as unknown as NodeEndProbeMessage).type = event.type;
 
     if (existingEntry.graphNodeData && "outputs" in event.data) {
       existingEntry.graphNodeData.outputs = event.data.outputs;

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -5,11 +5,9 @@
  */
 
 import * as BreadboardUI from "@google-labs/breadboard-ui";
-import {
-  createHarness,
-  HarnessRunResult,
-} from "@google-labs/breadboard/harness";
+import { createHarness } from "@google-labs/breadboard/harness";
 import { createHarnessConfig } from "./config";
+import { InputValues } from "@google-labs/breadboard";
 
 // TODO: Remove once all elements are Lit-based.
 BreadboardUI.register();
@@ -86,7 +84,7 @@ export class Main {
 
         const currentBoardId = this.#boardId;
         for await (const result of harness.run()) {
-          if (result.message.type !== "nodestart") {
+          if (result.type !== "nodestart") {
             await this.#suspendIfPaused();
             if (currentBoardId !== this.#boardId) {
               console.log("Changed board");
@@ -95,9 +93,9 @@ export class Main {
           }
           await sleep(this.#delay);
 
-          const answer = await this.#ui.handleStateChange(result.message);
+          const answer = await this.#ui.handleStateChange(result);
           if (answer) {
-            result.reply(answer);
+            result.reply({ inputs: answer as InputValues });
           }
         }
       }

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -93,9 +93,11 @@ export class Main {
           }
           await sleep(this.#delay);
 
-          const answer = await this.#ui.handleStateChange(result);
+          const answer = (await this.#ui.handleStateChange(
+            result
+          )) as InputValues;
           if (answer) {
-            result.reply({ inputs: answer as InputValues });
+            result.reply({ inputs: answer });
           }
         }
       }

--- a/packages/breadboard/src/harness/result.ts
+++ b/packages/breadboard/src/harness/result.ts
@@ -4,17 +4,82 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AnyRunResult, HarnessResult } from "./types.js";
+import { BreadboardRunResult, ProbeMessage } from "../types.js";
+import { HarnessRunResult } from "./types.js";
 
-export class LocalResult<R extends AnyRunResult> implements HarnessResult<R> {
-  message: R;
-  response?: unknown;
+// import { AnyRunResult } from "./types.js";
 
-  constructor(message: R) {
-    this.message = message;
+// export class LocalResult<R extends AnyRunResult> implements HarnessResult<R> {
+//   message: R;
+//   response?: unknown;
+
+//   constructor(message: R) {
+//     this.message = message;
+//   }
+
+//   reply(reply: unknown) {
+//     this.response = reply;
+//   }
+// }
+
+export const fromProbe = <Probe extends ProbeMessage>(probe: Probe) => {
+  return {
+    type: probe.type,
+    data: probe.data,
+    reply: async () => {
+      // Do nothing
+    },
+  } as HarnessRunResult;
+};
+
+export const fromRunnerResult = <Result extends BreadboardRunResult>(
+  result: Result
+) => {
+  const { type, node } = result;
+  if (type === "input") {
+    const { inputArguments } = result;
+    return {
+      type,
+      data: {
+        node,
+        inputArguments,
+      },
+      reply: async (value) => {
+        result.inputs = value;
+      },
+    } as HarnessRunResult;
+  } else if (type === "output") {
+    const { outputs } = result;
+    return {
+      type,
+      data: {
+        node,
+        outputs,
+      },
+      reply: async () => {
+        // Do nothing
+      },
+    } as HarnessRunResult;
   }
+  throw new Error(`Unknown result type "${type}".`);
+};
 
-  reply(reply: unknown) {
-    this.response = reply;
-  }
-}
+export const endResult = () => {
+  return {
+    type: "end",
+    data: {},
+    reply: async () => {
+      // Do nothing
+    },
+  } as HarnessRunResult;
+};
+
+export const errorResult = (error: string) => {
+  return {
+    type: "error",
+    data: { error },
+    reply: async () => {
+      // Do nothing
+    },
+  } as HarnessRunResult;
+};

--- a/packages/breadboard/src/harness/result.ts
+++ b/packages/breadboard/src/harness/result.ts
@@ -4,28 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { loadRunnerState } from "../serialization.js";
 import { BreadboardRunResult, ProbeMessage } from "../types.js";
 import { HarnessRunResult } from "./types.js";
 
-// import { AnyRunResult } from "./types.js";
-
-// export class LocalResult<R extends AnyRunResult> implements HarnessResult<R> {
-//   message: R;
-//   response?: unknown;
-
-//   constructor(message: R) {
-//     this.message = message;
-//   }
-
-//   reply(reply: unknown) {
-//     this.response = reply;
-//   }
-// }
-
 export const fromProbe = <Probe extends ProbeMessage>(probe: Probe) => {
+  const loadStateIfAny = () => {
+    if (probe.type === "nodestart") {
+      return loadRunnerState(probe.data.state as string).state;
+    }
+    return undefined;
+  };
+  const state = loadStateIfAny();
   return {
     type: probe.type,
     data: probe.data,
+    state,
     reply: async () => {
       // Do nothing
     },
@@ -45,7 +39,7 @@ export const fromRunnerResult = <Result extends BreadboardRunResult>(
         inputArguments,
       },
       reply: async (value) => {
-        result.inputs = value;
+        result.inputs = value.inputs;
       },
     } as HarnessRunResult;
   } else if (type === "output") {

--- a/packages/breadboard/src/harness/secrets.ts
+++ b/packages/breadboard/src/harness/secrets.ts
@@ -5,12 +5,12 @@
  */
 
 import { asRuntimeKit, type OutputValues } from "@google-labs/breadboard";
-import { HarnessRunResult } from "./types.js";
-import { LocalResult } from "./result.js";
+import { SecretResult } from "./types.js";
 import { KitBuilder } from "../kits/builder.js";
+import { ClientRunResult } from "../remote/run.js";
 
 export const createSecretAskingKit = (
-  next: (result: HarnessRunResult) => Promise<void>
+  next: (result: ClientRunResult<SecretResult>) => Promise<void>
 ) => {
   const secretAskingKit = new KitBuilder({
     url: "secret-asking-kit",
@@ -18,9 +18,15 @@ export const createSecretAskingKit = (
     secrets: async (inputs) => {
       const { keys } = inputs as { keys: string[] };
       if (!keys) return {};
-      const result = new LocalResult({ type: "secret", data: { keys } });
-      await next(result);
-      return result.response as OutputValues;
+      let outputs = {};
+      await next({
+        type: "secret",
+        data: { keys },
+        reply: async (value) => {
+          outputs = value.inputs;
+        },
+      });
+      return outputs as OutputValues;
     },
   });
   return asRuntimeKit(secretAskingKit);

--- a/packages/breadboard/src/harness/types.ts
+++ b/packages/breadboard/src/harness/types.ts
@@ -10,8 +10,6 @@ import {
   ErrorResponse,
   InputResponse,
   Kit,
-  NodeEndResponse,
-  NodeStartResponse,
   OutputResponse,
   OutputValues,
   ProbeMessage,
@@ -71,16 +69,6 @@ export type SecretResult = {
   data: { keys: string[] };
 };
 
-export type NodeStartResult = {
-  type: "nodestart";
-  data: NodeStartResponse;
-};
-
-export type NodeEndResult = {
-  type: "nodeend";
-  data: NodeEndResponse;
-};
-
 export type ErrorResult = {
   type: "error";
   data: ErrorResponse;
@@ -97,8 +85,6 @@ export type AnyRunResult = (
   | InputResult
   | OutputResult
   | SecretResult
-  | NodeStartResult
-  | NodeEndResult
   | ErrorResult
   | EndResult
   | ProbeMessage

--- a/packages/breadboard/src/harness/types.ts
+++ b/packages/breadboard/src/harness/types.ts
@@ -6,6 +6,7 @@
 
 import { NodeProxyConfig } from "../remote/config.js";
 import { LoadResponse } from "../remote/protocol.js";
+import { AnyClientRunResult, ClientRunResult } from "../remote/run.js";
 import {
   ErrorResponse,
   InputResponse,
@@ -71,12 +72,9 @@ export type AnyRunResult =
   | EndResult
   | ProbeMessage;
 
-export interface HarnessResult<R extends AnyRunResult> {
-  reply(reply: unknown): void;
-  message: R;
-}
-
-export type HarnessRunResult = HarnessResult<AnyRunResult>;
+export type HarnessRunResult =
+  | AnyClientRunResult
+  | ClientRunResult<SecretResult>;
 
 export interface Harness {
   load(): Promise<LoadResponse>;

--- a/packages/breadboard/src/harness/types.ts
+++ b/packages/breadboard/src/harness/types.ts
@@ -15,81 +15,61 @@ import {
   ProbeMessage,
 } from "../types.js";
 
-export type ResultType =
-  /**
-   * The board has been loaded
-   */
-  | "load"
-  /**
-   * The board is asking for input
-   */
-  | "input"
-  /**
-   * The board is sending output
-   */
-  | "output"
-  /**
-   * Sent before a handler for a particular node is invoked
-   */
-  | "nodestart"
-  /**
-   * Sent after a handler for a particular node is invoked
-   */
-  | "nodeend"
-  /**
-   * Sent when the harness is asking for secret
-   */
-  | "secret"
-  /**
-   * Sent when the board run process reports an error
-   */
-  | "error"
-  /**
-   * Sent when the board run finished
-   */
-  | "end";
-
+/**
+ * The board has been loaded
+ */
 export type LoadResult = {
   type: "load";
   data: LoadResponse;
 };
 
+/**
+ * The board is asking for input
+ */
 export type InputResult = {
   type: "input";
   data: InputResponse;
 };
 
+/**
+ * The board is sending output
+ */
 export type OutputResult = {
   type: "output";
   data: OutputResponse;
 };
 
+/**
+ * Sent when the harness is asking for secret
+ */
 export type SecretResult = {
   type: "secret";
   data: { keys: string[] };
 };
 
+/**
+ * Sent when the board run process reports an error
+ */
 export type ErrorResult = {
   type: "error";
   data: ErrorResponse;
 };
 
+/**
+ * Sent when the board run finished
+ */
 export type EndResult = {
   type: "end";
   data: Record<string, never>;
 };
 
-export type OptionalId = { id?: string };
-
-export type AnyRunResult = (
+export type AnyRunResult =
   | InputResult
   | OutputResult
   | SecretResult
   | ErrorResult
   | EndResult
-  | ProbeMessage
-) &
-  OptionalId;
+  | ProbeMessage;
 
 export interface HarnessResult<R extends AnyRunResult> {
   reply(reply: unknown): void;

--- a/packages/breadboard/src/harness/worker-harness.ts
+++ b/packages/breadboard/src/harness/worker-harness.ts
@@ -117,7 +117,6 @@ export class WorkerHarness implements Harness {
         if (this.#skipDiagnosticMessages(type)) {
           continue;
         }
-        console.log("Harness received:", data);
         await next(data);
       }
     });

--- a/packages/breadboard/src/harness/worker-harness.ts
+++ b/packages/breadboard/src/harness/worker-harness.ts
@@ -7,9 +7,8 @@
 import type { LoadRequestMessage } from "../worker/protocol.js";
 import { MessageController, WorkerTransport } from "../worker/controller.js";
 import type { Harness, HarnessConfig, HarnessRunResult } from "./types.js";
-import { Board, InputValues, asyncGen } from "../index.js";
+import { Board, asyncGen } from "../index.js";
 import { createSecretAskingKit } from "./secrets.js";
-import { LocalResult } from "./result.js";
 import { ProxyServer } from "../remote/proxy.js";
 import {
   PortDispatcher,
@@ -118,11 +117,8 @@ export class WorkerHarness implements Harness {
         if (this.#skipDiagnosticMessages(type)) {
           continue;
         }
-        const result = new LocalResult({ type, data });
-        await next(result);
-        if (type === "input") {
-          data.inputs = result.response as InputValues;
-        }
+        console.log("Harness received:", data);
+        await next(data);
       }
     });
   }

--- a/packages/breadboard/src/remote/protocol.ts
+++ b/packages/breadboard/src/remote/protocol.ts
@@ -178,8 +178,7 @@ export type AnyProxyResponseMessage =
 
 export type AnyRunRequestMessage =
   | RunRequestMessage
-  | InputResolveRequestMessage
-  | ProxyResolveRequestMessage;
+  | InputResolveRequestMessage;
 
 export type AnyRunResponseMessage =
   | OutputResponseMessage
@@ -189,7 +188,6 @@ export type AnyRunResponseMessage =
   | RemoteMessage<GraphEndProbeMessage>
   | RemoteMessage<SkipProbeMessage>
   | InputResponseMessage
-  | ProxyPromiseResponseMessage
   | EndResponseMessage
   | ErrorResponseMessage;
 

--- a/packages/breadboard/src/remote/protocol.ts
+++ b/packages/breadboard/src/remote/protocol.ts
@@ -7,7 +7,8 @@
 import { PatchedReadableStream } from "../stream.js";
 import {
   ErrorResponse,
-  GraphProbeData,
+  GraphEndProbeMessage,
+  GraphStartProbeMessage,
   InputResponse,
   InputValues,
   NodeDescriptor,
@@ -63,6 +64,10 @@ export type LoadResponse = {
 
 export type RunState = string;
 
+type GenericResult = { type: unknown; data: unknown };
+
+type RemoteMessage<T extends GenericResult> = [T["type"], T["data"], RunState?];
+
 /**
  * A run request is an empty object.
  * It basically just pokes the server to start running.
@@ -78,13 +83,13 @@ export type NodeStartResponseMessage = [
   RunState
 ];
 
-export type NodeEndResponseMessage = ["nodeend", NodeEndProbeMessage["data"]];
+export type NodeEndResponseMessage = RemoteMessage<NodeEndProbeMessage>;
 
-export type GraphStartResponseMessage = ["graphstart", GraphProbeData];
+export type GraphStartResponseMessage = RemoteMessage<GraphStartProbeMessage>;
 
-export type GraphEndResponseMessage = ["graphend", GraphProbeData];
+export type GraphEndResponseMessage = RemoteMessage<GraphEndProbeMessage>;
 
-export type SkipResponseMessage = ["skip", SkipProbeMessage["data"]];
+export type SkipResponseMessage = RemoteMessage<SkipProbeMessage>;
 
 export type InputResponseMessage = ["input", InputResponse, RunState];
 

--- a/packages/breadboard/src/remote/protocol.ts
+++ b/packages/breadboard/src/remote/protocol.ts
@@ -13,7 +13,7 @@ import {
   InputValues,
   NodeDescriptor,
   NodeEndProbeMessage,
-  NodeStartResponse,
+  NodeStartProbeMessage,
   OutputResponse,
   OutputValues,
   SkipProbeMessage,
@@ -64,7 +64,7 @@ export type LoadResponse = {
 
 export type RunState = string;
 
-type GenericResult = { type: unknown; data: unknown };
+type GenericResult = { type: string; data: unknown };
 
 type RemoteMessage<T extends GenericResult> = [T["type"], T["data"], RunState?];
 
@@ -76,20 +76,6 @@ export type RunRequest = Record<string, never>;
 export type RunRequestMessage = ["run", RunRequest, RunState?];
 
 export type OutputResponseMessage = ["output", OutputResponse];
-
-export type NodeStartResponseMessage = [
-  "nodestart",
-  NodeStartResponse,
-  RunState
-];
-
-export type NodeEndResponseMessage = RemoteMessage<NodeEndProbeMessage>;
-
-export type GraphStartResponseMessage = RemoteMessage<GraphStartProbeMessage>;
-
-export type GraphEndResponseMessage = RemoteMessage<GraphEndProbeMessage>;
-
-export type SkipResponseMessage = RemoteMessage<SkipProbeMessage>;
 
 export type InputResponseMessage = ["input", InputResponse, RunState];
 
@@ -197,11 +183,11 @@ export type AnyRunRequestMessage =
 
 export type AnyRunResponseMessage =
   | OutputResponseMessage
-  | NodeStartResponseMessage
-  | NodeEndResponseMessage
-  | GraphStartResponseMessage
-  | GraphEndResponseMessage
-  | SkipResponseMessage
+  | RemoteMessage<NodeStartProbeMessage>
+  | RemoteMessage<NodeEndProbeMessage>
+  | RemoteMessage<GraphStartProbeMessage>
+  | RemoteMessage<GraphEndProbeMessage>
+  | RemoteMessage<SkipProbeMessage>
   | InputResponseMessage
   | ProxyPromiseResponseMessage
   | EndResponseMessage

--- a/packages/breadboard/src/remote/protocol.ts
+++ b/packages/breadboard/src/remote/protocol.ts
@@ -17,6 +17,7 @@ import {
   OutputResponse,
   OutputValues,
   SkipProbeMessage,
+  TraversalResult,
 } from "../types.js";
 
 /**
@@ -62,7 +63,7 @@ export type LoadResponse = {
   nodes?: NodeDescriptor[];
 };
 
-export type RunState = string;
+export type RunState = string | TraversalResult;
 
 type GenericResult = { type: string; data: unknown };
 

--- a/packages/breadboard/src/remote/run.ts
+++ b/packages/breadboard/src/remote/run.ts
@@ -12,20 +12,14 @@ import {
   streamsToAsyncIterable,
   stubOutStreams,
 } from "../stream.js";
-import {
-  BreadboardRunResult,
-  InputValues,
-  NodeDescriptor,
-  NodeHandlerContext,
-  OutputValues,
-  RunResultType,
-  TraversalResult,
-} from "../types.js";
+import { InputValues, NodeHandlerContext, OutputValues } from "../types.js";
 import {
   AnyRunRequestMessage,
   AnyRunResponseMessage,
   ClientTransport,
+  InputResolveRequest,
   RunRequestMessage,
+  RunState,
   ServerTransport,
 } from "./protocol.js";
 
@@ -95,6 +89,7 @@ export class RunServer {
           }
         } else if (stop.type === "output") {
           const { node, outputs } = stop;
+          console.log("output", { node, outputs });
           await responses.write(["output", { node, outputs }]);
         }
       }
@@ -114,83 +109,46 @@ export class RunServer {
   }
 }
 
-class ClientRunResult implements BreadboardRunResult {
-  type: RunResultType;
-  node: NodeDescriptor;
-  invocationId = 0;
-  path?: number[];
-
-  #state?: string;
-  #inputArguments: InputValues = {};
-  #outputs: OutputValues = {};
-  #result: WritableResult<AnyRunResponseMessage, AnyRunRequestMessage>;
-
-  constructor(
-    result: WritableResult<AnyRunResponseMessage, AnyRunRequestMessage>
-  ) {
-    this.#result = result;
-
-    const [type, data, state] = result.data;
-    this.#state = state;
-    this.type = type as RunResultType;
-    if (type === "error") {
-      throw new Error("Server experienced an error", { cause: data.error });
-    }
-    if (type !== "graphend" && type !== "graphstart" && type !== "end") {
-      this.node = data.node;
-    } else {
-      // TODO: Remove this hack. Currently necessary, because
-      // BreadboardRunResult and ProbeMessages don't mix.
-      this.node = undefined as unknown as NodeDescriptor;
-    }
-
-    if (
-      type === "nodestart" ||
-      type === "nodeend" ||
-      type === "graphend" ||
-      type === "graphstart"
-    ) {
-      this.path = data.path;
-    }
-
-    if (type === "input") {
-      this.#inputArguments = data.inputArguments;
-    } else if (type === "output" || type == "nodeend") {
-      this.#outputs = data.outputs;
-    }
-  }
-
-  #checkState() {
-    if (!this.#state) {
-      throw new Error("State was not supplied for this ClientRunResult.");
-    }
-  }
-
-  set inputs(inputs: InputValues) {
-    if (this.type !== "input") return;
-    this.#checkState();
-    this.#result.reply(["input", { inputs }, this.#state || ""]);
-  }
-
-  get outputs(): OutputValues {
-    return this.#outputs;
-  }
-
-  get inputArguments(): InputValues {
-    return this.#inputArguments;
-  }
-
-  get state(): TraversalResult {
-    this.#checkState();
-    const runResult = RunResult.load(this.#state || "");
-    return runResult.state;
-  }
-}
-
 type RunClientTransport = ClientTransport<
   AnyRunRequestMessage,
   AnyRunResponseMessage
 >;
+
+type ReplyFunction = {
+  reply: (chunk: AnyRunRequestMessage[1]) => Promise<void>;
+};
+
+type ClientRunResultFromMessage<ResponseMessage> = ResponseMessage extends [
+  string,
+  object,
+  RunState?
+]
+  ? {
+      type: ResponseMessage[0];
+      data: ResponseMessage[1];
+      state?: RunState;
+    } & ReplyFunction
+  : never;
+
+export type AnyClientRunResult =
+  ClientRunResultFromMessage<AnyRunResponseMessage>;
+
+export type ClientRunResult<T> = T & ReplyFunction;
+
+const createRunResult = (
+  response: WritableResult<AnyRunResponseMessage, AnyRunRequestMessage>
+): AnyClientRunResult => {
+  const [type, data, state] = response.data;
+  const reply = async (chunk: AnyRunRequestMessage[1]) => {
+    if (type !== "input") {
+      throw new Error(
+        "For now, we cannot reply to messages other than 'input'."
+      );
+    }
+    await response.reply([type, chunk as InputResolveRequest, state]);
+  };
+  return { type, data, state, reply } as AnyClientRunResult;
+};
 
 export class RunClient {
   #transport: RunClientTransport;
@@ -199,7 +157,7 @@ export class RunClient {
     this.#transport = clientTransport;
   }
 
-  async *run(state?: string): AsyncGenerator<BreadboardRunResult> {
+  async *run(state?: string): AsyncGenerator<AnyClientRunResult> {
     const stream = this.#transport.createClientStream();
     const server = streamsToAsyncIterable(
       stream.writableRequests,
@@ -209,7 +167,7 @@ export class RunClient {
     state && request.push(state);
     await server.start(request);
     for await (const response of server) {
-      yield new ClientRunResult(response);
+      yield createRunResult(response);
     }
   }
 
@@ -217,10 +175,11 @@ export class RunClient {
     let outputs;
 
     for await (const stop of this.run()) {
-      if (stop.type === "input") {
-        stop.inputs = inputs;
-      } else if (stop.type === "output") {
-        outputs = stop.outputs;
+      const { type, data } = stop;
+      if (type === "input") {
+        stop.reply({ inputs });
+      } else if (type === "output") {
+        outputs = data.outputs;
         break;
       }
     }

--- a/packages/breadboard/src/serialization.ts
+++ b/packages/breadboard/src/serialization.ts
@@ -33,8 +33,8 @@ export const saveRunnerState = async (
   return JSON.stringify({ state, type }, replacer);
 };
 
-export const loadRunnerState = (stringifiedState: string) => {
-  const { state: o, type } = JSON.parse(stringifiedState, reviver);
+export const loadRunnerState = (s: string) => {
+  const { state: o, type } = JSON.parse(s, reviver);
   const state = MachineResult.fromObject(o);
   return { state, type };
 };


### PR DESCRIPTION
- Introduce `RemoteMessage` type and start using it.
- Deduplicate types.
- And more type cleanup.
- Remove LocalResult and make a big mess.
- Make breadboard-web work again.
- Make local harness work.
