### PR TITLE
[build] Strong types for instantiating nodes

### DIFF
--- a/packages/build/src/instance.ts
+++ b/packages/build/src/instance.ts
@@ -4,7 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { InputPort, OutputPort, type PortConfigMap } from "./port.js";
+import {
+  InputPort,
+  OutputPort,
+  type PortConfigMap,
+  type ValuesOrOutputPorts,
+} from "./port.js";
 
 /**
  * An instance of a Breadboard node, constructed from a Breadboard node
@@ -13,9 +18,11 @@ import { InputPort, OutputPort, type PortConfigMap } from "./port.js";
 export class NodeInstance<I extends PortConfigMap, O extends PortConfigMap> {
   readonly inputs: InputPorts<I>;
   readonly outputs: OutputPorts<O>;
-  constructor(inputs: I, outputs: O) {
+  readonly params: ValuesOrOutputPorts<I>;
+  constructor(inputs: I, outputs: O, params: ValuesOrOutputPorts<I>) {
     this.inputs = inputPortsFromPortConfigMap(inputs);
     this.outputs = outputPortsFromPortConfigMap(outputs);
+    this.params = params;
   }
 }
 
@@ -38,7 +45,7 @@ function outputPortsFromPortConfigMap<O extends PortConfigMap>(
       name,
       new OutputPort(config),
     ])
-  ) as InputPorts<O>;
+  ) as OutputPorts<O>;
 }
 
 type InputPorts<I extends PortConfigMap> = {
@@ -48,3 +55,6 @@ type InputPorts<I extends PortConfigMap> = {
 type OutputPorts<O extends PortConfigMap> = {
   [PortName in keyof O]: OutputPort<O[PortName]>;
 };
+
+export type InstantiateParams<Ports extends PortConfigMap> =
+  ValuesOrOutputPorts<Ports>;

--- a/packages/build/src/port.ts
+++ b/packages/build/src/port.ts
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { BreadboardType } from "./type.js";
+import type {
+  BreadboardType,
+  TypeScriptTypeFromBreadboardType,
+} from "./type.js";
 
 /**
  * Configuration parameters for a Breadboard node port.
@@ -27,17 +30,45 @@ export interface PortConfig {
  * A Breadboard node port which receives values.
  */
 export class InputPort<I extends PortConfig> {
-  constructor(_config: I) {}
+  readonly type: I["type"];
+
+  constructor(config: I) {
+    this.type = config.type;
+  }
 }
 
 /**
  * A Breadboard node port which sends values.
  */
 export class OutputPort<O extends PortConfig> {
-  constructor(_config: O) {}
+  readonly type: O["type"];
+
+  constructor(config: O) {
+    this.type = config.type;
+  }
 }
 
 /**
  * A map from port name to port config.
  */
 export type PortConfigMap = Record<string, PortConfig>;
+
+/**
+ * Convert a {@link PortConfigMap} to an object with concrete values for each
+ * port.
+ */
+export type ConcreteValues<Ports extends PortConfigMap> = {
+  [PortName in keyof Ports]: TypeScriptTypeFromBreadboardType<
+    Ports[PortName]["type"]
+  >;
+};
+
+/**
+ * Convert a {@link PortConfigMap} to an object with either concrete values for
+ * each port, or an output port for each port.
+ */
+export type ValuesOrOutputPorts<Ports extends PortConfigMap> = {
+  [PortName in keyof Ports]:
+    | TypeScriptTypeFromBreadboardType<Ports[PortName]["type"]>
+    | OutputPort<Ports[PortName]>;
+};


### PR DESCRIPTION
Nodes must now be instantiated with all input values fulfilled; either by concrete values (e.g. an actual string, number, etc.), or an output port of the same type.

Example:

```ts
const definitionA = defineNodeType(
  {},
  {
    out1: {
      type: "string",
    },
    out2: {
      type: "number",
    },
  },
  () => {
    return {
      out1: "foo",
      out2: 123,
    };
  }
);

const definitionB = defineNodeType(
  {
    in1: {
      type: "string",
    },
    in2: {
      type: "number",
    },
  },
  {},
  () => {
    return {};
  }
);

const instanceA = definitionA();

const instanceB = definitionB({
  in1: "foo",
  in2: instanceA.outputs.out2,
});
```

Part of https://github.com/breadboard-ai/breadboard/issues/1006