### PR TITLE
[website] Add GitHub Action to deploy documentation website to GitHub pages on merge to main

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,0 +1,55 @@
+name: Deploy Website
+on:
+  # Deploy whenever we merge to main.
+  push:
+    branches: ["main"]
+
+  # Allows deploying manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run
+# in-progress and latest queued. However, do NOT cancel in-progress runs as we
+# want to allow these production deployments to complete.
+concurrency:
+  group: deploy-website
+  cancel-in-progress: false
+
+jobs:
+  deploy-website:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - uses: google/wireit@setup-github-actions-caching/v1
+      - uses: actions/configure-pages@v4
+
+      - run: npm ci
+
+      - name: Build production website
+        working-directory: packages/website
+        run: npm run build:prod
+
+      - name: Upload website artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          name: breadboard-website
+          path: packages/website/dist/prod/breadboard
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4
+        with:
+          artifact_name: breadboard-website

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -38,7 +38,7 @@
       ]
     },
     "build:dev": {
-      "command": "cp -R dist/eleventy/* dist/dev/",
+      "command": "cp -R dist/eleventy/* dist/dev/breadboard/",
       "dependencies": [
         "build:dev:prepare",
         "build:eleventy",
@@ -47,20 +47,20 @@
       "files": [],
       "output": [
         "dist/dev/",
-        "!dist/dev/js",
-        "!dist/dev/static"
+        "!dist/dev/breadboard/js",
+        "!dist/dev/breadboard/static"
       ]
     },
     "build:dev:prepare": {
-      "command": "mkdir -p dist/dev && ln -s ../tsc dist/dev/js && ln -s ../../src/static dist/dev/static",
+      "command": "mkdir -p dist/dev/breadboard && ln -s ../../tsc dist/dev/breadboard/js && ln -s ../../../src/static dist/dev/breadboard/static",
       "files": [],
       "output": [
-        "dist/dev/js",
-        "dist/dev/static"
+        "dist/dev/breadboard/js",
+        "dist/dev/breadboard/static"
       ]
     },
     "build:prod": {
-      "command": "cp -R dist/eleventy/ dist/prod/ && cp -R src/static/ dist/prod/static/ && cp -R dist/rollup/ dist/prod/js",
+      "command": "mkdir -p dist/prod && cp -R dist/eleventy/ dist/prod/breadboard && cp -R src/static/ dist/prod/breadboard/static/ && cp -R dist/rollup/ dist/prod/breadboard/js",
       "dependencies": [
         "build:eleventy",
         "build:rollup"
@@ -108,7 +108,7 @@
       ]
     },
     "serve:dev": {
-      "command": "web-dev-server --root-dir dist/dev/ --node-resolve --watch",
+      "command": "web-dev-server --root-dir dist/dev/ --node-resolve --watch --open /breadboard/",
       "service": true,
       "dependencies": [
         {
@@ -119,7 +119,7 @@
       "files": []
     },
     "serve:prod": {
-      "command": "web-dev-server --root-dir dist/prod/ --watch",
+      "command": "web-dev-server --root-dir dist/prod/ --watch --open /breadboard/",
       "service": true,
       "dependencies": [
         {

--- a/packages/website/src/_includes/docs.njk
+++ b/packages/website/src/_includes/docs.njk
@@ -4,8 +4,13 @@ title: Breadboard | Docs
 
 <!DOCTYPE html>
 <title>{{title}} | Docs | Breadboard</title>
-<link rel="stylesheet" href="/static/common.css" />
-<script src="/js/pages/docs.js" type="module"></script>
+<base href="/breadboard/" />
+<link
+  href="https://fonts.googleapis.com/css2?family=Roboto&display=swap"
+  rel="stylesheet"
+/>
+<link rel="stylesheet" href="static/common.css" />
+<script src="js/pages/docs.js" type="module"></script>
 <bb-site-docs>
   {{content | safe}}
 </bb-site-docs>

--- a/packages/website/src/index.html
+++ b/packages/website/src/index.html
@@ -1,9 +1,11 @@
 <!DOCTYPE html>
 <title>Breadboard</title>
+<base href="/breadboard/" />
 <link
   href="https://fonts.googleapis.com/css2?family=Roboto&display=swap"
   rel="stylesheet"
 />
-<link rel="stylesheet" href="/static/common.css" />
-<script src="/js/pages/landing.js" type="module"></script>
+<link rel="icon" type="image/x-icon" href="static/breadboard.png" />
+<link rel="stylesheet" href="static/common.css" />
+<script src="js/pages/landing.js" type="module"></script>
 <bb-site-landing></bb-site-landing>

--- a/packages/website/src/js/header.ts
+++ b/packages/website/src/js/header.ts
@@ -42,9 +42,9 @@ export class BreadboardSiteHeader extends LitElement {
   render() {
     return html`
       <header>
-        <a id="logo" href="/">
+        <a id="logo" href="">
           <img
-            src="/static/breadboard.png"
+            src="static/breadboard.png"
             alt="Breadboard logo"
             width="30px"
             height="30px"
@@ -52,15 +52,15 @@ export class BreadboardSiteHeader extends LitElement {
           <h1>Breadboard</h1>
         </a>
         <nav>
-          <a href="/docs/">Docs</a>
-          <a href="/playground/">Playground</a>
+          <a href="docs/">Docs</a>
+          <a href="playground/">Playground</a>
           <a
             href="https://github.com/breadboard-ai/breadboard/"
             target="_blank"
             rel="noopener"
             title="Breadboard on GitHub"
             aria-label="Breadboard on GitHub"
-            ><img src="/static/github.svg" />
+            ><img src="static/github.svg" />
           </a>
         </nav>
       </header>

--- a/packages/website/src/js/pages/docs.ts
+++ b/packages/website/src/js/pages/docs.ts
@@ -35,9 +35,9 @@ export class BreadboardSiteDocs extends LitElement {
       <main>
         <nav>
           <ul>
-            <li><a href="/docs/">Intro</a></li>
-            <li><a href="/docs/getting-started/">Getting Started</a></li>
-            <li><a href="/docs/concepts/">Concepts</a></li>
+            <li><a href="docs/">Intro</a></li>
+            <li><a href="docs/getting-started/">Getting Started</a></li>
+            <li><a href="docs/concepts/">Concepts</a></li>
           </ul>
         </nav>
         <article>

--- a/packages/website/src/playground.html
+++ b/packages/website/src/playground.html
@@ -1,5 +1,11 @@
 <!DOCTYPE html>
 <title>Breadboard</title>
-<link rel="stylesheet" href="/static/common.css" />
-<script src="/js/pages/playground.js" type="module"></script>
+<base href="/breadboard/" />
+<link
+  href="https://fonts.googleapis.com/css2?family=Roboto&display=swap"
+  rel="stylesheet"
+/>
+<link rel="icon" type="image/x-icon" href="static/breadboard.png" />
+<link rel="stylesheet" href="static/common.css" />
+<script src="js/pages/playground.js" type="module"></script>
 <bb-site-playground></bb-site-playground>


### PR DESCRIPTION
Whenever we merge to main, `packages/website` will now be built, and deployed to GitHub pages, visible at https://breadboard-ai.github.io/breadboard/