### PR TITLE
[breadboard-ui] Reset node positions based on board ID

### DIFF
--- a/packages/breadboard-ui/src/elements/editor/editor.ts
+++ b/packages/breadboard-ui/src/elements/editor/editor.ts
@@ -43,6 +43,9 @@ export class Editor extends LitElement {
   loadInfo: LoadArgs | null = null;
 
   @property()
+  boardId: number = -1;
+
+  @property()
   kits: Kit[] = [];
 
   @property()
@@ -62,7 +65,7 @@ export class Editor extends LitElement {
   // Incremented each time a graph is updated, used to avoid extra work
   // inspecting ports when the graph is updated.
   #graphVersion = 0;
-  #lastGraphUrl: string | null = null;
+  #lastBoardId: number = -1;
   #onDropBound = this.#onDrop.bind(this);
   #onDragOverBound = this.#onDragOver.bind(this);
   #onResizeBound = this.#onResize.bind(this);
@@ -136,11 +139,11 @@ export class Editor extends LitElement {
   async #processGraph(descriptor: GraphDescriptor) {
     this.#graphVersion++;
 
-    if (this.loadInfo && this.#lastGraphUrl !== this.loadInfo.url) {
+    if (this.loadInfo && this.#lastBoardId !== this.boardId) {
       this.#graph.clearNodeLayoutPositions();
     }
 
-    this.#lastGraphUrl = this.loadInfo?.url || null;
+    this.#lastBoardId = this.boardId;
 
     const breadboardGraph = inspect(descriptor, { kits: this.kits });
     const ports = new Map<string, InspectableNodePorts>();

--- a/packages/breadboard-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/breadboard-ui/src/elements/ui-controller/ui-controller.ts
@@ -57,6 +57,9 @@ export class UI extends LitElement {
   @property()
   boards: Board[] = [];
 
+  @property()
+  boardId: number = -1;
+
   @state()
   config: UIConfig = {
     showNarrowTimeline: false,
@@ -230,6 +233,7 @@ export class UI extends LitElement {
       .loadInfo=${this.loadInfo}
       .kits=${this.kits}
       .highlightedNodeId=${nodeId}
+      .boardId=${this.boardId}
       @breadboardgraphnodeselected=${(evt: GraphNodeSelectedEvent) => {
         this.selectedNodeId = evt.id;
         this.#autoSwitchSidePanel = 1;

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -595,6 +595,7 @@ export class Main extends LitElement {
           .run=${currentRun}
           .kits=${this.kits}
           .status=${this.status}
+          .boardId=${this.#boardId}
           @breadboardfiledrop=${async (
             evt: BreadboardUI.Events.FileDropEvent
           ) => {


### PR DESCRIPTION
Fixes a bug where the node positions weren't resetting properly when the board changed