### PR TITLE
[breadboard-ui] Fix case sensitivity of file URLs

### DIFF
--- a/packages/breadboard-ui/src/elements/nav/nav.ts
+++ b/packages/breadboard-ui/src/elements/nav/nav.ts
@@ -26,7 +26,11 @@ export class Navigation extends LitElement {
   @property()
   storageItems: Map<
     string,
-    { permission: "prompt" | "granted"; items: Map<string, unknown> }
+    {
+      permission: "prompt" | "granted";
+      items: Map<string, unknown>;
+      title: string;
+    }
   > | null = null;
 
   @property({ reflect: true })
@@ -308,10 +312,10 @@ export class Navigation extends LitElement {
     if (this.storageItems) {
       storageItems = html`${map(
         this.storageItems,
-        ([location, { permission, items }]) => {
+        ([location, { permission, items, title }]) => {
           return html` <details open>
             <summary>
-              <span>${location}</span>
+              <span>${title}</span>
               <button
                 @click=${() => {
                   this.dispatchEvent(new FileStorageRefreshEvent(location));

--- a/packages/breadboard-web/src/file-storage/file-storage.ts
+++ b/packages/breadboard-web/src/file-storage/file-storage.ts
@@ -75,6 +75,7 @@ export class FileStorage implements GraphProvider {
     string,
     {
       permission: "unknown" | "prompt" | "granted";
+      title: string;
       items: Map<string, FileSystemFileHandle>;
     }
   >();
@@ -107,7 +108,7 @@ export class FileStorage implements GraphProvider {
 
       let files = this.#items.get(name);
       if (!files) {
-        files = { permission, items: new Map() };
+        files = { permission, items: new Map(), title: handle.name };
         this.#items.set(name, files);
       }
 
@@ -210,7 +211,7 @@ export class FileStorage implements GraphProvider {
       case "fileSystem": {
         try {
           const handle = await window.showDirectoryPicker();
-          this.#locations.set(handle.name, handle);
+          this.#locations.set(handle.name.toLowerCase(), handle);
           await this.#storeLocations();
           await this.#refreshItems();
         } catch (err) {


### PR DESCRIPTION
I noticed that files would fail to load from a mounted a folder with capital letters in its name. Because URL creation converts to lowercase it meant that we were failing to match the location portion of the URL with the folder name. Now we always store the location as lowercase, but we query the handle's name for the title in the nav.