### PR TITLE
[build] Document `board` in the README

### DIFF
--- a/.changeset/fair-sheep-beam.md
+++ b/.changeset/fair-sheep-beam.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": minor
+---
+
+Make "name" required when defining nodes, so that they can always be serialized

--- a/packages/build/src/internal/board/board.ts
+++ b/packages/build/src/internal/board/board.ts
@@ -21,12 +21,10 @@ import type { GenericSpecialInput } from "./input.js";
  * Example usage:
  *
  * ```ts
- * export const recipeMaker = board(
- *   // Inputs
- *   {recipeName},
- *   // Outputs
- *   {recipe: llmRecipeResult}
- * );
+ * export const recipeMaker = board({
+ *   inputs: {recipeName},
+ *   outputs: {recipe: llmRecipeResult}
+ * });
  * ```
  *
  * @param inputs The input ports that should be exposed from nodes in the board

--- a/packages/build/src/internal/define/define.ts
+++ b/packages/build/src/internal/define/define.ts
@@ -32,6 +32,7 @@ import {
  * import {defineNodeType} from "@breadboard-ai/build";
  *
  * export const reverseString = defineNodeType({
+ *   name: "reverseString",
  *   inputs: {
  *     forwards: {
  *       type: "string",
@@ -63,6 +64,7 @@ import {
  * import { defineNodeType, anyOf } from "@breadboard-ai/build";
  *
  * export const templater = defineNodeType({
+ *   name: "templater",
  *   inputs: {
  *     template: {
  *       type: "string",
@@ -113,7 +115,7 @@ export function defineNodeType<
   INPUTS extends PortConfigMap,
   OUTPUTS extends PortConfigMap,
 >(params: {
-  name?: string;
+  name: string;
   inputs: INPUTS;
   outputs: ForbidMultiplePrimaries<OUTPUTS>;
   invoke: IsPolymorphic<INPUTS> extends true

--- a/packages/build/src/test/board_test.ts
+++ b/packages/build/src/test/board_test.ts
@@ -9,6 +9,7 @@ import { test } from "node:test";
 import { board } from "../internal/board/board.js";
 
 const testNode = defineNodeType({
+  name: "example",
   inputs: {
     inStr: {
       type: "string",

--- a/packages/build/src/test/compatibility_test.ts
+++ b/packages/build/src/test/compatibility_test.ts
@@ -42,6 +42,7 @@ function setupKits<
 {
   // A monomorphic node definition
   const strLen = defineNodeType({
+    name: "example",
     inputs: {
       str: {
         type: "string",
@@ -151,6 +152,7 @@ function setupKits<
 {
   // A polymorphic node definition
   const adder = defineNodeType({
+    name: "example",
     inputs: {
       base: {
         type: "number",

--- a/packages/build/src/test/monomorphic-primary_test.ts
+++ b/packages/build/src/test/monomorphic-primary_test.ts
@@ -14,6 +14,7 @@ import {
 
 test("monomorphic node with primary output acts like that output port", () => {
   const withPrimaryOut = defineNodeType({
+    name: "example",
     inputs: {
       in1: {
         type: "string",
@@ -45,6 +46,7 @@ test("monomorphic node with primary output acts like that output port", () => {
   instance[OutputPortGetter];
 
   defineNodeType({
+    name: "example",
     inputs: { in1: { type: "number" } },
     outputs: {},
     invoke: () => ({}),
@@ -53,6 +55,7 @@ test("monomorphic node with primary output acts like that output port", () => {
   });
 
   defineNodeType({
+    name: "example",
     inputs: { in1: { type: "string" } },
     outputs: {},
     invoke: () => ({}),
@@ -64,6 +67,7 @@ test("monomorphic node with primary output acts like that output port", () => {
 
 test("type error: monomorphic node without primary output doesn't act like an output port", () => {
   const definition = defineNodeType({
+    name: "example",
     inputs: {},
     outputs: {
       out1: {
@@ -90,6 +94,7 @@ test("don't allow multiple primary output ports on monomorphic node", () => {
   assert.throws(
     () =>
       defineNodeType({
+        name: "example",
         inputs: {},
         outputs: {
           foo: {

--- a/packages/build/src/test/monomorphic_test.ts
+++ b/packages/build/src/test/monomorphic_test.ts
@@ -19,6 +19,7 @@ import { unsafeType } from "../internal/type-system/unsafe.js";
 test("expect types: 0 in, 0 out", () => {
   // $ExpectType MonomorphicDefinition<{}, {}>
   const definition = defineNodeType({
+    name: "example",
     inputs: {},
     outputs: {},
     invoke: () => ({}),
@@ -34,6 +35,7 @@ test("expect types: 0 in, 0 out", () => {
 test("expect types: 1 in, 0 out", () => {
   // $ExpectType MonomorphicDefinition<{ in1: { type: "string"; }; }, {}>
   const definition = defineNodeType({
+    name: "example",
     inputs: {
       in1: {
         type: "string",
@@ -63,6 +65,7 @@ test("expect types: 1 in, 0 out", () => {
 test("expect types: 0 in, 1 out", () => {
   // $ExpectType MonomorphicDefinition<{}, { out1: { type: "string"; }; }>
   const definition = defineNodeType({
+    name: "example",
     inputs: {},
     outputs: {
       out1: {
@@ -88,6 +91,7 @@ test("expect types: 0 in, 1 out", () => {
 test("expect types: 1 in, 1 out", () => {
   // $ExpectType MonomorphicDefinition<{ in1: { type: "string"; }; }, { out1: { type: "string"; }; }>
   const definition = defineNodeType({
+    name: "example",
     inputs: {
       in1: {
         type: "string",
@@ -125,6 +129,7 @@ test("expect types: 1 in, 1 out", () => {
 test("expect types: 2 in, 2 out", () => {
   // $ExpectType MonomorphicDefinition<{ in1: { type: "string"; }; in2: { type: "number"; }; }, { out1: { type: "boolean"; }; out2: { type: "string"; }; }>
   const definition = defineNodeType({
+    name: "example",
     inputs: {
       in1: {
         type: "string",
@@ -175,6 +180,7 @@ test("expect types: 2 in, 2 out", () => {
 
 test("expect type error: unknown invoke param", () => {
   defineNodeType({
+    name: "example",
     inputs: {
       in1: {
         type: "string",
@@ -197,6 +203,7 @@ test("expect type error: unknown invoke param", () => {
 
 test("expect type error: missing invoke return port", () => {
   defineNodeType({
+    name: "example",
     inputs: {
       in1: {
         type: "string",
@@ -216,6 +223,7 @@ test("expect type error: missing invoke return port", () => {
 
 test("expect type error: incorrect invoke return port type", () => {
   defineNodeType({
+    name: "example",
     inputs: {
       in1: {
         type: "string",
@@ -237,6 +245,7 @@ test("expect type error: incorrect invoke return port type", () => {
 
 test.skip("expect type error: unknown return port", () => {
   defineNodeType({
+    name: "example",
     inputs: {
       in1: {
         type: "string",
@@ -262,6 +271,7 @@ test.skip("expect type error: unknown return port", () => {
 
 test("expect type error: missing make instance param", () => {
   const definition = defineNodeType({
+    name: "example",
     inputs: {
       in1: {
         type: "string",
@@ -287,6 +297,7 @@ test("expect type error: missing make instance param", () => {
 
 test("expect type error: incorrect make instance param type", () => {
   const definition = defineNodeType({
+    name: "example",
     inputs: {
       in1: {
         type: "string",
@@ -309,6 +320,7 @@ test("expect type error: incorrect make instance param type", () => {
 
 test("expect types: definitions are NodeHandlers", () => {
   const definition = defineNodeType({
+    name: "example",
     inputs: {
       in1: {
         type: "string",
@@ -332,6 +344,7 @@ test("expect types: definitions are NodeHandlers", () => {
 
 test("describe function generates JSON schema", async () => {
   const definition = defineNodeType({
+    name: "example",
     inputs: {
       in1: {
         type: "string",
@@ -385,6 +398,7 @@ test("describe function generates JSON schema", async () => {
 
 test("describe function generates JSON schema with anyOf", async () => {
   const definition = defineNodeType({
+    name: "example",
     inputs: {
       in1: {
         type: anyOf("string", "number"),
@@ -443,6 +457,7 @@ test("describe function generates JSON schema with anyOf", async () => {
 
 test("describe function generates JSON schema with unsafeType", async () => {
   const definition = defineNodeType({
+    name: "example",
     inputs: {
       in1: {
         type: unsafeType<"FOO" | 123>({
@@ -506,6 +521,7 @@ test("describe function generates JSON schema with unsafeType", async () => {
 
 test("invoke returns value from sync function", async () => {
   const definition = defineNodeType({
+    name: "example",
     inputs: {
       a: {
         type: "string",
@@ -537,6 +553,7 @@ test("invoke returns value from sync function", async () => {
 
 test("invoke returns value from async function", async () => {
   const definition = defineNodeType({
+    name: "example",
     inputs: {
       a: {
         type: "string",
@@ -568,6 +585,7 @@ test("invoke returns value from async function", async () => {
 
 {
   const definitionA = defineNodeType({
+    name: "example",
     inputs: {},
     outputs: {
       out1: {
@@ -586,6 +604,7 @@ test("invoke returns value from async function", async () => {
   });
 
   const definitionB = defineNodeType({
+    name: "example",
     inputs: {
       in1: {
         type: "string",
@@ -666,6 +685,7 @@ test("invoke returns value from async function", async () => {
 
 test("type error: node with no input ports shouldn't allow inputs", () => {
   const definition = defineNodeType({
+    name: "example",
     inputs: {},
     outputs: {
       out1: {

--- a/packages/build/src/test/polymorphic-primary_test.ts
+++ b/packages/build/src/test/polymorphic-primary_test.ts
@@ -14,6 +14,7 @@ import {
 
 test("polymorphic node with primary output acts like that output port", () => {
   const withPrimaryOut = defineNodeType({
+    name: "example",
     inputs: {
       in1: {
         type: "string",
@@ -48,6 +49,7 @@ test("polymorphic node with primary output acts like that output port", () => {
   instance[OutputPortGetter];
 
   defineNodeType({
+    name: "example",
     inputs: { in1: { type: "number" } },
     outputs: {},
     invoke: () => ({}),
@@ -56,6 +58,7 @@ test("polymorphic node with primary output acts like that output port", () => {
   });
 
   defineNodeType({
+    name: "example",
     inputs: { in1: { type: "string" } },
     outputs: {},
     invoke: () => ({}),
@@ -67,6 +70,7 @@ test("polymorphic node with primary output acts like that output port", () => {
 
 test("type error: polymorphic node without primary output doesn't act like an output port", () => {
   const definition = defineNodeType({
+    name: "example",
     inputs: {
       "*": {
         type: "number",
@@ -97,6 +101,7 @@ test("don't allow multiple primary output ports on polymorphic node", () => {
   assert.throws(
     () =>
       defineNodeType({
+        name: "example",
         inputs: {
           "*": {
             type: "number",

--- a/packages/build/src/test/polymorphic_test.ts
+++ b/packages/build/src/test/polymorphic_test.ts
@@ -12,6 +12,7 @@ import { test } from "node:test";
 test("polymorphic inputs", () => {
   // $ExpectType PolymorphicDefinition<OmitDynamicPortConfig<{ in1: { type: "string"; }; "*": { type: "number"; }; }>, { type: "number"; }, { out1: { type: "string"; }; }>
   const definition = defineNodeType({
+    name: "example",
     inputs: {
       in1: {
         type: "string",
@@ -71,6 +72,7 @@ test("polymorphic inputs", () => {
   instance.inputs.in3;
 
   const definition2 = defineNodeType({
+    name: "example",
     inputs: {},
     outputs: {
       strOut: {
@@ -97,6 +99,7 @@ test("polymorphic inputs", () => {
 
 test("polymorphic inputs invoke returns value from sync function", async () => {
   const definition = defineNodeType({
+    name: "example",
     inputs: {
       in1: {
         type: "string",
@@ -130,6 +133,7 @@ test("polymorphic inputs invoke returns value from sync function", async () => {
 
 test("polymorphic inputs invoke returns value from async function", async () => {
   const definition = defineNodeType({
+    name: "example",
     inputs: {
       in1: {
         type: "string",
@@ -164,6 +168,7 @@ test("polymorphic inputs invoke returns value from async function", async () => 
 
 test("polymorphic describe function generates JSON schema with static ports", async () => {
   const definition = defineNodeType({
+    name: "example",
     inputs: {
       in1: {
         type: "string",
@@ -213,6 +218,7 @@ test("polymorphic describe function generates JSON schema with static ports", as
 
 test("polymorphic describe function generates JSON schema from static input", async () => {
   const definition = defineNodeType({
+    name: "example",
     inputs: {
       portList: {
         type: "string",


### PR DESCRIPTION
Also makes `name` required when calling `defineNodeType`, so that those nodes are always serializable.