### PR TITLE
no localhost

### DIFF
--- a/.changeset/moody-kids-sip.md
+++ b/.changeset/moody-kids-sip.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard-cli": patch
+---
+
+Avoid hard-coding `localhost` into a kit URL.

--- a/packages/breadboard-cli/src/commands/lib/kits.ts
+++ b/packages/breadboard-cli/src/commands/lib/kits.ts
@@ -61,6 +61,10 @@ export const compile = async (file: string) => {
   return output[0].code;
 };
 
+const isURLish = (s: string) => {
+  return URL.canParse(s) || s.startsWith("/");
+};
+
 export const getKits = async (
   defaultKits: string[],
   specifiedKits: string[] = []
@@ -69,7 +73,7 @@ export const getKits = async (
   const kits = [];
 
   for (const kit of kitNames) {
-    if (URL.canParse(kit)) {
+    if (isURLish(kit)) {
       kits.push({
         file: await createUniqueName(kit),
         url: kit,

--- a/packages/breadboard-cli/src/commands/lib/utils.ts
+++ b/packages/breadboard-cli/src/commands/lib/utils.ts
@@ -24,7 +24,7 @@ export const defaultKits = [
   "@google-labs/json-kit",
   "@google-labs/template-kit",
   "@google-labs/node-nursery-web",
-  `${SERVER_URL}/agent.kit.json`,
+  `/agent.kit.json`,
 ];
 
 export type BoardMetaData = {


### PR DESCRIPTION
- **Avoid encoding `localhost` into a kit URL.**
- **docs(changeset): Avoid hard-coding `localhost` into a kit URL.**
