### PR TITLE
[breadboard-ui] Name providers

### DIFF
--- a/packages/breadboard-cli/src/debugger/provider.ts
+++ b/packages/breadboard-cli/src/debugger/provider.ts
@@ -42,6 +42,8 @@ const api = {
 };
 
 export class DebuggerGraphProvider implements GraphProvider {
+  name = "DebuggerGraphProvider";
+
   #blank: URL | null = null;
   #items: Map<string, GraphProviderStore> = new Map();
 

--- a/packages/breadboard-ui/src/elements/nav/nav.ts
+++ b/packages/breadboard-ui/src/elements/nav/nav.ts
@@ -318,7 +318,7 @@ export class Navigation extends LitElement {
     location: string,
     { permission, items, title }: GraphProviderStore
   ) {
-    const providerName = provider.constructor.name;
+    const providerName = provider.name;
     const createBlankBoard = html`<button
       @click=${() => {
         const fileName = prompt(
@@ -420,8 +420,7 @@ export class Navigation extends LitElement {
     const supportsFileSystem =
       this.providers.find((provider) => {
         return (
-          provider.constructor.name === "FileSystemGraphProvider" &&
-          provider.isSupported()
+          provider.name === "FileSystemGraphProvider" && provider.isSupported()
         );
       }) !== undefined;
 

--- a/packages/breadboard-web/index.html
+++ b/packages/breadboard-web/index.html
@@ -49,8 +49,8 @@
 
     const config = {
       providers: [
-        IDBGraphProvider.instance(),
         FileSystemGraphProvider.instance(),
+        IDBGraphProvider.instance(),
         new ExamplesGraphProvider(boards),
       ],
     };

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -587,10 +587,7 @@ export class Main extends LitElement {
   }
 
   #getProviderByName(name: string) {
-    return (
-      this.#providers.find((provider) => provider.constructor.name === name) ||
-      null
-    );
+    return this.#providers.find((provider) => provider.name === name) || null;
   }
 
   #getProviderForURL(url: URL) {

--- a/packages/breadboard-web/src/providers/examples.ts
+++ b/packages/breadboard-web/src/providers/examples.ts
@@ -19,6 +19,8 @@ export type BoardInfo = {
 };
 
 export class ExamplesGraphProvider implements GraphProvider {
+  name = "ExamplesGraphProvider";
+
   #blank: URL | null = null;
   #items: Map<string, GraphProviderStore> = new Map();
 

--- a/packages/breadboard-web/src/providers/file-system.ts
+++ b/packages/breadboard-web/src/providers/file-system.ts
@@ -84,6 +84,8 @@ export class FileSystemGraphProvider implements GraphProvider {
   >();
   #locations = new Map<string, FileSystemDirectoryHandle>();
 
+  name = "FileSystemGraphProvider";
+
   private constructor() {}
 
   createURL(location: string, fileName: string) {

--- a/packages/breadboard-web/src/providers/indexed-db.ts
+++ b/packages/breadboard-web/src/providers/indexed-db.ts
@@ -63,6 +63,8 @@ export class IDBGraphProvider implements GraphProvider {
     }
   >();
 
+  name = "IDBGraphProvider";
+
   private constructor() {}
 
   isSupported() {

--- a/packages/breadboard/src/loader/default.ts
+++ b/packages/breadboard/src/loader/default.ts
@@ -38,6 +38,8 @@ export const loadWithFetch = async (url: string | URL) => {
 };
 
 export class DefaultGraphProvider implements GraphProvider {
+  name = "DefaultGraphProvider";
+
   isSupported(): boolean {
     return true;
   }

--- a/packages/breadboard/src/loader/types.ts
+++ b/packages/breadboard/src/loader/types.ts
@@ -70,6 +70,10 @@ export type GraphProviderExtendedCapabilities = {
  */
 export type GraphProvider = {
   /**
+   * The name of the provider.
+   */
+  name: string;
+  /**
    * Whether the provider is supported or not in the current environment.
    */
   isSupported(): boolean;


### PR DESCRIPTION
I used the constructor name for the providers, but that doesn't work when the classes are minified and their names change! This PR introduces a name property for each provider, which we can use even if the class name is changed.