### PR TITLE
[build] Add board function

### DIFF
--- a/packages/build/src/board.ts
+++ b/packages/build/src/board.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  NodeDescriberFunction,
+  NodeHandlerFunction,
+} from "@google-labs/breadboard";
+import type { NodeDefinition } from "./definition.js";
+import { NodeInstance, type InstantiateParams } from "./instance.js";
+import type { InputPort, OutputPort, PortConfig } from "./port.js";
+import type { BreadboardType } from "./type.js";
+
+// TODO(aomarks) There should be a chance to add data to the output node. You
+// pass in the port, which determines the type, but everything else should be
+// configurable (e.g. description). Maybe there is an option to automatically
+// pull the description.
+
+/**
+ * Define a new Breadboard board.
+ *
+ * Example usage:
+ *
+ * ```ts
+ * export const recipeMaker = board(
+ *   // Inputs
+ *   {recipeName},
+ *   // Outputs
+ *   {recipe: llmRecipeResult}
+ * );
+ * ```
+ *
+ * @param inputs The input ports that should be exposed from nodes in the board
+ * and under which name. An object that maps from an exposed port name to an
+ * input port from a node in the board.
+ * @param output The output ports that should be exposed from nodes in the board
+ * and under which name. An object that maps from an exposed port name to an
+ * output port from a node in the board.
+ * @return A {@link BoardDefinition} which can be serialized for execution or
+ * distribution, and which can be instantiated for composition into another
+ * board.
+ */
+export function board<
+  I extends Record<string, InputPort<PortConfig>>,
+  O extends Record<string, OutputPort<PortConfig>>,
+>(inputs: I, outputs: O): BoardDefinition<I, O> {
+  const def = (
+    params: InstantiateParams<BoardPortConfig<I>>
+  ): BoardInstance<I, O> => {
+    return new NodeInstance(
+      boardPortsConfig(inputs),
+      boardPortsConfig(outputs),
+      params
+    );
+  };
+  // TODO(aomarks) Implement (though, do we need to? maybe boards shouldn't have
+  // invoke and describe?)
+  def.invoke = (() => ({})) as unknown as NodeHandlerFunction;
+  def.describe = (() => ({})) as unknown as NodeDescriberFunction;
+  return def;
+}
+
+function boardPortsConfig<
+  PortMap extends Record<
+    string,
+    InputPort<PortConfig> | OutputPort<PortConfig>
+  >,
+>(portMap: PortMap): BoardPortConfig<PortMap> {
+  const configMap: Record<string, { type: BreadboardType }> = {};
+  for (const [portName, { type }] of Object.entries(portMap)) {
+    configMap[portName] = { type };
+  }
+  return configMap as BoardPortConfig<PortMap>;
+}
+
+export type BoardDefinition<
+  I extends Record<string, InputPort<PortConfig>>,
+  O extends Record<string, OutputPort<PortConfig>>,
+> = NodeDefinition<BoardPortConfig<I>, BoardPortConfig<O>>;
+
+export type BoardInstance<
+  I extends Record<string, InputPort<PortConfig>>,
+  O extends Record<string, OutputPort<PortConfig>>,
+> = NodeInstance<BoardPortConfig<I>, BoardPortConfig<O>>;
+
+type BoardPortConfig<
+  PortMap extends Record<
+    string,
+    InputPort<PortConfig> | OutputPort<PortConfig>
+  >,
+> = {
+  [PortName in keyof PortMap]: PortMap[PortName] extends
+    | InputPort<infer PortConfig>
+    | OutputPort<infer PortConfig>
+    ? PortConfig
+    : never;
+};

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -5,3 +5,4 @@
  */
 
 export { defineNodeType } from "./definition.js";
+export { board } from "./board.js";

