### PR TITLE
[breadboard] Implement stack-based 'RunState'.

### DIFF
--- a/packages/breadboard-server/tests/writer.ts
+++ b/packages/breadboard-server/tests/writer.ts
@@ -62,6 +62,7 @@ test("writes input", async (t) => {
       pendingOutputs: new Map(),
     },
     "input",
+    undefined,
     0
   );
   await writer.writeInput(stop);
@@ -90,6 +91,7 @@ test("writes output", async (t) => {
       pendingOutputs: new Map(),
     },
     "output",
+    undefined,
     0
   );
   await writer.writeOutput(stop);
@@ -132,6 +134,7 @@ test("transforms state", async (t) => {
       pendingOutputs: new Map(),
     },
     "output",
+    undefined,
     0
   );
   await writer.writeOutput(stop);

--- a/packages/breadboard-ui/src/elements/input/input-list/input-list.ts
+++ b/packages/breadboard-ui/src/elements/input/input-list/input-list.ts
@@ -5,14 +5,14 @@
  */
 
 import { NodeConfiguration, NodeValue } from "@google-labs/breadboard";
-import { AnyRunResult } from "@google-labs/breadboard/harness";
+import { HarnessRunResult } from "@google-labs/breadboard/harness";
 import { LitElement, html, css, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 @customElement("bb-input-list")
 export class InputList extends LitElement {
   @property({ reflect: false })
-  messages: AnyRunResult[] | null = null;
+  messages: HarnessRunResult[] | null = null;
 
   @property({ reflect: true })
   messagePosition = 0;
@@ -29,7 +29,7 @@ export class InputList extends LitElement {
   #obtainProcessedValuesIfAvailable(
     idx: number,
     id: string,
-    messages: AnyRunResult[]
+    messages: HarnessRunResult[]
   ): Record<string, NodeValue> | null {
     for (let i = idx; i < this.messagePosition; i++) {
       const message = messages[i];

--- a/packages/breadboard-ui/src/elements/output/output-list/output-list.ts
+++ b/packages/breadboard-ui/src/elements/output/output-list/output-list.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AnyRunResult } from "@google-labs/breadboard/harness";
+import { HarnessRunResult } from "@google-labs/breadboard/harness";
 import { LitElement, html, css } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { Output } from "../output.js";
@@ -12,7 +12,7 @@ import { Output } from "../output.js";
 @customElement("bb-output-list")
 export class OutputList extends LitElement {
   @property({ reflect: false })
-  messages: AnyRunResult[] | null = null;
+  messages: HarnessRunResult[] | null = null;
 
   @property({ reflect: true })
   messagePosition = 0;

--- a/packages/breadboard-ui/src/elements/timeline-controls/timeline-controls.ts
+++ b/packages/breadboard-ui/src/elements/timeline-controls/timeline-controls.ts
@@ -6,8 +6,10 @@
 
 import { LitElement, html, css, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
-import { AnyRunResult } from "@google-labs/breadboard/harness";
-import { ProbeMessage } from "@google-labs/breadboard";
+import {
+  HarnessProbeResult,
+  HarnessRunResult,
+} from "@google-labs/breadboard/harness";
 import { map } from "lit/directives/map.js";
 import { styleMap } from "lit/directives/style-map.js";
 import { classMap } from "lit/directives/class-map.js";
@@ -15,8 +17,8 @@ import { MessageTraversalEvent } from "../../events/events.js";
 import { repeat } from "lit/directives/repeat.js";
 import { guard } from "lit/directives/guard.js";
 
-type RunResultWithPath = ProbeMessage;
-const hasPath = (event: AnyRunResult): event is RunResultWithPath =>
+type RunResultWithPath = HarnessProbeResult;
+const hasPath = (event: HarnessRunResult): event is RunResultWithPath =>
   event.type === "nodestart" ||
   event.type === "nodeend" ||
   event.type === "graphstart" ||
@@ -37,7 +39,7 @@ type MessageIdx = number;
 @customElement("bb-timeline-controls")
 export class TimelineControls extends LitElement {
   @property({ reflect: false })
-  messages: AnyRunResult[] | null = null;
+  messages: HarnessRunResult[] | null = null;
 
   @property({ reflect: true })
   messagePosition = 0;

--- a/packages/breadboard-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/breadboard-ui/src/elements/ui-controller/ui-controller.ts
@@ -16,7 +16,6 @@ import {
 } from "../../events/events.js";
 import { Diagram } from "../diagram/diagram.js";
 import {
-  AnyRunResult,
   HarnessRunResult,
   InputResult,
   OutputResult,
@@ -57,7 +56,8 @@ type inputCallback = (data: Record<string, unknown>) => void;
 
 const CONFIG_MEMORY_KEY = "ui-config";
 const DIAGRAM_DEBOUNCE_RENDER_TIMEOUT = 60;
-const VISUALBLOCKS_URL = "https://storage.googleapis.com/tfweb/visual-breadboard/visual_breadboard_bin_202401161150.js";
+const VISUALBLOCKS_URL =
+  "https://storage.googleapis.com/tfweb/visual-breadboard/visual_breadboard_bin_202401161150.js";
 
 type UIConfig = {
   showNarrowTimeline: boolean;
@@ -112,7 +112,7 @@ export class UI extends LitElement {
   #memory = longTermMemory;
   #isUpdatingMemory = false;
   #messagePosition = 0;
-  #messageDurations: Map<AnyRunResult, number> = new Map();
+  #messageDurations: Map<HarnessRunResult, number> = new Map();
   #renderTimeout = 0;
   #rendering = false;
 
@@ -168,10 +168,11 @@ export class UI extends LitElement {
     if (this.visualizer === "mermaid") {
       this.#diagram = new Diagram();
       this.style.setProperty("--diagram-display", "flex");
-    } else { // visualizer === "visualblocks"
+    } else {
+      // visualizer === "visualblocks"
       // Load the visualblocks bundle
       await loadScript(VISUALBLOCKS_URL);
-      this.#diagram = document.createElement('visual-breadboard') as any;
+      this.#diagram = document.createElement("visual-breadboard") as any;
       this.style.setProperty("--diagram-display", "block");
     }
 
@@ -431,8 +432,8 @@ export class UI extends LitElement {
       this.#scheduleDiagramRender();
     }
 
-    let maybeDiagram = this.#diagram ?? "Loading..."
-    if ((this.visualizer === "mermaid" && !this.loadInfo.diagram)) {
+    let maybeDiagram = this.#diagram ?? "Loading...";
+    if (this.visualizer === "mermaid" && !this.loadInfo.diagram) {
       maybeDiagram = "No board diagram";
     }
 
@@ -571,9 +572,11 @@ export class UI extends LitElement {
 
 function loadScript(url: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    const script = document.createElement('script');
+    const script = document.createElement("script");
     script.src = url;
-    script.onload = () => {resolve(); };
+    script.onload = () => {
+      resolve();
+    };
     script.onerror = reject;
     document.head.appendChild(script);
   });

--- a/packages/breadboard-ui/src/types/types.ts
+++ b/packages/breadboard-ui/src/types/types.ts
@@ -12,7 +12,7 @@ import {
   NodeStartResponse,
   Schema,
 } from "@google-labs/breadboard";
-import { AnyRunResult } from "@google-labs/breadboard/harness";
+import { HarnessRunResult } from "@google-labs/breadboard/harness";
 
 export const enum HistoryEventType {
   DONE = "done",
@@ -50,7 +50,7 @@ export interface CanvasData {
   };
 }
 
-export type HistoryEntry = AnyRunResult & {
+export type HistoryEntry = HarnessRunResult & {
   id: string;
   guid: string;
   graphNodeData:

--- a/packages/breadboard/src/bubble.ts
+++ b/packages/breadboard/src/bubble.ts
@@ -134,7 +134,7 @@ export class RequestedInputsManager {
         },
       };
       console.log("requestInputResult", requestInputResult);
-      await next(new InputStageResult(requestInputResult, -1));
+      await next(new InputStageResult(requestInputResult, undefined, -1));
       const outputs = await requestInputResult.outputsPromise;
       let value = outputs && outputs[name];
       if (value === undefined) {

--- a/packages/breadboard/src/harness/local.ts
+++ b/packages/breadboard/src/harness/local.ts
@@ -5,7 +5,6 @@
  */
 
 import { Board, asyncGen } from "../index.js";
-import { loadRunnerState } from "../serialization.js";
 import { BreadboardRunResult, Kit, ProbeMessage } from "../types.js";
 import { Diagnostics } from "./diagnostics.js";
 import { RunConfig } from "./run.js";
@@ -15,7 +14,6 @@ const fromProbe = <Probe extends ProbeMessage>(probe: Probe) => {
   const loadStateIfAny = () => {
     if (probe.type === "nodestart") {
       return probe.state;
-      // return loadRunnerState(probe.state as string).state;
     }
     return undefined;
   };

--- a/packages/breadboard/src/harness/local.ts
+++ b/packages/breadboard/src/harness/local.ts
@@ -14,7 +14,7 @@ import { HarnessRunResult } from "./types.js";
 const fromProbe = <Probe extends ProbeMessage>(probe: Probe) => {
   const loadStateIfAny = () => {
     if (probe.type === "nodestart") {
-      return loadRunnerState(probe.data.state as string).state;
+      return loadRunnerState(probe.state as string).state;
     }
     return undefined;
   };

--- a/packages/breadboard/src/harness/local.ts
+++ b/packages/breadboard/src/harness/local.ts
@@ -14,7 +14,8 @@ import { HarnessRunResult } from "./types.js";
 const fromProbe = <Probe extends ProbeMessage>(probe: Probe) => {
   const loadStateIfAny = () => {
     if (probe.type === "nodestart") {
-      return loadRunnerState(probe.state as string).state;
+      return probe.state;
+      // return loadRunnerState(probe.state as string).state;
     }
     return undefined;
   };

--- a/packages/breadboard/src/harness/types.ts
+++ b/packages/breadboard/src/harness/types.ts
@@ -9,13 +9,16 @@ import {
   LoadResponse,
   ServerTransport,
 } from "../remote/protocol.js";
-import { AnyClientRunResult, ClientRunResult } from "../remote/run.js";
+import {
+  AnyClientRunResult,
+  AnyProbeClientRunResult,
+  ClientRunResult,
+} from "../remote/run.js";
 import {
   ErrorResponse,
   InputResponse,
   OutputResponse,
   OutputValues,
-  ProbeMessage,
 } from "../types.js";
 
 /**
@@ -66,17 +69,11 @@ export type EndResult = {
   data: Record<string, never>;
 };
 
-export type AnyRunResult =
-  | InputResult
-  | OutputResult
-  | SecretResult
-  | ErrorResult
-  | EndResult
-  | ProbeMessage;
-
 export type HarnessRunResult =
   | AnyClientRunResult
   | ClientRunResult<SecretResult>;
+
+export type HarnessProbeResult = AnyProbeClientRunResult;
 
 export type SecretHandler = (keys: {
   keys?: string[];

--- a/packages/breadboard/src/harness/worker.ts
+++ b/packages/breadboard/src/harness/worker.ts
@@ -5,7 +5,7 @@
  */
 
 import type { HarnessRunResult } from "./types.js";
-import { asyncGen } from "../index.js";
+import { RunState, asyncGen } from "../index.js";
 import { createSecretAskingKit } from "./secrets.js";
 import { ProxyServer } from "../remote/proxy.js";
 import {
@@ -28,7 +28,7 @@ export const createWorker = (url: string) => {
 export async function* runInWorker(
   workerURL: string,
   config: RunConfig,
-  state?: string
+  state?: RunState
 ) {
   const worker = createWorker(workerURL);
   const dispatcher = new PortDispatcher(worker);

--- a/packages/breadboard/src/index.ts
+++ b/packages/breadboard/src/index.ts
@@ -13,6 +13,7 @@ export { SchemaBuilder } from "./schema.js";
 export { RunResult } from "./run.js";
 export { TraversalMachine } from "./traversal/machine.js";
 export { MachineResult } from "./traversal/result.js";
+export { traversalResultFromStack } from "./stack.js";
 export { toMermaid } from "./mermaid.js";
 export { callHandler } from "./handler.js";
 export { asRuntimeKit } from "./kits/ctors.js";

--- a/packages/breadboard/src/remote.ts
+++ b/packages/breadboard/src/remote.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { RunState } from "./remote/protocol.js";
 import type { NodeValue } from "./types.js";
 
 // Polyfill to make ReadableStream async iterable
@@ -28,7 +29,7 @@ ReadableStream.prototype[Symbol.asyncIterator] ||
 
 export type RemoteRunResult = {
   inputs: NodeValue;
-  state: string;
+  state: RunState;
 };
 
 class BoardStreamer<ResponseType = unknown>

--- a/packages/breadboard/src/remote.ts
+++ b/packages/breadboard/src/remote.ts
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { RunState } from "./remote/protocol.js";
-import type { NodeValue } from "./types.js";
+import type { NodeValue, RunState } from "./types.js";
 
 // Polyfill to make ReadableStream async iterable
 // See https://bugs.chromium.org/p/chromium/issues/detail?id=929585

--- a/packages/breadboard/src/remote.ts
+++ b/packages/breadboard/src/remote.ts
@@ -91,7 +91,7 @@ export async function* runRemote(url: string) {
     const stream = await post(url, inputs, state);
     if (!stream) break;
     for await (const result of stream) {
-      state = result.state;
+      state = JSON.stringify(result.state);
       yield result;
       inputs = result.inputs;
     }

--- a/packages/breadboard/src/remote/protocol.ts
+++ b/packages/breadboard/src/remote/protocol.ts
@@ -141,16 +141,19 @@ export type AnyRunRequestMessage =
   | RunRequestMessage
   | InputResolveRequestMessage;
 
-export type AnyRunResponseMessage =
-  | OutputResponseMessage
+export type AnyProbeMessage =
   | RemoteMessage<NodeStartProbeMessage>
   | RemoteMessage<NodeEndProbeMessage>
   | RemoteMessage<GraphStartProbeMessage>
   | RemoteMessage<GraphEndProbeMessage>
-  | RemoteMessage<SkipProbeMessage>
+  | RemoteMessage<SkipProbeMessage>;
+
+export type AnyRunResponseMessage =
+  | OutputResponseMessage
   | InputResponseMessage
   | EndResponseMessage
-  | ErrorResponseMessage;
+  | ErrorResponseMessage
+  | AnyProbeMessage;
 
 export interface ClientBidirectionalStream<Request, Response> {
   writableRequests: WritableStream<Request>;

--- a/packages/breadboard/src/remote/protocol.ts
+++ b/packages/breadboard/src/remote/protocol.ts
@@ -16,6 +16,7 @@ import {
   NodeStartProbeMessage,
   OutputResponse,
   OutputValues,
+  RunState,
   SkipProbeMessage,
 } from "../types.js";
 
@@ -61,8 +62,6 @@ export type LoadResponse = {
    */
   nodes?: NodeDescriptor[];
 };
-
-export type RunState = string;
 
 type GenericResult = { type: string; data: unknown };
 

--- a/packages/breadboard/src/remote/run.ts
+++ b/packages/breadboard/src/remote/run.ts
@@ -13,12 +13,7 @@ import {
   streamsToAsyncIterable,
   stubOutStreams,
 } from "../stream.js";
-import {
-  InputValues,
-  NodeHandlerContext,
-  OutputValues,
-  TraversalResult,
-} from "../types.js";
+import { InputValues, NodeHandlerContext, OutputValues } from "../types.js";
 import {
   AnyRunRequestMessage,
   AnyRunResponseMessage,
@@ -134,7 +129,7 @@ type ClientRunResultFromMessage<ResponseMessage> = ResponseMessage extends [
   ? {
       type: ResponseMessage[0];
       data: ResponseMessage[1];
-      state?: TraversalResult;
+      state?: RunState;
     } & ReplyFunction
   : never;
 

--- a/packages/breadboard/src/remote/run.ts
+++ b/packages/breadboard/src/remote/run.ts
@@ -7,7 +7,6 @@
 import { Diagnostics } from "../harness/diagnostics.js";
 import { RunResult } from "../run.js";
 import { BoardRunner } from "../runner.js";
-import { loadRunnerState } from "../serialization.js";
 import {
   WritableResult,
   streamsToAsyncIterable,
@@ -20,6 +19,7 @@ import {
   RunState,
 } from "../types.js";
 import {
+  AnyProbeMessage,
   AnyRunRequestMessage,
   AnyRunResponseMessage,
   ClientTransport,
@@ -147,6 +147,9 @@ type ClientRunResultFromMessage<ResponseMessage> = ResponseMessage extends [
 export type AnyClientRunResult =
   ClientRunResultFromMessage<AnyRunResponseMessage>;
 
+export type AnyProbeClientRunResult =
+  ClientRunResultFromMessage<AnyProbeMessage>;
+
 export type ClientRunResult<T> = T & ReplyFunction;
 
 const createRunResult = (
@@ -161,14 +164,10 @@ const createRunResult = (
     }
     await response.reply([type, chunk as InputResolveRequest, state]);
   };
-  const inflateState = (state?: RunState) => {
-    if (!state) return undefined;
-    return typeof state === "string" ? loadRunnerState(state).state : state;
-  };
   return {
     type,
     data,
-    state: inflateState(state),
+    state,
     reply,
   } as AnyClientRunResult;
 };

--- a/packages/breadboard/src/remote/run.ts
+++ b/packages/breadboard/src/remote/run.ts
@@ -30,10 +30,17 @@ import {
 
 const resumeRun = (request: AnyRunRequestMessage) => {
   const [type, , state] = request;
-  // TODO: state is probably not a string here,
-  // it can also be a traversal result
-  const result = state ? RunResult.load(state as string) : undefined;
-  if (result && type === "input") {
+  console.log("resumeRun", type, state);
+
+  // There may not be any state to resume from.
+  if (!state) return undefined;
+
+  if (state.length > 1) {
+    throw new Error("I don't yet know how to resume from nested subgraphs.");
+  }
+
+  const result = RunResult.load(state[0].state as string);
+  if (type === "input") {
     const [, inputs] = request;
     result.inputs = inputs.inputs;
   }
@@ -82,7 +89,7 @@ export class RunServer {
     try {
       for await (const stop of runner.run(servingContext, result)) {
         if (stop.type === "input") {
-          const state = await stop.save();
+          const state = stop.runState as RunState;
           const { node, inputArguments } = stop;
           await responses.write(["input", { node, inputArguments }, state]);
           request = await requestReader.read();
@@ -173,7 +180,7 @@ export class RunClient {
     this.#transport = clientTransport;
   }
 
-  async *run(state?: string): AsyncGenerator<AnyClientRunResult> {
+  async *run(state?: RunState): AsyncGenerator<AnyClientRunResult> {
     const stream = this.#transport.createClientStream();
     const server = streamsToAsyncIterable(
       stream.writableRequests,

--- a/packages/breadboard/src/remote/run.ts
+++ b/packages/breadboard/src/remote/run.ts
@@ -13,13 +13,17 @@ import {
   streamsToAsyncIterable,
   stubOutStreams,
 } from "../stream.js";
-import { InputValues, NodeHandlerContext, OutputValues } from "../types.js";
+import {
+  InputValues,
+  NodeHandlerContext,
+  OutputValues,
+  RunState,
+} from "../types.js";
 import {
   AnyRunRequestMessage,
   AnyRunResponseMessage,
   ClientTransport,
   InputResolveRequest,
-  RunState,
   RunRequestMessage,
   ServerTransport,
 } from "./protocol.js";

--- a/packages/breadboard/src/remote/run.ts
+++ b/packages/breadboard/src/remote/run.ts
@@ -69,10 +69,11 @@ export class RunServer {
     const servingContext = {
       ...context,
       probe: diagnostics
-        ? new Diagnostics(async ({ type, data }) => {
+        ? new Diagnostics(async (message) => {
+            const { type, data } = message;
             const response = [type, stubOutStreams(data)];
             if (type == "nodestart") {
-              response.push(data.state);
+              response.push(message.state);
             }
             await responses.write(response as AnyRunResponseMessage);
           })

--- a/packages/breadboard/src/run.ts
+++ b/packages/breadboard/src/run.ts
@@ -12,20 +12,26 @@ import type {
   TraversalResult,
   BreadboardRunResult,
   RunResultType,
+  RunState,
 } from "./types.js";
 
 export class RunResult implements BreadboardRunResult {
   #type: RunResultType;
   #state: TraversalResult;
+  // TODO: Remove #state and rename this to #state
+  #runState: RunState | undefined;
+  // TODO: Remove this once RunState machinery works
   #invocationId;
 
   constructor(
     state: TraversalResult,
     type: RunResultType,
+    runState: RunState | undefined,
     invocationId: number
   ) {
     this.#state = state;
     this.#type = type;
+    this.#runState = runState;
     this.#invocationId = invocationId;
   }
 
@@ -61,6 +67,10 @@ export class RunResult implements BreadboardRunResult {
     return saveRunnerState(this.#type, this.#state);
   }
 
+  get runState(): RunState | undefined {
+    return this.#runState;
+  }
+
   isAtExitNode(): boolean {
     return (
       this.#state.newOpportunities.length === 0 &&
@@ -71,13 +81,17 @@ export class RunResult implements BreadboardRunResult {
 
   static load(stringifiedResult: string): RunResult {
     const { state, type } = loadRunnerState(stringifiedResult);
-    return new RunResult(state, type, 0);
+    return new RunResult(state, type, undefined, 0);
   }
 }
 
 export class InputStageResult extends RunResult {
-  constructor(state: TraversalResult, invocationId: number) {
-    super(state, "input", invocationId);
+  constructor(
+    state: TraversalResult,
+    runState: RunState | undefined,
+    invocationId: number
+  ) {
+    super(state, "input", runState, invocationId);
   }
 
   get outputs(): OutputValues {
@@ -87,7 +101,7 @@ export class InputStageResult extends RunResult {
 
 export class OutputStageResult extends RunResult {
   constructor(state: TraversalResult, invocationId: number) {
-    super(state, "output", invocationId);
+    super(state, "output", undefined, invocationId);
   }
 
   get inputArguments(): InputValues {

--- a/packages/breadboard/src/runner.ts
+++ b/packages/breadboard/src/runner.ts
@@ -160,8 +160,8 @@ export class BoardRunner implements BreadboardRunner {
             node: descriptor,
             inputs,
             path: path(),
-            state: await saveRunnerState("nodestart", result),
           },
+          state: await saveRunnerState("nodestart", result),
         });
 
         let outputsPromise: Promise<OutputValues> | undefined = undefined;

--- a/packages/breadboard/src/runner.ts
+++ b/packages/breadboard/src/runner.ts
@@ -152,6 +152,7 @@ export class BoardRunner implements BreadboardRunner {
         }
 
         stack.onNodeStart(result);
+        console.log("PATH", JSON.stringify(path()));
 
         await probe?.report?.({
           type: "nodestart",
@@ -187,7 +188,7 @@ export class BoardRunner implements BreadboardRunner {
             kits: [...(context.kits || []), ...this.kits],
             requestInput: requestedInputs.createHandler(next, result),
             invocationPath: path(),
-            state: stack.state(),
+            state: await stack.state(),
           };
 
           outputsPromise = callHandler(

--- a/packages/breadboard/src/serialization.ts
+++ b/packages/breadboard/src/serialization.ts
@@ -30,7 +30,7 @@ export const saveRunnerState = async (
   type: string,
   result: TraversalResult
 ) => {
-  const state = await TraversalMachine.prepareToSafe(result);
+  const state = await TraversalMachine.prepareToSave(result);
   return JSON.stringify({ state, type }, replacer);
 };
 

--- a/packages/breadboard/src/stack.ts
+++ b/packages/breadboard/src/stack.ts
@@ -5,43 +5,37 @@
  */
 
 import { saveRunnerState } from "./serialization.js";
-import { RunStack, TraversalResult } from "./types.js";
+import { RunState, TraversalResult } from "./types.js";
 
 // TODO: Support stream serialization somehow.
 // see https://github.com/breadboard-ai/breadboard/issues/423
 
 export class StackManager {
-  #stack: RunStack;
+  #stack: RunState;
   #result?: TraversalResult;
 
-  constructor(stack?: RunStack) {
+  constructor(stack?: RunState) {
     this.#stack = structuredClone(stack) || [];
   }
 
   onGraphStart(): void {
     this.#stack.push({ graph: 0, node: 0 });
-    console.log("onGraphStart", structuredClone(this.#stack));
-    // TODO: implement
   }
 
   onNodeStart(result: TraversalResult): void {
     this.#stack[this.#stack.length - 1].node++;
     this.#result = result;
-    console.log("onNodeStart", structuredClone(this.#stack));
-    // TODO: implement
   }
 
   onNodeEnd(): void {
-    console.log("onNodeEnd", structuredClone(this.#stack));
     // TODO: implement
   }
 
   onGraphEnd(): void {
-    console.log("onGraphEnd", structuredClone(this.#stack));
     // TODO: implement
   }
 
-  async state(): Promise<RunStack> {
+  async state(): Promise<RunState> {
     // Assemble the stack from existing pieces.
     const stack = structuredClone(this.#stack);
     if (this.#result) {

--- a/packages/breadboard/src/stack.ts
+++ b/packages/breadboard/src/stack.ts
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { saveRunnerState } from "./serialization.js";
 import { RunStack, TraversalResult } from "./types.js";
+
+// TODO: Support stream serialization somehow.
+// see https://github.com/breadboard-ai/breadboard/issues/423
 
 export class StackManager {
   #stack: RunStack;
@@ -37,11 +41,14 @@ export class StackManager {
     // TODO: implement
   }
 
-  state(): RunStack {
+  async state(): Promise<RunStack> {
     // Assemble the stack from existing pieces.
     const stack = structuredClone(this.#stack);
     if (this.#result) {
-      stack[stack.length - 1].state = structuredClone(this.#result);
+      stack[stack.length - 1].state = await saveRunnerState(
+        "nodestart",
+        this.#result
+      );
     }
     return stack;
   }

--- a/packages/breadboard/src/stack.ts
+++ b/packages/breadboard/src/stack.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { RunStack, TraversalResult } from "./types.js";
+
+export class StackManager {
+  #stack: RunStack;
+  #result?: TraversalResult;
+
+  constructor(stack?: RunStack) {
+    this.#stack = structuredClone(stack) || [];
+  }
+
+  onGraphStart(): void {
+    this.#stack.push({ graph: 0, node: 0 });
+    console.log("onGraphStart", structuredClone(this.#stack));
+    // TODO: implement
+  }
+
+  onNodeStart(result: TraversalResult): void {
+    this.#stack[this.#stack.length - 1].node++;
+    this.#result = result;
+    console.log("onNodeStart", structuredClone(this.#stack));
+    // TODO: implement
+  }
+
+  onNodeEnd(): void {
+    console.log("onNodeEnd", structuredClone(this.#stack));
+    // TODO: implement
+  }
+
+  onGraphEnd(): void {
+    console.log("onGraphEnd", structuredClone(this.#stack));
+    // TODO: implement
+  }
+
+  state(): RunStack {
+    // Assemble the stack from existing pieces.
+    const stack = structuredClone(this.#stack);
+    if (this.#result) {
+      stack[stack.length - 1].state = structuredClone(this.#result);
+    }
+    return stack;
+  }
+}

--- a/packages/breadboard/src/stack.ts
+++ b/packages/breadboard/src/stack.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { saveRunnerState } from "./serialization.js";
+import { MachineResult } from "./index.js";
+import { loadRunnerState, saveRunnerState } from "./serialization.js";
 import { RunState, TraversalResult } from "./types.js";
 
 // TODO: Support stream serialization somehow.
@@ -47,3 +48,10 @@ export class StackManager {
     return stack;
   }
 }
+
+export const traversalResultFromStack = (
+  stack: RunState
+): MachineResult | undefined => {
+  const { state } = stack[stack.length - 1];
+  return state ? loadRunnerState(state).state : undefined;
+};

--- a/packages/breadboard/src/traversal/machine.ts
+++ b/packages/breadboard/src/traversal/machine.ts
@@ -46,7 +46,7 @@ export class TraversalMachine implements AsyncIterable<TraversalResult> {
     return new TraversalMachineIterator(this.graph, entryResult);
   }
 
-  static async prepareToSafe(
+  static async prepareToSave(
     result: TraversalResult
   ): Promise<TraversalResult> {
     return await TraversalMachineIterator.processAllPendingNodes(result);

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { RunState } from "./remote/protocol.js";
+
 export type Schema = {
   title?: string;
   description?: string;
@@ -482,7 +484,7 @@ export type SkipProbeMessage = {
 export type NodeStartProbeMessage = {
   type: "nodestart";
   data: NodeStartResponse;
-  state: string;
+  state: RunState;
 };
 
 export type NodeEndProbeMessage = {

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { RunState } from "./remote/protocol.js";
-
 export type Schema = {
   title?: string;
   description?: string;
@@ -455,6 +453,8 @@ export interface BreadboardValidator {
     actualInputs?: string[]
   ): BreadboardValidator;
 }
+
+export type RunState = string;
 
 export type GraphProbeData = {
   metadata: GraphMetadata;

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -593,7 +593,7 @@ export type RunStackEntry = {
   /**
    * The state of the graph traversal at the time of the invocation.
    */
-  state?: TraversalResult;
+  state?: string;
 };
 
 /**

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -570,6 +570,40 @@ export interface Probe extends EventTarget {
   report?(message: ProbeMessage): Promise<void>;
 }
 
+/**
+ * Sequential number of the invocation of a node.
+ * Useful for understanding the relative position of a
+ * given invocation of node within the run.
+ */
+export type InvocationId = number;
+
+/**
+ * Information about a given invocation of a graph and
+ * node within the graph.
+ */
+export type RunStackEntry = {
+  /**
+   * The invocation id of the graph.
+   */
+  graph: InvocationId;
+  /**
+   * The invocation id of the node within that graph.
+   */
+  node: InvocationId;
+  /**
+   * The state of the graph traversal at the time of the invocation.
+   */
+  state?: TraversalResult;
+};
+
+/**
+ * A stack of all invocations of graphs and nodes within the graphs.
+ * The stack is ordered from the outermost graph to the innermost graph
+ * that is currently being run.
+ * Can be used to understand the current state of the run.
+ */
+export type RunStack = RunStackEntry[];
+
 export interface RunnerLike {
   run(
     context?: NodeHandlerContext,
@@ -624,6 +658,7 @@ export interface NodeHandlerContext {
     node: NodeDescriptor
   ) => Promise<NodeValue>;
   readonly invocationPath?: number[];
+  readonly state?: RunStack;
 }
 
 export interface BreadboardNode<Inputs, Outputs> {

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -482,6 +482,7 @@ export type SkipProbeMessage = {
 export type NodeStartProbeMessage = {
   type: "nodestart";
   data: NodeStartResponse;
+  state: string;
 };
 
 export type NodeEndProbeMessage = {
@@ -502,7 +503,6 @@ export type NodeEndResponse = {
   outputs: OutputValues;
   validatorMetadata?: BreadboardValidatorMetadata[];
   path: number[];
-  state?: TraversalResult;
 };
 
 /**
@@ -532,7 +532,6 @@ export type NodeStartResponse = {
   node: NodeDescriptor;
   inputs: InputValues;
   path: number[];
-  state?: string | TraversalResult;
 };
 
 /**

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -454,7 +454,39 @@ export interface BreadboardValidator {
   ): BreadboardValidator;
 }
 
-export type RunState = string;
+/**
+ * Sequential number of the invocation of a node.
+ * Useful for understanding the relative position of a
+ * given invocation of node within the run.
+ */
+export type InvocationId = number;
+
+/**
+ * Information about a given invocation of a graph and
+ * node within the graph.
+ */
+export type RunStackEntry = {
+  /**
+   * The invocation id of the graph.
+   */
+  graph: InvocationId;
+  /**
+   * The invocation id of the node within that graph.
+   */
+  node: InvocationId;
+  /**
+   * The state of the graph traversal at the time of the invocation.
+   */
+  state?: string;
+};
+
+/**
+ * A stack of all invocations of graphs and nodes within the graphs.
+ * The stack is ordered from the outermost graph to the innermost graph
+ * that is currently being run.
+ * Can be used to understand the current state of the run.
+ */
+export type RunState = RunStackEntry[];
 
 export type GraphProbeData = {
   metadata: GraphMetadata;
@@ -571,40 +603,6 @@ export interface Probe extends EventTarget {
   report?(message: ProbeMessage): Promise<void>;
 }
 
-/**
- * Sequential number of the invocation of a node.
- * Useful for understanding the relative position of a
- * given invocation of node within the run.
- */
-export type InvocationId = number;
-
-/**
- * Information about a given invocation of a graph and
- * node within the graph.
- */
-export type RunStackEntry = {
-  /**
-   * The invocation id of the graph.
-   */
-  graph: InvocationId;
-  /**
-   * The invocation id of the node within that graph.
-   */
-  node: InvocationId;
-  /**
-   * The state of the graph traversal at the time of the invocation.
-   */
-  state?: string;
-};
-
-/**
- * A stack of all invocations of graphs and nodes within the graphs.
- * The stack is ordered from the outermost graph to the innermost graph
- * that is currently being run.
- * Can be used to understand the current state of the run.
- */
-export type RunStack = RunStackEntry[];
-
 export interface RunnerLike {
   run(
     context?: NodeHandlerContext,
@@ -659,7 +657,7 @@ export interface NodeHandlerContext {
     node: NodeDescriptor
   ) => Promise<NodeValue>;
   readonly invocationPath?: number[];
-  readonly state?: RunStack;
+  readonly state?: RunState;
 }
 
 export interface BreadboardNode<Inputs, Outputs> {

--- a/packages/breadboard/tests/remote/transport.ts
+++ b/packages/breadboard/tests/remote/transport.ts
@@ -22,6 +22,7 @@ import {
   WorkerClientTransport,
   WorkerServerTransport,
 } from "../../src/remote/worker.js";
+import { RunState } from "../../src/types.js";
 
 test("Interruptible streaming", async (t) => {
   const board = new Board();
@@ -58,7 +59,7 @@ test("Interruptible streaming", async (t) => {
     {
       inputs: { hello: "world" },
     },
-    intermediateState as string,
+    intermediateState as RunState,
   ])) {
     const [type, , state] = result;
     if (type === "output") {
@@ -107,7 +108,7 @@ test("Continuous streaming", async (t) => {
     "input",
     { node: { type: "input" }, inputArguments: { foo: "bar" } },
   ]);
-  writer.write(["input", { inputs: { hello: "world" } }, ""]);
+  writer.write(["input", { inputs: { hello: "world" } }, undefined as never]);
   // second result was "beforehandler" (now "nodestart"), but I removed it
   // because of the refactoring to use diagnostics.
   const thirdResult = await reader.read();


### PR DESCRIPTION
- Sketch out StackManager.
- Shape the `stack.state()` a bit.
- Rename `prepareToSafe` to `prepareToSave`.
- Switch `state` to be on `MessageProbe`.
- Unify state under `RunState` type.
- Move `RunState` to `breadboard/src/types.ts`.
- Switch to use stack-based RunState.
- Start using the new RunState.
