### PR TITLE
[breadboard-extension] Move transpilation out

### DIFF
--- a/packages/breadboard-extension/src/breadboard-loader.ts
+++ b/packages/breadboard-extension/src/breadboard-loader.ts
@@ -1,0 +1,143 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as ts from "typescript";
+import vm from "node:vm";
+import * as vscode from "vscode";
+
+/**
+ * This loader transpiles TypeScript on the fly and into a graph that can be
+ * rendered in the Webview or passed to the debugger.
+ *
+ * We load in Breadboard and all of the kits. From here we take the TypeScript,
+ * run it through the TS compiler to get JS. We then ask Node to run it using
+ * node:vm, and we provide to it all of the kits that it would need in order to
+ * serialize the graph.
+ *
+ * If the compilation fails for any reason we will just leave it as-is.
+ */
+export class BreadboardLoader {
+  #mods:
+    | [
+        typeof import("@google-labs/breadboard"),
+        typeof import("@google-labs/core-kit"),
+        typeof import("@google-labs/json-kit"),
+        typeof import("@google-labs/template-kit"),
+        typeof import("@google-labs/node-nursery-web"),
+        typeof import("@google-labs/palm-kit")
+      ]
+    | null = null;
+
+  async #lazyLoadModulesIfNeeded() {
+    if (this.#mods) {
+      return this.#mods;
+    }
+
+    return await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        cancellable: false,
+        title: "Loading renderer...",
+      },
+      async () => {
+        return await Promise.all([
+          import("@google-labs/breadboard"),
+          import("@google-labs/core-kit"),
+          import("@google-labs/json-kit"),
+          import("@google-labs/template-kit"),
+          import("@google-labs/node-nursery-web"),
+          import("@google-labs/palm-kit"),
+        ]);
+      }
+    );
+  }
+
+  async #loadFromResource(resource: vscode.Uri) {
+    if (!this.#mods) {
+      this.#mods = await this.#lazyLoadModulesIfNeeded();
+    }
+
+    // Step 1. Load in the file contents.
+    const fileContents = await vscode.workspace.fs.readFile(resource);
+    const typeScriptContents = fileContents.toString();
+
+    // Step 2. Transpile using the TypeScript Compiler.
+    const result = ts.transpileModule(typeScriptContents, {
+      compilerOptions: {
+        module: ts.ModuleKind.CommonJS,
+        target: ts.ScriptTarget.ESNext,
+      },
+    });
+
+    // Step 3. Wrap it into something that looks like an iife.
+    const code = `(async (require) => {
+      const exports = globalThis.exports || {};
+      ${result.outputText}
+
+      return exports.default;
+    })`;
+
+    const [breadboard, coreKit, jsonKit, templateKit, nodeNurseryWeb, palmKit] =
+      this.#mods;
+
+    // Step 4. Try running the code. Where kits are requested, hand in the
+    // ones we already loaded here.
+    const descriptor = await vm.runInNewContext(code, {
+      filename: "board.js",
+    })((specifier: string) => {
+      switch (specifier) {
+        case "@google-labs/breadboard": {
+          return breadboard;
+        }
+
+        case "@google-labs/core-kit": {
+          return coreKit;
+        }
+
+        case "@google-labs/json-kit": {
+          return jsonKit;
+        }
+
+        case "@google-labs/template-kit": {
+          return templateKit;
+        }
+
+        case "@google-labs/node-nursery-web": {
+          return nodeNurseryWeb;
+        }
+        case "@google-labs/palm-kit": {
+          return palmKit;
+        }
+
+        default:
+          throw new Error("Unexpected import");
+      }
+    });
+
+    // Step 5. Post the graph over to the web view for rendering.
+    return descriptor;
+  }
+
+  async loadGraphFromResource(resource: vscode.Uri) {
+    if (!this.#mods) {
+      this.#mods = await this.#lazyLoadModulesIfNeeded();
+    }
+
+    const [breadboard] = this.#mods;
+    const descriptor = await this.#loadFromResource(resource);
+    return breadboard.toMermaid(descriptor);
+  }
+
+  async loadBoardFromResource(resource: vscode.Uri) {
+    if (!this.#mods) {
+      this.#mods = await this.#lazyLoadModulesIfNeeded();
+    }
+
+    const [breadboard] = this.#mods;
+    const descriptor = await this.#loadFromResource(resource);
+    return breadboard.Board.fromGraphDescriptor(descriptor);
+  }
+}

--- a/packages/breadboard-extension/src/breadboard-loader.ts
+++ b/packages/breadboard-extension/src/breadboard-loader.ts
@@ -117,7 +117,7 @@ export class BreadboardLoader {
       }
     });
 
-    // Step 5. Post the graph over to the web view for rendering.
+    // Step 5. Return the descriptor.
     return descriptor;
   }
 

--- a/packages/breadboard-extension/src/extension.ts
+++ b/packages/breadboard-extension/src/extension.ts
@@ -4,10 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as ts from "typescript";
-import vm from "node:vm";
 import * as vscode from "vscode";
 import { BreadboardDebugSession } from "./breadboard-debug-session.js";
+import { BreadboardLoader } from "./breadboard-loader.js";
 
 class BreadboardSessionFactory implements vscode.DebugAdapterDescriptorFactory {
   constructor(private output: vscode.OutputChannel) {}
@@ -86,69 +85,7 @@ export async function activate(context: vscode.ExtensionContext) {
     )
   );
 
