### PR TITLE
[breadboard-web] Add a simple agent board.

### DIFF
--- a/packages/breadboard-web/docs/graphs/agent.md
+++ b/packages/breadboard-web/docs/graphs/agent.md
@@ -3,12 +3,14 @@
 ```mermaid
 %%{init: 'themeVariables': { 'fontFamily': 'Fira Code, monospace' }}%%
 graph TD;
-generate["invoke <br> id='generate'"] -- "text->result" --> output2{{"output <br> id='output-2'"}}:::output
-generate["invoke <br> id='generate'"] -- "context->context" --> output2{{"output <br> id='output-2'"}}:::output
+assemble["jsonata <br> id='assemble'"] -- "result->context" --> output2{{"output <br> id='output-2'"}}:::output
+generate["invoke <br> id='generate'"] -- "context->generated" --> assemble["jsonata <br> id='assemble'"]
 prompt["promptTemplate <br> id='prompt'"] -- "prompt->text" --> generate["invoke <br> id='generate'"]
+prompt["promptTemplate <br> id='prompt'"] -- "prompt->text" --> assemble["jsonata <br> id='assemble'"]
 input1[/"input <br> id='input-1'"/]:::input -- "template->template" --> prompt["promptTemplate <br> id='prompt'"]
 input1[/"input <br> id='input-1'"/]:::input -- "topic->topic" --> prompt["promptTemplate <br> id='prompt'"]
 input1[/"input <br> id='input-1'"/]:::input -- "generator->path" --> generate["invoke <br> id='generate'"]
+input1[/"input <br> id='input-1'"/]:::input -- "context->context" --> assemble["jsonata <br> id='assemble'"]
 classDef default stroke:#ffab40,fill:#fff2ccff,color:#000
 classDef input stroke:#3c78d8,fill:#c9daf8ff,color:#000
 classDef output stroke:#38761d,fill:#b6d7a8ff,color:#000

--- a/packages/breadboard-web/docs/graphs/agent.md
+++ b/packages/breadboard-web/docs/graphs/agent.md
@@ -1,0 +1,20 @@
+## agent.ts
+
+```mermaid
+%%{init: 'themeVariables': { 'fontFamily': 'Fira Code, monospace' }}%%
+graph TD;
+generate["invoke <br> id='generate'"] -- "text->result" --> output2{{"output <br> id='output-2'"}}:::output
+generate["invoke <br> id='generate'"] -- "context->context" --> output2{{"output <br> id='output-2'"}}:::output
+prompt["promptTemplate <br> id='prompt'"] -- "prompt->text" --> generate["invoke <br> id='generate'"]
+input1[/"input <br> id='input-1'"/]:::input -- "template->template" --> prompt["promptTemplate <br> id='prompt'"]
+input1[/"input <br> id='input-1'"/]:::input -- "topic->topic" --> prompt["promptTemplate <br> id='prompt'"]
+input1[/"input <br> id='input-1'"/]:::input -- "generator->path" --> generate["invoke <br> id='generate'"]
+classDef default stroke:#ffab40,fill:#fff2ccff,color:#000
+classDef input stroke:#3c78d8,fill:#c9daf8ff,color:#000
+classDef output stroke:#38761d,fill:#b6d7a8ff,color:#000
+classDef passthrough stroke:#a64d79,fill:#ead1dcff,color:#000
+classDef slot stroke:#a64d79,fill:#ead1dcff,color:#000
+classDef config stroke:#a64d79,fill:#ead1dcff,color:#000
+classDef secrets stroke:#db4437,fill:#f4cccc,color:#000
+classDef slotted stroke:#a64d79
+```

--- a/packages/breadboard-web/public/graphs/agent.json
+++ b/packages/breadboard-web/public/graphs/agent.json
@@ -4,20 +4,26 @@
   "version": "0.0.1",
   "edges": [
     {
-      "from": "generate",
+      "from": "assemble",
       "to": "output-2",
-      "out": "text",
-      "in": "result"
+      "out": "result",
+      "in": "context"
     },
     {
       "from": "generate",
-      "to": "output-2",
+      "to": "assemble",
       "out": "context",
-      "in": "context"
+      "in": "generated"
     },
     {
       "from": "prompt",
       "to": "generate",
+      "out": "prompt",
+      "in": "text"
+    },
+    {
+      "from": "prompt",
+      "to": "assemble",
       "out": "prompt",
       "in": "text"
     },
@@ -38,6 +44,12 @@
       "to": "generate",
       "out": "generator",
       "in": "path"
+    },
+    {
+      "from": "input-1",
+      "to": "assemble",
+      "out": "context",
+      "in": "context"
     }
   ],
   "nodes": [
@@ -48,20 +60,23 @@
         "schema": {
           "type": "object",
           "properties": {
-            "result": {
-              "type": "string",
-              "title": "result"
-            },
             "context": {
-              "type": "string",
-              "title": "context"
+              "title": "result",
+              "description": "The result of the Jsonata expression",
+              "type": "string"
             }
           },
           "required": [
-            "result",
             "context"
           ]
         }
+      }
+    },
+    {
+      "id": "assemble",
+      "type": "jsonata",
+      "configuration": {
+        "expression": "$append(context ? context, $append([\n      {\n          \"role\": \"user\",\n          \"parts\": [\n              {\n                  \"text\": text\n              }\n          ]\n      }\n  ], [generated]))"
       }
     },
     {
@@ -86,11 +101,11 @@
               "description": "The template with placeholders to fill in.",
               "type": "string",
               "examples": [
-                "You are the most amazing poet who specializes in two-line rhyming poems.\n  Given any topic, you can quickly whip up a two-line rhyming poem about it.\n  Ready?\n\n  The topic is: {{topic}}"
+                "\nYou are a brilliant poet who specializes in two-line rhyming poems.\nGiven any topic, you can quickly whip up a two-line rhyming poem about it.\nReady?\n\nThe topic is: {{topic}}"
               ]
             },
             "topic": {
-              "title": "Instruction",
+              "title": "Topic",
               "examples": [
                 "The universe within us"
               ],
@@ -103,12 +118,20 @@
               "examples": [
                 "gemini-generator.json"
               ]
+            },
+            "context": {
+              "title": "Context",
+              "type": "array",
+              "examples": [
+                "[]"
+              ]
             }
           },
           "required": [
             "template",
             "topic",
-            "generator"
+            "generator",
+            "context"
           ]
         }
       }

--- a/packages/breadboard-web/public/graphs/agent.json
+++ b/packages/breadboard-web/public/graphs/agent.json
@@ -1,0 +1,118 @@
+{
+  "title": "Agent",
+  "description": "A prototype of an agent-like board",
+  "version": "0.0.1",
+  "edges": [
+    {
+      "from": "generate",
+      "to": "output-2",
+      "out": "text",
+      "in": "result"
+    },
+    {
+      "from": "generate",
+      "to": "output-2",
+      "out": "context",
+      "in": "context"
+    },
+    {
+      "from": "prompt",
+      "to": "generate",
+      "out": "prompt",
+      "in": "text"
+    },
+    {
+      "from": "input-1",
+      "to": "prompt",
+      "out": "template",
+      "in": "template"
+    },
+    {
+      "from": "input-1",
+      "to": "prompt",
+      "out": "topic",
+      "in": "topic"
+    },
+    {
+      "from": "input-1",
+      "to": "generate",
+      "out": "generator",
+      "in": "path"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "output-2",
+      "type": "output",
+      "configuration": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string",
+              "title": "result"
+            },
+            "context": {
+              "type": "string",
+              "title": "context"
+            }
+          },
+          "required": [
+            "result",
+            "context"
+          ]
+        }
+      }
+    },
+    {
+      "id": "generate",
+      "type": "invoke",
+      "configuration": {}
+    },
+    {
+      "id": "prompt",
+      "type": "promptTemplate",
+      "configuration": {}
+    },
+    {
+      "id": "input-1",
+      "type": "input",
+      "configuration": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "template": {
+              "title": "Template",
+              "description": "The template with placeholders to fill in.",
+              "type": "string",
+              "examples": [
+                "You are the most amazing poet who specializes in two-line rhyming poems.\n  Given any topic, you can quickly whip up a two-line rhyming poem about it.\n  Ready?\n\n  The topic is: {{topic}}"
+              ]
+            },
+            "topic": {
+              "title": "Instruction",
+              "examples": [
+                "The universe within us"
+              ],
+              "type": "string"
+            },
+            "generator": {
+              "title": "Generator",
+              "description": "The path to the board to invoke.",
+              "type": "string",
+              "examples": [
+                "gemini-generator.json"
+              ]
+            }
+          },
+          "required": [
+            "template",
+            "topic",
+            "generator"
+          ]
+        }
+      }
+    }
+  ],
+  "graphs": {}
+}

--- a/packages/breadboard-web/public/local-boards.json
+++ b/packages/breadboard-web/public/local-boards.json
@@ -5,6 +5,11 @@
     "version": "0.0.2"
   },
   {
+    "title": "Agent",
+    "url": "/graphs/agent.json",
+    "version": "0.0.1"
+  },
+  {
     "title": "Board as Function",
     "url": "/graphs/board-as-function.json",
     "version": "0.0.2"

--- a/packages/breadboard-web/src/boards/agent.ts
+++ b/packages/breadboard-web/src/boards/agent.ts
@@ -8,20 +8,16 @@ import { recipe } from "@google-labs/breadboard";
 import { core } from "@google-labs/core-kit";
 import { starter } from "@google-labs/llm-starter";
 
-export default await recipe(({ topic, template, generator }) => {
+export default await recipe(({ topic, template, generator, context }) => {
   const prompt = starter.promptTemplate({
     $id: "prompt",
-    template: template
-      .title("Template")
-      .isString()
-      .examples(
-        `You are the most amazing poet who specializes in two-line rhyming poems.
-  Given any topic, you can quickly whip up a two-line rhyming poem about it.
-  Ready?
+    template: template.title("Template").isString().examples(`
+You are a brilliant poet who specializes in two-line rhyming poems.
+Given any topic, you can quickly whip up a two-line rhyming poem about it.
+Ready?
 
-  The topic is: {{topic}}`
-      ),
-    topic: topic.title("Instruction").examples("The universe within us"),
+The topic is: {{topic}}`),
+    topic: topic.title("Topic").examples("The universe within us"),
   });
   const generate = core.invoke({
     $id: "generate",
@@ -32,7 +28,24 @@ export default await recipe(({ topic, template, generator }) => {
       .examples("gemini-generator.json"),
   });
 
-  return { result: generate.text, context: generate.context };
+  const assemble = starter.jsonata({
+    $id: "assemble",
+    expression: `$append(context ? context, $append([
+      {
+          "role": "user",
+          "parts": [
+              {
+                  "text": text
+              }
+          ]
+      }
+  ], [generated]))`,
+    generated: generate.context,
+    text: prompt.prompt,
+    context: context.title("Context").isArray().examples("[]"),
+  });
+
+  return { context: assemble.result };
 }).serialize({
   title: "Agent",
   description: "A prototype of an agent-like board",

--- a/packages/breadboard-web/src/boards/agent.ts
+++ b/packages/breadboard-web/src/boards/agent.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { recipe } from "@google-labs/breadboard";
+import { core } from "@google-labs/core-kit";
+import { starter } from "@google-labs/llm-starter";
+
+export default await recipe(({ topic, template, generator }) => {
+  const prompt = starter.promptTemplate({
+    $id: "prompt",
+    template: template
+      .title("Template")
+      .isString()
+      .examples(
+        `You are the most amazing poet who specializes in two-line rhyming poems.
+  Given any topic, you can quickly whip up a two-line rhyming poem about it.
+  Ready?
+
+  The topic is: {{topic}}`
+      ),
+    topic: topic.title("Instruction").examples("The universe within us"),
+  });
+  const generate = core.invoke({
+    $id: "generate",
+    text: prompt.prompt,
+    path: generator
+      .isString()
+      .title("Generator")
+      .examples("gemini-generator.json"),
+  });
+
+  return { result: generate.text, context: generate.context };
+}).serialize({
+  title: "Agent",
+  description: "A prototype of an agent-like board",
+  version: "0.0.1",
+});

--- a/packages/breadboard/src/new/recipe-grammar/types.ts
+++ b/packages/breadboard/src/new/recipe-grammar/types.ts
@@ -294,6 +294,7 @@ export abstract class AbstractValue<T extends NodeValue = NodeValue>
 
   abstract title(title: string): AbstractValue<T>;
   abstract description(description: string): AbstractValue<T>;
+  abstract examples(...examples: string[]): AbstractValue<T>;
 }
 
 /**

--- a/packages/breadboard/src/new/recipe-grammar/value.ts
+++ b/packages/breadboard/src/new/recipe-grammar/value.ts
@@ -243,6 +243,11 @@ export class Value<T extends NodeValue = NodeValue>
     return this;
   }
 
+  examples(...examples: string[]): AbstractValue<T> {
+    this.#schema.examples = examples;
+    return this;
+  }
+
   #remapKeys(newKeys: KeyMap) {
     const newMap = { ...this.#keymap };
     Object.entries(newKeys).forEach(([fromKey, toKey]) => {


### PR DESCRIPTION
- Add support for `examples` Schema field.
- Add the seedling of an agent.
- Teach agent to assemble full context.
