### PR TITLE
[build] Check for multiple primary output ports

### DIFF
--- a/packages/build/src/test/define-primary-port_test.ts
+++ b/packages/build/src/test/define-primary-port_test.ts
@@ -74,3 +74,26 @@ test("type error: node without primary output doesn't act like an output port", 
     undefined
   );
 });
+
+test("don't allow multiple primary output ports", () => {
+  assert.throws(
+    () =>
+      defineNodeType(
+        {},
+        {
+          foo: {
+            type: "string",
+            // @ts-expect-error more than one primary
+            primary: true,
+          },
+          bar: {
+            type: "string",
+            // @ts-expect-error more than one primary
+            primary: true,
+          },
+        },
+        () => ({ foo: "foo", bar: "bar" })
+      ),
+    /Node definition has more than one primary output port: foo, bar/
+  );
+});

--- a/packages/build/src/type-util.ts
+++ b/packages/build/src/type-util.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Count the number of items in a type union.
+ *
+ * Examples:
+ *
+ * never ........... 0
+ * "foo" ........... 1
+ * "foo" | "bar" ... 2
+ */
+export type CountUnion<U> = PermuteUnion<U>["length"];
+
+/**
+ * Generate all permutations of the given union as a union of tuples.
+ *
+ * WARNING: This type has quadratic complexity, so it should only be used where
+ * it is expected that the number of values is very small, such as enforcing
+ * that something is 0 or 1.
+ *
+ * Examples:
+ *
+ * never ........... []
+ * "foo" ........... ["foo"]
+ * "foo" | "bar" ... ["foo", "bar"] | ["bar", "foo"]
+ */
+type PermuteUnion<U, T = U> = [U] extends [never]
+  ? []
+  : T extends unknown
+    ? [T, ...PermuteUnion<Exclude<U, T>>]
+    : never;


### PR DESCRIPTION
Don't allow more than one primary output port when defining a node.