### PR TITLE
[build] add `anyOf` and `escapeHatch`

### DIFF
--- a/packages/build/src/test/define_test.ts
+++ b/packages/build/src/test/define_test.ts
@@ -13,7 +13,7 @@ import type {
   NodeHandlerFunction,
 } from "@google-labs/breadboard";
 import assert from "node:assert/strict";
-import { anyOf } from "../type.js";
+import { anyOf, escapeHatch } from "../type.js";
 
 test("expect types: 0 in, 0 out", () => {
   // $ExpectType NodeDefinition<{}, {}>
@@ -403,6 +403,69 @@ test("describe function generates JSON schema with anyOf", async () => {
       return {
         out1: true,
         out2: "foo",
+      };
+    }
+  );
+  assert.deepEqual(await definition.describe(), {
+    inputSchema: {
+      type: "object",
+      properties: {
+        in1: {
+          title: "in1",
+          description: "Description of in1",
+          anyOf: [{ type: "string" }, { type: "number" }],
+        },
+      },
+      required: ["in1"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        out1: {
+          title: "out1",
+          description: "Description of out1",
+          anyOf: [{ type: "boolean" }, { type: "string" }],
+        },
+        out2: {
+          title: "out2",
+          description: "Description of out2",
+          anyOf: [{ type: "boolean" }, { type: "string" }],
+        },
+      },
+      required: ["out1", "out2"],
+    },
+  });
+});
+
+test("describe function generates JSON schema with escapeHatch", async () => {
+  const definition = defineNodeType(
+    {
+      in1: {
+        type: escapeHatch<"FOO" | 123>({
+          anyOf: [{ type: "string" }, { type: "number" }],
+        }),
+        description: "Description of in1",
+      },
+    },
+    {
+      out1: {
+        type: escapeHatch<true | 456>({
+          anyOf: [{ type: "boolean" }, { type: "string" }],
+        }),
+        description: "Description of out1",
+      },
+      out2: {
+        type: escapeHatch<false | 789>({
+          anyOf: [{ type: "boolean" }, { type: "string" }],
+        }),
+        description: "Description of out2",
+      },
+    },
+    (params) => {
+      params.in1 satisfies 123 | "FOO";
+      return {
+        out1: 456,
+        out2: false,
       };
     }
   );

--- a/packages/build/src/test/define_test.ts
+++ b/packages/build/src/test/define_test.ts
@@ -13,6 +13,7 @@ import type {
   NodeHandlerFunction,
 } from "@google-labs/breadboard";
 import assert from "node:assert/strict";
+import { anyOf } from "../type.js";
 
 test("expect types: 0 in, 0 out", () => {
   // $ExpectType NodeDefinition<{}, {}>
@@ -374,6 +375,64 @@ test("describe function generates JSON schema", async () => {
         },
       },
       required: ["out1"],
+    },
+  });
+});
+
+test("describe function generates JSON schema with anyOf", async () => {
+  const definition = defineNodeType(
+    {
+      in1: {
+        type: anyOf("string", "number"),
+        description: "Description of in1",
+      },
+    },
+    {
+      out1: {
+        type: anyOf("boolean", "string"),
+        description: "Description of out1",
+      },
+      out2: {
+        type: anyOf("boolean", "string"),
+        description: "Description of out2",
+      },
+    },
+    (params) => {
+      // $ExpectType string | number
+      params.in1;
+      return {
+        out1: true,
+        out2: "foo",
+      };
+    }
+  );
+  assert.deepEqual(await definition.describe(), {
+    inputSchema: {
+      type: "object",
+      properties: {
+        in1: {
+          title: "in1",
+          description: "Description of in1",
+          anyOf: [{ type: "string" }, { type: "number" }],
+        },
+      },
+      required: ["in1"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        out1: {
+          title: "out1",
+          description: "Description of out1",
+          anyOf: [{ type: "boolean" }, { type: "string" }],
+        },
+        out2: {
+          title: "out2",
+          description: "Description of out2",
+          anyOf: [{ type: "boolean" }, { type: "string" }],
+        },
+      },
+      required: ["out1", "out2"],
     },
   });
 });

