### PR TITLE
[build] Support for polymorphic inputs

### DIFF
--- a/packages/build/src/board.ts
+++ b/packages/build/src/board.ts
@@ -9,8 +9,13 @@ import type {
   NodeHandlerFunction,
 } from "@google-labs/breadboard";
 import type { NodeDefinition } from "./definition.js";
-import { NodeInstance, type InstantiateParams } from "./instance.js";
-import type { InputPort, OutputPort, StaticPortConfig } from "./port.js";
+import { NodeInstance } from "./instance.js";
+import type {
+  InputPort,
+  OutputPort,
+  StaticPortConfig,
+  ValuesOrOutputPorts,
+} from "./port.js";
 import type { BreadboardType } from "./type.js";
 
 // TODO(aomarks) Support primary nodes in boards too.
@@ -49,7 +54,7 @@ export function board<
   O extends Record<string, OutputPort<StaticPortConfig>>,
 >(inputs: I, outputs: O): BoardDefinition<I, O> {
   const def = (
-    params: InstantiateParams<BoardPortConfig<I>>
+    params: ValuesOrOutputPorts<BoardPortConfig<I>>
   ): BoardInstance<I, O> => {
     return new NodeInstance(
       boardPortsConfig(inputs),
@@ -61,7 +66,8 @@ export function board<
   // invoke and describe?)
   def.invoke = (() => ({})) as unknown as NodeHandlerFunction;
   def.describe = (() => ({})) as unknown as NodeDescriberFunction;
-  return def;
+  // TODO(aomarks) Remove this cast.
+  return def as unknown as BoardDefinition<I, O>;
 }
 
 function boardPortsConfig<

--- a/packages/build/src/board.ts
+++ b/packages/build/src/board.ts
@@ -10,7 +10,7 @@ import type {
 } from "@google-labs/breadboard";
 import type { NodeDefinition } from "./definition.js";
 import { NodeInstance, type InstantiateParams } from "./instance.js";
-import type { InputPort, OutputPort, PortConfig } from "./port.js";
+import type { InputPort, OutputPort, StaticPortConfig } from "./port.js";
 import type { BreadboardType } from "./type.js";
 
 // TODO(aomarks) Support primary nodes in boards too.
@@ -45,8 +45,8 @@ import type { BreadboardType } from "./type.js";
  * board.
  */
 export function board<
-  I extends Record<string, InputPort<PortConfig>>,
-  O extends Record<string, OutputPort<PortConfig>>,
+  I extends Record<string, InputPort<StaticPortConfig>>,
+  O extends Record<string, OutputPort<StaticPortConfig>>,
 >(inputs: I, outputs: O): BoardDefinition<I, O> {
   const def = (
     params: InstantiateParams<BoardPortConfig<I>>
@@ -67,7 +67,7 @@ export function board<
 function boardPortsConfig<
   PortMap extends Record<
     string,
-    InputPort<PortConfig> | OutputPort<PortConfig>
+    InputPort<StaticPortConfig> | OutputPort<StaticPortConfig>
   >,
 >(portMap: PortMap): BoardPortConfig<PortMap> {
   const configMap: Record<string, { type: BreadboardType }> = {};
@@ -79,19 +79,19 @@ function boardPortsConfig<
 }
 
 export type BoardDefinition<
-  I extends Record<string, InputPort<PortConfig>>,
-  O extends Record<string, OutputPort<PortConfig>>,
+  I extends Record<string, InputPort<StaticPortConfig>>,
+  O extends Record<string, OutputPort<StaticPortConfig>>,
 > = NodeDefinition<BoardPortConfig<I>, BoardPortConfig<O>>;
 
 export type BoardInstance<
-  I extends Record<string, InputPort<PortConfig>>,
-  O extends Record<string, OutputPort<PortConfig>>,
+  I extends Record<string, InputPort<StaticPortConfig>>,
+  O extends Record<string, OutputPort<StaticPortConfig>>,
 > = NodeInstance<BoardPortConfig<I>, BoardPortConfig<O>>;
 
 type BoardPortConfig<
   PortMap extends Record<
     string,
-    InputPort<PortConfig> | OutputPort<PortConfig>
+    InputPort<StaticPortConfig> | OutputPort<StaticPortConfig>
   >,
 > = {
   [PortName in keyof PortMap]: PortMap[PortName] extends

--- a/packages/build/src/definition.ts
+++ b/packages/build/src/definition.ts
@@ -68,11 +68,27 @@ export function defineNodeType<
   return def;
 }
 
-export interface NodeDefinition<
+/**
+ * The return type for {@link defineNodeType}. An instantiation function for use
+ * in boards, and also a {@link NodeHandler} which can be added to kits.
+ */
+export type NodeDefinition<
   I extends StaticPortConfigMap,
   O extends StaticPortConfigMap,
-> {
-  (params: InstantiateParams<I>): NodeInstance<I, O>;
+> = InstantiateFunction<I, O> & StrictNodeHandler;
+
+/**
+ * A function that creates a {@link NodeInstance}.
+ */
+export type InstantiateFunction<
+  I extends StaticPortConfigMap,
+  O extends StaticPortConfigMap,
+> = (params: InstantiateParams<I>) => NodeInstance<I, O>;
+
+/**
+ * A more tightly constrained version of {@link NodeHandler}.
+ */
+export interface StrictNodeHandler {
   readonly invoke: NodeHandlerFunction;
   readonly describe: NodeDescriberFunction;
 }

--- a/packages/build/src/instance.ts
+++ b/packages/build/src/instance.ts
@@ -8,7 +8,7 @@ import {
   InputPort,
   OutputPort,
   OutputPortGetter,
-  type PortConfigMap,
+  type StaticPortConfigMap,
   type ValuesOrOutputPorts,
 } from "./port.js";
 
@@ -16,7 +16,10 @@ import {
  * An instance of a Breadboard node, constructed from a Breadboard node
  * definition.
  */
-export class NodeInstance<I extends PortConfigMap, O extends PortConfigMap> {
+export class NodeInstance<
+  I extends StaticPortConfigMap,
+  O extends StaticPortConfigMap,
+> {
   readonly inputs: InputPorts<I>;
   readonly outputs: OutputPorts<O>;
   readonly params: ValuesOrOutputPorts<I>;
@@ -44,7 +47,7 @@ export class NodeInstance<I extends PortConfigMap, O extends PortConfigMap> {
   }
 }
 
-function inputPortsFromPortConfigMap<I extends PortConfigMap>(
+function inputPortsFromPortConfigMap<I extends StaticPortConfigMap>(
   inputs: I
 ): InputPorts<I> {
   return Object.fromEntries(
@@ -56,7 +59,7 @@ function inputPortsFromPortConfigMap<I extends PortConfigMap>(
   ) as InputPorts<I>;
 }
 
-function outputPortsFromPortConfigMap<O extends PortConfigMap>(
+function outputPortsFromPortConfigMap<O extends StaticPortConfigMap>(
   outputs: O
 ): OutputPorts<O> {
   return Object.fromEntries(
@@ -68,24 +71,24 @@ function outputPortsFromPortConfigMap<O extends PortConfigMap>(
   ) as OutputPorts<O>;
 }
 
-type InputPorts<I extends PortConfigMap> = {
+type InputPorts<I extends StaticPortConfigMap> = {
   [PortName in keyof I]: InputPort<I[PortName]>;
 };
 
-type OutputPorts<O extends PortConfigMap> = {
+type OutputPorts<O extends StaticPortConfigMap> = {
   [PortName in keyof O]: OutputPort<O[PortName]>;
 };
 
-export type InstantiateParams<Ports extends PortConfigMap> =
+export type InstantiateParams<Ports extends StaticPortConfigMap> =
   ValuesOrOutputPorts<Ports>;
 
-type GetPrimaryPortType<Ports extends PortConfigMap> = {
+type GetPrimaryPortType<Ports extends StaticPortConfigMap> = {
   [Name in keyof Ports]: Ports[Name] extends { primary: true }
     ? Ports[Name]
     : never;
 }[keyof Ports]["type"];
 
-type PrimaryOutputPort<O extends PortConfigMap> =
+type PrimaryOutputPort<O extends StaticPortConfigMap> =
   GetPrimaryPortType<O> extends never
     ? undefined
     : OutputPort<{ type: GetPrimaryPortType<O> }>;

--- a/packages/build/src/instance.ts
+++ b/packages/build/src/instance.ts
@@ -79,9 +79,6 @@ type OutputPorts<O extends StaticPortConfigMap> = {
   [PortName in keyof O]: OutputPort<O[PortName]>;
 };
 
-export type InstantiateParams<Ports extends StaticPortConfigMap> =
-  ValuesOrOutputPorts<Ports>;
-
 type GetPrimaryPortType<Ports extends StaticPortConfigMap> = {
   [Name in keyof Ports]: Ports[Name] extends { primary: true }
     ? Ports[Name]

--- a/packages/build/src/test/define-polymorphic_test.ts.ts
+++ b/packages/build/src/test/define-polymorphic_test.ts.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { defineNodeType } from "@breadboard-ai/build";
+import { test } from "node:test";
+
+test("polymorphic inputs", () => {
+  // $ExpectType NodeDefinition<{ in1: { type: "string"; }; "*": { type: "number"; }; }, { out1: { type: "string"; }; }>
+  const definition = defineNodeType(
+    {
+      in1: {
+        type: "string",
+      },
+      "*": {
+        type: "number",
+      },
+    },
+    {
+      out1: {
+        type: "string",
+      },
+    },
+
+    (
+      // TODO(aomarks) $ExpectType { in1: string; } & Record<string, number>
+      params
+    ) => {
+      // $ExpectType string
+      params.in1;
+      // TODO(aomarks) $ExpectType number | undefined
+      // @ts-expect-error TODO(aomarks) should compile
+      params.in2;
+      return {
+        out1: "foo",
+      };
+    }
+  );
+  // @ts-expect-error missing required parameter
+  definition({});
+  definition({ in1: "foo" });
+  definition({ in1: "foo", in2: 123 });
+  definition({
+    in1: "foo",
+    // @ts-expect-error expected number, got string
+    in2: "123",
+  });
+  definition({
+    in1: "foo",
+    // @ts-expect-error expected number, got null
+    in2: null,
+  });
+  const instance = definition({ in1: "foo", in2: 123 });
+  // TODO(aomarks) @ts-expect-error Wildcard port isn't real
+  instance.inputs["*"];
+  // $ExpectType InputPort<{ type: "string"; }>
+  instance.inputs.in1;
+  // $ExpectType InputPort<{ type: number; }>
+  instance.inputs.in2;
+  // @ts-expect-error No such port
+  instance.inputs.in3;
+
+  const definition2 = defineNodeType(
+    {},
+    {
+      strOut: {
+        type: "string",
+      },
+      numOut: {
+        type: "number",
+      },
+    },
+    () => {
+      return {
+        strOut: "foo",
+        numOut: 123,
+      };
+    }
+  );
+  const instance2 = definition2({});
+  definition({ in1: "foo", in2: instance2.outputs.numOut });
+  // @ts-expect-error expected number, got string
+  definition({ in1: "foo", in2: instance2.outputs.strOut });
+  // @ts-expect-error expected number, got instance
+  definition({ in1: "foo", in2: instance2 });
+});

--- a/packages/build/src/test/define-primary-port_test.ts
+++ b/packages/build/src/test/define-primary-port_test.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { defineNodeType } from "@breadboard-ai/build";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { OutputPortGetter, type OutputPortReference } from "../port.js";
+
+test("node with primary output acts like that output port", () => {
+  const withPrimaryOut = defineNodeType(
+    {
+      in1: {
+        type: "string",
+      },
+    },
+    {
+      out1: {
+        type: "string",
+      },
+      out2: {
+        type: "number",
+        primary: true,
+      },
+      out3: {
+        type: "boolean",
+      },
+    },
+    () => {
+      return {
+        out1: "foo",
+        out2: 123,
+        out3: true,
+      };
+    }
+  );
+  const instance = withPrimaryOut({ in1: "foo" });
+  instance satisfies OutputPortReference<{ type: "number" }>;
+  // $ExpectType OutputPort<{ type: "number"; }>
+  instance[OutputPortGetter];
+
+  defineNodeType({ in1: { type: "number" } }, {}, () => ({}))({
+    in1: instance,
+  });
+
+  defineNodeType({ in1: { type: "string" } }, {}, () => ({}))({
+    // @ts-expect-error in1 expects string, not number
+    in1: instance,
+  });
+});
+
+test("type error: node without primary output doesn't act like an output port", () => {
+  const definition = defineNodeType(
+    {},
+    {
+      out1: {
+        type: "string",
+      },
+    },
+    () => {
+      return {
+        out1: "foo",
+      };
+    }
+  );
+  const instance = definition({ in1: "foo" });
+  // @ts-expect-error no primary output, not an output
+  instance satisfies OutputPortReference<{ type: "string" }>;
+  assert.equal(
+    // $ExpectType undefined
+    instance[OutputPortGetter],
+    undefined
+  );
+});

--- a/packages/build/src/test/define_test.ts
+++ b/packages/build/src/test/define_test.ts
@@ -13,7 +13,6 @@ import type {
   NodeHandlerFunction,
 } from "@google-labs/breadboard";
 import assert from "node:assert/strict";
-import { OutputPortGetter, type OutputPortReference } from "../port.js";
 
 test("expect types: 0 in, 0 out", () => {
   // $ExpectType NodeDefinition<{}, {}>
@@ -503,7 +502,7 @@ test("invoke returns value from async function", async () => {
     });
   });
 
-  test("expect error: instantiate with incorrectlty typed concrete value", () => {
+  test("expect error: instantiate with incorrectly typed concrete value", () => {
     definitionB({
       // @ts-expect-error Expect string, got number
       in1: 123,
@@ -538,69 +537,3 @@ test("invoke returns value from async function", async () => {
     });
   });
 }
-
-test("node with primary output acts like that output port", () => {
-  const withPrimaryOut = defineNodeType(
-    {
-      in1: {
-        type: "string",
-      },
-    },
-    {
-      out1: {
-        type: "string",
-      },
-      out2: {
-        type: "number",
-        primary: true,
-      },
-      out3: {
-        type: "boolean",
-      },
-    },
-    () => {
-      return {
-        out1: "foo",
-        out2: 123,
-        out3: true,
-      };
-    }
-  );
-  const instance = withPrimaryOut({ in1: "foo" });
-  instance satisfies OutputPortReference<{ type: "number" }>;
-  // $ExpectType OutputPort<{ type: "number"; }>
-  instance[OutputPortGetter];
-
-  defineNodeType({ in1: { type: "number" } }, {}, () => ({}))({
-    in1: instance,
-  });
-
-  defineNodeType({ in1: { type: "string" } }, {}, () => ({}))({
-    // @ts-expect-error in1 expects string, not number
-    in1: instance,
-  });
-});
-
-test("type error: node without primary output doesn't act like an output port", () => {
-  const definition = defineNodeType(
-    {},
-    {
-      out1: {
-        type: "string",
-      },
-    },
-    () => {
-      return {
-        out1: "foo",
-      };
-    }
-  );
-  const instance = definition({ in1: "foo" });
-  // @ts-expect-error no primary output, not an output
-  instance satisfies OutputPortReference<{ type: "string" }>;
-  assert.equal(
-    // $ExpectType undefined
-    instance[OutputPortGetter],
-    undefined
-  );
-});

--- a/packages/build/src/type.ts
+++ b/packages/build/src/type.ts
@@ -11,6 +11,12 @@
 export type BreadboardType = "string" | "number" | "boolean";
 
 /**
+ * The TypeScript types that can be automatically mapped back to
+ * BreadboardTypes.
+ */
+export type BreadboardTypeScriptTypes = string | number | boolean;
+
+/**
  * Convert from {@link BreadboardType} to TypeScript type.
  */
 export type TypeScriptTypeFromBreadboardType<BT extends BreadboardType> =
@@ -21,3 +27,16 @@ export type TypeScriptTypeFromBreadboardType<BT extends BreadboardType> =
       : BT extends "boolean"
         ? boolean
         : never;
+
+/**
+ * Convert from TypeScript type to {@link BreadboardType}.
+ */
+export type BreadboardTypeFromTypeScriptType<
+  TT extends BreadboardTypeScriptTypes,
+> = TT extends string
+  ? "string"
+  : TT extends number
+    ? "number"
+    : TT extends boolean
+      ? "boolean"
+      : never;


### PR DESCRIPTION
Add to the `@breadboard-ai/build` package the ability to use `"*"` (syntax subject to change!) to declare a node that can dynamically receive input ports when it is instantiated.

Example:

```ts
import {defineNodeType} from '@breadboard-ai/build';

const template = defineNodeType(
{
  template: {
    type: "string",
  },
  "*": {
    type: string"
  }
},
{
  result: {
    type: "string"
  }
},
({template, ...rest}) => {
  return ...
}

const prompt = template({
  template: "Write a recipe for the dish {{dish}}",
  dish: "Mashed potatoes"
});

prompt.inputs.dish; // string
```