### PR TITLE
[build] Require all concrete values to be JSON serializable

### DIFF
--- a/packages/build/src/internal/define/definition-monomorphic.ts
+++ b/packages/build/src/internal/define/definition-monomorphic.ts
@@ -119,7 +119,8 @@ class MonomorphicNodeInstance<
     this.inputs = Object.fromEntries(
       Object.entries(inputs).map(([name, config]) => [
         name,
-        new InputPort(config, name, this, values[name]),
+        // TODO(aomarks) Can we remove this `!`?
+        new InputPort(config, name, this, values[name]!),
       ])
     ) as InputPorts<ISHAPE>;
     this.outputs = Object.fromEntries(

--- a/packages/build/src/internal/define/definition-polymorphic.ts
+++ b/packages/build/src/internal/define/definition-polymorphic.ts
@@ -268,7 +268,8 @@ class PolymorphicNodeInstance<
     this.inputs = Object.fromEntries([
       ...Object.entries(staticInputs).map(([name, config]) => [
         name,
-        new InputPort(config, name, this, values[name]),
+        // TODO(aomarks) Can we remove this `!`?
+        new InputPort(config, name, this, values[name]!),
       ]),
       ...Object.entries(values)
         .filter(([name]) => staticInputs[name] === undefined)

--- a/packages/build/src/internal/type-system/type.ts
+++ b/packages/build/src/internal/type-system/type.ts
@@ -12,19 +12,28 @@ import type { JSONSchema4 } from "json-schema";
  */
 export type BreadboardType =
   | BasicBreadboardType
-  | AdvancedBreadboardType<unknown>;
+  | AdvancedBreadboardType<JsonSerializable>;
 
 /**
- * The basic types that can be referenced directly.
+ * The basic Breadboard types that can be written directly.
  */
 export type BasicBreadboardType = "string" | "number" | "boolean" | "unknown";
 
 /**
- * A type that's more complicated than a {@link BasicBreadboardType}.
- *
- * By implementing this interface, you are providing a function that will
- * convert you to a JSON Schema at runtime, and also to a TypeScript type at
- * compile time via {@link ConvertBreadboardType}.
+ * All Breadboard values must be JSON serializable, and this is the set of
+ * JSON serializable types.
+ */
+export type JsonSerializable =
+  | string
+  | number
+  | boolean
+  | null
+  | Array<JsonSerializable>
+  | { [K: string]: JsonSerializable };
+
+/**
+ * A type that's more complicated than a {@link BasicBreadboardType}. Directly
+ * owns a TypeScript type for compile time, and a JSON schema for run time.
  */
 export interface AdvancedBreadboardType<
   // We only need to hold onto this type parameter so that we can infer it
@@ -47,7 +56,7 @@ export type ConvertBreadboardType<BT extends BreadboardType> =
       : BT extends "boolean"
         ? boolean
         : BT extends "unknown"
-          ? unknown
+          ? JsonSerializable
           : BT extends AdvancedBreadboardType<infer TT>
             ? TT
             : never;

--- a/packages/build/src/test/type_test.ts
+++ b/packages/build/src/test/type_test.ts
@@ -54,7 +54,7 @@ test("unknown", () => {
   "xunknown" satisfies BreadboardType;
   assert.deepEqual(toJSONSchema("unknown"), {});
   /* eslint-disable @typescript-eslint/no-unused-vars */
-  // $ExpectType unknown
+  // $ExpectType JsonSerializable
   type t = ConvertBreadboardType<"unknown">;
   /* eslint-enable @typescript-eslint/no-unused-vars */
 });


### PR DESCRIPTION
This adds a new `JsonSerializable` type which is now the base type that all `BreadboardType`'s must be convertible to. This e.g. eliminates `undefined` as a possible value, since that's not JSON serializable. We want everything to be JSON serializable so that we can easily support save/restore for runs.