### PR TITLE
[breadboard-ui] Allow saving of non-FS boards

### DIFF
--- a/.changeset/empty-vans-sip.md
+++ b/.changeset/empty-vans-sip.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard-web": patch
+---
+
+Allow saving of non FS files


### PR DESCRIPTION
With this change you can now open a blank file (or any non-FS-backed board) and hit the "Save button". This will trigger the "Save file" flow. If you save a file to an existing sources we'll pick it up, otherwise the file will be fairly similar to an export.