### PR TITLE
[breadboard-ui] Color-code wires

### DIFF
--- a/.changeset/strong-sloths-relax.md
+++ b/.changeset/strong-sloths-relax.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard-ui": minor
+---
+
+Editor is now the main visualizer; various other fixes

--- a/packages/breadboard-ui/src/elements/editor/graph-edge.ts
+++ b/packages/breadboard-ui/src/elements/editor/graph-edge.ts
@@ -113,7 +113,7 @@ export class GraphEdge extends PIXI.Graphics {
     const midX = Math.round((inLocation.x - outLocation.x) / 2);
     const midY = Math.round((inLocation.y - outLocation.y) / 2);
     const color =
-      this.#overrideColor !== null ? this.#overrideColor : this.#edgeColor;
+      this.#overrideColor ?? this.fromNode.edgeColor ?? this.#edgeColor;
 
     this.lineStyle(2, color);
     this.moveTo(outLocation.x, outLocation.y);

--- a/packages/breadboard-ui/src/elements/editor/graph-node.ts
+++ b/packages/breadboard-ui/src/elements/editor/graph-node.ts
@@ -41,37 +41,45 @@ export class GraphNode extends PIXI.Graphics {
   #editable = false;
   #selected = false;
 
+  public edgeColor: number;
+
   constructor(id: string, type: string, title: string) {
     super();
 
     this.#nodeTtitle = title;
     this.id = id;
     this.type = type;
+    this.edgeColor = 0xcccccc;
 
     switch (type) {
       case "input":
         this.color = 0xc9daf8;
+        this.edgeColor = 0x7791bb;
         this.titleTextColor = 0x2c5598;
         break;
 
       case "secrets":
         this.color = 0xf4cccc;
+        this.edgeColor = 0xe88b8b;
         this.titleTextColor = 0xac342a;
         break;
 
       case "output":
         this.color = 0xb6d7a8;
+        this.edgeColor = 0x93c87b;
         this.titleTextColor = 0x2a5a15;
         break;
 
       case "slot":
       case "passthrough":
         this.color = 0xead1dc;
+        this.edgeColor = 0xe283b2;
         this.titleTextColor = 0x87365e;
         break;
 
       default:
         this.color = 0xfff2cc;
+        this.edgeColor = 0xe7ba7c;
         this.titleTextColor = 0xb3772c;
         break;
     }

--- a/packages/breadboard-ui/src/elements/editor/graph.ts
+++ b/packages/breadboard-ui/src/elements/editor/graph.ts
@@ -37,6 +37,8 @@ export class Graph extends PIXI.Container {
   #highlightPadding = 10;
   #editable = false;
 
+  layoutRect: DOMRectReadOnly | null = null;
+
   constructor() {
     super();
 
@@ -64,7 +66,18 @@ export class Graph extends PIXI.Container {
     }
 
     const g = new Dagre.graphlib.Graph();
-    g.setGraph({ marginx: 0, marginy: 0, nodesep: 20, rankdir: "LR" });
+    const opts: Partial<Dagre.GraphLabel> = {
+      marginx: 0,
+      marginy: 0,
+      rankdir: "LR",
+      align: "UL",
+    };
+    if (this.layoutRect) {
+      opts.width = Math.floor(this.layoutRect.width);
+      opts.height = Math.floor(this.layoutRect.height);
+    }
+
+    g.setGraph(opts);
     g.setDefaultEdgeLabel(() => ({}));
 
     let nodesAdded = 0;


### PR DESCRIPTION
This allows a GraphNode to set the outgoing edge color. Hopefully it'll help disambiguate wires in a few cases.