### PR TITLE
[build] Example of a sugar function

### DIFF
--- a/.changeset/hungry-peas-marry.md
+++ b/.changeset/hungry-peas-marry.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Add a Value type which can represent a value or a stand-in for a value (output port, input object, etc.)

--- a/packages/breadboard-web/public/graphs/build-example.json
+++ b/packages/breadboard-web/public/graphs/build-example.json
@@ -44,7 +44,7 @@
       "id": "templater-0",
       "type": "templater",
       "configuration": {
-        "template": "The word \"{{forwards}}\" is \"{{backwards}}\" in reverse."
+        "template": "The word \"{{p0}}\" is \"{{p1}}\" in reverse"
       }
     }
   ],
@@ -59,13 +59,13 @@
       "from": "input-0",
       "out": "word",
       "to": "templater-0",
-      "in": "forwards"
+      "in": "p0"
     },
     {
       "from": "reverseString-0",
       "out": "backwards",
       "to": "templater-0",
-      "in": "backwards"
+      "in": "p1"
     },
     {
       "from": "templater-0",

--- a/packages/breadboard-web/src/boards/build-example.ts
+++ b/packages/breadboard-web/src/boards/build-example.ts
@@ -5,14 +5,12 @@
  */
 
 import { board, input } from "@breadboard-ai/build";
-import { reverseString, templater } from "../build-example-kit.js";
+import { reverseString, prompt } from "../build-example-kit.js";
 
 const word = input({ description: "The word to reverse" });
-const result = templater({
-  template: `The word "{{forwards}}" is "{{backwards}}" in reverse.`,
-  forwards: word,
-  backwards: reverseString({ forwards: word }),
-});
+const reversed = reverseString({ forwards: word });
+const result = prompt`The word "${word}" is "${reversed}" in reverse`;
+
 export default board({
   title: "Example of @breadboard-ai/build",
   description: "A simple example of using the @breadboard-ai/build API",

--- a/packages/breadboard-web/src/build-example-kit.ts
+++ b/packages/breadboard-web/src/build-example-kit.ts
@@ -7,6 +7,7 @@
 import {
   defineNodeType,
   anyOf,
+  type Value,
   type NodeFactoryFromDefinition,
 } from "@breadboard-ai/build";
 import { addKit } from "@google-labs/breadboard";
@@ -90,6 +91,32 @@ function substituteTemplatePlaceholders(
     (acc, [key, value]) => acc.replace(`{{${key}}}`, String(value)),
     template
   );
+}
+
+/**
+ * An example of a sugar function which wraps instantiation of a node (in this
+ * case, a template), in a more convenient syntax (in this case, a tagged
+ * template literal function).
+ */
+export function prompt(
+  strings: TemplateStringsArray,
+  ...values: Value<string>[]
+) {
+  let template = "";
+  const placeholders: Record<string, Value<string>> = {};
+  for (let i = 0; i < strings.length; i++) {
+    if (i > 0) {
+      template += "}}";
+    }
+    template += strings[i];
+    if (i < strings.length - 1) {
+      template += `{{`;
+      const name = `p${i}`;
+      template += name;
+      placeholders[name] = values[i]!;
+    }
+  }
+  return templater({ template, ...placeholders });
 }
 
 const BuildExampleKit = new KitBuilder({

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -4,11 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { Input, InputWithDefault } from "./internal/board/input.js";
+import type { OutputPortReference } from "./internal/common/port.js";
+import type { JsonSerializable } from "./internal/type-system/type.js";
+
 export { board } from "./internal/board/board.js";
 export { input } from "./internal/board/input.js";
 export {
   serialize,
-  // TODO(aomarks) Not quite happy with this export.
+  // TODO(aomarks) Not quite sure about exporting and/or the name of
+  // SerializableBoard.
   type SerializableBoard,
 } from "./internal/board/serialize.js";
 export { defineNodeType } from "./internal/define/define.js";
@@ -17,3 +22,20 @@ export { anyOf } from "./internal/type-system/any-of.js";
 export { array } from "./internal/type-system/array.js";
 export { object } from "./internal/type-system/object.js";
 export { unsafeType } from "./internal/type-system/unsafe.js";
+
+/**
+ * A value, or something that can stand-in for a value when wiring together
+ * boards.
+ *
+ * For example, for a string, this could be any of:
+ *
+ * - An actual string.
+ * - A string-typed output port.
+ * - A node with a primary string-typed output port.
+ * - A string-typed `input`.
+ */
+export type Value<T extends JsonSerializable> =
+  | T
+  | OutputPortReference<T>
+  | Input<T>
+  | InputWithDefault<T>;


### PR DESCRIPTION
Demonstrates a `prompt` function, which is an example of how we can vend sugar functions to make it easier to use certain nodes. In this case, using a [tagged template literal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals) to build up a template node.

```ts
import { board, input } from "@breadboard-ai/build";
import { reverseString, prompt } from "../build-example-kit.js";

const word = input({ description: "The word to reverse" });
const reversed = reverseString({ forwards: word });
const result = prompt`The word "${word}" is "${reversed}" in reverse`;

export default board({
  inputs: { word },
  outputs: { result },
});

```

Also exports a `Value` type which is useful for building such sugar functions.