### PR TITLE
editor sketch

### DIFF
--- a/.changeset/healthy-socks-tan.md
+++ b/.changeset/healthy-socks-tan.md
@@ -1,0 +1,6 @@
+---
+"@google-labs/breadboard": minor
+"@google-labs/breadboard-website": minor
+---
+
+Introduce the Editor API.

--- a/packages/breadboard/src/editor/graph.ts
+++ b/packages/breadboard/src/editor/graph.ts
@@ -1,0 +1,165 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { handlersFromKits } from "../handler.js";
+import { inspectableGraph } from "../inspector/graph.js";
+import { InspectableGraph } from "../inspector/types.js";
+import { GraphDescriptor, NodeHandlers, NodeIdentifier } from "../types.js";
+import {
+  EditableEdgeSpec,
+  EditableGraph,
+  EditableGraphOptions,
+  EditableNodeSpec,
+} from "./types.js";
+
+export const editGraph = (
+  graph: GraphDescriptor,
+  options: EditableGraphOptions = {}
+): EditableGraph => {
+  return new Graph(graph, options);
+};
+
+class Graph implements EditableGraph {
+  #options: EditableGraphOptions;
+  #nodes?: Map<NodeIdentifier, EditableNodeSpec>;
+  #inspector?: InspectableGraph;
+  #handlers?: NodeHandlers;
+  #graph: GraphDescriptor;
+
+  constructor(graph: GraphDescriptor, options: EditableGraphOptions) {
+    this.#graph = graph;
+    this.#options = options;
+  }
+
+  #getNodes() {
+    return (this.#nodes ??= new Map(
+      this.#graph.nodes.map((node) => [node.id, node])
+    ));
+  }
+
+  #getHandlers() {
+    return (this.#handlers ??= handlersFromKits(this.#options?.kits || []));
+  }
+
+  async canAddNode(spec: EditableNodeSpec) {
+    const duplicate = this.#getNodes().has(spec.id);
+    if (duplicate) {
+      return {
+        success: false,
+        error: `Node with id "${spec.id}" already exists`,
+      };
+    }
+
+    const validType = !!this.#getHandlers()[spec.type];
+    if (!validType) {
+      return {
+        success: false,
+        error: `Node type "${spec.type}" is not a known type`,
+      };
+    }
+
+    return { success: true };
+  }
+
+  async addNode(spec: EditableNodeSpec) {
+    const can = await this.canAddNode(spec);
+    if (!can.success) return can;
+
+    this.#graph.nodes.push(spec);
+    return { success: true };
+  }
+
+  async canRemoveNode(id: NodeIdentifier) {
+    const exists = this.#getNodes().has(id);
+    if (!exists) {
+      return {
+        success: false,
+        error: `Node with id "${id}" does not exist`,
+      };
+    }
+    return { success: true };
+  }
+
+  async removeNode(id: NodeIdentifier) {
+    const can = await this.canRemoveNode(id);
+    if (!can.success) return can;
+
+    this.#graph.nodes = this.#graph.nodes.filter((node) => node.id != id);
+    this.#nodes = undefined;
+    return { success: true };
+  }
+
+  async canAddEdge(spec: EditableEdgeSpec) {
+    const exists = !!this.#graph.edges.find((edge) => {
+      return (
+        edge.from === spec.from &&
+        edge.to === spec.to &&
+        edge.out === spec.out &&
+        edge.in === spec.in
+      );
+    });
+    if (exists) {
+      return {
+        success: false,
+        error: `Edge from "${spec.from}" to "${spec.to}" already exists`,
+      };
+    }
+    const inspector = this.inspect();
+    const from = inspector.nodeById(spec.from);
+    if (!from) {
+      return {
+        success: false,
+        error: `Node with id "${spec.from}" does not exist, but is required as the "from" part of the edge`,
+      };
+    }
+    const to = inspector.nodeById(spec.to);
+    if (!to) {
+      return {
+        success: false,
+        error: `Node with id "${spec.to}" does not exist, but is required as the "to" part of the edge`,
+      };
+    }
+    const fromPorts = (await from.ports()).outputs;
+    if (fromPorts.fixed) {
+      const found = fromPorts.ports.find((port) => port.name === spec.out);
+      if (!found) {
+        return {
+          success: false,
+          error: `Node with id "${spec.from}" does not have an output port named "${spec.out}"`,
+        };
+      }
+    }
+    const toPorts = (await to.ports()).inputs;
+    if (toPorts.fixed) {
+      const found = toPorts.ports.find((port) => port.name === spec.in);
+      if (!found) {
+        return {
+          success: false,
+          error: `Node with id "${spec.to}" does not have an input port named "${spec.in}"`,
+        };
+      }
+    }
+    return { success: true };
+  }
+
+  async addEdge(spec: EditableEdgeSpec) {
+    const can = await this.canAddEdge(spec);
+    if (!can.success) return can;
+    this.#graph.edges.push(spec);
+    this.#inspector = undefined;
+    return { success: true };
+  }
+
+  raw() {
+    return this.#graph;
+  }
+
+  inspect() {
+    return (this.#inspector ??= inspectableGraph(this.#graph, {
+      kits: this.#options.kits,
+    }));
+  }
+}

