### PR TITLE
Fix self not defined error, and re-run tests when JSON datafiles change

### DIFF
--- a/.changeset/witty-seas-try.md
+++ b/.changeset/witty-seas-try.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard": patch
+---
+
+Fix self not defined error

--- a/packages/breadboard/package.json
+++ b/packages/breadboard/package.json
@@ -71,7 +71,9 @@
       "dependencies": [
         "build:tsc"
       ],
-      "files": [],
+      "files": [
+        "tests/**/*.json"
+      ],
       "output": []
     },
     "lint": {

--- a/packages/breadboard/src/harness/url.ts
+++ b/packages/breadboard/src/harness/url.ts
@@ -9,6 +9,6 @@ import { ServeConfig } from "./serve.js";
 
 export const baseURL = (config: RunConfig | ServeConfig) => {
   if (config.base) return config.base;
-  if ("window" in self) return new URL(self.location.href);
+  if ("window" in globalThis) return new URL(self.location.href);
   return new URL(import.meta.url);
 };


### PR DESCRIPTION
- Check for window in globalThis instead of self, since self doesn't exist in Node
- Re-run breadboard tests when JSON data files change