### PR TITLE
use agent kit

### DIFF
--- a/.changeset/brave-moles-explode.md
+++ b/.changeset/brave-moles-explode.md
@@ -1,0 +1,6 @@
+---
+"@google-labs/breadboard-web": minor
+"@google-labs/agent-kit": minor
+---
+
+Introduce "Agent Kit" to the Breadboard Kit family.

--- a/package-lock.json
+++ b/package-lock.json
@@ -26598,6 +26598,7 @@
       }
     },
     "packages/agent-kit": {
+      "name": "@google-labs/agent-kit",
       "version": "0.0.1",
       "license": "Apache-2.0",
       "devDependencies": {
@@ -27238,6 +27239,7 @@
       "version": "1.1.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "@google-labs/agent-kit": "0.0.1",
         "@google-labs/breadboard": "^0.10.1",
         "@google-labs/breadboard-ui": "^0.0.6",
         "@google-labs/core-kit": "^0.2.2",
@@ -28188,6 +28190,7 @@
       "version": "1.2.2",
       "license": "Apache-2.0",
       "dependencies": {
+        "@google-labs/agent-kit": "0.0.1",
         "@google-labs/breadboard": "^0.10.1",
         "@google-labs/breadboard-cli": "0.4.1",
         "@google-labs/core-kit": "0.2.2",

--- a/packages/agent-kit/package.json
+++ b/packages/agent-kit/package.json
@@ -12,6 +12,8 @@
   "scripts": {
     "prepack": "npm run build",
     "dev": "wireit",
+    "dev:samples": "npm run samples --watch",
+    "samples": "wireit",
     "test": "wireit",
     "build": "wireit",
     "lint": "wireit"
@@ -19,6 +21,14 @@
   "wireit": {
     "dev": {
       "command": "breadboard debug src/boards --watch -n",
+      "dependencies": [
+        "build",
+        "../breadboard-cli:build"
+      ]
+    },
+    "samples": {
+      "command": "breadboard debug src/samples --watch -n",
+      "service": true,
       "dependencies": [
         "build",
         "../breadboard-cli:build"
@@ -48,6 +58,7 @@
       ],
       "files": [
         "src/**/*.ts",
+        "!src/samples/**/*.ts",
         "tests/**/*.ts",
         "tsconfig.json",
         "../../core/tsconfig/base.json"

--- a/packages/agent-kit/src/boards/instruction.ts
+++ b/packages/agent-kit/src/boards/instruction.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  NewNodeFactory,
+  NewNodeValue,
+  board,
+  code,
+} from "@google-labs/breadboard";
+
+export type InstructionType = NewNodeFactory<
+  InstructionTypeInput,
+  InstructionTypeOutput
+>;
+
+export type InstructionTypeInput = {
+  /**
+   * The context to use for the agent.
+   */
+  context?: NewNodeValue;
+  /**
+   * The prompt to use for the agent.
+   */
+  prompt: NewNodeValue;
+};
+
+export type InstructionTypeOutput = {
+  /**
+   * The context after generation.
+   */
+  context: NewNodeValue;
+};
+
+type ContextItem = {
+  role: string;
+  parts: { text: string }[];
+};
+
+const contextBuilder = code(({ context, prompt }) => {
+  const list = (context as unknown[]) || [];
+  if (list.length > 0) {
+    const last = list[list.length - 1] as ContextItem;
+    if (last.role === "user") {
+      last.parts.push({ text: prompt as string });
+      return { context: list };
+    }
+  }
+  return {
+    context: [...list, { role: "user", parts: [{ text: prompt }] }],
+  };
+});
+
+export default await board(({ context, prompt }) => {
+  context.title("Context").isArray().optional().default("[]");
+  prompt.title("Prompt").isString().format("multiline")
+    .examples(`You are a brilliant poet who specializes in two-line rhyming poems.
+Given any topic, you can quickly whip up a two-line rhyming poem about it.
+Ready?
+
+The topic is: the universe within us`);
+
+  const { context: newContext } = contextBuilder({
+    $id: "buildContext",
+    context,
+    prompt,
+  });
+
+  return { context: newContext };
+}).serialize({
+  title: "Instruction",
+  description:
+    "Use this board to specify an instruction for the agent. Think of it as a system prompt.",
+});

--- a/packages/agent-kit/src/boards/worker.ts
+++ b/packages/agent-kit/src/boards/worker.ts
@@ -4,9 +4,36 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { board } from "@google-labs/breadboard";
+import { NewNodeFactory, NewNodeValue, board } from "@google-labs/breadboard";
 import { json } from "@google-labs/json-kit";
 import { gemini } from "@google-labs/gemini-kit";
+
+export type WorkerType = NewNodeFactory<
+  {
+    /**
+     * The generator to use for the agent.
+     */
+    generator?: NewNodeValue;
+    /**
+     * The context to use for the agent.
+     */
+    context: NewNodeValue;
+    /**
+     * The stop sequences to use for the agent.
+     */
+    stopSequences: NewNodeValue;
+  },
+  {
+    /**
+     * The context after generation.
+     */
+    context: NewNodeValue;
+    /**
+     * The output from the agent.
+     */
+    text: NewNodeValue;
+  }
+>;
 
 const sampleContext = JSON.stringify(
   [

--- a/packages/agent-kit/src/boards/worker.ts
+++ b/packages/agent-kit/src/boards/worker.ts
@@ -14,7 +14,8 @@ const sampleContext = JSON.stringify(
       role: "user",
       parts: [
         {
-          text: `You are a brilliant poet who specializes in two-line rhyming poems.
+          text: `
+You are a brilliant poet who specializes in two-line rhyming poems.
 Given any topic, you can quickly whip up a two-line rhyming poem about it.
 Ready?
 
@@ -27,8 +28,7 @@ The topic is: the universe within us`,
   2
 );
 
-export default await board(({ generator, context, stopSequences }) => {
-  generator.title("Generator").optional().default("gemini-generator.json");
+export default await board(({ context, stopSequences }) => {
   context
     .title("Context")
     .isArray()

--- a/packages/agent-kit/src/index.ts
+++ b/packages/agent-kit/src/index.ts
@@ -7,7 +7,9 @@
 import { GraphToKitAdapter, KitBuilder } from "@google-labs/breadboard/kits";
 
 import kit from "./kit.js";
-import { NewNodeFactory, NewNodeValue, addKit } from "@google-labs/breadboard";
+import { addKit } from "@google-labs/breadboard";
+import { WorkerType } from "./boards/worker.js";
+import { InstructionType } from "./boards/instruction.js";
 
 // TODO: Replace with the actual URL.
 const KIT_BASE_URL =
@@ -27,6 +29,7 @@ const builder = new KitBuilder(
 
 const AgentKit = builder.build({
   worker: adapter.handlerForNode("worker"),
+  instruction: adapter.handlerForNode("instruction"),
 });
 
 export type AgentKit = InstanceType<typeof AgentKit>;
@@ -35,32 +38,8 @@ export type AgentKitType = {
   /**
    * The essential building block of the Agent Kit.
    */
-  worker: NewNodeFactory<
-    {
-      /**
-       * The generator to use for the agent.
-       */
-      generator?: NewNodeValue;
-      /**
-       * The context to use for the agent.
-       */
-      context: NewNodeValue;
-      /**
-       * The stop sequences to use for the agent.
-       */
-      stopSequences: NewNodeValue;
-    },
-    {
-      /**
-       * The context after generation.
-       */
-      context: NewNodeValue;
-      /**
-       * The output from the agent.
-       */
-      text: NewNodeValue;
-    }
-  >;
+  worker: WorkerType;
+  instruction: InstructionType;
 };
 
 export default AgentKit;

--- a/packages/agent-kit/src/kit.ts
+++ b/packages/agent-kit/src/kit.ts
@@ -20,12 +20,7 @@ const kit = new Board({
 });
 const core = kit.addKit(Core);
 
-kit.graphs = {
-  instruction,
-  worker,
-};
-
-core.invoke({ $id: "worker", path: "#worker" });
-core.invoke({ $id: "instruction", path: "#instruction" });
+core.invoke({ $id: "worker", graph: worker });
+core.invoke({ $id: "instruction", graph: instruction });
 
 export default kit;

--- a/packages/agent-kit/src/kit.ts
+++ b/packages/agent-kit/src/kit.ts
@@ -7,6 +7,7 @@
 import { Board } from "@google-labs/breadboard";
 
 import worker from "./boards/worker.js";
+import instruction from "./boards/instruction.js";
 
 import { Core } from "@google-labs/core-kit";
 
@@ -20,9 +21,11 @@ const kit = new Board({
 const core = kit.addKit(Core);
 
 kit.graphs = {
+  instruction,
   worker,
 };
 
 core.invoke({ $id: "worker", path: "#worker" });
+core.invoke({ $id: "instruction", path: "#instruction" });
 
 export default kit;

--- a/packages/agent-kit/src/samples/poet.ts
+++ b/packages/agent-kit/src/samples/poet.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { board, code } from "@google-labs/breadboard";
+import { agents } from "@google-labs/agent-kit";
+
+const contextMaker = code(({ topic }) => {
+  return {
+    context: [
+      {
+        role: "user",
+        parts: [
+          {
+            text: `
+You are a brilliant poet who specializes in two-line rhyming poems.
+Given any topic, you can quickly whip up a two-line rhyming poem about it.
+Ready?
+
+${topic}`,
+          },
+        ],
+      },
+    ],
+  };
+});
+
+export default await board(({ topic }) => {
+  topic.title("Poem topic").isString().examples("the universe within us");
+  const { context } = agents.worker({
+    $id: "writePoetry",
+    context: contextMaker({ $id: "makeContext", topic }),
+  });
+  return { context };
+}).serialize({
+  title: "Two-line Rhyming Poet",
+  description: "A simple example of using of the Worker node",
+});

--- a/packages/agent-kit/src/samples/poet.ts
+++ b/packages/agent-kit/src/samples/poet.ts
@@ -7,33 +7,28 @@
 import { board, code } from "@google-labs/breadboard";
 import { agents } from "@google-labs/agent-kit";
 
-const contextMaker = code(({ topic }) => {
+const makePoetPrompt = code(({ topic }) => {
   return {
-    context: [
-      {
-        role: "user",
-        parts: [
-          {
-            text: `
+    prompt: `
 You are a brilliant poet who specializes in two-line rhyming poems.
 Given any topic, you can quickly whip up a two-line rhyming poem about it.
 Ready?
 
-${topic}`,
-          },
-        ],
-      },
-    ],
+The topic is: ${topic}`,
   };
 });
 
 export default await board(({ topic }) => {
   topic.title("Poem topic").isString().examples("the universe within us");
-  const { context } = agents.worker({
-    $id: "writePoetry",
-    context: contextMaker({ $id: "makeContext", topic }).context,
+  const instruction = agents.instruction({
+    $id: "poetPrompt",
+    prompt: makePoetPrompt({ $id: "makePoetPrompt", topic }).prompt,
   });
-  return { context };
+  const worker = agents.worker({
+    $id: "writePoetry",
+    context: instruction.context,
+  });
+  return { context: worker.context };
 }).serialize({
   title: "Two-line Rhyming Poet",
   description: "A simple example of using of the Worker node",

--- a/packages/agent-kit/src/samples/poet.ts
+++ b/packages/agent-kit/src/samples/poet.ts
@@ -31,7 +31,7 @@ export default await board(({ topic }) => {
   topic.title("Poem topic").isString().examples("the universe within us");
   const { context } = agents.worker({
     $id: "writePoetry",
-    context: contextMaker({ $id: "makeContext", topic }),
+    context: contextMaker({ $id: "makeContext", topic }).context,
   });
   return { context };
 }).serialize({

--- a/packages/breadboard-web/package.json
+++ b/packages/breadboard-web/package.json
@@ -40,6 +40,7 @@
   "wireit": {
     "build": {
       "dependencies": [
+        "../agent-kit:build",
         "../breadboard:build",
         "../breadboard-ui:build",
         "../core-kit:build",
@@ -56,6 +57,7 @@
     },
     "typescript-files-and-deps": {
       "dependencies": [
+        "../agent-kit:build:tsc",
         "../breadboard:build:tsc",
         "../breadboard-ui:build:tsc",
         "../core-kit:build:tsc",

--- a/packages/breadboard-web/src/config.ts
+++ b/packages/breadboard-web/src/config.ts
@@ -18,6 +18,7 @@ import NodeNurseryWeb from "@google-labs/node-nursery-web";
 import PaLMKit from "@google-labs/palm-kit";
 import Pinecone from "@google-labs/pinecone-kit";
 import GeminiKit from "@google-labs/gemini-kit";
+import AgentKit from "@google-labs/agent-kit";
 
 const PROXY_NODES = [
   "palm-generateText",
@@ -51,6 +52,7 @@ const kits = [
   GeminiKit,
   NodeNurseryWeb,
   JSONKit,
+  AgentKit,
 ].map((kitConstructor) => asRuntimeKit(kitConstructor));
 
 export const createRunConfig = (url: string) => {


### PR DESCRIPTION
- Start using Agent Kit in debugger
- Establish a way to build + use agent kit.
- Make context output port explicit.
- A non-working poet that uses `instruction` node.
- Make poet work with `instruction`.
- docs(changeset): Introduce "Agent Kit" to the Breadboard Kit family.
