### PR TITLE
[build] Add `object` utility to type system

### DIFF
--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -88,6 +88,9 @@ TypeScript API.
 - `anyOf(<type1>, <type2>, ...)`: A function which generates a JSON Schema
   `anyOf` and its corresponding TypeScript union (`type1 | type2`).
 
+- `object({ prop1: <type1>, prop2: <type2> })`: A function which generates a
+  JSON Schema `object` and its corresponding TypeScript `{...}` type.
+
 ### Unsafe type escape hatch
 
 The `unsafeType` function can be used as a last resort escape hatch when the
@@ -231,11 +234,7 @@ export const exampleKit = addKit(ExampleKit) as {
 
 3. `describe` is only passed values for fixed ports, not dynamic ones.
 
-4. There is not yet an `object` type utility (though `unsafeType` can be used as
-   an escape hatch), along with probably a number of other basic and utility
-   types we'll need.
-
-5. There is not currently a type check for excess properties on the return type
+4. There is not currently a type check for excess properties on the return type
    of monomorphic invoke. That is, while TypeScript will enforce that all
    configured output ports have a value, it will not yet complain if an output
    is returned that does not match a configured output port.

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -7,4 +7,5 @@
 export { defineNodeType } from "./internal/define.js";
 export { anyOf } from "./internal/type-system/any-of.js";
 export { unsafeType } from "./internal/type-system/unsafe.js";
+export { object } from "./internal/type-system/object.js";
 export type { NodeFactoryFromDefinition } from "./internal/compatibility.js";

--- a/packages/build/src/internal/type-system/object.ts
+++ b/packages/build/src/internal/type-system/object.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  toJSONSchema,
+  type BreadboardType,
+  type AdvancedBreadboardType,
+  type ConvertBreadboardType,
+} from "./type.js";
+
+/**
+ * Make a Breadboard type for an object.
+ *
+ * @param properties A map from property name to Breadboard Type.
+ */
+export function object<T extends Record<string, BreadboardType>>(
+  properties: T
+): AdvancedBreadboardType<{
+  [P in keyof T]: ConvertBreadboardType<T[P]>;
+}> {
+  return {
+    jsonSchema: {
+      type: "object",
+      properties: Object.fromEntries(
+        Object.entries(properties).map(([name, type]) => [
+          name,
+          toJSONSchema(type),
+        ])
+      ),
+      required: Object.keys(properties),
+    },
+  };
+}

--- a/packages/build/src/test/type_test.ts
+++ b/packages/build/src/test/type_test.ts
@@ -6,6 +6,7 @@
 
 import { anyOf } from "@breadboard-ai/build";
 import { unsafeType } from "@breadboard-ai/build";
+import { object } from "@breadboard-ai/build";
 
 import {
   toJSONSchema,
@@ -73,6 +74,90 @@ test("anyOf", () => {
   type t3 = ConvertBreadboardType<typeof with3>;
   assert.deepEqual(toJSONSchema(with3), {
     anyOf: [{ type: "number" }, { type: "boolean" }, { type: "string" }],
+  });
+
+  /* eslint-enable @typescript-eslint/no-unused-vars */
+});
+
+test("object", () => {
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+
+  // @ts-expect-error no arguments
+  assert.throws(() => object());
+
+  const obj1 = object({});
+  // $ExpectType {}
+  type t1 = ConvertBreadboardType<typeof obj1>;
+  assert.deepEqual(toJSONSchema(obj1), {
+    type: "object",
+    properties: {},
+    required: [],
+  });
+
+  const obj2 = object({ foo: "string", bar: "number" });
+  // $ExpectType { foo: string; bar: number; }
+  type t2 = ConvertBreadboardType<typeof obj2>;
+  assert.deepEqual(toJSONSchema(obj2), {
+    type: "object",
+    properties: {
+      foo: {
+        type: "string",
+      },
+      bar: {
+        type: "number",
+      },
+    },
+    required: ["foo", "bar"],
+  });
+
+  const obj3 = object({ foo: object({ bar: "string" }) });
+  // $ExpectType { foo: { bar: string; }; }
+  type t3 = ConvertBreadboardType<typeof obj3>;
+  assert.deepEqual(toJSONSchema(obj3), {
+    type: "object",
+    properties: {
+      foo: {
+        type: "object",
+        properties: {
+          bar: {
+            type: "string",
+          },
+        },
+        required: ["bar"],
+      },
+    },
+    required: ["foo"],
+  });
+
+  const obj4 = object({ foo: anyOf("string", "number") });
+  // $ExpectType { foo: string | number; }
+  type t4 = ConvertBreadboardType<typeof obj4>;
+  assert.deepEqual(toJSONSchema(obj4), {
+    type: "object",
+    properties: {
+      foo: { anyOf: [{ type: "string" }, { type: "number" }] },
+    },
+    required: ["foo"],
+  });
+
+  const obj5 = object({ foo: anyOf("string", object({ bar: "string" })) });
+  // $ExpectType { foo: string | { bar: string; }; }
+  type t5 = ConvertBreadboardType<typeof obj5>;
+  assert.deepEqual(toJSONSchema(obj5), {
+    type: "object",
+    properties: {
+      foo: {
+        anyOf: [
+          { type: "string" },
+          {
+            type: "object",
+            properties: { bar: { type: "string" } },
+            required: ["bar"],
+          },
+        ],
+      },
+    },
+    required: ["foo"],
   });
 
   /* eslint-enable @typescript-eslint/no-unused-vars */


### PR DESCRIPTION
Adds an `object` Breadboard Type utility that can be used like this:

```ts
import {defineNodeType, object, anyOf} from '@breadboard-ai/build';

export const someNodeTypeThatTakesAnObject = defineNodeType({
  inputs: {
    foo: {
      type: object({
        foo: "string",
        bar: anyOf("string", "number"),
      }),
    },
  },
  ...
});
```

cc @Mearman 