### PR TITLE
[build] Add input function

### DIFF
--- a/packages/build/src/internal/board/input.ts
+++ b/packages/build/src/internal/board/input.ts
@@ -1,0 +1,121 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  BreadboardType,
+  ConvertBreadboardType,
+  JsonSerializable,
+} from "../type-system/type.js";
+
+// Neither type nor default
+export function input(): Input<string>;
+
+// Type and default
+export function input<T extends BreadboardType>(
+  params: InputParamsWithTypeAndDefault<T>
+): InputWithDefault<ConvertBreadboardType<T>>;
+
+// Only default
+export function input<
+  T extends InputParamsWithOnlyDefault<"string" | "number" | "boolean">,
+>(params: T): InputWithDefault<BroadenBasicType<T["default"]>>;
+
+// Only type
+export function input<T extends InputParamsWithOnlyType<BreadboardType>>(
+  params: T
+): Input<ConvertBreadboardType<T["type"]>>;
+
+/**
+ * Declare an input for a board.
+ *
+ * @param params
+ * @returns
+ */
+export function input(
+  params?: GenericInputParams
+): Input<JsonSerializable> | InputWithDefault<JsonSerializable> {
+  let type: BreadboardType;
+  if (params?.type !== undefined) {
+    type = params.type;
+  } else if (params?.default !== undefined) {
+    switch (typeof params.default) {
+      case "string": {
+        type = "string";
+        break;
+      }
+      case "number": {
+        type = "number";
+        break;
+      }
+      case "boolean": {
+        type = "boolean";
+        break;
+      }
+      default: {
+        throw new Error(
+          `Unknown default type: ${JSON.stringify(params.default)}`
+        );
+      }
+    }
+  } else {
+    type = "string";
+  }
+  return {
+    type,
+    description: params?.description,
+    default: params?.default,
+  } satisfies
+    | Omit<Input<JsonSerializable>, "__type">
+    | InputWithDefault<JsonSerializable> as
+    | Input<JsonSerializable>
+    | InputWithDefault<JsonSerializable>;
+}
+
+interface Input<T extends JsonSerializable> {
+  readonly __type: T & never;
+  readonly type: BreadboardType;
+  readonly description?: string;
+  readonly default: undefined;
+}
+
+interface InputWithDefault<T extends JsonSerializable> {
+  readonly type: BreadboardType;
+  readonly description?: string;
+  readonly default: T;
+}
+
+type GenericInputParams =
+  | InputParamsWithOnlyType<BreadboardType>
+  | InputParamsWithOnlyDefault<"string" | "number" | "boolean">
+  | InputParamsWithTypeAndDefault<BreadboardType>;
+
+interface InputParamsWithOnlyType<T extends BreadboardType> {
+  type: T;
+  description?: string;
+  default?: undefined;
+}
+
+interface InputParamsWithOnlyDefault<
+  T extends "string" | "number" | "boolean",
+> {
+  type?: undefined;
+  description?: string;
+  default: ConvertBreadboardType<T>;
+}
+
+interface InputParamsWithTypeAndDefault<T extends BreadboardType> {
+  type: T;
+  description?: string;
+  default: ConvertBreadboardType<T>;
+}
+
+type BroadenBasicType<T extends string | number | boolean> = T extends string
+  ? string
+  : T extends number
+    ? number
+    : T extends boolean
+      ? boolean
+      : never;

--- a/packages/build/src/test/input_test.ts
+++ b/packages/build/src/test/input_test.ts
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from "node:assert/strict";
+import { input } from "../internal/board/input.js";
+import { test } from "node:test";
+import { anyOf, array, object } from "../index.js";
+import type { BreadboardType } from "../internal/type-system/type.js";
+
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+
+function assertType<T extends { type: BreadboardType }>(
+  input: T,
+  expected: BreadboardType
+): T {
+  assert.equal(input.type, expected);
+  return input;
+}
+
+test("defaults to string", () => {
+  // $ExpectType Input<string>
+  assertType(input(), "string");
+});
+
+test("only type", () => {
+  // $ExpectType Input<string>
+  assertType(input({ type: "string" }), "string");
+
+  // $ExpectType Input<number>
+  assertType(input({ type: "number" }), "number");
+
+  // $ExpectType Input<boolean>
+  assertType(input({ type: "boolean" }), "boolean");
+
+  // $ExpectType Input<string | number>
+  input({ type: anyOf("string", "number") });
+
+  // $ExpectType Input<{ foo: string; }>
+  input({ type: object({ foo: "string" }) });
+});
+
+test("only default", () => {
+  // $ExpectType InputWithDefault<string>
+  assertType(input({ default: "foo" }), "string");
+
+  // $ExpectType InputWithDefault<number>
+  assertType(input({ default: 42 }), "number");
+
+  // $ExpectType InputWithDefault<boolean>
+  assertType(input({ default: true }), "boolean");
+});
+
+test("type and default", () => {
+  // $ExpectType InputWithDefault<string>
+  assertType(input({ type: "string", default: "foo" }), "string");
+
+  // $ExpectType InputWithDefault<number>
+  assertType(input({ type: "number", default: 42 }), "number");
+
+  // $ExpectType InputWithDefault<boolean>
+  assertType(input({ type: "boolean", default: true }), "boolean");
+
+  // $ExpectType InputWithDefault<{ foo: string[]; }>
+  input({
+    type: object({ foo: array("string") }),
+    default: { foo: ["bar"] },
+  });
+});
+
+test("default doesn't match type", () => {
+  // @ts-expect-error
+  input({ type: "string", default: 42 });
+
+  // @ts-expect-error
+  input({ type: "number", default: true });
+
+  // @ts-expect-error
+  input({ type: "boolean", default: "foo" });
+
+  input({
+    type: object({ foo: array("string") }),
+    // @ts-expect-error
+    default: {
+      foo: [42],
+    },
+  });
+});
+
+test("invalid types", () => {
+  // @ts-expect-error
+  input({ type: undefined });
+
+  // @ts-expect-error
+  input({ type: null });
+
+  // @ts-expect-error
+  input({ type: "foo" });
+});
+
+test("invalid defaults", () => {
+  // @ts-expect-error
+  input({ default: undefined });
+
+  // @ts-expect-error
+  assert.throws(() => input({ default: null }), /Unknown default type: null/);
+
+  assert.throws(
+    // @ts-expect-error
+    () => input({ default: { foo: "bar" } }),
+    /Error: Unknown default type: {"foo":"bar"}/
+  );
+});


### PR DESCRIPTION
Adds an `input` function used for board inputs. Not yet hooked up to the `board` function or `serialize`.