### PR TITLE
RELEASING: Releasing 6 package(s)

### DIFF
--- a/.changeset/bright-guests-clean.md
+++ b/.changeset/bright-guests-clean.md
@@ -1,6 +1,0 @@
----
-"@google-labs/breadboard-web": patch
-"@google-labs/breadboard-ui": patch
----
-
-Fixes Continue button in debugger and preview

--- a/.changeset/clever-days-crash.md
+++ b/.changeset/clever-days-crash.md
@@ -1,5 +1,0 @@
----
-"@google-labs/breadboard-cli": patch
----
-
-Add missing `vite` dependency.

--- a/.changeset/itchy-carrots-deny.md
+++ b/.changeset/itchy-carrots-deny.md
@@ -1,5 +1,0 @@
----
-"@google-labs/breadboard-website": major
----
-
-Add home page design

--- a/.changeset/rich-lamps-sin.md
+++ b/.changeset/rich-lamps-sin.md
@@ -1,7 +1,0 @@
----
-"@google-labs/create-breadboard": major
-"@google-labs/breadboard-hello-world": major
----
-
-@google-labs/create-breadboard now uses @google-labs/breadboard-hello-world as template,
-which includes an entirely different starting project.

--- a/packages/breadboard-cli/CHANGELOG.md
+++ b/packages/breadboard-cli/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @google-labs/breadboard-cli
 
+## 0.2.1
+
+### Patch Changes
+
+- 1779e50: Add missing `vite` dependency.
+- Updated dependencies [bbbd9f4]
+  - @google-labs/breadboard-web@1.0.3
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/breadboard-cli/package.json
+++ b/packages/breadboard-cli/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://wombat-dressing-room.appspot.com"
   },
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A suite of tools for interacting with the Breadboard.",
   "bin": {
     "breadboard": "dist/src/index.js"
@@ -133,7 +133,7 @@
   },
   "dependencies": {
     "@google-labs/breadboard": "^0.9.0",
-    "@google-labs/breadboard-web": "^1.0.0",
+    "@google-labs/breadboard-web": "^1.0.3",
     "@google-labs/core-kit": "^0.2.0",
     "@google-labs/template-kit": "^0.1.2",
     "commander": "^11.1.0",

--- a/packages/breadboard-ui/CHANGELOG.md
+++ b/packages/breadboard-ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.0.5
+
+### Patch Changes
+
+- bbbd9f4: Fixes Continue button in debugger and preview
+
 ## 0.0.4
 
 ### Patch Changes

--- a/packages/breadboard-ui/package.json
+++ b/packages/breadboard-ui/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://wombat-dressing-room.appspot.com"
   },
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "The UI components for @google-labs/breadboard",
   "main": "./dist/src/index.js",
   "exports": {

--- a/packages/breadboard-web/CHANGELOG.md
+++ b/packages/breadboard-web/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @google-labs/breadboard-web
 
+## 1.0.3
+
+### Patch Changes
+
+- bbbd9f4: Fixes Continue button in debugger and preview
+- Updated dependencies [bbbd9f4]
+  - @google-labs/breadboard-ui@0.0.5
+
 ## 1.0.2
 
 ### Patch Changes

--- a/packages/breadboard-web/package.json
+++ b/packages/breadboard-web/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://wombat-dressing-room.appspot.com"
   },
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "The Web runtime for Breadboard",
   "main": "./build/index.js",
   "exports": {
@@ -198,7 +198,7 @@
   },
   "dependencies": {
     "@google-labs/breadboard": "^0.9.1",
-    "@google-labs/breadboard-ui": "^0.0.4",
+    "@google-labs/breadboard-ui": "^0.0.5",
     "@google-labs/core-kit": "^0.2.0",
     "@google-labs/json-kit": "^0.0.4",
     "@google-labs/node-nursery-web": "^1.0.0",

--- a/packages/create-breadboard/CHANGELOG.md
+++ b/packages/create-breadboard/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.0.0
+
+### Major Changes
+
+- 5d72c02: @google-labs/create-breadboard now uses @google-labs/breadboard-hello-world as template,
+  which includes an entirely different starting project.
+
+### Patch Changes
+
+- Updated dependencies [5d72c02]
+  - @google-labs/breadboard-hello-world@1.0.0
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/create-breadboard/package.json
+++ b/packages/create-breadboard/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://wombat-dressing-room.appspot.com"
   },
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "A starter kit for your Breadboard projects",
   "main": "dist/src/index.js",
   "bin": {
@@ -71,7 +71,7 @@
   },
   "types": "./dist/src/index.d.ts",
   "dependencies": {
-    "@google-labs/breadboard-hello-world": "^0.1.0",
+    "@google-labs/breadboard-hello-world": "^1.0.0",
     "chalk": "^5.3.0"
   }
 }

--- a/packages/hello-world/CHANGELOG.md
+++ b/packages/hello-world/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @google-labs/breadboard-hello-world
 
+## 1.0.0
+
+### Major Changes
+
+- 5d72c02: @google-labs/create-breadboard now uses @google-labs/breadboard-hello-world as template,
+  which includes an entirely different starting project.
+
+### Patch Changes
+
+- Updated dependencies [1779e50]
+  - @google-labs/breadboard-cli@0.2.1
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/hello-world/package.json
+++ b/packages/hello-world/package.json
@@ -6,6 +6,10 @@
   "version": "1.0.0",
   "description": "A template for creating a new Breadboard project",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/breadboard-ai/breadboard.git"
+  },
   "scripts": {
     "dev": "breadboard debug src/ --watch"
   },

--- a/packages/hello-world/package.json
+++ b/packages/hello-world/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://wombat-dressing-room.appspot.com"
   },
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "A template for creating a new Breadboard project",
   "type": "module",
   "scripts": {
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@google-labs/breadboard": "^0.9.0",
-    "@google-labs/breadboard-cli": "0.2.0",
+    "@google-labs/breadboard-cli": "0.2.1",
     "@google-labs/core-kit": "0.2.0",
     "@google-labs/template-kit": "0.1.2",
     "@google-labs/json-kit": "0.0.4",

--- a/packages/website/CHANGELOG.md
+++ b/packages/website/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @google-labs/breadboard-website
+
+## 2.0.0
+
+### Major Changes
+
+- 64b5016: Add home page design

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -4,7 +4,7 @@
     "registry": "https://wombat-dressing-room.appspot.com"
   },
   "private": true,
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "The public documentation website for Breadboard",
   "author": "Google Labs Team",
   "license": "Apache-2.0",


### PR DESCRIPTION
Releases:
  @google-labs/breadboard-web@1.0.3
  @google-labs/breadboard-ui@0.0.5
  @google-labs/breadboard-cli@0.2.1
  @google-labs/breadboard-website@2.0.0
  @google-labs/create-breadboard@1.0.0
  @google-labs/breadboard-hello-world@1.0.0

[skip ci]
