### PR TITLE
[build] Generate invoke and describe functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27781,6 +27781,9 @@
       "name": "@breadboard-ai/build",
       "version": "0.0.0",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@google-labs/breadboard": "^0.11.2"
+      },
       "devDependencies": {
         "@types/node": "^20.11.25",
         "eslint": "^8.57.0",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -30,6 +30,7 @@
   ],
   "scripts": {
     "build": "wireit",
+    "build:tsc": "wireit",
     "test": "wireit",
     "test:only": "wireit",
     "lint": "wireit",
@@ -89,6 +90,9 @@
         "lint"
       ]
     }
+  },
+  "dependencies": {
+    "@google-labs/breadboard": "^0.11.2"
   },
   "devDependencies": {
     "@types/node": "^20.11.25",

--- a/packages/build/src/definition.ts
+++ b/packages/build/src/definition.ts
@@ -5,6 +5,10 @@
  */
 
 import { NodeInstance } from "./instance.js";
+import type {
+  NodeHandlerFunction,
+  NodeDescriberFunction,
+} from "@google-labs/breadboard";
 import type { PortConfigMap } from "./port.js";
 import type { TypeScriptTypeFromBreadboardType } from "./type.js";
 
@@ -59,9 +63,8 @@ export function defineNodeType<
   const def = () => {
     return new NodeInstance(inputs, outputs);
   };
-  def.inputs = inputs;
-  def.outputs = outputs;
-  def.invoke = invoke;
+  def.invoke = makeInvokeFunction(invoke);
+  def.describe = makeDescribeFunction(inputs, outputs);
   return def;
 }
 
@@ -70,14 +73,81 @@ export interface NodeDefinition<
   O extends PortConfigMap,
 > {
   (): NodeInstance<I, O>;
-  readonly inputs: I;
-  readonly outputs: O;
-  readonly invoke: InvokeFunction<I, O>;
+  readonly invoke: NodeHandlerFunction;
+  readonly describe: NodeDescriberFunction;
 }
 
