### PR TITLE
[build] Nodes without primary outputs should never be OutputPortReferences

### DIFF
--- a/packages/build/src/instance.ts
+++ b/packages/build/src/instance.ts
@@ -87,5 +87,5 @@ type GetPrimaryPortType<Ports extends PortConfigMap> = {
 
 type PrimaryOutputPort<O extends PortConfigMap> =
   GetPrimaryPortType<O> extends never
-    ? never
+    ? undefined
     : OutputPort<{ type: GetPrimaryPortType<O> }>;

--- a/packages/build/src/test/define_test.ts
+++ b/packages/build/src/test/define_test.ts
@@ -580,3 +580,27 @@ test("node with primary output acts like that output port", () => {
     in1: instance,
   });
 });
+
+test("type error: node without primary output doesn't act like an output port", () => {
+  const definition = defineNodeType(
+    {},
+    {
+      out1: {
+        type: "string",
+      },
+    },
+    () => {
+      return {
+        out1: "foo",
+      };
+    }
+  );
+  const instance = definition({ in1: "foo" });
+  // @ts-expect-error no primary output, not an output
+  instance satisfies OutputPortReference<{ type: "string" }>;
+  assert.equal(
+    // $ExpectType undefined
+    instance[OutputPortGetter],
+    undefined
+  );
+});


### PR DESCRIPTION
Bugfix for the type system for `@breadboard-ai/build`. Previously nodes *without* an annotated primary output would still act like they were output ports.