### PR TITLE
[breadboard-ui] Only show Board Selector for strings/URLs

### DIFF
--- a/packages/breadboard-ui/src/elements/node-info/node-info.ts
+++ b/packages/breadboard-ui/src/elements/node-info/node-info.ts
@@ -597,7 +597,10 @@ export class NodeInfo extends LitElement {
                           id="${name}"
                           name="${name}"
                         ></bb-schema-editor>`;
-                      } else if (port.schema.behavior?.includes("board")) {
+                      } else if (
+                        port.schema.behavior?.includes("board") &&
+                        typeof value !== "object"
+                      ) {
                         input = html`<bb-board-selector
                           .subGraphIds=${this.graph && this.graph.graphs
                             ? Object.keys(this.graph.graphs)


### PR DESCRIPTION
It turns out that some of our `$boards` are set as objects. In those cases we shouldn't show the Board Selector.