### PR TITLE
[breadboard-web] Stop raising exception if Python boards fail to load

### DIFF
--- a/packages/breadboard-web/src/make-graphs.ts
+++ b/packages/breadboard-web/src/make-graphs.ts
@@ -116,7 +116,7 @@ async function savePythonBoard(
 
     return manifestEntry;
   } catch (e) {
-    throw new Error(`Error loading ${filePath}: ${e}`);
+    console.error(`Error loading ${filePath}: ${e}`);
   }
 }
 


### PR DESCRIPTION
Unblocks developers that don't have a Python environment set up that can run breadboard-python.