### PR TITLE
[website] Restore TOC; tweak styles

### DIFF
--- a/packages/website/filter-toc.cjs
+++ b/packages/website/filter-toc.cjs
@@ -22,6 +22,7 @@ module.exports = function (content) {
 
   let html = `<aside class="toc">
     <h1>Table of Contents</h1>
+    <div id="toc-container">
   `;
   let lastLevel = 0;
   for (const header of headers) {
@@ -52,6 +53,6 @@ module.exports = function (content) {
   }
 
   html += "</ol>\n".repeat(lastLevel);
-  html += `</aside>`;
+  html += `</div></aside>`;
   return html;
 };

--- a/packages/website/src/docs/editor.md
+++ b/packages/website/src/docs/editor.md
@@ -4,8 +4,6 @@ title: Editor API
 tags:
   - general
   - wip
-hide_toc: true
-date: 2012-01-01 # Done to place the index atop the list.
 ---
 
 The Editor API provides a way to edit a graph. It is designed to work in conjuction with the [Inspector API](../inspector) and helps ensure that the graph edits retain their structural integrity.

--- a/packages/website/src/docs/inspector.md
+++ b/packages/website/src/docs/inspector.md
@@ -4,8 +4,6 @@ title: Inspector API
 tags:
   - general
   - wip
-hide_toc: true
-date: 2012-01-01 # Done to place the index atop the list.
 ---
 
 The Inspector API provides a way to inspect a graph to make sense of it. Because a serialized graph representation (also known as the [BGL document](../concepts/#breadboard-graph-language-bgl)) is basically just JSON containing arrays of nodes and edges, a the actual semantics of the graph need to be added separately. This is what the Inspector API does. Think of it as the DOM API for the graph.

--- a/packages/website/src/docs/io.md
+++ b/packages/website/src/docs/io.md
@@ -4,8 +4,6 @@ title: Inputs and Outputs
 tags:
   - general
   - wip
-hide_toc: true
-date: 2023-02-20 # Done to place the index atop the list.
 ---
 
 Every node has inputs and outputs. A node consumes its inputs and produces outputs.

--- a/packages/website/src/docs/kits/agents.md
+++ b/packages/website/src/docs/kits/agents.md
@@ -3,8 +3,6 @@ layout: docs.njk
 title: Agent Kit
 tags:
   - kits
-hide_toc: true
-date: 2012-01-01 # Done to place the index atop the list.
 ---
 
 {% assign src_url = "https://github.com/breadboard-ai/breadboard/tree/main/packages/agent-kit/src/nodes/" %}
@@ -288,11 +286,11 @@ const bot = agents.repeater({
 
     const bot = agents.worker({
       context: human.context,
-      instruction: `As a friendly assistant bot, reply to request below in a 
+      instruction: `As a friendly assistant bot, reply to request below in a
         helpful, delighted, and brief manner to assist the user as quickly as
         possible.
 
-        Pretend you have access to ordering food, booking a table, and other 
+        Pretend you have access to ordering food, booking a table, and other
         useful services. You can also ask for more information if needed.`,
     });
     return { context: bot.context };

--- a/packages/website/src/docs/kits/core.md
+++ b/packages/website/src/docs/kits/core.md
@@ -4,8 +4,6 @@ title: Core Kit
 tags:
   - kits
   - wip
-hide_toc: true
-date: 2012-01-01 # Done to place the index atop the list.
 ---
 
 {% assign src_url = "https://github.com/breadboard-ai/breadboard/tree/main/packages/core-kit/src/nodes/" %}

--- a/packages/website/src/docs/kits/json.md
+++ b/packages/website/src/docs/kits/json.md
@@ -4,7 +4,6 @@ title: JSON Kit
 tags:
   - kits
   - wip
-date: 2012-01-01 # Done to place the index atop the list.
 ---
 
 {% assign src_url = "https://github.com/breadboard-ai/breadboard/tree/main/packages/json-kit/src/nodes/" %}

--- a/packages/website/src/docs/kits/template.md
+++ b/packages/website/src/docs/kits/template.md
@@ -4,7 +4,6 @@ title: Template Kit
 tags:
   - kits
   - wip
-date: 2012-01-01 # Done to place the index atop the list.
 ---
 
 {% assign src_url = "https://github.com/breadboard-ai/breadboard/tree/main/packages/template-kit/src/nodes/" %}

--- a/packages/website/src/docs/python.md
+++ b/packages/website/src/docs/python.md
@@ -4,8 +4,6 @@ title: Breadboard Python
 tags:
   - general
   - wip
-hide_toc: true
-date: 2012-01-01 # Done to place the index atop the list.
 ---
 
 Breadboard-python is a library that allows developers to define Breadboards with Python.

--- a/packages/website/src/static/docs.css
+++ b/packages/website/src/static/docs.css
@@ -242,8 +242,15 @@ code[class*="language-"] {
   margin: 0 0 8px 0;
 }
 
-.toc > ol {
+.toc > #toc-container {
+  border-radius: 0 0 12px 12px;
+  overflow: auto;
+}
+
+.toc > #toc-container > ol {
   padding: 20px;
+  overflow-y: auto;
+  max-height: 50vh;
 }
 
 .toc a {


### PR DESCRIPTION
There were some missing TOCs in some of the docs pages because of an erroneous `hide_toc` in the YAML front matter. This PR removes those and also tweaks the styles for super long TOCs so they don't run off the bottom of the screen.