### PR TITLE
even more inspector

### DIFF
--- a/.changeset/wise-ghosts-draw.md
+++ b/.changeset/wise-ghosts-draw.md
@@ -1,0 +1,6 @@
+---
+"@google-labs/breadboard-ui": patch
+"@google-labs/breadboard": patch
+---
+
+Fix various bugs in inspector API.

--- a/packages/breadboard-ui/src/elements/editor/editor.ts
+++ b/packages/breadboard-ui/src/elements/editor/editor.ts
@@ -15,7 +15,6 @@ import {
 import { customElement, property, state } from "lit/decorators.js";
 import { LoadArgs } from "../../types/types.js";
 import {
-  Schema,
   inspect,
   GraphDescriptor,
   InspectableNode,

--- a/packages/breadboard/src/inspector/graph.ts
+++ b/packages/breadboard/src/inspector/graph.ts
@@ -9,6 +9,7 @@ import { combineSchemas } from "../schema.js";
 import {
   Edge,
   GraphDescriptor,
+  NodeDescriberContext,
   NodeDescriberResult,
   NodeIdentifier,
   NodeTypeIdentifier,
@@ -99,12 +100,17 @@ class Graph implements InspectableGraph {
     if (!handler || typeof handler === "function" || !handler.describe) {
       return asWired;
     }
-    const maybeContext = this.#url ? { base: this.#url } : undefined;
+    const context: NodeDescriberContext = {
+      outerGraph: this.#graph,
+    };
+    if (this.#url) {
+      context.base = this.#url;
+    }
     return handler.describe(
       options?.inputs || undefined,
       asWired.inputSchema,
       asWired.outputSchema,
-      maybeContext
+      context
     );
   }
 

--- a/packages/breadboard/src/inspector/schemas.ts
+++ b/packages/breadboard/src/inspector/schemas.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { SchemaBuilder } from "../schema.js";
 import { NodeDescriberResult, Schema } from "../types.js";
 import { InspectableEdge, NodeTypeDescriberOptions } from "./types.js";
 
@@ -53,7 +54,10 @@ export const describeInput = (
   const schema = options.inputs?.schema as Schema | undefined;
   if (schema) return { inputSchema: {}, outputSchema: schema };
   return {
-    inputSchema: {},
+    inputSchema: new SchemaBuilder()
+      // TODO: Specify actual "schema" schema.
+      .addProperty("schema", { type: "object" })
+      .build(),
     outputSchema: edgesToSchema(EdgeType.Out, options.outgoing),
   };
 };

--- a/packages/breadboard/src/inspector/schemas.ts
+++ b/packages/breadboard/src/inspector/schemas.ts
@@ -41,6 +41,7 @@ export const edgesToSchema = (
   if (!edges) return {};
   return new SchemaBuilder()
     .addProperties(edgesToProperties(edgeType, edges, keepStar))
+    .setAdditionalProperties(true)
     .build();
 };
 
@@ -55,6 +56,7 @@ export const describeInput = (
   const schema = options.inputs?.schema as Schema | undefined;
   const inputSchema = new SchemaBuilder()
     .addProperty("schema", SCHEMA_SCHEMA)
+    .setAdditionalProperties(true)
     .build();
   if (schema) return { inputSchema, outputSchema: schema };
   return {
@@ -72,10 +74,9 @@ export const describeOutput = (
   options: NodeTypeDescriberOptions
 ): NodeDescriberResult => {
   const schema = options.inputs?.schema as Schema | undefined;
-  const inputSchemaBuilder = new SchemaBuilder().addProperty(
-    "schema",
-    SCHEMA_SCHEMA
-  );
+  const inputSchemaBuilder = new SchemaBuilder()
+    .addProperty("schema", SCHEMA_SCHEMA)
+    .setAdditionalProperties(true);
   if (schema)
     return {
       inputSchema: inputSchemaBuilder.addSchema(schema).build(),

--- a/packages/breadboard/src/inspector/schemas.ts
+++ b/packages/breadboard/src/inspector/schemas.ts
@@ -20,12 +20,12 @@ const DEFAULT_SCHEMA = { type: "string" };
 
 const edgesToProperties = (
   edgeType: EdgeType,
-  edges?: InspectableEdge[]
+  edges?: InspectableEdge[],
+  keepStar = false
 ): Record<string, Schema> => {
   if (!edges) return {};
   return edges.reduce((acc, edge) => {
-    // Remove star edges from the schema. These must be handled separately.
-    if (edge.out === "*") return acc;
+    if (!keepStar && edge.out === "*") return acc;
     const key = edgeType === EdgeType.In ? edge.in : edge.out;
     if (acc[key]) return acc;
     acc[key] = DEFAULT_SCHEMA;
@@ -35,11 +35,12 @@ const edgesToProperties = (
 
 export const edgesToSchema = (
   edgeType: EdgeType,
-  edges?: InspectableEdge[]
+  edges?: InspectableEdge[],
+  keepStar = false
 ): Schema => {
   if (!edges) return {};
   return new SchemaBuilder()
-    .addProperties(edgesToProperties(edgeType, edges))
+    .addProperties(edgesToProperties(edgeType, edges, keepStar))
     .build();
 };
 
@@ -52,12 +53,13 @@ export const describeInput = (
   options: NodeTypeDescriberOptions
 ): NodeDescriberResult => {
   const schema = options.inputs?.schema as Schema | undefined;
-  if (schema) return { inputSchema: {}, outputSchema: schema };
+  const inputSchema = new SchemaBuilder()
+    .addProperty("schema", SCHEMA_SCHEMA)
+    .build();
+  if (schema) return { inputSchema, outputSchema: schema };
   return {
-    inputSchema: new SchemaBuilder()
-      .addProperty("schema", SCHEMA_SCHEMA)
-      .build(),
-    outputSchema: edgesToSchema(EdgeType.Out, options.outgoing),
+    inputSchema,
+    outputSchema: edgesToSchema(EdgeType.Out, options.outgoing, true),
   };
 };
 
@@ -70,11 +72,18 @@ export const describeOutput = (
   options: NodeTypeDescriberOptions
 ): NodeDescriberResult => {
   const schema = options.inputs?.schema as Schema | undefined;
-  if (schema) return { inputSchema: schema, outputSchema: {} };
+  const inputSchemaBuilder = new SchemaBuilder().addProperty(
+    "schema",
+    SCHEMA_SCHEMA
+  );
+  if (schema)
+    return {
+      inputSchema: inputSchemaBuilder.addSchema(schema).build(),
+      outputSchema: {},
+    };
   return {
-    inputSchema: new SchemaBuilder()
-      .addProperties(edgesToProperties(EdgeType.In, options.incoming))
-      .addProperty("schema", SCHEMA_SCHEMA)
+    inputSchema: inputSchemaBuilder
+      .addProperties(edgesToProperties(EdgeType.In, options.incoming, true))
       .build(),
     outputSchema: {},
   };

--- a/packages/breadboard/src/schema.ts
+++ b/packages/breadboard/src/schema.ts
@@ -37,8 +37,10 @@ export class SchemaBuilder {
     const result: Schema = {
       type: "object",
       properties: this.properties,
-      additionalProperties: this.additionalProperties,
     };
+    if (!this.additionalProperties) {
+      result.additionalProperties = false;
+    }
     if (this.required.length > 0) {
       result.required = this.required;
     }

--- a/packages/breadboard/src/schema.ts
+++ b/packages/breadboard/src/schema.ts
@@ -45,6 +45,15 @@ export class SchemaBuilder {
     return result;
   }
 
+  addSchema(schema: Schema) {
+    if (schema.type === "object") {
+      this.addProperties(schema.properties);
+      this.addRequired(schema.required);
+      this.setAdditionalProperties(schema.additionalProperties as boolean);
+    }
+    return this;
+  }
+
   setAdditionalProperties(additionalProperties?: boolean) {
     if (additionalProperties !== undefined) {
       this.additionalProperties = additionalProperties;

--- a/packages/breadboard/src/schema.ts
+++ b/packages/breadboard/src/schema.ts
@@ -28,6 +28,7 @@ export const getSchemaType = (value: unknown): SchemaType => {
 };
 
 export class SchemaBuilder {
+  type = "object";
   additionalProperties = false;
   required: string[] = [];
   properties: SchemaProperties = {};

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -320,7 +320,11 @@ export type NodeDescriberContext = {
   /**
    * The base URL of the graph.
    */
-  base: URL;
+  base?: URL;
+  /**
+   * The graph in which the node is described.
+   */
+  outerGraph: GraphDescriptor;
 };
 
 /**

--- a/packages/breadboard/tests/inspector/describe.ts
+++ b/packages/breadboard/tests/inspector/describe.ts
@@ -38,20 +38,15 @@ test("simple graph description works as expected", async (t) => {
     inputSchema: {
       type: "object",
       properties: {
-        text: {
-          type: "string",
-        },
+        text: { type: "string" },
       },
-      required: ["text"],
     },
     outputSchema: {
       type: "object",
       properties: {
-        text: {
-          type: "string",
-        },
+        schema: { type: "object" },
+        text: { type: "string" },
       },
-      required: ["text"],
     },
   });
 });
@@ -66,7 +61,14 @@ test("inspector API can describe the input in simplest.json", async (t) => {
   const api = await input.describe();
 
   t.deepEqual(api, {
-    inputSchema: {},
+    inputSchema: {
+      type: "object",
+      properties: {
+        schema: {
+          type: "object",
+        },
+      },
+    },
     outputSchema: {
       type: "object",
       properties: {
@@ -92,9 +94,17 @@ test("inspector API can describe the input in simplest-no-schema.json", async (t
   const api = await input.describe();
 
   t.deepEqual(api, {
-    inputSchema: {},
+    inputSchema: {
+      type: "object",
+      properties: {
+        schema: { type: "object" },
+      },
+    },
     outputSchema: {
       type: "object",
+      properties: {
+        "*": { type: "string" },
+      },
     },
   });
 });
@@ -109,15 +119,17 @@ test("inspector API can describe the input in simplest-no-schema-strict.json", a
   const api = await input.describe();
 
   t.deepEqual(api, {
-    inputSchema: {},
+    inputSchema: {
+      type: "object",
+      properties: {
+        schema: { type: "object" },
+      },
+    },
     outputSchema: {
       type: "object",
       properties: {
-        text: {
-          type: "string",
-        },
+        text: { type: "string" },
       },
-      required: ["text"],
     },
   });
 });
@@ -135,6 +147,7 @@ test("inspector API can describe the output in simplest.json", async (t) => {
     inputSchema: {
       type: "object",
       properties: {
+        schema: { type: "object" },
         text: {
           type: "string",
           title: "Response",
@@ -159,6 +172,10 @@ test("inspector API can describe the output in simplest-no-schema.json", async (
   t.deepEqual(api, {
     inputSchema: {
       type: "object",
+      properties: {
+        schema: { type: "object" },
+        "*": { type: "string" },
+      },
     },
     outputSchema: {},
   });
@@ -177,11 +194,9 @@ test("inspector API can describe the output in simplest-no-schema-strict.json", 
     inputSchema: {
       type: "object",
       properties: {
-        text: {
-          type: "string",
-        },
+        schema: { type: "object" },
+        text: { type: "string" },
       },
-      required: ["text"],
     },
     outputSchema: {},
   });

--- a/packages/breadboard/tests/schema.ts
+++ b/packages/breadboard/tests/schema.ts
@@ -92,7 +92,6 @@ test("SchemaBuilder can set `additionalProperties`", (t) => {
     t.deepEqual(schema, {
       type: "object",
       properties: {},
-      additionalProperties: true,
     });
   }
   {


### PR DESCRIPTION
- Remove unused import.
- Pass `outerGraph` in `NodeDescriberContext`.
- Teach `output` node to expect a schema input.
- Handle `Indeterminate` state.
- docs(changeset): Fix various bugs in inspector API.
