### PR TITLE
begin to expose UI component configurability for use externally

### DIFF
--- a/.changeset/funny-bikes-provide.md
+++ b/.changeset/funny-bikes-provide.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard-ui": patch
+---
+
+begin to expose UI component configurability for use externally #965

--- a/packages/breadboard-ui/src/elements/input/input.ts
+++ b/packages/breadboard-ui/src/elements/input/input.ts
@@ -24,7 +24,12 @@ import { customElement, property } from "lit/decorators.js";
 import { InputEnterEvent } from "../../events/events.js";
 import { WebcamInput } from "./webcam/webcam.js";
 import { DrawableInput } from "./drawable/drawable.js";
-import { BreadboardElementError, BreadboardElementErrorCode, BreadboardWebElement, InputArgs } from "../../types/types.js";
+import {
+  BreadboardElementError,
+  BreadboardElementErrorCode,
+  BreadboardWebElement,
+  InputArgs,
+} from "../../types/types.js";
 import { Ref, createRef, ref } from "lit/directives/ref.js";
 
 export type InputData = Record<string, unknown>;
@@ -50,7 +55,9 @@ const parseValue = (type: Schema["type"], input: HTMLInputElement) => {
 @customElement("bb-input")
 export class Input extends LitElement implements BreadboardWebElement {
   @property()
-  onError = (error: BreadboardElementError) => { console.log(error.code, error.message)} ;
+  onError = (error: BreadboardElementError) => {
+    console.log(error.code, error.message);
+  };
 
   @property({ reflect: false })
   remember = false;
@@ -230,17 +237,22 @@ export class Input extends LitElement implements BreadboardWebElement {
         const input = form[key];
         if (input && input.value) {
           try {
-			const parsedValue = parseValue(property.type, input);
-          	data[key] = parsedValue;
-			//throw new Error("Error when parsing input values.");
-			
-		  } catch (error) {
-			if (error instanceof Error) {
-				const event = new CustomEvent(`${BreadboardElementErrorCode.PARSE}`, { bubbles: true, detail: error.message });
-				this.dispatchEvent(event);
-				this.onError({code: event.type as BreadboardElementErrorCode, message: event.detail});
-			}
-		  }
+            const parsedValue = parseValue(property.type, input);
+            data[key] = parsedValue;
+            //throw new Error("Error when parsing input values.");
+          } catch (error) {
+            if (error instanceof Error) {
+              const event = new CustomEvent(
+                `${BreadboardElementErrorCode.PARSE}`,
+                { bubbles: true, detail: error.message }
+              );
+              this.dispatchEvent(event);
+              this.onError({
+                code: event.type as BreadboardElementErrorCode,
+                message: event.detail,
+              });
+            }
+          }
         } else {
           // Custom elements don't look like form elements, so they need to be
           // processed separately.
@@ -289,17 +301,22 @@ export class Input extends LitElement implements BreadboardWebElement {
       return;
     }
 
-	try {
-		return this.#renderForm(properties, values);
-		//throw new Error("Error when rendering input form.");
-		
-	  } catch (error) {
-		if (error instanceof Error) {
-			const event = new CustomEvent(`${BreadboardElementErrorCode.RENDER}`, { bubbles: true, detail: error.message });
-			this.dispatchEvent(event);
-			this.onError({code: event.type as BreadboardElementErrorCode, message: event.detail});
-		}
-	  }
+    try {
+      return this.#renderForm(properties, values);
+      //throw new Error("Error when rendering input form.");
+    } catch (error) {
+      if (error instanceof Error) {
+        const event = new CustomEvent(`${BreadboardElementErrorCode.RENDER}`, {
+          bubbles: true,
+          detail: error.message,
+        });
+        this.dispatchEvent(event);
+        this.onError({
+          code: event.type as BreadboardElementErrorCode,
+          message: event.detail,
+        });
+      }
+    }
   }
 
   #renderForm(properties: Record<string, Schema>, values: InputData) {

--- a/packages/breadboard-ui/src/elements/input/input.ts
+++ b/packages/breadboard-ui/src/elements/input/input.ts
@@ -24,7 +24,7 @@ import { customElement, property } from "lit/decorators.js";
 import { InputEnterEvent } from "../../events/events.js";
 import { WebcamInput } from "./webcam/webcam.js";
 import { DrawableInput } from "./drawable/drawable.js";
-import { InputArgs } from "../../types/types.js";
+import { BreadboardElementError, BreadboardElementErrorCode, BreadboardWebElement, InputArgs } from "../../types/types.js";
 import { Ref, createRef, ref } from "lit/directives/ref.js";
 
 export type InputData = Record<string, unknown>;
@@ -48,7 +48,10 @@ const parseValue = (type: Schema["type"], input: HTMLInputElement) => {
 };
 
 @customElement("bb-input")
-export class Input extends LitElement {
+export class Input extends LitElement implements BreadboardWebElement {
+  @property()
+  onError = (error: BreadboardElementError) => { console.log(error.code, error.message)} ;
+
   @property({ reflect: false })
   remember = false;
 
@@ -226,8 +229,18 @@ export class Input extends LitElement {
       } else {
         const input = form[key];
         if (input && input.value) {
-          const parsedValue = parseValue(property.type, input);
-          data[key] = parsedValue;
+          try {
+			const parsedValue = parseValue(property.type, input);
+          	data[key] = parsedValue;
+			//throw new Error("Error when parsing input values.");
+			
+		  } catch (error) {
+			if (error instanceof Error) {
+				const event = new CustomEvent(`${BreadboardElementErrorCode.PARSE}`, { bubbles: true, detail: error.message });
+				this.dispatchEvent(event);
+				this.onError({code: event.type as BreadboardElementErrorCode, message: event.detail});
+			}
+		  }
         } else {
           // Custom elements don't look like form elements, so they need to be
           // processed separately.
@@ -276,7 +289,17 @@ export class Input extends LitElement {
       return;
     }
 
-    return this.#renderForm(properties, values);
+	try {
+		return this.#renderForm(properties, values);
+		//throw new Error("Error when rendering input form.");
+		
+	  } catch (error) {
+		if (error instanceof Error) {
+			const event = new CustomEvent(`${BreadboardElementErrorCode.RENDER}`, { bubbles: true, detail: error.message });
+			this.dispatchEvent(event);
+			this.onError({code: event.type as BreadboardElementErrorCode, message: event.detail});
+		}
+	  }
   }
 
   #renderForm(properties: Record<string, Schema>, values: InputData) {

--- a/packages/breadboard-ui/src/elements/input/input.ts
+++ b/packages/breadboard-ui/src/elements/input/input.ts
@@ -227,14 +227,13 @@ export class Input extends LitElement {
         const input = form[key];
         if (input && input.value) {
           try {
-			const parsedValue = parseValue(property.type, input);
-          	data[key] = parsedValue;
-			//throw new Error("Error when parsing input values.");
-			
-		  } catch (e) {
-			const event = new InputErrorEvent(`${e}`);
-			this.dispatchEvent(event);
-		  }
+            const parsedValue = parseValue(property.type, input);
+            data[key] = parsedValue;
+            //throw new Error("Error when parsing input values.");
+          } catch (e) {
+            const event = new InputErrorEvent(`${e}`);
+            this.dispatchEvent(event);
+          }
         } else {
           // Custom elements don't look like form elements, so they need to be
           // processed separately.
@@ -283,15 +282,13 @@ export class Input extends LitElement {
       return;
     }
 
-	try {
-		//throw new Error("Error when rendering input form.");
-		return this.#renderForm(properties, values);
-		
-		
-	  } catch (e) {
-		const event = new InputErrorEvent(`${e}`);
-		this.dispatchEvent(event);
-	  }
+    try {
+      //throw new Error("Error when rendering input form.");
+      return this.#renderForm(properties, values);
+    } catch (e) {
+      const event = new InputErrorEvent(`${e}`);
+      this.dispatchEvent(event);
+    }
   }
 
   #renderForm(properties: Record<string, Schema>, values: InputData) {

--- a/packages/breadboard-ui/src/elements/input/input.ts
+++ b/packages/breadboard-ui/src/elements/input/input.ts
@@ -229,7 +229,6 @@ export class Input extends LitElement {
           try {
             const parsedValue = parseValue(property.type, input);
             data[key] = parsedValue;
-            //throw new Error("Error when parsing input values.");
           } catch (e) {
             const event = new InputErrorEvent(`${e}`);
             this.dispatchEvent(event);
@@ -283,7 +282,6 @@ export class Input extends LitElement {
     }
 
     try {
-      //throw new Error("Error when rendering input form.");
       return this.#renderForm(properties, values);
     } catch (e) {
       const event = new InputErrorEvent(`${e}`);

--- a/packages/breadboard-ui/src/events/events.ts
+++ b/packages/breadboard-ui/src/events/events.ts
@@ -8,6 +8,7 @@ import {
   type InspectableEdge,
   type NodeConfiguration,
 } from "@google-labs/breadboard";
+import { ErrorNames } from "../types/types.js";
 
 export class StartEvent extends Event {
   static eventName = "breadboardstart";
@@ -103,6 +104,16 @@ export class InputEnterEvent extends Event {
       composed: true,
     });
   }
+}
+
+export class InputErrorEvent extends Event {
+	static eventName = ErrorNames.INPUT_ERROR;
+
+	constructor(public detail: string) {
+		super(InputErrorEvent.eventName, {
+			bubbles: true
+		})
+	}
 }
 
 export class BoardUnloadEvent extends Event {

--- a/packages/breadboard-ui/src/events/events.ts
+++ b/packages/breadboard-ui/src/events/events.ts
@@ -8,7 +8,6 @@ import {
   type InspectableEdge,
   type NodeConfiguration,
 } from "@google-labs/breadboard";
-import { ErrorNames } from "../types/types.js";
 
 export class StartEvent extends Event {
   static eventName = "breadboardstart";
@@ -107,13 +106,13 @@ export class InputEnterEvent extends Event {
 }
 
 export class InputErrorEvent extends Event {
-	static eventName = ErrorNames.INPUT_ERROR;
+  static eventName = "inputerror";
 
-	constructor(public detail: string) {
-		super(InputErrorEvent.eventName, {
-			bubbles: true
-		})
-	}
+  constructor(public detail: string) {
+    super(InputErrorEvent.eventName, {
+      bubbles: true,
+    });
+  }
 }
 
 export class BoardUnloadEvent extends Event {

--- a/packages/breadboard-ui/src/events/events.ts
+++ b/packages/breadboard-ui/src/events/events.ts
@@ -106,7 +106,7 @@ export class InputEnterEvent extends Event {
 }
 
 export class InputErrorEvent extends Event {
-  static eventName = "inputerror";
+  static eventName = "breadboardinputerror";
 
   constructor(public detail: string) {
     super(InputErrorEvent.eventName, {

--- a/packages/breadboard-ui/src/types/types.ts
+++ b/packages/breadboard-ui/src/types/types.ts
@@ -96,18 +96,10 @@ export type OutputArgs = {
   } & Record<string, unknown>;
 };
 
-export const ErrorNames = {
-	INPUT_ERROR: "inputError",
-	//possibility to add more values here (as required) in the future, e.g., embedError, toastError, and so on
-} as const;
-
-export type ErrorNames =
-	(typeof ErrorNames)[keyof typeof ErrorNames];
-
 export type BreadboardElementError = InputErrorEvent; //more error types can be added for different components later on i.e., "& ElementErrorEvent & OtherElementErrorEvent" and so on
 
 export type BreadboardErrorHandler = (error: BreadboardElementError) => void;
 
 export type BreadboardReactComponentProps = {
-	onError?: BreadboardErrorHandler;
-}
+  onError?: BreadboardErrorHandler;
+};

--- a/packages/breadboard-ui/src/types/types.ts
+++ b/packages/breadboard-ui/src/types/types.ts
@@ -95,11 +95,3 @@ export type OutputArgs = {
     schema?: Schema;
   } & Record<string, unknown>;
 };
-
-export type BreadboardElementError = InputErrorEvent; //more error types can be added for different components later on i.e., "& ElementErrorEvent & OtherElementErrorEvent" and so on
-
-export type BreadboardErrorHandler = (error: BreadboardElementError) => void;
-
-export type BreadboardReactComponentProps = {
-  onError?: BreadboardErrorHandler;
-};

--- a/packages/breadboard-ui/src/types/types.ts
+++ b/packages/breadboard-ui/src/types/types.ts
@@ -94,3 +94,26 @@ export type OutputArgs = {
     schema?: Schema;
   } & Record<string, unknown>;
 };
+
+export const BreadboardElementErrorCode = {
+	PARSE: "parseError",
+	RENDER: "renderError"
+} as const;
+
+export type BreadboardElementErrorCode =
+	(typeof BreadboardElementErrorCode)[keyof typeof BreadboardElementErrorCode];
+
+export type BreadboardElementError = {
+	code: BreadboardElementErrorCode,
+	message: string;
+};
+
+export type BreadboardErrorHandler = (error: BreadboardElementError) => void;
+
+export interface BreadboardWebElement {
+	onError: BreadboardErrorHandler;
+}
+
+export type BreadboardReactComponentProps = {
+	onError?: BreadboardErrorHandler;
+}

--- a/packages/breadboard-ui/src/types/types.ts
+++ b/packages/breadboard-ui/src/types/types.ts
@@ -13,6 +13,7 @@ import {
   Schema,
 } from "@google-labs/breadboard";
 import { HarnessRunResult } from "@google-labs/breadboard/harness";
+import { InputErrorEvent } from "../events/events.js";
 
 export const enum HistoryEventType {
   DONE = "done",
@@ -95,24 +96,17 @@ export type OutputArgs = {
   } & Record<string, unknown>;
 };
 
-export const BreadboardElementErrorCode = {
-	PARSE: "parseError",
-	RENDER: "renderError"
+export const ErrorNames = {
+	INPUT_ERROR: "inputError",
+	//possibility to add more values here (as required) in the future, e.g., embedError, toastError, and so on
 } as const;
 
-export type BreadboardElementErrorCode =
-	(typeof BreadboardElementErrorCode)[keyof typeof BreadboardElementErrorCode];
+export type ErrorNames =
+	(typeof ErrorNames)[keyof typeof ErrorNames];
 
-export type BreadboardElementError = {
-	code: BreadboardElementErrorCode,
-	message: string;
-};
+export type BreadboardElementError = InputErrorEvent; //more error types can be added for different components later on i.e., "& ElementErrorEvent & OtherElementErrorEvent" and so on
 
 export type BreadboardErrorHandler = (error: BreadboardElementError) => void;
-
-export interface BreadboardWebElement {
-	onError: BreadboardErrorHandler;
-}
 
 export type BreadboardReactComponentProps = {
 	onError?: BreadboardErrorHandler;


### PR DESCRIPTION
work by @alexandraM98 to expose UI component configuration for use externally
relates to:
- https://github.com/breadboard-ai/breadboard/issues/877
- https://github.com/breadboard-ai/breadboard/issues/722
- https://github.com/breadboard-ai/breadboard/issues/885

- define error type to be able to identify specific errors
- errors for passing to and handling in react component
- create interface for Lit components to implement which specifies the onError handler, which can then be accessed by react components (and others in the future)
- add interface implementation on `input` Lit component
- within the input component, wrap likely causes of errors in try...catch 