### PR TITLE
[build] Support serializing build boards from web UI

### DIFF
--- a/.changeset/old-turtles-unite.md
+++ b/.changeset/old-turtles-unite.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": minor
+---
+
+Add new board function for creating boards, and serialize for making BGL from them

--- a/.changeset/wise-ants-whisper.md
+++ b/.changeset/wise-ants-whisper.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard-web": minor
+---
+
+Add support for boards created with new @breadboard-ai/build package

--- a/packages/breadboard-web/public/graphs/build-example.json
+++ b/packages/breadboard-web/public/graphs/build-example.json
@@ -1,58 +1,7 @@
 {
-  "title": "Build example",
-  "description": "An example that uses a kit created with @breadboard-ai/build",
-  "version": "0.0.1",
-  "edges": [
-    {
-      "from": "templater-4",
-      "to": "output-2",
-      "out": "result",
-      "in": "result"
-    },
-    {
-      "from": "input-1",
-      "to": "reverseString-3",
-      "out": "word",
-      "in": "forwards"
-    },
-    {
-      "from": "input-1",
-      "to": "templater-4",
-      "out": "word",
-      "in": "forwards"
-    },
-    {
-      "from": "reverseString-3",
-      "to": "templater-4",
-      "out": "backwards",
-      "in": "backwards"
-    }
-  ],
   "nodes": [
     {
-      "id": "output-2",
-      "type": "output",
-      "configuration": {
-        "schema": {
-          "type": "object",
-          "properties": {
-            "result": {
-              "type": "string",
-              "title": "result"
-            }
-          }
-        }
-      }
-    },
-    {
-      "id": "templater-4",
-      "type": "templater",
-      "configuration": {
-        "template": "The word \"{{forwards}}\" is \"{{backwards}}\" in reverse."
-      }
-    },
-    {
-      "id": "input-1",
+      "id": "input-0",
       "type": "input",
       "configuration": {
         "schema": {
@@ -60,7 +9,7 @@
           "properties": {
             "word": {
               "type": "string",
-              "title": "word"
+              "description": "The word to reverse"
             }
           },
           "required": [
@@ -70,10 +19,59 @@
       }
     },
     {
-      "id": "reverseString-3",
+      "id": "output-0",
+      "type": "output",
+      "configuration": {
+        "schema": {
+          "type": "object",
+          "properties": {
+            "result": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "result"
+          ]
+        }
+      }
+    },
+    {
+      "id": "reverseString-0",
       "type": "reverseString",
       "configuration": {}
+    },
+    {
+      "id": "templater-0",
+      "type": "templater",
+      "configuration": {
+        "template": "The word \"{{forwards}}\" is \"{{backwards}}\" in reverse."
+      }
     }
   ],
-  "graphs": {}
+  "edges": [
+    {
+      "from": "input-0",
+      "out": "word",
+      "to": "reverseString-0",
+      "in": "forwards"
+    },
+    {
+      "from": "input-0",
+      "out": "word",
+      "to": "templater-0",
+      "in": "forwards"
+    },
+    {
+      "from": "reverseString-0",
+      "out": "backwards",
+      "to": "templater-0",
+      "in": "backwards"
+    },
+    {
+      "from": "templater-0",
+      "out": "result",
+      "to": "output-0",
+      "in": "result"
+    }
+  ]
 }

--- a/packages/breadboard-web/public/local-boards.json
+++ b/packages/breadboard-web/public/local-boards.json
@@ -50,9 +50,9 @@
     "version": "0.0.6"
   },
   {
-    "title": "Build example",
+    "title": "Example of @breadboard-ai/build",
     "url": "/graphs/build-example.json",
-    "version": "0.0.1"
+    "version": "1.0.0"
   },
   {
     "title": "Chat bot 2.0",

--- a/packages/breadboard-web/src/boards/build-example.ts
+++ b/packages/breadboard-web/src/boards/build-example.ts
@@ -4,23 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { board } from "@google-labs/breadboard";
-import { buildExampleKit } from "../build-example-kit.js";
+import { board, input } from "@breadboard-ai/build";
+import { reverseString, templater } from "../build-example-kit.js";
 
-export default await board(({ word }) => {
-  const { backwards } = buildExampleKit.reverseString({
-    forwards: word.isString(),
-  });
-
-  const { result } = buildExampleKit.templater({
-    template: `The word "{{forwards}}" is "{{backwards}}" in reverse.`,
-    forwards: word.isString(),
-    backwards: backwards.isString(),
-  });
-
-  return { result };
-}).serialize({
-  title: "Build example",
-  description: "An example that uses a kit created with @breadboard-ai/build",
-  version: "0.0.1",
+const word = input({ description: "The word to reverse" });
+const result = templater({
+  template: `The word "{{forwards}}" is "{{backwards}}" in reverse.`,
+  forwards: word,
+  backwards: reverseString({ forwards: word }),
+});
+export default board({
+  title: "Example of @breadboard-ai/build",
+  description: "A simple example of using the @breadboard-ai/build API",
+  version: "1.0.0",
+  inputs: { word },
+  outputs: { result },
 });

--- a/packages/breadboard-web/src/build-example-kit.ts
+++ b/packages/breadboard-web/src/build-example-kit.ts
@@ -12,7 +12,8 @@ import {
 import { addKit } from "@google-labs/breadboard";
 import { KitBuilder } from "@google-labs/breadboard/kits";
 
-const reverseString = defineNodeType({
+export const reverseString = defineNodeType({
+  name: "reverseString",
   inputs: {
     forwards: {
       type: "string",
@@ -34,6 +35,7 @@ const reverseString = defineNodeType({
 });
 
 export const templater = defineNodeType({
+  name: "templater",
   inputs: {
     template: {
       type: "string",
@@ -48,6 +50,7 @@ export const templater = defineNodeType({
     result: {
       type: "string",
       description: "The template with {{placeholders}} substituted.",
+      primary: true,
     },
   },
   describe: ({ template }) => {

--- a/packages/breadboard-web/src/make-graphs.ts
+++ b/packages/breadboard-web/src/make-graphs.ts
@@ -5,6 +5,7 @@
  */
 
 // import { GraphDescriptor } from "@google-labs/breadboard";
+import { SerializableBoard, serialize } from "@breadboard-ai/build";
 import { Dirent } from "fs";
 import { mkdir, readdir, writeFile } from "fs/promises";
 import path from "path";
@@ -54,9 +55,9 @@ async function findTsFiles(dir: string): Promise<string[]> {
 
 async function saveBoard(filePath: string): Promise<ManifestItem | undefined> {
   try {
-    const board = await import(filePath);
+    const module = await import(filePath);
 
-    if (!board.default) {
+    if (!module.default) {
       // This is probably not a board or a board that doesn't want to be in the
       // manifest.
       return;
@@ -71,17 +72,32 @@ async function saveBoard(filePath: string): Promise<ManifestItem | undefined> {
     // Make sure the directories exist
     await mkdir(graphDir, { recursive: true });
 
-    const manifestEntry: ManifestItem = {
-      title: board.default.title ?? "Untitled",
-      url: `/graphs/${relativePath.replace(".ts", ".json")}`,
-      version: board.default.version ?? undefined,
-    };
-
-    await writeFile(
-      path.join(graphDir, jsonFile),
-      JSON.stringify(board.default, null, 2)
-    );
-    return manifestEntry;
+    const url = `/graphs/${relativePath.replace(".ts", ".json")}`;
+    if ("inputs" in module.default && "outputs" in module.default) {
+      const board = module.default as SerializableBoard;
+      const manifest: ManifestItem = {
+        title: module.default.title ?? "Untitled (build API)",
+        url,
+        version: module.default.version ?? "",
+      };
+      await writeFile(
+        path.join(graphDir, jsonFile),
+        JSON.stringify(serialize(board), null, 2)
+      );
+      return manifest;
+    } else {
+      const board = module.default as SerializableBoard;
+      const manifest: ManifestItem = {
+        title: module.default.title ?? "Untitled",
+        url,
+        version: module.default.version ?? undefined,
+      };
+      await writeFile(
+        path.join(graphDir, jsonFile),
+        JSON.stringify(board, null, 2)
+      );
+      return manifest;
+    }
   } catch (e) {
     if (e instanceof Error) {
       console.error(e.stack);

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+export { board } from "./internal/board/board.js";
+export { input } from "./internal/board/input.js";
+export {
+  serialize,
+  // TODO(aomarks) Not quite happy with this export.
+  type SerializableBoard,
+} from "./internal/board/serialize.js";
 export { defineNodeType } from "./internal/define/define.js";
 export type { NodeFactoryFromDefinition } from "./internal/define/node-factory.js";
 export { anyOf } from "./internal/type-system/any-of.js";

--- a/packages/build/src/internal/board/board.ts
+++ b/packages/build/src/internal/board/board.ts
@@ -45,12 +45,32 @@ export function board<
   // was to have used an input(), so only inputs should be allowed, right?
   IPORTS extends BoardInputPorts,
   OPORTS extends BoardOutputPorts,
->(inputs: IPORTS, outputs: OPORTS): BoardDefinition<IPORTS, OPORTS> {
+>({
+  inputs,
+  outputs,
+  title,
+  description,
+  version,
+}: BoardParameters<IPORTS, OPORTS>): BoardDefinition<IPORTS, OPORTS> {
   const def = new BoardDefinitionImpl(inputs, outputs);
   return Object.assign(def.instantiate.bind(def), {
     inputs,
     outputs,
+    title,
+    description,
+    version,
   });
+}
+
+export interface BoardParameters<
+  IPORTS extends BoardInputPorts,
+  OPORTS extends BoardOutputPorts,
+> {
+  inputs: IPORTS;
+  outputs: OPORTS;
+  title?: string;
+  description?: string;
+  version?: string;
 }
 
 export type BoardInputPorts = Record<

--- a/packages/build/src/internal/board/input.ts
+++ b/packages/build/src/internal/board/input.ts
@@ -11,7 +11,9 @@ import type {
 } from "../type-system/type.js";
 
 // Neither type nor default
-export function input(): Input<string>;
+export function input(
+  params?: InputParamsWithNeitherTypeNorDefault
+): Input<string>;
 
 // Type and default
 export function input<T extends BreadboardType>(
@@ -95,6 +97,7 @@ export interface InputWithDefault<T extends JsonSerializable> {
 }
 
 type GenericInputParams =
+  | InputParamsWithNeitherTypeNorDefault
   | InputParamsWithOnlyType<BreadboardType>
   | InputParamsWithOnlyDefault<"string" | "number" | "boolean">
   | InputParamsWithTypeAndDefault<BreadboardType>;
@@ -117,6 +120,12 @@ interface InputParamsWithTypeAndDefault<T extends BreadboardType> {
   type: T;
   description?: string;
   default: ConvertBreadboardType<T>;
+}
+
+interface InputParamsWithNeitherTypeNorDefault {
+  type?: undefined;
+  description: string;
+  default?: undefined;
 }
 
 type BroadenBasicType<T extends string | number | boolean> = T extends string

--- a/packages/build/src/internal/board/serialize.ts
+++ b/packages/build/src/internal/board/serialize.ts
@@ -60,8 +60,13 @@ export function serialize(board: SerializableBoard): GraphDescriptor {
     inputNames.set(input, mainInputName);
     unconnectedInputs.add(input);
     const schema = toJSONSchema(input.type);
-    if (isSpecialInput(input) && input.default !== undefined) {
-      schema.default = input.default;
+    if (isSpecialInput(input)) {
+      if (input.default !== undefined) {
+        schema.default = input.default;
+      }
+      if (input.description !== undefined) {
+        schema.description = input.description;
+      }
     }
     mainInputSchema[mainInputName] = schema;
   }

--- a/packages/build/src/internal/board/serialize.ts
+++ b/packages/build/src/internal/board/serialize.ts
@@ -237,7 +237,7 @@ function isOutputPortReference(
   );
 }
 
-interface SerializableBoard {
+export interface SerializableBoard {
   inputs: Record<string, SerializableInputPort | GenericSpecialInput>;
   outputs: Record<string, SerializableOutputPortReference>;
 }

--- a/packages/build/src/internal/common/port.ts
+++ b/packages/build/src/internal/common/port.ts
@@ -70,7 +70,9 @@ interface DynamicPortConfig extends StaticPortConfig {
   primary?: never;
 }
 
-export const OutputPortGetter = Symbol();
+// TODO(aomarks) Just make this a normal property, no need to export (it was
+// originally a symbol to try and make a package-private API).
+export const OutputPortGetter = "__output";
 
 /**
  * A Breadboard node port which receives values.

--- a/packages/build/src/internal/define/definition-polymorphic.ts
+++ b/packages/build/src/internal/define/definition-polymorphic.ts
@@ -289,6 +289,20 @@ class PolymorphicNodeInstance<
         new OutputPort(portConfig.type, portName, this),
       ])
     ) as OutputPorts<STATIC_OUTPUTS>;
+    // TODO(aomarks) Share with monomorphic (function or base class).
+    const primaryOutputPortNames = Object.entries(staticOutputs)
+      .filter(([, config]) => config.primary)
+      .map(([name]) => name);
+    if (primaryOutputPortNames.length === 1) {
+      this[OutputPortGetter] = this.outputs[
+        primaryOutputPortNames[0]!
+        // TODO(aomarks) It might be possible to avoid this cast.
+      ] as unknown as PrimaryOutputPort<STATIC_OUTPUTS>;
+    } else if (primaryOutputPortNames.length > 0) {
+      throw new Error(
+        `Node was configured with >1 primary output nodes: ${primaryOutputPortNames.join(" ")}`
+      );
+    }
   }
 }
 

--- a/packages/build/src/test/board_test.ts
+++ b/packages/build/src/test/board_test.ts
@@ -37,7 +37,7 @@ const { outNum, outStr } = testNode.outputs;
 
 test("expect type: 0 in, 0 out", () => {
   // $ExpectType BoardDefinition<{}, {}>
-  const definition = board({}, {});
+  const definition = board({ inputs: {}, outputs: {} });
   // $ExpectType BoardInstance<{}, {}>
   definition({});
   // $ExpectType BoardInstance<{}, {}>
@@ -50,7 +50,7 @@ test("expect type: 0 in, 0 out", () => {
 
 test("expect type: 1 in, 1 out", () => {
   // $ExpectType BoardDefinition<{ inStr: InputPort<string>; }, { outNum: OutputPort<number>; }>
-  const definition = board({ inStr }, { outNum });
+  const definition = board({ inputs: { inStr }, outputs: { outNum } });
   // NodeInstance<BoardPortConfig<{ inStr: InputPort<string>; }>, BoardPortConfig<{ outNum: OutputPort<{ type: "boolean"; }>; }>>
   const instance = definition({ inStr: "inStr" });
   // $ExpectType { inStr: InputPort<string>; }
@@ -64,8 +64,8 @@ test("expect type: 1 in, 1 out", () => {
 });
 
 test("expect type: nested boards", () => {
-  const defA = board({ inNum }, { outStr });
-  const defB = board({ inStr }, { outNum });
+  const defA = board({ inputs: { inNum }, outputs: { outStr } });
+  const defB = board({ inputs: { inStr }, outputs: { outNum } });
   const instanceA = defA({ inNum: 123 });
   // $ExpectType BoardInstance<{ inStr: InputPort<string>; }, { outNum: OutputPort<number>; }>
   const instanceB = defB({ inStr: instanceA.outputs.outStr });
@@ -80,7 +80,7 @@ test("expect type: nested boards", () => {
 });
 
 test("expect type error: missing instantiate param", () => {
-  const definition = board({ inStr, inNum }, { outNum });
+  const definition = board({ inputs: { inStr, inNum }, outputs: { outNum } });
   // @ts-expect-error missing both
   definition();
   // @ts-expect-error missing both
@@ -92,7 +92,7 @@ test("expect type error: missing instantiate param", () => {
 });
 
 test("expect type error: incorrect make instance param type", () => {
-  const definition = board({ inStr, inNum }, {});
+  const definition = board({ inputs: { inStr, inNum }, outputs: {} });
   definition({
     inStr: "foo",
     // @ts-expect-error inNum should be number, not string
@@ -100,9 +100,20 @@ test("expect type error: incorrect make instance param type", () => {
   });
 });
 
+test("allow setting title, description, version", () => {
+  // $ExpectType BoardDefinition<{ inStr: InputPort<string>; }, { outNum: OutputPort<number>; }>
+  board({
+    title: "My Title",
+    description: "My Description",
+    version: "1.0.0",
+    inputs: { inStr },
+    outputs: { outNum },
+  });
+});
+
 {
-  const boardA = board({}, { outNum, outStr });
-  const boardB = board({ inStr, inNum }, {});
+  const boardA = board({ inputs: {}, outputs: { outNum, outStr } });
+  const boardB = board({ inputs: { inStr, inNum }, outputs: {} });
   const instanceA = boardA({});
   const instanceB = boardB({ inStr: "foo", inNum: 123 });
 

--- a/packages/build/src/test/input_test.ts
+++ b/packages/build/src/test/input_test.ts
@@ -23,6 +23,9 @@ function assertType<T extends { type: BreadboardType }>(
 test("defaults to string", () => {
   // $ExpectType Input<string>
   assertType(input(), "string");
+
+  // $ExpectType Input<string>
+  assertType(input({ description: "Hello" }), "string");
 });
 
 test("only type", () => {

--- a/packages/build/src/test/serialize_test.ts
+++ b/packages/build/src/test/serialize_test.ts
@@ -39,42 +39,48 @@ test("0 inputs, 1 output", () => {
     },
     invoke: () => ({ myNodeOut: "aaa" }),
   })({});
-  checkSerialization(board({}, { boardOut: myNode.outputs.myNodeOut }), {
-    nodes: [
-      {
-        id: "input-0",
-        type: "input",
-        configuration: {
-          schema: {
-            type: "object",
-            properties: {},
-            required: [],
-          },
-        },
-      },
-      {
-        id: "output-0",
-        type: "output",
-        configuration: {
-          schema: {
-            type: "object",
-            properties: {
-              boardOut: { type: "string" },
+  checkSerialization(
+    board({
+      inputs: {},
+      outputs: { boardOut: myNode.outputs.myNodeOut },
+    }),
+    {
+      nodes: [
+        {
+          id: "input-0",
+          type: "input",
+          configuration: {
+            schema: {
+              type: "object",
+              properties: {},
+              required: [],
             },
-            required: ["boardOut"],
           },
         },
-      },
-      {
-        id: "myNode-0",
-        type: "myNode",
-        configuration: {},
-      },
-    ],
-    edges: [
-      { from: "myNode-0", out: "myNodeOut", to: "output-0", in: "boardOut" },
-    ],
-  });
+        {
+          id: "output-0",
+          type: "output",
+          configuration: {
+            schema: {
+              type: "object",
+              properties: {
+                boardOut: { type: "string" },
+              },
+              required: ["boardOut"],
+            },
+          },
+        },
+        {
+          id: "myNode-0",
+          type: "myNode",
+          configuration: {},
+        },
+      ],
+      edges: [
+        { from: "myNode-0", out: "myNodeOut", to: "output-0", in: "boardOut" },
+      ],
+    }
+  );
 });
 
 test("monomorphic node with primary output can itself act as that output", () => {
@@ -86,47 +92,53 @@ test("monomorphic node with primary output can itself act as that output", () =>
     },
     invoke: () => ({ myNodeOutPrimary: "aaa" }),
   })({});
-  checkSerialization(board({}, { boardOut: myNode }), {
-    nodes: [
-      {
-        id: "input-0",
-        type: "input",
-        configuration: {
-          schema: {
-            type: "object",
-            properties: {},
-            required: [],
-          },
-        },
-      },
-      {
-        id: "output-0",
-        type: "output",
-        configuration: {
-          schema: {
-            type: "object",
-            properties: {
-              boardOut: { type: "string" },
+  checkSerialization(
+    board({
+      inputs: {},
+      outputs: { boardOut: myNode },
+    }),
+    {
+      nodes: [
+        {
+          id: "input-0",
+          type: "input",
+          configuration: {
+            schema: {
+              type: "object",
+              properties: {},
+              required: [],
             },
-            required: ["boardOut"],
           },
         },
-      },
-      {
-        id: "myNode-0",
-        type: "myNode",
-        configuration: {},
-      },
-    ],
-    edges: [
-      {
-        from: "myNode-0",
-        out: "myNodeOutPrimary",
-        to: "output-0",
-        in: "boardOut",
-      },
-    ],
-  });
+        {
+          id: "output-0",
+          type: "output",
+          configuration: {
+            schema: {
+              type: "object",
+              properties: {
+                boardOut: { type: "string" },
+              },
+              required: ["boardOut"],
+            },
+          },
+        },
+        {
+          id: "myNode-0",
+          type: "myNode",
+          configuration: {},
+        },
+      ],
+      edges: [
+        {
+          from: "myNode-0",
+          out: "myNodeOutPrimary",
+          to: "output-0",
+          in: "boardOut",
+        },
+      ],
+    }
+  );
 });
 
 test("polymorphic node with primary output can itself act as that output", () => {
@@ -142,47 +154,53 @@ test("polymorphic node with primary output can itself act as that output", () =>
     },
     invoke: () => ({ myNodeOutPrimary: "aaa" }),
   })({});
-  checkSerialization(board({}, { boardOut: myNode }), {
-    nodes: [
-      {
-        id: "input-0",
-        type: "input",
-        configuration: {
-          schema: {
-            type: "object",
-            properties: {},
-            required: [],
-          },
-        },
-      },
-      {
-        id: "output-0",
-        type: "output",
-        configuration: {
-          schema: {
-            type: "object",
-            properties: {
-              boardOut: { type: "string" },
+  checkSerialization(
+    board({
+      inputs: {},
+      outputs: { boardOut: myNode },
+    }),
+    {
+      nodes: [
+        {
+          id: "input-0",
+          type: "input",
+          configuration: {
+            schema: {
+              type: "object",
+              properties: {},
+              required: [],
             },
-            required: ["boardOut"],
           },
         },
-      },
-      {
-        id: "myNode-0",
-        type: "myNode",
-        configuration: {},
-      },
-    ],
-    edges: [
-      {
-        from: "myNode-0",
-        out: "myNodeOutPrimary",
-        to: "output-0",
-        in: "boardOut",
-      },
-    ],
-  });
+        {
+          id: "output-0",
+          type: "output",
+          configuration: {
+            schema: {
+              type: "object",
+              properties: {
+                boardOut: { type: "string" },
+              },
+              required: ["boardOut"],
+            },
+          },
+        },
+        {
+          id: "myNode-0",
+          type: "myNode",
+          configuration: {},
+        },
+      ],
+      edges: [
+        {
+          from: "myNode-0",
+          out: "myNodeOutPrimary",
+          to: "output-0",
+          in: "boardOut",
+        },
+      ],
+    }
+  );
 });
 
 test("raw value input is serialized to configuration", () => {
@@ -198,43 +216,46 @@ test("raw value input is serialized to configuration", () => {
   })({
     myNodeIn: "bbb",
   });
-  checkSerialization(board({}, { boardOut: myNode.outputs.myNodeOut }), {
-    nodes: [
-      {
-        id: "input-0",
-        type: "input",
-        configuration: {
-          schema: {
-            type: "object",
-            properties: {},
-            required: [],
+  checkSerialization(
+    board({ inputs: {}, outputs: { boardOut: myNode.outputs.myNodeOut } }),
+    {
+      nodes: [
+        {
+          id: "input-0",
+          type: "input",
+          configuration: {
+            schema: {
+              type: "object",
+              properties: {},
+              required: [],
+            },
           },
         },
-      },
-      {
-        id: "output-0",
-        type: "output",
-        configuration: {
-          schema: {
-            type: "object",
-            properties: { boardOut: { type: "string" } },
-            required: ["boardOut"],
+        {
+          id: "output-0",
+          type: "output",
+          configuration: {
+            schema: {
+              type: "object",
+              properties: { boardOut: { type: "string" } },
+              required: ["boardOut"],
+            },
           },
         },
-      },
-      {
-        id: "myNode-0",
-        type: "myNode",
-        configuration: {
-          myNodeIn: "bbb",
-          //        ^^^^^ here it is
+        {
+          id: "myNode-0",
+          type: "myNode",
+          configuration: {
+            myNodeIn: "bbb",
+            //        ^^^^^ here it is
+          },
         },
-      },
-    ],
-    edges: [
-      { from: "myNode-0", out: "myNodeOut", to: "output-0", in: "boardOut" },
-    ],
-  });
+      ],
+      edges: [
+        { from: "myNode-0", out: "myNodeOut", to: "output-0", in: "boardOut" },
+      ],
+    }
+  );
 });
 
 test("input", () => {
@@ -252,7 +273,10 @@ test("input", () => {
     myNodeIn: myInput,
   });
   checkSerialization(
-    board({ myInput }, { boardOut: myNode.outputs.myNodeOut }),
+    board({
+      inputs: { myInput },
+      outputs: { boardOut: myNode.outputs.myNodeOut },
+    }),
     {
       nodes: [
         {
@@ -310,7 +334,10 @@ test("input with default", () => {
     myNodeIn: myInput,
   });
   checkSerialization(
-    board({ myInput }, { boardOut: myNode.outputs.myNodeOut }),
+    board({
+      inputs: { myInput },
+      outputs: { boardOut: myNode.outputs.myNodeOut },
+    }),
     {
       nodes: [
         {
@@ -372,7 +399,10 @@ test("input with description", () => {
     myNodeIn: myInput,
   });
   checkSerialization(
-    board({ myInput }, { boardOut: myNode.outputs.myNodeOut }),
+    board({
+      inputs: { myInput },
+      outputs: { boardOut: myNode.outputs.myNodeOut },
+    }),
     {
       nodes: [
         {
@@ -438,7 +468,10 @@ test("fancy types", () => {
     myNodeIn2: ["aaa", { foo: 123 }],
   });
   checkSerialization(
-    board({ boardInput1: myInput1 }, { boardOut: myNode.outputs.myNodeOut }),
+    board({
+      inputs: { boardInput1: myInput1 },
+      outputs: { boardOut: myNode.outputs.myNodeOut },
+    }),
     {
       nodes: [
         {
@@ -558,10 +591,10 @@ test("long chain", () => {
   });
 
   checkSerialization(
-    board(
-      { boardNumInput: numInput },
-      { boardStringArrayOut: boolToStringArray }
-    ),
+    board({
+      inputs: { boardNumInput: numInput },
+      outputs: { boardStringArrayOut: boolToStringArray },
+    }),
     {
       nodes: [
         {
@@ -647,48 +680,54 @@ test("polymorphic inputs", () => {
     },
     invoke: (_, values) => ({ out: Object.values(values)[0] ?? 0 }),
   })({ a: 1, b: bInput, c: 3 });
-  checkSerialization(board({ bInput }, { boardOut: myNode.outputs.out }), {
-    nodes: [
-      {
-        id: "input-0",
-        type: "input",
-        configuration: {
-          schema: {
-            type: "object",
-            properties: {
-              bInput: { type: "number" },
+  checkSerialization(
+    board({
+      inputs: { bInput },
+      outputs: { boardOut: myNode.outputs.out },
+    }),
+    {
+      nodes: [
+        {
+          id: "input-0",
+          type: "input",
+          configuration: {
+            schema: {
+              type: "object",
+              properties: {
+                bInput: { type: "number" },
+              },
+              required: ["bInput"],
             },
-            required: ["bInput"],
           },
         },
-      },
-      {
-        id: "output-0",
-        type: "output",
-        configuration: {
-          schema: {
-            type: "object",
-            properties: {
-              boardOut: { type: "number" },
+        {
+          id: "output-0",
+          type: "output",
+          configuration: {
+            schema: {
+              type: "object",
+              properties: {
+                boardOut: { type: "number" },
+              },
+              required: ["boardOut"],
             },
-            required: ["boardOut"],
           },
         },
-      },
-      {
-        id: "myNode-0",
-        type: "myNode",
-        configuration: {
-          a: 1,
-          c: 3,
+        {
+          id: "myNode-0",
+          type: "myNode",
+          configuration: {
+            a: 1,
+            c: 3,
+          },
         },
-      },
-    ],
-    edges: [
-      { from: "input-0", out: "bInput", to: "myNode-0", in: "b" },
-      { from: "myNode-0", out: "out", to: "output-0", in: "boardOut" },
-    ],
-  });
+      ],
+      edges: [
+        { from: "input-0", out: "bInput", to: "myNode-0", in: "b" },
+        { from: "myNode-0", out: "out", to: "output-0", in: "boardOut" },
+      ],
+    }
+  );
 });
 
 test("error: input not passed to board", () => {
@@ -706,7 +745,15 @@ test("error: input not passed to board", () => {
     myNodeIn: myInput,
   });
   assert.throws(
-    () => serialize(board({}, { boardOut: myNode.outputs.myNodeOut })),
+    () =>
+      serialize(
+        board({
+          inputs: {},
+          outputs: {
+            boardOut: myNode.outputs.myNodeOut,
+          },
+        })
+      ),
     /myNode-0:myNodeIn was wired to an input, but that input was not provided to the board inputs./
   );
 });
@@ -728,10 +775,10 @@ test("error: same input used twice", () => {
   assert.throws(
     () =>
       serialize(
-        board(
-          { boardInput1: myInput, boardInput2: myInput },
-          { boardOut: myNode.outputs.myNodeOut }
-        )
+        board({
+          inputs: { boardInput1: myInput, boardInput2: myInput },
+          outputs: { boardOut: myNode.outputs.myNodeOut },
+        })
       ),
     /The same input was used as both boardInput1 and boardInput2/
   );
@@ -755,10 +802,10 @@ test("error: input not reachable from output", () => {
   assert.throws(
     () =>
       serialize(
-        board(
-          { boardInput1: myInput, boardInput2: myOrphanInput },
-          { boardOut: myNode.outputs.myNodeOut }
-        )
+        board({
+          inputs: { boardInput1: myInput, boardInput2: myOrphanInput },
+          outputs: { boardOut: myNode.outputs.myNodeOut },
+        })
       ),
     /Board input "boardInput2" is not reachable from any of its outputs./
   );

--- a/packages/build/src/test/serialize_test.ts
+++ b/packages/build/src/test/serialize_test.ts
@@ -357,6 +357,67 @@ test("input with default", () => {
   );
 });
 
+test("input with description", () => {
+  const myInput = input({ description: "This is my description" });
+  const myNode = defineNodeType({
+    name: "myNode",
+    inputs: {
+      myNodeIn: { type: "string" },
+    },
+    outputs: {
+      myNodeOut: { type: "string" },
+    },
+    invoke: () => ({ myNodeOut: "aaa" }),
+  })({
+    myNodeIn: myInput,
+  });
+  checkSerialization(
+    board({ myInput }, { boardOut: myNode.outputs.myNodeOut }),
+    {
+      nodes: [
+        {
+          id: "input-0",
+          type: "input",
+          configuration: {
+            schema: {
+              type: "object",
+              properties: {
+                myInput: {
+                  type: "string",
+                  description: "This is my description",
+                },
+              },
+              required: ["myInput"],
+            },
+          },
+        },
+        {
+          id: "output-0",
+          type: "output",
+          configuration: {
+            schema: {
+              type: "object",
+              properties: {
+                boardOut: { type: "string" },
+              },
+              required: ["boardOut"],
+            },
+          },
+        },
+        {
+          id: "myNode-0",
+          type: "myNode",
+          configuration: {},
+        },
+      ],
+      edges: [
+        { from: "input-0", out: "myInput", to: "myNode-0", in: "myNodeIn" },
+        { from: "myNode-0", out: "myNodeOut", to: "output-0", in: "boardOut" },
+      ],
+    }
+  );
+});
+
 test("fancy types", () => {
   const fancyType1 = anyOf("number", object({ foo: "boolean" }));
   const fancyType2 = array(anyOf("string", object({ foo: "number" })));


### PR DESCRIPTION
Also:

- Export the new `board`, `input`, and `serialize` functions
- Fix a few bugs
- Update the `build` example graph to use the new `board` function
- Allow passing manifest metadata (`title`, `version`, `description`) to new `board` function