--- a/packages/build/src/port.ts
+++ b/packages/build/src/port.ts
@@ -30,6 +30,7 @@ export interface PortConfig {
  * A Breadboard node port which receives values.
  */
 export class InputPort<I extends PortConfig> {
+  readonly __InputPortBrand__!: never;
   readonly type: I["type"];
 
   constructor(config: I) {
@@ -41,6 +42,7 @@ export class InputPort<I extends PortConfig> {
  * A Breadboard node port which sends values.
  */
 export class OutputPort<O extends PortConfig> {
+  readonly __OutputPortBrand__!: never;
   readonly type: O["type"];
 
   constructor(config: O) {

--- a/packages/build/src/test/board_test.ts
+++ b/packages/build/src/test/board_test.ts
@@ -1,0 +1,167 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { test } from "node:test";
+import { board, defineNodeType } from "@breadboard-ai/build";
+
+const testNode = defineNodeType(
+  {
+    inStr: {
+      type: "string",
+    },
+    inNum: {
+      type: "number",
+    },
+  },
+  {
+    outNum: {
+      type: "number",
+    },
+    outStr: {
+      type: "string",
+    },
+  },
+  () => {
+    return {
+      outNum: 123,
+      outStr: "foo",
+    };
+  }
+)({ inStr: "foo", inNum: 123 });
+const { inStr, inNum } = testNode.inputs;
+const { outNum, outStr } = testNode.outputs;
+
+test("expect type: 0 in, 0 out", () => {
+  // $ExpectType BoardDefinition<{}, {}>
+  const definition = board({}, {});
+  // $ExpectType NodeInstance<BoardPortConfig<{}>, BoardPortConfig<{}>>
+  definition({});
+  // $ExpectType NodeInstance<BoardPortConfig<{}>, BoardPortConfig<{}>>
+  const instance = definition({});
+  // $ExpectType InputPorts<BoardPortConfig<{}>>
+  instance.inputs;
+  // $ExpectType OutputPorts<BoardPortConfig<{}>>
+  instance.outputs;
+});
+
+test("expect type: 1 in, 1 out", () => {
+  // $ExpectType BoardDefinition<{ inStr: InputPort<{ type: "string"; }>; }, { outNum: OutputPort<{ type: "number"; }>; }>
+  const definition = board({ inStr }, { outNum });
+  // NodeInstance<BoardPortConfig<{ inStr: InputPort<{ type: "string"; }>; }>, BoardPortConfig<{ outNum: OutputPort<{ type: "boolean"; }>; }>>
+  const instance = definition({ inStr: "inStr" });
+  // $ExpectType InputPorts<BoardPortConfig<{ inStr: InputPort<{ type: "string"; }>; }>>
+  instance.inputs;
+  // $ExpectType InputPort<{ type: "string"; }>
+  instance.inputs.inStr;
+  // $ExpectType OutputPorts<BoardPortConfig<{ outNum: OutputPort<{ type: "number"; }>; }>>
+  instance.outputs;
+  // $ExpectType OutputPort<{ type: "number"; }>
+  instance.outputs.outNum;
+});
+
+test("expect type: nested boards", () => {
+  const defA = board({ inNum }, { outStr });
+  const defB = board({ inStr }, { outNum });
+  const instanceA = defA({ inNum: 123 });
+  // $ExpectType NodeInstance<BoardPortConfig<{ inStr: InputPort<{ type: "string"; }>; }>, BoardPortConfig<{ outNum: OutputPort<{ type: "number"; }>; }>>
+  const instanceB = defB({ inStr: instanceA.outputs.outStr });
+  // $ExpectType InputPorts<BoardPortConfig<{ inStr: InputPort<{ type: "string"; }>; }>>
+  instanceB.inputs;
+  // $ExpectType InputPort<{ type: "string"; }>
+  instanceB.inputs.inStr;
+  // $ExpectType OutputPorts<BoardPortConfig<{ outNum: OutputPort<{ type: "number"; }>; }>>
+  instanceB.outputs;
+  // $ExpectType OutputPort<{ type: "number"; }>
+  instanceB.outputs.outNum;
+});
+
+test("expect type error: missing instantiate param", () => {
+  const definition = board({ inStr, inNum }, { outNum });
+  // @ts-expect-error missing both
+  definition();
+  // @ts-expect-error missing both
+  definition({});
+  // @ts-expect-error missing inStr
+  definition({ inNum: 123 });
+  // @ts-expect-error missing inNum
+  definition({ inStr: "inStr" });
+});
+
+test("expect type error: incorrect make instance param type", () => {
+  const definition = board({ inStr, inNum }, {});
+  definition({
+    inStr: "foo",
+    // @ts-expect-error inNum should be number, not string
+    inNum: "123",
+  });
+});
+
+{
+  const boardA = board({}, { outNum, outStr });
+  const boardB = board({ inStr, inNum }, {});
+  const instanceA = boardA({});
+  const instanceB = boardB({ inStr: "foo", inNum: 123 });
+
+  test("can instantiate node with concrete values", () => {
+    boardB({
+      inStr: "foo",
+      inNum: 123,
+    });
+  });
+
+  test("can instantiate node with output ports", () => {
+    boardB({
+      inStr: instanceA.outputs.outStr,
+      inNum: instanceA.outputs.outNum,
+    });
+  });
+
+  test("can instantiate node with mix of concrete values and output ports", () => {
+    boardB({
+      inStr: "foo",
+      inNum: instanceA.outputs.outNum,
+    });
+    boardB({
+      inStr: instanceA.outputs.outStr,
+      inNum: 123,
+    });
+  });
+
+  test("expect error: instantiate with incorrectlty typed concrete value", () => {
+    boardB({
+      // @ts-expect-error Expect string, got number
+      inStr: 123,
+      inNum: 123,
+    });
+    boardB({
+      inStr: "foo",
+      // @ts-expect-error Expect number, got string
+      inNum: "123",
+    });
+  });
+
+  test("expect error: instantiate with incorrectly typed output port", () => {
+    boardB({
+      // @ts-expect-error Expect string, got number
+      inStr: instanceA.outputs.outNum,
+      inNum: instanceA.outputs.outNum,
+    });
+    boardB({
+      inStr: instanceA.outputs.outStr,
+      // @ts-expect-error Expect number, got string
+      inNum: instanceA.outputs.outStr,
+    });
+  });
+
+  test("expect error: wrong kind of port", () => {
+    boardB({
+      // @ts-expect-error Expect OutputPort, got InputPort
+      inStr: instanceB.inputs.inStr,
+      // @ts-expect-error Expect OutputPort, got InputPort
+      inNum: instanceB.inputs.inNum,
+    });
+  });
+}

--- a/packages/build/src/test/define_test.ts
+++ b/packages/build/src/test/define_test.ts
@@ -475,6 +475,7 @@ test("invoke returns value from async function", async () => {
   );
 
   const instanceA = definitionA({});
+  const instanceB = definitionB({ in1: "foo", in2: 123 });
 
   test("can instantiate node with concrete values", () => {
     definitionB({
@@ -524,6 +525,15 @@ test("invoke returns value from async function", async () => {
       in1: instanceA.outputs.out1,
       // @ts-expect-error Expect number, got string
       in2: instanceA.outputs.out1,
+    });
+  });
+
+  test("expect error: wrong kind of port", () => {
+    definitionB({
+      // @ts-expect-error Expect OutputPort, got InputPort
+      in1: instanceB.inputs.in1,
+      // @ts-expect-error Expect OutputPort, got InputPort
+      in2: instanceB.inputs.in2,
     });
   });
 }


### PR DESCRIPTION
Adds a `board()` function to `@breadboard-ai/build`. It takes the input ports/output ports from nodes in that board which should be exposed as input/output nodes on that board.

Example:

```ts
...

export const recipeMaker = board(
  {dish: prompt.inputs.recipe},
  {recipe: llm.outputs.completion}
);
```

Part of https://github.com/breadboard-ai/breadboard/issues/1006