### PR TITLE
[breadboard-ui] Remove loadInfo from Activity Log

### DIFF
--- a/.changeset/tricky-sloths-report.md
+++ b/.changeset/tricky-sloths-report.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard-ui": patch
+---
+
+Remove loadInfo from Activity Log

--- a/packages/breadboard-ui/src/elements/activity-log/activity-log.ts
+++ b/packages/breadboard-ui/src/elements/activity-log/activity-log.ts
@@ -18,14 +18,10 @@ import { Ref, createRef, ref } from "lit/directives/ref.js";
 import { InputRequestedEvent } from "../../events/events.js";
 import { map } from "lit/directives/map.js";
 import { styleMap } from "lit/directives/style-map.js";
-import { LoadArgs } from "../../types/types.js";
 import { until } from "lit/directives/until.js";
 
 @customElement("bb-activity-log")
 export class ActivityLog extends LitElement {
-  @property()
-  loadInfo: LoadArgs | null = null;
-
   @property({ reflect: false })
   run: InspectableRun | null = null;
 

--- a/packages/breadboard-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/breadboard-ui/src/elements/ui-controller/ui-controller.ts
@@ -273,7 +273,6 @@ export class UI extends LitElement {
           : nothing}
       >
         <bb-activity-log
-          .loadInfo=${this.loadInfo}
           .run=${this.run}
           .events=${events}
           .eventPosition=${eventPosition}


### PR DESCRIPTION
I noticed we were passing `loadInfo` through to Activity Log, but this is no longer necessary since Activity Log is populated by the current `run`. This PR removes it.