### PR TITLE
[breadboard-ui] Improved node placement in graph

### DIFF
--- a/.changeset/beige-rivers-explode.md
+++ b/.changeset/beige-rivers-explode.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard-ui": patch
+---
+
+Improved node placement in graph

--- a/packages/breadboard-ui/src/elements/editor/graph.ts
+++ b/packages/breadboard-ui/src/elements/editor/graph.ts
@@ -342,10 +342,9 @@ export class Graph extends PIXI.Container {
 
     const g = new Dagre.graphlib.Graph();
     const opts: Partial<Dagre.GraphLabel> = {
-      marginx: 0,
-      marginy: 0,
+      ranksep: 60,
       rankdir: "LR",
-      align: "UL",
+      align: "DR",
     };
     if (this.layoutRect) {
       opts.width = Math.floor(this.layoutRect.width);
@@ -386,8 +385,8 @@ export class Graph extends PIXI.Container {
           continue;
         }
 
-        const { x, y } = g.node(id);
-        this.#layout.set(id, { x, y });
+        const { x, y, width, height } = g.node(id);
+        this.#layout.set(id, { x: x - width / 2, y: y - height / 2 });
       }
     }
 


### PR DESCRIPTION
It turns out I had missed an important element of Dagre layout: it provides `x` and `y` coordinates of the middle of the node, not the top left. I am therefore adjusting the node position by half the `width` and `height` and things are now much better aligned.