### PR TITLE
Open-source Breadboard -> VisualBlocks conversion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1222,7 +1222,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/breadboard-ui/src/elements/diagram/diagram.ts
+++ b/packages/breadboard-ui/src/elements/diagram/diagram.ts
@@ -501,7 +501,7 @@ export class Diagram extends HTMLElement {
     this.#translation.y = 0;
   }
 
-  async render(diagram: string | LoadArgs, highlightedNode: string) {
+  async draw(diagram: string | LoadArgs, highlightedNode: string) {
     if (!(typeof diagram === 'string')) {
       if (!diagram.diagram) {
         throw new Error('No diagram string provided');

--- a/packages/breadboard-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/breadboard-ui/src/elements/ui-controller/ui-controller.ts
@@ -30,7 +30,6 @@ import { Ref, createRef, ref } from "lit/directives/ref.js";
 import { longTermMemory } from "../../utils/long-term-memory.js";
 import { classMap } from "lit/directives/class-map.js";
 import { styles as uiControllerStyles } from "./ui-controller.styles.js";
-import { until } from "lit/directives/until.js";
 import { guard } from "lit/directives/guard.js";
 import { type InputList } from "../input/input-list/input-list.js";
 import '../visual-breadboard/visual-breadboard.js';

--- a/packages/breadboard-ui/src/elements/visual-breadboard/breadboard-to-visualblocks.ts
+++ b/packages/breadboard-ui/src/elements/visual-breadboard/breadboard-to-visualblocks.ts
@@ -1,0 +1,127 @@
+
+import {OutputIdentifier} from '@google-labs/breadboard';
+import {NodeDescriptor, GraphDescriptor, InputIdentifier} from '@google-labs/breadboard'
+
+
+function breadboardNodeToVisualBlocks(
+    node: NodeDescriptor,
+) {
+  return {
+    id: node.id,
+    displayLabel: node.id,
+    nodeSpecId: 'default', // TODO: More node specs for different node types
+    uiData: { // This gets overwritten by auto-layout
+      hovered: false,
+      posX: 194.49770545401046,
+      posY: 138.6742722180565,
+      selected: false,
+      width: 150,
+    },
+    inputValues: node.configuration,
+  };
+}
+
+export function breadboardToVisualBlocks(
+  graph: GraphDescriptor,
+) {
+  const serializedGraphMap: any = {}; // TODO: VB Types
+
+  for (const node of graph.nodes) {
+    serializedGraphMap[node.id] = breadboardNodeToVisualBlocks(node);
+  }
+
+  // Collect the current set of inputs and outputs for each node.
+  // This is used to initialize the dynamic io field for the visual blocks
+  // node so that it doesn't immediately delete the connections.
+  const nodeIO = new Map(
+    graph.nodes.map((node: {id: string}) => [ // TODO: VB types
+      node.id,
+      {
+        inputs: new Set<InputIdentifier>(),
+        outputs: new Set<OutputIdentifier>(),
+      },
+    ]),
+  );
+
+  for (const edge of graph.edges) {
+    const source = serializedGraphMap[edge.from];
+    const destination = serializedGraphMap[edge.to];
+    if (destination == null) {
+      throw new Error(
+        'Graph is missing destination node for edge from' +
+          ` ${edge.from} to ${edge.to}`,
+      );
+    }
+    destination.incomingEdges = destination.incomingEdges ?? {};
+
+    // Handle special edges like control flow and '*' edges.
+    let edgeIn = edge.in;
+    let edgeOut = edge.out;
+    if (edgeIn == null) {
+      if (edgeOut == null) {
+        edgeIn = '-';
+        edgeOut = '-';
+      } else if (edgeOut === '*') {
+        edgeIn = '*';
+        edgeOut = '*';
+        // TODO(msoulanille): Handle '*' edges.
+        //throw new Error('"*" edges are not supported yet');
+      } else {
+        throw new Error(
+          `Wire output '${edgeOut}' from '${edge.from}' to ` +
+            `'${edge.to}' does not specify an input that it's wired to.`,
+        );
+      }
+    }
+
+    if (edgeOut == null) {
+      throw new Error(
+        `Wire does not specify an output from '${edge.from}'` +
+          ` but does specify the input '${edgeIn}' on '${edge.to}'.`,
+      );
+    }
+
+    nodeIO.get(edge.from)?.outputs.add(edgeOut);
+    nodeIO.get(edge.to)?.inputs.add(edgeIn);
+
+    // TODO(msoulanille): Refactor the input node and remove `BB Prop`.
+    if (source.nodeSpecId === 'input') {
+      source.propValues = {
+        'BB Prop': edgeOut,
+      };
+    }
+
+    destination.incomingEdges[edgeIn] =
+      destination.incomingEdges[edgeIn] ?? [];
+    destination.incomingEdges[edgeIn].push({
+      outputId: edgeOut,
+      sourceNodeId: edge.from,
+    });
+  }
+
+  // Set the dynamic input / output specs to the current configuration
+  // so VB doesn't immediately break connections that don't appear in the
+  // static I/O config for the given nodes.
+  for (const node of graph.nodes) {
+    const vbNode = serializedGraphMap[node.id];
+    const {inputs, outputs} = nodeIO.get(node.id)!;
+
+    vbNode.nodeDynamicSpec = {
+      inputSpecs: [...inputs].map((name) => ({
+        name,
+        // TODO(msoulanille): Some kind of any type, as a placeholder
+        // until the user first runs the graph (and we get real
+        // vals to pass to the reflection function).
+        type: 'string',
+      })),
+      outputSpecs: [...outputs].map((name) => ({
+        name,
+        type: 'string',
+      })),
+    };
+  }
+
+  return {
+    nodes: Object.values(serializedGraphMap),
+  };
+}

--- a/packages/breadboard-ui/src/elements/visual-breadboard/breadboard-to-visualblocks.ts
+++ b/packages/breadboard-ui/src/elements/visual-breadboard/breadboard-to-visualblocks.ts
@@ -24,6 +24,7 @@ function breadboardNodeToVisualBlocks(
 export function breadboardToVisualBlocks(
   graph: GraphDescriptor,
 ) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const serializedGraphMap: any = {}; // TODO: VB Types
 
   for (const node of graph.nodes) {

--- a/packages/breadboard-ui/src/elements/visual-breadboard/visual-breadboard.ts
+++ b/packages/breadboard-ui/src/elements/visual-breadboard/visual-breadboard.ts
@@ -1,0 +1,74 @@
+import { LitElement, html, nothing} from "lit";
+import {customElement, property} from "lit/decorators.js";
+import {LoadArgs} from "../../types/types.js";
+import { Ref, createRef, ref } from "lit/directives/ref.js";
+import { until } from "lit/directives/until.js";
+import {breadboardToVisualBlocks} from "./breadboard-to-visualblocks.js";
+
+const VISUALBLOCKS_URL =
+  "https://storage.googleapis.com/tfweb/node-graph-editor/node_graph_editor_20240130001456/node_graph_editor_bin.js"
+
+@customElement("visual-breadboard")
+export class VisualBreadboard extends LitElement {
+  // TODO: Make this 'implement DiagramElement'
+  #requestedVB = false;
+  #visualBlocks: Ref<HTMLElement> = createRef();
+
+  @property()
+  serializedGraph: any;
+
+  reset() {
+
+  }
+
+  async draw(diagram: LoadArgs, highlightedNode: string) {
+    if (!diagram.graphDescriptor) {
+      return;
+    }
+    this.serializedGraph = breadboardToVisualBlocks(diagram.graphDescriptor);
+    await this.updateComplete;
+
+    // TODO: Don't do this setTimeout hackery.
+    // It's necessary now because the angular visualblocks component hasn't
+    // yet registered all its `@Input` handlers, so the `smartLayout` property
+    // isn't available yet.
+    //
+    // We probably need to pass the component a callback that it can call
+    // after it's set up. This seems like it will work, since it's able to render
+    // the `serializedGraph`.
+    setTimeout(() => {
+      (this.#visualBlocks.value as any)?.smartLayout(); // TODO: Types
+    }, 100);
+  }
+
+  render() {
+    const loadVisualBlocks = async () => {
+      if (
+        !this.#requestedVB &&
+        customElements.get("graph-editor") == null
+      ) {
+        this.#requestedVB = true;
+        await loadScript(VISUALBLOCKS_URL);
+        //this.#scheduleDiagramRender();
+      }
+      return html`<graph-editor
+        ${ref(this.#visualBlocks)}
+        .serializedGraph=${this.serializedGraph}
+        ></graph-editor>`;
+    };
+
+    return until(loadVisualBlocks(), html`Loading...`);
+  }
+}
+
+function loadScript(url: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const script = document.createElement("script");
+    script.src = url;
+    script.onload = () => {
+      resolve();
+    };
+    script.onerror = reject;
+    document.head.appendChild(script);
+  });
+}

--- a/packages/breadboard-ui/src/elements/visual-breadboard/visual-breadboard.ts
+++ b/packages/breadboard-ui/src/elements/visual-breadboard/visual-breadboard.ts
@@ -1,9 +1,9 @@
-import { LitElement, html, nothing} from "lit";
-import {customElement, property} from "lit/decorators.js";
-import {LoadArgs} from "../../types/types.js";
-import { Ref, createRef, ref } from "lit/directives/ref.js";
+import { LitElement, html } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { LoadArgs } from "../../types/types.js";
+import { ref } from "lit/directives/ref.js";
 import { until } from "lit/directives/until.js";
-import {breadboardToVisualBlocks} from "./breadboard-to-visualblocks.js";
+import { breadboardToVisualBlocks } from "./breadboard-to-visualblocks.js";
 
 const VISUALBLOCKS_URL =
   "https://storage.googleapis.com/tfweb/node-graph-editor/node_graph_editor_20240201160419/node_graph_editor_bin.js"
@@ -20,7 +20,7 @@ export class VisualBreadboard extends LitElement {
   });
 
   @property()
-  serializedGraph: any;
+  serializedGraph: unknown;
 
   #updateGraph = valueDebounce(async (diagram: LoadArgs | null) => {
     if (!diagram?.graphDescriptor) {
@@ -30,6 +30,7 @@ export class VisualBreadboard extends LitElement {
     this.serializedGraph = breadboardToVisualBlocks(diagram.graphDescriptor);
     await this.updateComplete;
     await this.#visualBlocksLoaded;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (this.#visualBlocks as any)?.smartLayout(); // TODO: Types
   }, 2000);
 
@@ -37,7 +38,7 @@ export class VisualBreadboard extends LitElement {
     this.#updateGraph(null);
   }
 
-  async draw(diagram: LoadArgs, highlightedNode: string) {
+  async draw(diagram: LoadArgs, _highlightedNode: string) {
     this.#updateGraph(diagram);
   }
 


### PR DESCRIPTION
Move the Breadboard to VisualBlocks conversion from google3 to the `breadboard-to-visualblocks.ts` file and add a new `visual-breadboard` component to wrap the google3 VisualBlocks component.

This PR also renames `render` to `draw` for the graph drawing components (like `diagram.ts`), since Lit-element reserves the function name `render` (and the `visual-breadboard` component uses Lit).

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
