### PR TITLE
[build] Compatibility with runner and inspector

### DIFF
--- a/.changeset/wise-lobsters-impress.md
+++ b/.changeset/wise-lobsters-impress.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard": patch
+---
+
+Allow node describe() and invoke() to work as long as an object provides those properties

--- a/packages/breadboard/src/handler.ts
+++ b/packages/breadboard/src/handler.ts
@@ -15,8 +15,8 @@ import type {
 } from "./types.js";
 
 const getHandlerFunction = (handler: NodeHandler): NodeHandlerFunction => {
+  if ("invoke" in handler && handler.invoke) return handler.invoke;
   if (handler instanceof Function) return handler;
-  if (handler.invoke) return handler.invoke;
   throw new Error("Invalid handler");
 };
 

--- a/packages/breadboard/src/inspector/graph.ts
+++ b/packages/breadboard/src/inspector/graph.ts
@@ -93,7 +93,7 @@ class Graph implements InspectableGraphWithStore {
       inputSchema: edgesToSchema(EdgeType.In, options?.incoming),
       outputSchema: edgesToSchema(EdgeType.Out, options?.outgoing),
     } satisfies NodeDescriberResult;
-    if (!handler || typeof handler === "function" || !handler.describe) {
+    if (!handler || !("describe" in handler) || !handler.describe) {
       return asWired;
     }
     const loader = this.#options.loader || createLoader();

--- a/packages/build/src/compatibility.ts
+++ b/packages/build/src/compatibility.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { NewNodeFactory } from "@google-labs/breadboard";
+import type { MonomorphicDefinition } from "./definition-monomorphic.js";
+import type { PolymorphicDefinition } from "./definition-polymorphic.js";
+import type { TypeScriptTypeFromBreadboardType } from "./type.js";
+
+/**
+ * `KitSignature` takes a {@link NodeDefinition} type (as returned by
+ * {@link defineNodeType}) and produces a {@link NodeFactory} type suitable for
+ * use with {@link KitBuilder}.
+ */
+export type NodeFactoryFromDefinition<
+  // TODO(aomarks) We should use PolymorphicDefinition<PortConfigMap,
+  // PortConfigMap> here instead of <any, any>, but for a currently unknown
+  // reason that won't match some definitions.
+  //
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  DEF extends MonomorphicDefinition<any, any> | PolymorphicDefinition<any, any>,
+> =
+  DEF extends MonomorphicDefinition<infer ISHAPE, infer OSHAPE>
+    ? NewNodeFactory<
+        {
+          [PORT in keyof ISHAPE]: TypeScriptTypeFromBreadboardType<
+            ISHAPE[PORT]["type"]
+          >;
+        },
+        {
+          [PORT in keyof OSHAPE]: TypeScriptTypeFromBreadboardType<
+            OSHAPE[PORT]["type"]
+          >;
+        }
+      >
+    : DEF extends PolymorphicDefinition<infer ISHAPE, infer OSHAPE>
+      ? NewNodeFactory<
+          {
+            [PORT in keyof Omit<ISHAPE, "*">]: TypeScriptTypeFromBreadboardType<
+              ISHAPE[PORT]["type"]
+            >;
+          } & Record<string, unknown>,
+          {
+            [PORT in keyof Omit<OSHAPE, "*">]: TypeScriptTypeFromBreadboardType<
+              OSHAPE[PORT]["type"]
+            >;
+          } & Record<string, unknown>
+        >
+      : never;

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -6,3 +6,4 @@
 
 export { defineNodeType } from "./define.js";
 export { board } from "./board.js";
+export type { NodeFactoryFromDefinition } from "./compatibility.js";

--- a/packages/build/src/test/compatibility_test.ts
+++ b/packages/build/src/test/compatibility_test.ts
@@ -5,62 +5,275 @@
  */
 
 import {
+  addKit,
+  asRuntimeKit,
+  board,
+  Board,
+  inspect,
+} from "@google-labs/breadboard";
+import { KitBuilder } from "@google-labs/breadboard/kits";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
   defineNodeType,
   type NodeFactoryFromDefinition,
 } from "@breadboard-ai/build";
-import { test } from "node:test";
-import { anyOf } from "../type.js";
+import type { MonomorphicDefinition } from "../definition-monomorphic.js";
+import type { PolymorphicDefinition } from "../definition-polymorphic.js";
 
