### PR TITLE
[breadboard-ui] Use inputArguments for inputs

### DIFF
--- a/packages/breadboard-ui/src/input-list.ts
+++ b/packages/breadboard-ui/src/input-list.ts
@@ -20,9 +20,6 @@ export class InputList extends LitElement {
   @property()
   lastUpdate: number = Number.NaN;
 
-  @property()
-  showAllInputs = false;
-
   static styles = css`
     :host {
       display: block;
@@ -61,10 +58,7 @@ export class InputList extends LitElement {
     const inputs: InputDescription[] = [];
     for (let idx = this.messagePosition; idx >= 0; idx--) {
       const message = this.messages[idx];
-      if (
-        !message ||
-        (message.type !== "nodestart" && message.type !== "secret")
-      ) {
+      if (!message || (message.type !== "input" && message.type !== "secret")) {
         continue;
       }
 
@@ -96,39 +90,10 @@ export class InputList extends LitElement {
       }
 
       // Capture all inputs.
-      if (message.type === "nodestart" && message.data.node.type === "input") {
-        // It may be that the user wants to see all inputs, and not just those
-        // that require user interaction. If that's not the case, though, we now
-        // need to track forward through any future messsages to decide if
-        // there is an `input` event. If there is then this require(s|d) user
-        // interaction and should be retained in the UI.
-        if (!this.showAllInputs) {
-          let inputShouldBeRetained = false;
-          for (let n = idx + 1; n < this.messages.length; n++) {
-            const nextMessage = this.messages[n];
-
-            // If we land on an input message before the nodeend then we know
-            // this node requires user interaction and should be retained.
-            if (
-              nextMessage.type === "input" &&
-              nextMessage.data.node.id === message.data.node.id
-            ) {
-              inputShouldBeRetained = true;
-            }
-
-            if (nextMessage.type === "nodeend") {
-              break;
-            }
-          }
-
-          if (!inputShouldBeRetained) {
-            continue;
-          }
-        }
-
+      if (message.type === "input") {
         inputs.push({
           id: message.data.node.id,
-          configuration: message.data.node.configuration,
+          configuration: message.data.inputArguments,
           remember: false,
           secret: false,
         });

--- a/packages/breadboard-ui/src/ui.ts
+++ b/packages/breadboard-ui/src/ui.ts
@@ -60,9 +60,6 @@ const enum MODE {
 }
 
 type inputCallback = (data: Record<string, unknown>) => void;
-type UIConfig = {
-  showAllInputs: boolean;
-};
 
 const CONFIG_MEMORY_KEY = "ui-config";
 const DIAGRAM_DEBOUNCE_RENDER_TIMEOUT = 60;
@@ -98,11 +95,6 @@ export class UI extends LitElement {
 
   @state()
   messages: HarnessRunResult[] = [];
-
-  @state()
-  config: UIConfig = {
-    showAllInputs: false,
-  };
 
   #diagram = new Diagram();
   #nodeInfo: Map<string, ExtendedNodeInformation> = new Map();
@@ -501,14 +493,6 @@ export class UI extends LitElement {
       const nodeSelect = evt as NodeSelectEvent;
       this.selectedNode = this.#nodeInfo.get(nodeSelect.id) || null;
     });
-
-    this.#memory.retrieve(CONFIG_MEMORY_KEY).then((value) => {
-      if (!value) {
-        return;
-      }
-
-      this.config = JSON.parse(value) as UIConfig;
-    });
   }
 
   toast(message: string, type: ToastType) {
@@ -766,19 +750,6 @@ export class UI extends LitElement {
     }
   }
 
-  async #toggleConfigOption(key: keyof UIConfig) {
-    if (this.#isUpdatingMemory) {
-      return;
-    }
-
-    this.#isUpdatingMemory = true;
-    this.config[key] = !this.config[key];
-    await this.#memory.store(CONFIG_MEMORY_KEY, JSON.stringify(this.config));
-    this.#isUpdatingMemory = false;
-
-    this.requestUpdate();
-  }
-
   #scheduleDiagramRender() {
     // We do a debounced render here because rendering the Mermaid chart it very
     // expensive, and we can't keep on top of the animation if we render it on
@@ -873,19 +844,9 @@ export class UI extends LitElement {
             <section id="inputs" ${ref(this.#inputRef)}>
                 <header>
                   <h1>Inputs</h1>
-                  <div id="input-options">
-                    <label for="show-all-inputs">Show all inputs</label>
-                    <input
-                      type="checkbox"
-                      id="show-all-inputs"
-                      ?checked=${this.config.showAllInputs}
-                      @input=${() => this.#toggleConfigOption("showAllInputs")}
-                    />
-                  </div>
                 </header>
                 <div id="inputs-list">
                   <bb-input-list
-                    .showAllInputs=${this.config.showAllInputs}
                     .messages=${this.messages}
                     .messagePosition=${this.#messagePosition}
                     @breadboardinputenter=${(event: InputEnterEvent) => {


### PR DESCRIPTION
I was basing the inputs on `nodestart` nodes, but it turns out it's better to use `inputArguments` from the `input` nodes. So that's what this PR changes.