### PR TITLE
[breadboard-cli] Fix resolver & URLs

### DIFF
--- a/packages/breadboard-cli/src/commands/debug.ts
+++ b/packages/breadboard-cli/src/commands/debug.ts
@@ -143,7 +143,7 @@ evtSource.addEventListener("update", () => { window.location.reload(); });</scri
 
     return handler(request, response, {
       public: distDir,
-      cleanUrls: ["/preview"],
+      cleanUrls: ["/"],
     });
   });
 

--- a/packages/breadboard-cli/vite.config.ts
+++ b/packages/breadboard-cli/vite.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "vitest/config";
 import { fileURLToPath } from "url";
+import { createRequire } from "module";
+import { dirname, join } from "path";
 
 // Carry through the breadboard-web public dir as the public dir for the
 // debugger here. It's essentially a passthrough.
@@ -10,9 +12,9 @@ if (import.meta.resolve) {
   );
   breadboardWebPublic = fileURLToPath(publicPath);
 } else {
-  console.warn(
-    "Unable to resolve breadboard-web resources - you may need a newer nodejs runtime"
-  );
+  const require = createRequire(import.meta.url);
+  const breadboardWebIndex = require.resolve("@google-labs/breadboard-web");
+  breadboardWebPublic = join(dirname(breadboardWebIndex), "..", "public");
 }
 
 export default defineConfig({


### PR DESCRIPTION
This fixes a couple of issues:

1. For older nodejs installations we now use [createRequire](https://nodejs.org/docs/latest-v19.x/api/module.html#modulecreaterequirefilename) to try and get to the `breadboard-web` dir.
2. The serving of the debugger was failing on the index because of the `cleanUrls` flag - it should now work