### PR TITLE
[breadboard-ui] Handle strings in array-editor a little better

### DIFF
--- a/.changeset/brown-camels-melt.md
+++ b/.changeset/brown-camels-melt.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard-ui": patch
+---
+
+Fix issue with string values in array-editor

--- a/packages/breadboard-ui/src/elements/node-info/array-editor.ts
+++ b/packages/breadboard-ui/src/elements/node-info/array-editor.ts
@@ -251,7 +251,11 @@ export class ArrayEditor extends LitElement {
           assertIsLLMContent(formValueObject);
         }
 
-        items.push(formValueObject);
+        if (typeof formValueObject === "string") {
+          items.push(formValue);
+        } else {
+          items.push(formValueObject);
+        }
       } catch (err) {
         if (err instanceof SyntaxError) {
           field.setCustomValidity("Invalid JSON");

--- a/packages/breadboard-ui/src/elements/node-info/node-info.ts
+++ b/packages/breadboard-ui/src/elements/node-info/node-info.ts
@@ -386,7 +386,7 @@ export class NodeInfo extends LitElement {
 
           // Set nulls & undefineds for deletion.
           if (objectValue === null || objectValue === undefined) {
-            data.delete(name);
+            delete configuration[name];
             continue;
           }
 


### PR DESCRIPTION
Fixes #1356. This was a really subtle one – thanks for the super clear bug report, @PaulKinlan!