### PR TITLE
Add Package repository directories

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,5 +147,9 @@
   },
   "dependencies": {
     "litegraph.js": "^0.7.18"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/breadboard-ai/breadboard.git"
   }
 }

--- a/packages/agent-kit/package.json
+++ b/packages/agent-kit/package.json
@@ -96,7 +96,7 @@
   "repository": {
     "directory": "packages/agent-kit",
     "type": "git",
-    "url": "https://github.com/breadboard-ai/breadboard"
+    "url": "https://github.com/breadboard-ai/breadboard.git"
   },
   "files": [
     "dist/src"

--- a/packages/agent-kit/package.json
+++ b/packages/agent-kit/package.json
@@ -94,6 +94,7 @@
     }
   },
   "repository": {
+    "directory": "packages/agent-kit",
     "type": "git",
     "url": "https://github.com/breadboard-ai/breadboard"
   },

--- a/packages/breadboard-cli/package.json
+++ b/packages/breadboard-cli/package.json
@@ -97,6 +97,7 @@
     }
   },
   "repository": {
+    "directory": "packages/breadboard-cli",
     "type": "git",
     "url": "git+https://github.com/breadboard-ai/breadboard.git"
   },

--- a/packages/breadboard-extension/package.json
+++ b/packages/breadboard-extension/package.json
@@ -172,6 +172,7 @@
     }
   },
   "repository": {
+    "directory": "packages/breadboard-extension",
     "type": "git",
     "url": "git+https://github.com/breadboard-ai/breadboard.git"
   },

--- a/packages/breadboard-server/package.json
+++ b/packages/breadboard-server/package.json
@@ -84,6 +84,7 @@
     }
   },
   "repository": {
+    "directory": "packages/breadboard-server",
     "type": "git",
     "url": "git+https://github.com/breadboard-ai/breadboard.git"
   },

--- a/packages/breadboard-ui/package.json
+++ b/packages/breadboard-ui/package.json
@@ -107,6 +107,7 @@
     }
   },
   "repository": {
+    "directory": "packages/breadboard-ui",
     "type": "git",
     "url": "git+https://github.com/breadboard-ai/breadboard.git"
   },

--- a/packages/breadboard-web/package.json
+++ b/packages/breadboard-web/package.json
@@ -154,6 +154,7 @@
     }
   },
   "repository": {
+    "directory": "packages/breadboard-web",
     "type": "git",
     "url": "git+https://github.com/breadboard-ai/breadboard.git"
   },

--- a/packages/breadboard/package.json
+++ b/packages/breadboard/package.json
@@ -113,6 +113,7 @@
     }
   },
   "repository": {
+    "directory": "packages/breadboard",
     "type": "git",
     "url": "git+https://github.com/breadboard-ai/breadboard.git"
   },

--- a/packages/cloud-function/package.json
+++ b/packages/cloud-function/package.json
@@ -58,6 +58,7 @@
     }
   },
   "repository": {
+    "directory": "packages/cloud-function",
     "type": "git",
     "url": "git+https://github.com/breadboard-ai/breadboard.git"
   },

--- a/packages/coffee-bot-board/package.json
+++ b/packages/coffee-bot-board/package.json
@@ -103,6 +103,7 @@
     }
   },
   "repository": {
+    "directory": "packages/coffee-bot-board",
     "type": "git",
     "url": "git+https://github.com/breadboard-ai/breadboard.git"
   },

--- a/packages/core-kit/package.json
+++ b/packages/core-kit/package.json
@@ -68,6 +68,7 @@
     }
   },
   "repository": {
+    "directory": "packages/core-kit",
     "type": "git",
     "url": "git+https://github.com/breadboard-ai/breadboard.git"
   },

--- a/packages/create-breadboard-kit/package.json
+++ b/packages/create-breadboard-kit/package.json
@@ -62,6 +62,7 @@
     }
   },
   "repository": {
+    "directory": "packages/create-breadboard-kit",
     "type": "git",
     "url": "git+https://github.com/breadboard-ai/breadboard.git"
   },

--- a/packages/create-breadboard/package.json
+++ b/packages/create-breadboard/package.json
@@ -49,6 +49,7 @@
     }
   },
   "repository": {
+    "directory": "packages/create-breadboard",
     "type": "git",
     "url": "git+https://github.com/breadboard-ai/breadboard.git"
   },

--- a/packages/discovery-types/package.json
+++ b/packages/discovery-types/package.json
@@ -80,6 +80,7 @@
     }
   },
   "repository": {
+    "directory": "packages/discovery-types",
     "type": "git",
     "url": "git+https://github.com/breadboard-ai/breadboard.git"
   },

--- a/packages/gemini-kit/package.json
+++ b/packages/gemini-kit/package.json
@@ -85,7 +85,7 @@
   "repository": {
     "directory": "packages/gemini-kit",
     "type": "git",
-    "url": "https://github.com/breadboard-ai/breadboard"
+    "url": "https://github.com/breadboard-ai/breadboard.git"
   },
   "files": [
     "dist/src"

--- a/packages/gemini-kit/package.json
+++ b/packages/gemini-kit/package.json
@@ -83,6 +83,7 @@
     }
   },
   "repository": {
+    "directory": "packages/gemini-kit",
     "type": "git",
     "url": "https://github.com/breadboard-ai/breadboard"
   },

--- a/packages/graph-integrity/package.json
+++ b/packages/graph-integrity/package.json
@@ -83,6 +83,7 @@
     }
   },
   "repository": {
+    "directory": "packages/graph-integrity",
     "type": "git",
     "url": "git+https://github.com/breadboard-ai/breadboard.git"
   },

