### PR TITLE
Break circular dependency in import graph

### DIFF
--- a/packages/breadboard/src/serialization.ts
+++ b/packages/breadboard/src/serialization.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { MachineResult, TraversalMachine } from "./index.js";
+import { TraversalMachine } from "./traversal/machine.js";
+import { MachineResult } from "./traversal/result.js";
 import { TraversalResult } from "./types.js";
 
 export const replacer = (key: string, value: unknown) => {


### PR DESCRIPTION
There was a circular dependency caused by this import chain:

`board.ts > runner.ts > serialization.ts > index.ts > board.ts` (a few other paths too, but the `serialization.ts > index.ts` import is the culprit in all cases).

This could cause errors like:

```
export class Board extends BoardRunner {
                           ^

ReferenceError: Cannot access 'BoardRunner' before initialization
```

because depending on where you enter that loop, you could end up executing `board.js` before `runner.js`.

This fix is to import `MachineResult` and `TraversalMachine` directly from their source files, instead of via `index.js.