### PR TITLE
Handle ts2774 error in breadboard-cli bundle.ts

### DIFF
--- a/packages/breadboard-cli/src/commands/bundle.ts
+++ b/packages/breadboard-cli/src/commands/bundle.ts
@@ -12,7 +12,7 @@ import readline from "readline/promises";
 
 export async function bundle(board: string, flags: { output: string }) {
   let breadboardWebPublic;
-  if (import.meta.resolve) {
+  if (typeof import.meta.resolve === 'function') {
     const publicPath = await import.meta.resolve(
       "@google-labs/breadboard-web/public"
     );


### PR DESCRIPTION
detected previously, but most recently here: https://github.com/breadboard-ai/breadboard/actions/runs/7835167140/job/21379970219?pr=628#step:8:48

> [TS2774](https://github.com/microsoft/TypeScript/blob/main/src/compiler/diagnosticMessages.json#L3414-L3417)
> This condition will always return true since this function is always defined.