--- a/packages/breadboard/src/editor/graph.ts
+++ b/packages/breadboard/src/editor/graph.ts
@@ -7,8 +7,14 @@
 import { handlersFromKits } from "../handler.js";
 import { inspectableGraph } from "../inspector/graph.js";
 import { InspectableGraph } from "../inspector/types.js";
-import { GraphDescriptor, NodeHandlers, NodeIdentifier } from "../types.js";
 import {
+  GraphDescriptor,
+  NodeConfiguration,
+  NodeHandlers,
+  NodeIdentifier,
+} from "../types.js";
+import {
+  EditResult,
   EditableEdgeSpec,
   EditableGraph,
   EditableGraphOptions,
@@ -183,6 +189,30 @@ class Graph implements EditableGraph {
       );
     });
     this.#inspector = undefined;
+    return { success: true };
+  }
+
+  async canChangeConfiguration(id: NodeIdentifier): Promise<EditResult> {
+    const node = this.inspect().nodeById(id);
+    if (!node) {
+      return {
+        success: false,
+        error: `Node with id "${id}" does not exist`,
+      };
+    }
+    return { success: true };
+  }
+
+  async changeConfiguration(
+    id: NodeIdentifier,
+    configuration: NodeConfiguration
+  ): Promise<EditResult> {
+    const can = await this.canChangeConfiguration(id);
+    if (!can.success) return can;
+    const node = this.inspect().nodeById(id);
+    if (node) {
+      node.descriptor.configuration = configuration;
+    }
     return { success: true };
   }
 

--- a/packages/breadboard/src/editor/graph.ts
+++ b/packages/breadboard/src/editor/graph.ts
@@ -153,6 +153,39 @@ class Graph implements EditableGraph {
     return { success: true };
   }
 
+  async canRemoveEdge(spec: EditableEdgeSpec) {
+    const exists = !!this.#graph.edges.find((edge) => {
+      return (
+        edge.from === spec.from &&
+        edge.to === spec.to &&
+        edge.out === spec.out &&
+        edge.in === spec.in
+      );
+    });
+    if (!exists) {
+      return {
+        success: false,
+        error: `Edge from "${spec.from}" to "${spec.to}" does not exist`,
+      };
+    }
+    return { success: true };
+  }
+
+  async removeEdge(spec: EditableEdgeSpec) {
+    const can = await this.canRemoveEdge(spec);
+    if (!can.success) return can;
+    this.#graph.edges = this.#graph.edges.filter((edge) => {
+      return (
+        edge.from !== spec.from ||
+        edge.to !== spec.to ||
+        edge.out !== spec.out ||
+        edge.in !== spec.in
+      );
+    });
+    this.#inspector = undefined;
+    return { success: true };
+  }
+
   raw() {
     return this.#graph;
   }

