### PR TITLE
[breadboard] Allow pre-existing runners

### DIFF
--- a/packages/breadboard-web/src/config.ts
+++ b/packages/breadboard-web/src/config.ts
@@ -10,6 +10,7 @@ import {
   HarnessRemoteConfig,
   KitConfig,
   defineServeConfig,
+  RunConfig,
 } from "@google-labs/breadboard/harness";
 import Core from "@google-labs/core-kit";
 import JSONKit from "@google-labs/json-kit";
@@ -55,7 +56,7 @@ const kits = [
   AgentKit,
 ].map((kitConstructor) => asRuntimeKit(kitConstructor));
 
-export const createRunConfig = (url: string) => {
+export const createRunConfig = (url: string): RunConfig => {
   const harness =
     globalThis.localStorage.getItem(HARNESS_SWITCH_KEY) ?? DEFAULT_HARNESS;
 
@@ -74,7 +75,7 @@ export const createRunConfig = (url: string) => {
     url: WORKER_URL,
   };
   const diagnostics = true;
-  return { url, kits, remote, proxy, diagnostics };
+  return { url, kits, remote, proxy, diagnostics, runner: undefined };
 };
 
 export const serveConfig = defineServeConfig({

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -11,7 +11,7 @@ import { customElement, property, state } from "lit/decorators.js";
 import { LitElement, html, css, HTMLTemplateResult, nothing } from "lit";
 import * as BreadboardUI from "@google-labs/breadboard-ui";
 import { InputResolveRequest } from "@google-labs/breadboard/remote";
-import { Board, GraphDescriptor } from "@google-labs/breadboard";
+import { Board, BoardRunner, GraphDescriptor } from "@google-labs/breadboard";
 import { cache } from "lit/directives/cache.js";
 
 export const getBoardInfo = async (
@@ -710,15 +710,14 @@ export class Main extends LitElement {
               return;
             }
 
+            const runner = await BoardRunner.fromGraphDescriptor(
+              this.loadInfo.graphDescriptor
+            );
+
             const config = createRunConfig(this.loadInfo.graphDescriptor.url);
             config.remote = false;
             config.proxy = [];
-
-            // TODO: Allow pre-made runners in the config.
-            // const runner = await BoardRunner.fromGraphDescriptor(
-            //   this.loadInfo.graphDescriptor
-            // );
-            // config.runner = runner;
+            config.runner = runner;
 
             this.#runBoard(run(config));
           }}

--- a/packages/breadboard/src/harness/index.ts
+++ b/packages/breadboard/src/harness/index.ts
@@ -11,6 +11,7 @@ export {
   run,
   type HarnessProxyConfig,
   type HarnessRemoteConfig,
+  type RunConfig,
 } from "./run.js";
 
 export type * from "./serve.js";

--- a/packages/breadboard/src/harness/local.ts
+++ b/packages/breadboard/src/harness/local.ts
@@ -87,7 +87,7 @@ const errorResult = (error: string) => {
 export async function* runLocally(config: RunConfig, kits: Kit[]) {
   yield* asyncGen<HarnessRunResult>(async (next) => {
     const base = baseURL(config);
-    const runner = await Board.load(config.url, { base });
+    const runner = config.runner || (await Board.load(config.url, { base }));
 
     try {
       const probe = config.diagnostics

--- a/packages/breadboard/src/harness/run.ts
+++ b/packages/breadboard/src/harness/run.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Kit, asyncGen } from "../index.js";
+import { BreadboardRunner, Kit, asyncGen } from "../index.js";
 import { NodeProxyConfig } from "../remote/config.js";
 import { HTTPClientTransport } from "../remote/http.js";
 import { ProxyClient } from "../remote/proxy.js";
@@ -70,6 +70,11 @@ export type RunConfig = {
    * Defaults to `false`.
    */
   diagnostics?: boolean;
+  /**
+   * Specifies a runner to use. This can be used instead of loading a board
+   * from a URL.
+   */
+  runner?: BreadboardRunner;
 };
 
 const configureKits = (config: RunConfig) => {


### PR DESCRIPTION
One of the challenges I've run into with visual editing is that our board runner expects a URL. In the case where we're modifying a board "in memory", we don't have a JSON board to load via fetch. What I've done here, which might not be the right way (in which case we can just close this PR), is to allow a `BoardRunner` in the config. If that's set it's used in preference to the URL for `run`. This just means I can do something like the following:

```ts
const runner = await BoardRunner.fromGraphDescriptor(
  this.loadInfo.graphDescriptor
);

const config = createRunConfig(this.loadInfo.graphDescriptor.url);
config.remote = false;
config.proxy = [];
config.runner = runner;
```

And now I can run a modified board locally. @dglazkov is there a better way to do this?