### PR TITLE
[create-breadboard] Clear out the repository field

### DIFF
--- a/.changeset/light-beers-crash.md
+++ b/.changeset/light-beers-crash.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/create-breadboard": patch
+---
+
+Clear the repository field from user projects

--- a/packages/create-breadboard/src/projects/index.ts
+++ b/packages/create-breadboard/src/projects/index.ts
@@ -68,6 +68,7 @@ const run = async () => {
       author: "Your Name Here",
       private: true,
       publishConfig: undefined,
+      repository: undefined,
     },
     skipGitignore: false,
     skipReadme: true,


### PR DESCRIPTION
Because we don't want users to get the same `git+https://github.com/breadboard-ai/breadboard.git` repository that our own packages have.