### PR TITLE
[breadboard-web] Fix duplicate UI

### DIFF
--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -56,6 +56,7 @@ export class Main extends LitElement {
   #uiRef: Ref<BreadboardUI.Elements.UI> = createRef();
   #previewRef: Ref<HTMLIFrameElement> = createRef();
   #boardId = 0;
+  #lastBoardId = 0;
   #delay = 0;
   #status = BreadboardUI.Types.STATUS.STOPPED;
   #statusObservers: Array<(value: BreadboardUI.Types.STATUS) => void> = [];
@@ -312,6 +313,12 @@ export class Main extends LitElement {
       return;
     }
 
+    // Board has already started; don't restart.
+    if (this.#lastBoardId === this.#boardId) {
+      return;
+    }
+
+    this.#lastBoardId = this.#boardId;
     this.loadInfo = await getBoardInfo(this.url);
 
     if (this.mode === MODE.BUILD) {
@@ -329,7 +336,6 @@ export class Main extends LitElement {
     ui.load(this.loadInfo);
 
     const currentBoardId = this.#boardId;
-
     let lastEventTime = globalThis.performance.now();
     for await (const result of run(createRunConfig(this.url))) {
       const runDuration = result.data.timestamp - lastEventTime;
@@ -431,7 +437,6 @@ export class Main extends LitElement {
     this.#bootWithUrl = null;
     this.#setActiveBreadboard(null);
 
-    this.#boardId++;
     if (!this.#uiRef.value) {
       return;
     }


### PR DESCRIPTION
Fixes #637 

We were restarting the harness but not creating a new UI when switching between Build & Preview. This caused the UI to receive a new set of messages from the new harness which, in most cases, would be duplicates of the original harness. And in turn that caused duplicate inputs as logged in #637. 

This PR fixes it by tracking the board ID so that we avoid starting a new harness if we've not changed boards. The net effect is that Build holds onto the current state of the world whereas Preview is a fresh copy every time we switch to it. I _think_ that's the right behavior here, because intuitively going to the Preview feels like something you do when you're wanting to run through a journey from the start... but I can change that if needed.