-type InvokeFunction<I extends PortConfigMap, O extends PortConfigMap> = (
+/**
+ * Wrap the user's invoke function so that it (1) consistently returns a
+ * promise, and (2) is typed for compatibility with the NodeHandlerFunction type
+ * that is expected by the Breadboard runner, KitBuilder, etc.
+ */
+function makeInvokeFunction<I extends PortConfigMap, O extends PortConfigMap>(
+  invoke: InvokeFunction<I, O>
+): NodeHandlerFunction {
+  return (inputs) => {
+    // The user's invoke function is allowed to return a promise or a concrete
+    // value, but we always return a promise so that any sync -> async change
+    // this node might need to make in the future will not be a breaking change
+    // for its consumers.
+    return Promise.resolve(
+      invoke(
+        // TODO(aomarks) This cast is needed because at runtime we don't get any
+        // guarantee about port shape and types. Consider adding schema
+        // validation here so that we can raise type errors automatically and
+        // prevent the invoke function from being invoked with unexpected input
+        // types.
+        inputs as InvokeParams<I>
+      )
+    );
+  };
+}
+
+/**
+ * Generate a JSON schema that describes the input and output ports of this node
+ * type, and wrap that in a promise-returning function (a function is expected
+ * because some node types change their shape at runtime).
+ */
+function makeDescribeFunction<I extends PortConfigMap, O extends PortConfigMap>(
+  inputs: I,
+  outputs: O
+): NodeDescriberFunction {
+  // Note result is memoized. This is a monmorphic node, so the ports never
+  // change.
+  const result = Promise.resolve({
+    inputSchema: {
+      type: "object",
+      properties: Object.fromEntries(
+        [...Object.entries(inputs)].map(([title, { description, type }]) => {
+          return [title, { title, description, type }];
+        })
+      ),
+      required: [...Object.keys(inputs)],
+    },
+    outputSchema: {
+      type: "object",
+      properties: Object.fromEntries(
+        [...Object.entries(outputs)].map(([title, { description, type }]) => {
+          return [title, { title, description, type }];
+        })
+      ),
+      required: [...Object.keys(outputs)],
+    },
+  });
+  return () => result;
+}
+
+type InvokeFunction<I extends PortConfigMap, O extends PortConfigMap> =
+  | InvokeFunctionSync<I, O>
+  | InvokeFunctionAsync<I, O>;
+
+type InvokeFunctionSync<I extends PortConfigMap, O extends PortConfigMap> = (
   params: InvokeParams<I>
 ) => InvokeReturn<O>;
+
+type InvokeFunctionAsync<I extends PortConfigMap, O extends PortConfigMap> = (
+  params: InvokeParams<I>
+) => Promise<InvokeReturn<O>>;
 
 type InvokeParams<Ports extends PortConfigMap> = {
   [PortName in keyof Ports]: TypeScriptTypeFromBreadboardType<
@@ -85,7 +155,7 @@ type InvokeParams<Ports extends PortConfigMap> = {
   >;
 };
 
-export type InvokeReturn<Ports extends PortConfigMap> = {
+type InvokeReturn<Ports extends PortConfigMap> = {
   [PortName in keyof Ports]: TypeScriptTypeFromBreadboardType<
     Ports[PortName]["type"]
   >;

--- a/packages/build/src/test/define_test.ts
+++ b/packages/build/src/test/define_test.ts
@@ -6,6 +6,13 @@
 
 import { defineNodeType } from "@breadboard-ai/build";
 import { test } from "node:test";
+import type {
+  NodeDescriberFunction,
+  NodeHandler,
+  NodeHandlerContext,
+  NodeHandlerFunction,
+} from "@google-labs/breadboard";
+import assert from "node:assert/strict";
 
 test("expect types: 0 in, 0 out", () => {
   // $ExpectType NodeDefinition<{}, {}>
@@ -238,4 +245,143 @@ test.skip("expect type error: unknown return port", () => {
       };
     }
   );
+});
+
+test("expect types: definitions are NodeHandlers", () => {
+  const definition = defineNodeType(
+    {
+      in1: {
+        type: "string",
+      },
+    },
+    {
+      out1: {
+        type: "string",
+      },
+    },
+    () => {
+      return {
+        out1: "foo",
+      };
+    }
+  );
+  definition satisfies NodeHandler;
+  definition.invoke satisfies NodeHandlerFunction;
+  definition.describe satisfies NodeDescriberFunction;
+});
+
+test("describe function generates JSON schema", async () => {
+  const definition = defineNodeType(
+    {
+      in1: {
+        type: "string",
+        description: "Description of in1",
+      },
+      in2: {
+        type: "number",
+      },
+    },
+    {
+      out1: {
+        type: "boolean",
+        description: "Description of out1",
+      },
+    },
+    () => {
+      return {
+        out1: true,
+      };
+    }
+  );
+  assert.deepEqual(await definition.describe(), {
+    inputSchema: {
+      type: "object",
+      properties: {
+        in1: {
+          title: "in1",
+          description: "Description of in1",
+          type: "string",
+        },
+        in2: {
+          title: "in2",
+          description: undefined,
+          type: "number",
+        },
+      },
+      required: ["in1", "in2"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        out1: {
+          title: "out1",
+          description: "Description of out1",
+          type: "boolean",
+        },
+      },
+      required: ["out1"],
+    },
+  });
+});
+
+test("invoke returns value from sync function", async () => {
+  const definition = defineNodeType(
+    {
+      a: {
+        type: "string",
+      },
+      b: {
+        type: "string",
+      },
+    },
+    {
+      concat: {
+        type: "string",
+      },
+    },
+    // Synchronous
+    ({ a, b }) => {
+      return {
+        concat: a + b,
+      };
+    }
+  );
+  const result = definition.invoke(
+    { a: "foo", b: "bar" },
+    // Not currently used.
+    null as unknown as NodeHandlerContext
+  );
+  assert(result instanceof Promise);
+  assert.deepEqual(await result, { concat: "foobar" });
+});
+
+test("invoke returns value from async function", async () => {
+  const definition = defineNodeType(
+    {
+      a: {
+        type: "string",
+      },
+      b: {
+        type: "string",
+      },
+    },
+    {
+      concat: {
+        type: "string",
+      },
+    },
+    async ({ a, b }) => {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      return {
+        concat: a + b,
+      };
+    }
+  );
+  const result = definition.invoke(
+    { a: "foo", b: "bar" },
+    // Not currently used.
+    null as unknown as NodeHandlerContext
+  );
+  assert(result instanceof Promise);
+  assert.deepEqual(await result, { concat: "foobar" });
 });

--- a/packages/build/tsconfig.json
+++ b/packages/build/tsconfig.json
@@ -7,7 +7,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "types": ["node"],
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM"],
     "incremental": true,
     "declaration": true,
     "sourceMap": true,


### PR DESCRIPTION
`defineNodeType` now returns a `NodeHandler`, meaning it has an `invoke` and `describe` function that will work with other Breadboard systems like the runner and kit builder.

Since `defineNodeType` currently only supports static/monomorphic nodes (polymorphic coming in a follow-up), the schema is completely pre-determined from the configuration.

Part of https://github.com/breadboard-ai/breadboard/issues/1006