### PR TITLE
[breadboard-ui] Fix for inputs failing to ask for data

### DIFF
--- a/.changeset/honest-cups-glow.md
+++ b/.changeset/honest-cups-glow.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard-ui": patch
+---
+
+Fixed hanging inputs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1191,6 +1191,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -23868,7 +23869,7 @@
     },
     "packages/breadboard": {
       "name": "@google-labs/breadboard",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.22.4",
@@ -23895,13 +23896,13 @@
     },
     "packages/breadboard-cli": {
       "name": "@google-labs/breadboard-cli",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google-labs/breadboard": "^0.7.0",
-        "@google-labs/breadboard-web": "^0.0.1",
-        "@google-labs/core-kit": "^0.1.2",
-        "@google-labs/template-kit": "^0.1.0",
+        "@google-labs/breadboard": "^0.8.0",
+        "@google-labs/breadboard-web": "^0.0.2",
+        "@google-labs/core-kit": "^0.1.3",
+        "@google-labs/template-kit": "^0.1.1",
         "commander": "^11.1.0",
         "esbuild": "^0.19.9",
         "serve": "^14.2.1",
@@ -23931,15 +23932,15 @@
     },
     "packages/breadboard-extension": {
       "name": "@google-labs/breadboard-extension",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google-labs/breadboard": "^0.7.0",
-        "@google-labs/core-kit": "^0.1.2",
-        "@google-labs/json-kit": "^0.0.2",
-        "@google-labs/node-nursery-web": "^0.0.1",
-        "@google-labs/palm-kit": "^0.0.1",
-        "@google-labs/template-kit": "^0.1.0",
+        "@google-labs/breadboard": "^0.8.0",
+        "@google-labs/core-kit": "^0.1.3",
+        "@google-labs/json-kit": "^0.0.3",
+        "@google-labs/node-nursery-web": "^0.0.2",
+        "@google-labs/palm-kit": "^0.0.2",
+        "@google-labs/template-kit": "^0.1.1",
         "@types/node": "^20.11.5",
         "@types/vscode": "^1.85.0",
         "@vscode/debugadapter": "^1.64.0",
@@ -23963,15 +23964,15 @@
     },
     "packages/breadboard-server": {
       "name": "@google-labs/breadboard-server",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/firestore": "^6.7.0",
-        "@google-labs/breadboard": "^0.7.0"
+        "@google-labs/breadboard": "^0.8.0"
       },
       "devDependencies": {
         "@ava/typescript": "^4.0.0",
-        "@google-labs/core-kit": "^0.1.2",
+        "@google-labs/core-kit": "^0.1.3",
         "@google-labs/tsconfig": "^0.0.1",
         "@types/express": "^4.17.17",
         "@types/node": "^18.16.3",
@@ -23996,10 +23997,10 @@
     },
     "packages/breadboard-ui": {
       "name": "@google-labs/breadboard-ui",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google-labs/breadboard": "^0.7.0",
+        "@google-labs/breadboard": "^0.8.0",
         "lit": "^3.1.0",
         "mermaid": "^10.6.1"
       },
