### PR TITLE
[build] Add "primary" setting which allows nodes to be wired more concisely

### DIFF
--- a/packages/build/src/board.ts
+++ b/packages/build/src/board.ts
@@ -13,6 +13,8 @@ import { NodeInstance, type InstantiateParams } from "./instance.js";
 import type { InputPort, OutputPort, PortConfig } from "./port.js";
 import type { BreadboardType } from "./type.js";
 
+// TODO(aomarks) Support primary nodes in boards too.
+
 // TODO(aomarks) There should be a chance to add data to the output node. You
 // pass in the port, which determines the type, but everything else should be
 // configurable (e.g. description). Maybe there is an option to automatically
@@ -72,6 +74,7 @@ function boardPortsConfig<
   for (const [portName, { type }] of Object.entries(portMap)) {
     configMap[portName] = { type };
   }
+  // TODO(aomarks) It might be possible to avoid this cast.
   return configMap as BoardPortConfig<PortMap>;
 }
 

--- a/packages/build/src/definition.ts
+++ b/packages/build/src/definition.ts
@@ -31,7 +31,8 @@ import type { PortConfigMap, ConcreteValues } from "./port.js";
  *   // Outputs
  *   {
  *     backwards: {
- *       type: "string"
+ *       type: "string",
+ *       primary: true
  *     }
  *   },
  *   // Invoke function

--- a/packages/build/src/instance.ts
+++ b/packages/build/src/instance.ts
@@ -7,6 +7,7 @@
 import {
   InputPort,
   OutputPort,
+  OutputPortGetter,
   type PortConfigMap,
   type ValuesOrOutputPorts,
 } from "./port.js";
@@ -19,10 +20,27 @@ export class NodeInstance<I extends PortConfigMap, O extends PortConfigMap> {
   readonly inputs: InputPorts<I>;
   readonly outputs: OutputPorts<O>;
   readonly params: ValuesOrOutputPorts<I>;
+  readonly [OutputPortGetter]!: PrimaryOutputPort<O>;
+
   constructor(inputs: I, outputs: O, params: ValuesOrOutputPorts<I>) {
     this.inputs = inputPortsFromPortConfigMap(inputs);
     this.outputs = outputPortsFromPortConfigMap(outputs);
     this.params = params;
+
+    const primaryOutputPortNames = Object.keys(
+      Object.entries(outputs).filter(([, config]) => config.primary)
+    );
+    if (primaryOutputPortNames.length === 1) {
+      this[OutputPortGetter] = this.outputs[
+        primaryOutputPortNames[0]!
+        // TODO(aomarks) It might be possible to avoid this cast.
+      ] as unknown as PrimaryOutputPort<O>;
+    } else if (primaryOutputPortNames.length > 0) {
+      // TODO(aomarks) Also catch this error earlier, inside `defineNodeType`.
+      throw new Error(
+        `Node was configured with >1 primary output nodes: ${primaryOutputPortNames.join(" ")}`
+      );
+    }
   }
 }
 
@@ -34,6 +52,7 @@ function inputPortsFromPortConfigMap<I extends PortConfigMap>(
       name,
       new InputPort(config),
     ])
+    // TODO(aomarks) It might be possible to avoid this cast.
   ) as InputPorts<I>;
 }
 
@@ -45,6 +64,7 @@ function outputPortsFromPortConfigMap<O extends PortConfigMap>(
       name,
       new OutputPort(config),
     ])
+    // TODO(aomarks) It might be possible to avoid this cast.
   ) as OutputPorts<O>;
 }
 
@@ -58,3 +78,14 @@ type OutputPorts<O extends PortConfigMap> = {
 
 export type InstantiateParams<Ports extends PortConfigMap> =
   ValuesOrOutputPorts<Ports>;
+
+type GetPrimaryPortType<Ports extends PortConfigMap> = {
+  [Name in keyof Ports]: Ports[Name] extends { primary: true }
+    ? Ports[Name]
+    : never;
+}[keyof Ports]["type"];
+
+type PrimaryOutputPort<O extends PortConfigMap> =
+  GetPrimaryPortType<O> extends never
+    ? never
+    : OutputPort<{ type: GetPrimaryPortType<O> }>;


### PR DESCRIPTION
Allows annotating an output port as `primary`, which means that the node that owns the port will itself act like the primary port in contexts where output ports are expected. (Will add input ports in a follow up, primary output ports seem a bit more useful).

Example:

```ts
import { defineNodeType, board } from "@breadboard-ai/build";

const template = defineNodeType(..., {
  result: {
    type: "string",
    primary: true
  }
}, ...);

const prompt = template(...);
const recipe = gemini({prompt});
export const board({dish: prompt.inputs.dish}, {recipe});
```

Part of https://github.com/breadboard-ai/breadboard/issues/1006