### PR TITLE
more inspector

### DIFF
--- a/.changeset/real-maps-try.md
+++ b/.changeset/real-maps-try.md
@@ -1,0 +1,8 @@
+---
+"@google-labs/breadboard-ui": patch
+"@google-labs/breadboard": patch
+"@google-labs/core-kit": patch
+"@google-labs/breadboard-website": patch
+---
+
+Taught `core.invoke` to describe its own subgraphs.

--- a/packages/breadboard-ui/src/elements/editor/editor.ts
+++ b/packages/breadboard-ui/src/elements/editor/editor.ts
@@ -18,12 +18,10 @@ import {
   Schema,
   inspect,
   GraphDescriptor,
-  loadToInspect,
   InspectableNode,
   NodeConfiguration,
   Edge,
   Kit,
-  combineSchemas,
   InspectablePortList,
 } from "@google-labs/breadboard";
 import { Ref, createRef, ref } from "lit/directives/ref.js";
@@ -422,7 +420,7 @@ export class Editor extends LitElement {
       // HACK: Convert the output of ports to something that looks like
       // describer result for now.
       // TODO: Refactor addIOToNode to take the `InspectablePort`.
-      let describerResult = await (async () => {
+      const describerResult = await (async () => {
         const ports = await node.ports();
         const createSchema = (p: InspectablePortList): Schema => {
           return {
@@ -439,32 +437,6 @@ export class Editor extends LitElement {
         return { inputSchema, outputSchema };
       })();
 
-      if (node.containsGraph()) {
-        if (!descriptor.url) {
-          console.warn("Descriptor does not have a URL");
-          break;
-        }
-
-        const subgraph = await node.subgraph(
-          loadToInspect(new URL(descriptor.url))
-        );
-
-        if (subgraph) {
-          const { inputSchema, outputSchema } = await subgraph.describe();
-          // Flat-out combining schemas is probably not exactly right.
-          // TODO: Figure out how to handle dangling wires.
-          describerResult = {
-            inputSchema: combineSchemas([
-              describerResult.inputSchema,
-              inputSchema,
-            ]),
-            outputSchema: combineSchemas([
-              describerResult.outputSchema,
-              outputSchema,
-            ]),
-          };
-        }
-      }
       const inputs = describerResult.inputSchema.properties;
       if (inputs) {
         addIOtoNode(graphNode, "input", inputs);

--- a/packages/breadboard/src/index.ts
+++ b/packages/breadboard/src/index.ts
@@ -64,7 +64,4 @@ export { asyncGen } from "./utils/async-gen.js";
  * The Inspector API.
  */
 export type * from "./inspector/types.js";
-export {
-  inspectableGraph as inspect,
-  loadToInspect,
-} from "./inspector/index.js";
+export { inspectableGraph as inspect } from "./inspector/index.js";

--- a/packages/breadboard/src/inspector/graph.ts
+++ b/packages/breadboard/src/inspector/graph.ts
@@ -35,7 +35,13 @@ export const inspectableGraph = (
   return new Graph(graph, options);
 };
 
+const maybeURL = (url?: string): URL | undefined => {
+  url = url || "";
+  return URL.canParse(url) ? new URL(url) : undefined;
+};
+
 class Graph implements InspectableGraph {
+  #url?: URL;
   #graph: GraphDescriptor;
   #nodes: InspectableNode[];
   #nodeMap: Map<NodeIdentifier, InspectableNode>;
@@ -46,6 +52,7 @@ class Graph implements InspectableGraph {
 
   constructor(graph: GraphDescriptor, options?: InspectableGraphOptions) {
     this.#graph = graph;
+    this.#url = maybeURL(graph.url);
     this.#options = options || {};
     this.#nodes = this.#graph.nodes.map((node) => inspectableNode(node, this));
     this.#nodeMap = new Map(
@@ -92,10 +99,12 @@ class Graph implements InspectableGraph {
     if (!handler || typeof handler === "function" || !handler.describe) {
       return asWired;
     }
+    const maybeContext = this.#url ? { base: this.#url } : undefined;
     return handler.describe(
       options?.inputs || undefined,
       asWired.inputSchema,
-      asWired.outputSchema
+      asWired.outputSchema,
+      maybeContext
     );
   }
 

--- a/packages/breadboard/src/inspector/index.ts
+++ b/packages/breadboard/src/inspector/index.ts
@@ -4,48 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { BoardLoader } from "../loader.js";
-import { GraphDescriptor } from "../types.js";
-import { inspectableGraph } from "./graph.js";
-import { InspectableGraphLoader } from "./types.js";
-
 export { inspectableGraph } from "./graph.js";
-
-/**
- * Use this function to create a simple graph loader for inspection.
- *
- * Example:
- *
- * ```ts
- * const inspectable = inspectableGraph(someGraphDescriptor);
- * const invoke = inspectable.nodesByType("invoke")[0];
- * const subgraph = invoke.subgraph(
- *   loadToInspect(new URL("http://localhost:3000"))
- * );
- * ```
- *
- * @param base the base URL that will be used to resolve the path to the
- * subgraph in case it's relative
- * @returns the `InspectableGraph`
- */
-export const loadToInspect = (base: URL): InspectableGraphLoader => {
-  return async (
-    graph: string | GraphDescriptor,
-    loadingGraph: GraphDescriptor
-  ) => {
-    if (graph === undefined) {
-      return undefined;
-    } else if (typeof graph === "string") {
-      // This logic is lifted from `BoardRunner.load`.
-      // TODO: Deduplicate.
-      const graphs = loadingGraph.graphs;
-      const loader = new BoardLoader({ base, graphs });
-      const result = await loader.load(graph);
-      if (!result) return undefined;
-      return inspectableGraph(result.graph);
-    } else {
-      // TODO: Check that this is a valid GraphDescriptor
-      return inspectableGraph(graph);
-    }
-  };
-};

--- a/packages/breadboard/src/inspector/node.ts
+++ b/packages/breadboard/src/inspector/node.ts
@@ -5,7 +5,6 @@
  */
 
 import {
-  GraphDescriptor,
   InputValues,
   NodeConfiguration,
   NodeDescriberResult,
@@ -16,7 +15,6 @@ import { EdgeType } from "./schemas.js";
 import {
   InspectableEdge,
   InspectableGraph,
-  InspectableGraphLoader,
   InspectableNode,
   InspectableNodePorts,
   InspectablePortList,
@@ -54,24 +52,6 @@ class Node implements InspectableNode {
 
   isExit(): boolean {
     return this.outgoing().length === 0;
-  }
-
-  containsGraph(): boolean {
-    // This is likely too naive, since map also invokes subgraphs.
-    // TODO: Flesh this out some more.
-    return this.descriptor.type === "invoke";
-  }
-
-  async subgraph(
-    loader: InspectableGraphLoader
-  ): Promise<InspectableGraph | undefined> {
-    if (!this.containsGraph()) return undefined;
-
-    // Find the subgraph
-    type InvokeInputs = { graph: GraphDescriptor; path: string };
-    // TODO: Support subgraphs that are dynamically loaded from values.
-    const { graph, path } = this.configuration() as InvokeInputs;
-    return await loader(graph ? graph : path, this.#graph.raw());
   }
 
   configuration(): NodeConfiguration {

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -37,21 +37,7 @@ export type InspectableNode = {
    * Return true if the node is an exit node (no outgoing edges)
    */
   isExit(): boolean;
-  /**
-   * Returns true if the node contains a subgraph
-   */
-  containsGraph(): boolean;
-  /**
-   * Returns an inspectable subgraph, if one is present or `undefined`
-   * otherwise
-   *
-   * @param loader - a loader that is called with the path to load when the
-   * subgraph needs to be loaded (over the network or filesystem). The subgraph
-   * could also be embedded directly in the graph.
-   */
-  subgraph(
-    loader: InspectableGraphLoader
-  ): Promise<InspectableGraph | undefined>;
+
   /**
    * Returns the API of the node.
    *
@@ -150,19 +136,6 @@ export type InspectableGraph = {
    */
   describe(): Promise<NodeDescriberResult>;
 };
-
-export type InspectableGraphLoader = (
-  /**
-   * The `path` value of the `invoke`. It may be a relative or an absolute URL,
-   * a file path, a `GraphDescriptor` or undefined.
-   */
-  graph: GraphDescriptor | string,
-  /**
-   * The full GraphDescriptor of the graph in whose context the loading happens.
-   * This is the graph that contains the `invoke` node.
-   */
-  loadingGraph: GraphDescriptor
-) => Promise<InspectableGraph | undefined>;
 
 /**
  * Options to supply to the `inspectableGraph` function.

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -314,6 +314,16 @@ export type NodeDescriberResult = {
 };
 
 /**
+ * Context that is supplied to the `NodeDescriberFunction`.
+ */
+export type NodeDescriberContext = {
+  /**
+   * The base URL of the graph.
+   */
+  base: URL;
+};
+
+/**
  * Asks to describe a node. Can be called in multiple ways:
  * - when called with no arguments, will produce the "default schema". That is,
  * the inputs/outputs that are always available.
@@ -325,7 +335,11 @@ export type NodeDescriberResult = {
 export type NodeDescriberFunction = (
   inputs?: InputValues,
   inputSchema?: Schema,
-  outputSchema?: Schema
+  outputSchema?: Schema,
+  /**
+   * The context in which the node is described.
+   */
+  context?: NodeDescriberContext
 ) => Promise<NodeDescriberResult>;
 
 export type NodeHandler =

--- a/packages/breadboard/tests/inspector/describe.ts
+++ b/packages/breadboard/tests/inspector/describe.ts
@@ -8,15 +8,16 @@ import test from "ava";
 
 import { inspectableGraph } from "../../src/inspector/index.js";
 import { GraphDescriptor } from "../../src/types.js";
-
-import { loadToInspect } from "../../src/inspector/index.js";
+import { BoardLoader } from "../../src/loader.js";
 
 const BASE_URL = new URL("../../../tests/inspector/data/", import.meta.url);
 
 const load = async (url: string) => {
   const base = BASE_URL;
-  const loader = loadToInspect(base);
-  return loader(url, { nodes: [], edges: [] });
+  const loader = new BoardLoader({ base });
+  const result = await loader.load(url);
+  if (!result) return undefined;
+  return inspectableGraph(result.graph);
 };
 
 test("simple graph description works as expected", async (t) => {

--- a/packages/breadboard/tests/inspector/node.ts
+++ b/packages/breadboard/tests/inspector/node.ts
@@ -7,23 +7,6 @@
 import test from "ava";
 
 import { inspectableGraph } from "../../src/inspector/index.js";
-import { GraphDescriptor } from "../../src/types.js";
-
-test("inspectableNode detects a subgraph", (t) => {
-  const graph = {
-    nodes: [
-      { id: "a", type: "foo" },
-      { id: "b", type: "invoke" },
-      { id: "c", type: "foo" },
-    ],
-    edges: [
-      { from: "a", to: "b" },
-      { from: "b", to: "c" },
-    ],
-  };
-  const inspectable = inspectableGraph(graph);
-  t.true(inspectable.nodeById("b")?.containsGraph());
-});
 
 test("inspectableNode correctly returns node configuration", (t) => {
   const graph = {
@@ -40,90 +23,4 @@ test("inspectableNode correctly returns node configuration", (t) => {
   };
   const inspectable = inspectableGraph(graph);
   t.deepEqual(inspectable.nodeById("a")?.configuration(), { foo: "test" });
-});
-
-test("inspectableNode supports undefined subgraphs", async (t) => {
-  const graph = {
-    nodes: [
-      { id: "a", type: "foo" },
-      { id: "b", type: "invoke" },
-      { id: "c", type: "foo" },
-    ],
-    edges: [
-      { from: "a", to: "b" },
-      { from: "b", to: "c" },
-    ],
-  };
-  const inspectable = inspectableGraph(graph);
-  const b = inspectable.nodeById("b");
-  t.true(b?.containsGraph());
-  const subgraph = await b?.subgraph(async () => undefined);
-  t.assert(subgraph === undefined);
-});
-
-test("inspectableNode supports `graph` subgraphs", async (t) => {
-  const graph = {
-    nodes: [
-      { id: "a", type: "foo" },
-      {
-        id: "b",
-        type: "invoke",
-        configuration: {
-          graph: {
-            nodes: [{ id: "d", type: "bar" }],
-            edges: [],
-          },
-        },
-      },
-      { id: "c", type: "foo" },
-    ],
-    edges: [
-      { from: "a", to: "b" },
-      { from: "b", to: "c" },
-    ],
-  };
-  const inspectable = inspectableGraph(graph);
-  const b = inspectable.nodeById("b");
-  t.true(b?.containsGraph());
-  const subgraph = await b?.subgraph(async (graph) => {
-    t.deepEqual(graph, {
-      nodes: [{ id: "d", type: "bar" }],
-      edges: [],
-    });
-    return inspectableGraph(graph as GraphDescriptor);
-  });
-  t.truthy(subgraph);
-  t.deepEqual(subgraph?.nodeById("d")?.descriptor.type, "bar");
-});
-
-test("inspectableNode supports `path` subgraphs", async (t) => {
-  const graph = {
-    nodes: [
-      { id: "a", type: "foo" },
-      {
-        id: "b",
-        type: "invoke",
-        configuration: {
-          path: "http://example.com/graphs/foo.json",
-        },
-      },
-      { id: "c", type: "foo" },
-    ],
-    edges: [
-      { from: "a", to: "b" },
-      { from: "b", to: "c" },
-    ],
-  };
-  const inspectable = inspectableGraph(graph);
-  const b = inspectable.nodeById("b");
-  t.true(b?.containsGraph());
-  const subgraph = await b?.subgraph(async (path) => {
-    t.is(path, "http://example.com/graphs/foo.json");
-    return inspectableGraph({
-      nodes: [{ id: "d", type: "bar" }],
-      edges: [],
-    });
-  });
-  t.truthy(subgraph);
-  t.deepEqual(subgraph?.nodeById("d")?.descriptor.type, "bar");
 });

--- a/packages/breadboard/tests/inspector/traversal.ts
+++ b/packages/breadboard/tests/inspector/traversal.ts
@@ -7,15 +7,17 @@
 // These test traversal of the inspector API.
 
 import test from "ava";
-
-import { loadToInspect } from "../../src/inspector/index.js";
+import { BoardLoader } from "../../src/loader.js";
+import { inspectableGraph } from "../../src/inspector/graph.js";
 
 const BASE_URL = new URL("../../../tests/inspector/data/", import.meta.url);
 
 const load = async (url: string) => {
   const base = BASE_URL;
-  const loader = loadToInspect(base);
-  return loader(url, { nodes: [], edges: [] });
+  const loader = new BoardLoader({ base });
+  const result = await loader.load(url);
+  if (!result) return undefined;
+  return inspectableGraph(result.graph);
 };
 
 test("inspector API can traverse simplest.json", async (t) => {
@@ -37,13 +39,6 @@ test("inspector API can traverse simplest.json", async (t) => {
 
   const invoke = fromInput[0].to;
   t.assert(invoke.descriptor.type == "invoke", "The next node is an invoke");
-  t.assert(invoke.containsGraph(), "The invoke is a subgraph");
-
-  const geminiGenerator = await invoke.subgraph(loadToInspect(BASE_URL));
-  if (!geminiGenerator) {
-    return t.fail("Subgraph is undefined");
-  }
-  t.is(geminiGenerator.nodes().length, 11, "The subgraph has eleven nodes");
 
   const fromInvoke = invoke.outgoing();
   t.assert(fromInvoke.length == 1, "The invoke has one outgoing edge");
@@ -51,126 +46,4 @@ test("inspector API can traverse simplest.json", async (t) => {
   const output = fromInvoke[0].to;
   t.assert(output.descriptor.type == "output", "The next node is an output");
   t.assert(output.isExit(), "The output is an exit node");
-});
-
-test("inspector API can describe the subgraph in simplest-no-schema.json", async (t) => {
-  const simplest = await load("simplest-no-schema.json");
-  if (!simplest) {
-    return t.fail("Graph is undefined");
-  }
-  const invoke = simplest.nodesByType("invoke")[0];
-
-  const geminiGenerator = await invoke.subgraph(loadToInspect(BASE_URL));
-
-  const api = await geminiGenerator?.describe();
-
-  t.deepEqual(api, {
-    inputSchema: {
-      type: "object",
-      properties: { useStreaming: { type: "string" } },
-      required: ["useStreaming"],
-    },
-    outputSchema: {
-      type: "object",
-      properties: {
-        stream: { type: "string" },
-        context: { type: "string" },
-        text: { type: "string" },
-        toolCalls: { type: "string" },
-      },
-      required: ["context", "stream", "text", "toolCalls"],
-    },
-  });
-});
-
-test("inspector API can describe the subgraph in simplest.json", async (t) => {
-  const simplest = await load("simplest.json");
-  if (!simplest) {
-    return t.fail("Graph is undefined");
-  }
-  const invoke = simplest.nodesByType("invoke")[0];
-
-  const geminiGenerator = await invoke.subgraph(loadToInspect(BASE_URL));
-
-  const api = await geminiGenerator?.describe();
-
-  t.deepEqual(api, {
-    inputSchema: {
-      type: "object",
-      properties: {
-        text: {
-          type: "string",
-          title: "Text",
-          description: "The text to generate",
-          examples: ["What is the square root of pi?"],
-        },
-        tools: {
-          type: "array",
-          title: "Tools",
-          description: "An array of functions to use for tool-calling",
-          items: {
-            type: "string",
-          },
-          default: "[]",
-          examples: [
-            '[\n  {\n    "name": "The_Calculator_Board",\n    "description": "A simple AI pattern that leans on the power of the LLMs to generate language to solve math problems.",\n    "parameters": {\n      "type": "object",\n      "properties": {\n        "text": {\n          "type": "string",\n          "description": "Ask a math question"\n        }\n      },\n      "required": [\n        "text"\n      ]\n    }\n  },\n  {\n    "name": "The_Search_Summarizer_Board",\n    "description": "A simple AI pattern that first uses Google Search to find relevant bits of information and then summarizes them using LLM.",\n    "parameters": {\n      "type": "object",\n      "properties": {\n        "text": {\n          "type": "string",\n          "description": "What would you like to search for?"\n        }\n      },\n      "required": [\n        "text"\n      ]\n    }\n  }\n]',
-          ],
-        },
-        context: {
-          type: "array",
-          title: "Context",
-          description: "An array of messages to use as conversation context",
-          items: {
-            type: "object",
-          },
-          default: "[]",
-          examples: [
-            '[\n  {\n    "role": "user",\n    "parts": [\n      {\n        "text": "You are a pirate. Please talk like a pirate."\n      }\n    ]\n  },\n  {\n    "role": "model",\n    "parts": [\n      {\n        "text": "Arr, matey!"\n      }\n    ]\n  }\n]',
-          ],
-        },
-        useStreaming: {
-          type: "boolean",
-          title: "Stream",
-          description: "Whether to stream the output",
-          default: "false",
-        },
-        stopSequences: {
-          type: "array",
-          title: "Stop Sequences",
-          description: "An array of strings that will stop the output",
-          items: {
-            type: "string",
-          },
-          default: "[]",
-        },
-      },
-      required: ["text"],
-    },
-    outputSchema: {
-      type: "object",
-      properties: {
-        text: {
-          type: "string",
-          title: "Text",
-          description: "The generated text",
-        },
-        toolCalls: {
-          type: "array",
-          title: "Tool Calls",
-          description: "The generated tool calls",
-        },
-        stream: {
-          type: "object",
-          title: "Stream",
-          format: "stream",
-          description: "The generated text",
-        },
-        context: {
-          type: "array",
-          title: "Context",
-          description: "The conversation context",
-        },
-      },
-    },
-  });
 });

--- a/packages/website/src/docs/concepts.md
+++ b/packages/website/src/docs/concepts.md
@@ -50,9 +50,9 @@ expected to provide an implementation for some portion of the graph themselves.
 
 ## Breadboard Graph Language (BGL)
 
-Breadboard Graph Language (BGL) is a JSON file format format described by [this
+Breadboard Graph Language (BGL) is a graph serialization format described by [this
 JSON
-schema](../../../schema/breadboard.schema.json).
+schema](https://github.com/breadboard-ai/breadboard/blob/main/packages/schema/breadboard.schema.json).
 
 ## Runtimes
 

--- a/packages/website/src/docs/inspector.md
+++ b/packages/website/src/docs/inspector.md
@@ -8,7 +8,7 @@ hide_toc: true
 date: 2012-01-01 # Done to place the index atop the list.
 ---
 
-The Inspector API provides a way to inspect a graph to make sense of it. Because a serialized graph representation (also known as the BGL document) is basically just JSON containing arrays of nodes and edges, a the actual semantics of the graph need to be added separately. This is what the Inspector API does. Think of it as the DOM API for the graph.
+The Inspector API provides a way to inspect a graph to make sense of it. Because a serialized graph representation (also known as the [BGL document](../concepts/#breadboard-graph-language-bgl)) is basically just JSON containing arrays of nodes and edges, a the actual semantics of the graph need to be added separately. This is what the Inspector API does. Think of it as the DOM API for the graph.
 
 > [!NOTE]
 > The full list of types of Inspector API can be found in [/packages/breadboard/src/inspector/types.ts](https://github.com/breadboard-ai/breadboard/blob/main/packages/breadboard/src/inspector/types.ts)

--- a/packages/website/src/docs/inspector.md
+++ b/packages/website/src/docs/inspector.md
@@ -240,34 +240,14 @@ The port status can be one of the following values:
 
 ## Subgraphs
 
-> [!WARNING]
-> This part of the API is still in flux. Even more than the stuff above.
-
 Some nodes may represent entire subgraphs. For instance, `core.invoke` node takes a `board` as its argument, and invokes that graph, passing its own inputs to this subgaph and returning its results as own outputs.
 
-To find out if a node represents a subgraph, use the `containsGraph` method of the `InspectableNode` instance:
+> [!TIP]
+> Make sure that when calling `inspect`, the BGL document argument has the `url` property set to
+> a valid URL that represents the current location of this graph. It will enable nodes that do loading as part of describing themselves (such as `core.invoke`) to correctly resolve any relative paths that might be given as their inputs.
+>
+> This value will be automatically set when loading a BGL file using the `BoardRunner.load` method.
 
-```ts
-// Returns boolean.
-const containsGraph = node.containsGraph();
-```
+It is the responsibility of the respective nodes to provide an accurate description of their input and output ports.
 
-We can then load the subgraph using the `InspectableNode.subgraph` method. The loading logic is intentionally not part of the Inspector API. Instead, we must supply an loader function with the signature, specified by `InspectableGraphLoader`.
-
-For convenience, there's a `loadToInspect` helper function that creates a basic loader for just that purpose. This helper function takes a single argument of the base URL that will be used to resolve relative paths while loading:
-
-```ts
-import { inspect, loadToInspect } from "@google-labs/breadboard";
-
-// .. somewhere down in the code
-
-// Returns an `InspectableGraph` instance.
-const subgraph = await node.subgraph(loadToInspect(new URL(base)));
-```
-
-To help with understanding the expected inputs and outputs of a graph, the `InspectableGraph` has a `describe` method. It returns an object with two members: `inputSchema` and `outputSchema`. These objects represent what the graph expects as its inputs and its outputs.
-
-```ts
-// async, returns Promise<NodeDescriberResult>
-const { inputSchema, outputSchema } = await graph.describe();
-```
+For instance, when `core.invoke` is asked to describe itself -- and provided it has all the necessary information, and the BGL document has a valid `url` property, -- it will show the invoked graph's inputs and outputs as its own ports.

--- a/packages/website/src/docs/inspector.md
+++ b/packages/website/src/docs/inspector.md
@@ -125,8 +125,10 @@ const ports = await node.ports();
 This method also takes an optional `InputValues` argument that can be useful for some types of nodes that change their input/output port configuration based on the inputs.
 
 ```ts
+// Given this argument, the `promptTemplate` node will parse the template,
+// see that it needs a `name` value to correctly fill in the template,
+// and change its shape to expect `name` as an additional input port
 const promptTemplatePorts = await promptTemplate.ports({
-  // prettier-ignore
   template: "Hello {% raw %}{{name}}{% endraw %}!",
 });
 ```
@@ -195,7 +197,7 @@ always `false` for the output ports.
 const configured = firstInputPort.configured;
 ```
 
-We can get the JSON schema of the port:
+We can get the [JSON schema](https://json-schema.org/) of the port:
 
 ```ts
 // Returns `Schema`.


### PR DESCRIPTION
- Tweak docs a bit.
- More doc tweaks.
- Teach `invoke` to properly describe itself.
- Update docs.
- Remove `containsGraph` and `subgraph` APIs.
- Start using `ports` directly in the editor.
- docs(changeset): Taught `core.invoke` to describe its own subgraphs.
