### PR TITLE
[breadboard-cli] Add bundle option

### DIFF
--- a/packages/breadboard-cli/package.json
+++ b/packages/breadboard-cli/package.json
@@ -30,7 +30,7 @@
         "FORCE_COLOR": "1"
       },
       "dependencies": [
-        "../breadboard-web:build"
+        "../breadboard-web:build:tsc"
       ],
       "files": [
         "vite.config.ts",

--- a/packages/breadboard-cli/src/bundle/index.html
+++ b/packages/breadboard-cli/src/bundle/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Breadboard</title>
+    <link rel="stylesheet" href="/styles/preview.css" />
+    <style>
+      html,
+      body {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+    </style>
+  </head>
+  <body>
+    <bb-preview embed="true"></bb-preview>
+    <script type="module">
+      const pageUrl = new URL(window.location.href);
+      pageUrl.searchParams.set("board", "/graphs/bundled-board.json");
+      window.history.replaceState(null, "", pageUrl);
+    </script>
+    <script type="module" src="@google-labs/breadboard-web/preview.js"></script>
+  </body>
+</html>

--- a/packages/breadboard-cli/src/bundle/worker.ts
+++ b/packages/breadboard-cli/src/bundle/worker.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { serve } from "@google-labs/breadboard/harness";
+import { serveConfig } from "@google-labs/breadboard-web/config.js";
+
+serve(serveConfig);

--- a/packages/breadboard-cli/src/commands/bundle.ts
+++ b/packages/breadboard-cli/src/commands/bundle.ts
@@ -1,0 +1,136 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { build } from "vite";
+import { fileURLToPath } from "url";
+import path from "path";
+import fs from "fs/promises";
+import readline from "readline/promises";
+
+export async function bundle(board: string, flags: { output: string }) {
+  let breadboardWebPublic;
+  if (import.meta.resolve) {
+    const publicPath = await import.meta.resolve(
+      "@google-labs/breadboard-web/public"
+    );
+    breadboardWebPublic = fileURLToPath(publicPath);
+  }
+
+  if (!breadboardWebPublic) {
+    console.error("Unable to locate Breadboard files");
+    process.exit(1);
+  }
+
+  const dirName = fileURLToPath(import.meta.url);
+  const bundleDir = path.join(dirName, "..", "..", "..", "..", "src", "bundle");
+
+  if (!path.isAbsolute(flags.output)) {
+    flags.output = path.join(process.cwd(), flags.output);
+  }
+
+  if (!path.isAbsolute(board)) {
+    board = path.join(process.cwd(), board);
+  }
+
+  const query = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+
+  const answer = await query.question(`Write to ${flags.output}? Y/n: `);
+  if (!(answer === "" || answer === "Y" || answer == "y")) {
+    process.exit(1);
+  }
+  query.close();
+
+  await Promise.all([
+    fs.mkdir(flags.output, { recursive: true }),
+    fs.mkdir(path.join(flags.output, "graphs"), { recursive: true }),
+  ]);
+
+  console.log("✨ Bundling...");
+  const bundle = await build({
+    build: {
+      lib: {
+        entry: {
+          index: path.join(bundleDir, "index.html"),
+          worker: path.join(bundleDir, "worker.ts"),
+        },
+        name: "Breaboard",
+        formats: ["es"],
+      },
+      target: "esnext",
+      write: false,
+    },
+    root: bundleDir,
+    publicDir: breadboardWebPublic,
+    logLevel: "silent",
+  });
+
+  console.log("🔨 Writing files...");
+  if (Array.isArray(bundle)) {
+    const [{ output }] = bundle;
+    await Promise.all([
+      // Bundler outputs.
+      ...output.map(async (file) => {
+        const filePath = path.join(flags.output, file.fileName);
+        const dir = path.dirname(filePath);
+        await fs.mkdir(dir, { recursive: true });
+
+        switch (file.type) {
+          case "asset":
+            if (typeof file.source === "string") {
+              return fs.writeFile(filePath, file.source, { encoding: "utf-8" });
+            } else {
+              return fs.writeFile(filePath, file.source);
+            }
+
+          case "chunk":
+            return fs.writeFile(filePath, file.code, { encoding: "utf-8" });
+        }
+      }),
+
+      // The board.
+      fs.copyFile(
+        board,
+        path.join(flags.output, "graphs", "bundled-board.json")
+      ),
+
+      // Styles.
+      fs.cp(
+        path.join(breadboardWebPublic, "styles"),
+        path.join(flags.output, "styles"),
+        { recursive: true }
+      ),
+
+      // Third Party.
+      fs.cp(
+        path.join(breadboardWebPublic, "third_party"),
+        path.join(flags.output, "third_party"),
+        { recursive: true }
+      ),
+
+      // Images.
+      fs.cp(
+        path.join(breadboardWebPublic, "images"),
+        path.join(flags.output, "images"),
+        { recursive: true }
+      ),
+
+      // Boards.
+      fs.cp(
+        path.join(breadboardWebPublic, "graphs"),
+        path.join(flags.output, "graphs"),
+        { recursive: true }
+      ),
+    ]);
+  } else {
+    console.error("Unable to generate bundle - unexpected bundler output");
+    process.exit(1);
+  }
+
+  console.log(`🥳 Written to ${flags.output}`);
+}

--- a/packages/breadboard-cli/src/index.ts
+++ b/packages/breadboard-cli/src/index.ts
@@ -13,8 +13,10 @@ import { mermaid } from "./commands/mermaid.js";
 import { makeGraph } from "./commands/make-graph.js";
 import { run } from "./commands/run.js";
 import { importGraph } from "./commands/import.js";
+import { bundle } from "./commands/bundle.js";
 
 import { program } from "commander";
+import path from "path";
 
 program.version("0.0.1");
 
@@ -31,6 +33,19 @@ program
   .option("-n, --no-save", "Do not save the compiled graph to disk.")
   .option("-w, --watch", "Watch the file for changes.")
   .action(debug);
+
+program
+  .command("bundle [file]")
+  .description("Generates a deployable bundle.")
+  .option(
+    "-o, --output <path>",
+    "Sets the output directory of the compiled graph (current directory by default.)",
+    path.join(
+      process.cwd(),
+      `build-${new Date().toISOString().replaceAll(/\W/gim, "-")}`
+    )
+  )
+  .action(bundle);
 
 program
   .command("import [url]")

--- a/packages/breadboard-web/src/preview.ts
+++ b/packages/breadboard-web/src/preview.ts
@@ -6,7 +6,7 @@
 
 import { HarnessRunResult, run } from "@google-labs/breadboard/harness";
 import { createRunConfig } from "./config";
-import { customElement, state } from "lit/decorators.js";
+import { customElement, property, state } from "lit/decorators.js";
 import { HTMLTemplateResult, LitElement, css, html, nothing } from "lit";
 import * as BreadboardUI from "@google-labs/breadboard-ui";
 import {
@@ -34,14 +34,14 @@ BreadboardUI.register();
 
 @customElement("bb-preview")
 export class Preview extends LitElement {
+  @property({ reflect: true })
+  embed = false;
+
   @state()
   uiElement: HTMLTemplateResult | symbol = nothing;
 
   @state()
   boardInfo: Awaited<ReturnType<typeof getBoardInfo>> | null = null;
-
-  @state()
-  embed = false;
 
   #config: ReturnType<typeof createRunConfig> | null = null;
   #url: string | null = null;


### PR DESCRIPTION
Adds the ability to call `breadboard bundle /path/to/board.json`. This will create a deployable web app based on the Debugger's Preview view.