### PR TITLE
subgraph descriptors

### DIFF
--- a/.changeset/funny-pianos-admire.md
+++ b/.changeset/funny-pianos-admire.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard": patch
+---
+
+Switch to use `GraphDescriptors` in subgraph editing.

--- a/packages/breadboard/src/editor/graph.ts
+++ b/packages/breadboard/src/editor/graph.ts
@@ -293,17 +293,15 @@ export class Graph implements EditableGraph {
     return this.#graphs[id] || null;
   }
 
-  addGraph(id: GraphIdentifier, graph: EditableGraph): EditResult {
+  addGraph(id: GraphIdentifier, graph: GraphDescriptor): EditableGraph | null {
     if (this.#graphs[id]) {
-      return {
-        success: false,
-        error: `Subgraph with id "${id}" already exists`,
-      };
+      return null;
     }
 
-    this.#graphs[id] = graph;
+    const editable = new Graph(graph, this.#options);
+    this.#graphs[id] = editable;
 
-    return { success: true };
+    return editable;
   }
 
   removeGraph(id: GraphIdentifier): EditResult {
@@ -317,16 +315,18 @@ export class Graph implements EditableGraph {
     return { success: true };
   }
 
-  replaceGraph(id: GraphIdentifier, graph: EditableGraph): EditResult {
+  replaceGraph(
+    id: GraphIdentifier,
+    graph: GraphDescriptor
+  ): EditableGraph | null {
     if (!this.#graphs[id]) {
-      return {
-        success: false,
-        error: `Subgraph with id "${id}" does not exist`,
-      };
+      return null;
     }
 
-    this.#graphs[id] = graph;
-    return { success: true };
+    const editable = new Graph(graph, this.#options);
+    this.#graphs[id] = editable;
+
+    return editable;
   }
 
   raw() {

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -39,19 +39,24 @@ export type EditableGraph = {
    */
   getGraph(id: GraphIdentifier): EditableGraph | null;
   /**
-   * If does not exist already, adds a subgraph with the specified id. Fails if
-   * the subgraph with this id already exists.
+   * If does not exist already, adds a subgraph with the specified id.
+   * Fails (returns null) if the subgraph with this id already exists.
    * @param id - id of the new subgraph
    * @param graph - the subgraph to add
+   * @returns - the `EditableGraph` instance of the subgraph
    */
-  addGraph(id: GraphIdentifier, graph: EditableGraph): EditResult;
+  addGraph(id: GraphIdentifier, graph: GraphDescriptor): EditableGraph | null;
   /**
-   * Replaces the subgraph with the specified id. Fails if the subgraph with
-   * this id does not already exist.
+   * Replaces the subgraph with the specified id. Fails (returns null)
+   * if the subgraph with this id does not already exist.
    * @param id - id of the subgraph being replaced
    * @param graph - the subgraph with which to replace the existing subgraph
+   * @returns - the `EditableGraph` instance of the newly replaced subgraph.
    */
-  replaceGraph(id: GraphIdentifier, graph: EditableGraph): EditResult;
+  replaceGraph(
+    id: GraphIdentifier,
+    graph: GraphDescriptor
+  ): EditableGraph | null;
   /**
    * Removes the subgraph with the specified id. Fails if the subgraph does not
    * exist.

--- a/packages/breadboard/tests/editor/graph.ts
+++ b/packages/breadboard/tests/editor/graph.ts
@@ -392,22 +392,22 @@ test("editor API correctly works with no subgraphs", (t) => {
 
 test("editor API correctly allows adding, removing, replacing subgraphs", (t) => {
   const graph = testEditGraph();
-  const subgraph = testEditGraph();
+  const subgraph = testEditGraph().raw();
 
-  t.true(graph.addGraph("foo", subgraph).success);
+  t.assert(graph.addGraph("foo", subgraph) !== null);
 
   t.truthy(graph.raw().graphs);
 
-  t.false(graph.addGraph("foo", subgraph).success);
+  t.assert(graph.addGraph("foo", subgraph) === null);
 
   t.true(graph.removeGraph("foo").success);
   t.false(graph.removeGraph("foo").success);
 
   t.falsy(graph.raw().graphs);
 
-  t.false(graph.replaceGraph("foo", subgraph).success);
-  t.true(graph.addGraph("foo", subgraph).success);
-  t.true(graph.replaceGraph("foo", subgraph).success);
+  t.assert(graph.replaceGraph("foo", subgraph) === null);
+  t.assert(graph.addGraph("foo", subgraph) !== null);
+  t.assert(graph.replaceGraph("foo", subgraph) !== null);
 
   t.truthy(graph.raw().graphs);
 });

--- a/packages/website/src/docs/editor.md
+++ b/packages/website/src/docs/editor.md
@@ -77,9 +77,25 @@ There are five edit operations that we can perform on the graph:
 
 - `changeMetadata` -- change metadata (title and description) of a node (`canChangeMetadata` to check only).
 
+## Starting a new graph
+
+If we want to start a brand-new graph, we can use the handy `blank` method, provided by the Editor API:
+
+```ts
+import { blank } from "google-labs/breadboard";
+
+// Returns a new `GraphDescriptor` instance
+// of a pre-built blank graph.
+const myNewGraph = blank();
+```
+
+The newly-created graph will have a pre-filled title and description, a version of `0.0.1` and two connected nodes: the `input` node connected to the `output` node with one wire. The wire will go from `text` port to `text` port of the respective nodes.
+
+![Blank graph diagram](/breadboard/static/images/editor-blank.png)
+
 ## Editing subgraphs
 
-Since every graph may have **embedded subgraphs** in it, we can use the Editor API to access and edit these subgraphs as well. Every subgraph has an identifier that is unique among all subgraphs within their graph. The API uses this id to add, remove, replace, and retrieve the `EditableGraph` instances for subgraphs:
+Since every graph may have **embedded subgraphs** in it, we can use the Editor API to access and edit these subgraphs as well. Every subgraph has an identifier that is unique among all subgraphs within their graph. The API uses this id to add, remove, replace subgraphs and manages the `EditableGraph` instances for subgraphs.
 
 ```ts
 // Returns an `EditableGraph` instance or `null` if not found.
@@ -90,16 +106,29 @@ if (subgraph) {
 }
 
 // Attempts to add a new subgraph and returns `EditResult`.
-// Will fail if a subgraph with this id already exists.
-graph.addGraph("bar", someEditableGraph);
+// Returns null if a subgraph with this id already exists,
+// and an `EditableGraph` instance otherwise.
+const newSubgraph = graph.addGraph("bar", blank());
+if (!newSubgraph) {
+  console.log("A graph with id 'bar' already exists.");
+}
 
 // Attempts to remove the subgraph and returns `EditResult`.
 // Will fail if a subgraph with this id does not exist.
-graph.removeGraph("bar");
+const result = graph.removeGraph("bar");
+if (result.success) {
+  console.log("Yay, removed subgraph 'bar'.");
+} else {
+  console.log("The subgraph 'bar' does not exist".)
+}
 
 // Attempts to replace a subgraph and returns `EditResult`.
-// Will fail if a subgraph with this id does not exist.
-graph.replaceGraph("foo", someEditableGraph);
+// Returns null if a subgraph with this id does not exist,
+// and an `EditableGraph` instance of the new subgraph otherwise.
+const replaced = graph.replaceGraph("foo", blank());
+if (!replaced) {
+  console.log("A graph with id 'foo' already exists.")
+}
 ```
 
 ## Accessing the graph
@@ -125,19 +154,3 @@ const inspectableGraph = graph.inspect();
 ```
 
 In term of lifecycle, the `InspectableGraph` changes more frequently than the `EditableGraph`. So, hang on to the `EditableGraph` instance and use it to create `InspectableGraph` instances. It will cache them for you, only creating a new inspector when the graph changes.
-
-## Starting a new graph
-
-If we want to start a brand-new graph, we can use the handy `blank` method, provided by the Editor API:
-
-```ts
-import { blank } from "google-labs/breadboard";
-
-// Returns a new `GraphDescriptor` instance
-// of a pre-built blank graph.
-const myNewGraph = blank();
-```
-
-The newly-created graph will have a pre-filled title and description, a version of `0.0.1` and two connected nodes: the `input` node connected to the `output` node with one wire. The wire will go from `text` port to `text` port of the respective nodes.
-
-![Blank graph diagram](/breadboard/static/images/editor-blank.png)

--- a/packages/website/src/docs/editor.md
+++ b/packages/website/src/docs/editor.md
@@ -127,7 +127,7 @@ if (result.success) {
 // and an `EditableGraph` instance of the new subgraph otherwise.
 const replaced = graph.replaceGraph("foo", blank());
 if (!replaced) {
-  console.log("A graph with id 'foo' already exists.")
+  console.log("A graph with id 'foo' does not exist.")
 }
 ```
 


### PR DESCRIPTION
- **Switch to use `GraphDescriptor` in subgraph editing.**
- **Update docs.**
- **Tweak docs.**
- **docs(changeset): Switch to use `GraphDescriptors` in subgraph editing.**