--- a/packages/breadboard/src/editor/graph.ts
+++ b/packages/breadboard/src/editor/graph.ts
@@ -87,6 +87,12 @@ class Graph implements EditableGraph {
   }
 
   async canAddEdge(spec: EditableEdgeSpec) {
+    if ((spec.out === "*" && spec.in !== "") || spec.in === "*") {
+      return {
+        success: false,
+        error: `The "*" output port cannot be connected to a specific input port`,
+      };
+    }
     const exists = !!this.#graph.edges.find((edge) => {
       return (
         edge.from === spec.from &&
@@ -159,7 +165,7 @@ class Graph implements EditableGraph {
     if (!exists) {
       return {
         success: false,
-        error: `Edge from "${spec.from}" to "${spec.to}" does not exist`,
+        error: `Edge from "${spec.from}:${spec.out}" to "${spec.to}${spec.in}" does not exist`,
       };
     }
     return { success: true };

--- a/packages/breadboard/src/editor/graph.ts
+++ b/packages/breadboard/src/editor/graph.ts
@@ -171,7 +171,7 @@ class Graph implements EditableGraph {
     if (!exists) {
       return {
         success: false,
-        error: `Edge from "${spec.from}:${spec.out}" to "${spec.to}${spec.in}" does not exist`,
+        error: `Edge from "${spec.from}:${spec.out}" to "${spec.to}:${spec.in}" does not exist`,
       };
     }
     return { success: true };

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -21,6 +21,10 @@ export type EditableGraph = {
 
   canAddEdge(spec: EditableEdgeSpec): Promise<EditResult>;
   addEdge(spec: EditableEdgeSpec): Promise<EditResult>;
+
+  canRemoveEdge(spec: EditableEdgeSpec): Promise<EditResult>;
+  removeEdge(spec: EditableEdgeSpec): Promise<EditResult>;
+
   raw(): GraphDescriptor;
 
   inspect(): InspectableGraph;

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -8,6 +8,7 @@ import { InspectableGraph, InspectableGraphOptions } from "../index.js";
 import {
   Edge,
   GraphDescriptor,
+  NodeConfiguration,
   NodeDescriptor,
   NodeIdentifier,
 } from "../types.js";
@@ -24,6 +25,12 @@ export type EditableGraph = {
 
   canRemoveEdge(spec: EditableEdgeSpec): Promise<EditResult>;
   removeEdge(spec: EditableEdgeSpec): Promise<EditResult>;
+
+  canChangeConfiguration(id: NodeIdentifier): Promise<EditResult>;
+  changeConfiguration(
+    id: NodeIdentifier,
+    configuration: NodeConfiguration
+  ): Promise<EditResult>;
 
   raw(): GraphDescriptor;
 

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { InspectableGraph, InspectableGraphOptions } from "../index.js";
+import {
+  Edge,
+  GraphDescriptor,
+  NodeDescriptor,
+  NodeIdentifier,
+} from "../types.js";
+
+export type EditableGraph = {
+  canAddNode(spec: EditableNodeSpec): Promise<EditResult>;
+  addNode(spec: EditableNodeSpec): Promise<EditResult>;
+
+  canRemoveNode(id: NodeIdentifier): Promise<EditResult>;
+  removeNode(id: NodeIdentifier): Promise<EditResult>;
+
+  canAddEdge(spec: EditableEdgeSpec): Promise<EditResult>;
+  addEdge(spec: EditableEdgeSpec): Promise<EditResult>;
+  raw(): GraphDescriptor;
+
+  inspect(): InspectableGraph;
+};
+
+export type EditableGraphOptions = InspectableGraphOptions;
+
+export type EditableNodeSpec = NodeDescriptor;
+
+export type EditResult = {
+  success: boolean;
+  error?: string;
+};
+
+export type EditableEdgeSpec = Edge;

--- a/packages/breadboard/src/index.ts
+++ b/packages/breadboard/src/index.ts
@@ -65,3 +65,9 @@ export { asyncGen } from "./utils/async-gen.js";
  */
 export type * from "./inspector/types.js";
 export { inspectableGraph as inspect } from "./inspector/index.js";
+
+/**
+ * The Editor API.
+ */
+export type * from "./editor/types.js";
+export { editGraph as edit } from "./editor/graph.js";

--- a/packages/breadboard/tests/editor/graph.ts
+++ b/packages/breadboard/tests/editor/graph.ts
@@ -1,0 +1,240 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import test from "ava";
+
+import { editGraph } from "../../src/editor/graph.js";
+import { NodeHandler } from "../../src/types.js";
+
+const testEditGraph = () => {
+  return editGraph(
+    structuredClone({
+      nodes: [
+        {
+          id: "node0",
+          type: "foo",
+        },
+        {
+          id: "node2",
+          type: "bar",
+        },
+      ],
+      edges: [{ from: "node0", out: "out", to: "node0", in: "in" }],
+    }),
+    {
+      kits: [
+        {
+          url: "",
+          handlers: {
+            foo: {
+              invoke: async () => {},
+              describe: async () => {
+                return {
+                  inputSchema: {
+                    additionalProperties: false,
+                    properties: {
+                      in: { type: "string" },
+                    },
+                  },
+                  outputSchema: {
+                    additionalProperties: false,
+                    properties: {
+                      out: { type: "string" },
+                    },
+                  },
+                };
+              },
+            } as NodeHandler,
+            bar: {
+              invoke: async () => {},
+              describe: async () => {
+                return {
+                  inputSchema: {},
+                  outputSchema: {
+                    additionalProperties: false,
+                    properties: {
+                      out: { type: "string" },
+                    },
+                  },
+                };
+              },
+            } as NodeHandler,
+          },
+        },
+      ],
+    }
+  );
+};
+
+test("editor API successfully tests for node addition", async (t) => {
+  const graph = testEditGraph();
+
+  {
+    const result = await graph.canAddNode({
+      id: "node1",
+      type: "foo",
+    });
+
+    t.true(result.success);
+  }
+  {
+    const result = await graph.canAddNode({
+      id: "node0",
+      type: "foo",
+    });
+
+    t.false(result.success);
+  }
+  {
+    const result = await graph.canAddNode({
+      id: "node1",
+      type: "unknown type",
+    });
+
+    t.false(result.success);
+  }
+});
+
+test("editor API successfully adds a node", async (t) => {
+  const graph = testEditGraph();
+
+  const result = await graph.addNode({
+    id: "node1",
+    type: "foo",
+  });
+
+  t.true(result.success);
+
+  const raw = graph.raw();
+  t.deepEqual(
+    raw.nodes.map((n) => n.id),
+    ["node0", "node2", "node1"]
+  );
+});
+
+test("editor API successfully tests for node removal", async (t) => {
+  const graph = testEditGraph();
+
+  {
+    const result = await graph.canRemoveNode("node0");
+
+    t.true(result.success);
+  }
+  {
+    const result = await graph.canRemoveNode("node1");
+
+    t.false(result.success);
+  }
+});
+
+test("editor API successfully removes a node", async (t) => {
+  const graph = testEditGraph();
+  {
+    const result = await graph.removeNode("node0");
+
+    t.true(result.success);
+
+    const raw = graph.raw();
+    t.deepEqual(
+      raw.nodes.map((n) => n.id),
+      ["node2"]
+    );
+  }
+
+  {
+    const result = await graph.canAddNode({ id: "node0", type: "foo" });
+    t.true(result.success);
+  }
+});
+
+test("editor API successfully tests for edge addition", async (t) => {
+  const graph = testEditGraph();
+
+  {
+    const result = await graph.canAddEdge({
+      from: "node0",
+      out: "out",
+      to: "node2",
+      in: "in",
+    });
+
+    t.true(result.success);
+  }
+  {
+    const result = await graph.canAddEdge({
+      from: "node0",
+      out: "out",
+      to: "node0",
+      in: "in",
+    });
+
+    t.false(result.success);
+  }
+  {
+    const result = await graph.canAddEdge({
+      from: "node0",
+      out: "out",
+      to: "node0",
+      in: "baz",
+    });
+
+    t.false(result.success);
+  }
+  {
+    const result = await graph.canAddEdge({
+      from: "unknown node",
+      out: "out",
+      to: "node2",
+      in: "in",
+    });
+
+    t.false(result.success);
+  }
+  {
+    const result = await graph.canAddEdge({
+      from: "node0",
+      out: "out",
+      to: "unknown node",
+      in: "in",
+    });
+
+    t.false(result.success);
+  }
+});
+
+test("editor API successfully adds an edge", async (t) => {
+  const graph = testEditGraph();
+
+  {
+    const result = await graph.addEdge({
+      from: "node0",
+      out: "out",
+      to: "node2",
+      in: "in",
+    });
+
+    t.true(result.success);
+
+    const raw = graph.raw();
+    t.deepEqual(
+      raw.edges.map((e) => [e.from, e.to]),
+      [
+        ["node0", "node0"],
+        ["node0", "node2"],
+      ]
+    );
+  }
+  {
+    const result = await graph.canAddEdge({
+      from: "node0",
+      out: "out",
+      to: "node2",
+      in: "in",
+    });
+
+    t.false(result.success);
+  }
+});

--- a/packages/breadboard/tests/editor/graph.ts
+++ b/packages/breadboard/tests/editor/graph.ts
@@ -238,3 +238,79 @@ test("editor API successfully adds an edge", async (t) => {
     t.false(result.success);
   }
 });
+
+test("editor API successfully tests for edge removal", async (t) => {
+  const graph = testEditGraph();
+
+  {
+    const result = await graph.canRemoveEdge({
+      from: "node0",
+      out: "out",
+      to: "node0",
+      in: "in",
+    });
+
+    t.true(result.success);
+  }
+  {
+    const result = await graph.canRemoveEdge({
+      from: "node0",
+      out: "out",
+      to: "node0",
+      in: "baz",
+    });
+
+    t.false(result.success);
+  }
+  {
+    const result = await graph.canRemoveEdge({
+      from: "unknown node",
+      out: "out",
+      to: "node0",
+      in: "in",
+    });
+
+    t.false(result.success);
+  }
+  {
+    const result = await graph.canRemoveEdge({
+      from: "node0",
+      out: "out",
+      to: "unknown node",
+      in: "in",
+    });
+
+    t.false(result.success);
+  }
+});
+
+test("editor API successfully removes an edge", async (t) => {
+  const graph = testEditGraph();
+
+  {
+    const result = await graph.removeEdge({
+      from: "node0",
+      out: "out",
+      to: "node0",
+      in: "in",
+    });
+
+    t.true(result.success);
+
+    const raw = graph.raw();
+    t.deepEqual(
+      raw.edges.map((e) => [e.from, e.to]),
+      []
+    );
+  }
+  {
+    const result = await graph.canRemoveEdge({
+      from: "node0",
+      out: "out",
+      to: "node0",
+      in: "in",
+    });
+
+    t.false(result.success);
+  }
+});

--- a/packages/pinecone-kit/graphs/kit.json
+++ b/packages/pinecone-kit/graphs/kit.json
@@ -36,6 +36,7 @@
   ],
   "kits": [
     {
+      "title": "Core Kit",
       "url": "npm:@google-labs/core-kit"
     }
   ],
@@ -169,9 +170,11 @@
       ],
       "kits": [
         {
+          "title": "Core Kit",
           "url": "npm:@google-labs/core-kit"
         },
         {
+          "title": "JSON Kit",
           "url": "npm:@google-labs/json-kit"
         }
       ]
@@ -268,9 +271,11 @@
       ],
       "kits": [
         {
+          "title": "Core Kit",
           "url": "npm:@google-labs/core-kit"
         },
         {
+          "title": "JSON Kit",
           "url": "npm:@google-labs/json-kit"
         }
       ]
@@ -375,6 +380,7 @@
       ],
       "kits": [
         {
+          "title": "Core Kit",
           "url": "npm:@google-labs/core-kit"
         }
       ]
@@ -540,12 +546,15 @@
       ],
       "kits": [
         {
+          "title": "Template Kit",
           "url": "npm:@google-labs/template-kit"
         },
         {
+          "title": "Core Kit",
           "url": "npm:@google-labs/core-kit"
         },
         {
+          "title": "JSON Kit",
           "url": "npm:@google-labs/json-kit"
         }
       ]

