### PR TITLE
dglazkov/issue774

### DIFF
--- a/.changeset/short-monkeys-peel.md
+++ b/.changeset/short-monkeys-peel.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard": patch
+---
+
+Enable adding input/output nodes with the Editor API.

--- a/packages/breadboard/tests/editor/graph.ts
+++ b/packages/breadboard/tests/editor/graph.ts
@@ -318,3 +318,37 @@ test("editor API successfully removes an edge", async (t) => {
     t.false(result.success);
   }
 });
+
+test("editor API allows adding built-in nodes", async (t) => {
+  const graph = testEditGraph();
+
+  {
+    const result = await graph.addNode({
+      id: "node1",
+      type: "input",
+    });
+
+    t.true(result.success);
+
+    const raw = graph.raw();
+    t.deepEqual(
+      raw.nodes.map((n) => n.id),
+      ["node0", "node2", "node1"]
+    );
+  }
+
+  {
+    const result = await graph.addNode({
+      id: "node3",
+      type: "output",
+    });
+
+    t.true(result.success);
+
+    const raw = graph.raw();
+    t.deepEqual(
+      raw.nodes.map((n) => n.id),
+      ["node0", "node2", "node1", "node3"]
+    );
+  }
+});


### PR DESCRIPTION
- **Editor API: Allow the creation of input & output nodes Fixes #774**
- **docs(changeset): Enable adding input/output nodes with the Editor API.**
