### PR TITLE
[build] Add placeholders for representing cycles

### DIFF
--- a/.changeset/unlucky-bikes-thank.md
+++ b/.changeset/unlucky-bikes-thank.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": minor
+---
+
+Add placeholder() function, useful for representing cycles.

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -5,11 +5,13 @@
  */
 
 import type { Input, InputWithDefault } from "./internal/board/input.js";
+import type { Placeholder } from "./internal/board/placeholder.js";
 import type { OutputPortReference } from "./internal/common/port.js";
 import type { JsonSerializable } from "./internal/type-system/type.js";
 
 export { board } from "./internal/board/board.js";
 export { input } from "./internal/board/input.js";
+export { placeholder } from "./internal/board/placeholder.js";
 export {
   serialize,
   // TODO(aomarks) Not quite sure about exporting and/or the name of
@@ -38,4 +40,5 @@ export type Value<T extends JsonSerializable> =
   | T
   | OutputPortReference<T>
   | Input<T>
-  | InputWithDefault<T>;
+  | InputWithDefault<T>
+  | Placeholder<T>;

--- a/packages/build/src/internal/board/placeholder.ts
+++ b/packages/build/src/internal/board/placeholder.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { OutputPortReference } from "../common/port.js";
+import type {
+  BreadboardType,
+  ConvertBreadboardType,
+  JsonSerializable,
+} from "../type-system/type.js";
+
+export function placeholder(): Placeholder<string>;
+
+export function placeholder<T extends BreadboardType>(
+  params: PlaceholderParams<T>
+): Placeholder<ConvertBreadboardType<T>>;
+
+/**
+ * Create a new Breadboard placeholder.
+ *
+ * Placeholders can be used in place of real output ports for situations where
+ * it is not yet possible to provide an actual output port, most notably because
+ * of a cycle.
+ *
+ * IMPORTANT: The `resolve` method must be called on placeholders before the
+ * `board` function is called.
+ */
+export function placeholder(
+  params?: PlaceholderParams<BreadboardType>
+): Placeholder<JsonSerializable> {
+  return new Placeholder(params?.type ?? "string");
+}
+
+interface PlaceholderParams<T extends BreadboardType> {
+  type: T;
+}
+
+const PLACEHOLDER_ENTITY_NAME = "Placeholder";
+
+export type { Placeholder };
+/**
+ * Placeholders can be used in place of real output ports for situations where
+ * it is not yet possible to provide an actual output port, most notably because
+ * of a cycle.
+ *
+ * IMPORTANT: The `resolve` method must be called on placeholders before the
+ * `board` function is called.
+ */
+class Placeholder<T extends JsonSerializable> {
+  readonly __BreadboardEntity__ = PLACEHOLDER_ENTITY_NAME;
+  readonly type: BreadboardType;
+  #value?: OutputPortReference<T>;
+
+  constructor(type: BreadboardType) {
+    this.type = type;
+  }
+
+  /**
+   * Set the value of this Placeholder. Throws if this Placeholder has already
+   * been resolved.
+   */
+  resolve(value: OutputPortReference<T>): void {
+    if (this.#value !== undefined) {
+      throw new Error("Placeholder has already been resolved");
+    }
+    this.#value = value;
+  }
+
+  /**
+   * Get the resolved value, or `undefined` if it has not yet been resolved.
+   */
+  get value(): OutputPortReference<T> | undefined {
+    return this.#value;
+  }
+}
+
+/**
+ * Test whether the given object is a Breadboard {@link Placeholder}.
+ */
+export function isPlaceholder(
+  value: unknown
+): value is Placeholder<JsonSerializable> {
+  return isBreadboardEntity(value, PLACEHOLDER_ENTITY_NAME);
+}
+
+// TODO(aomarks) Use this pattern elsewhere.
+function isBreadboardEntity(value: unknown, type: string): boolean {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { __BreadboardEntity__?: unknown }).__BreadboardEntity__ === type
+  );
+}

--- a/packages/build/src/internal/common/port.ts
+++ b/packages/build/src/internal/common/port.ts
@@ -5,6 +5,7 @@
  */
 
 import type { Input, InputWithDefault } from "../board/input.js";
