### PR TITLE
[breadboard-ui] Check for icons

### DIFF
--- a/packages/breadboard-ui/src/elements/activity-log/activity-log.ts
+++ b/packages/breadboard-ui/src/elements/activity-log/activity-log.ts
@@ -855,8 +855,10 @@ export class ActivityLog extends LitElement {
                 string,
                 string
               >;
-              classes.icon = true;
-              styles["--node-icon"] = `url(${visual.icon})`;
+              if (visual.icon) {
+                classes.icon = true;
+                styles["--node-icon"] = `url(${visual.icon})`;
+              }
             }
 
             return html`<div


### PR DESCRIPTION
I was assuming that if `visual` existed on `metadata` that we were dealing with a node which had an icon. In fact it may just be that the node has `[x, y]` coordinates. This PR changes things so we confirm that there is an icon before we set the class and icon value in Activity Log