### PR TITLE
inspectable kits

### DIFF
--- a/.changeset/quick-spoons-grab.md
+++ b/.changeset/quick-spoons-grab.md
@@ -1,0 +1,10 @@
+---
+"@google-labs/node-nursery-web": patch
+"@google-labs/breadboard-web": patch
+"@google-labs/breadboard-ui": patch
+"@google-labs/breadboard": patch
+"@google-labs/agent-kit": patch
+"@google-labs/breadboard-website": patch
+---
+
+Introduce a way to inspect kits.

--- a/packages/agent-kit/src/hacks.ts
+++ b/packages/agent-kit/src/hacks.ts
@@ -26,6 +26,7 @@ export const workerDescriber: NodeDescriberFunction = async () => {
             "The instruction we want to give to the worker so that shapes its character and orients it a bit toward the task we want to give it.",
         },
       },
+      additionalProperties: false,
     },
     outputSchema: {
       type: "object",
@@ -43,6 +44,7 @@ export const workerDescriber: NodeDescriberFunction = async () => {
             "The output from the agent. Use this to just get the output without any previous context.",
         },
       },
+      additionalProperties: false,
     },
   };
 };

--- a/packages/breadboard-ui/src/elements/editor/editor.ts
+++ b/packages/breadboard-ui/src/elements/editor/editor.ts
@@ -540,14 +540,15 @@ export class Editor extends LitElement {
     const breadboardGraph = inspect(descriptor, { kits: this.kits });
     // TODO: Remove once all the kit bits are settled.
     // For now, this is a good way to inspect all the kits.
-    console.groupCollapsed("Kit inspection");
+    console.group("Kit inspection");
     for (const kit of breadboardGraph.kits()) {
-      console.log("kit:", kit.descriptor.title);
+      console.groupCollapsed(`Kit: ${kit.descriptor.title}`);
       for (const nodeType of kit.nodeTypes) {
         console.group("type", nodeType.type());
         console.log("ports", await nodeType.ports());
         console.groupEnd();
       }
+      console.groupEnd();
     }
     console.groupEnd();
     this.#nodes = breadboardGraph.nodes();

--- a/packages/breadboard-ui/src/elements/editor/editor.ts
+++ b/packages/breadboard-ui/src/elements/editor/editor.ts
@@ -538,6 +538,18 @@ export class Editor extends LitElement {
     const y = this.#height / 2;
 
     const breadboardGraph = inspect(descriptor, { kits: this.kits });
+    // TODO: Remove once all the kit bits are settled.
+    // For now, this is a good way to inspect all the kits.
+    console.groupCollapsed("Kit inspection");
+    for (const kit of breadboardGraph.kits()) {
+      console.log("kit:", kit.descriptor.title);
+      for (const nodeType of kit.nodeTypes) {
+        console.group("type", nodeType.type());
+        console.log("ports", await nodeType.ports());
+        console.groupEnd();
+      }
+    }
+    console.groupEnd();
     this.#nodes = breadboardGraph.nodes();
 
     // Create nodes first.

--- a/packages/breadboard-web/public/graphs/list-files.json
+++ b/packages/breadboard-web/public/graphs/list-files.json
@@ -140,6 +140,7 @@
   ],
   "kits": [
     {
+      "title": "Node Nursery (Web)",
       "url": "npm:@google-labs/node-nursery-web"
     },
     {

--- a/packages/breadboard/src/inspector/graph.ts
+++ b/packages/breadboard/src/inspector/graph.ts
@@ -14,6 +14,7 @@ import {
   NodeIdentifier,
   NodeTypeIdentifier,
 } from "../types.js";
+import { collectKits } from "./kits.js";
 import { inspectableNode } from "./node.js";
 import {
   EdgeType,
@@ -25,6 +26,7 @@ import {
   InspectableEdge,
   InspectableGraph,
   InspectableGraphOptions,
+  InspectableKit,
   InspectableNode,
   NodeTypeDescriberOptions,
 } from "./types.js";
@@ -49,6 +51,7 @@ class Graph implements InspectableGraph {
   #typeMap: Map<NodeTypeIdentifier, InspectableNode[]> = new Map();
   #entries?: InspectableNode[];
   #edges?: InspectableEdge[];
+  #kits?: InspectableKit[];
   #options: InspectableGraphOptions;
 
   constructor(graph: GraphDescriptor, options?: InspectableGraphOptions) {
@@ -106,12 +109,17 @@ class Graph implements InspectableGraph {
     if (this.#url) {
       context.base = this.#url;
     }
-    return handler.describe(
-      options?.inputs || undefined,
-      asWired.inputSchema,
-      asWired.outputSchema,
-      context
-    );
+    try {
+      return handler.describe(
+        options?.inputs || undefined,
+        asWired.inputSchema,
+        asWired.outputSchema,
+        context
+      );
+    } catch (e) {
+      console.warn(`Error describing node type ${type}`, e);
+      return asWired;
+    }
   }
 
   nodeById(id: NodeIdentifier) {
@@ -138,6 +146,10 @@ class Graph implements InspectableGraph {
     return (this.#edges ??= this.#graph.edges.map((edge) =>
       this.#edgeToInspectableEdge(edge)
     ));
+  }
+
+  kits(): InspectableKit[] {
+    return (this.#kits ??= collectKits(this.#options.kits || []));
   }
 
   incomingForNode(id: NodeIdentifier): InspectableEdge[] {

--- a/packages/breadboard/src/inspector/kits.ts
+++ b/packages/breadboard/src/inspector/kits.ts
@@ -5,11 +5,9 @@
  */
 
 import {
-  KitDescriptor,
   Kit,
   NodeHandlers,
   NodeHandler,
-  NodeDescriberFunction,
   NodeDescriberResult,
 } from "../types.js";
 import { collectPortsForType } from "./ports.js";

--- a/packages/breadboard/src/inspector/kits.ts
+++ b/packages/breadboard/src/inspector/kits.ts
@@ -22,8 +22,8 @@ import {
 const createBuiltInKit = (): InspectableKit => {
   return {
     descriptor: {
-      title: "Built-in",
-      description: "Built-in Breadboard nodes",
+      title: "Built-in Kit",
+      description: "A kit containing built-in Breadboard nodes",
       url: "",
     },
     nodeTypes: [

--- a/packages/breadboard/src/inspector/kits.ts
+++ b/packages/breadboard/src/inspector/kits.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { KitDescriptor, Kit, NodeHandlers, NodeHandler } from "../types.js";
+import { collectPortsForType } from "./ports.js";
+import {
+  InspectableKit,
+  InspectableNodePorts,
+  InspectableNodeType,
+} from "./types.js";
+
+export const collectKits = (kits: Kit[]): InspectableKit[] => {
+  return kits.map((kit) => ({
+    descriptor: kit as KitDescriptor,
+    nodeTypes: collectNodeTypes(kit.handlers),
+  }));
+};
+
+const collectNodeTypes = (handlers: NodeHandlers): InspectableNodeType[] => {
+  return Object.entries(handlers).map(
+    ([type, handler]) => new NodeType(type, handler)
+  );
+};
+
+class NodeType implements InspectableNodeType {
+  #type: string;
+  #handler: NodeHandler;
+
+  constructor(type: string, handler: NodeHandler) {
+    this.#type = type;
+    this.#handler = handler;
+  }
+
+  type() {
+    return this.#type;
+  }
+
+  async ports(): Promise<InspectableNodePorts> {
+    if (typeof this.#handler === "function" || !this.#handler.describe) {
+      return emptyPorts();
+    }
+    try {
+      const described = await this.#handler.describe();
+      return {
+        inputs: {
+          fixed: described.inputSchema.additionalProperties === false,
+          ports: collectPortsForType(described.inputSchema),
+        },
+        outputs: {
+          fixed: described.outputSchema.additionalProperties === false,
+          ports: collectPortsForType(described.outputSchema),
+        },
+      };
+    } catch (e) {
+      console.warn(`Error describing node type ${this.#type}:`, e);
+      return emptyPorts();
+    }
+  }
+}
+
+export const emptyPorts = (): InspectableNodePorts => ({
+  inputs: {
+    ports: [],
+    fixed: false,
+  },
+  outputs: {
+    ports: [],
+    fixed: false,
+  },
+});

--- a/packages/breadboard/src/inspector/ports.ts
+++ b/packages/breadboard/src/inspector/ports.ts
@@ -72,3 +72,23 @@ export const collectPorts = (
     };
   });
 };
+
+export const collectPortsForType = (schema: Schema) => {
+  const portNames = Object.keys(schema.properties || {});
+  const requiredPortNames = schema.required || [];
+  portNames.sort();
+  return portNames.map((port) => {
+    return {
+      name: port,
+      configured: false,
+      star: false,
+      status: computePortStatus(
+        false,
+        true,
+        requiredPortNames.includes(port),
+        false
+      ),
+      schema: schema.properties?.[port],
+    };
+  });
+};

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -8,6 +8,7 @@ import {
   GraphDescriptor,
   InputValues,
   Kit,
+  KitDescriptor,
   NodeConfiguration,
   NodeDescriberResult,
   NodeDescriptor,
@@ -104,6 +105,10 @@ export type InspectableGraph = {
    * Returns all edges of the graph.
    */
   edges(): InspectableEdge[];
+  /**
+   * Returns all kits in the graph.
+   */
+  kits(): InspectableKit[];
   /**
    * Returns all nodes of the given type.
    * @param type type of the nodes to find
@@ -258,4 +263,20 @@ export type InspectableNodePorts = {
    * Returns the output ports of the node.
    */
   outputs: InspectablePortList;
+};
+
+/**
+ * Represents a Breadboard Kit associated with the board.
+ */
+export type InspectableKit = {
+  /**
+   * Returns the descriptor of the kit.
+   */
+  descriptor: KitDescriptor;
+  nodeTypes: InspectableNodeType[];
+};
+
+export type InspectableNodeType = {
+  type(): NodeTypeIdentifier;
+  ports(): Promise<InspectableNodePorts>;
 };

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -273,10 +273,19 @@ export type InspectableKit = {
    * Returns the descriptor of the kit.
    */
   descriptor: KitDescriptor;
+  /**
+   * Returns the node types of the kit.
+   */
   nodeTypes: InspectableNodeType[];
 };
 
 export type InspectableNodeType = {
+  /**
+   * Returns the type of the node.
+   */
   type(): NodeTypeIdentifier;
+  /**
+   * Returns the ports of the node.
+   */
   ports(): Promise<InspectableNodePorts>;
 };

--- a/packages/node-nursery-web/src/index.ts
+++ b/packages/node-nursery-web/src/index.ts
@@ -11,6 +11,9 @@ import transformStream from "./nodes/transform-stream.js";
 import listToStream from "./nodes/list-to-stream.js";
 
 const NodeNurseryWeb = new KitBuilder({
+  title: "Node Nursery (Web)",
+  description:
+    "A kit that holds nodes that run in a Web-based environment, and are still WIP",
   url: "npm:@google-labs/node-nursery-web",
 }).build({
   credentials,


### PR DESCRIPTION
- First cut of `InspectableGraph.kits()`.
- Add built-in Kit.
- Remove spurious imports.
- Pretty things up a bit.
- Write docs.
- docs(changeset): Introduce a way to inspect kits.