+import type { Placeholder } from "../board/placeholder.js";
 import type {
   BreadboardType,
   ConvertBreadboardType,
@@ -178,9 +179,5 @@ export type ValueOrOutputPort<T extends JsonSerializable> =
   | T
   | OutputPortReference<T>
   | Input<T>
-  | InputWithDefault<T>;
-
-// export type InputValue<T extends JsonSerializable> =
-//   | { raw: T }
-//   | { port: OutputPortReference<T> }
-//   | { input: InputWithoutDefault<T> | InputWithDefault<T> };
+  | InputWithDefault<T>
+  | Placeholder<T>;

--- a/packages/build/src/internal/define/definition-monomorphic.ts
+++ b/packages/build/src/internal/define/definition-monomorphic.ts
@@ -110,10 +110,6 @@ class MonomorphicNodeInstance<
   readonly inputs: InputPorts<INPUT_CONFIGS>;
   readonly outputs: OutputPorts<OUTPUT_CONFIGS>;
   readonly type: string;
-  // TODO(aomarks) This should get used somehow.
-  readonly #values: ValuesOrOutputPorts<
-    ExtractPortTypesFromConfigs<INPUT_CONFIGS>
-  >;
   readonly [OutputPortGetter]!: PrimaryOutputPort<OUTPUT_CONFIGS>;
 
   constructor(
@@ -123,7 +119,6 @@ class MonomorphicNodeInstance<
     values: ValuesOrOutputPorts<ExtractPortTypesFromConfigs<INPUT_CONFIGS>>
   ) {
     this.type = name;
-    this.#values = values;
     this.inputs = Object.fromEntries(
       Object.entries(inputs).map(([name, config]) => [
         name,

--- a/packages/build/src/test/compatibility_test.ts
+++ b/packages/build/src/test/compatibility_test.ts
@@ -176,7 +176,7 @@ function setupKits<
   const { kit: adderKit, runtimeKit: adderRuntimeKit } = setupKits({
     adder,
   });
-  // $ExpectType { adder: NodeFactory<{ base: number; } & Record<string, unknown>, { sum: number; } & Record<string, unknown>>; }
+  // $ExpectType { adder: NodeFactory<{ base: number; }, { sum: number; }>; }
   adderKit;
   // $ExpectType Lambda<InputValues, Required<{ boardSum: number; }>>
   const adderBoard = await board(({ num1, num2, num3 }) => {

--- a/packages/build/src/test/placeholder_test.ts
+++ b/packages/build/src/test/placeholder_test.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { anyOf, defineNodeType, input, object } from "../index.js";
+import { placeholder } from "../internal/board/placeholder.js";
+import type { BreadboardType } from "../internal/type-system/type.js";
+
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+
+function assertType<T extends { type: BreadboardType }>(
+  placeholder: T,
+  expected: BreadboardType
+): T {
+  assert.equal(placeholder.type, expected);
+  return placeholder;
+}
+
+test("defaults to string", () => {
+  // $ExpectType Placeholder<string>
+  assertType(placeholder(), "string");
+});
+
+test("only type", () => {
+  // $ExpectType Placeholder<string>
+  assertType(placeholder({ type: "string" }), "string");
+
+  // $ExpectType Placeholder<number>
+  assertType(placeholder({ type: "number" }), "number");
+
+  // $ExpectType Placeholder<boolean>
+  assertType(placeholder({ type: "boolean" }), "boolean");
+
+  // $ExpectType Placeholder<string | number>
+  placeholder({ type: anyOf("string", "number") });
+
+  // $ExpectType Placeholder<{ foo: string; }>
+  placeholder({ type: object({ foo: "string" }) });
+});
+
+test("invalid types", () => {
+  // @ts-expect-error
+  placeholder({ type: undefined });
+
+  // @ts-expect-error
+  placeholder({ type: null });
+
+  // @ts-expect-error
+  placeholder({ type: "foo" });
+});
+
+test("error: missing resolve value", () => {
+  // @ts-expect-error
+  placeholder().resolve();
+
+  // @ts-expect-error
+  placeholder().resolve(undefined);
+
+  // @ts-expect-error
+  placeholder().resolve(null);
+});
+
+test("error: resolve with raw value", () => {
+  // @ts-expect-error
+  placeholder().resolve("foo");
+});
+
+test("error: resolve with input", () => {
+  // @ts-expect-error
+  placeholder().resolve(input());
+});
+
+test("error: resolve with another placeholder", () => {
+  // @ts-expect-error
+  placeholder().resolve(placeholder());
+});
+
+test("error: resolve multiple times", () => {
+  const node = defineNodeType({
+    name: "node",
+    inputs: {},
+    outputs: { a: { type: "string" } },
+    invoke: () => ({ a: "a" }),
+  })({});
+  const p = placeholder();
+  p.resolve(node.outputs.a);
+  assert.throws(
+    () => p.resolve(node.outputs.a),
+    /Placeholder has already been resolved/
+  );
+});


### PR DESCRIPTION
Placeholders can be used in place of real output ports for situations where it is not yet possible to provide an actual output port, most notably because of a cycle:

```ts
import {placeholder} from "@breadboard-ai/build";

const barPlaceholder = placeholder({type: "number"});
const cyclicNode = someNode({ foo: barPlaceholder });
barPlaceholder.resolve(node.outputs.bar);
```