### PR TITLE
Fix cli dependency bundling

### DIFF
--- a/.changeset/late-knives-prove.md
+++ b/.changeset/late-knives-prove.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard-cli": patch
+---
+
+remove bundleDependencies

--- a/packages/breadboard-cli/package.json
+++ b/packages/breadboard-cli/package.json
@@ -164,16 +164,5 @@
     "serve": "^14.2.1",
     "vite": "^5.1.4",
     "yaml": "^2.3.4"
-  },
-  "bundleDependencies": [
-    "@google-labs/breadboard",
-    "@google-labs/breadboard-web",
-    "@google-labs/core-kit",
-    "@google-labs/template-kit",
-    "commander",
-    "esbuild",
-    "serve",
-    "vite",
-    "yaml"
-  ]
+  }
 }


### PR DESCRIPTION
It is a little bizarre as the addition of the `bundleDependencies` was to try and remove this issue in the first place

see pipeline: https://github.com/ExaDev-io/breadboard/actions?query=branch%3Afix-cli-dependency-bundling

branched from https://github.com/breadboard-ai/breadboard/pull/789