### PR TITLE
[breadboard-ui] Performance improvements

### DIFF
--- a/packages/breadboard-ui/src/history-tree.ts
+++ b/packages/breadboard-ui/src/history-tree.ts
@@ -136,7 +136,6 @@ export class HistoryTree extends LitElement {
 
     thead td:last-of-type {
       padding-right: calc(var(--bb-grid-size) * 5);
-      width: calc(var(--bb-grid-size) * 25);
     }
 
     thead td {
@@ -170,7 +169,6 @@ export class HistoryTree extends LitElement {
     }
 
     td:last-of-type {
-      text-align: right;
       padding-right: calc(var(--bb-grid-size) * 5);
     }
 


### PR DESCRIPTION
I noticed that the default rendering of a large timeline wasn't particularly performant, mostly because we're there are style properties that aren't necessarily cached, and which cause a re-render. This PR adds a guard around both the tracks and the marker so that they are only re-rendered when absolutely necessary.

On a related note, I really like Lit Element and how much easier it makes doing this kind of work 💖 