### PR TITLE
[breadboard-extension] Add user setting for board locations

### DIFF
--- a/.changeset/spicy-peas-film.md
+++ b/.changeset/spicy-peas-film.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard-extension": minor
+---
+
+Add user config setting for choosing where JSON boards are located

--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,6 @@ build
 
 .wireit
 *.vsix
+
+# User-specific configuration
+.vscode/settings.json

--- a/packages/breadboard-extension/package.json
+++ b/packages/breadboard-extension/package.json
@@ -32,7 +32,7 @@
   "contributes": {
     "commands": [
       {
-        "command": "breaboard.runBoard",
+        "command": "breaboard.debugBoard",
         "title": "Debug Board",
         "category": "Breadboard",
         "enablement": "!inDebugMode && (resourceExtname == .json || resourceExtname == .ts || resourceExtname == .js)"
@@ -42,6 +42,18 @@
         "title": "Render Board",
         "category": "Breadboard",
         "enablement": "resourceExtname == .ts"
+      }
+    ],
+    "configuration": [
+      {
+        "title": "Breadboard",
+        "properties": {
+          "breadboard.boardLocations": {
+            "type": "string",
+            "default": null,
+            "description": "The location of your boards"
+          }
+        }
       }
     ],
     "debuggers": [

--- a/packages/breadboard-extension/src/breadboard-loader.ts
+++ b/packages/breadboard-extension/src/breadboard-loader.ts
@@ -40,7 +40,7 @@ export class BreadboardLoader {
       {
         location: vscode.ProgressLocation.Notification,
         cancellable: false,
-        title: "Loading renderer...",
+        title: "Loading Breadboard & kits...",
       },
       async () => {
         return await Promise.all([

--- a/packages/breadboard-extension/src/extension.ts
+++ b/packages/breadboard-extension/src/extension.ts
@@ -62,8 +62,8 @@ export async function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.commands.registerCommand(
-      "breaboard.runBoard",
-      (resource: vscode.Uri) => {
+      "breaboard.debugBoard",
+      async (resource: vscode.Uri) => {
         let fileForDebuggging = resource;
         if (!fileForDebuggging && vscode.window.activeTextEditor) {
           fileForDebuggging = vscode.window.activeTextEditor.document.uri;


### PR DESCRIPTION
To try and smooth things out a bit for choosing sub boards I've added a user configuration option. When a user runs the extension for the first time (or if they clear the setting), the extension will ask them where the JSON boards are located. It then uses this path whenever it encounters an input value whose default ends in `.json`.

It would be good to figure out a neater way to encode the location of sub boards, though, as this approach is somewhat brittle and will only work if the user is asked for a particular board location as part of the outer board's execution.