### PR TITLE
[breadboard-ui] Highlight nodes and snap wire

### DIFF
--- a/packages/breadboard-ui/src/elements/editor/graph-renderer.ts
+++ b/packages/breadboard-ui/src/elements/editor/graph-renderer.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { InspectableEdge } from "@google-labs/breadboard";
+import { InspectableEdge, PortStatus } from "@google-labs/breadboard";
 import { LitElement, html, css } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import * as PIXI from "pixi.js";
@@ -24,6 +24,7 @@ import {
   GraphNodePortType,
 } from "./types.js";
 import { Graph } from "./graph.js";
+import { GraphNodePort } from "./graph-node-port.js";
 
 @customElement("bb-graph-renderer")
 export class GraphRenderer extends LitElement {
@@ -148,6 +149,10 @@ export class GraphRenderer extends LitElement {
             return;
           }
 
+          // This is cleared by the InteractionTracker when the interaction is
+          // finished.
+          activeGraphNodePort.overrideStatus = PortStatus.Connected;
+
           let edgeGraphic = activeGraph.findEdge(
             activeGraphNode.name,
             activeGraphNodePort
@@ -216,6 +221,18 @@ export class GraphRenderer extends LitElement {
                 edgeGraphic.edge.out = name;
                 edgeGraphic.fromNode = interactionTracker.hoveredGraphNode;
               }
+
+              interactionTracker.hoveredGraphNodePort.overrideStatus =
+                PortStatus.Connected;
+
+              interactionTracker.hoveredGraphNodePort.once(
+                "pointerout",
+                function (this: GraphNodePort) {
+                  this.overrideStatus = PortStatus.Inteterminate;
+                },
+                interactionTracker.hoveredGraphNodePort
+              );
+              return;
             }
 
             edgeGraphic.overrideColor = 0xffcc00;

--- a/packages/breadboard-ui/src/elements/editor/interaction-tracker.ts
+++ b/packages/breadboard-ui/src/elements/editor/interaction-tracker.ts
@@ -52,6 +52,14 @@ export class InteractionTracker {
   }
 
   clear() {
+    if (this.hoveredGraphNodePort) {
+      this.hoveredGraphNodePort.overrideStatus = null;
+    }
+
+    if (this.activeGraphNodePort) {
+      this.activeGraphNodePort.overrideStatus = null;
+    }
+
     this.hoveredGraphNodePort = null;
     this.hoveredGraphNode = null;
     this.activeGraphNodePort = null;


### PR DESCRIPTION
I had a slight regression where a) wires/edges weren't snapping when you hovered over a port, and b) the ports weren't lighting up on hover. This PR fixes both of those issues.