### PR TITLE
[build] Allow custom describe function for polymorphic nodes

### DIFF
--- a/packages/build/src/define.ts
+++ b/packages/build/src/define.ts
@@ -11,6 +11,7 @@ import {
 } from "./definition-monomorphic.js";
 import {
   definePolymorphicNodeType,
+  type DescribeInputsFunction,
   type PolymorphicDefinition,
   type PolymorphicInvokeFunction,
 } from "./definition-polymorphic.js";
@@ -70,11 +71,14 @@ export function defineNodeType<
   outputs: ForbidMultiplePrimaries<OSHAPE>,
   invoke: IsPolymorphic<ISHAPE> extends true
     ? PolymorphicInvokeFunction<ISHAPE, OSHAPE>
-    : MonomorphicInvokeFunction<ISHAPE, OSHAPE>
+    : MonomorphicInvokeFunction<ISHAPE, OSHAPE>,
+  describe?: IsPolymorphic<ISHAPE> extends true
+    ? DescribeInputsFunction<ISHAPE>
+    : never
 ): NodeDefinition<ISHAPE, OSHAPE> {
   validateOutputs(outputs);
   const def = isPolymorphic(inputs, invoke)
-    ? definePolymorphicNodeType(inputs, outputs, invoke)
+    ? definePolymorphicNodeType(inputs, outputs, invoke, describe)
     : defineMonomorphicNodeType(inputs, outputs, invoke);
   return def as NodeDefinition<ISHAPE, OSHAPE>;
 }

--- a/packages/build/src/definition.ts
+++ b/packages/build/src/definition.ts
@@ -20,6 +20,9 @@ export type ValueOrPort<CONFIG extends PortConfig> =
 
 /**
  * A more tightly constrained version of {@link NodeHandler}.
+ *
+ * TODO(aomarks) Give stronger types to invoke and describe, parameterized by
+ * the node definition they belong to.
  */
 export interface StrictNodeHandler {
   readonly invoke: NodeHandlerFunction;

--- a/packages/build/src/json-schema.ts
+++ b/packages/build/src/json-schema.ts
@@ -11,11 +11,13 @@ export function shapeToJSONSchema(shape: PortConfigMap) {
   return {
     type: "object",
     properties: Object.fromEntries(
-      [...Object.entries(shape)].map(([title, { description, type }]) => {
-        return [
-          title,
-          Object.assign({ title, description }, toJSONSchema(type)),
-        ];
+      [...Object.entries(shape)].map(([name, { description, type }]) => {
+        const schema = toJSONSchema(type);
+        schema.title = name;
+        if (description !== undefined) {
+          schema.description = description;
+        }
+        return [name, schema];
       })
     ),
     required: [...Object.keys(shape)],

--- a/packages/build/src/test/monomorphic_test.ts
+++ b/packages/build/src/test/monomorphic_test.ts
@@ -359,7 +359,6 @@ test("describe function generates JSON schema", async () => {
         },
         in2: {
           title: "in2",
-          description: undefined,
           type: "number",
         },
       },

--- a/packages/build/src/type.ts
+++ b/packages/build/src/type.ts
@@ -83,9 +83,10 @@ export type BreadboardTypeFromTypeScriptType<
 
 // TODO(aomarks) Expand this to the full vocabulary of JSONSchema so that
 // `escapeHatch` can be fully flexible (for now it's OK to cast to JSONSchema).
-export type JSONSchema =
-  | { type: "string" | "number" | "boolean" }
-  | { anyOf: JSONSchema[] };
+export type JSONSchema = {
+  title?: string;
+  description?: string;
+} & ({ type: "string" | "number" | "boolean" } | { anyOf: JSONSchema[] });
 
 export function toJSONSchema(type: BreadboardType): JSONSchema {
   return typeof type === "string" ? { type } : type.toJSONSchema();


### PR DESCRIPTION
Limitations:
- Only works for input ports (for now)
- Only static inputs are passed to describe function (probably will change this)

Part of https://github.com/breadboard-ai/breadboard/issues/1006