-  /**
-   * Here we offer the "render board" command. To do that, however, we need to
-   * be able to transpile TypeScript on the fly and into a graph that can be
-   * rendered in the Webview.
-   *
-   * What we therefore do is wait until the first invocation of the command to
-   * load in Breadboard and all of the kits. From here we proceed to create the
-   * panel and a watcher for when the file is changed or deleted. When the
-   * contents of the file are changed we take the TypeScript, run it through
-   * the TS compiler to get JS. We then ask Node to run it using node:vm, and we
-   * provide to it all of the kits that it would need in order to serialize the
-   * graph.
-   *
-   * If the compilation fails for any reason we will just leave it as-is. If,
-   * however, we get a new graph, we will post it to the webview and ask for it
-   * to be rendered.
-   */
-
   let panelJS: string | null = null;
-  let mods:
-    | [
-        typeof import("@google-labs/breadboard"),
-        typeof import("@google-labs/core-kit"),
-        typeof import("@google-labs/json-kit"),
-        typeof import("@google-labs/template-kit"),
-        typeof import("@google-labs/node-nursery-web"),
-        typeof import("@google-labs/palm-kit")
-      ]
-    | null = null;
-
-  let hasLoaded = false;
-  async function lazyLoadModulesIfNeeded() {
-    if (hasLoaded) {
-      return;
-    }
-
-    const panelJSUri = vscode.Uri.joinPath(
-      context.extensionUri,
-      "./dist/renderer.js"
-    );
-
-    await vscode.window.withProgress(
-      {
-        location: vscode.ProgressLocation.Notification,
-        cancellable: false,
-        title: "Loading renderer...",
-      },
-      async () => {
-        panelJS = (await vscode.workspace.fs.readFile(panelJSUri)).toString();
-        mods = await Promise.all([
-          import("@google-labs/breadboard"),
-          import("@google-labs/core-kit"),
-          import("@google-labs/json-kit"),
-          import("@google-labs/template-kit"),
-          import("@google-labs/node-nursery-web"),
-          import("@google-labs/palm-kit"),
-        ]);
-      }
-    );
-
-    hasLoaded = true;
-  }
-
   context.subscriptions.push(
     vscode.commands.registerCommand(
       "breaboard.renderBoard",
@@ -162,6 +99,7 @@ export async function activate(context: vscode.ExtensionContext) {
           return;
         }
 
+        const loader = new BreadboardLoader();
         const watcher = vscode.workspace.createFileSystemWatcher(
           resource.fsPath,
           true,
@@ -184,90 +122,13 @@ export async function activate(context: vscode.ExtensionContext) {
           vscode.window.showInformationMessage(message.msg);
         });
 
-        // Lazy load all the things...
-        await lazyLoadModulesIfNeeded();
-
         const sendGraphToPanel = async (resource: vscode.Uri) => {
-          if (!panel || !mods) {
+          if (!panel) {
             return;
           }
 
-          // Step 1. Load in the file contents.
-          const fileContents = await vscode.workspace.fs.readFile(resource);
-          const typeScriptContents = fileContents.toString();
-
-          // Step 2. Transpile using the TypeScript Compiler.
-          const result = ts.transpileModule(typeScriptContents, {
-            compilerOptions: {
-              module: ts.ModuleKind.CommonJS,
-              target: ts.ScriptTarget.ESNext,
-            },
-          });
-
-          // Step 3. Wrap it into something that looks like an iife.
-          const code = `(async (require) => {
-            const exports = globalThis.exports || {};
-            ${result.outputText}
-
-            return exports.default;
-          })`;
-
-          const [
-            breadboard,
-            coreKit,
-            jsonKit,
-            templateKit,
-            nodeNurseryWeb,
-            palmKit,
-          ] = mods;
-
-          // Step 4. Try running the code. Where kits are requested, hand in the
-          // ones we already loaded here.
           try {
-            const descriptor = await vm.runInNewContext(code, {
-              filename: "board.js",
-            })((specifier: string) => {
-              if (!mods) {
-                throw new Error("Unexpected import");
-              }
-
-              switch (specifier) {
-                case "@google-labs/breadboard": {
-                  return breadboard;
-                }
-
-                case "@google-labs/core-kit": {
-                  return coreKit;
-                }
-
-                case "@google-labs/json-kit": {
-                  return jsonKit;
-                }
-
-                case "@google-labs/template-kit": {
-                  return templateKit;
-                }
-
-                case "@google-labs/node-nursery-web": {
-                  return nodeNurseryWeb;
-                }
-                case "@google-labs/palm-kit": {
-                  return palmKit;
-                }
-
-                default:
-                  throw new Error("Unexpected import");
-              }
-            });
-
-            const boardDesription =
-              await breadboard.BoardRunner.fromGraphDescriptor(descriptor);
-            panel.title = `Board Diagram (${
-              boardDesription.title || "Untitled Board"
-            })`;
-
-            // Step 5. Post the graph over to the web view for rendering.
-            const graph = breadboard.toMermaid(descriptor);
+            const graph = await loader.loadGraphFromResource(resource);
             panel.webview.postMessage({ graph });
           } catch (err) {
             // Likely failed to compile...";
@@ -275,6 +136,15 @@ export async function activate(context: vscode.ExtensionContext) {
             return;
           }
         };
+
+        const panelJSUri = vscode.Uri.joinPath(
+          context.extensionUri,
+          "./dist/renderer.js"
+        );
+
+        if (!panelJS) {
+          panelJS = (await vscode.workspace.fs.readFile(panelJSUri)).toString();
+        }
 
         panel.webview.html = `<!DOCTYPE html>
             <html lang="en">


### PR DESCRIPTION
Since I now have code that can convert TS to the graph JSON on the fly, I'm moving it to a separate file. That way I can reuse it in the Debugger Runtime and allow it to run from TS files like the renderer does.