### PR TITLE
[breadboard-ui] Small UI tweaks

### DIFF
--- a/packages/breadboard-ui/src/elements/editor/graph-renderer.ts
+++ b/packages/breadboard-ui/src/elements/editor/graph-renderer.ts
@@ -70,6 +70,7 @@ export class GraphRenderer extends LitElement {
 
     canvas {
       display: block;
+      touch-action: none;
     }
   `;
 

--- a/packages/breadboard-ui/src/elements/ui-controller/ui-controller.styles.ts
+++ b/packages/breadboard-ui/src/elements/ui-controller/ui-controller.styles.ts
@@ -14,6 +14,7 @@ export const styles = css`
     display: grid;
     height: 100%;
     overscroll-behavior: contain;
+    overflow: auto;
     --diagram-display: flex;
     margin: 8px;
   }


### PR DESCRIPTION
Should improve the situation for #926 inasmuch as pinch zoom shouldn't apply to the canvas. I suspect we'll need to add actual pinch zoom support for touch/mobile at some stage.

This PR also includes a fix for overscrolling, since I noticed that the outputs were causing a scrollbar to appear at the top level element.