### PR TITLE
[breadboard-ui/-web] Add basic edge rewiring

### DIFF
--- a/packages/breadboard-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/breadboard-ui/src/elements/ui-controller/ui-controller.ts
@@ -158,11 +158,15 @@ export class UI extends LitElement {
     return this.#diagram.value.render(this.loadInfo, highlightedDiagramNode);
   }
 
+  clearMessages() {
+    this.messages.length = 0;
+    this.#messagePosition = 0;
+  }
+
   unloadCurrentBoard() {
     this.url = null;
     this.loadInfo = null;
-    this.messages.length = 0;
-    this.#messagePosition = 0;
+    this.clearMessages();
 
     this.#messageDurations.clear();
     this.#nodeInfo.clear();
@@ -484,6 +488,8 @@ export class UI extends LitElement {
       case "editor":
         diagram = html`<bb-editor
           .loadInfo=${this.loadInfo}
+          .nodeCount=${this.loadInfo?.graphDescriptor?.nodes.length || 0}
+          .edgeCount=${this.loadInfo?.graphDescriptor?.edges.length || 0}
           ${ref(this.#diagram)}
         ></bb-editor>`;
         break;

--- a/packages/breadboard-ui/src/events/events.ts
+++ b/packages/breadboard-ui/src/events/events.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { type NodeConfiguration } from "@google-labs/breadboard";
+
 export class StartEvent extends Event {
   static eventName = "breadboardstart";
 
@@ -99,6 +101,40 @@ export class ResumeEvent extends Event {
 
   constructor() {
     super(ResumeEvent.eventName, {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    });
+  }
+}
+
+export class NodeCreateEvent extends Event {
+  static eventName = "breadboardnodecreate";
+
+  constructor(
+    public id: string,
+    public nodeType: string,
+    public configuration: NodeConfiguration
+  ) {
+    super(NodeCreateEvent.eventName, {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    });
+  }
+}
+
+export class EdgeChangeEvent extends Event {
+  static eventName = "breadboardedgechange";
+
+  constructor(
+    public changeType: "add" | "remove",
+    public from: string,
+    public outPort: string,
+    public to: string,
+    public inPort: string
+  ) {
+    super(EdgeChangeEvent.eventName, {
       bubbles: true,
       cancelable: true,
       composed: true,

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -11,7 +11,7 @@ import { customElement, property, state } from "lit/decorators.js";
 import { LitElement, html, css, HTMLTemplateResult, nothing } from "lit";
 import * as BreadboardUI from "@google-labs/breadboard-ui";
 import { InputResolveRequest } from "@google-labs/breadboard/remote";
-import { Board, BoardRunner, GraphDescriptor } from "@google-labs/breadboard";
+import { Board, GraphDescriptor } from "@google-labs/breadboard";
 import { cache } from "lit/directives/cache.js";
 
 export const getBoardInfo = async (

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -11,7 +11,7 @@ import { customElement, property, state } from "lit/decorators.js";
 import { LitElement, html, css, HTMLTemplateResult, nothing } from "lit";
 import * as BreadboardUI from "@google-labs/breadboard-ui";
 import { InputResolveRequest } from "@google-labs/breadboard/remote";
-import { Board, GraphDescriptor } from "@google-labs/breadboard";
+import { Board, BoardRunner, GraphDescriptor } from "@google-labs/breadboard";
 import { cache } from "lit/directives/cache.js";
 
 export const getBoardInfo = async (
@@ -122,23 +122,34 @@ export class Main extends LitElement {
       margin: 0 calc(var(--bb-grid-size) * 5);
     }
 
+    #run-board-locally,
     #download {
       font-size: var(--bb-text-pico);
       padding: 4px 8px 4px 24px;
       border-radius: 32px;
-      background: #fff var(--bb-icon-download) 4px 2px no-repeat;
-      background-size: 16px 16px;
+      background: #fff;
       color: #333;
       margin-right: 8px;
       cursor: default;
       transition: opacity var(--bb-easing-duration-out) var(--bb-easing);
       opacity: 0.8;
       text-decoration: none;
+      border: none;
     }
 
+    #run-board-locally:hover,
     #download:hover {
       transition: opacity var(--bb-easing-duration-in) var(--bb-easing);
       opacity: 1;
+    }
+
+    #run-board-locally {
+      padding: 4px 8px;
+    }
+
+    #download {
+      background: #fff var(--bb-icon-download) 4px 2px no-repeat;
+      background-size: 16px 16px;
     }
 
     #header-bar h1 {
@@ -318,7 +329,6 @@ export class Main extends LitElement {
     this.#setActiveBreadboard(startEvent.url);
     this.url = startEvent.url;
     this.mode = MODE.BUILD;
-    this.status = BreadboardUI.Types.STATUS.RUNNING;
   }
 
   protected async updated(changedProperties: Map<PropertyKey, unknown>) {
@@ -343,22 +353,34 @@ export class Main extends LitElement {
     this.loadInfo = await getBoardInfo(this.url);
 
     if (this.mode === MODE.BUILD) {
-      await this.#startHarnessIfNeeded();
+      await this.#createHarnessAndRunFromUrl();
     }
   }
 
-  async #startHarnessIfNeeded() {
-    if (!(this.url && this.#uiRef.value && this.loadInfo)) {
+  async #createHarnessAndRunFromUrl() {
+    if (!(this.url && this.loadInfo)) {
+      return;
+    }
+
+    const runner = run(createRunConfig(this.url));
+    await this.#runBoard(runner);
+  }
+
+  // TODO: Allow this to run boards directly.
+  async #runBoard(runner: ReturnType<typeof run>) {
+    if (!(this.#uiRef.value && this.loadInfo)) {
       return;
     }
 
     const ui = this.#uiRef.value;
-    ui.url = this.url;
     ui.load(this.loadInfo);
+    ui.clearMessages();
 
     const currentBoardId = this.#boardId;
+
+    this.status = BreadboardUI.Types.STATUS.RUNNING;
     let lastEventTime = globalThis.performance.now();
-    for await (const result of run(createRunConfig(this.url))) {
+    for await (const result of runner) {
       const runDuration = result.data.timestamp - lastEventTime;
       if (this.#delay !== 0) {
         await new Promise((r) => setTimeout(r, this.#delay));
@@ -378,7 +400,6 @@ export class Main extends LitElement {
         await result.reply({ inputs: answer } as InputResolveRequest);
       }
     }
-
     this.status = BreadboardUI.Types.STATUS.STOPPED;
   }
 
@@ -576,6 +597,54 @@ export class Main extends LitElement {
           .loadInfo=${this.loadInfo}
           .status=${this.status}
           .visualizer=${this.#visualizer}
+          @breadboardedgechange=${(
+            evt: BreadboardUI.Events.EdgeChangeEvent
+          ) => {
+            if (!this.loadInfo || !this.loadInfo.graphDescriptor) {
+              return;
+            }
+
+            if (evt.changeType === "add") {
+              this.loadInfo.graphDescriptor.edges.push({
+                from: evt.from,
+                to: evt.to,
+                out: evt.outPort,
+                in: evt.inPort,
+              });
+            } else {
+              const idx = this.loadInfo.graphDescriptor.edges.findIndex(
+                (edge) => {
+                  return (
+                    edge.from === evt.from &&
+                    edge.to === evt.to &&
+                    edge.in === evt.inPort &&
+                    edge.out === evt.outPort
+                  );
+                }
+              );
+
+              if (idx === -1) {
+                return;
+              }
+
+              this.loadInfo.graphDescriptor.edges.splice(idx, 1);
+            }
+
+            this.#uiRef.value?.requestUpdate();
+            return;
+          }}
+          @breadboardnodecreate=${(
+            evt: BreadboardUI.Events.NodeCreateEvent
+          ) => {
+            const { id, nodeType, configuration } = evt;
+            const newNode = {
+              id,
+              type: nodeType,
+              configuration,
+            };
+            this.loadInfo?.graphDescriptor?.nodes.push(newNode);
+            this.#uiRef.value?.requestUpdate();
+          }}
           @breadboardmessagetraversal=${() => {
             if (this.status !== BreadboardUI.Types.STATUS.RUNNING) {
               return;
@@ -628,11 +697,41 @@ export class Main extends LitElement {
       }
     }
 
+    // Only show the local run button when there is no URL set.
+    const localRunButton = this.url
+      ? nothing
+      : html`<button
+          id="run-board-locally"
+          @click=${async () => {
+            if (
+              !this.loadInfo?.graphDescriptor ||
+              !this.loadInfo.graphDescriptor.url
+            ) {
+              return;
+            }
+
+            const config = createRunConfig(this.loadInfo.graphDescriptor.url);
+            config.remote = false;
+            config.proxy = [];
+
+            // TODO: Allow pre-made runners in the config.
+            // const runner = await BoardRunner.fromGraphDescriptor(
+            //   this.loadInfo.graphDescriptor
+            // );
+            // config.runner = runner;
+
+            this.#runBoard(run(config));
+          }}
+        >
+          Run this board
+        </button>`;
+
     tmpl = html`<div id="header-bar">
         <a id="back" href="/" @click=${this.#unloadCurrentBoard}
           >Back to list</a
         >
         <h1>${this.loadInfo?.title || "Untitled board"}</h1>
+        ${localRunButton}
         <a id="download" @click=${this.#downloadLog}>Download log</a>
       </div>
       <div id="side-bar">


### PR DESCRIPTION
This adds drag and drop nodes for invoke/input/output (yet to be configurable!), and allows for rewiring of the edges. There are a few things that this has highlighted, such as:

1. We could probably do with a board modifier (maybe on the inspector?)
2. We could probably do with being able to run a board with a runner passed to the config.

Sure there are other things that will come out in the mix.