### PR TITLE
[breadboard-cli] Remove support for reading a boards `{args}`.

### DIFF
--- a/packages/breadboard-cli/src/commands/run.ts
+++ b/packages/breadboard-cli/src/commands/run.ts
@@ -41,7 +41,7 @@ async function runBoard(
     if (stop.type === "input") {
       const nodeInputs = stop.inputArguments;
       // we won't mutate the inputs.
-      const newInputs = { ...board.args, ...inputs };
+      const newInputs = { ...inputs };
       const schema = nodeInputs.schema as Schema;
 
       /* 


### PR DESCRIPTION
Fixes #1210 

This was originaly added to enable boards to run that had been saved from the `openapi` board of boards. It would save the inputs to the lambda in the `args` property. With the new import method in the CLI this is no longer needed.
