### PR TITLE
[core-kit] Add describe function to resolve

### DIFF
--- a/.changeset/happy-buses-live.md
+++ b/.changeset/happy-buses-live.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/core-kit": patch
+---
+
+Added a describe function to core kit's resolve node

--- a/packages/core-kit/src/nodes/resolve.ts
+++ b/packages/core-kit/src/nodes/resolve.ts
@@ -4,37 +4,60 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {
-  InputValues,
-  NodeHandlerContext,
-  OutputValues,
+import {
+  SchemaBuilder,
+  type InputValues,
+  type NodeHandler,
+  type NodeHandlerContext,
+  type OutputValues,
 } from "@google-labs/breadboard";
 
-export default async (
-  inputs: InputValues,
-  context: NodeHandlerContext
-): Promise<OutputValues> => {
-  const base = inputs.$base ?? context.base?.href;
-  if (!base) {
-    throw new Error(
-      `Resolve could not find a base URL. The $base input was undefined, ` +
-        `and so was the handler context base.`
-    );
-  }
-  if (typeof base !== "string") {
-    throw new Error(`Resolve base must be a string, got ${typeof base}.`);
-  }
-  const resolved: Record<string, string> = {};
-  for (const [name, value] of Object.entries(inputs)) {
-    if (name === "$base") {
-      continue;
-    }
-    if (typeof value !== "string") {
+export default {
+  describe: async (_inputs?: InputValues) => {
+    // TODO(aomarks) Should I be doing something with inputs?
+    return {
+      inputSchema: new SchemaBuilder()
+        .addProperties({
+          // TODO(aomarks) Is this supposed to show up in the serialized BGL? It
+          // doesn't seem to.
+          $base: {
+            title: "$base",
+            description:
+              "Base URL to use for resolution. " +
+              "If omitted, the base URL of the current graph is used.",
+            type: "string",
+          },
+        })
+        .build(),
+      outputSchema: new SchemaBuilder().build(),
+    };
+  },
+  invoke: async (
+    inputs: InputValues,
+    context: NodeHandlerContext
+  ): Promise<OutputValues> => {
+    const base = inputs.$base ?? context.base?.href;
+    if (!base) {
       throw new Error(
-        `Resolve requires string inputs. Input "${name}" had type "${typeof value}".`
+        `Resolve could not find a base URL. The $base input was undefined, ` +
+          `and so was the handler context base.`
       );
     }
-    resolved[name] = new URL(value, base).href;
-  }
-  return resolved;
-};
+    if (typeof base !== "string") {
+      throw new Error(`Resolve base must be a string, got ${typeof base}.`);
+    }
+    const resolved: Record<string, string> = {};
+    for (const [name, value] of Object.entries(inputs)) {
+      if (name === "$base") {
+        continue;
+      }
+      if (typeof value !== "string") {
+        throw new Error(
+          `Resolve requires string inputs. Input "${name}" had type "${typeof value}".`
+        );
+      }
+      resolved[name] = new URL(value, base).href;
+    }
+    return resolved;
+  },
+} satisfies NodeHandler;

--- a/packages/core-kit/tests/resolve.ts
+++ b/packages/core-kit/tests/resolve.ts
@@ -12,7 +12,7 @@ import resolve from "../src/nodes/resolve.js";
 
 test("resolve resolves paths relative to the board base by default", async (t) => {
   t.deepEqual(
-    await resolve(
+    await resolve.invoke(
       { path: "./bar.json" },
       { base: new URL("http://example.com/graphs/foo.json") }
     ),
@@ -22,7 +22,7 @@ test("resolve resolves paths relative to the board base by default", async (t) =
 
 test("resolve resolves paths relative to the $base input when provided", async (t) => {
   t.deepEqual(
-    await resolve(
+    await resolve.invoke(
       {
         path: "./bar.json",
         $base: "file://not/the/default/foo.json",
@@ -35,7 +35,7 @@ test("resolve resolves paths relative to the $base input when provided", async (
 
 test("resolve resolves multiple input properties", async (t) => {
   t.deepEqual(
-    await resolve(
+    await resolve.invoke(
       {
         bar: "./bar.json",
         abc123: "./abc123.json",
@@ -51,7 +51,10 @@ test("resolve resolves multiple input properties", async (t) => {
 
 test("resolve does nothing with no inputs", async (t) => {
   t.deepEqual(
-    await resolve({}, { base: new URL("http://example.com/graphs/foo.json") }),
+    await resolve.invoke(
+      {},
+      { base: new URL("http://example.com/graphs/foo.json") }
+    ),
     {}
   );
 });


### PR DESCRIPTION
There are a couple TODOs here: I suspect I should be doing something with `inputs`, but I'm not sure what the use case would be for something like `resolve({"foo": "bar"})`.