@@ -24021,17 +24022,17 @@
     },
     "packages/breadboard-web": {
       "name": "@google-labs/breadboard-web",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google-labs/breadboard": "^0.7.0",
-        "@google-labs/breadboard-ui": "^0.0.2",
-        "@google-labs/core-kit": "^0.1.2",
-        "@google-labs/json-kit": "^0.0.2",
-        "@google-labs/node-nursery-web": "^0.0.1",
-        "@google-labs/palm-kit": "^0.0.1",
-        "@google-labs/pinecone-kit": "^0.0.1",
-        "@google-labs/template-kit": "^0.1.0",
+        "@google-labs/breadboard": "^0.8.0",
+        "@google-labs/breadboard-ui": "^0.0.3",
+        "@google-labs/core-kit": "^0.1.3",
+        "@google-labs/json-kit": "^0.0.3",
+        "@google-labs/node-nursery-web": "^0.0.2",
+        "@google-labs/palm-kit": "^0.0.2",
+        "@google-labs/pinecone-kit": "^0.0.2",
+        "@google-labs/template-kit": "^0.1.1",
         "lit": "^3.1.1",
         "zod": "^3.22.4",
         "zod-to-json-schema": "^3.22.0"
@@ -24718,10 +24719,10 @@
     },
     "packages/breadbuddy": {
       "name": "@google-labs/breadbuddy",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google-labs/breadboard": "^0.7.0",
+        "@google-labs/breadboard": "^0.8.0",
         "@lit/task": "^1.0.0",
         "jszip": "^3.10.1",
         "lit": "^3.1.0",
@@ -24750,12 +24751,12 @@
     },
     "packages/cloud-function": {
       "name": "@google-labs/cloud-function",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google-labs/breadboard": "^0.7.0",
-        "@google-labs/breadboard-server": "^0.1.3",
-        "@google-labs/template-kit": "^0.1.0",
+        "@google-labs/breadboard": "^0.8.0",
+        "@google-labs/breadboard-server": "^0.1.4",
+        "@google-labs/template-kit": "^0.1.1",
         "dotenv": "^16.3.1"
       },
       "devDependencies": {
@@ -24765,16 +24766,16 @@
     },
     "packages/coffee-bot-board": {
       "name": "@google-labs/coffee-bot-board",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.6.3",
-        "@google-labs/breadboard": "^0.7.0",
-        "@google-labs/core-kit": "^0.1.2",
-        "@google-labs/json-kit": "^0.0.2",
-        "@google-labs/node-nursery": "^0.0.1",
-        "@google-labs/palm-kit": "^0.0.1",
-        "@google-labs/template-kit": "^0.1.0",
+        "@google-labs/breadboard": "^0.8.0",
+        "@google-labs/core-kit": "^0.1.3",
+        "@google-labs/json-kit": "^0.0.3",
+        "@google-labs/node-nursery": "^0.0.2",
+        "@google-labs/palm-kit": "^0.0.2",
+        "@google-labs/template-kit": "^0.1.1",
         "dotenv": "^16.3.1"
       },
       "devDependencies": {
@@ -24790,14 +24791,14 @@
     },
     "packages/core-kit": {
       "name": "@google-labs/core-kit",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google-labs/breadboard": "^0.7.0"
+        "@google-labs/breadboard": "^0.8.0"
       },
       "devDependencies": {
         "@ava/typescript": "^4.0.0",
-        "@google-labs/template-kit": "^0.1.0",
+        "@google-labs/template-kit": "^0.1.1",
         "@google-labs/tsconfig": "^0.0.1",
         "@types/node": "^18.16.3",
         "@typescript-eslint/eslint-plugin": "^5.56.0",
@@ -24808,7 +24809,7 @@
     },
     "packages/create-breadboard": {
       "name": "@google-labs/create-breadboard",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "Apache-2.0",
       "dependencies": {
         "chalk": "^5.3.0"
@@ -24877,10 +24878,10 @@
     },
     "packages/graph-integrity": {
       "name": "@google-labs/graph-integrity",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google-labs/breadboard": "^0.7.0"
+        "@google-labs/breadboard": "^0.8.0"
       },
       "devDependencies": {
         "@ava/typescript": "^4.0.0",
@@ -24895,18 +24896,18 @@
     },
     "packages/graph-playground": {
       "name": "@google-labs/graph-playground",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.6.3",
-        "@google-labs/breadboard": "^0.7.0",
-        "@google-labs/core-kit": "^0.1.2",
-        "@google-labs/graph-integrity": "^0.0.1",
-        "@google-labs/json-kit": "^0.0.2",
-        "@google-labs/node-nursery": "^0.0.1",
-        "@google-labs/palm-kit": "^0.0.1",
-        "@google-labs/pinecone-kit": "^0.0.1",
-        "@google-labs/template-kit": "^0.1.0",
+        "@google-labs/breadboard": "^0.8.0",
+        "@google-labs/core-kit": "^0.1.3",
+        "@google-labs/graph-integrity": "^0.0.2",
+        "@google-labs/json-kit": "^0.0.3",
+        "@google-labs/node-nursery": "^0.0.2",
+        "@google-labs/palm-kit": "^0.0.2",
+        "@google-labs/pinecone-kit": "^0.0.2",
+        "@google-labs/template-kit": "^0.1.1",
         "dotenv": "^16.3.1"
       },
       "devDependencies": {
@@ -24941,10 +24942,10 @@
     },
     "packages/hello-world": {
       "name": "@google-labs/hello-world",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google-labs/breadboard": "^0.7.0"
+        "@google-labs/breadboard": "^0.8.0"
       },
       "devDependencies": {
         "@ava/typescript": "^4.0.0",
@@ -24958,10 +24959,10 @@
     },
     "packages/json-kit": {
       "name": "@google-labs/json-kit",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google-labs/breadboard": "^0.7.0",
+        "@google-labs/breadboard": "^0.8.0",
         "@rgrove/parse-xml": "^4.1.0",
         "ajv": "^8.12.0",
         "jsonata": "^2.0.3",
@@ -24997,10 +24998,10 @@
     },
     "packages/llm-starter": {
       "name": "@google-labs/llm-starter",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google-labs/breadboard": "^0.7.0",
+        "@google-labs/breadboard": "^0.8.0",
         "url-template": "^3.1.0"
       },
       "devDependencies": {
@@ -25020,14 +25021,14 @@
     },
     "packages/node-nursery": {
       "name": "@google-labs/node-nursery",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google-labs/breadboard": "^0.7.0",
+        "@google-labs/breadboard": "^0.8.0",
         "@google-labs/chunker": "^0.0.1",
-        "@google-labs/core-kit": "^0.1.2",
+        "@google-labs/core-kit": "^0.1.3",
         "@google-labs/palm-lite": "^0.0.3",
-        "@google-labs/template-kit": "^0.1.0",
+        "@google-labs/template-kit": "^0.1.1",
         "json-stable-stringify": "^1.0.2",
         "jsonschema": "^1.4.1",
         "ml-distance": "^4.0.1",
@@ -25049,16 +25050,16 @@
     },
     "packages/node-nursery-web": {
       "name": "@google-labs/node-nursery-web",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google-labs/breadboard": "^0.7.0",
+        "@google-labs/breadboard": "^0.8.0",
         "firebase": "^10.5.2"
       },
       "devDependencies": {
         "@ava/typescript": "^4.0.0",
-        "@google-labs/core-kit": "^0.1.2",
-        "@google-labs/template-kit": "^0.1.0",
+        "@google-labs/core-kit": "^0.1.3",
+        "@google-labs/template-kit": "^0.1.1",
         "@google-labs/tsconfig": "^0.0.1",
         "@types/gapi": "^0.0.46",
         "@types/node": "^18.16.3",
@@ -25089,9 +25090,9 @@
         "firebase-functions": "^4.3.1"
       },
       "devDependencies": {
-        "@google-labs/breadboard": "^0.7.0",
-        "@google-labs/palm-kit": "^0.0.1",
-        "@google-labs/template-kit": "^0.1.0",
+        "@google-labs/breadboard": "^0.8.0",
+        "@google-labs/palm-kit": "^0.0.2",
+        "@google-labs/template-kit": "^0.1.1",
         "@rollup/plugin-commonjs": "^25.0.7",
         "@rollup/plugin-json": "^6.0.1",
         "@rollup/plugin-node-resolve": "^15.2.3",
@@ -25119,10 +25120,10 @@
     },
     "packages/palm-kit": {
       "name": "@google-labs/palm-kit",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google-labs/breadboard": "^0.7.0",
+        "@google-labs/breadboard": "^0.8.0",
         "@google-labs/palm-lite": "^0.0.3"
       },
       "devDependencies": {
@@ -25137,15 +25138,15 @@
     },
     "packages/pinecone-kit": {
       "name": "@google-labs/pinecone-kit",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google-labs/breadboard": "^0.7.0",
-        "@google-labs/core-kit": "^0.1.2"
+        "@google-labs/breadboard": "^0.8.0",
+        "@google-labs/core-kit": "^0.1.3"
       },
       "devDependencies": {
         "@ava/typescript": "^4.0.0",
-        "@google-labs/template-kit": "^0.1.0",
+        "@google-labs/template-kit": "^0.1.1",
         "@google-labs/tsconfig": "^0.0.1",
         "@types/node": "^18.16.3",
         "@typescript-eslint/eslint-plugin": "^5.56.0",
@@ -25156,10 +25157,10 @@
     },
     "packages/template-kit": {
       "name": "@google-labs/template-kit",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google-labs/breadboard": "^0.7.0",
+        "@google-labs/breadboard": "^0.8.0",
         "url-template": "^3.1.0"
       },
       "devDependencies": {


### PR DESCRIPTION
In the `input-list` we work through all the messages we've received so far. We do this so that we create the UI entirely from the messages received and we don't base it on any internal state. So that we can stack newer inputs first we work through the list backwards. When we find an input we then track forwards again to see if there are any subsequent messages we received that tell us what the input value should be. So, for example, an input in the middle of the messages that has already been answered by the user will have a subsequent message with its value set. We use that to populate the field and make it readonly.

There was a bug in the code where we do that, and it wasn't traversing correctly. As such it would mistakenly switch off inputs we'd already seen because it would find an "answer" message for the older input of the same ID.

This PR fixes all that.