--- a/packages/build/src/test/type_test.ts
+++ b/packages/build/src/test/type_test.ts
@@ -9,6 +9,7 @@ import {
   toJSONSchema,
   type BreadboardType,
   type TypeScriptTypeFromBreadboardType,
+  escapeHatch,
 } from "../type.js";
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -73,4 +74,27 @@ test("anyOf", () => {
   // $ExpectType string | number | boolean
   type t3 = TypeScriptTypeFromBreadboardType<typeof with3>;
   /* eslint-enable @typescript-eslint/no-unused-vars */
+});
+
+test("escapeHatch", () => {
+  // @ts-expect-error no JSON schema
+  escapeHatch();
+  // @ts-expect-error invalid JSON schema
+  escapeHatch(undefined);
+  // @ts-expect-error invalid JSON schema
+  escapeHatch("string");
+
+  // $ExpectType EscapeHatch<string>
+  const str = escapeHatch<string>({ type: "string" }) satisfies BreadboardType;
+  assert.deepEqual(toJSONSchema(str), {
+    type: "string",
+  });
+
+  // $ExpectType EscapeHatch<string | number>
+  const strOrNum = escapeHatch<string | number>({
+    anyOf: [{ type: "string" }, { type: "number" }],
+  }) satisfies BreadboardType;
+  assert.deepEqual(toJSONSchema(strOrNum), {
+    anyOf: [{ type: "string" }, { type: "number" }],
+  });
 });

