### PR TITLE
Fix - Typo "describe"

### DIFF
--- a/.changeset/quick-donuts-kneel.md
+++ b/.changeset/quick-donuts-kneel.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/core-kit": minor
+---
+
+Fixing typo in describe that would mean passthrough and reflect would not tell the system of their inputs

--- a/packages/core-kit/src/nodes/passthrough.ts
+++ b/packages/core-kit/src/nodes/passthrough.ts
@@ -8,7 +8,7 @@ import type { InputValues, OutputValues } from "@google-labs/breadboard";
 import { SchemaBuilder } from "@google-labs/breadboard/kits";
 
 export default {
-  desribe: async (inputs?: InputValues) => {
+  describe: async (inputs?: InputValues) => {
     if (!inputs) {
       return {
         inputSchema: SchemaBuilder.empty(true),

--- a/packages/core-kit/src/nodes/reflect.ts
+++ b/packages/core-kit/src/nodes/reflect.ts
@@ -17,7 +17,7 @@ const deepCopy = (graph: GraphDescriptor): GraphDescriptor => {
 };
 
 export default {
-  desribe: async () => {
+  describe: async () => {
     return {
       inputSchema: SchemaBuilder.empty(),
       outputSchema: new SchemaBuilder()


### PR DESCRIPTION
`passthrough` and `reflect` had the `describe` attribute mispelt.