### PR TITLE
[breadboard-ui] Get the user's attention when an input is needed

### DIFF
--- a/packages/breadboard-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/breadboard-ui/src/elements/ui-controller/ui-controller.ts
@@ -250,6 +250,10 @@ export class UI extends LitElement {
         <bb-activity-log
           .events=${events}
           .eventPosition=${eventPosition}
+          @breadboardinputrequested=${() => {
+            this.#autoSwitchSidePanel = 0;
+            this.requestUpdate();
+          }}
           @pointerdown=${(evt: PointerEvent) => {
             if (!this.#detailsRef.value) {
               return;

--- a/packages/breadboard-ui/src/events/events.ts
+++ b/packages/breadboard-ui/src/events/events.ts
@@ -78,6 +78,18 @@ export class NodeSelectEvent extends Event {
   }
 }
 
+export class InputRequestedEvent extends Event {
+  static eventName = "breadboardinputrequested";
+
+  constructor() {
+    super(InputRequestedEvent.eventName, {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    });
+  }
+}
+
 export class InputEnterEvent extends Event {
   static eventName = "breadboardinputenter";
 


### PR DESCRIPTION
When the user is on the Selected Node or History tab and an input is needed, we now switch back to the Board tab and fade the input background a little to let them know.