### PR TITLE
agent kit

### DIFF
--- a/.changeset/plenty-queens-scream.md
+++ b/.changeset/plenty-queens-scream.md
@@ -1,0 +1,7 @@
+---
+"@google-labs/agent-kit": minor
+"@google-labs/breadboard-web": patch
+"@google-labs/breadboard-hello-world": patch
+---
+
+Introduce Agent Kit.

--- a/.changeset/tame-plants-brake.md
+++ b/.changeset/tame-plants-brake.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard-cli": patch
+---
+
+Remove temporary files created by TypeScript loader.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2925,6 +2925,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@google-labs/agent-kit": {
+      "resolved": "packages/agent-kit",
+      "link": true
+    },
     "node_modules/@google-labs/breadboard": {
       "resolved": "packages/breadboard",
       "link": true
@@ -26593,9 +26597,22 @@
         "zod": "^3.22.4"
       }
     },
+    "packages/agent-kit": {
+      "version": "0.0.1",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@ava/typescript": "^4.0.0",
+        "@google-labs/tsconfig": "^0.0.1",
+        "@types/node": "^18.16.3",
+        "@typescript-eslint/eslint-plugin": "^6.20.0",
+        "@typescript-eslint/parser": "^6.20.0",
+        "ava": "^5.2.0",
+        "typescript": "^5.0.4"
+      }
+    },
     "packages/breadboard": {
       "name": "@google-labs/breadboard",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-labs/breadboard-schema": "^1.2.0",
@@ -26625,7 +26642,7 @@
     },
     "packages/breadboard-cli": {
       "name": "@google-labs/breadboard-cli",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "bundleDependencies": [
         "@google-labs/breadboard",
         "@google-labs/breadboard-web",
@@ -26640,7 +26657,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@google-labs/breadboard": "^0.10.0",
-        "@google-labs/breadboard-web": "^1.0.4",
+        "@google-labs/breadboard-web": "^1.1.1",
         "@google-labs/core-kit": "^0.2.1",
         "@google-labs/template-kit": "^0.1.3",
         "commander": "^11.1.0",
@@ -27218,18 +27235,18 @@
     },
     "packages/breadboard-web": {
       "name": "@google-labs/breadboard-web",
-      "version": "1.0.4",
+      "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google-labs/breadboard": "^0.10.0",
+        "@google-labs/breadboard": "^0.10.1",
         "@google-labs/breadboard-ui": "^0.0.6",
-        "@google-labs/core-kit": "^0.2.1",
-        "@google-labs/gemini-kit": "^0.0.1",
+        "@google-labs/core-kit": "^0.2.2",
+        "@google-labs/gemini-kit": "^0.1.1",
         "@google-labs/json-kit": "^0.0.5",
         "@google-labs/node-nursery-web": "^1.0.2",
         "@google-labs/palm-kit": "^0.0.4",
         "@google-labs/pinecone-kit": "^0.1.1",
-        "@google-labs/template-kit": "^0.1.3",
+        "@google-labs/template-kit": "^0.1.4",
         "lit": "^3.1.1",
         "zod": "^3.22.4",
         "zod-to-json-schema": "^3.22.0"
@@ -27992,14 +28009,14 @@
     },
     "packages/core-kit": {
       "name": "@google-labs/core-kit",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google-labs/breadboard": "^0.10.0"
+        "@google-labs/breadboard": "^0.10.1"
       },
       "devDependencies": {
         "@ava/typescript": "^4.0.0",
-        "@google-labs/template-kit": "^0.1.3",
+        "@google-labs/template-kit": "^0.1.4",
         "@google-labs/tsconfig": "^0.0.1",
         "@types/node": "^18.16.3",
         "@typescript-eslint/eslint-plugin": "^6.20.0",
@@ -28010,11 +28027,11 @@
     },
     "packages/create-breadboard": {
       "name": "@google-labs/create-breadboard",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-labs/breadboard": "^0.10.0",
-        "@google-labs/breadboard-hello-world": "^1.0.1",
+        "@google-labs/breadboard-hello-world": "^1.2.2",
         "chalk": "^5.3.0"
       },
       "bin": {
@@ -28031,7 +28048,7 @@
     },
     "packages/create-breadboard-kit": {
       "name": "@google-labs/create-breadboard-kit",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@google-labs/breadboard": "^0.10.0",
@@ -28082,18 +28099,18 @@
     },
     "packages/gemini-kit": {
       "name": "@google-labs/gemini-kit",
-      "version": "0.0.1",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google-labs/breadboard": "0.10.0",
-        "@google-labs/core-kit": "0.2.1",
+        "@google-labs/breadboard": "0.10.1",
+        "@google-labs/core-kit": "0.2.2",
         "@google-labs/json-kit": "0.0.5",
         "@google-labs/node-nursery-web": "1.0.2",
-        "@google-labs/template-kit": "0.1.3"
+        "@google-labs/template-kit": "0.1.4"
       },
       "devDependencies": {
         "@ava/typescript": "^4.0.0",
-        "@google-labs/breadboard-cli": "0.4.0",
+        "@google-labs/breadboard-cli": "0.4.1",
         "@google-labs/tsconfig": "^0.0.1",
         "@types/node": "^18.16.3",
         "@typescript-eslint/eslint-plugin": "^6.20.0",
@@ -28168,16 +28185,16 @@
     },
     "packages/hello-world": {
       "name": "@google-labs/breadboard-hello-world",
-      "version": "1.1.0",
+      "version": "1.2.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google-labs/breadboard": "^0.10.0",
-        "@google-labs/breadboard-cli": "0.4.0",
-        "@google-labs/core-kit": "0.2.1",
-        "@google-labs/gemini-kit": "0.0.1",
+        "@google-labs/breadboard": "^0.10.1",
+        "@google-labs/breadboard-cli": "0.4.1",
+        "@google-labs/core-kit": "0.2.2",
+        "@google-labs/gemini-kit": "0.1.1",
         "@google-labs/json-kit": "0.0.5",
         "@google-labs/palm-kit": "0.0.4",
-        "@google-labs/template-kit": "0.1.3"
+        "@google-labs/template-kit": "0.1.4"
       },
       "devDependencies": {
         "tsx": "^4.7.0",
@@ -28436,10 +28453,10 @@
     },
     "packages/template-kit": {
       "name": "@google-labs/template-kit",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@google-labs/breadboard": "^0.10.0",
+        "@google-labs/breadboard": "^0.10.1",
         "url-template": "^3.1.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "wireit": {
     "build": {
       "dependencies": [
+        "./packages/agent-kit:build",
         "./packages/breadboard:build",
         "./packages/breadboard-cli:build",
         "./packages/breadboard-server:build",

--- a/packages/agent-kit/.npmignore
+++ b/packages/agent-kit/.npmignore
@@ -1,0 +1,2 @@
+.env
+tsconfig.tsbuildinfo

--- a/packages/agent-kit/README.md
+++ b/packages/agent-kit/README.md
@@ -1,0 +1,3 @@
+# Breadboard Agent Kit
+
+This is a collection of Breadboard nodes that facilitates building agent-like experiences.

--- a/packages/agent-kit/package.json
+++ b/packages/agent-kit/package.json
@@ -1,0 +1,114 @@
+{
+  "name": "@google-labs/agent-kit",
+  "publishConfig": {
+    "registry": "https://wombat-dressing-room.appspot.com"
+  },
+  "private": true,
+  "version": "0.0.1",
+  "description": "A Breadboard Kit for building agent-like experiences",
+  "main": "./dist/src/index.js",
+  "exports": "./dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "type": "module",
+  "scripts": {
+    "prepack": "npm run build",
+    "test": "wireit",
+    "build": "wireit",
+    "lint": "wireit"
+  },
+  "wireit": {
+    "build": {
+      "dependencies": [
+        "../breadboard:build",
+        "../core-kit:build",
+        "../json-kit:build",
+        "../template-kit:build",
+        "../gemini-kit:build",
+        "build:tsc"
+      ]
+    },
+    "build:tsc": {
+      "command": "tsc -b",
+      "env": {
+        "FORCE_COLOR": "1"
+      },
+      "dependencies": [
+        "../breadboard:build:tsc",
+        "../core-kit:build:tsc",
+        "../json-kit:build:tsc",
+        "../template-kit:build:tsc",
+        "../gemini-kit:build:tsc"
+      ],
+      "files": [
+        "src/**/*.ts",
+        "tests/**/*.ts",
+        "tsconfig.json",
+        "../../core/tsconfig/base.json"
+      ],
+      "output": [
+        "dist/",
+        "!dist/**/*.min.js{,.map}"
+      ],
+      "clean": "if-file-deleted"
+    },
+    "test": {
+      "command": "ava",
+      "env": {
+        "FORCE_COLOR": "1"
+      },
+      "dependencies": [
+        "build:tsc"
+      ],
+      "files": [],
+      "output": []
+    },
+    "lint": {
+      "command": "eslint . --ext .ts",
+      "env": {
+        "FORCE_COLOR": "1"
+      },
+      "files": [
+        "src/**/*.ts",
+        "tests/**/*.ts",
+        "../../.eslintrc.json"
+      ],
+      "output": []
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/breadboard-ai/breadboard"
+  },
+  "files": [
+    "dist/src"
+  ],
+  "ava": {
+    "timeout": "30s",
+    "files": [
+      "tests/**/*.ts"
+    ],
+    "workerThreads": false,
+    "typescript": {
+      "rewritePaths": {
+        "./": "dist/"
+      },
+      "compile": false
+    }
+  },
+  "keywords": [],
+  "author": "Google Labs Team",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/breadboard-ai/breadboard/issues"
+  },
+  "homepage": "https://github.com/breadboard-ai/breadboard#readme",
+  "devDependencies": {
+    "@ava/typescript": "^4.0.0",
+    "@typescript-eslint/eslint-plugin": "^6.20.0",
+    "@typescript-eslint/parser": "^6.20.0",
+    "@types/node": "^18.16.3",
+    "ava": "^5.2.0",
+    "typescript": "^5.0.4",
+    "@google-labs/tsconfig": "^0.0.1"
+  }
+}

--- a/packages/agent-kit/package.json
+++ b/packages/agent-kit/package.json
@@ -3,7 +3,6 @@
   "publishConfig": {
     "registry": "https://wombat-dressing-room.appspot.com"
   },
-  "private": true,
   "version": "0.0.1",
   "description": "A Breadboard Kit for building agent-like experiences",
   "main": "./dist/src/index.js",

--- a/packages/agent-kit/package.json
+++ b/packages/agent-kit/package.json
@@ -12,11 +12,19 @@
   "type": "module",
   "scripts": {
     "prepack": "npm run build",
+    "dev": "wireit",
     "test": "wireit",
     "build": "wireit",
     "lint": "wireit"
   },
   "wireit": {
+    "dev": {
+      "command": "breadboard debug src/boards --watch -n",
+      "dependencies": [
+        "build",
+        "../breadboard-cli:build"
+      ]
+    },
     "build": {
       "dependencies": [
         "../breadboard:build",

--- a/packages/agent-kit/src/boards/worker.ts
+++ b/packages/agent-kit/src/boards/worker.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { board } from "@google-labs/breadboard";
+import { core } from "@google-labs/core-kit";
+import { json } from "@google-labs/json-kit";
+
+const sampleContext = JSON.stringify(
+  [
+    {
+      role: "user",
+      parts: [
+        {
+          text: `You are a brilliant poet who specializes in two-line rhyming poems.
+Given any topic, you can quickly whip up a two-line rhyming poem about it.
+Ready?
+
+The topic is: the universe within us`,
+        },
+      ],
+    },
+  ],
+  null,
+  2
+);
+
+export default await board(({ generator, context, stopSequences }) => {
+  generator.title("Generator").optional().default("gemini-generator.json");
+  context
+    .title("Context")
+    .isArray()
+    .format("multiline")
+    .examples(sampleContext);
+  stopSequences.title("Stop Sequences").isArray().optional().default("[]");
+
+  const { context: generated, text: output } = core.invoke({
+    $id: "generate",
+    context,
+    stopSequences,
+    text: "unused", // A gross hack (see TODO in gemini-generator.ts)
+    path: generator.isString(),
+  });
+
+  const { result } = json.jsonata({
+    $id: "assemble",
+    expression: `$append(context ? context, [generated])`,
+    generated,
+    context,
+  });
+
+  result
+    .title("Context")
+    .isObject()
+    .description("Agent context after generation");
+  output.title("Output").isString().description("Agent's output");
+
+  return { context: result, text: output };
+}).serialize({
+  title: "Worker",
+  description: "The essential Agent building block",
+  version: "0.0.1",
+});

--- a/packages/agent-kit/src/boards/worker.ts
+++ b/packages/agent-kit/src/boards/worker.ts
@@ -5,8 +5,8 @@
  */
 
 import { board } from "@google-labs/breadboard";
-import { core } from "@google-labs/core-kit";
 import { json } from "@google-labs/json-kit";
+import { gemini } from "@google-labs/gemini-kit";
 
 const sampleContext = JSON.stringify(
   [
@@ -36,12 +36,11 @@ export default await board(({ generator, context, stopSequences }) => {
     .examples(sampleContext);
   stopSequences.title("Stop Sequences").isArray().optional().default("[]");
 
-  const { context: generated, text: output } = core.invoke({
+  const { context: generated, text: output } = gemini.text({
     $id: "generate",
     context,
     stopSequences,
     text: "unused", // A gross hack (see TODO in gemini-generator.ts)
-    path: generator.isString(),
   });
 
   const { result } = json.jsonata({

--- a/packages/agent-kit/src/index.ts
+++ b/packages/agent-kit/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+console.log("code goes here");

--- a/packages/agent-kit/src/index.ts
+++ b/packages/agent-kit/src/index.ts
@@ -1,7 +1,72 @@
 /**
  * @license
- * Copyright 2023 Google LLC
+ * Copyright 2024 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 
-console.log("code goes here");
+import { GraphToKitAdapter, KitBuilder } from "@google-labs/breadboard/kits";
+
+import kit from "./kit.js";
+import { NewNodeFactory, NewNodeValue, addKit } from "@google-labs/breadboard";
+
+// TODO: Replace with the actual URL.
+const KIT_BASE_URL =
+  "https://raw.githubusercontent.com/breadboard-ai/breadboard/main/packages/agent-kit/graphs/kit.json";
+
+const adapter = await GraphToKitAdapter.create(kit, KIT_BASE_URL, []);
+
+const builder = new KitBuilder(
+  adapter.populateDescriptor({
+    url: "npm:@google-labs/agent-kit",
+    // TODO: This currently doesn't work, because "addKit" below translates
+    // handler id directly into the node name. We need to make it work without
+    // prefix.
+    // namespacePrefix: "agent-",
+  })
+);
+
+const AgentKit = builder.build({
+  worker: adapter.handlerForNode("worker"),
+});
+
+export type AgentKit = InstanceType<typeof AgentKit>;
+
+export type AgentKitType = {
+  /**
+   * The essential building block of the Agent Kit.
+   */
+  worker: NewNodeFactory<
+    {
+      /**
+       * The generator to use for the agent.
+       */
+      generator?: NewNodeValue;
+      /**
+       * The context to use for the agent.
+       */
+      context: NewNodeValue;
+      /**
+       * The stop sequences to use for the agent.
+       */
+      stopSequences: NewNodeValue;
+    },
+    {
+      /**
+       * The context after generation.
+       */
+      context: NewNodeValue;
+      /**
+       * The output from the agent.
+       */
+      text: NewNodeValue;
+    }
+  >;
+};
+
+export default AgentKit;
+
+/**
+ * The Agent Kit. Use members of this object to create nodes to create
+ * agent-like experiences.
+ */
+export const agents = addKit(AgentKit) as unknown as AgentKitType;

--- a/packages/agent-kit/src/kit.ts
+++ b/packages/agent-kit/src/kit.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Board } from "@google-labs/breadboard";
+
+import worker from "./boards/worker.js";
+
+import { Core } from "@google-labs/core-kit";
+
+// TODO: Convert to new syntax
+const kit = new Board({
+  title: "Agent Kit",
+  description:
+    "This board is actually a kit: a collection of nodes for building Agent-like experiences.",
+  version: "0.0.1",
+});
+const core = kit.addKit(Core);
+
+kit.graphs = {
+  worker,
+};
+
+core.invoke({ $id: "worker", path: "#worker" });
+
+export default kit;

--- a/packages/agent-kit/tsconfig.json
+++ b/packages/agent-kit/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "extends": "@google-labs/tsconfig/base.json"
+}

--- a/packages/breadboard-cli/src/commands/lib/loaders/typescript.ts
+++ b/packages/breadboard-cli/src/commands/lib/loaders/typescript.ts
@@ -65,6 +65,7 @@ export class TypeScriptLoader extends Loader {
       console.error(e);
       return undefined;
     } finally {
+      tmpFileStat = await stat(tmpFilePath);
       // remove the file
       if (tmpFileStat && tmpFileStat.isFile()) {
         await unlink(tmpFilePath);

--- a/packages/breadboard-web/package.json
+++ b/packages/breadboard-web/package.json
@@ -199,6 +199,7 @@
     "vitest": "^0.34.6"
   },
   "dependencies": {
+    "@google-labs/agent-kit": "0.0.1",
     "@google-labs/breadboard": "^0.10.1",
     "@google-labs/breadboard-ui": "^0.0.6",
     "@google-labs/core-kit": "^0.2.2",

--- a/packages/hello-world/package.json
+++ b/packages/hello-world/package.json
@@ -21,6 +21,7 @@
     "typescript": "^5.0.4"
   },
   "dependencies": {
+    "@google-labs/agent-kit": "0.0.1",
     "@google-labs/breadboard": "^0.10.1",
     "@google-labs/breadboard-cli": "0.4.1",
     "@google-labs/core-kit": "0.2.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@google-labs/tsconfig/base.json",
   "files": [],
   "references": [
+    { "path": "packages/agent-kit" },
     { "path": "packages/breadboard" },
     { "path": "packages/breadboard-cli" },
     { "path": "packages/breadboard-extension" },


### PR DESCRIPTION
- Stub out agent-kit
- Copy a board and make it build
- Make the Worker board actually work.
- Remove temp files created by TypeScript loader.
- Make it a real kit.
- Mark package as public.
- docs(changeset): Remove temporary files created by TypeScript loader.
- docs(changeset): Introduce Agent Kit.
