### PR TITLE
star edges

### DIFF
--- a/.changeset/hot-games-smoke.md
+++ b/.changeset/hot-games-smoke.md
@@ -1,0 +1,7 @@
+---
+"@google-labs/breadboard-ui": patch
+"@google-labs/breadboard": patch
+"@google-labs/json-kit": patch
+---
+
+Introduce `InspectableNode.ports`, which enumerates ports of a node.

--- a/packages/breadboard-ui/src/elements/editor/editor.ts
+++ b/packages/breadboard-ui/src/elements/editor/editor.ts
@@ -379,14 +379,16 @@ export class Editor extends LitElement {
             ? value.type
             : 0;
 
+        const extraInfo = value.title ? { label: value.title } : undefined;
+
         // We appease the types here, which don't currently match. They say that
         // a type must be a valid one or -1. However, the docs suggest a value
         // of 0 is also valid.
         if (schemaType === "input") {
-          const input = graphNode.addInput(name, type as -1);
+          const input = graphNode.addInput(name, type as -1, extraInfo);
           input.color_on = "#c9daf8";
         } else {
-          const output = graphNode.addOutput(name, type as -1);
+          const output = graphNode.addOutput(name, type as -1, extraInfo);
           output.color_on = "#b6d7a8";
         }
       }
@@ -492,31 +494,18 @@ export class Editor extends LitElement {
           continue;
         }
 
