### PR TITLE
[build] Parameterize ports by actual type instead of port config type

### DIFF
--- a/packages/build/src/internal/board/board.ts
+++ b/packages/build/src/internal/board/board.ts
@@ -7,12 +7,9 @@
 import {
   InputPort,
   OutputPort,
-  type InputPorts,
-  type OutputPorts,
-  type PortConfig,
-  type PortConfigMap,
   type ValuesOrOutputPorts,
 } from "../common/port.js";
+import type { JsonSerializable } from "../type-system/type.js";
 
 // TODO(aomarks) Support primary ports in boards.
 // TODO(aomarks) Support adding descriptions to board ports.
@@ -42,9 +39,12 @@ import {
  * board.
  */
 export function board<
-  IPORTS extends BoardInputPorts,
-  OPORTS extends BoardOutputPorts,
->(inputs: IPORTS, outputs: OPORTS): BoardDefinition<IPORTS, OPORTS> {
+  INPUT_PORTS extends BoardInputPorts,
+  OUTPUT_PORTS extends BoardOutputPorts,
+>(
+  inputs: INPUT_PORTS,
+  outputs: OUTPUT_PORTS
+): BoardDefinition<INPUT_PORTS, OUTPUT_PORTS> {
   const def = new BoardDefinitionImpl(inputs, outputs);
   return Object.assign(def.instantiate.bind(def), {
     inputs,
@@ -53,26 +53,26 @@ export function board<
 }
 
 export type BoardDefinition<
-  IPORTS extends BoardInputPorts,
-  OPORTS extends BoardOutputPorts,
-> = BoardInstantiateFunction<IPORTS, OPORTS> & {
-  readonly inputs: IPORTS;
-  readonly outputs: OPORTS;
+  INPUT_PORTS extends BoardInputPorts,
+  OUTPUT_PORTS extends BoardOutputPorts,
+> = BoardInstantiateFunction<INPUT_PORTS, OUTPUT_PORTS> & {
+  readonly inputs: INPUT_PORTS;
+  readonly outputs: OUTPUT_PORTS;
 };
 
 type BoardInstantiateFunction<
-  IPORTS extends BoardInputPorts,
-  OPORTS extends BoardOutputPorts,
+  INPUT_PORTS extends BoardInputPorts,
+  OUTPUT_PORTS extends BoardOutputPorts,
 > = <VALUES extends Record<string, unknown>>(
-  values: BoardInputValues<IPORTS, VALUES>
-) => BoardInstance<IPORTS, OPORTS>;
+  values: BoardInputValues<INPUT_PORTS, VALUES>
+) => BoardInstance<INPUT_PORTS, OUTPUT_PORTS>;
 
 type BoardInputValues<
-  IPORTS extends BoardInputPorts,
-  VALUES extends Record<string, unknown>,
-> = ValuesOrOutputPorts<ExtractPortConfigs<IPORTS>> & {
-  [PORT_NAME in keyof VALUES]: PORT_NAME extends keyof IPORTS
-    ? ValuesOrOutputPorts<ExtractPortConfigs<IPORTS>>[PORT_NAME]
+  INPUT_PORTS extends BoardInputPorts,
+  INPUT_VALUES extends Record<string, unknown>,
+> = ValuesOrOutputPorts<ExtractPortTypes<INPUT_PORTS>> & {
+  [NAME in keyof INPUT_VALUES]: NAME extends keyof INPUT_PORTS
+    ? ValuesOrOutputPorts<ExtractPortTypes<INPUT_PORTS>>[NAME]
     : never;
 };
 
@@ -96,36 +96,32 @@ class BoardDefinitionImpl<
 }
 
 class BoardInstance<
-  IPORTS extends BoardInputPorts,
-  OPORTS extends BoardOutputPorts,
+  INPUT_PORTS extends BoardInputPorts,
+  OUTPUT_PORTS extends BoardOutputPorts,
 > {
-  readonly inputs: InputPorts<ExtractPortConfigs<IPORTS>>;
-  readonly outputs: OutputPorts<ExtractPortConfigs<OPORTS>>;
-  readonly #values: ValuesOrOutputPorts<ExtractPortConfigs<IPORTS>>;
+  readonly inputs: INPUT_PORTS;
+  readonly outputs: OUTPUT_PORTS;
+  // TODO(aomarks) This should get used somewhere.
+  readonly #values: ValuesOrOutputPorts<ExtractPortTypes<INPUT_PORTS>>;
 
   constructor(
-    inputs: IPORTS,
-    outputs: OPORTS,
-    values: ValuesOrOutputPorts<ExtractPortConfigs<IPORTS>>
+    inputs: INPUT_PORTS,
+    outputs: OUTPUT_PORTS,
+    values: ValuesOrOutputPorts<ExtractPortTypes<INPUT_PORTS>>
   ) {
-    // TODO(aomarks) Shouldn't need these casts.
-    this.inputs = inputs as InputPorts<PortConfigMap> as InputPorts<
-      ExtractPortConfigs<IPORTS>
-    >;
-    this.outputs = outputs as OutputPorts<PortConfigMap> as OutputPorts<
-      ExtractPortConfigs<OPORTS>
-    >;
+    this.inputs = inputs;
+    this.outputs = outputs;
     this.#values = values;
   }
 }
 
-type ExtractPortConfigs<PORTS extends BoardInputPorts | BoardOutputPorts> = {
+type ExtractPortTypes<PORTS extends BoardInputPorts | BoardOutputPorts> = {
   [PORT_NAME in keyof PORTS]: PORTS[PORT_NAME] extends
-    | InputPort<infer PORT_CONFIG>
-    | OutputPort<infer PORT_CONFIG>
-    ? { type: PORT_CONFIG["type"] }
+    | InputPort<infer TYPE>
+    | OutputPort<infer TYPE>
+    ? TYPE
     : never;
 };
 
-export type BoardInputPorts = Record<string, InputPort<PortConfig>>;
-export type BoardOutputPorts = Record<string, OutputPort<PortConfig>>;
+export type BoardInputPorts = Record<string, InputPort<JsonSerializable>>;
+export type BoardOutputPorts = Record<string, OutputPort<JsonSerializable>>;

--- a/packages/build/src/internal/common/instance.ts
+++ b/packages/build/src/internal/common/instance.ts
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { InputPort, OutputPortReference, PortConfig } from "./port.js";
+import type { JsonSerializable } from "../type-system/type.js";
+import type { InputPort, OutputPortReference } from "./port.js";
 
 export interface BreadboardNodeInstance<
-  INPUT_PORTS extends Record<string, InputPort<PortConfig>>,
-  OUTPUT_PORTS extends Record<string, OutputPortReference<PortConfig>>,
+  INPUT_PORTS extends Record<string, InputPort<JsonSerializable>>,
+  OUTPUT_PORTS extends Record<string, OutputPortReference<JsonSerializable>>,
 > {
   type: string;
   inputs: INPUT_PORTS;
@@ -16,6 +17,6 @@ export interface BreadboardNodeInstance<
 }
 
 export type GenericBreadboardNodeInstance = BreadboardNodeInstance<
-  Record<string, InputPort<PortConfig>>,
-  Record<string, OutputPortReference<PortConfig>>
+  Record<string, InputPort<JsonSerializable>>,
+  Record<string, OutputPortReference<JsonSerializable>>
 >;

--- a/packages/build/src/test/board_test.ts
+++ b/packages/build/src/test/board_test.ts
@@ -42,24 +42,24 @@ test("expect type: 0 in, 0 out", () => {
   definition({});
   // $ExpectType BoardInstance<{}, {}>
   const instance = definition({});
-  // $ExpectType InputPorts<ExtractPortConfigs<{}>>
+  // $ExpectType {}
   instance.inputs;
-  // $ExpectType OutputPorts<ExtractPortConfigs<{}>>
+  // $ExpectType {}
   instance.outputs;
 });
 
 test("expect type: 1 in, 1 out", () => {
-  // $ExpectType BoardDefinition<{ inStr: InputPort<{ type: "string"; }>; }, { outNum: OutputPort<{ type: "number"; }>; }>
+  // $ExpectType BoardDefinition<{ inStr: InputPort<string>; }, { outNum: OutputPort<number>; }>
   const definition = board({ inStr }, { outNum });
-  // NodeInstance<BoardPortConfig<{ inStr: InputPort<{ type: "string"; }>; }>, BoardPortConfig<{ outNum: OutputPort<{ type: "boolean"; }>; }>>
+  // NodeInstance<BoardPortConfig<{ inStr: InputPort<string>; }>, BoardPortConfig<{ outNum: OutputPort<{ type: "boolean"; }>; }>>
   const instance = definition({ inStr: "inStr" });
-  // $ExpectType InputPorts<ExtractPortConfigs<{ inStr: InputPort<{ type: "string"; }>; }>>
+  // $ExpectType { inStr: InputPort<string>; }
   instance.inputs;
-  // $ExpectType InputPort<{ type: "string"; }>
+  // $ExpectType InputPort<string>
   instance.inputs.inStr;
-  // $ExpectType OutputPorts<ExtractPortConfigs<{ outNum: OutputPort<{ type: "number"; }>; }>>
+  // $ExpectType { outNum: OutputPort<number>; }
   instance.outputs;
-  // $ExpectType OutputPort<{ type: "number"; }>
+  // $ExpectType OutputPort<number>
   instance.outputs.outNum;
 });
 
@@ -67,15 +67,15 @@ test("expect type: nested boards", () => {
   const defA = board({ inNum }, { outStr });
   const defB = board({ inStr }, { outNum });
   const instanceA = defA({ inNum: 123 });
-  // $ExpectType BoardInstance<{ inStr: InputPort<{ type: "string"; }>; }, { outNum: OutputPort<{ type: "number"; }>; }>
+  // $ExpectType BoardInstance<{ inStr: InputPort<string>; }, { outNum: OutputPort<number>; }>
   const instanceB = defB({ inStr: instanceA.outputs.outStr });
-  // $ExpectType InputPorts<ExtractPortConfigs<{ inStr: InputPort<{ type: "string"; }>; }>>
+  // $ExpectType { inStr: InputPort<string>; }
   instanceB.inputs;
-  // $ExpectType InputPort<{ type: "string"; }>
+  // $ExpectType InputPort<string>
   instanceB.inputs.inStr;
-  // $ExpectType OutputPorts<ExtractPortConfigs<{ outNum: OutputPort<{ type: "number"; }>; }>>
+  // $ExpectType { outNum: OutputPort<number>; }
   instanceB.outputs;
-  // $ExpectType OutputPort<{ type: "number"; }>
+  // $ExpectType OutputPort<number>
   instanceB.outputs.outNum;
 });
 

--- a/packages/build/src/test/monomorphic-primary_test.ts
+++ b/packages/build/src/test/monomorphic-primary_test.ts
@@ -40,8 +40,8 @@ test("monomorphic node with primary output acts like that output port", () => {
     },
   });
   const instance = withPrimaryOut({ in1: "foo" });
-  instance satisfies OutputPortReference<{ type: "number" }>;
-  // $ExpectType OutputPort<{ type: "number"; }>
+  instance satisfies OutputPortReference<number>;
+  // $ExpectType OutputPort<number>
   instance[OutputPortGetter];
 
   defineNodeType({

--- a/packages/build/src/test/monomorphic_test.ts
+++ b/packages/build/src/test/monomorphic_test.ts
@@ -54,7 +54,7 @@ test("expect types: 1 in, 0 out", () => {
   });
   // $ExpectType InputPorts<{ in1: { type: "string"; }; }>
   instance.inputs;
-  // $ExpectType InputPort<{ type: "string"; }>
+  // $ExpectType InputPort<string>
   instance.inputs.in1;
   // $ExpectType OutputPorts<{}>
   instance.outputs;
@@ -81,7 +81,7 @@ test("expect types: 0 in, 1 out", () => {
   instance.inputs;
   // $ExpectType OutputPorts<{ out1: { type: "string"; }; }>
   instance.outputs;
-  // $ExpectType OutputPort<{ type: "string"; }>
+  // $ExpectType OutputPort<string>
   instance.outputs.out1;
 });
 
@@ -114,11 +114,11 @@ test("expect types: 1 in, 1 out", () => {
   });
   // $ExpectType InputPorts<{ in1: { type: "string"; }; }>
   instance.inputs;
-  // $ExpectType InputPort<{ type: "string"; }>
+  // $ExpectType InputPort<string>
   instance.inputs.in1;
   // $ExpectType OutputPorts<{ out1: { type: "string"; }; }>
   instance.outputs;
-  // $ExpectType OutputPort<{ type: "string"; }>
+  // $ExpectType OutputPort<string>
   instance.outputs.out1;
 });
 
@@ -161,15 +161,15 @@ test("expect types: 2 in, 2 out", () => {
   });
   // $ExpectType InputPorts<{ in1: { type: "string"; }; in2: { type: "number"; }; }>
   instance.inputs;
-  // $ExpectType InputPort<{ type: "string"; }>
+  // $ExpectType InputPort<string>
   instance.inputs.in1;
-  // $ExpectType InputPort<{ type: "number"; }>
+  // $ExpectType InputPort<number>
   instance.inputs.in2;
   // $ExpectType OutputPorts<{ out1: { type: "boolean"; }; out2: { type: "string"; }; }>
   instance.outputs;
-  // $ExpectType OutputPort<{ type: "boolean"; }>
+  // $ExpectType OutputPort<boolean>
   instance.outputs.out1;
-  // $ExpectType OutputPort<{ type: "string"; }>
+  // $ExpectType OutputPort<string>
   instance.outputs.out2;
 });
 

--- a/packages/build/src/test/polymorphic-primary_test.ts
+++ b/packages/build/src/test/polymorphic-primary_test.ts
@@ -43,8 +43,8 @@ test("polymorphic node with primary output acts like that output port", () => {
     },
   });
   const instance = withPrimaryOut({ in1: "foo", in2: 123 });
-  instance satisfies OutputPortReference<{ type: "number" }>;
-  // $ExpectType OutputPort<{ type: "number"; }>
+  instance satisfies OutputPortReference<number>;
+  // $ExpectType OutputPort<number>
   instance[OutputPortGetter];
 
   defineNodeType({

--- a/packages/build/src/test/polymorphic_test.ts
+++ b/packages/build/src/test/polymorphic_test.ts
@@ -63,7 +63,7 @@ test("polymorphic inputs", () => {
   const instance = definition({ in1: "foo", in2: 123 });
   // @ts-expect-error Wildcard port isn't real
   instance.inputs["*"];
-  // $ExpectType InputPort<{ type: "string"; }>
+  // $ExpectType InputPort<string>
   instance.inputs.in1;
   // @ts-expect-error dynamic ports not exposed
   instance.inputs.in2;

--- a/packages/build/src/test/serialize_test.ts
+++ b/packages/build/src/test/serialize_test.ts
@@ -101,8 +101,7 @@ test("serialize", () => {
   const prompt = templater({
     template: "The word {{forwards}} is {{backwards}} in reverse.",
     forwards: "potato",
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    backwards: backwards.outputs.backwards as any,
+    backwards: backwards.outputs.backwards,
   });
   const myBoard = board({}, { result: prompt.outputs.result });
   assert.deepEqual(


### PR DESCRIPTION
This simplifies IDE tooltips a bunch, e.g. instead of `InputPort<{ type: "string"; }>` we now will just show `InputPort<string>`.

It also fixes an assignment bug in the type system, since we were previously asking the type system to understand that `{type: "string"}` was assignable to `{ type: anyOf("string", "number") }`, which it doesn't actually know; we have to convert to actual types first (since it does know that `string` is assignable to `string | number`).