### PR TITLE
[breadboard] Tighten some types in new-syntax kits.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22493,11 +22493,8 @@
     },
     "packages/create-breadboard": {
       "name": "@google-labs/create-breadboard",
-      "version": "0.0.7",
+      "version": "0.0.8",
       "license": "Apache-2.0",
-      "dependencies": {
-        "base-create": "^3.0.8"
-      },
       "bin": {
         "create-breadboard": "dist/src/index.js"
       },
@@ -22673,7 +22670,7 @@
     },
     "packages/llm-starter": {
       "name": "@google-labs/llm-starter",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-labs/breadboard": "^0.7.0",

--- a/packages/breadboard-web/src/boards/math-imperative.ts
+++ b/packages/breadboard-web/src/boards/math-imperative.ts
@@ -28,7 +28,7 @@ export const graph = recipe(
       question: question,
     });
     const { completion } = palm.generateText({
-      text: prompt,
+      text: prompt.isString(),
       PALM_KEY: core.secrets({ keys: ["PALM_KEY"] }).PALM_KEY,
     });
     const { result } = core.runJavascript({

--- a/packages/core-kit/README.md
+++ b/packages/core-kit/README.md
@@ -325,3 +325,37 @@ We will get:
 #### Implementation:
 
 - [src/nodes/run-javascript.ts](src/nodes/run-javascript.ts)
+
+### The `secrets` node
+
+Use this node to access secrets, such as API keys or other valuable bits of information that you might not want to store in the graph itself. The node takes in an array of strings named `keys`, matches the process environment values, and returns them as outputs. This enables connecting edges from environment variables.
+
+#### Example:
+
+Use this node to pass the `PALM_KEY` environment variable to the `text-completion` node. The input:
+
+```json
+{
+  "keys": ["PALM_KEY"]
+}
+```
+
+Will produce this output:
+
+```json
+{
+  "PALM_KEY": "<value of the API key from the environment>"
+}
+```
+
+#### Inputs:
+
+- `keys` - required, must contain an array of strings that represent the keys to look up in the environment. If not supplied, empty output is returned.
+
+#### Outputs:
+
+- one output for each key that was found in the environment.
+
+#### Implementation:
+
+- [src/nodes/secrets.ts](src/nodes/secrets.ts)

--- a/packages/core-kit/src/index.ts
+++ b/packages/core-kit/src/index.ts
@@ -189,12 +189,18 @@ export const core = addKit(Core) as unknown as {
     { accumulator: NodeValue }
   >;
   invoke: NodeFactory<
-    {
-      path?: string;
-      graph?: string;
-      board?: NodeValue;
-      [key: string]: NodeValue;
-    },
+    | {
+        path: string;
+        [key: string]: NodeValue;
+      }
+    | {
+        graph: string;
+        [key: string]: NodeValue;
+      }
+    | {
+        board: NodeValue;
+        [key: string]: NodeValue;
+      },
     { [key: string]: unknown }
   >;
   map: NodeFactory<

--- a/packages/json-kit/src/index.ts
+++ b/packages/json-kit/src/index.ts
@@ -40,13 +40,13 @@ export const json = addKit(JSONKit) as unknown as {
   >;
   schemish: NodeFactory<{ schema: NodeValue }, { schemish: NodeValue }>;
   jsonata: NodeFactory<
-    {
-      expression: string;
-      json: string;
-      raw: boolean;
-      [key: string]: NodeValue;
-    },
-    { result: string; [key: string]: NodeValue }
+    | {
+        expression: string;
+        json: string;
+        raw: boolean;
+      }
+    | { expression: string; [key: string]: NodeValue; raw: boolean },
+    { result: string } | { [key: string]: NodeValue }
   >;
   xmlToJson: NodeFactory<{ xml: string }, { json: NodeValue }>;
 };

--- a/packages/template-kit/README.md
+++ b/packages/template-kit/README.md
@@ -53,40 +53,6 @@ We will get this output:
 
 - [src/nodes/prompt-template.ts](src/nodes/prompt-template.ts)
 
-### The `secrets` node
-
-Use this node to access secrets, such as API keys or other valuable bits of information that you might not want to store in the graph itself. The node takes in an array of strings named `keys`, matches the process environment values, and returns them as outputs. This enables connecting edges from environment variables.
-
-#### Example:
-
-Use this node to pass the `PALM_KEY` environment variable to the `text-completion` node. The input:
-
-```json
-{
-  "keys": ["PALM_KEY"]
-}
-```
-
-Will produce this output:
-
-```json
-{
-  "PALM_KEY": "<value of the API key from the environment>"
-}
-```
-
-#### Inputs:
-
-- `keys` - required, must contain an array of strings that represent the keys to look up in the environment. If not supplied, empty output is returned.
-
-#### Outputs:
-
-- one output for each key that was found in the environment.
-
-#### Implementation:
-
-- [src/nodes/secrets.ts](src/nodes/secrets.ts)
-
 ### The `urlTemplate` node
 
 Use this node to safely construct URLs. It's similar in spirit to the `promptTemplate` node, except it ensures that the handlebar parameters are properly encoded as part of the URL. This node relies on the [URI template specification](https://tools.ietf.org/html/rfc6570) to construct URLs, so the syntax is using single curly braces instead of double curly braces.

--- a/packages/template-kit/src/index.ts
+++ b/packages/template-kit/src/index.ts
@@ -38,10 +38,46 @@ import {
 } from "@google-labs/breadboard";
 
 export const templates = addKit(TemplateKit) as unknown as {
+  /**
+   * Use this node to populate simple handlebar-style templates. A required
+   * input is `template`, which is a string that contains the template prompt
+   * template. The template can contain zero or more placeholders that will be
+   * replaced with values from inputs. Specify placeholders as `{{inputName}}`
+   * in the template. The placeholders in the template must match the inputs
+   * wired into this node. The node will replace all placeholders with values
+   * from the input property bag and pass the result along as the `prompt`
+   * output property.
+   */
   promptTemplate: NodeFactory<
-    { template: string; [key: string]: NodeValue },
-    { prompt: string }
+    {
+      /**
+       * The template to use for the prompt.
+       */
+      template: string;
+      /**
+       * The values to fill in the template.
+       */
+      [key: string]: NodeValue;
+    },
+    | {
+        /**
+         * The result of template with placeholders being replaced with values.
+         */
+        prompt: string;
+      }
+    | {
+        /**
+         * The result of template with placeholders being replaced with values.
+         */
+        text: string;
+      }
   >;
+  /**
+   * Use this node to safely construct URLs. This node relies on the
+   * [URI template specification](https://tools.ietf.org/html/rfc6570) to
+   * construct URLs, so the syntax is using single curly braces instead of
+   * double curly braces.
+   */
   urlTemplate: NodeFactory<
     { template: string; [key: string]: NodeValue },
     { url: string }


### PR DESCRIPTION
- Tighten up some types and write docs.
- Express `invoke` inputs more accurately.
