### PR TITLE
catch ts errors

### DIFF
--- a/.changeset/proud-pots-rest.md
+++ b/.changeset/proud-pots-rest.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard-cli": patch
+---
+
+Catch compile/load errors to keep `breadboard debug` running.


### PR DESCRIPTION
- [breadboard-cli] Catch errors to keep debugger running.
- docs(changeset): Catch compile/load errors to keep `breadboard debug` running.
