### PR TITLE
[breadboard-cli] Tweaks to debug

### DIFF
--- a/packages/breadboard-cli/src/commands/debug.ts
+++ b/packages/breadboard-cli/src/commands/debug.ts
@@ -143,7 +143,7 @@ evtSource.addEventListener("update", () => { window.location.reload(); });</scri
 
     return handler(request, response, {
       public: distDir,
-      cleanUrls: ["/"],
+      //cleanUrls: ["/"],
     });
   });
 

--- a/packages/breadboard-cli/src/debugger/index.html
+++ b/packages/breadboard-cli/src/debugger/index.html
@@ -1,21 +1,25 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Debugger</title>
-    <link rel="stylesheet" href="/styles/global.css" />
-  </head>
-  <body>
-    <script type="module">
-      import { Main } from "@google-labs/breadboard-web";
 
-      const config = {
-        boards: [],
-      };
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Debugger</title>
+  <link rel="stylesheet" href="/styles/global.css" />
+</head>
 
-      const main = new Main(config);
-      document.body.appendChild(main);
-    </script>
-  </body>
+<body>
+  <script type="module">
+    import { Main } from "@google-labs/breadboard-web";
+    const localBoards = await (await fetch("/local-boards.json")).json();
+
+    const config = {
+      boards: localBoards,
+    };
+
+    const main = new Main(config);
+    document.body.appendChild(main);
+  </script>
+</body>
+
 </html>

--- a/recipes/use-case/fetch-atom/index.js
+++ b/recipes/use-case/fetch-atom/index.js
@@ -26,7 +26,7 @@ const urlSchema = {
   required: ["text"],
 };
 
-export default await recipe(async () => {
+export default await recipe(() => {
   const fetchFeed = base
     .input({ $id: "input", schema: urlSchema })
     .url.to(

--- a/recipes/use-case/fetch-rss/index.js
+++ b/recipes/use-case/fetch-rss/index.js
@@ -26,7 +26,7 @@ const urlSchema = {
   required: ["text"],
 };
 
-export default await recipe(async () => {
+export default await recipe(() => {
   const fetchFeed = base
     .input({ $id: "input", schema: urlSchema })
     .url.to(

--- a/recipes/use-case/search-google/index.js
+++ b/recipes/use-case/search-google/index.js
@@ -26,7 +26,7 @@ const queryScheme = {
   required: ["text"],
 };
 
-export default await recipe(async () => {
+export default await recipe(() => {
   const query = base.input({ $id: "input", schema: queryScheme });
 
   return starter


### PR DESCRIPTION
Loads the boards so whatever is input is accessible via the temp server.

Also fixes some boards that used `recipe(async ...`
