### PR TITLE
[breadboard-ui] Only save to settings when a value is changed or added

### DIFF
--- a/.changeset/friendly-shirts-remember.md
+++ b/.changeset/friendly-shirts-remember.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard-web": patch
+---
+
+Be a little more economical with settings saves

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -1055,22 +1055,24 @@ export class Main extends LitElement {
 
             const name = event.id;
             const value = event.data.secret as string;
-            const settingsItems = this.#settings.getSection(
+            const secrets = this.#settings.getSection(
               BreadboardUI.Types.SETTINGS_TYPE.SECRETS
             ).items;
-            if (settingsItems.has(event.id)) {
-              const settingsItem = settingsItems.get(event.id);
-              if (settingsItem) {
-                if (settingsItem.value === value) {
-                  return;
-                }
-
-                settingsItem.value = value;
+            let shouldSave = false;
+            if (secrets.has(event.id)) {
+              const secret = secrets.get(event.id);
+              if (secret && secret.value !== value) {
+                secret.value = value;
+                shouldSave = true;
               }
             } else {
-              settingsItems.set(name, { name, value });
+              secrets.set(name, { name, value });
+              shouldSave = true;
             }
 
+            if (!shouldSave) {
+              return;
+            }
             await this.#settings.save(this.#settings.values);
             this.requestUpdate();
           }}

--- a/packages/breadboard-web/src/preview-run.ts
+++ b/packages/breadboard-web/src/preview-run.ts
@@ -345,19 +345,24 @@ export class PreviewRun extends LitElement {
             if (isSecret && shouldSaveSecrets) {
               const name = event.id;
               const value = event.data.secret as string;
-              const settingsItems = this.#settings.getSection(
+              const secrets = this.#settings.getSection(
                 BreadboardUI.Types.SETTINGS_TYPE.SECRETS
               ).items;
-              if (settingsItems.has(event.id)) {
-                const settingsItem = settingsItems.get(event.id);
+              let shouldSave = false;
+              if (secrets.has(event.id)) {
+                const settingsItem = secrets.get(event.id);
                 if (settingsItem && settingsItem.value !== value) {
                   settingsItem.value = value;
+                  shouldSave = true;
                 }
               } else {
-                settingsItems.set(name, { name, value });
+                secrets.set(name, { name, value });
+                shouldSave = true;
               }
 
-              await this.#settings.save(this.#settings.values);
+              if (shouldSave) {
+                await this.#settings.save(this.#settings.values);
+              }
             }
           }
 


### PR DESCRIPTION
I noticed we were saving settings changes a little too eagerly; this fixes that