### PR TITLE
dglazkov/issue771

### DIFF
--- a/.changeset/spotty-students-rule.md
+++ b/.changeset/spotty-students-rule.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard": patch
+---
+
+Delete affected edges when removing a node in editor API.

--- a/packages/breadboard/src/editor/graph.ts
+++ b/packages/breadboard/src/editor/graph.ts
@@ -87,6 +87,11 @@ class Graph implements EditableGraph {
     const can = await this.canRemoveNode(id);
     if (!can.success) return can;
 
+    // Remove any edges that are connected to the removed node.
+    this.#graph.edges = this.#graph.edges.filter(
+      (edge) => edge.from !== id && edge.to !== id
+    );
+    // Remove the node from the graph.
     this.#graph.nodes = this.#graph.nodes.filter((node) => node.id != id);
     this.#inspector = undefined;
     return { success: true };

--- a/packages/breadboard/tests/editor/graph.ts
+++ b/packages/breadboard/tests/editor/graph.ts
@@ -142,6 +142,10 @@ test("editor API successfully removes a node", async (t) => {
       raw.nodes.map((n) => n.id),
       ["node2"]
     );
+    t.deepEqual(
+      raw.edges.map((e) => [e.from, e.to]),
+      []
+    );
   }
 
   {


### PR DESCRIPTION
- **[FR] Have Editor API delete affected edges when a node is deleted Fixes #771**
- **docs(changeset): Delete affected edges when removing a node in editor API.**
