### PR TITLE
Fix registering visual-breadboard multiple times

### DIFF
--- a/packages/breadboard-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/breadboard-ui/src/elements/ui-controller/ui-controller.ts
@@ -429,11 +429,9 @@ export class UI extends LitElement {
     this.#scheduleDiagramRender();
 
     const loadVisualBreadboard = async () => {
-      if (!this.#requestedVB) {
+      if (!this.#requestedVB && customElements.get('visual-breadboard') == null) {
         this.#requestedVB = true;
-        if (customElements.get('visual-breadboard') == null) {
-          await loadScript(VISUALBLOCKS_URL);
-        }
+        await loadScript(VISUALBLOCKS_URL);
         this.#scheduleDiagramRender();
       }
       return html`<visual-breadboard

--- a/packages/breadboard-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/breadboard-ui/src/elements/ui-controller/ui-controller.ts
@@ -58,7 +58,7 @@ type inputCallback = (data: Record<string, unknown>) => void;
 const CONFIG_MEMORY_KEY = "ui-config";
 const DIAGRAM_DEBOUNCE_RENDER_TIMEOUT = 60;
 const VISUALBLOCKS_URL =
-  "https://storage.googleapis.com/tfweb/visual-breadboard/visual_breadboard_bin_202401161150.js";
+  "https://storage.googleapis.com/tfweb/visual-breadboard/visual_breadboard_20240118164814/visual_breadboard_bin.js";
 
 type UIConfig = {
   showNarrowTimeline: boolean;
@@ -431,7 +431,9 @@ export class UI extends LitElement {
     const loadVisualBreadboard = async () => {
       if (!this.#requestedVB) {
         this.#requestedVB = true;
-        await loadScript(VISUALBLOCKS_URL);
+        if (customElements.get('visual-breadboard') == null) {
+          await loadScript(VISUALBLOCKS_URL);
+        }
         this.#scheduleDiagramRender();
       }
       return html`<visual-breadboard


### PR DESCRIPTION
When switching graphs, ui-controller tries to load visual-breadboard again, which throws an error since that custom web component is already loaded from the previous graph. Check if the `visual-breadboard` component already exists in the custom component registry before loading it.

Also, update to a newer visual-breadboard build that fixes css issues and properly wraps incoming calls in ngzone.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
