### PR TITLE
simpler loader

### DIFF
--- a/.changeset/nine-melons-confess.md
+++ b/.changeset/nine-melons-confess.md
@@ -1,0 +1,8 @@
+---
+"@google-labs/breadboard-web": patch
+"@google-labs/breadboard-ui": patch
+"@google-labs/breadboard": patch
+"@google-labs/core-kit": patch
+---
+
+Bring loader machinery closer to cacheable load state.

--- a/packages/breadboard-ui/src/elements/editor/editor.ts
+++ b/packages/breadboard-ui/src/elements/editor/editor.ts
@@ -13,7 +13,7 @@ import {
   Kit,
   NodeConfiguration,
   InspectableNodePorts,
-  GraphProvider,
+  GraphLoader,
 } from "@google-labs/breadboard";
 import {
   EdgeChangeEvent,
@@ -53,7 +53,7 @@ export class Editor extends LitElement {
   kits: Kit[] = [];
 
   @property()
-  graphProviders: GraphProvider[] = [];
+  loader: GraphLoader | null = null;
 
   @property()
   editable = false;
@@ -156,7 +156,7 @@ export class Editor extends LitElement {
 
     const breadboardGraph = inspect(descriptor, {
       kits: this.kits,
-      graphProviders: this.graphProviders || [],
+      loader: this.loader || undefined,
     });
     const ports = new Map<string, InspectableNodePorts>();
     const graphVersion = this.#graphVersion;

--- a/packages/breadboard-ui/src/elements/node-info/node-info.ts
+++ b/packages/breadboard-ui/src/elements/node-info/node-info.ts
@@ -9,7 +9,7 @@ import { LitElement, html, css, PropertyValueMap } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { LoadArgs } from "../../types/types.js";
 import {
-  GraphProvider,
+  GraphLoader,
   InspectableNode,
   InspectablePort,
   Kit,
@@ -31,7 +31,7 @@ export class NodeInfo extends LitElement {
   kits: Kit[] = [];
 
   @property()
-  graphProviders: GraphProvider[] = [];
+  loader: GraphLoader | null = null;
 
   @property()
   editable = false;
@@ -52,7 +52,7 @@ export class NodeInfo extends LitElement {
       const descriptor = loadInfo.graphDescriptor;
       const breadboardGraph = inspect(descriptor, {
         kits: this.kits,
-        graphProviders: this.graphProviders,
+        loader: this.loader || undefined,
       });
       const node = breadboardGraph.nodeById(nodeId);
 
@@ -283,7 +283,7 @@ export class NodeInfo extends LitElement {
     const descriptor = this.loadInfo.graphDescriptor;
     const breadboardGraph = inspect(descriptor, {
       kits: this.kits,
-      graphProviders: this.graphProviders,
+      loader: this.loader || undefined,
     });
     const node = breadboardGraph.nodeById(id);
     if (!node) {

--- a/packages/breadboard-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/breadboard-ui/src/elements/ui-controller/ui-controller.ts
@@ -16,7 +16,7 @@ import {
   ToastType,
 } from "../../events/events.js";
 import { HarnessRunResult } from "@google-labs/breadboard/harness";
-import { GraphProvider, InspectableRun, Kit } from "@google-labs/breadboard";
+import { GraphLoader, InspectableRun, Kit } from "@google-labs/breadboard";
 import { Ref, createRef, ref } from "lit/directives/ref.js";
 import { styles as uiControllerStyles } from "./ui-controller.styles.js";
 import { JSONTree } from "../elements.js";
@@ -50,7 +50,7 @@ export class UI extends LitElement {
   kits: Kit[] = [];
 
   @property()
-  graphProviders: GraphProvider[] = [];
+  loader: GraphLoader | null = null;
 
   @property({ reflect: true })
   status = STATUS.RUNNING;
@@ -242,7 +242,7 @@ export class UI extends LitElement {
       .editable=${true}
       .loadInfo=${this.loadInfo}
       .kits=${this.kits}
-      .graphProviders=${this.graphProviders}
+      .loader=${this.loader}
       .highlightedNodeId=${nodeId}
       .boardId=${this.boardId}
       @breadboardnodedelete=${(evt: NodeDeleteEvent) => {
@@ -346,7 +346,7 @@ export class UI extends LitElement {
           .selectedNodeId=${this.selectedNodeId}
           .loadInfo=${this.loadInfo}
           .kits=${this.kits}
-          .graphProviders=${this.graphProviders}
+          .loader=${this.loader}
           .editable=${true}
           name="Selected Node"
           slot="slot-1"

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -5,7 +5,7 @@
  */
 
 import { FileStorage } from "./file-storage/file-storage.js";
-import { run, RunConfig } from "@google-labs/breadboard/harness";
+import { run } from "@google-labs/breadboard/harness";
 import { createRef, ref, type Ref } from "lit/directives/ref.js";
 import { customElement, property, state } from "lit/decorators.js";
 import { LitElement, html, css, HTMLTemplateResult, nothing } from "lit";
@@ -603,7 +603,7 @@ export class Main extends LitElement {
           .loadInfo=${this.loadInfo}
           .run=${currentRun}
           .kits=${this.kits}
-          .graphProviders=${[this.#boardStorage]}
+          .loader=${this.#loader}
           .status=${this.status}
           .boardId=${this.#boardId}
           @breadboardfiledrop=${async (
@@ -637,14 +637,15 @@ export class Main extends LitElement {
               this.loadInfo.graphDescriptor
             );
 
-            const runConfig: RunConfig = {
-              url: this.loadInfo.graphDescriptor.url,
-              runner,
-              diagnostics: true,
-              kits: this.kits,
-              graphProviders: [this.#boardStorage],
-            };
-            this.#runBoard(run(runConfig));
+            this.#runBoard(
+              run({
+                url: this.loadInfo.graphDescriptor.url,
+                runner,
+                diagnostics: true,
+                kits: this.kits,
+                loader: this.#loader,
+              })
+            );
           }}
           @breadboardedgechange=${(
             evt: BreadboardUI.Events.EdgeChangeEvent
@@ -662,7 +663,7 @@ export class Main extends LitElement {
 
             const editableGraph = edit(loadInfo.graphDescriptor, {
               kits: this.kits,
-              graphProviders: [this.#boardStorage],
+              loader: this.#loader,
             });
 
             let editResult: Promise<EditResult>;

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -14,6 +14,7 @@ import { InputResolveRequest } from "@google-labs/breadboard/remote";
 import {
   Board,
   BoardRunner,
+  createLoader,
   edit,
   EditResult,
   GraphDescriptor,
@@ -30,10 +31,14 @@ import GeminiKit from "@google-labs/gemini-kit";
 const getBoardInfo = async (
   url: string
 ): Promise<BreadboardUI.Types.LoadArgs> => {
-  const runner = await Board.load(url, {
-    base: new URL(window.location.href),
-    graphProviders: [FileStorage.instance()],
-  });
+  const loader = createLoader([FileStorage.instance()]);
+  const base = new URL(window.location.href);
+  const graph = await loader.load(url, { base });
+  if (!graph) {
+    // TODO: Better error handling, maybe a toast?
+    throw new Error(`Unable to load graph: ${url}`);
+  }
+  const runner = await BoardRunner.fromGraphDescriptor(graph);
 
   const { title, description, version } = runner;
   const diagram = runner.mermaid("TD", true, true);

--- a/packages/breadboard-web/src/preview-run.ts
+++ b/packages/breadboard-web/src/preview-run.ts
@@ -9,20 +9,29 @@ import { customElement, property, state } from "lit/decorators.js";
 import { LitElement, PropertyValueMap, css, html, nothing } from "lit";
 import * as BreadboardUI from "@google-labs/breadboard-ui";
 import {
-  Board,
   type InputValues,
   Kit,
   InspectableRunObserver,
   createRunObserver,
   InspectableRun,
+  BoardRunner,
+  createLoader,
 } from "@google-labs/breadboard";
 import { InputResolveRequest } from "@google-labs/breadboard/remote";
 import { InputEnterEvent } from "../../breadboard-ui/dist/src/events/events";
+import { FileStorage } from "./file-storage/file-storage";
 
 type inputCallback = (data: Record<string, unknown>) => void;
 
 export const getBoardInfo = async (url: string) => {
-  const runner = await Board.load(url, { base: new URL(window.location.href) });
+  const loader = createLoader([FileStorage.instance()]);
+  const base = new URL(window.location.href);
+  const graph = await loader.load(url, { base });
+  if (!graph) {
+    // TODO: Better error handling, maybe a toast?
+    throw new Error(`Unable to load graph: ${url}`);
+  }
+  const runner = await BoardRunner.fromGraphDescriptor(graph);
   const { title, description, version } = runner;
   return { title, description, version };
 };

--- a/packages/breadboard/src/editor/graph.ts
+++ b/packages/breadboard/src/editor/graph.ts
@@ -37,9 +37,7 @@ class Graph implements EditableGraph {
   constructor(graph: GraphDescriptor, options: EditableGraphOptions) {
     this.#graph = graph;
     this.#options = options;
-    this.#inspector = inspectableGraph(this.#graph, {
-      kits: this.#options.kits,
-    });
+    this.#inspector = inspectableGraph(this.#graph, options);
   }
 
   #isValidType(type: NodeTypeIdentifier) {

--- a/packages/breadboard/src/harness/local.ts
+++ b/packages/breadboard/src/harness/local.ts
@@ -88,7 +88,7 @@ const errorResult = (error: string | ErrorObject) => {
 
 const load = async (config: RunConfig): Promise<BreadboardRunner> => {
   const base = baseURL(config);
-  const loader = createLoader(config.graphProviders);
+  const loader = config.loader || createLoader();
   const graph = await loader.load(config.url, { base });
   if (!graph) {
     throw new Error(`Unable to load graph from "${config.url}"`);
@@ -99,7 +99,7 @@ const load = async (config: RunConfig): Promise<BreadboardRunner> => {
 export async function* runLocally(config: RunConfig, kits: Kit[]) {
   yield* asyncGen<HarnessRunResult>(async (next) => {
     const runner = config.runner || (await load(config));
-    const loader = createLoader(config.graphProviders);
+    const loader = config.loader || createLoader();
 
     try {
       const probe = config.diagnostics

--- a/packages/breadboard/src/harness/run.ts
+++ b/packages/breadboard/src/harness/run.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { BreadboardRunner, GraphProvider, Kit, asyncGen } from "../index.js";
+import { BreadboardRunner, Kit, asyncGen } from "../index.js";
 import { NodeProxyConfig } from "../remote/config.js";
 import { HTTPClientTransport } from "../remote/http.js";
 import { ProxyClient } from "../remote/proxy.js";
@@ -12,6 +12,7 @@ import { runLocally } from "./local.js";
 import { createSecretAskingKit } from "./secrets.js";
 import { HarnessRunResult } from "./types.js";
 import { runInWorker } from "./worker.js";
+import { GraphProvider, GraphLoader } from "../loader/types.js";
 
 export type ProxyLocation = "main" | "worker" | "http";
 
@@ -53,12 +54,9 @@ export type RunConfig = {
    */
   kits: Kit[];
   /**
-   * The providers of graphs to use by the runtime. These
-   * enable the runtime to load graphs from different sources.
-   *
-   * Currently, providers are only supported in local mode.
+   * The loader to use when loading boards.
    */
-  graphProviders?: GraphProvider[];
+  loader?: GraphLoader;
   /**
    * Specifies the remote environment in which to run the harness.
    * In this situation, the harness creates a runtime client, and relies

--- a/packages/breadboard/src/harness/run.ts
+++ b/packages/breadboard/src/harness/run.ts
@@ -12,7 +12,7 @@ import { runLocally } from "./local.js";
 import { createSecretAskingKit } from "./secrets.js";
 import { HarnessRunResult } from "./types.js";
 import { runInWorker } from "./worker.js";
-import { GraphProvider, GraphLoader } from "../loader/types.js";
+import { GraphLoader } from "../loader/types.js";
 
 export type ProxyLocation = "main" | "worker" | "http";
 

--- a/packages/breadboard/src/index.ts
+++ b/packages/breadboard/src/index.ts
@@ -77,3 +77,4 @@ export { editGraph as edit } from "./editor/graph.js";
  * The Loader API
  */
 export type * from "./loader/types.js";
+export { createLoader } from "./loader/index.js";

--- a/packages/breadboard/src/inspector/graph.ts
+++ b/packages/breadboard/src/inspector/graph.ts
@@ -96,9 +96,10 @@ class Graph implements InspectableGraphWithStore {
     if (!handler || typeof handler === "function" || !handler.describe) {
       return asWired;
     }
+    const loader = this.#options.loader || createLoader();
     const context: NodeDescriberContext = {
       outerGraph: this.#graph,
-      loader: createLoader(this.#options.graphProviders),
+      loader,
     };
     if (this.#url) {
       context.base = this.#url;

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -5,7 +5,7 @@
  */
 
 import { HarnessRunResult, SecretResult } from "../harness/types.js";
-import { GraphProvider } from "../loader/types.js";
+import { GraphLoader } from "../loader/types.js";
 import {
   Edge,
   ErrorResponse,
@@ -176,10 +176,9 @@ export type InspectableGraphOptions = {
    */
   kits?: Kit[];
   /**
-   * Optional, a list of graph providers to use when
-   * inspecting the graph.
+   * The loader to use when loading boards.
    */
-  graphProviders?: GraphProvider[];
+  loader?: GraphLoader;
 };
 
 /**

--- a/packages/core-kit/src/load-board.ts
+++ b/packages/core-kit/src/load-board.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BoardRunner, NodeHandlerContext } from "@google-labs/breadboard";
+
+export const loadBoardFromPath = async (
+  path: string,
+  context: NodeHandlerContext
+) => {
+  const graph = await context.loader?.load(path, context);
+  if (!graph) throw new Error(`Unable to load graph from "${path}"`);
+  return BoardRunner.fromGraphDescriptor(graph);
+};

--- a/packages/core-kit/src/nodes/import.ts
+++ b/packages/core-kit/src/nodes/import.ts
@@ -13,6 +13,7 @@ import type {
   GraphDescriptor,
   LambdaNodeOutputs,
 } from "@google-labs/breadboard";
+import { loadBoardFromPath } from "../load-board.js";
 
 export type ImportNodeInputs = InputValues & {
   path?: string;
@@ -54,18 +55,13 @@ export default {
   ): Promise<LambdaNodeOutputs> => {
     const { path, graph, ...args } = inputs as ImportNodeInputs;
 
-    const base = context.base || new URL(import.meta.url);
-
     const board = graph
       ? (graph as BoardRunner).runOnce // TODO: Hack! Use JSON schema or so instead.
         ? ({ ...graph } as BoardRunner)
         : await BoardRunner.fromGraphDescriptor(graph)
       : path
-      ? await BoardRunner.load(path, {
-          base,
-          outerGraph: context.outerGraph,
-        })
-      : undefined;
+        ? await loadBoardFromPath(path, context)
+        : undefined;
     if (!board) throw Error("No board provided");
     board.args = args;
 

--- a/packages/core-kit/src/nodes/include.ts
+++ b/packages/core-kit/src/nodes/include.ts
@@ -14,6 +14,7 @@ import type {
 } from "@google-labs/breadboard";
 import { BoardRunner } from "@google-labs/breadboard";
 import { SchemaBuilder } from "@google-labs/breadboard/kits";
+import { loadBoardFromPath } from "../load-board.js";
 
 export type IncludeNodeInputs = InputValues & {
   path?: string;
@@ -72,17 +73,12 @@ export default {
 
     // TODO: Please fix the $ref/path mess.
     const source = path || $ref || "";
-    const base = context.base || new URL(import.meta.url);
 
     const runnableBoard = board
       ? await BoardRunner.fromBreadboardCapability(board)
       : graph
-      ? await BoardRunner.fromGraphDescriptor(graph)
-      : await BoardRunner.load(source, {
-          slotted: slottedWithUrls,
-          base,
-          outerGraph: context.outerGraph,
-        });
+        ? await BoardRunner.fromGraphDescriptor(graph)
+        : await loadBoardFromPath(source, context);
 
     return await runnableBoard.runOnce(args, context);
   },

--- a/packages/core-kit/src/nodes/invoke.ts
+++ b/packages/core-kit/src/nodes/invoke.ts
@@ -15,21 +15,13 @@ import type {
 } from "@google-labs/breadboard";
 import { BoardRunner, inspect } from "@google-labs/breadboard";
 import { SchemaBuilder } from "@google-labs/breadboard/kits";
+import { loadBoardFromPath } from "../load-board.js";
 
 export type InvokeNodeInputs = InputValues & {
   $board?: string | BreadboardCapability | GraphDescriptor;
   path?: string;
   board?: BreadboardCapability;
   graph?: GraphDescriptor;
-};
-
-export const loadBoardFromPath = async (
-  path: string,
-  context: NodeHandlerContext
-) => {
-  const graph = await context.loader?.load(path, context);
-  if (!graph) throw new Error(`Unable to load graph from "${path}"`);
-  return BoardRunner.fromGraphDescriptor(graph);
 };
 
 type RunnableBoardWithArgs = {


### PR DESCRIPTION
- **Remove a few more `BoardRunner.load` call sites and simplify it too,**
- **Switch `breadboard-web` away from `Board.load`.**
- **Start using one loader instance for all loads.**
- **Switch to use one instance of `GraphLoader`.**
- **Remove spurious import.**
- **docs(changeset): Bring loader machinery closer to cacheable load state.**