--- a/packages/website/src/docs/editor.md
+++ b/packages/website/src/docs/editor.md
@@ -1,0 +1,100 @@
+---
+layout: docs.njk
+title: Editor API
+tags:
+  - general
+  - wip
+hide_toc: true
+date: 2012-01-01 # Done to place the index atop the list.
+---
+
+The Editor API provides a way to edit a graph. It is designed to work in conjuction with the [Inspector API](../inspector) and helps ensure that the graph edits retain their structural integrity.
+
+> [!NOTE]
+> The full list of types of Editor API can be found in [/packages/breadboard/src/editor/types.ts](https://github.com/breadboard-ai/breadboard/blob/main/packages/breadboard/src/editor/types.ts)
+
+## Creating an editor
+
+Calling the `edit` method creates an instance of an `EditableGraph`. This method expects a `GraphDescriptor` as its first argument:
+
+```ts
+import { edit } from "google-labs/breadboard";
+
+// Returns an instance of `EditableGraph`.
+const graph = edit(bgl);
+```
+
+The editor contains a few methods that are paired together: there's one method that performs an edit and the second method that tells us whether we can perform this edit. Both methods return the same value: an `EditResult` promise.
+
+The first method usually has a name like `doStuff` and the second one looks like `canDoStuff`.
+
+This pairing enables checking whether an edit would be valid without actually making an edit. The method that performs an edit calls the method to check whether an edit is valid first, so it is not necessary to call them in succession.
+
+For example we can add nodes to the graph using the `addNode` method:
+
+```ts
+// Returns `Promise<EditResult>`.
+const result = await graph.addNode({ id "foo", type: "bar" });
+if (!result.success) {
+  console.warn("Adding node failed with this error", result.error);
+}
+```
+
+And we can use its sidekick `canAddNode` to simply check if adding this node is possible:
+
+```ts
+// Returns `Promise<EditResult>`.
+const result = await graph.canAddNode({ id: "foo", type: "bar" });
+if (result.success) {
+  console.log("Yay, we can add this node, proceed forth");
+} else {
+  console.warn("Can't add this node", result.error);
+}
+```
+
+## Kits
+
+To ensure that `canDoStuff` methods tell us useful things, we need to supply the editor a list of kits. Kits are collections of functions that are invoked during running the graph. We can provide kits as `kits` property on the second, optional `EditableGraphOptions` argument of the `edit` method:
+
+```ts
+import Core from "@google-labs/core-kit";
+import JSONKit from "@google-labs/json-kit";
+
+const graph = edit(bgl, { kits: [asRuntime(Core), asRunTime(JSONKit)] });
+```
+
+## Editing a graph
+
+There are five edit operations that we can perform on the graph:
+
+- `addNode` -- adds a new node to the graph (or check if we can do so with `canAddNode`)
+
+- `removeNode` -- remove a node from the graph (with `canRemoveNode` companion)
+
+- `addEdge` -- add an edge to the graph (`canAddEdge` to check if that's possible)
+
+- `removeEdge` -- remove an edge from the graph (`canRemoveEdge` to check only)
+
+- `changeConfiguration` -- change configuration of a node (`canChangeConfiguration` to check only).
+
+## Accesing the graph
+
+To access the resulting graph, use the `raw()` method on the `EditableGraph` instance.
+
+```ts
+const graph = edit(bgl, { kits });
+await graph.addNode({ id: "foo", type: "bar" });
+const newBgl = graph.raw();
+```
+
+## Inspecting the graph
+
+Because the graph constantly changes, it can be tedious to keep track of the latest changes and keep creating new instances of `InspectableGraph`. To help with that, there's an `inspect` method on the `EditableGraph`:
+
+```ts
+// Guaranteed to be inspecting the latest graph.
+// Returns `InspectableGraph`.
+const inspectableGraph = graph.inspect();
+```
+
+In term of lifecycle, the `InspectableGraph` changes more frequently than the `EditableGraph`. So, hang on to the `EditabelGraph` instance and use it to create `InspectableGraph` instances. It will cache them for you, only creating a new inspector when the graph changes.

--- a/packages/website/src/docs/index.md
+++ b/packages/website/src/docs/index.md
@@ -11,3 +11,4 @@ date: 2012-01-01 # Done to place the index atop the list.
 These are the docs for Breadboard.
 
 - [Inspector API](inspector/)
+- [Editor API](editor/)


### PR DESCRIPTION
- Add the basic sketch.
- Add support for removing edges.
- Switch to use inspector all around.
- Add error handling for the star ports.
- Add ability to change configuration.
- Fix typo in error message.
- Add docs and export `edit`.
- docs(changeset): Introduce the Editor API.
