### PR TITLE
[breadboard-ui] Deselect a node when it is deleted

### DIFF
--- a/packages/breadboard-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/breadboard-ui/src/elements/ui-controller/ui-controller.ts
@@ -10,6 +10,7 @@ import { Board, LoadArgs, STATUS } from "../../types/types.js";
 import {
   GraphNodeSelectedEvent,
   InputEnterEvent,
+  NodeDeleteEvent,
   RunEvent,
   ToastEvent,
   ToastType,
@@ -244,6 +245,13 @@ export class UI extends LitElement {
       .graphProviders=${this.graphProviders}
       .highlightedNodeId=${nodeId}
       .boardId=${this.boardId}
+      @breadboardnodedelete=${(evt: NodeDeleteEvent) => {
+        if (evt.id !== this.selectedNodeId) {
+          return;
+        }
+
+        this.selectedNodeId = null;
+      }}
       @breadboardgraphnodeselected=${(evt: GraphNodeSelectedEvent) => {
         this.selectedNodeId = evt.id;
         this.#autoSwitchSidePanel = 1;


### PR DESCRIPTION
I noticed that when a node is deleted it might still be the selected node. This watches for delete events on the editor and deselects the node if need be.