-        // Locate the ports and connect them up. If there's a wildcard '*' then
-        // match outgoing and incoming ports by name. Otherwise locate the
-        // precise ports and connect those alone.
-        if (connection.out === "*") {
-          for (let o = 0; o < sourceNode.outputs.length; o++) {
-            for (let i = 0; i < destNode.inputs.length; i++) {
-              if (sourceNode.outputs[o].name === destNode.inputs[i].name) {
-                this.#connectNodes(sourceNode, destNode, o, i);
-              }
-            }
+        sourceLoop: for (let o = 0; o < sourceNode.outputs.length; o++) {
+          if (sourceNode.outputs[o].name !== connection.out) {
+            continue;
           }
-        } else {
-          sourceLoop: for (let o = 0; o < sourceNode.outputs.length; o++) {
-            if (sourceNode.outputs[o].name !== connection.out) {
+
+          for (let i = 0; i < destNode.inputs.length; i++) {
+            if (connection.in !== destNode.inputs[i].name) {
               continue;
             }
 
-            for (let i = 0; i < destNode.inputs.length; i++) {
-              if (connection.in !== destNode.inputs[i].name) {
-                continue;
-              }
-
-              this.#connectNodes(sourceNode, destNode, o, i);
-              break sourceLoop;
-            }
+            this.#connectNodes(sourceNode, destNode, o, i);
+            break sourceLoop;
           }
         }
       }

--- a/packages/breadboard/src/inspector/graph.ts
+++ b/packages/breadboard/src/inspector/graph.ts
@@ -109,11 +109,12 @@ class Graph implements InspectableGraph {
     return this.#graph.edges
       .filter((edge) => edge.to === id)
       .map((edge) => {
+        const edgein = edge.out === "*" ? "*" : edge.in;
         return {
           from: this.nodeById(edge.from),
           out: edge.out,
           to: this.nodeById(edge.to),
-          in: edge.in,
+          in: edgein,
         };
       })
       .filter(

--- a/packages/breadboard/src/inspector/graph.ts
+++ b/packages/breadboard/src/inspector/graph.ts
@@ -15,8 +15,8 @@ import {
 import { inspectableNode } from "./node.js";
 import {
   EdgeType,
-  createInputSchema,
-  createOutputSchema,
+  createSchemaForInput,
+  createSchemaForOutput,
   edgesToSchema,
 } from "./schemas.js";
 import {
@@ -75,10 +75,10 @@ class Graph implements InspectableGraph {
     // The schema of an input or an output is defined by their
     // configuration schema or their incoming/outgoing edges.
     if (type === "input") {
-      return createInputSchema(options);
+      return createSchemaForInput(options);
     }
     if (type === "output") {
-      return createOutputSchema(options);
+      return createSchemaForOutput(options);
     }
 
     const { kits } = this.#options;

--- a/packages/breadboard/src/inspector/node.ts
+++ b/packages/breadboard/src/inspector/node.ts
@@ -129,6 +129,7 @@ const collectPorts = (
 ) => {
   // Get the list of all ports wired to this node.
   const wiredPortNames = edges.map((edge) => {
+    if (edge.out === "*") return "*";
     return type === EdgeType.In ? edge.in : edge.out;
   });
   const schemaPortNames = Object.keys(schema.properties || {});

--- a/packages/breadboard/src/inspector/node.ts
+++ b/packages/breadboard/src/inspector/node.ts
@@ -10,12 +10,17 @@ import {
   NodeConfiguration,
   NodeDescriberResult,
   NodeDescriptor,
+  Schema,
 } from "../types.js";
+import { EdgeType } from "./schemas.js";
 import {
   InspectableEdge,
   InspectableGraph,
   InspectableGraphLoader,
   InspectableNode,
+  InspectableNodePorts,
+  InspectablePortList,
+  PortStatus,
 } from "./types.js";
 
 export const inspectableNode = (
@@ -81,4 +86,78 @@ class Node implements InspectableNode {
       outgoing: this.outgoing(),
     });
   }
+
+  async ports(inputValues?: InputValues): Promise<InspectableNodePorts> {
+    const described = await this.describe(inputValues);
+    const inputs: InspectablePortList = {
+      fixed: described.inputSchema.additionalProperties === false,
+      ports: collectPorts(
+        EdgeType.In,
+        this.incoming(),
+        described.inputSchema,
+        this.configuration()
+      ),
+    };
+    const outputs: InspectablePortList = {
+      fixed: described.outputSchema.additionalProperties === false,
+      ports: collectPorts(
+        EdgeType.Out,
+        this.outgoing(),
+        described.outputSchema
+      ),
+    };
+    return { inputs, outputs };
+  }
 }
+
+const computePortStatus = (
+  wired: boolean,
+  expected: boolean,
+  required: boolean
+): PortStatus => {
+  if (wired) {
+    return expected ? PortStatus.Connected : PortStatus.Dangling;
+  }
+  return required ? PortStatus.Missing : PortStatus.Ready;
+};
+
+const collectPorts = (
+  type: EdgeType,
+  edges: InspectableEdge[],
+  schema: Schema,
+  configuration?: NodeConfiguration
+) => {
+  // Get the list of all ports wired to this node.
+  const wiredPortNames = edges.map((edge) => {
+    return type === EdgeType.In ? edge.in : edge.out;
+  });
+  const schemaPortNames = Object.keys(schema.properties || {});
+  const requiredPortNames = schema.required || [];
+  const configuredPortNames = Object.keys(configuration || {});
+  const portNames = [
+    ...new Set([
+      ...wiredPortNames,
+      ...schemaPortNames,
+      ...configuredPortNames,
+      "*", // Always include the star port.
+    ]),
+  ];
+  // TODO: Do something about the "schema" in the "output": it's a configured
+  // value, but isn't an expected input. oops. Shows up as "Dangling".
+  // TODO: When star is connected, all other ports are in a weird state: they
+  // are "missing". They probably should be "wired" or "ready" instead?
+  return portNames.map((port) => {
+    const star = port === "*";
+    const configured = configuredPortNames.includes(port);
+    const wired = wiredPortNames.includes(port);
+    const expected = schemaPortNames.includes(port) || star;
+    const required = requiredPortNames.includes(port);
+    return {
+      name: port,
+      configured,
+      star,
+      status: computePortStatus(wired || configured, expected, required),
+      schema: schema.properties?.[port],
+    };
+  });
+};

--- a/packages/breadboard/src/inspector/schemas.ts
+++ b/packages/breadboard/src/inspector/schemas.ts
@@ -30,14 +30,23 @@ const schemaFromProperties = (
   properties: Record<string, Schema>,
   additionalProperties: boolean
 ): Schema => {
-  const required = Object.keys(properties);
+  const keys = Object.keys(properties);
+  const required = keys.filter((key) => key !== "*" && key !== "");
   let schema = { type: "object", additionalProperties } as Schema;
+  if (keys.length > 0) {
+    schema = { ...schema, properties };
+  }
   if (required.length > 0) {
-    schema = { ...schema, required, properties };
+    schema = { ...schema, required };
   }
   return schema;
 };
 
+/**
+ * Constructs a Schema for an input node.
+ * @param options
+ * @returns
+ */
 export const createInputSchema = (
   options: NodeTypeDescriberOptions
 ): NodeDescriberResult => {
@@ -50,7 +59,6 @@ export const createInputSchema = (
   options.outgoing?.forEach((edge) => {
     if (edge.out === "*") {
       additionalProperties = true;
-      return;
     }
     properties[edge.out] = { type: "string" };
   });
@@ -60,6 +68,11 @@ export const createInputSchema = (
   };
 };
 
+/**
+ * Constructs a Schema for an output node.
+ * @param options
+ * @returns
+ */
 export const createOutputSchema = (
   options: NodeTypeDescriberOptions
 ): NodeDescriberResult => {
@@ -72,6 +85,7 @@ export const createOutputSchema = (
   options.incoming?.forEach((edge) => {
     if (edge.out === "*") {
       additionalProperties = true;
+      properties[edge.in] = { type: "string", title: "*" };
       return;
     }
     properties[edge.in] = { type: "string" };

--- a/packages/breadboard/src/inspector/schemas.ts
+++ b/packages/breadboard/src/inspector/schemas.ts
@@ -47,7 +47,7 @@ export const edgesToSchema = (
  * @param options
  * @returns
  */
-export const createInputSchema = (
+export const createSchemaForInput = (
   options: NodeTypeDescriberOptions
 ): NodeDescriberResult => {
   const schema = options.inputs?.schema as Schema | undefined;
@@ -65,7 +65,7 @@ export const createInputSchema = (
  * @param options
  * @returns
  */
-export const createOutputSchema = (
+export const createSchemaForOutput = (
   options: NodeTypeDescriberOptions
 ): NodeDescriberResult => {
   const schema = options.inputs?.schema as Schema | undefined;

--- a/packages/breadboard/src/inspector/schemas.ts
+++ b/packages/breadboard/src/inspector/schemas.ts
@@ -27,7 +27,8 @@ const schemaFromProperties = (properties: Record<string, Schema>): Schema => {
 
 export const edgesToSchema = (
   edgeType: EdgeType,
-  edges?: InspectableEdge[]
+  edges?: InspectableEdge[],
+  properties: Record<string, Schema> = {}
 ): Schema => {
   if (!edges) return {};
   return schemaFromProperties(
@@ -38,7 +39,7 @@ export const edgesToSchema = (
         acc[edgeType === EdgeType.In ? edge.in : edge.out] = { type: "string" };
       }
       return acc;
-    }, {} as Record<string, Schema>)
+    }, properties)
   );
 };
 
@@ -51,12 +52,13 @@ export const createSchemaForInput = (
   options: NodeTypeDescriberOptions
 ): NodeDescriberResult => {
   const schema = options.inputs?.schema as Schema | undefined;
-  if (schema) {
-    return { inputSchema: {}, outputSchema: schema };
-  }
   return {
     inputSchema: {},
-    outputSchema: edgesToSchema(EdgeType.Out, options.outgoing),
+    outputSchema: edgesToSchema(
+      EdgeType.Out,
+      options.outgoing,
+      schema?.properties
+    ),
   };
 };
 
@@ -69,11 +71,12 @@ export const createSchemaForOutput = (
   options: NodeTypeDescriberOptions
 ): NodeDescriberResult => {
   const schema = options.inputs?.schema as Schema | undefined;
-  if (schema) {
-    return { inputSchema: schema, outputSchema: {} };
-  }
   return {
-    inputSchema: edgesToSchema(EdgeType.In, options.incoming),
+    inputSchema: edgesToSchema(
+      EdgeType.In,
+      options.incoming,
+      schema?.properties
+    ),
     outputSchema: {},
   };
 };

--- a/packages/breadboard/src/inspector/schemas.ts
+++ b/packages/breadboard/src/inspector/schemas.ts
@@ -33,11 +33,9 @@ export const edgesToSchema = (
   if (!edges) return {};
   return schemaFromProperties(
     edges.reduce((acc, edge) => {
-      if (edge.out === "*" && edgeType === EdgeType.In) {
-        acc[edge.in] = { type: "string", title: "*" };
-      } else {
-        acc[edgeType === EdgeType.In ? edge.in : edge.out] = { type: "string" };
-      }
+      // Remove star edges from the schema. These must be handled separately.
+      if (edge.out === "*") return acc;
+      acc[edgeType === EdgeType.In ? edge.in : edge.out] = { type: "string" };
       return acc;
     }, properties)
   );

--- a/packages/breadboard/tests/inspector/describe.ts
+++ b/packages/breadboard/tests/inspector/describe.ts
@@ -94,9 +94,6 @@ test("inspector API can describe the input in simplest-no-schema.json", async (t
     inputSchema: {},
     outputSchema: {
       type: "object",
-      properties: {
-        "*": { type: "string" },
-      },
     },
   });
 });
@@ -161,12 +158,6 @@ test("inspector API can describe the output in simplest-no-schema.json", async (
   t.deepEqual(api, {
     inputSchema: {
       type: "object",
-      properties: {
-        "": {
-          type: "string",
-          title: "*",
-        },
-      },
     },
     outputSchema: {},
   });

--- a/packages/breadboard/tests/inspector/describe.ts
+++ b/packages/breadboard/tests/inspector/describe.ts
@@ -36,7 +36,6 @@ test("simple graph description works as expected", async (t) => {
   t.deepEqual(api, {
     inputSchema: {
       type: "object",
-      additionalProperties: false,
       properties: {
         text: {
           type: "string",
@@ -46,7 +45,6 @@ test("simple graph description works as expected", async (t) => {
     },
     outputSchema: {
       type: "object",
-      additionalProperties: false,
       properties: {
         text: {
           type: "string",
@@ -99,7 +97,6 @@ test("inspector API can describe the input in simplest-no-schema.json", async (t
       properties: {
         "*": { type: "string" },
       },
-      additionalProperties: true,
     },
   });
 });
@@ -117,7 +114,6 @@ test("inspector API can describe the input in simplest-no-schema-strict.json", a
     inputSchema: {},
     outputSchema: {
       type: "object",
-      additionalProperties: false,
       properties: {
         text: {
           type: "string",
@@ -171,7 +167,6 @@ test("inspector API can describe the output in simplest-no-schema.json", async (
           title: "*",
         },
       },
-      additionalProperties: true,
     },
     outputSchema: {},
   });
@@ -189,7 +184,6 @@ test("inspector API can describe the output in simplest-no-schema-strict.json", 
   t.deepEqual(api, {
     inputSchema: {
       type: "object",
-      additionalProperties: false,
       properties: {
         text: {
           type: "string",

--- a/packages/breadboard/tests/inspector/describe.ts
+++ b/packages/breadboard/tests/inspector/describe.ts
@@ -96,6 +96,9 @@ test("inspector API can describe the input in simplest-no-schema.json", async (t
     inputSchema: {},
     outputSchema: {
       type: "object",
+      properties: {
+        "*": { type: "string" },
+      },
       additionalProperties: true,
     },
   });
@@ -162,6 +165,12 @@ test("inspector API can describe the output in simplest-no-schema.json", async (
   t.deepEqual(api, {
     inputSchema: {
       type: "object",
+      properties: {
+        "": {
+          type: "string",
+          title: "*",
+        },
+      },
       additionalProperties: true,
     },
     outputSchema: {},

--- a/packages/breadboard/tests/inspector/traversal.ts
+++ b/packages/breadboard/tests/inspector/traversal.ts
@@ -67,7 +67,7 @@ test("inspector API can describe the subgraph in simplest-no-schema.json", async
   t.deepEqual(api, {
     inputSchema: {
       type: "object",
-      properties: { useStreaming: { type: "string" } },
+      properties: { useStreaming: { type: "string" }, "*": { type: "string" } },
       required: ["useStreaming"],
       additionalProperties: true,
     },

--- a/packages/breadboard/tests/inspector/traversal.ts
+++ b/packages/breadboard/tests/inspector/traversal.ts
@@ -67,7 +67,7 @@ test("inspector API can describe the subgraph in simplest-no-schema.json", async
   t.deepEqual(api, {
     inputSchema: {
       type: "object",
-      properties: { useStreaming: { type: "string" }, "*": { type: "string" } },
+      properties: { useStreaming: { type: "string" } },
       required: ["useStreaming"],
     },
     outputSchema: {

--- a/packages/breadboard/tests/inspector/traversal.ts
+++ b/packages/breadboard/tests/inspector/traversal.ts
@@ -69,7 +69,6 @@ test("inspector API can describe the subgraph in simplest-no-schema.json", async
       type: "object",
       properties: { useStreaming: { type: "string" }, "*": { type: "string" } },
       required: ["useStreaming"],
-      additionalProperties: true,
     },
     outputSchema: {
       type: "object",
@@ -80,7 +79,6 @@ test("inspector API can describe the subgraph in simplest-no-schema.json", async
         toolCalls: { type: "string" },
       },
       required: ["context", "stream", "text", "toolCalls"],
-      additionalProperties: false,
     },
   });
 });

--- a/packages/json-kit/src/nodes/jsonata.ts
+++ b/packages/json-kit/src/nodes/jsonata.ts
@@ -60,7 +60,6 @@ export const computeOutputSchema = async (
     const outputSchema = {
       type: "object",
       properties,
-      additionalProperties: false,
     };
     Object.entries(result).forEach(([key, value]) => {
       properties[key] = {
@@ -72,7 +71,6 @@ export const computeOutputSchema = async (
   } catch (e) {
     return {
       type: "object",
-      additionalProperties: false,
       properties: {},
     };
   }

--- a/packages/json-kit/tests/jsonata.ts
+++ b/packages/json-kit/tests/jsonata.ts
@@ -64,7 +64,6 @@ test("`jsonataDescriber` correctly reacts to invalid input", async (t) => {
     outputSchema: {
       type: "object",
       properties: {},
-      additionalProperties: false,
     },
   });
 });


### PR DESCRIPTION
- Make '*" ports explicit
- Simplify schema-creating code in inspector API.
- Light renaming.
- Ccombine as-wired and config schemas for inputs/outputs.
- Sketch out `node.ports`.
- Start using `node.ports` in editor.
- Handle star edges correctly.
- Undo schema merging in inputs.
- docs(changeset): Introduce `InspectableNode.ports`, which enumerates ports of a node.
