### PR TITLE
[breadboard-web] Use URI Component for paths

### DIFF
--- a/packages/breadboard-web/src/file-storage/file-storage.ts
+++ b/packages/breadboard-web/src/file-storage/file-storage.ts
@@ -243,7 +243,10 @@ export class FileStorage implements GraphProvider {
       case "fileSystem": {
         try {
           const handle = await window.showDirectoryPicker();
-          this.#locations.set(handle.name.toLowerCase(), handle);
+          this.#locations.set(
+            encodeURIComponent(handle.name.toLocaleLowerCase()),
+            handle
+          );
           await this.#storeLocations();
           await this.#refreshItems();
         } catch (err) {


### PR DESCRIPTION
Following on from earlier, any special characters (like spaces) also need URI encoding so that they match with the URL. So now the location path that is stored uses `encodeURIComponent`.