### PR TITLE
[breadboard-cli] Add warning for nodejs

### DIFF
--- a/packages/breadboard-cli/vite.config.ts
+++ b/packages/breadboard-cli/vite.config.ts
@@ -9,6 +9,10 @@ if (import.meta.resolve) {
     "@google-labs/breadboard-web/public"
   );
   breadboardWebPublic = fileURLToPath(publicPath);
+} else {
+  console.warn(
+    "Unable to resolve breadboard-web resources - you may need a newer nodejs runtime"
+  );
 }
 
 export default defineConfig({


### PR DESCRIPTION
It turns out that `import.meta.resolve` is only available in node 20.6+. For now I'll pop a warning in to let a developer know that building without `resolve` might cause issues.