### PR TITLE
[breadboard-ui] Store metadata for node positions on move

### DIFF
--- a/packages/breadboard-ui/src/elements/editor/editor.ts
+++ b/packages/breadboard-ui/src/elements/editor/editor.ts
@@ -20,8 +20,10 @@ import {
   GraphNodeEdgeAttachEvent,
   GraphNodeEdgeChangeEvent,
   GraphNodeEdgeDetachEvent,
+  GraphNodeMoveEvent,
   NodeCreateEvent,
   NodeDeleteEvent,
+  NodeMoveEvent,
 } from "../../events/events.js";
 import { GraphRenderer } from "./graph-renderer.js";
 import { Graph } from "./graph.js";
@@ -64,6 +66,7 @@ export class Editor extends LitElement {
   #onDragOverBound = this.#onDragOver.bind(this);
   #onResizeBound = this.#onResize.bind(this);
   #onPointerDownBound = this.#onPointerDown.bind(this);
+  #onGraphNodeMoveBound = this.#onGraphNodeMove.bind(this);
   #onGraphEdgeAttachBound = this.#onGraphEdgeAttach.bind(this);
   #onGraphEdgeDetachBound = this.#onGraphEdgeDetach.bind(this);
   #onGraphEdgeChangeBound = this.#onGraphEdgeChange.bind(this);
@@ -174,6 +177,11 @@ export class Editor extends LitElement {
       this.#onGraphNodeDeleteBound
     );
 
+    this.#graphRenderer.addEventListener(
+      GraphNodeMoveEvent.eventName,
+      this.#onGraphNodeMoveBound
+    );
+
     window.addEventListener("resize", this.#onResizeBound);
     this.addEventListener("pointerdown", this.#onPointerDownBound);
     this.addEventListener("dragover", this.#onDragOverBound);
@@ -203,6 +211,11 @@ export class Editor extends LitElement {
       this.#onGraphNodeDeleteBound
     );
 
+    this.#graphRenderer.removeEventListener(
+      GraphNodeMoveEvent.eventName,
+      this.#onGraphNodeMoveBound
+    );
+
     window.removeEventListener("resize", this.#onResizeBound);
     this.removeEventListener("pointerdown", this.#onPointerDownBound);
     this.removeEventListener("dragover", this.#onDragOverBound);
@@ -225,12 +238,25 @@ export class Editor extends LitElement {
     }
   }
 
-  #onPointerDown() {
+  #onPointerDown(evt: Event) {
     if (!this.#addButtonRef.value) {
       return;
     }
 
+    const [top] = evt.composedPath();
+    if (
+      top instanceof HTMLLabelElement &&
+      top.getAttribute("for") === "add-node"
+    ) {
+      return;
+    }
+
     this.#addButtonRef.value.checked = false;
+  }
+
+  #onGraphNodeMove(evt: Event) {
+    const { id, x, y } = evt as GraphNodeMoveEvent;
+    this.dispatchEvent(new NodeMoveEvent(id, x, y));
   }
 
   #onGraphEdgeAttach(evt: Event) {

--- a/packages/breadboard-ui/src/elements/editor/graph-node.ts
+++ b/packages/breadboard-ui/src/elements/editor/graph-node.ts
@@ -126,13 +126,14 @@ export class GraphNode extends PIXI.Graphics {
         this.x = Math.round(originalPosition.x + dragDeltaX);
         this.y = Math.round(originalPosition.y + dragDeltaY);
 
-        this.emit(GRAPH_OPERATIONS.GRAPH_NODE_MOVED, this.x, this.y);
+        this.emit(GRAPH_OPERATIONS.GRAPH_NODE_MOVED, this.x, this.y, false);
       }
     );
 
     const onPointerUp = () => {
       dragStart = null;
       originalPosition = null;
+      this.emit(GRAPH_OPERATIONS.GRAPH_NODE_MOVED, this.x, this.y, true);
     };
 
     this.addEventListener("pointerupoutside", onPointerUp);

--- a/packages/breadboard-ui/src/elements/editor/graph-renderer.ts
+++ b/packages/breadboard-ui/src/elements/editor/graph-renderer.ts
@@ -13,6 +13,7 @@ import {
   GraphNodeEdgeAttachEvent,
   GraphNodeEdgeChangeEvent,
   GraphNodeEdgeDetachEvent,
+  GraphNodeMoveEvent,
 } from "../../events/events.js";
 import { GRAPH_OPERATIONS } from "./types.js";
 import { Graph } from "./graph.js";
@@ -183,6 +184,13 @@ export class GraphRenderer extends LitElement {
 
   addGraph(graph: Graph) {
     graph.editable = this.editable;
+
+    graph.on(
+      GRAPH_OPERATIONS.GRAPH_NODE_MOVED,
+      (id: string, x: number, y: number) => {
+        this.dispatchEvent(new GraphNodeMoveEvent(id, x, y));
+      }
+    );
 
     graph.on(
       GRAPH_OPERATIONS.GRAPH_NODE_DETAILS_REQUESTED,

--- a/packages/breadboard-ui/src/elements/editor/graph.ts
+++ b/packages/breadboard-ui/src/elements/editor/graph.ts
@@ -479,7 +479,12 @@ export class Graph extends PIXI.Container {
     return this.#edgeGraphics.get(edgeToString(edge)) || null;
   }
 
-  #onChildMoved(this: { graph: Graph; id: string }, x: number, y: number) {
+  #onChildMoved(
+    this: { graph: Graph; id: string },
+    x: number,
+    y: number,
+    hasSettled: boolean
+  ) {
     this.graph.setNodeLayoutPosition(
       this.id,
       this.graph.toGlobal({ x, y }),
@@ -488,6 +493,13 @@ export class Graph extends PIXI.Container {
 
     this.graph.#drawEdges();
     this.graph.#drawNodeHighlight();
+
+    if (!hasSettled) {
+      return;
+    }
+
+    // Propagate the move event out to the graph renderer when the cursor is released.
+    this.graph.emit(GRAPH_OPERATIONS.GRAPH_NODE_MOVED, this.id, x, y);
   }
 
   #drawNodeHighlight() {

--- a/packages/breadboard-ui/src/events/events.ts
+++ b/packages/breadboard-ui/src/events/events.ts
@@ -209,6 +209,38 @@ export class EdgeChangeEvent extends Event {
   }
 }
 
+export class NodeMoveEvent extends Event {
+  static eventName = "breadboardnodemove";
+
+  constructor(
+    public readonly id: string,
+    public readonly x: number,
+    public readonly y: number
+  ) {
+    super(NodeMoveEvent.eventName, {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    });
+  }
+}
+
+export class GraphNodeMoveEvent extends Event {
+  static eventName = "breadboardgraphnodemove";
+
+  constructor(
+    public readonly id: string,
+    public readonly x: number,
+    public readonly y: number
+  ) {
+    super(GraphNodeMoveEvent.eventName, {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+    });
+  }
+}
+
 export class GraphNodeSelectedEvent extends Event {
   static eventName = "breadboardgraphnodeselected";
 

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -664,6 +664,35 @@ export class Main extends LitElement {
               this.#updateLoadInfo(editableGraph.raw());
             });
           }}
+          @breadboardnodemove=${(evt: BreadboardUI.Events.NodeMoveEvent) => {
+            if (!this.loadInfo) {
+              console.warn("Unable to update node metadata; no active graph");
+              return;
+            }
+
+            const loadInfo = this.loadInfo;
+            if (!loadInfo.graphDescriptor) {
+              console.warn(
+                "Unable to update node metadata; no graph descriptor"
+              );
+              return;
+            }
+
+            const editableGraph = edit(loadInfo.graphDescriptor, {
+              kits: this.kits,
+            });
+
+            const { id, x, y } = evt;
+            editableGraph
+              .changeMetadata(id, { visual: { x, y } })
+              .then((result) => {
+                if (!result.success) {
+                  this.toast(result.error, BreadboardUI.Events.ToastType.ERROR);
+                }
+
+                this.#updateLoadInfo(editableGraph.raw());
+              });
+          }}
           @breadboardnodecreate=${(
             evt: BreadboardUI.Events.NodeCreateEvent
           ) => {


### PR DESCRIPTION
This is the first bit of work to persist node positions in the board/graph descriptor. When a node is moved its position is now held in the `metadata.visual` section. Next steps:

1. Apply the visual information to the node when it's received.
2. Emit visual information in more cases (initial layout, node added).