### PR TITLE
[core-kit] Add resolve node

### DIFF
--- a/.changeset/heavy-eagles-warn.md
+++ b/.changeset/heavy-eagles-warn.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/core-kit": patch
+---
+
+Add a resolve node to core-kit which resolves relative URLs to absolute URLs.

--- a/packages/core-kit/package.json
+++ b/packages/core-kit/package.json
@@ -51,7 +51,9 @@
       "dependencies": [
         "build:tsc"
       ],
-      "files": [],
+      "files": [
+        "tests/**/*.json"
+      ],
       "output": []
     },
     "lint": {

--- a/packages/core-kit/src/index.ts
+++ b/packages/core-kit/src/index.ts
@@ -9,6 +9,7 @@ import { KitBuilder } from "@google-labs/breadboard/kits";
 import importHandler from "./nodes/import.js";
 import include from "./nodes/include.js";
 import invoke from "./nodes/invoke.js";
+import resolve from "./nodes/resolve.js";
 import passthrough from "./nodes/passthrough.js";
 import reflect from "./nodes/reflect.js";
 import slot from "./nodes/slot.js";
@@ -83,6 +84,24 @@ export const Core = builder.build({
    * @returns - a `Node` object that represents the placed node.
    */
   invoke,
+
+  /**
+   * Places a `resolve` node on the board.
+   *
+   * Use this node to resolve relative URLs to absolute URLs.
+   *
+   * `resolve` has one special input:
+   *  - `$base`: The base URL to use for resolution. If not provided, the URL of
+   *    the current graph is used by default.
+   *
+   * All other inputs will be resolved to absolute URLs and returned on output
+   * ports with the same names as the corresponding input.
+   *
+   * @param config - optional configuration for the node.
+   * @returns - a `Node` object that represents the placed node.
+   */
+  resolve,
+
   /**
    * Places the `passthrough` node on the board.
    *
@@ -255,6 +274,7 @@ export type CoreKitType = {
       },
     { [key: string]: unknown }
   >;
+  resolve: NodeFactory<{ [k: string]: string }, { [k: string]: string }>;
   map: NodeFactory<
     {
       list: NodeValue[];

--- a/packages/core-kit/src/nodes/resolve.ts
+++ b/packages/core-kit/src/nodes/resolve.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  InputValues,
+  NodeHandlerContext,
+  OutputValues,
+} from "@google-labs/breadboard";
+
+export default async (
+  inputs: InputValues,
+  context: NodeHandlerContext
+): Promise<OutputValues> => {
+  const base = inputs.$base ?? context.base?.href;
+  if (!base) {
+    throw new Error(
+      `Resolve could not find a base URL. The $base input was undefined, ` +
+        `and so was the handler context base.`
+    );
+  }
+  if (typeof base !== "string") {
+    throw new Error(`Resolve base must be a string, got ${typeof base}.`);
+  }
+  const resolved: Record<string, string> = {};
+  for (const [name, value] of Object.entries(inputs)) {
+    if (name === "$base") {
+      continue;
+    }
+    if (typeof value !== "string") {
+      throw new Error(
+        `Resolve requires string inputs. Input "${name}" had type "${typeof value}".`
+      );
+    }
+    resolved[name] = new URL(value, base).href;
+  }
+  return resolved;
+};

--- a/packages/core-kit/tests/data/resolve/invokee.json
+++ b/packages/core-kit/tests/data/resolve/invokee.json
@@ -1,0 +1,30 @@
+{
+  "nodes": [
+    {
+      "id": "invokee-input",
+      "type": "input",
+      "configuration": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "default": "invokee-data"
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "invoker-output",
+      "type": "output"
+    }
+  ],
+  "edges": [
+    {
+      "from": "invokee-input",
+      "out": "result",
+      "to": "invoker-output",
+      "in": "result"
+    }
+  ]
+}

--- a/packages/core-kit/tests/data/resolve/main.json
+++ b/packages/core-kit/tests/data/resolve/main.json
@@ -1,0 +1,43 @@
+{
+  "nodes": [
+    {
+      "id": "main-input",
+      "type": "input"
+    },
+    {
+      "id": "main-output",
+      "type": "output"
+    },
+    {
+      "id": "main-resolve",
+      "type": "resolve"
+    },
+    {
+      "id": "main-invoke",
+      "type": "invoke",
+      "configuration": {
+        "path": "./subdir/invoker.json"
+      }
+    }
+  ],
+  "edges": [
+    {
+      "from": "main-input",
+      "out": "next-path",
+      "to": "main-resolve",
+      "in": "next-path"
+    },
+    {
+      "from": "main-resolve",
+      "out": "next-path",
+      "to": "main-invoke",
+      "in": "next-path"
+    },
+    {
+      "from": "main-invoke",
+      "out": "result",
+      "to": "main-output",
+      "in": "result"
+    }
+  ]
+}

--- a/packages/core-kit/tests/data/resolve/subdir/invoker.json
+++ b/packages/core-kit/tests/data/resolve/subdir/invoker.json
@@ -1,0 +1,30 @@
+{
+  "nodes": [
+    {
+      "id": "invoker-input",
+      "type": "input"
+    },
+    {
+      "id": "invoker-output",
+      "type": "output"
+    },
+    {
+      "id": "invoker-invoke",
+      "type": "invoke"
+    }
+  ],
+  "edges": [
+    {
+      "from": "invoker-input",
+      "out": "next-path",
+      "to": "invoker-invoke",
+      "in": "path"
+    },
+    {
+      "from": "invoker-invoke",
+      "out": "result",
+      "to": "invoker-output",
+      "in": "result"
+    }
+  ]
+}

--- a/packages/core-kit/tests/resolve.ts
+++ b/packages/core-kit/tests/resolve.ts
@@ -1,0 +1,142 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import test from "ava";
+import { run } from "@google-labs/breadboard/harness";
+import { board, asRuntimeKit } from "@google-labs/breadboard";
+import Core, { core } from "@google-labs/core-kit";
+import resolve from "../src/nodes/resolve.js";
+
+test("resolve resolves paths relative to the board base by default", async (t) => {
+  t.deepEqual(
+    await resolve(
+      { path: "./bar.json" },
+      { base: new URL("http://example.com/graphs/foo.json") }
+    ),
+    { path: "http://example.com/graphs/bar.json" }
+  );
+});
+
+test("resolve resolves paths relative to the $base input when provided", async (t) => {
+  t.deepEqual(
+    await resolve(
+      {
+        path: "./bar.json",
+        $base: "file://not/the/default/foo.json",
+      },
+      { base: new URL("http://example.com/graphs/foo.json") }
+    ),
+    { path: "file://not/the/default/bar.json" }
+  );
+});
+
+test("resolve resolves multiple input properties", async (t) => {
+  t.deepEqual(
+    await resolve(
+      {
+        bar: "./bar.json",
+        abc123: "./abc123.json",
+      },
+      { base: new URL("http://example.com/graphs/foo.json") }
+    ),
+    {
+      bar: "http://example.com/graphs/bar.json",
+      abc123: "http://example.com/graphs/abc123.json",
+    }
+  );
+});
+
+test("resolve does nothing with no inputs", async (t) => {
+  t.deepEqual(
+    await resolve({}, { base: new URL("http://example.com/graphs/foo.json") }),
+    {}
+  );
+});
+
+test("resolve can be used to fully qualify a path prior to passing to a graph with a different base", async (t) => {
+  const config = {
+    url: "../../tests/data/resolve/main.json",
+    base: new URL(import.meta.url),
+    kits: [asRuntimeKit(Core)],
+  };
+  let output: string | undefined;
+  for await (const result of run(config)) {
+    if (result.type === "error") {
+      t.fail(result.data.error.toString());
+    } else if (result.type == "input" && result.data.node.id === "main-input") {
+      result.reply({ inputs: { "next-path": "./invokee.json" } });
+    } else if (
+      result.type === "output" &&
+      result.data.node.id === "main-output"
+    ) {
+      output = result.data.outputs.result?.toString();
+    }
+  }
+  t.is(output, "invokee-data");
+});
+
+test("resolve generates expected BGL", async (t) => {
+  const serialized = await board(({ path }) => {
+    const resolve = core.resolve();
+    path.to(resolve);
+    return { resolved: resolve.resolved };
+  }).serialize();
+  t.deepEqual(serialized, {
+    edges: [
+      {
+        from: "resolve-3",
+        in: "resolved",
+        out: "resolved",
+        to: "output-2",
+      },
+      {
+        from: "input-1",
+        in: "path",
+        out: "path",
+        to: "resolve-3",
+      },
+    ],
+    graphs: {},
+    nodes: [
+      {
+        configuration: {
+          schema: {
+            properties: {
+              resolved: {
+                title: "resolved",
+                type: "string",
+              },
+            },
+            type: "object",
+          },
+        },
+        id: "output-2",
+        type: "output",
+      },
+      {
+        configuration: {},
+        id: "resolve-3",
+        type: "resolve",
+      },
+      {
+        configuration: {
+          schema: {
+            properties: {
+              path: {
+                title: "path",
+                type: "string",
+              },
+            },
+            required: ["path"],
+            type: "object",
+          },
+        },
+        id: "input-1",
+        type: "input",
+      },
+    ],
+  });
+});


### PR DESCRIPTION
Adds a `resolve` node to `core-kit`.

It expects inputs that are relative URL strings, and returns absolute URL strings on outputs with the same name.

The special `$base` input sets the base for resolution. By default, it is the URL of the graph containing the node itself.

This is useful for addressing the problem raised in https://github.com/breadboard-ai/breadboard/issues/733, where if you have a relative path (e.g. a user input specifying a board URL to load), and you pass it to a child graph which has a different base URL to the parent graph, and then pass that path to invoke, invoke will try to resolve that path relative to the *child* graph. In this scenario, the parent graph should pass the user's path through the resolve node before passing it down to the child, so that it gets resolved with the correct base path.