### PR TITLE
Add a visualizer based on Visual Blocks to breadboard-web

### DIFF
--- a/packages/breadboard-ui/src/elements/diagram/diagram.ts
+++ b/packages/breadboard-ui/src/elements/diagram/diagram.ts
@@ -5,6 +5,7 @@
  */
 
 import { NodeSelectEvent } from "../../events/events.js";
+import { LoadArgs } from "../../types/types.js";
 import {
   assertHTMLElement,
   assertMouseWheelEvent,
@@ -500,7 +501,14 @@ export class Diagram extends HTMLElement {
     this.#translation.y = 0;
   }
 
-  async render(diagram: string, highlightedNode: string) {
+  async render(diagram: string | LoadArgs, highlightedNode: string) {
+    if (!(typeof diagram === 'string')) {
+      if (!diagram.diagram) {
+        throw new Error('No diagram string provided');
+      }
+      diagram = diagram.diagram;
+    }
+
     highlightedNode = highlightedNode.replace(/-/g, "");
     if (highlightedNode) {
       diagram += `\nclass ${highlightedNode} active`;

--- a/packages/breadboard-ui/src/elements/ui-controller/ui-controller.styles.ts
+++ b/packages/breadboard-ui/src/elements/ui-controller/ui-controller.styles.ts
@@ -16,6 +16,7 @@ export const styles = css`
     column-gap: 8px;
     height: 100%;
     margin: 8px;
+    --diagram-display: flex;
   }
 
   @media (orientation: portrait) {
@@ -32,7 +33,7 @@ export const styles = css`
     overflow: auto;
     border: 1px solid rgb(227, 227, 227);
     border-radius: calc(var(--bb-grid-size) * 5);
-    display: flex;
+    display: var(--diagram-display);
   }
 
   #rhs {

--- a/packages/breadboard-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/breadboard-ui/src/elements/ui-controller/ui-controller.ts
@@ -4,12 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { LitElement, html, HTMLTemplateResult, nothing } from "lit";
+import { LitElement, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import { until } from 'lit/directives/until.js';
 import { Board, HistoryEntry, LoadArgs, STATUS } from "../../types/types.js";
 import {
-  BoardUnloadEvent,
   InputEnterEvent,
   MessageTraversalEvent,
   NodeSelectEvent,

--- a/packages/breadboard-ui/src/types/types.ts
+++ b/packages/breadboard-ui/src/types/types.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  GraphDescriptor,
   GraphProbeData,
   NodeDescriptor,
   NodeEndResponse,
@@ -70,6 +71,7 @@ export type LoadArgs = {
   description?: string;
   version?: string;
   diagram?: string;
+  graphDescriptor?: GraphDescriptor;
   url?: string;
   nodes?: NodeDescriptor[];
 };

--- a/packages/breadboard-web/index.html
+++ b/packages/breadboard-web/index.html
@@ -6,7 +6,6 @@
   <title>Breadboard Playground</title>
 </head>
 <body>
-  <script src="https://storage.googleapis.com/tfweb/visual-breadboard/visual_breadboard_bin_202401161150.js"></script>
 
   <script type="module">
     import { Main } from "./src/index.ts";

--- a/packages/breadboard-web/index.html
+++ b/packages/breadboard-web/index.html
@@ -6,6 +6,8 @@
   <title>Breadboard Playground</title>
 </head>
 <body>
+  <script src="https://storage.googleapis.com/tfweb/visual-breadboard/visual_breadboard_bin_202401161150.js"></script>
+
   <script type="module">
     import { Main } from "./src/index.ts";
 

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -11,7 +11,7 @@ import { customElement, property, state } from "lit/decorators.js";
 import { LitElement, html, css, HTMLTemplateResult, nothing } from "lit";
 import * as BreadboardUI from "@google-labs/breadboard-ui";
 import { InputResolveRequest } from "@google-labs/breadboard/remote";
-import { Board } from "@google-labs/breadboard";
+import { Board, GraphDescriptor } from "@google-labs/breadboard";
 import { cache } from "lit/directives/cache.js";
 
 export const getBoardInfo = async (url: string) => {
@@ -20,8 +20,9 @@ export const getBoardInfo = async (url: string) => {
   const { title, description, version } = runner;
   const diagram = runner.mermaid("TD", true);
   const nodes = runner.nodes;
+  const graphDescriptor: GraphDescriptor = runner;
 
-  return { title, description, version, diagram, url, nodes };
+  return { title, description, version, diagram, url, graphDescriptor, nodes };
 };
 
 const enum MODE {
@@ -59,6 +60,7 @@ export class Main extends LitElement {
   #status = BreadboardUI.Types.STATUS.STOPPED;
   #statusObservers: Array<(value: BreadboardUI.Types.STATUS) => void> = [];
   #bootWithUrl: string | null = null;
+  #visualizer: "mermaid" | "visualblocks" = "mermaid";
 
   static styles = css`
     :host {
@@ -244,6 +246,10 @@ export class Main extends LitElement {
     this.embed = currentUrl.searchParams.get("embed") !== null;
     if (boardFromUrl) {
       this.#bootWithUrl = boardFromUrl;
+    }
+    const visualizer = currentUrl.searchParams.get("visualizer");
+    if (visualizer === "mermaid" || visualizer === "visualblocks") {
+      this.#visualizer = visualizer;
     }
 
     if (modeFromUrl) {
@@ -431,6 +437,7 @@ export class Main extends LitElement {
             .loadInfo=${this.loadInfo}
             .status=${this.status}
             .bootWithUrl=${this.#bootWithUrl}
+            .visualizer=${this.#visualizer}
             @breadboardmessagetraversal=${() => {
               if (this.status !== BreadboardUI.Types.STATUS.RUNNING) {
                 return;


### PR DESCRIPTION
Use [Visual Blocks](https://github.com/google/visualblocks) to display the graph of a breadboard. For now, you need to manually add the url query parameter `&visualizer=visualblocks` to activate the new visualizer, but we can add a button to switch between them.

Also, there's a known issue with the Visual Blocks custom element where you need to reload the page after switching graphs. This should be fixed soon.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
