### PR TITLE
inspectable run

### DIFF
--- a/.changeset/large-berries-guess.md
+++ b/.changeset/large-berries-guess.md
@@ -1,0 +1,7 @@
+---
+"@google-labs/breadboard-web": minor
+"@google-labs/breadboard-ui": minor
+"@google-labs/breadboard": minor
+---
+
+Get the Run Inspector API ready to ship

--- a/packages/breadboard-ui/src/elements/activity-log/activity-log.ts
+++ b/packages/breadboard-ui/src/elements/activity-log/activity-log.ts
@@ -336,13 +336,7 @@ export class ActivityLog extends LitElement {
                   // if (idx !== this.eventPosition) {
                   //   return nothing;
                   // }
-                  if (node.type === "input" && event.result) {
-                    if (event.result.type !== "input") {
-                      content = html`Input types don't match - unable to request
-                      input`;
-                      break;
-                    }
-
+                  if (node.type === "input") {
                     content = html`<section
                       class=${classMap({ "user-required": this.#isHidden })}
                     >
@@ -351,7 +345,7 @@ export class ActivityLog extends LitElement {
                         id="${node.id}"
                         .secret=${false}
                         .remember=${false}
-                        .configuration=${event.result.data.inputArguments}
+                        .configuration=${event.inputs}
                       ></bb-input>
                     </section>`;
                     break;
@@ -429,7 +423,7 @@ export class ActivityLog extends LitElement {
               }
 
               case "secret": {
-                if (event.result === null) {
+                if (event.end !== null) {
                   return nothing;
                 }
 

--- a/packages/breadboard-ui/src/elements/activity-log/activity-log.ts
+++ b/packages/breadboard-ui/src/elements/activity-log/activity-log.ts
@@ -324,7 +324,6 @@ export class ActivityLog extends LitElement {
       <h1>Activity Log</h1>
       ${this.events && this.events.length
         ? this.events.map((event, idx) => {
-            console.log("🌻 event", event);
             let content: HTMLTemplateResult | symbol = nothing;
             switch (event.type) {
               case "node": {

--- a/packages/breadboard-ui/src/elements/activity-log/activity-log.ts
+++ b/packages/breadboard-ui/src/elements/activity-log/activity-log.ts
@@ -324,6 +324,7 @@ export class ActivityLog extends LitElement {
       <h1>Activity Log</h1>
       ${this.events && this.events.length
         ? this.events.map((event, idx) => {
+            console.log("🌻 event", event);
             let content: HTMLTemplateResult | symbol = nothing;
             switch (event.type) {
               case "node": {

--- a/packages/breadboard-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/breadboard-ui/src/elements/ui-controller/ui-controller.ts
@@ -56,7 +56,7 @@ export class UI extends LitElement {
   status = STATUS.RUNNING;
 
   @property()
-  inspectableRun: InspectableRun | null = null;
+  run: InspectableRun | null = null;
 
   @property()
   boards: Board[] = [];
@@ -171,7 +171,7 @@ export class UI extends LitElement {
     duration: number
   ): Promise<Record<string, unknown> | void> {
     if (this.status === STATUS.RUNNING) {
-      const messages = this.inspectableRun?.messages || [];
+      const messages = this.run?.messages || [];
       this.#messagePosition = messages.length - 1;
     }
     this.#messageDurations.set(message, duration);
@@ -220,11 +220,10 @@ export class UI extends LitElement {
   }
 
   render() {
-    const messages = this.inspectableRun?.messages || [];
-    const nodeId =
-      this.inspectableRun?.currentNode(this.#messagePosition) || "";
+    const messages = this.run?.messages || [];
+    const nodeId = this.run?.currentNode(this.#messagePosition) || "";
 
-    const events = this.inspectableRun?.events || [];
+    const events = this.run?.events || [];
     const eventPosition = events.length - 1;
 
     /**

--- a/packages/breadboard-web/public/graphs/error.json
+++ b/packages/breadboard-web/public/graphs/error.json
@@ -1,0 +1,70 @@
+{
+  "title": "Error board",
+  "description": "Use this board to test error handling. It will throw an error when run.",
+  "edges": [
+    {
+      "from": "jsonata-3",
+      "to": "output-2",
+      "out": "result",
+      "in": "stub"
+    },
+    {
+      "from": "input-1",
+      "to": "jsonata-3",
+      "out": "text",
+      "in": "json"
+    }
+  ],
+  "nodes": [
+    {
+      "id": "output-2",
+      "type": "output",
+      "configuration": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "stub": {
+              "title": "result",
+              "description": "The result of the Jsonata expression",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "jsonata-3",
+      "type": "jsonata",
+      "configuration": {
+        "expression": "$assert(false, \"Here is an error!\")"
+      },
+      "metadata": {
+        "title": "Throw An Error"
+      }
+    },
+    {
+      "id": "input-1",
+      "type": "input",
+      "configuration": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "text": {
+              "title": "json",
+              "description": "The JSON object to evaluate",
+              "type": [
+                "object",
+                "string"
+              ],
+              "default": "Could you please throw an error?"
+            }
+          },
+          "required": [
+            "text"
+          ]
+        }
+      }
+    }
+  ],
+  "graphs": {}
+}

--- a/packages/breadboard-web/public/local-boards.json
+++ b/packages/breadboard-web/public/local-boards.json
@@ -65,6 +65,10 @@
     "version": "0.0.2"
   },
   {
+    "title": "Error board",
+    "url": "/graphs/error.json"
+  },
+  {
     "title": "Gemini Pro Generator",
     "url": "/graphs/gemini-generator.json",
     "version": "0.0.2"

--- a/packages/breadboard-web/src/boards/error.ts
+++ b/packages/breadboard-web/src/boards/error.ts
@@ -1,0 +1,16 @@
+import { board } from "@google-labs/breadboard";
+import { json } from "@google-labs/json-kit";
+
+export default await board(({ text }) => {
+  text.default("Could you please throw an error?");
+  const throwError = json.jsonata({
+    $metadata: { title: "Throw An Error" },
+    json: text,
+    expression: '$assert(false, "Here is an error!")',
+  });
+  return { stub: throwError.result };
+}).serialize({
+  title: "Error board",
+  description:
+    "Use this board to test error handling. It will throw an error when run.",
+});

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -350,6 +350,7 @@ export class Main extends LitElement {
     this.status = BreadboardUI.Types.STATUS.RUNNING;
     let lastEventTime = globalThis.performance.now();
     for await (const result of runner) {
+      // Update "runs" to ensure the UI is aware when the new run begins.
       this.runs = this.#runObserver?.observe(result);
       const runDuration = result.data.timestamp - lastEventTime;
       if (this.#delay !== 0) {

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -23,7 +23,7 @@ import {
 } from "@google-labs/breadboard";
 import { cache } from "lit/directives/cache.js";
 import { classMap } from "lit/directives/class-map.js";
-import { createRunObserver } from "../../breadboard/dist/src/inspector";
+import { createRunObserver } from "@google-labs/breadboard";
 
 export const getBoardInfo = async (
   url: string

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -18,11 +18,12 @@ import {
   EditResult,
   GraphDescriptor,
   InspectableRun,
-  inspectRun,
+  InspectableRunObserver,
   Kit,
 } from "@google-labs/breadboard";
 import { cache } from "lit/directives/cache.js";
 import { classMap } from "lit/directives/class-map.js";
+import { createRunObserver } from "../../breadboard/dist/src/inspector";
 
 export const getBoardInfo = async (
   url: string
@@ -61,6 +62,9 @@ export class Main extends LitElement {
   kits: Kit[] = [];
 
   @state()
+  runs: InspectableRun[] | null = null;
+
+  @state()
   mode = MODE.LIST;
 
   @state()
@@ -76,7 +80,7 @@ export class Main extends LitElement {
   #delay = 0;
   #status = BreadboardUI.Types.STATUS.STOPPED;
   #statusObservers: Array<(value: BreadboardUI.Types.STATUS) => void> = [];
-  #inspector: InspectableRun | null = null;
+  #runObserver: InspectableRunObserver = createRunObserver();
 
   static styles = css`
     * {
@@ -339,16 +343,14 @@ export class Main extends LitElement {
     const ui = this.#uiRef.value;
     ui.load(this.loadInfo);
 
-    this.#inspector = inspectRun(
-      this.loadInfo.graphDescriptor as GraphDescriptor
-    );
     ui.clearPosition();
 
     const currentBoardId = this.#boardId;
 
     this.status = BreadboardUI.Types.STATUS.RUNNING;
     let lastEventTime = globalThis.performance.now();
-    for await (const result of this.#inspector.observe(runner)) {
+    for await (const result of runner) {
+      this.runs = this.#runObserver?.observe(result);
       const runDuration = result.data.timestamp - lastEventTime;
       if (this.#delay !== 0) {
         await new Promise((r) => setTimeout(r, this.#delay));
@@ -454,7 +456,6 @@ export class Main extends LitElement {
     if (!this.#uiRef.value) {
       return;
     }
-    this.#inspector = null;
     this.#uiRef.value.unloadCurrentBoard();
   }
 
@@ -467,7 +468,7 @@ export class Main extends LitElement {
       URL.revokeObjectURL(evt.target.href);
     }
 
-    const messages = this.#inspector?.messages || [];
+    const messages = this.#runObserver?.runs()[0].messages || [];
 
     const secrets = [];
     const inputs = [];
@@ -584,13 +585,14 @@ export class Main extends LitElement {
 
     let tmpl: HTMLTemplateResult | symbol = nothing;
     let content: HTMLTemplateResult | symbol = nothing;
+    const currentRun = this.#runObserver.runs()[0];
     switch (this.mode) {
       case MODE.BUILD: {
         content = html`<bb-ui-controller
           ${ref(this.#uiRef)}
           .url=${this.url}
           .loadInfo=${this.loadInfo}
-          .inspectableRun=${this.#inspector}
+          .run=${currentRun}
           .kits=${this.kits}
           .status=${this.status}
           @breadboardrunboard=${async () => {

--- a/packages/breadboard/src/harness/error.ts
+++ b/packages/breadboard/src/harness/error.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ErrorObject } from "../types.js";
+
+export const extractError = (e: unknown) => {
+  const error = e as Error;
+  let message;
+  if (error?.cause) {
+    const { cause } = error as { cause: ErrorObject };
+    message = cause;
+  } else {
+    message = error.message;
+  }
+  return message;
+};

--- a/packages/breadboard/src/index.ts
+++ b/packages/breadboard/src/index.ts
@@ -64,7 +64,7 @@ export { asyncGen } from "./utils/async-gen.js";
  * The Inspector API.
  */
 export type * from "./inspector/types.js";
-export { inspect, inspectRun } from "./inspector/index.js";
+export { inspect, createRunObserver } from "./inspector/index.js";
 export { PortStatus } from "./inspector/types.js";
 
 /**

--- a/packages/breadboard/src/inspector/event.ts
+++ b/packages/breadboard/src/inspector/event.ts
@@ -243,12 +243,10 @@ export class EventManager {
 
     switch (result.type) {
       case "graphstart": {
-        // TODO: Figure out what to do with these.
         this.#addGraphstart(result.data);
         break;
       }
       case "graphend": {
-        // TODO: Figure out what to do with these.
         this.#addGraphend(result.data);
         break;
       }

--- a/packages/breadboard/src/inspector/event.ts
+++ b/packages/breadboard/src/inspector/event.ts
@@ -5,6 +5,7 @@
  */
 
 import { HarnessRunResult } from "../harness/types.js";
+import { timestamp } from "../timestamp.js";
 import {
   GraphEndProbeData,
   GraphStartProbeData,
@@ -260,6 +261,8 @@ export class EventManager {
           type: "secret",
           data: result.data,
           result,
+          start: timestamp(),
+          end: null,
         });
         break;
       }

--- a/packages/breadboard/src/inspector/event.ts
+++ b/packages/breadboard/src/inspector/event.ts
@@ -173,7 +173,6 @@ export class EventManager {
         console.error("Expected an existing event for", path);
         return;
       }
-      existing.result = result;
     }
   }
 
@@ -218,7 +217,6 @@ export class EventManager {
     }
     existing.end = data.timestamp;
     existing.outputs = data.outputs;
-    existing.result = null;
     this.#pathRegistry.finalizeSidecar(path, data);
   }
 
@@ -260,7 +258,6 @@ export class EventManager {
         this.#addSecret({
           type: "secret",
           data: result.data,
-          result,
           start: timestamp(),
           end: null,
         });

--- a/packages/breadboard/src/inspector/event.ts
+++ b/packages/breadboard/src/inspector/event.ts
@@ -36,7 +36,7 @@ class NestedRun implements InspectableRun {
   graphId: GraphUUID;
   start: number;
   end: number | null;
-  graphVersion: number;
+  graphVersion = 0;
   messages: HarnessRunResult[] = [];
   events: InspectableRunEvent[];
 
@@ -44,8 +44,6 @@ class NestedRun implements InspectableRun {
     this.graphId = entry.graphId as GraphUUID;
     this.start = entry.graphStart;
     this.end = entry.graphEnd;
-    this.graphVersion = 0;
-    this.messages = [];
     this.events = entry.events;
   }
 

--- a/packages/breadboard/src/inspector/event.ts
+++ b/packages/breadboard/src/inspector/event.ts
@@ -17,7 +17,7 @@ import {
   OutputResponse,
   OutputValues,
 } from "../types.js";
-import { PathRegistry, SECRET_PATH, ERROR_PATH } from "./path-registry.js";
+import { PathRegistry, SECRET_PATH } from "./path-registry.js";
 import {
   GraphUUID,
   InspectableGraphStore,
@@ -201,6 +201,11 @@ export class EventManager {
         console.error("Expected an existing event for", path);
         return;
       }
+      if (existing.type !== "node") {
+        throw new Error(
+          `Expected an existing event to be of type "node", but got ${existing.type}`
+        );
+      }
       existing.inputs = (result.data as OutputResponse).outputs;
     }
   }
@@ -215,6 +220,11 @@ export class EventManager {
       console.error("Expected an existing event for", path);
       return;
     }
+    if (existing.type !== "node") {
+      throw new Error(
+        `Expected an existing event to be of type "node", but got ${existing.type}`
+      );
+    }
     existing.end = data.timestamp;
     existing.outputs = data.outputs;
     this.#pathRegistry.finalizeSidecar(path, data);
@@ -225,7 +235,7 @@ export class EventManager {
   }
 
   #addError(error: InspectableRunErrorEvent) {
-    this.#pathRegistry.addSidecar(ERROR_PATH, error);
+    this.#pathRegistry.addError(error);
   }
 
   add(result: HarnessRunResult) {

--- a/packages/breadboard/src/inspector/event.ts
+++ b/packages/breadboard/src/inspector/event.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { HarnessRunResult, HarnessRunner } from "../harness/types.js";
+import { HarnessRunResult } from "../harness/types.js";
 import {
   GraphEndProbeData,
   GraphStartProbeData,
@@ -49,10 +49,6 @@ class NestedRun implements InspectableRun {
 
   currentNode(): string {
     return "";
-  }
-
-  observe(runner: HarnessRunner) {
-    return runner;
   }
 }
 

--- a/packages/breadboard/src/inspector/index.ts
+++ b/packages/breadboard/src/inspector/index.ts
@@ -7,7 +7,7 @@
 import { GraphDescriptor } from "../types.js";
 import { GraphStore } from "./graph-store.js";
 import { inspectableGraph } from "./graph.js";
-import { RunObserver, inspectableRun } from "./run.js";
+import { RunObserver } from "./run.js";
 import {
   InspectableGraph,
   InspectableGraphOptions,
@@ -25,5 +25,3 @@ export const createRunObserver = (): InspectableRunObserver => {
   const store = new GraphStore();
   return new RunObserver(store);
 };
-
-export const inspectRun = inspectableRun;

--- a/packages/breadboard/src/inspector/index.ts
+++ b/packages/breadboard/src/inspector/index.ts
@@ -5,15 +5,25 @@
  */
 
 import { GraphDescriptor } from "../types.js";
+import { GraphStore } from "./graph-store.js";
 import { inspectableGraph } from "./graph.js";
-import { inspectableRun } from "./run.js";
-import { InspectableGraph, InspectableGraphOptions } from "./types.js";
+import { RunObserver, inspectableRun } from "./run.js";
+import {
+  InspectableGraph,
+  InspectableGraphOptions,
+  InspectableRunObserver,
+} from "./types.js";
 
 export const inspect = (
   graph: GraphDescriptor,
   options?: InspectableGraphOptions
 ): InspectableGraph => {
   return inspectableGraph(graph, options);
+};
+
+export const createRunObserver = (): InspectableRunObserver => {
+  const store = new GraphStore();
+  return new RunObserver(store);
 };
 
 export const inspectRun = inspectableRun;

--- a/packages/breadboard/src/inspector/path-registry.ts
+++ b/packages/breadboard/src/inspector/path-registry.ts
@@ -8,19 +8,19 @@ import { timestamp } from "../timestamp.js";
 import { OutputValues } from "../types.js";
 import {
   GraphUUID,
+  InspectableRunErrorEvent,
   InspectableRunEvent,
   InspectableRunNodeEvent,
   PathRegistryEntry,
 } from "./types.js";
 
 export const SECRET_PATH = [-2];
-export const ERROR_PATH = [-3];
 
 class Entry implements PathRegistryEntry {
   #events: InspectableRunEvent[] = [];
   #eventsIsDirty = false;
   #children: Entry[] = [];
-  event: InspectableRunNodeEvent | null = null;
+  event: InspectableRunEvent | null = null;
   sidecars: InspectableRunEvent[] = [];
   // Keep track of some sidecar events so that we can clean them up later.
   // We only need to keep track of input and output events, since the
@@ -43,6 +43,16 @@ class Entry implements PathRegistryEntry {
     this.#eventsIsDirty = true;
   }
 
+  /**
+   * We handle error specially, because unlike sidecars, errors result
+   * in stopping the run, and we need to display them at the end of the run.
+   * @param event -- The error event to add.
+   */
+  addError(event: InspectableRunErrorEvent) {
+    const entry = this.create([this.#children.length]);
+    entry.event = event as unknown as InspectableRunNodeEvent;
+  }
+
   finalizeSidecar(
     path: number[],
     data?: { timestamp: number; outputs: OutputValues }
@@ -50,6 +60,7 @@ class Entry implements PathRegistryEntry {
     const key = path.join("-");
     const sidecar = this.#trackedSidecars.get(key);
     switch (sidecar?.type) {
+      // These are bubbling inputs and inputs.
       case "node": {
         if (data) {
           sidecar.end = data.timestamp;
@@ -119,7 +130,7 @@ class Entry implements PathRegistryEntry {
   }
 
   create(path: number[]) {
-    return this.#findOrCreate(false, path, path);
+    return this.#findOrCreate(false, path, path) as Entry;
   }
 
   get children() {

--- a/packages/breadboard/src/inspector/path-registry.ts
+++ b/packages/breadboard/src/inspector/path-registry.ts
@@ -55,12 +55,10 @@ class Entry implements PathRegistryEntry {
           sidecar.end = data.timestamp;
           sidecar.outputs = data.outputs;
         }
-        sidecar.result = null;
         break;
       }
       case "secret": {
         sidecar.end = timestamp();
-        sidecar.result = null;
         break;
       }
     }

--- a/packages/breadboard/src/inspector/path-registry.ts
+++ b/packages/breadboard/src/inspector/path-registry.ts
@@ -23,7 +23,7 @@ class Entry implements PathRegistryEntry {
   sidecars: InspectableRunEvent[] = [];
   // Keep track of some sidecar events so that we can clean them up later.
   // We only need to keep track of input and output events, since the
-  // secret and events do not have a corresponding `nodeend` event.
+  // secret and error do not have a corresponding `nodeend` event.
   #trackedSidecars: Map<string, InspectableRunEvent> = new Map();
 
   graphId: GraphUUID | null = null;

--- a/packages/breadboard/src/inspector/run.ts
+++ b/packages/breadboard/src/inspector/run.ts
@@ -4,11 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { HarnessRunResult, HarnessRunner } from "../harness/types.js";
+import { HarnessRunResult } from "../harness/types.js";
 import { timestamp } from "../timestamp.js";
 import { GraphDescriptor, NodeDescriptor } from "../types.js";
 import { EventManager } from "./event.js";
-import { GraphStore } from "./graph-store.js";
 import {
   GraphUUID,
   InspectableGraphStore,
@@ -123,11 +122,6 @@ export class RunObserver implements InspectableRunObserver {
   }
 }
 
-export const inspectableRun = (graph: GraphDescriptor): InspectableRun => {
-  const store = new GraphStore();
-  return new Run(store, graph);
-};
-
 export class Run implements InspectableRun {
   #events: EventManager;
   #highlightHelper = new NodeHighlightHelper();
@@ -155,45 +149,7 @@ export class Run implements InspectableRun {
     this.#highlightHelper.add(result);
   }
 
-  observe(runner: HarnessRunner): HarnessRunner {
-    return new Observer(runner, (event) => {
-      this.messages.push(event);
-      this.#events.add(event);
-      this.#highlightHelper.add(event);
-    });
-  }
-
   currentNode(position: number) {
     return this.#highlightHelper.currentNode(position);
-  }
-}
-
-type OnResult = (message: HarnessRunResult) => void;
-
-class Observer implements HarnessRunner {
-  #runner: HarnessRunner;
-  #onResult: OnResult;
-
-  constructor(runner: HarnessRunner, onResult: OnResult) {
-    this.#onResult = onResult;
-    this.#runner = runner;
-  }
-
-  async next() {
-    const result = await this.#runner.next();
-    if (result.done) {
-      return result;
-    }
-    this.#onResult(result.value);
-    return result;
-  }
-  async return() {
-    return this.#runner.return();
-  }
-  async throw(error?: unknown) {
-    return this.#runner.throw(error);
-  }
-  [Symbol.asyncIterator]() {
-    return this;
   }
 }

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -4,11 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  HarnessRunResult,
-  HarnessRunner,
-  SecretResult,
-} from "../harness/types.js";
+import { HarnessRunResult, SecretResult } from "../harness/types.js";
 import {
   Edge,
   ErrorResponse,
@@ -533,11 +529,6 @@ export type InspectableRun = {
    */
   messages: HarnessRunResult[];
   currentNode(position: number): string;
-
-  // TODO: Figure out what to do here. I don't really like how observing is
-  // part of the otherwise read-only API. But I can't think of an elegant
-  // solution right now.
-  observe(runner: HarnessRunner): HarnessRunner;
 };
 
 export type PathRegistryEntry = {

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -536,7 +536,7 @@ export type PathRegistryEntry = {
   graphId: GraphUUID | null;
   graphStart: number;
   graphEnd: number | null;
-  event: InspectableRunNodeEvent | null;
+  event: InspectableRunEvent | null;
   /**
    * Sidecars are events that are displayed at a top-level, but aren't
    * part of the main event list. Currently, sidecar events are:

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -400,6 +400,23 @@ export type InspectableVersionedGraph = {
 };
 
 /**
+ * Represents an observer of the graph runs.
+ */
+export type InspectableRunObserver = {
+  /**
+   * Returns the list of runs that were observed. The current run is always
+   * at the top of the list.
+   */
+  runs(): InspectableRun[];
+  /**
+   * Observes the given result and collects it into the list of runs.
+   * @param result -- the result to observe
+   * @returns -- the list of runs that were observed
+   */
+  observe(result: HarnessRunResult): InspectableRun[];
+};
+
+/**
  * Represents a store of all graphs that the system has seen so far.
  */
 export type InspectableGraphStore = {

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -489,6 +489,14 @@ export type InspectableRunSecretEvent = {
   type: "secret";
   data: SecretResult["data"];
   result: HarnessRunResult | null;
+  /**
+   * When the `secrets` node was first observerd.
+   */
+  start: number;
+  /**
+   * When the `secrets` node was handled.
+   */
+  end: number | null;
 };
 
 /**

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -459,13 +459,6 @@ export type InspectableRunNodeEvent = {
    */
   outputs: OutputValues | null;
   /**
-   * The underlying result that generated this event.
-   * Only available for `input` and `secret` nodes, and
-   * only before `nodeend` event has been received.
-   * Can be used to reply to the `input` or `secret` node.
-   */
-  result: HarnessRunResult | null;
-  /**
    * Returns true when the input or output node was bubbled up from a nested
    * graph. This is only populated for the top-level graph.
    */
@@ -488,7 +481,6 @@ export type InspectableRunErrorEvent = {
 export type InspectableRunSecretEvent = {
   type: "secret";
   data: SecretResult["data"];
-  result: HarnessRunResult | null;
   /**
    * When the `secrets` node was first observerd.
    */

--- a/packages/breadboard/src/remote/run.ts
+++ b/packages/breadboard/src/remote/run.ts
@@ -5,6 +5,7 @@
  */
 
 import { Diagnostics } from "../harness/diagnostics.js";
+import { extractError } from "../harness/error.js";
 import { RunResult } from "../run.js";
 import { BoardRunner } from "../runner.js";
 import {
@@ -14,7 +15,6 @@ import {
 } from "../stream.js";
 import { timestamp } from "../timestamp.js";
 import {
-  ErrorObject,
   InputValues,
   NodeHandlerContext,
   OutputValues,
@@ -120,19 +120,9 @@ export class RunServer {
       await responses.write(["end", { timestamp: timestamp() }]);
       await responses.close();
     } catch (e) {
-      const error = e as Error;
-      let message;
-      if (error?.cause) {
-        const { cause } = error as { cause: ErrorObject };
-        message = cause;
-      } else {
-        message = error.message;
-      }
-      console.error("Run Server error:", message);
-      await responses.write([
-        "error",
-        { error: message, timestamp: timestamp() },
-      ]);
+      const error = extractError(e);
+      console.error("Run Server error:", error);
+      await responses.write(["error", { error, timestamp: timestamp() }]);
       await responses.close();
     }
   }


### PR DESCRIPTION
- **Clean up.**
- **Introduce `RunObserver` and start using it.**
- **Remove unused APIs.**
- **Stop using `InspectableRunEvent.result`.**
- **Remove `InspectableRunEvent.result`.**
- **Add an error-throwing board.**
- **Put error events at the end of the run.**
- **Handle errors consistently in worker and local harness.**
- **docs(changeset): Get the Run Inspector API ready to ship**
