### PR TITLE
inspector

### DIFF
--- a/.changeset/dry-bananas-ring.md
+++ b/.changeset/dry-bananas-ring.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard": minor
+---
+
+Added `subgraph` method to `InspectableNode`.

--- a/packages/breadboard/src/inspector/graph.ts
+++ b/packages/breadboard/src/inspector/graph.ts
@@ -23,6 +23,7 @@ class Graph implements InspectableGraph {
   #nodes: InspectableNode[];
   #nodeMap: Map<NodeIdentifier, InspectableNode>;
   #typeMap: Map<NodeTypeIdentifier, InspectableNode[]> = new Map();
+  #entries?: InspectableNode[];
 
   constructor(graph: GraphDescriptor) {
     this.#graph = graph;
@@ -83,6 +84,10 @@ class Graph implements InspectableGraph {
       .filter(
         (edge) => edge.from !== undefined && edge.to !== undefined
       ) as InspectableEdge[];
+  }
+
+  entries(): InspectableNode[] {
+    return (this.#entries ??= this.#nodes.filter((node) => node.isEntry()));
   }
 
   async describe(): Promise<NodeDescriberResult> {

--- a/packages/breadboard/src/inspector/graph.ts
+++ b/packages/breadboard/src/inspector/graph.ts
@@ -12,20 +12,33 @@ import {
   NodeTypeIdentifier,
 } from "../types.js";
 import { inspectableNode } from "./node.js";
-import { InspectableEdge, InspectableGraph, InspectableNode } from "./types.js";
+import {
+  InspectableEdge,
+  InspectableGraph,
+  InspectableGraphOptions,
+  InspectableNode,
+} from "./types.js";
 
-export const inspectableGraph = (graph: GraphDescriptor): InspectableGraph => {
-  return new Graph(graph);
+export const inspectableGraph = (
+  graph: GraphDescriptor,
+  options?: InspectableGraphOptions
+): InspectableGraph => {
+  return new Graph(graph, options);
 };
 
 class Graph implements InspectableGraph {
+  #baseURL: URL;
   #graph: GraphDescriptor;
   #nodes: InspectableNode[];
   #nodeMap: Map<NodeIdentifier, InspectableNode>;
   #typeMap: Map<NodeTypeIdentifier, InspectableNode[]> = new Map();
   #entries?: InspectableNode[];
 
-  constructor(graph: GraphDescriptor) {
+  constructor(
+    graph: GraphDescriptor,
+    { baseURL }: InspectableGraphOptions = {}
+  ) {
+    this.#baseURL = baseURL || new URL(import.meta.url);
     this.#graph = graph;
     this.#nodes = this.#graph.nodes.map((node) => inspectableNode(node, this));
     this.#nodeMap = new Map(
@@ -40,6 +53,14 @@ class Graph implements InspectableGraph {
       }
       list.push(node);
     });
+  }
+
+  raw() {
+    return this.#graph;
+  }
+
+  baseURL(): URL {
+    return this.#baseURL;
   }
 
   nodesByType(type: NodeTypeIdentifier): InspectableNode[] {

--- a/packages/breadboard/src/inspector/graph.ts
+++ b/packages/breadboard/src/inspector/graph.ts
@@ -12,33 +12,20 @@ import {
   NodeTypeIdentifier,
 } from "../types.js";
 import { inspectableNode } from "./node.js";
-import {
-  InspectableEdge,
-  InspectableGraph,
-  InspectableGraphOptions,
-  InspectableNode,
-} from "./types.js";
+import { InspectableEdge, InspectableGraph, InspectableNode } from "./types.js";
 
-export const inspectableGraph = (
-  graph: GraphDescriptor,
-  options?: InspectableGraphOptions
-): InspectableGraph => {
-  return new Graph(graph, options);
+export const inspectableGraph = (graph: GraphDescriptor): InspectableGraph => {
+  return new Graph(graph);
 };
 
 class Graph implements InspectableGraph {
-  #baseURL: URL;
   #graph: GraphDescriptor;
   #nodes: InspectableNode[];
   #nodeMap: Map<NodeIdentifier, InspectableNode>;
   #typeMap: Map<NodeTypeIdentifier, InspectableNode[]> = new Map();
   #entries?: InspectableNode[];
 
-  constructor(
-    graph: GraphDescriptor,
-    { baseURL }: InspectableGraphOptions = {}
-  ) {
-    this.#baseURL = baseURL || new URL(import.meta.url);
+  constructor(graph: GraphDescriptor) {
     this.#graph = graph;
     this.#nodes = this.#graph.nodes.map((node) => inspectableNode(node, this));
     this.#nodeMap = new Map(
@@ -57,10 +44,6 @@ class Graph implements InspectableGraph {
 
   raw() {
     return this.#graph;
-  }
-
-  baseURL(): URL {
-    return this.#baseURL;
   }
 
   nodesByType(type: NodeTypeIdentifier): InspectableNode[] {

--- a/packages/breadboard/src/inspector/index.ts
+++ b/packages/breadboard/src/inspector/index.ts
@@ -4,15 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { InspectableGraph } from "./types.js";
-
 export { inspectableGraph } from "./graph.js";
-
-export const getGraphAPI = (inspectableGraph: InspectableGraph) => {
-  const inputs = inspectableGraph.nodesByType("input");
-  const outputs = inspectableGraph.nodesByType("output");
-  return {
-    inputs,
-    outputs,
-  };
-};

--- a/packages/breadboard/src/inspector/index.ts
+++ b/packages/breadboard/src/inspector/index.ts
@@ -4,4 +4,45 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { BoardLoader } from "../loader.js";
+import { GraphDescriptor } from "../types.js";
+import { inspectableGraph } from "./graph.js";
+import { InspectableGraphLoader } from "./types.js";
+
 export { inspectableGraph } from "./graph.js";
+
+/**
+ * Use this function to create a simple graph loader for inspection.
+ *
+ * Example:
+ *
+ * ```ts
+ * const inspectable = inspectableGraph(someGraphDescriptor);
+ * const invoke = inspectable.nodesByType("invoke")[0];
+ * const subgraph = invoke.subgraph(
+ *   loadToInspect(new URL("http://localhost:3000"))
+ * );
+ * ```
+ *
+ * @param base the base URL that will be used to resolve the path to the
+ * subgraph in case it's relative
+ * @returns the `InspectableGraph`
+ */
+export const loadToInspect = (base: URL): InspectableGraphLoader => {
+  return async (
+    graph: string | GraphDescriptor,
+    loadingGraph: GraphDescriptor
+  ) => {
+    if (typeof graph === "string") {
+      // This logic is lifted from `BoardRunner.load`.
+      // TODO: Deduplicate.
+      const graphs = loadingGraph.graphs;
+      const loader = new BoardLoader({ base, graphs });
+      const result = await loader.load(graph);
+      return inspectableGraph(result.graph);
+    } else {
+      // TODO: Check that this is a valid GraphDescriptor
+      return inspectableGraph(graph);
+    }
+  };
+};

--- a/packages/breadboard/src/inspector/node.ts
+++ b/packages/breadboard/src/inspector/node.ts
@@ -67,13 +67,6 @@ class Node implements InspectableNode {
     // TODO: Support subgraphs that are dynamically loaded from values.
     const { graph, path } = this.configuration() as InvokeInputs;
     return await loader(graph ? graph : path, this.#graph.raw());
-    // // TODO: Don't use `raw()` here.
-    // const graphs = this.#graph.raw().graphs;
-    // // This logic is lifted from `BoardRunner.load`.
-    // // TODO: Deduplicate.
-    // const loader = new BoardLoader({ base, graphs });
-    // const { graph } = await loader.load(path);
-    // return inspectableGraph(graph, { baseURL: new URL(path, base) });
   }
 
   configuration(): NodeConfiguration {

--- a/packages/breadboard/src/inspector/node.ts
+++ b/packages/breadboard/src/inspector/node.ts
@@ -10,7 +10,6 @@ import {
   NodeDescriberResult,
   NodeDescriptor,
 } from "../types.js";
-import { inspectableGraph } from "./graph.js";
 import {
   InspectableEdge,
   InspectableGraph,
@@ -59,23 +58,15 @@ class Node implements InspectableNode {
   }
 
   async subgraph(
-    loader?: InspectableGraphLoader
+    loader: InspectableGraphLoader
   ): Promise<InspectableGraph | undefined> {
     if (!this.isSubgraph()) return undefined;
 
     // Find the subgraph
     type InvokeInputs = { graph: GraphDescriptor; path: string };
-    const { graph, path } = this.configuration() as InvokeInputs;
-    const base = this.#graph.baseURL();
-    if (graph) {
-      return inspectableGraph(graph, { baseURL: base });
-    }
-
     // TODO: Support subgraphs that are dynamically loaded from values.
-    if (!path) return undefined;
-
-    if (!loader) return undefined;
-    return await loader(path, this.#graph.raw());
+    const { graph, path } = this.configuration() as InvokeInputs;
+    return await loader(graph ? graph : path, this.#graph.raw());
     // // TODO: Don't use `raw()` here.
     // const graphs = this.#graph.raw().graphs;
     // // This logic is lifted from `BoardRunner.load`.

--- a/packages/breadboard/src/inspector/node.ts
+++ b/packages/breadboard/src/inspector/node.ts
@@ -4,8 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { NodeDescriptor } from "../types.js";
-import { InspectableEdge, InspectableGraph, InspectableNode } from "./types.js";
+import {
+  GraphDescriptor,
+  NodeConfiguration,
+  NodeDescriberResult,
+  NodeDescriptor,
+} from "../types.js";
+import { inspectableGraph } from "./graph.js";
+import {
+  InspectableEdge,
+  InspectableGraph,
+  InspectableGraphLoader,
+  InspectableNode,
+} from "./types.js";
 
 export const inspectableNode = (
   descriptor: NodeDescriptor,
@@ -39,5 +50,46 @@ class Node implements InspectableNode {
 
   isExit(): boolean {
     return this.outgoing().length === 0;
+  }
+
+  isSubgraph(): boolean {
+    // This is likely too naive, since map also invokes subgraphs.
+    // TODO: Flesh this out some more.
+    return this.descriptor.type === "invoke";
+  }
+
+  async subgraph(
+    loader?: InspectableGraphLoader
+  ): Promise<InspectableGraph | undefined> {
+    if (!this.isSubgraph()) return undefined;
+
+    // Find the subgraph
+    type InvokeInputs = { graph: GraphDescriptor; path: string };
+    const { graph, path } = this.configuration() as InvokeInputs;
+    const base = this.#graph.baseURL();
+    if (graph) {
+      return inspectableGraph(graph, { baseURL: base });
+    }
+
+    // TODO: Support subgraphs that are dynamically loaded from values.
+    if (!path) return undefined;
+
+    if (!loader) return undefined;
+    return await loader(path, this.#graph.raw());
+    // // TODO: Don't use `raw()` here.
+    // const graphs = this.#graph.raw().graphs;
+    // // This logic is lifted from `BoardRunner.load`.
+    // // TODO: Deduplicate.
+    // const loader = new BoardLoader({ base, graphs });
+    // const { graph } = await loader.load(path);
+    // return inspectableGraph(graph, { baseURL: new URL(path, base) });
+  }
+
+  configuration(): NodeConfiguration {
+    return this.descriptor.configuration || {};
+  }
+
+  async describe(): Promise<NodeDescriberResult> {
+    throw new Error("Not yet implemented");
   }
 }

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -79,6 +79,10 @@ export type InspectableGraph = {
    */
   outgoingForNode(id: NodeIdentifier): InspectableEdge[];
   /**
+   * Returns a list of entry nodes for the graph.
+   */
+  entries(): InspectableNode[];
+  /**
    * Returns the API of the graph. This function is designed to match the
    * output of the `NodeDescriberFunction`.
    */

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -43,12 +43,11 @@ export type InspectableNode = {
    * otherwise
    *
    * @param loader - a loader that is called with the path to load when the
-   * subgraph needs to be loaded (over the network or filesystem). If not
-   * provided, `subgraph` will define `undefined` for all subgraphs that aren't
-   * directly embedded,
+   * subgraph needs to be loaded (over the network or filesystem). The subgraph
+   * could also be embedded directly in the graph.
    */
   subgraph(
-    loader?: InspectableGraphLoader
+    loader: InspectableGraphLoader
   ): Promise<InspectableGraph | undefined>;
   /**
    * Returns the API of the node.
@@ -100,11 +99,6 @@ export type InspectableGraph = {
    */
   raw(): GraphDescriptor;
   /**
-   * Returns the base URL of the graph. Used to resolve the relative URLs of
-   * subgraphs.
-   */
-  baseURL(): URL;
-  /**
    * Returns the node with the given id, or undefined if no such node exists.
    * @param id id of the node to find
    */
@@ -139,22 +133,15 @@ export type InspectableGraph = {
   describe(): Promise<NodeDescriberResult>;
 };
 
-export type InspectableGraphOptions = {
-  /**
-   * The base URL of the graph. Used to resolve the URLs of subgraphs.
-   */
-  baseURL?: URL;
-};
-
 export type InspectableGraphLoader = (
   /**
    * The `path` value of the `invoke`. It may be a relative or an absolute URL,
-   * or a file path.
+   * a file path, a `GraphDescriptor` or undefined.
    */
-  path: string,
+  graph: GraphDescriptor | string,
   /**
    * The full GraphDescriptor of the graph in whose context the loading happens.
    * This is the graph that contains the `invoke` node.
    */
   loadingGraph: GraphDescriptor
-) => Promise<InspectableGraph>;
+) => Promise<InspectableGraph | undefined>;

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -5,6 +5,8 @@
  */
 
 import {
+  GraphDescriptor,
+  NodeConfiguration,
   NodeDescriberResult,
   NodeDescriptor,
   NodeIdentifier,
@@ -32,6 +34,44 @@ export type InspectableNode = {
    * Return true if the node is an exit node (no outgoing edges)
    */
   isExit(): boolean;
+  /**
+   * Returns true if the node represents a subgraph
+   */
+  isSubgraph(): boolean;
+  /**
+   * Returns an inspectable subgraph, if one is present or `undefined`
+   * otherwise
+   *
+   * @param loader - a loader that is called with the path to load when the
+   * subgraph needs to be loaded (over the network or filesystem). If not
+   * provided, `subgraph` will define `undefined` for all subgraphs that aren't
+   * directly embedded,
+   */
+  subgraph(
+    loader?: InspectableGraphLoader
+  ): Promise<InspectableGraph | undefined>;
+  /**
+   * Returns the API of the node.
+   *
+   * A note about the relationship between `describe`, `subgraph.describe`,
+   * and `incoming`/`outgoing`:
+   * - the `describe` returns the API as the node itself expects it
+   * - the `incoming` and `outgoing` return the actual wires going in/out
+   * - the `subgraph.describe` returns the API of the subgraph that the node
+   *   contains (or represents). For instance, the `invoke` node has a `path`
+   *   required property. This property will show up in `describe` (since it
+   *   specifies the path of the graph), but not in `subgraph.describe` (since
+   *   the subgraph itself doesn't actually use it).
+   *
+   * This function is designed to match the output of the
+   * `NodeDescriberFunction`.
+   */
+  describe(): Promise<NodeDescriberResult>;
+  /**
+   * Returns configuration of the node.
+   * TODO: Use a friendlier to inspection return type.
+   */
+  configuration(): NodeConfiguration;
 };
 
 export type InspectableEdge = {
@@ -54,6 +94,16 @@ export type InspectableEdge = {
 };
 
 export type InspectableGraph = {
+  /**
+   * Returns the underlying `GraphDescriptor` object.
+   * TODO: Replace all uses of it with a proper inspector API.
+   */
+  raw(): GraphDescriptor;
+  /**
+   * Returns the base URL of the graph. Used to resolve the relative URLs of
+   * subgraphs.
+   */
+  baseURL(): URL;
   /**
    * Returns the node with the given id, or undefined if no such node exists.
    * @param id id of the node to find
@@ -88,3 +138,23 @@ export type InspectableGraph = {
    */
   describe(): Promise<NodeDescriberResult>;
 };
+
+export type InspectableGraphOptions = {
+  /**
+   * The base URL of the graph. Used to resolve the URLs of subgraphs.
+   */
+  baseURL?: URL;
+};
+
+export type InspectableGraphLoader = (
+  /**
+   * The `path` value of the `invoke`. It may be a relative or an absolute URL,
+   * or a file path.
+   */
+  path: string,
+  /**
+   * The full GraphDescriptor of the graph in whose context the loading happens.
+   * This is the graph that contains the `invoke` node.
+   */
+  loadingGraph: GraphDescriptor
+) => Promise<InspectableGraph>;

--- a/packages/breadboard/tests/inspector/index.ts
+++ b/packages/breadboard/tests/inspector/index.ts
@@ -67,3 +67,22 @@ test("inspectableGraph tailsForNode and headsForNode work as expected", (t) => {
   t.deepEqual(b?.isEntry(), false);
   t.deepEqual(b?.isExit(), false);
 });
+
+test("Graph correctly returns entry nodes for a graph", (t) => {
+  const graph = {
+    nodes: [
+      { id: "a", type: "foo" },
+      { id: "b", type: "bar" },
+      { id: "c", type: "foo" },
+    ],
+    edges: [
+      { from: "a", to: "b" },
+      { from: "b", to: "c" },
+    ],
+  };
+  const inspectable = inspectableGraph(graph);
+  t.deepEqual(
+    inspectable.entries().map((n) => n.descriptor.id),
+    ["a"]
+  );
+});

--- a/packages/breadboard/tests/inspector/node.ts
+++ b/packages/breadboard/tests/inspector/node.ts
@@ -1,0 +1,122 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import test from "ava";
+
+import { inspectableGraph } from "../../src/inspector/index.js";
+
+test("inspectableNode detects a subgraph", (t) => {
+  const graph = {
+    nodes: [
+      { id: "a", type: "foo" },
+      { id: "b", type: "invoke" },
+      { id: "c", type: "foo" },
+    ],
+    edges: [
+      { from: "a", to: "b" },
+      { from: "b", to: "c" },
+    ],
+  };
+  const inspectable = inspectableGraph(graph);
+  t.true(inspectable.nodeById("b")?.isSubgraph());
+});
+
+test("inspectableNode correctly returns node configuration", (t) => {
+  const graph = {
+    nodes: [
+      {
+        id: "a",
+        type: "foo",
+        configuration: {
+          foo: "test",
+        },
+      },
+    ],
+    edges: [],
+  };
+  const inspectable = inspectableGraph(graph);
+  t.deepEqual(inspectable.nodeById("a")?.configuration(), { foo: "test" });
+});
+
+test("inspectableNode supports undefined subgraphs", async (t) => {
+  const graph = {
+    nodes: [
+      { id: "a", type: "foo" },
+      { id: "b", type: "invoke" },
+      { id: "c", type: "foo" },
+    ],
+    edges: [
+      { from: "a", to: "b" },
+      { from: "b", to: "c" },
+    ],
+  };
+  const inspectable = inspectableGraph(graph);
+  const b = inspectable.nodeById("b");
+  t.true(b?.isSubgraph());
+  const subgraph = await b?.subgraph();
+  t.assert(subgraph === undefined);
+});
+
+test("inspectableNode supports `graph` subgraphs", async (t) => {
+  const graph = {
+    nodes: [
+      { id: "a", type: "foo" },
+      {
+        id: "b",
+        type: "invoke",
+        configuration: {
+          graph: {
+            nodes: [{ id: "d", type: "bar" }],
+            edges: [],
+          },
+        },
+      },
+      { id: "c", type: "foo" },
+    ],
+    edges: [
+      { from: "a", to: "b" },
+      { from: "b", to: "c" },
+    ],
+  };
+  const inspectable = inspectableGraph(graph);
+  const b = inspectable.nodeById("b");
+  t.true(b?.isSubgraph());
+  const subgraph = await b?.subgraph();
+  t.truthy(subgraph);
+  t.deepEqual(subgraph?.nodeById("d")?.descriptor.type, "bar");
+});
+
+test("inspectableNode supports `path` subgraphs", async (t) => {
+  const graph = {
+    nodes: [
+      { id: "a", type: "foo" },
+      {
+        id: "b",
+        type: "invoke",
+        configuration: {
+          path: "http://example.com/graphs/foo.json",
+        },
+      },
+      { id: "c", type: "foo" },
+    ],
+    edges: [
+      { from: "a", to: "b" },
+      { from: "b", to: "c" },
+    ],
+  };
+  const inspectable = inspectableGraph(graph);
+  const b = inspectable.nodeById("b");
+  t.true(b?.isSubgraph());
+  const subgraph = await b?.subgraph(async (path) => {
+    t.is(path, "http://example.com/graphs/foo.json");
+    return inspectableGraph({
+      nodes: [{ id: "d", type: "bar" }],
+      edges: [],
+    });
+  });
+  t.truthy(subgraph);
+  t.deepEqual(subgraph?.nodeById("d")?.descriptor.type, "bar");
+});

--- a/packages/breadboard/tests/inspector/node.ts
+++ b/packages/breadboard/tests/inspector/node.ts
@@ -7,6 +7,7 @@
 import test from "ava";
 
 import { inspectableGraph } from "../../src/inspector/index.js";
+import { GraphDescriptor } from "../../src/types.js";
 
 test("inspectableNode detects a subgraph", (t) => {
   const graph = {
@@ -56,7 +57,7 @@ test("inspectableNode supports undefined subgraphs", async (t) => {
   const inspectable = inspectableGraph(graph);
   const b = inspectable.nodeById("b");
   t.true(b?.isSubgraph());
-  const subgraph = await b?.subgraph();
+  const subgraph = await b?.subgraph(async () => undefined);
   t.assert(subgraph === undefined);
 });
 
@@ -84,7 +85,13 @@ test("inspectableNode supports `graph` subgraphs", async (t) => {
   const inspectable = inspectableGraph(graph);
   const b = inspectable.nodeById("b");
   t.true(b?.isSubgraph());
-  const subgraph = await b?.subgraph();
+  const subgraph = await b?.subgraph(async (graph) => {
+    t.deepEqual(graph, {
+      nodes: [{ id: "d", type: "bar" }],
+      edges: [],
+    });
+    return inspectableGraph(graph as GraphDescriptor);
+  });
   t.truthy(subgraph);
   t.deepEqual(subgraph?.nodeById("d")?.descriptor.type, "bar");
 });


### PR DESCRIPTION
- Remove unused bits.
- Introduce the `entries` API.
- Implement `subgraph` and `isSubgraph`.
- Clean up a bit, remove `baseURL`.
- Add `loadToInspect`.
- docs(changeset): Added `subgraph` method to `InspectableNode`.
