### PR TITLE
neural activity

### DIFF
--- a/.changeset/four-stingrays-accept.md
+++ b/.changeset/four-stingrays-accept.md
@@ -1,0 +1,6 @@
+---
+"@google-labs/breadboard-ui": patch
+"@google-labs/breadboard": patch
+---
+
+Implement handling subgraphs in Run Inspector API.

--- a/packages/breadboard-ui/src/elements/activity-log/activity-log.ts
+++ b/packages/breadboard-ui/src/elements/activity-log/activity-log.ts
@@ -420,11 +420,6 @@ export class ActivityLog extends LitElement {
                   return nothing;
                 }
 
-                // can ask for secret here. Use
-                // `event.result` to get to the `HarnessRunResult`.
-                // TODO: Figure out how the actual asking for secret will work
-                // TODO: Figure out how to signal when already know the secret
-                //       (probably just return `nothing`)
                 content = html`<section
                   class=${classMap({ "user-required": this.#isHidden })}
                 >

--- a/packages/breadboard-ui/src/elements/activity-log/activity-log.ts
+++ b/packages/breadboard-ui/src/elements/activity-log/activity-log.ts
@@ -14,6 +14,7 @@ import { customElement, property } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { Ref, createRef, ref } from "lit/directives/ref.js";
 import { InputRequestedEvent } from "../../events/events.js";
+import { map } from "lit/directives/map.js";
 
 @customElement("bb-activity-log")
 export class ActivityLog extends LitElement {
@@ -356,7 +357,7 @@ export class ActivityLog extends LitElement {
                     break;
                   }
                   // prettier-ignore
-                  content = html`Working: (<pre>${node.id}</pre>)`;
+                  content = html`Working: (<pre>${node.id} (${map(event.nested || [], (run) => html`<div>${map(run.events, (event) => event.type == "node" ? html`<span>${event.node.id}</span>✨` : nothing )}</div>`)})</pre>)`;
                 } else {
                   // This is fiddly. Output nodes don't have any outputs.
                   let additionalData: HTMLTemplateResult | symbol = nothing;

--- a/packages/breadboard/src/inspector/event.ts
+++ b/packages/breadboard/src/inspector/event.ts
@@ -23,7 +23,7 @@ import {
   PathRegistryEntry,
 } from "./types.js";
 
-class Event implements InspectableRunNodeEvent {
+class RunNodeEvent implements InspectableRunNodeEvent {
   type: "node";
   node: NodeDescriptor;
   start: number;
@@ -68,7 +68,8 @@ export class EventManager {
   }
 
   #addGraphend(path: number[]) {
-    this.#registry.find(path);
+    const entry = this.#registry.find(path);
+    console.log("Graphend", path, entry);
   }
 
   #addNodestart(path: number[], result: HarnessRunResult) {
@@ -77,14 +78,14 @@ export class EventManager {
       throw new Error(`Expected an existing entry for ${JSON.stringify(path)}`);
     }
     const { node, timestamp, inputs } = result.data as NodeStartResponse;
-    const event = new Event(entry, node, timestamp, inputs);
+    const event = new RunNodeEvent(entry, node, timestamp, inputs);
     entry.event = event;
   }
 
   #addInput(path: number[], result: HarnessRunResult, bubbled: boolean) {
     if (bubbled) {
       const input = result.data as InputResponse;
-      const event = new Event(
+      const event = new RunNodeEvent(
         null,
         input.node,
         input.timestamp,
@@ -113,7 +114,7 @@ export class EventManager {
     if (bubbled) {
       // Create a new entry for the sidecar output event.
       const output = result.data as OutputResponse;
-      const event = new Event(
+      const event = new RunNodeEvent(
         null,
         output.node,
         output.timestamp,

--- a/packages/breadboard/src/inspector/event.ts
+++ b/packages/breadboard/src/inspector/event.ts
@@ -61,6 +61,6 @@ export class EventManager {
   }
 
   get events(): InspectableRunEvent[] {
-    return this.#registry.events();
+    return this.#registry.events;
   }
 }

--- a/packages/breadboard/src/inspector/event.ts
+++ b/packages/breadboard/src/inspector/event.ts
@@ -5,41 +5,191 @@
  */
 
 import { HarnessRunResult } from "../harness/types.js";
-import { PathRegistry } from "./path-registry.js";
-import { InspectableRunEvent } from "./types.js";
+import {
+  InputResponse,
+  InputValues,
+  NodeDescriptor,
+  NodeEndResponse,
+  NodeStartResponse,
+  OutputResponse,
+  OutputValues,
+} from "../types.js";
+import { PathRegistry, SECRET_PATH, ERROR_PATH } from "./path-registry.js";
+import {
+  InspectableRunErrorEvent,
+  InspectableRunEvent,
+  InspectableRunNodeEvent,
+  InspectableRunSecretEvent,
+  PathRegistryEntry,
+} from "./types.js";
+
+class Event implements InspectableRunNodeEvent {
+  type: "node";
+  node: NodeDescriptor;
+  start: number;
+  end: number | null;
+  inputs: InputValues;
+  outputs: OutputValues | null;
+  result: HarnessRunResult | null;
+  bubbled: boolean;
+
+  /**
+   * The path registry entry associated with this event.
+   */
+  #entry: PathRegistryEntry | null;
+
+  constructor(
+    entry: PathRegistryEntry | null,
+    node: NodeDescriptor,
+    start: number,
+    inputs: InputValues
+  ) {
+    this.#entry = entry;
+    this.type = "node";
+    this.node = node;
+    this.start = start;
+    this.end = null;
+    this.inputs = inputs;
+    this.outputs = null;
+    this.result = null;
+    this.bubbled = false;
+  }
+
+  get nested() {
+    return this.#entry?.nested() || [];
+  }
+}
 
 export class EventManager {
   #registry = new PathRegistry();
-  #level = 0;
+
+  #addGraphstart(path: number[]) {
+    this.#registry.create(path);
+  }
+
+  #addGraphend(path: number[]) {
+    this.#registry.find(path);
+  }
+
+  #addNodestart(path: number[], result: HarnessRunResult) {
+    const entry = this.#registry.create(path);
+    if (!entry) {
+      throw new Error(`Expected an existing entry for ${JSON.stringify(path)}`);
+    }
+    const { node, timestamp, inputs } = result.data as NodeStartResponse;
+    const event = new Event(entry, node, timestamp, inputs);
+    entry.event = event;
+  }
+
+  #addInput(path: number[], result: HarnessRunResult, bubbled: boolean) {
+    if (bubbled) {
+      const input = result.data as InputResponse;
+      const event = new Event(
+        null,
+        input.node,
+        input.timestamp,
+        input.inputArguments
+      );
+      event.bubbled = true;
+      event.result = result;
+      this.#registry.addSidecar(path, event);
+    } else {
+      const entry = this.#registry.find(path);
+      if (!entry) {
+        throw new Error(
+          `Expected an existing entry for ${JSON.stringify(path)}`
+        );
+      }
+      const existing = entry.event;
+      if (!existing) {
+        console.error("Expected an existing event for", path);
+        return;
+      }
+      existing.result = result;
+    }
+  }
+
+  #addOutput(path: number[], result: HarnessRunResult, bubbled: boolean) {
+    if (bubbled) {
+      // Create a new entry for the sidecar output event.
+      const output = result.data as OutputResponse;
+      const event = new Event(
+        null,
+        output.node,
+        output.timestamp,
+        output.outputs
+      );
+      event.bubbled = true;
+      event.result = result;
+      this.#registry.addSidecar(path, event);
+    } else {
+      const entry = this.#registry.find(path);
+      if (!entry) {
+        throw new Error(
+          `Expected an existing entry for ${JSON.stringify(path)}`
+        );
+      }
+      const existing = entry.event;
+      if (!existing) {
+        console.error("Expected an existing event for", path);
+        return;
+      }
+      existing.inputs = (result.data as OutputResponse).outputs;
+    }
+  }
+
+  #addNodeend(path: number[], data: NodeEndResponse) {
+    const entry = this.#registry.find(path);
+    if (!entry) {
+      throw new Error(`Expected an existing entry for ${JSON.stringify(path)}`);
+    }
+    const existing = entry.event;
+    if (!existing) {
+      console.error("Expected an existing event for", path);
+      return;
+    }
+    existing.end = data.timestamp;
+    existing.outputs = data.outputs;
+    existing.result = null;
+    this.#registry.finalizeSidecar(path, data);
+  }
+
+  #addSecret(event: InspectableRunSecretEvent) {
+    this.#registry.addSidecar(SECRET_PATH, event);
+  }
+
+  #addError(error: InspectableRunErrorEvent) {
+    this.#registry.addSidecar(ERROR_PATH, error);
+  }
 
   add(result: HarnessRunResult) {
-    this.#registry.cleanUpSecrets();
+    this.#registry.finalizeSidecar(SECRET_PATH);
 
     switch (result.type) {
       case "graphstart": {
-        this.#registry.graphstart(result.data.path);
-        this.#level++;
+        // TODO: Figure out what to do with these.
+        this.#addGraphstart(result.data.path);
         break;
       }
       case "graphend": {
-        this.#registry.graphend(result.data.path);
-        this.#level--;
+        // TODO: Figure out what to do with these.
+        this.#addGraphend(result.data.path);
         break;
       }
       case "nodestart": {
-        this.#registry.nodestart(result.data.path, result.data);
+        this.#addNodestart(result.data.path, result);
         break;
       }
       case "input": {
-        this.#registry.input(result.data.path, result, result.data.bubbled);
+        this.#addInput(result.data.path, result, result.data.bubbled);
         break;
       }
       case "output": {
-        this.#registry.output(result.data.path, result, result.data.bubbled);
+        this.#addOutput(result.data.path, result, result.data.bubbled);
         break;
       }
       case "secret": {
-        this.#registry.secret({
+        this.#addSecret({
           type: "secret",
           data: result.data,
           result,
@@ -47,11 +197,11 @@ export class EventManager {
         break;
       }
       case "nodeend": {
-        this.#registry.nodeend(result.data.path, result.data);
+        this.#addNodeend(result.data.path, result.data);
         break;
       }
       case "error": {
-        this.#registry.error({
+        this.#addError({
           type: "error",
           error: result.data,
         });

--- a/packages/breadboard/src/inspector/path-registry.ts
+++ b/packages/breadboard/src/inspector/path-registry.ts
@@ -149,7 +149,7 @@ class Entry implements PathRegistryEntry {
       ];
     } else {
       // This is a map.
-      return this.#children.map((entry) => {
+      return this.#children.filter(Boolean).map((entry) => {
         return {
           id: -10,
           graphId: crypto.randomUUID(),

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -489,3 +489,21 @@ export type InspectableRun = {
 };
 
 type Runner = AsyncGenerator<HarnessRunResult, void, unknown>;
+
+export type PathRegistryEntry = {
+  children: PathRegistryEntry[];
+  event: InspectableRunNodeEvent | null;
+  /**
+   * Sidecars are events that are displayed at a top-level, but aren't
+   * part of the main event list. Currently, sidecar events are:
+   * - Input events that have bubbled up.
+   * - Output events that have bubbled up.
+   * - Secret events.
+   * - Error events.
+   */
+  sidecars: InspectableRunEvent[];
+  /**
+   * Computes nested runs for the given path.
+   */
+  nested(): InspectableRun[];
+};


### PR DESCRIPTION
- **Clean up traversal a bit.**
- **Make `PathRegistry` an `Entry`.**
- **Working `nested` runs.**
- **Organize event-getting logic.**
- **Remove `markEventsAsDirty`.**
- **Get rid of `PathRegistryEntryUpdater`.**
- **Split the `Entry` API to `find` and `create`.**
- **Shift more stuff to `event.ts`.**
- **Minor tweaks.**
- **docs(changeset): Implement handling subgraphs in Run Inspector API.**
