### PR TITLE
[breadboard-web] Enforce lowercase entry names

### DIFF
--- a/packages/breadboard-web/src/providers/file-system.ts
+++ b/packages/breadboard-web/src/providers/file-system.ts
@@ -311,11 +311,11 @@ export class FileSystemGraphProvider implements GraphProvider {
       }
 
       entries.push([
-        name,
+        name.toLocaleLowerCase(),
         {
           url: this.createURL(
             encodeURIComponent(handle.name.toLocaleLowerCase()),
-            encodeURIComponent(entry.name.toLocaleLowerCase())
+            encodeURIComponent(name.toLocaleLowerCase())
           ),
           handle: entry,
         },


### PR DESCRIPTION
I noticed that FS API labels can have capitals, but because we use URLs (which generally converts components to lower case) we were failing to match. One option was to do a second pass with case insensitivity when we fail to find a match between the URL and the FS API label, but in the end I opted for lowercasing the file name. This will have the corresponding effect of erroneously deduping FS API labels when files share the name but are differentiated by casing, e.g., foo.json and FOO.json, but hopefully that won't occur often enough to be problematic.