### PR TITLE
manifest kits

### DIFF
--- a/.changeset/healthy-baboons-accept.md
+++ b/.changeset/healthy-baboons-accept.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard-cli": minor
+---
+
+Support loading kits via URL (both heavy and light kits)

--- a/packages/breadboard-cli/src/commands/lib/debug-server.ts
+++ b/packages/breadboard-cli/src/commands/lib/debug-server.ts
@@ -74,11 +74,18 @@ export const startServer = async (file: string, options: DebugOptions) => {
       const kitName = requestURL.pathname.replace("/kits/", "");
       const kit = kits.find((kit) => kit.file === kitName);
       if (kit) {
-        response.writeHead(200, {
-          "Content-Type": "application/javascript",
-        });
+        if ("data" in kit) {
+          response.writeHead(200, {
+            "Content-Type": "application/javascript",
+          });
 
-        return response.end(kit.data);
+          return response.end(kit.data);
+        } else {
+          response.writeHead(302, {
+            Location: kit.url,
+          });
+          return response.end();
+        }
       }
     }
 

--- a/packages/breadboard-cli/src/commands/lib/debug-server.ts
+++ b/packages/breadboard-cli/src/commands/lib/debug-server.ts
@@ -75,13 +75,12 @@ export const startServer = async (file: string, options: DebugOptions) => {
       const kitName = requestURL.pathname.replace("/kits/", "");
       const kit = kitNames?.find((kit) => kit === kitName);
       if (kit && kit in kits) {
-        const kitCode = kits[kit].code;
+        const data = kits[kit].data;
         response.writeHead(200, {
           "Content-Type": "application/javascript",
-          // "Content-Length": kitCode.length,
         });
 
-        return response.end(kitCode);
+        return response.end(data);
       }
     }
 

--- a/packages/breadboard-cli/src/commands/lib/kits.ts
+++ b/packages/breadboard-cli/src/commands/lib/kits.ts
@@ -29,9 +29,10 @@ const commonjs = commonjsDefault as unknown as typeof commonjsDefault.default;
 
 const createUniqueName = async (url: string) => {
   const a = await crypto.subtle.digest("SHA-1", new TextEncoder().encode(url));
-  return Array.from(new Uint8Array(a))
+  const uniqueName = Array.from(new Uint8Array(a))
     .map((b) => b.toString(16).padStart(2, "0"))
     .join("");
+  return url.endsWith(".kit.json") ? `${uniqueName}.kit.json` : uniqueName;
 };
 
 /*

--- a/packages/breadboard-cli/src/commands/lib/kits.ts
+++ b/packages/breadboard-cli/src/commands/lib/kits.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { rollup } from "rollup";
+import virtualDefault from "@rollup/plugin-virtual";
+import nodeResolveDefault from "@rollup/plugin-node-resolve";
+import commonjsDefault from "@rollup/plugin-commonjs";
+
+import jsonDefault from "@rollup/plugin-json";
+
+export type KitData = {
+  file: string;
+  code: string;
+};
+
+const virtual = virtualDefault as unknown as typeof virtualDefault.default;
+const nodeResolve =
+  nodeResolveDefault as unknown as typeof nodeResolveDefault.default;
+const json = jsonDefault as unknown as typeof jsonDefault.default;
+const commonjs = commonjsDefault as unknown as typeof commonjsDefault.default;
+
+/*
+  This function compiles and bundles known 'node_module' into a single string.
+
+  If the compilation fails, it will throw an error and halt the entire application.
+*/
+export const compile = async (file: string) => {
+  console.log(`Compiling ${file}`);
+  const bundle = await rollup({
+    input: "entry",
+    // Hide our sins like circular dependencies.
+    logLevel: "silent",
+    plugins: [
+      virtual({
+        entry: `import * as kit from "${file}"; export default kit.default;`,
+      }),
+      json(),
+      commonjs(),
+      nodeResolve(),
+    ],
+  });
+
+  const { output } = await bundle.generate({ format: "es" });
+
+  return output[0].code;
+};
+
+export const getKits = async (
+  kitNames: string[]
+): Promise<Record<string, KitData>> => {
+  const kits: Record<string, KitData> = {};
+
+  for (const kit of kitNames) {
+    kits[kit] = {
+      file: kit,
+      code: await compile(kit),
+    };
+  }
+
+  return kits;
+};

