### PR TITLE
happier invoke describer

### DIFF
--- a/.changeset/three-plums-give.md
+++ b/.changeset/three-plums-give.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/core-kit": patch
+---
+
+Do not throw in `invoke` describer when board couldn't be loaded.

--- a/packages/core-kit/src/nodes/invoke.ts
+++ b/packages/core-kit/src/nodes/invoke.ts
@@ -107,7 +107,13 @@ const describe = async (
   });
   const outputBuilder = new SchemaBuilder();
   if (context?.base) {
-    const { board } = await getRunnableBoard(context, inputs || {});
+    let board: GraphDescriptor | undefined;
+    try {
+      board = (await getRunnableBoard(context, inputs || {})).board;
+    } catch {
+      // eat any exceptions.
+      // This is a describer, so it must always return some valid value.
+    }
     if (board) {
       const inspectableGraph = inspect(board);
       const { inputSchema, outputSchema } = await inspectableGraph.describe();


### PR DESCRIPTION
- **Do not throw when URL couldn't be loaded in `core.invoke` describer.**
- **docs(changeset): Do not throw in `invoke` describer when board couldn't be loaded.**