--- a/packages/build/src/test/type_test.ts
+++ b/packages/build/src/test/type_test.ts
@@ -4,34 +4,73 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {
-  BreadboardType,
-  TypeScriptTypeFromBreadboardType,
+import {
+  anyOf,
+  toJSONSchema,
+  type BreadboardType,
+  type TypeScriptTypeFromBreadboardType,
 } from "../type.js";
 import { test } from "node:test";
+import assert from "node:assert/strict";
 
-test("basic types are valid", () => {
+test("string", () => {
   "string" satisfies BreadboardType;
-  "number" satisfies BreadboardType;
-  "boolean" satisfies BreadboardType;
-});
-
-test("basic type typos are invalid", () => {
   // @ts-expect-error not a valid basic type
   "xstring" satisfies BreadboardType;
-  // @ts-expect-error not a valid basic type
-  "xnumber" satisfies BreadboardType;
-  // @ts-expect-error not a valid basic type
-  "xboolean" satisfies BreadboardType;
-});
-
-test("convert basic types to typescript", () => {
+  assert.deepEqual(toJSONSchema("string"), { type: "string" });
   /* eslint-disable @typescript-eslint/no-unused-vars */
   // $ExpectType string
-  type s = TypeScriptTypeFromBreadboardType<"string">;
+  type t = TypeScriptTypeFromBreadboardType<"string">;
+  /* eslint-enable @typescript-eslint/no-unused-vars */
+});
+
+test("number", () => {
+  "number" satisfies BreadboardType;
+  // @ts-expect-error not a valid basic type
+  "xnumber" satisfies BreadboardType;
+  assert.deepEqual(toJSONSchema("number"), { type: "number" });
+  /* eslint-disable @typescript-eslint/no-unused-vars */
   // $ExpectType number
-  type n = TypeScriptTypeFromBreadboardType<"number">;
+  type t = TypeScriptTypeFromBreadboardType<"number">;
+  /* eslint-enable @typescript-eslint/no-unused-vars */
+});
+
+test("boolean", () => {
+  "boolean" satisfies BreadboardType;
+  // @ts-expect-error not a valid basic type
+  "xboolean" satisfies BreadboardType;
+  assert.deepEqual(toJSONSchema("boolean"), { type: "boolean" });
+  /* eslint-disable @typescript-eslint/no-unused-vars */
   // $ExpectType boolean
-  type b = TypeScriptTypeFromBreadboardType<"boolean">;
+  type t = TypeScriptTypeFromBreadboardType<"boolean">;
+  /* eslint-enable @typescript-eslint/no-unused-vars */
+});
+
+test("anyOf", () => {
+  // @ts-expect-error no arguments
+  anyOf();
+  // @ts-expect-error only one argument
+  anyOf("number");
+  // @ts-expect-error not a valid type
+  anyOf(undefined);
+  // @ts-expect-error not a valid type
+  anyOf("xnumber", "xstring");
+
+  const with2 = anyOf("number", "boolean") satisfies BreadboardType;
+  assert.deepEqual(toJSONSchema(with2), {
+    anyOf: [{ type: "number" }, { type: "boolean" }],
+  });
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  // $ExpectType number | boolean
+  type t2 = TypeScriptTypeFromBreadboardType<typeof with2>;
+  /* eslint-enable @typescript-eslint/no-unused-vars */
+
+  const with3 = anyOf("number", "boolean", "string") satisfies BreadboardType;
+  assert.deepEqual(toJSONSchema(with3), {
+    anyOf: [{ type: "number" }, { type: "boolean" }, { type: "string" }],
+  });
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  // $ExpectType string | number | boolean
+  type t3 = TypeScriptTypeFromBreadboardType<typeof with3>;
   /* eslint-enable @typescript-eslint/no-unused-vars */
 });

--- a/packages/build/src/type.ts
+++ b/packages/build/src/type.ts
@@ -81,6 +81,8 @@ export type BreadboardTypeFromTypeScriptType<
       ? "boolean"
       : never;
 
+// TODO(aomarks) Expand this to the full vocabulary of JSONSchema so that
+// `escapeHatch` can be fully flexible (for now it's OK to cast to JSONSchema).
 export type JSONSchema =
   | { type: "string" | "number" | "boolean" }
   | { anyOf: JSONSchema[] };

--- a/packages/build/src/type.ts
+++ b/packages/build/src/type.ts
@@ -14,6 +14,33 @@ export type BreadboardType =
 
 export type BasicBreadboardType = "string" | "number" | "boolean";
 
+/**
+ * Create a type that can have any of the given `members`. Equivalent to JSON
+ * Schema's `anyOf`, and TypeScript's union operator (`|`).
+ *
+ * @param members The types which are allowed to match.
+ * @returns A `BreadboardType` which
+ */
+export function anyOf<
+  T extends [BreadboardType, BreadboardType, ...BreadboardType[]],
+>(...members: T) {
+  return new AnyOf<T>(members);
+}
+
+/**
+ * If none of the included type utilities are able to express both the required
+ * JSON Schema and its corresponding TypeScript type, then `escapeHatch` can be
+ * used to create a type that directly specifies both.
+ *
+ * @param jsonSchema The JSON schema that will always be returned when a port
+ * has this type.
+ * @returns A `BreadboardType` which carries both the TypeScript type provided
+ * via the `T` generic parameter, and the corresponding JSON schema.
+ */
+export function escapeHatch<T>(jsonSchema: JSONSchema) {
+  return new EscapeHatch<T>(jsonSchema);
+}
+
 const AdvancedType = Symbol();
 
 export interface AdvancedBreadboardType<T> {
@@ -62,12 +89,6 @@ export function toJSONSchema(type: BreadboardType): JSONSchema {
   return typeof type === "string" ? { type } : type.toJSONSchema();
 }
 
-export function anyOf<
-  T extends [BreadboardType, BreadboardType, ...BreadboardType[]],
->(...members: T) {
-  return new AnyOf<T>(members);
-}
-
 export type { AnyOf };
 class AnyOf<T extends [BreadboardType, BreadboardType, ...BreadboardType[]]> {
   #members: T;
@@ -81,5 +102,17 @@ class AnyOf<T extends [BreadboardType, BreadboardType, ...BreadboardType[]]> {
     return {
       anyOf: this.#members.map(toJSONSchema),
     };
+  }
+}
+
+export type { EscapeHatch };
+class EscapeHatch<T> {
+  #jsonSchema: JSONSchema;
+  readonly [AdvancedType]!: T;
+  constructor(jsonSchema: JSONSchema) {
+    this.#jsonSchema = jsonSchema;
+  }
+  toJSONSchema() {
+    return this.#jsonSchema;
   }
 }


### PR DESCRIPTION
Adds an `anyOf` function that allows defining ports that are allowed to have more than one type. For example, `anyOf("string", "number")` will generate the TypeScript type `string|number`, and also the JSON schema `{anyOf: [{type: "string"}, {type: "number"}]`.

Also adds an `escapeHatch` function that allows defining arbitrary TypeScript + JSON Schema mappings for port types. Useful for when none of the other type utilities we have will suffice. For example: `escapeHatch<MyWeirdType>({my: {weird: {jsonSchema}}})`.