-test("NodeFactory from monomorphic node definition", () => {
-  const definition = defineNodeType(
+function setupKits<
+  DEFS extends Record<
+    string,
+    // TODO(aomarks) See TODO about `any` at {@link NodeFactoryFromDefinition}.
+    //
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    MonomorphicDefinition<any, any> | PolymorphicDefinition<any, any>
+  >,
+>(definitions: DEFS) {
+  const ctr = new KitBuilder({ url: "N/A" }).build(definitions);
+  return {
+    kit: addKit(ctr) as {
+      [NAME in keyof DEFS]: NodeFactoryFromDefinition<DEFS[NAME]>;
+    },
+    runtimeKit: asRuntimeKit(ctr),
+  };
+}
+
+{
+  // A monomorphic node definition
+  const strLen = defineNodeType(
     {
-      in1: {
+      str: {
         type: "string",
       },
-      in2: {
-        type: anyOf("string", "number"),
-      },
     },
     {
-      out1: {
-        type: "boolean",
-      },
-      out2: {
-        type: anyOf("number", "boolean"),
+      len: {
+        type: "number",
       },
     },
-    () => ({
-      out1: true,
-      out2: 42,
-    })
+    ({ str }) => {
+      return {
+        len: str.length,
+      };
+    }
   );
-  /* eslint-disable @typescript-eslint/no-unused-vars */
-  // $ExpectType NodeFactory<{ in1: string; in2: string | number; }, { out1: boolean; out2: number | boolean; }>
-  type _ = NodeFactoryFromDefinition<typeof definition>;
-  /* eslint-enable @typescript-eslint/no-unused-vars */
-});
 
-test("NodeFactory from polymorphic node definition", () => {
-  const definition = defineNodeType(
+  const { kit: strLenKit, runtimeKit: strLenRuntimeKit } = setupKits({
+    strLen,
+  });
+  // $ExpectType { strLen: NodeFactory<{ str: string; }, { len: number; }>; }
+  strLenKit;
+  // $ExpectType Lambda<InputValues, Required<{ boardLen: number; }>>
+  const strLenBoard = await board(({ str }) => {
+    const { len } = strLenKit.strLen({ str: str?.isString() });
+    // TODO(aomarks) Can we provide a type to len automatically?
+    return { boardLen: len.isNumber() };
+  });
+  const strLenSerialized = await strLenBoard.serialize();
+
+  test("monomorphic result via BoardRunner", async () => {
+    const runner = await Board.fromGraphDescriptor(strLenSerialized);
+    const result = await runner.runOnce(
+      { str: "12345" },
+      { kits: [strLenRuntimeKit] }
+    );
+    assert.deepEqual(result, {
+      boardLen: 5,
+      schema: {
+        type: "object",
+        properties: {
+          boardLen: {
+            title: "boardLen",
+            type: "number",
+          },
+        },
+      },
+    });
+  });
+
+  test("monomorphic board schema via inspector", async () => {
+    const inspectable = inspect(strLenSerialized, { kits: [strLenRuntimeKit] });
+    assert.deepEqual(await inspectable.describe(), {
+      inputSchema: {
+        properties: {
+          str: {
+            title: "str",
+            type: "string",
+          },
+        },
+        required: ["str"],
+        type: "object",
+      },
+      outputSchema: {
+        properties: {
+          boardLen: {
+            title: "boardLen",
+            type: "number",
+          },
+          schema: {
+            type: "object",
+          },
+        },
+        type: "object",
+      },
+    });
+  });
+
+  test("monomorphic node schema via inspector", async () => {
+    const inspectable = inspect(strLenSerialized, { kits: [strLenRuntimeKit] });
+    const descriptors = inspectable.nodesByType("strLen");
+    assert.equal(descriptors.length, 1);
+    const descriptor = descriptors[0]!;
+    assert.deepEqual(await descriptor.describe(), {
+      inputSchema: {
+        properties: {
+          str: {
+            title: "str",
+            type: "string",
+          },
+        },
+        required: ["str"],
+        type: "object",
+      },
+      outputSchema: {
+        properties: {
+          len: {
+            title: "len",
+            type: "number",
+          },
+        },
+        required: ["len"],
+        type: "object",
+      },
+    });
+  });
+}
+
+{
+  // A polymorphic node definition
+  const adder = defineNodeType(
     {
-      in1: {
-        type: "string",
+      base: {
+        type: "number",
       },
       "*": {
-        type: anyOf("string", "number"),
+        type: "number",
       },
     },
     {
-      out1: {
-        type: "boolean",
+      sum: {
+        type: "number",
       },
     },
-    () => ({
-      out1: true,
-    })
+    ({ base }, operands) => {
+      return {
+        sum: Object.values(operands).reduce((sum, num) => sum + num, base),
+      };
+    }
   );
-  /* eslint-disable @typescript-eslint/no-unused-vars */
-  // $ExpectType NodeFactory<{ in1: string; } & Record<string, unknown>, { out1: boolean; } & Record<string, unknown>>
-  type _ = NodeFactoryFromDefinition<typeof definition>;
-  /* eslint-enable @typescript-eslint/no-unused-vars */
-});
+
+  const { kit: adderKit, runtimeKit: adderRuntimeKit } = setupKits({
+    adder,
+  });
+  // $ExpectType { adder: NodeFactory<{ base: number; } & Record<string, unknown>, { sum: number; } & Record<string, unknown>>; }
+  adderKit;
+  // $ExpectType Lambda<InputValues, Required<{ boardSum: number; }>>
+  const adderBoard = await board(({ num1, num2, num3 }) => {
+    const { sum } = adderKit.adder({
+      base: 0,
+      num1,
+      num2,
+      num3,
+    });
+    // TODO(aomarks) Can we provide a type to sum automatically?
+    return { boardSum: sum.isNumber() };
+  });
+  const adderSerialized = await adderBoard.serialize();
+
+  test("polymorphic result via BoardRunner", async () => {
+    const runner = await Board.fromGraphDescriptor(adderSerialized);
+    const result = await runner.runOnce(
+      { num1: 1, num2: 2, num3: 3 },
+      { kits: [adderRuntimeKit] }
+    );
+    assert.deepEqual(result, {
+      boardSum: 6,
+      schema: {
+        type: "object",
+        properties: {
+          boardSum: {
+            title: "boardSum",
+            type: "number",
+          },
+        },
+      },
+    });
+  });
+
+  test("polymorphic board schema via inspector", async () => {
+    const inspectable = inspect(adderSerialized, { kits: [adderRuntimeKit] });
+    assert.deepEqual(await inspectable.describe(), {
+      inputSchema: {
+        properties: {
+          num1: {
+            title: "num1",
+            type: "string",
+          },
+          num2: {
+            title: "num2",
+            type: "string",
+          },
+          num3: {
+            title: "num3",
+            type: "string",
+          },
+        },
+        required: ["num1", "num2", "num3"],
+        type: "object",
+      },
+      outputSchema: {
+        properties: {
+          boardSum: {
+            title: "boardSum",
+            type: "number",
+          },
+          schema: {
+            type: "object",
+          },
+        },
+        type: "object",
+      },
+    });
+  });
+
+  test("polymorphic node schema via inspector", async () => {
+    const inspectable = inspect(adderSerialized, { kits: [adderRuntimeKit] });
+    const descriptors = inspectable.nodesByType("adder");
+    assert.equal(descriptors.length, 1);
+    const descriptor = descriptors[0]!;
+    assert.deepEqual(await descriptor.describe(), {
+      inputSchema: {
+        properties: {
+          base: {
+            title: "base",
+            type: "number",
+          },
+          // TODO(aomarks) Shouldn't num1, num2, num3 show up here?
+        },
+        required: ["base"],
+        type: "object",
+      },
+      outputSchema: {
+        properties: {
+          sum: {
+            title: "sum",
+            type: "number",
+          },
+        },
+        required: ["sum"],
+        type: "object",
+      },
+    });
+  });
+}

--- a/packages/build/src/test/compatibility_test.ts
+++ b/packages/build/src/test/compatibility_test.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  defineNodeType,
+  type NodeFactoryFromDefinition,
+} from "@breadboard-ai/build";
+import { test } from "node:test";
+import { anyOf } from "../type.js";
+
+test("NodeFactory from monomorphic node definition", () => {
+  const definition = defineNodeType(
+    {
+      in1: {
+        type: "string",
+      },
+      in2: {
+        type: anyOf("string", "number"),
+      },
+    },
+    {
+      out1: {
+        type: "boolean",
+      },
+      out2: {
+        type: anyOf("number", "boolean"),
+      },
+    },
+    () => ({
+      out1: true,
+      out2: 42,
+    })
+  );
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  // $ExpectType NodeFactory<{ in1: string; in2: string | number; }, { out1: boolean; out2: number | boolean; }>
+  type _ = NodeFactoryFromDefinition<typeof definition>;
+  /* eslint-enable @typescript-eslint/no-unused-vars */
+});
+
+test("NodeFactory from polymorphic node definition", () => {
+  const definition = defineNodeType(
+    {
+      in1: {
+        type: "string",
+      },
+      "*": {
+        type: anyOf("string", "number"),
+      },
+    },
+    {
+      out1: {
+        type: "boolean",
+      },
+    },
+    () => ({
+      out1: true,
+    })
+  );
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  // $ExpectType NodeFactory<{ in1: string; } & Record<string, unknown>, { out1: boolean; } & Record<string, unknown>>
+  type _ = NodeFactoryFromDefinition<typeof definition>;
+  /* eslint-enable @typescript-eslint/no-unused-vars */
+});


### PR DESCRIPTION
Nodes defined with the `@breadboard-ai/build` package are now compatible with the Breadboard runner and inspector API.

Just required a small tweak to the way those APIs check whether something looks like a node type. Previously there were short-circuits for when something was a function, but since `@breadboard-ai/build` node definitions are themselves functions (for use with its `board` API), we instead now just look for an `invoke` or `describe` property.

This also adds a new `NodeFactoryFromDefinition` type utility, which generates a signature for a node type so that it doesn't need to be written out manually when building kits.

Also added integration tests.