### PR TITLE
graph cache

### DIFF
--- a/.changeset/hungry-waves-begin.md
+++ b/.changeset/hungry-waves-begin.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard": patch
+---
+
+Prepare InspectableGraph instances to have a mutable backing store.

--- a/packages/breadboard/src/inspector/edge.ts
+++ b/packages/breadboard/src/inspector/edge.ts
@@ -52,7 +52,7 @@ class Edge implements InspectableEdge {
   }
 }
 
-export class InspectableEdgeCache {
+export class EdgeCache {
   #graph: InspectableGraph;
   #map?: Map<EdgeDescriptor, InspectableEdge>;
 

--- a/packages/breadboard/src/inspector/edge.ts
+++ b/packages/breadboard/src/inspector/edge.ts
@@ -4,8 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Edge as EdgeDescriptor } from "../types.js";
-import { InspectableEdge, InspectableGraph, InspectableNode } from "./types.js";
+import { Edge as EdgeDescriptor, GraphDescriptor } from "../types.js";
+import {
+  InspectableEdge,
+  InspectableNode,
+  InspectableNodeCache,
+} from "./types.js";
 
 /**
  * This helper is necessary because both "*" and "" are valid representations
@@ -22,16 +26,16 @@ export const fixUpStarEdge = (edge: EdgeDescriptor): EdgeDescriptor => {
 };
 
 class Edge implements InspectableEdge {
-  #graph: InspectableGraph;
+  #nodes: InspectableNodeCache;
   #edge: EdgeDescriptor;
 
-  constructor(graph: InspectableGraph, edge: EdgeDescriptor) {
-    this.#graph = graph;
+  constructor(nodes: InspectableNodeCache, edge: EdgeDescriptor) {
+    this.#nodes = nodes;
     this.#edge = edge;
   }
 
   get from() {
-    const from = this.#graph.nodeById(this.#edge.from);
+    const from = this.#nodes.get(this.#edge.from);
     console.assert(from, "From node not found when getting from.");
     return from as InspectableNode;
   }
@@ -41,7 +45,7 @@ class Edge implements InspectableEdge {
   }
 
   get to() {
-    const to = this.#graph.nodeById(this.#edge.to);
+    const to = this.#nodes.get(this.#edge.to);
     console.assert(to, "To node not found when getting to.");
     return to as InspectableNode;
   }
@@ -53,24 +57,23 @@ class Edge implements InspectableEdge {
 }
 
 export class EdgeCache {
-  #graph: InspectableGraph;
-  #map?: Map<EdgeDescriptor, InspectableEdge>;
+  #nodes: InspectableNodeCache;
+  #map: Map<EdgeDescriptor, InspectableEdge> = new Map();
 
-  constructor(graph: InspectableGraph) {
-    this.#graph = graph;
+  constructor(nodes: InspectableNodeCache) {
+    this.#nodes = nodes;
   }
 
-  #ensureEdgeMap() {
+  populate(graph: GraphDescriptor) {
     // Initialize the edge map from the graph. This is only done once, and all
     // following updates are performed incrementally.
-    const graph = this.#graph;
-    return (this.#map ??= new Map(
-      graph.raw().edges.map((edge) => [edge, new Edge(graph, edge)])
+    return (this.#map = new Map(
+      graph.edges.map((edge) => [edge, new Edge(this.#nodes, edge)])
     ));
   }
 
   get(edge: EdgeDescriptor): InspectableEdge | undefined {
-    return this.#ensureEdgeMap().get(edge);
+    return this.#map.get(edge);
   }
 
   getOrCreate(edge: EdgeDescriptor): InspectableEdge {
@@ -78,42 +81,32 @@ export class EdgeCache {
     if (result) {
       return result;
     }
-    result = new Edge(this.#graph, edge);
-    console.assert(this.#map, "Edge map not initialized when adding.");
+    result = new Edge(this.#nodes, edge);
     this.add(edge);
     return result;
   }
 
   add(edge: EdgeDescriptor) {
-    if (!this.#map) {
-      // If the map is not yet initialized, we can exit early. since we presume
-      // that this.#graph is the source of truth and next time this.#map is
-      // accessed, it will be initialized.
-      return;
-    }
     console.assert(!this.#map.has(edge), "Edge already exists when adding.");
-    this.#map.set(edge, new Edge(this.#graph, edge));
+    this.#map.set(edge, new Edge(this.#nodes, edge));
   }
 
   remove(edge: EdgeDescriptor) {
-    if (!this.#map) {
-      // Same as above ...
-      return;
-    }
     console.assert(this.#map.has(edge), "Edge not found when removing.");
     this.#map.delete(edge);
   }
 
   has(edge: EdgeDescriptor): boolean {
-    return this.#ensureEdgeMap().has(edge);
+    return this.#map.has(edge);
   }
 
   hasByValue(edge: EdgeDescriptor): boolean {
     edge = fixUpStarEdge(edge);
-    return !!this.#graph.raw().edges.find((e) => {
+    const edges = this.edges();
+    return !!edges.find((e) => {
       return (
-        e.from === edge.from &&
-        e.to === edge.to &&
+        e.from.descriptor.id === edge.from &&
+        e.to.descriptor.id === edge.to &&
         e.out === edge.out &&
         e.in === edge.in
       );
@@ -121,6 +114,6 @@ export class EdgeCache {
   }
 
   edges(): InspectableEdge[] {
-    return Array.from(this.#ensureEdgeMap().values());
+    return Array.from(this.#map.values());
   }
 }

--- a/packages/breadboard/src/inspector/graph-store.ts
+++ b/packages/breadboard/src/inspector/graph-store.ts
@@ -5,13 +5,13 @@
  */
 
 import { GraphDescriptor } from "../types.js";
-import { GraphUUID, InspectableGraphStore } from "./types.js";
+import { GraphUUID, GraphDescriptorStore } from "./types.js";
 
 const toUUID = (url: string, version: number): GraphUUID => {
   return `${version}|${url}`;
 };
 
-export class GraphStore implements InspectableGraphStore {
+export class GraphStore implements GraphDescriptorStore {
   #entries = new Map<GraphUUID, GraphDescriptor>();
   #ids = new Map<string, GraphUUID>();
 

--- a/packages/breadboard/src/inspector/graph.ts
+++ b/packages/breadboard/src/inspector/graph.ts
@@ -16,7 +16,7 @@ import {
   NodeTypeIdentifier,
   Schema,
 } from "../types.js";
-import { InspectableEdgeCache } from "./edge.js";
+import { EdgeCache } from "./edge.js";
 import { collectKits } from "./kits.js";
 import { NodeCache } from "./node.js";
 import {
@@ -58,14 +58,14 @@ class Graph implements InspectableGraphWithStore {
 
   #graph: GraphDescriptor;
   #nodes: NodeCache;
-  #edges: InspectableEdgeCache;
+  #edges: EdgeCache;
   #graphs: InspectableSubgraphs | null = null;
 
   constructor(graph: GraphDescriptor, options?: InspectableGraphOptions) {
     this.#graph = graph;
     this.#url = maybeURL(graph.url);
     this.#options = options || {};
-    this.#edges = new InspectableEdgeCache(this);
+    this.#edges = new EdgeCache(this);
     this.#nodes = new NodeCache(this);
   }
 

--- a/packages/breadboard/src/inspector/graph.ts
+++ b/packages/breadboard/src/inspector/graph.ts
@@ -65,7 +65,10 @@ class Graph implements InspectableGraphWithStore {
     this.#graph = graph;
     this.#url = maybeURL(graph.url);
     this.#options = options || {};
-    this.#cache = { edges: new EdgeCache(this), nodes: new NodeCache(this) };
+    const nodes = new NodeCache(this);
+    const edges = new EdgeCache(nodes);
+    edges.populate(graph);
+    this.#cache = { edges, nodes };
   }
 
   raw() {

--- a/packages/breadboard/src/inspector/graph.ts
+++ b/packages/breadboard/src/inspector/graph.ts
@@ -27,7 +27,7 @@ import {
 } from "./schemas.js";
 import {
   InspectableEdge,
-  InspectableGraphCache,
+  MutableGraph,
   InspectableGraphOptions,
   InspectableGraphWithStore,
   InspectableKit,
@@ -58,7 +58,7 @@ class Graph implements InspectableGraphWithStore {
   #options: InspectableGraphOptions;
 
   #graph: GraphDescriptor;
-  #cache: InspectableGraphCache;
+  #cache: MutableGraph;
   #graphs: InspectableSubgraphs | null = null;
 
   constructor(graph: GraphDescriptor, options?: InspectableGraphOptions) {

--- a/packages/breadboard/src/inspector/graph.ts
+++ b/packages/breadboard/src/inspector/graph.ts
@@ -18,7 +18,7 @@ import {
 } from "../types.js";
 import { InspectableEdgeCache } from "./edge.js";
 import { collectKits } from "./kits.js";
-import { InspectableNodeCache } from "./node.js";
+import { NodeCache } from "./node.js";
 import {
   EdgeType,
   describeInput,
@@ -57,7 +57,7 @@ class Graph implements InspectableGraphWithStore {
   #options: InspectableGraphOptions;
 
   #graph: GraphDescriptor;
-  #nodes: InspectableNodeCache;
+  #nodes: NodeCache;
   #edges: InspectableEdgeCache;
   #graphs: InspectableSubgraphs | null = null;
 
@@ -66,7 +66,7 @@ class Graph implements InspectableGraphWithStore {
     this.#url = maybeURL(graph.url);
     this.#options = options || {};
     this.#edges = new InspectableEdgeCache(this);
-    this.#nodes = new InspectableNodeCache(this);
+    this.#nodes = new NodeCache(this);
   }
 
   raw() {

--- a/packages/breadboard/src/inspector/node.ts
+++ b/packages/breadboard/src/inspector/node.ts
@@ -126,7 +126,7 @@ class Node implements InspectableNode {
   }
 }
 
-export class InspectableNodeCache {
+export class NodeCache {
   #graph: InspectableGraph;
   #map?: Map<NodeIdentifier, InspectableNode>;
   #typeMap?: Map<NodeTypeIdentifier, InspectableNode[]>;

--- a/packages/breadboard/src/inspector/node.ts
+++ b/packages/breadboard/src/inspector/node.ts
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { NodeMetadata } from "@google-labs/breadboard-schema/graph.js";
+import {
+  GraphDescriptor,
+  NodeMetadata,
+} from "@google-labs/breadboard-schema/graph.js";
 import {
   InputValues,
   NodeConfiguration,
@@ -135,6 +138,10 @@ export class NodeCache {
     this.#graph = graph;
   }
 
+  populate(graph: GraphDescriptor) {
+    graph.nodes.forEach((node) => this.#addNodeInternal(node));
+  }
+
   #addNodeInternal(node: NodeDescriptor) {
     this.#typeMap ??= new Map();
     this.#map ??= new Map();
@@ -152,7 +159,7 @@ export class NodeCache {
 
   #ensureNodeMap() {
     if (this.#map) return this.#map;
-    this.#graph.raw().nodes.forEach((node) => this.#addNodeInternal(node));
+    this.populate(this.#graph.raw());
     this.#map ??= new Map();
     return this.#map!;
   }

--- a/packages/breadboard/src/inspector/run/event-manager.ts
+++ b/packages/breadboard/src/inspector/run/event-manager.ts
@@ -32,7 +32,7 @@ import {
 import { RunSerializer, SequenceEntry } from "./serializer.js";
 import {
   EventIdentifier,
-  InspectableGraphStore,
+  GraphDescriptorStore,
   InspectableRunErrorEvent,
   InspectableRunEvent,
   InspectableRunSecretEvent,
@@ -68,7 +68,7 @@ export class EventManager {
   #serializer = new RunSerializer();
   #sequence: SequenceEntry[] = [];
 
-  constructor(store: InspectableGraphStore, options: RunObserverOptions) {
+  constructor(store: GraphDescriptorStore, options: RunObserverOptions) {
     this.#graphStore = store;
     this.#options = options;
   }

--- a/packages/breadboard/src/inspector/run/run.ts
+++ b/packages/breadboard/src/inspector/run/run.ts
@@ -11,7 +11,7 @@ import { RunLoader } from "./loader.js";
 import {
   EventIdentifier,
   GraphUUID,
-  InspectableGraphStore,
+  GraphDescriptorStore,
   InspectableRun,
   InspectableRunEvent,
   InspectableRunLoadResult,
@@ -23,11 +23,11 @@ import {
 } from "../types.js";
 
 export class RunObserver implements InspectableRunObserver {
-  #store: InspectableGraphStore;
+  #store: GraphDescriptorStore;
   #options: RunObserverOptions;
   #runs: Run[] = [];
 
-  constructor(store: InspectableGraphStore, options: RunObserverOptions) {
+  constructor(store: GraphDescriptorStore, options: RunObserverOptions) {
     this.#store = store;
     this.#options = options;
   }
@@ -82,7 +82,7 @@ export class Run implements InspectableRun {
 
   constructor(
     timestamp: number,
-    graphStore: InspectableGraphStore,
+    graphStore: GraphDescriptorStore,
     graph: GraphDescriptor,
     options: RunObserverOptions
   ) {

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -521,7 +521,7 @@ export type StoreAdditionResult = {
 /**
  * Represents a store of all graphs that the system has seen so far.
  */
-export type InspectableGraphStore = {
+export type GraphDescriptorStore = {
   /**
    * Retrieves a graph with the given id.
    * @param id -- the id of the graph to retrieve

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -402,7 +402,7 @@ export type InspectableNodeCache = {
   nodes(): InspectableNode[];
 };
 
-export type InspectableGraphCache = {
+export type MutableGraph = {
   nodes: InspectableNodeCache;
   edges: InspectableEdgeCache;
 };

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -402,6 +402,10 @@ export type InspectableNodeCache = {
   nodes(): InspectableNode[];
 };
 
+/**
+ * A backing store for `InspectableGraph` instances, representing a stable
+ * instance of a graph whose properties mutate.
+ */
 export type MutableGraph = {
   nodes: InspectableNodeCache;
   edges: InspectableEdgeCache;

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -385,6 +385,28 @@ export type EdgeStoreMutator = {
 
 export type InspectableGraphWithStore = InspectableGraph & GraphStoreMutator;
 
+export type InspectableEdgeCache = {
+  get(edge: Edge): InspectableEdge | undefined;
+  getOrCreate(edge: Edge): InspectableEdge;
+  add(edge: Edge): void;
+  remove(edge: Edge): void;
+  hasByValue(edge: Edge): boolean;
+  edges(): InspectableEdge[];
+};
+
+export type InspectableNodeCache = {
+  byType(type: NodeTypeIdentifier): InspectableNode[];
+  get(id: string): InspectableNode | undefined;
+  add(node: NodeDescriptor): void;
+  remove(id: NodeIdentifier): void;
+  nodes(): InspectableNode[];
+};
+
+export type InspectableGraphCache = {
+  nodes: InspectableNodeCache;
+  edges: InspectableEdgeCache;
+};
+
 /**
  * Represents a store of graph versions.
  */


### PR DESCRIPTION
- **Rename `InspectableGraphStore` to `GraphDescriptorStore`.**
- **Rename `InspectableNodeCache` to `NodeCache`.**
- **Rename `InspectableEdgeCache` to `EdgeCache`.**
- **Add types for cache.**
- **Use `InspectableGraphCache` in Graph.**
- **Wean inspector edgy stuff off `InspectableGraph`.**
- **Introduce the idea of a `MutableGraph`.**
- **Minor massage.**
- **docs(changeset): Prepare InspectableGraph instances to have a mutable backing store.**