--- a/packages/graph-playground/package.json
+++ b/packages/graph-playground/package.json
@@ -132,6 +132,7 @@
     }
   },
   "repository": {
+    "directory": "packages/graph-playground",
     "type": "git",
     "url": "git+https://github.com/breadboard-ai/breadboard.git"
   },

--- a/packages/graph-runner/package.json
+++ b/packages/graph-runner/package.json
@@ -93,6 +93,7 @@
     }
   },
   "repository": {
+    "directory": "packages/graph-runner",
     "type": "git",
     "url": "git+https://github.com/breadboard-ai/breadboard.git"
   },

--- a/packages/hello-world/package.json
+++ b/packages/hello-world/package.json
@@ -7,6 +7,7 @@
   "description": "A template for creating a new Breadboard project",
   "type": "module",
   "repository": {
+    "directory": "packages/hello-world",
     "type": "git",
     "url": "git+https://github.com/breadboard-ai/breadboard.git"
   },

--- a/packages/json-kit/package.json
+++ b/packages/json-kit/package.json
@@ -66,6 +66,7 @@
     }
   },
   "repository": {
+    "directory": "packages/json-kit",
     "type": "git",
     "url": "git+https://github.com/breadboard-ai/breadboard.git"
   },

--- a/packages/llm-starter/package.json
+++ b/packages/llm-starter/package.json
@@ -82,6 +82,7 @@
     }
   },
   "repository": {
+    "directory": "packages/llm-starter",
     "type": "git",
     "url": "git+https://github.com/breadboard-ai/breadboard.git"
   },

--- a/packages/node-nursery-web/package.json
+++ b/packages/node-nursery-web/package.json
@@ -69,6 +69,7 @@
     }
   },
   "repository": {
+    "directory": "packages/node-nursery-web",
     "type": "git",
     "url": "git+https://github.com/breadboard-ai/breadboard.git"
   },

--- a/packages/node-nursery/package.json
+++ b/packages/node-nursery/package.json
@@ -83,6 +83,7 @@
     }
   },
   "repository": {
+    "directory": "packages/node-nursery",
     "type": "git",
     "url": "git+https://github.com/breadboard-ai/breadboard.git"
   },

--- a/packages/node-proxy-server/package.json
+++ b/packages/node-proxy-server/package.json
@@ -42,6 +42,7 @@
     }
   },
   "repository": {
+    "directory": "packages/node-proxy-server",
     "type": "git",
     "url": "git+https://github.com/breadboard-ai/breadboard.git"
   },

--- a/packages/palm-kit/package.json
+++ b/packages/palm-kit/package.json
@@ -66,6 +66,7 @@
     }
   },
   "repository": {
+    "directory": "packages/palm-kit",
     "type": "git",
     "url": "git+https://github.com/breadboard-ai/breadboard.git"
   },

--- a/packages/pinecone-kit/package.json
+++ b/packages/pinecone-kit/package.json
@@ -84,6 +84,7 @@
     }
   },
   "repository": {
+    "directory": "packages/pinecone-kit",
     "type": "git",
     "url": "git+https://github.com/breadboard-ai/breadboard.git"
   },

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -17,6 +17,7 @@
     "registry": "https://wombat-dressing-room.appspot.com"
   },
   "repository": {
+    "directory": "packages/schema",
     "type": "git",
     "url": "git+https://github.com/breadboard-ai/breadboard.git"
   },

--- a/packages/template-kit/package.json
+++ b/packages/template-kit/package.json
@@ -82,6 +82,7 @@
     }
   },
   "repository": {
+    "directory": "packages/template-kit",
     "type": "git",
     "url": "https://github.com/breadboard-ai/breadboard"
   },

--- a/packages/template-kit/package.json
+++ b/packages/template-kit/package.json
@@ -84,7 +84,7 @@
   "repository": {
     "directory": "packages/template-kit",
     "type": "git",
-    "url": "https://github.com/breadboard-ai/breadboard"
+    "url": "https://github.com/breadboard-ai/breadboard.git"
   },
   "files": [
     "dist/src"

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -10,6 +10,7 @@
   "license": "Apache-2.0",
   "homepage": "https://github.com/breadboard-ai/breadboard#readme",
   "repository": {
+    "directory": "packages/website",
     "type": "git",
     "url": "git+https://github.com/breadboard-ai/breadboard.git"
   },

--- a/templates/blank/package.json
+++ b/templates/blank/package.json
@@ -18,6 +18,7 @@
     "lint": "FORCE_COLOR=1 eslint . --ext .ts"
   },
   "repository": {
+    "directory": "packages/blank",
     "type": "git",
     "url": "https://github.com/breadboard-ai/breadboard"
   },

--- a/templates/blank/package.json
+++ b/templates/blank/package.json
@@ -20,7 +20,7 @@
   "repository": {
     "directory": "packages/blank",
     "type": "git",
-    "url": "https://github.com/breadboard-ai/breadboard"
+    "url": "https://github.com/breadboard-ai/breadboard.git"
   },
   "files": [
     "dist/src"


### PR DESCRIPTION
allows npmjs.com to navigate to the correct directory when browsing to the repository from the registry see [here](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository:~:text=If%20the%20package.json%20for%20your%20package%20is%20not%20in%20the%20root%20directory%20(for%20example%20if%20it%20is%20part%20of%20a%20monorepo)%2C%20you%20can%20specify%20the%20directory%20in%20which%20it%20lives%3A)