--- a/packages/breadboard-cli/src/commands/lib/kits.ts
+++ b/packages/breadboard-cli/src/commands/lib/kits.ts
@@ -49,15 +49,17 @@ export const compile = async (file: string) => {
 };
 
 export const getKits = async (
-  kitNames: string[]
-): Promise<Record<string, KitData>> => {
-  const kits: Record<string, KitData> = {};
+  defaultKits: string[],
+  specifiedKits: string[] = []
+): Promise<KitData[]> => {
+  const kitNames = [...new Set([...specifiedKits, ...defaultKits])];
+  const kits = [];
 
   for (const kit of kitNames) {
-    kits[kit] = {
+    kits.push({
       file: kit,
       data: await compile(kit),
-    };
+    });
   }
 
   return kits;

--- a/packages/breadboard-cli/src/commands/lib/kits.ts
+++ b/packages/breadboard-cli/src/commands/lib/kits.ts
@@ -13,7 +13,7 @@ import jsonDefault from "@rollup/plugin-json";
 
 export type KitData = {
   file: string;
-  code: string;
+  data: string;
 };
 
 const virtual = virtualDefault as unknown as typeof virtualDefault.default;
@@ -56,7 +56,7 @@ export const getKits = async (
   for (const kit of kitNames) {
     kits[kit] = {
       file: kit,
-      code: await compile(kit),
+      data: await compile(kit),
     };
   }
 

--- a/packages/breadboard-cli/src/index.ts
+++ b/packages/breadboard-cli/src/index.ts
@@ -28,7 +28,7 @@ program
   )
   .option(
     "-k, --kit <kit...>",
-    "The kit to use can be an NPM package name or a URL to the bundled kit."
+    "The kit to use can be an NPM package name or a URL to the bundled kit (for heavy kits) or a kit manifest (for light kits)."
   )
   .option("-n, --no-save", "Do not save the compiled graph to disk.")
   .option(

--- a/packages/breadboard-cli/src/index.ts
+++ b/packages/breadboard-cli/src/index.ts
@@ -26,7 +26,10 @@ program
   .description(
     "Starts a simple HTTP server that serves the breadboard-web app, and outputs a URL that contains a link to a breadboard file that the user provided."
   )
-  .option("-k, --kit <kit...>", "The kit to use.")
+  .option(
+    "-k, --kit <kit...>",
+    "The kit to use can be an NPM package name or a URL to the bundled kit."
+  )
   .option("-n, --no-save", "Do not save the compiled graph to disk.")
   .option(
     "-o, --output <path>",

--- a/packages/breadboard/src/kits/load.ts
+++ b/packages/breadboard/src/kits/load.ts
@@ -86,6 +86,7 @@ export const load = async (url: URL): Promise<Kit> => {
       }
     } else {
       // Assume that this is a URL to a JS file.
+      console.log("WILL TRY TO IMPORT", url.href);
       const module = await import(/* @vite-ignore */ url.href);
       if (module.default == undefined) {
         throw new Error(`Module ${url} does not have a default export.`);

--- a/packages/breadboard/src/kits/load.ts
+++ b/packages/breadboard/src/kits/load.ts
@@ -86,7 +86,6 @@ export const load = async (url: URL): Promise<Kit> => {
       }
     } else {
       // Assume that this is a URL to a JS file.
-      console.log("WILL TRY TO IMPORT", url.href);
       const module = await import(/* @vite-ignore */ url.href);
       if (module.default == undefined) {
         throw new Error(`Module ${url} does not have a default export.`);


### PR DESCRIPTION
- **Move kits bits to own file**
- **Rename KitData.code to KitData.data**
- **Use KitData in debug-server.**
- **Implement importing from URLs.**
- **Add command line help blurb.**
- **Support kit manifests.**
- **docs(changeset): Support loading kits via URL (both heavy and light kits)**
