### PR TITLE
Updated happy path doc init command to specify folder.

### DIFF
--- a/packages/website/src/docs/happy-path.md
+++ b/packages/website/src/docs/happy-path.md
@@ -20,7 +20,7 @@ Go to the [Breadboard Starter Project](https://replit.com/@dglazkov/Breadboard-S
 
 1. Install [Node.js >=v19](https://nodejs.org/en). If you already have an earlier version of Node installed, you can use [nvm](https://github.com/nvm-sh/nvm) to get to the version that Breadboard needs.
 
-2. Run `npm init @google-labs/breadboard` to set up the project.
+2. Run `npm init @google-labs/breadboard ./breadboard-starter` to set up the project. This will create it in a new directory called `breadboard-starter`, but feel free to choose a different name.
 
 This will create a simple starter project that contains most of the bits you need to build AI boards.
 


### PR DESCRIPTION
Specified a directory in the `npm init @google-labs/breadboard` command to set up the project in the [Breadboard Happy Path](https://breadboard-ai.github.io/breadboard/docs/happy-path/) doc because it fails without it ("Must provide directory as an argument.").