### PR TITLE
[cli] Add support for @breadboard-ai/build boards

### DIFF
--- a/.changeset/sharp-schools-hunt.md
+++ b/.changeset/sharp-schools-hunt.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard-cli": minor
+---
+
+Add CLI support for @breadboard-ai/build boards

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "./packages/node-proxy-server/functions"
       ],
       "dependencies": {
-        "@rollup/rollup-darwin-arm64": "^4.13.2",
         "litegraph.js": "^0.7.18"
       },
       "devDependencies": {
@@ -27696,6 +27695,7 @@
       "version": "0.7.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "@breadboard-ai/build": "^0.1.2",
         "@google-labs/breadboard": "^0.13.0",
         "@google-labs/breadboard-web": "^1.4.0",
         "@google-labs/core-kit": "^0.5.1",

--- a/packages/breadboard-cli/package.json
+++ b/packages/breadboard-cli/package.json
@@ -156,6 +156,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
+    "@breadboard-ai/build": "^0.1.2",
     "@google-labs/breadboard": "^0.13.0",
     "@google-labs/breadboard-web": "^1.4.0",
     "@google-labs/core-kit": "^0.5.1",

--- a/packages/breadboard-cli/src/commands/lib/loader.ts
+++ b/packages/breadboard-cli/src/commands/lib/loader.ts
@@ -1,3 +1,4 @@
+import { SerializableBoard, serialize } from "@breadboard-ai/build";
 import { Board, BoardRunner, GraphDescriptor } from "@google-labs/breadboard";
 import { pathToFileURL } from "url";
 
@@ -21,6 +22,11 @@ export abstract class Loader {
 
     if (board == undefined)
       throw new Error(`Board ${file} does not have a default export`);
+
+    if ("inputs" in board && "outputs" in board) {
+      // TODO(aomarks) Not a great way to detect build boards.
+      board = serialize(board as SerializableBoard);
+    }
 
     if (boardLike(board)) {
       // A graph descriptor has been exported.. Possibly a lambda.

--- a/packages/breadboard-web/src/make-graphs.ts
+++ b/packages/breadboard-web/src/make-graphs.ts
@@ -74,6 +74,7 @@ async function saveBoard(filePath: string): Promise<ManifestItem | undefined> {
 
     const url = `/graphs/${relativePath.replace(".ts", ".json")}`;
     if ("inputs" in module.default && "outputs" in module.default) {
+      // TODO(aomarks) Not a great way to detect build boards.
       const board = module.default as SerializableBoard;
       const manifest: ManifestItem = {
         title: module.default.title ?? "Untitled (build API)",


### PR DESCRIPTION
You can now run/make boards defined using `@breadboard-ai/build` with the CLI.