### PR TITLE
runtime urls

### DIFF
--- a/.changeset/four-steaks-clean.md
+++ b/.changeset/four-steaks-clean.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard": minor
+---
+
+Split run-time and build-time URL resolutions for loading graphs.

--- a/packages/breadboard-ui/src/elements/node-info/node-info.ts
+++ b/packages/breadboard-ui/src/elements/node-info/node-info.ts
@@ -30,6 +30,7 @@ import {
 import { ArrayEditor } from "./array-editor.js";
 import { NodeMetadata } from "@google-labs/breadboard-schema/graph.js";
 import { BoardSelector } from "./board-selector.js";
+import { isBoard } from "../../utils/board.js";
 
 @customElement("bb-node-info")
 export class NodeInfo extends LitElement {
@@ -604,21 +605,12 @@ export class NodeInfo extends LitElement {
                           id="${name}"
                           name="${name}"
                         ></bb-schema-editor>`;
-                      } else if (port.schema.behavior?.includes("board")) {
-                        // TODO: Make this nice and tidy one day.
-                        let selectorValue = value;
-                        if (typeof value === "object") {
-                          const maybeCapability = value as {
-                            kind: "board";
-                            path: string;
-                          };
-                          if (
-                            maybeCapability.kind === "board" &&
-                            maybeCapability.path
-                          ) {
-                            selectorValue = maybeCapability.path;
-                          }
-                        }
+                      } else if (isBoard(port, value)) {
+                        const selectorValue = value
+                          ? typeof value === "string"
+                            ? value
+                            : value.path
+                          : "";
                         input = html`<bb-board-selector
                           .subGraphIds=${this.graph && this.graph.graphs
                             ? Object.keys(this.graph.graphs)

--- a/packages/breadboard-ui/src/utils/board.ts
+++ b/packages/breadboard-ui/src/utils/board.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  InspectablePort,
+  NodeValue,
+  UnresolvedPathBoardCapability,
+} from "@google-labs/breadboard";
+
+export const isBoard = (
+  port: InspectablePort,
+  value: NodeValue
+): value is UnresolvedPathBoardCapability | string | undefined => {
+  if (!value) return true;
+  if (!port.schema.behavior?.includes("board")) return false;
+  if (typeof value === "string") return true;
+  if (typeof value === "object") {
+    const maybeCapability = value as UnresolvedPathBoardCapability;
+    return maybeCapability.kind === "board" && !!maybeCapability.path;
+  }
+  return false;
+};

--- a/packages/breadboard/src/capability.ts
+++ b/packages/breadboard/src/capability.ts
@@ -7,8 +7,10 @@
 import { baseURLFromContext } from "./loader/loader.js";
 import {
   BreadboardCapability,
+  GraphDescriptor,
   GraphDescriptorBoardCapability,
   NodeHandlerContext,
+  NodeValue,
   OutputValues,
   ResolvedURLBoardCapability,
   UnresolvedPathBoardCapability,
@@ -47,6 +49,67 @@ export const isUnresolvedPathBoardCapability = (
   return !!path;
 };
 
+const isGraphDescriptor = (
+  candidate: unknown
+): candidate is GraphDescriptor => {
+  const graph = candidate as GraphDescriptor;
+  return (
+    graph && typeof graph === "object" && graph.nodes && graph.edges && true
+  );
+};
+
+export const graphDescriptorFromCapability = async (
+  capability: BreadboardCapability,
+  context: NodeHandlerContext
+) => {
+  if (isGraphDescriptorCapability(capability)) {
+    // If all we got is a GraphDescriptor, build a runnable board from it.
+    // TODO: Use JSON schema to validate rather than this hack.
+    return capability.board;
+  } else if (isResolvedURLBoardCapability(capability)) {
+    if (!context.loader) {
+      throw new Error(
+        `The "board" Capability is a URL, but no loader was supplied.`
+      );
+    }
+    const graph = await context.loader.load(capability.url, context);
+    if (!graph) {
+      throw new Error(
+        `Unable to load "board" Capability with the URL of ${capability.url}.`
+      );
+    }
+    return graph;
+  } else if (isUnresolvedPathBoardCapability(capability)) {
+    throw new Error(
+      `Integrity error: somehow, the unresolved path "board" Capability snuck through the processing of inputs`
+    );
+  }
+  throw new Error(
+    `Unsupported type of "board" Capability. Perhaps the supplied board isn't actually a GraphDescriptor?`
+  );
+};
+
+// TODO: Maybe this is just a GraphLoader API? Instead of taking a `string`,
+// the `load` method should take an `unknown` that it then tries to
+// shape-detect? And this is the code to do it.
+export const getGraphDescriptor = async (
+  board: unknown,
+  context: NodeHandlerContext
+): Promise<GraphDescriptor | undefined> => {
+  if (!board) return undefined;
+
+  if (typeof board === "string") {
+    const graph = await context.loader?.load(board, context);
+    if (!graph) throw new Error(`Unable to load graph from "${board}"`);
+    return graph;
+  } else if (isBreadboardCapability(board)) {
+    return graphDescriptorFromCapability(board, context);
+  } else if (isGraphDescriptor(board)) {
+    return board;
+  }
+  return undefined;
+};
+
 const resolvePath = (
   capability: UnresolvedPathBoardCapability,
   base: URL
@@ -66,17 +129,28 @@ const resolvePath = (
  */
 export const resolveBoardCapabilities = async (
   outputsPromise: Promise<OutputValues>,
-  context: NodeHandlerContext
+  context: NodeHandlerContext,
+  url?: string
 ): Promise<OutputValues> => {
   const outputs = await outputsPromise;
-  for (const name in outputs) {
-    const property = outputs[name];
+  resolveBoardCapabilitiesInInputs(outputs, context, url);
+  return Promise.resolve(outputs);
+};
+
+export const resolveBoardCapabilitiesInInputs = (
+  values: Record<string, NodeValue>,
+  context: NodeHandlerContext,
+  url?: string
+) => {
+  for (const name in values) {
+    const property = values[name];
     if (
       isBreadboardCapability(property) &&
       isUnresolvedPathBoardCapability(property)
     ) {
-      outputs[name] = resolvePath(property, baseURLFromContext(context));
+      const base = url ? new URL(url) : baseURLFromContext(context);
+      values[name] = resolvePath(property, base);
     }
   }
-  return Promise.resolve(outputs);
+  return values;
 };

--- a/packages/breadboard/src/capability.ts
+++ b/packages/breadboard/src/capability.ts
@@ -80,9 +80,18 @@ export const graphDescriptorFromCapability = async (
     }
     return graph;
   } else if (isUnresolvedPathBoardCapability(capability)) {
-    throw new Error(
-      `Integrity error: somehow, the unresolved path "board" Capability snuck through the processing of inputs`
-    );
+    if (!context.loader) {
+      throw new Error(
+        `The "board" Capability is a URL, but no loader was supplied.`
+      );
+    }
+    const graph = await context.loader.load(capability.path, context);
+    if (!graph) {
+      throw new Error(
+        `Unable to load "board" Capability with the path of ${capability.path}.`
+      );
+    }
+    return graph;
   }
   throw new Error(
     `Unsupported type of "board" Capability. Perhaps the supplied board isn't actually a GraphDescriptor?`

--- a/packages/breadboard/src/capability.ts
+++ b/packages/breadboard/src/capability.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  BreadboardCapability,
+  GraphDescriptorBoardCapability,
+  ResolvedURLBoardCapability,
+  UnresolvedPathBoardCapability,
+} from "./types.js";
+
+// Helpers for BreadboardCapability
+
+export const isBreadboardCapability = (
+  o: unknown
+): o is BreadboardCapability => {
+  const maybe = o as BreadboardCapability;
+  return !!maybe && maybe.kind === "board";
+};
+
+export const isGraphDescriptorCapability = (
+  capability: BreadboardCapability
+): capability is GraphDescriptorBoardCapability => {
+  const maybe = capability as GraphDescriptorBoardCapability;
+  const board = maybe.board;
+  return !!board && !!board.edges && !!board.nodes;
+};
+
+export const isResolvedURLBoardCapability = (
+  capability: BreadboardCapability
+): capability is ResolvedURLBoardCapability => {
+  const maybe = capability as ResolvedURLBoardCapability;
+  const url = maybe.url;
+  return !!url;
+};
+
+export const isUnresolvedPathBoardCapability = (
+  capability: UnresolvedPathBoardCapability
+): capability is UnresolvedPathBoardCapability => {
+  const maybe = capability as UnresolvedPathBoardCapability;
+  const path = maybe.path;
+  return !!path;
+};

--- a/packages/breadboard/src/index.ts
+++ b/packages/breadboard/src/index.ts
@@ -61,6 +61,11 @@ export type {
 export { asyncGen } from "./utils/async-gen.js";
 
 /**
+ * Helpers for handling BreadboardCapability.
+ */
+export { getGraphDescriptor } from "./capability.js";
+
+/**
  * The Inspector API.
  */
 export type * from "./inspector/types.js";

--- a/packages/breadboard/src/kits/ctors.ts
+++ b/packages/breadboard/src/kits/ctors.ts
@@ -9,6 +9,7 @@ import {
   BreadboardCapability,
   ConfigOrLambda,
   GraphDescriptor,
+  GraphDescriptorBoardCapability,
   InputValues,
   Kit,
   KitConstructor,
@@ -58,7 +59,7 @@ export const asComposeTimeKit = (
 };
 
 /**
- * Synctactic sugar for node factories that accept lambdas. This allows passing
+ * Syntactic sugar for node factories that accept lambdas. This allows passing
  * either
  *  - A JS function that is a lambda function defining the board
  *  - A board capability, i.e. the result of calling lambda()
@@ -85,7 +86,7 @@ const getConfigWithLambda = <In = InputValues, Out = OutputValues>(
     typeof config === "function" ||
     config instanceof Node ||
     ((config as BreadboardCapability).kind === "board" &&
-      (config as BreadboardCapability).board);
+      (config as GraphDescriptorBoardCapability).board);
 
   const result = (
     gotBoard

--- a/packages/breadboard/src/runner.ts
+++ b/packages/breadboard/src/runner.ts
@@ -47,6 +47,7 @@ import {
   isResolvedURLBoardCapability,
   isUnresolvedPathBoardCapability,
   resolveBoardCapabilities,
+  resolveBoardCapabilitiesInInputs,
 } from "./capability.js";
 
 /**
@@ -205,7 +206,7 @@ export class BoardRunner implements BreadboardRunner {
             path()
           );
           outputsPromise = result.outputsPromise
-            ? resolveBoardCapabilities(result.outputsPromise, context)
+            ? resolveBoardCapabilities(result.outputsPromise, context, this.url)
             : undefined;
         } else if (descriptor.type === "output") {
           if (
@@ -241,7 +242,7 @@ export class BoardRunner implements BreadboardRunner {
 
           outputsPromise = callHandler(
             handler,
-            inputs,
+            resolveBoardCapabilitiesInInputs(inputs, context, this.url),
             newContext
           ) as Promise<OutputValues>;
         }
@@ -431,6 +432,7 @@ export class BoardRunner implements BreadboardRunner {
       );
     }
 
+    // TODO: Deduplicate, replace with `getGraphDescriptor`.
     if (isGraphDescriptorCapability(capability)) {
       // If all we got is a GraphDescriptor, build a runnable board from it.
       // TODO: Use JSON schema to validate rather than this hack.

--- a/packages/breadboard/src/runner.ts
+++ b/packages/breadboard/src/runner.ts
@@ -46,6 +46,7 @@ import {
   isGraphDescriptorCapability,
   isResolvedURLBoardCapability,
   isUnresolvedPathBoardCapability,
+  resolveBoardCapabilities,
 } from "./capability.js";
 
 /**
@@ -203,7 +204,9 @@ export class BoardRunner implements BreadboardRunner {
             result,
             path()
           );
-          outputsPromise = result.outputsPromise;
+          outputsPromise = result.outputsPromise
+            ? resolveBoardCapabilities(result.outputsPromise, context)
+            : undefined;
         } else if (descriptor.type === "output") {
           if (
             !(await bubbleUpOutputsIfNeeded(

--- a/packages/breadboard/src/runner.ts
+++ b/packages/breadboard/src/runner.ts
@@ -39,8 +39,14 @@ import { asyncGen } from "./utils/async-gen.js";
 import { StackManager } from "./stack.js";
 import { timestamp } from "./timestamp.js";
 import breadboardSchema from "@google-labs/breadboard-schema/breadboard.schema.json" assert { type: "json" };
-import { GraphProvider } from "./loader/types.js";
+import { GraphLoader, GraphProvider } from "./loader/types.js";
 import { SENTINEL_BASE_URL, createLoader } from "./loader/index.js";
+import {
+  isBreadboardCapability,
+  isGraphDescriptorCapability,
+  isResolvedURLBoardCapability,
+  isUnresolvedPathBoardCapability,
+} from "./capability.js";
 
 /**
  * This class is the main entry point for running a board.
@@ -412,28 +418,46 @@ export class BoardRunner implements BreadboardRunner {
    * @returns {Board} A runnable board.
    */
   static async fromBreadboardCapability(
-    board: BreadboardCapability
+    capability: BreadboardCapability,
+    loader?: GraphLoader,
+    context?: NodeHandlerContext
   ): Promise<BoardRunner> {
-    if (board.kind !== "board" || !(board as BreadboardCapability).board) {
-      throw new Error(`Expected a "board" Capability, but got ${board}`);
-    }
-
-    // TODO: Use JSON schema to validate rather than this hack.
-    const boardish = (board as BreadboardCapability).board as GraphDescriptor;
-    if (!(boardish.edges && boardish.kits && boardish.nodes)) {
+    if (!isBreadboardCapability(capability)) {
       throw new Error(
-        'Supplied "board" Capability argument is not actually a board'
+        `Expected a "board" Capability, but got "${JSON.stringify(capability)}`
       );
     }
 
-    // If all we got is a GraphDescriptor, build a runnable board from it.
-    // TODO: Use JSON schema to validate rather than this hack.
-    let runnableBoard = (board as BreadboardCapability).board as BoardRunner;
-    if (!runnableBoard.runOnce) {
-      runnableBoard = await BoardRunner.fromGraphDescriptor(boardish);
+    if (isGraphDescriptorCapability(capability)) {
+      // If all we got is a GraphDescriptor, build a runnable board from it.
+      // TODO: Use JSON schema to validate rather than this hack.
+      const board = capability.board;
+      const runnableBoard = board as BoardRunner;
+      if (!runnableBoard.runOnce) {
+        return await BoardRunner.fromGraphDescriptor(board);
+      }
+      return runnableBoard;
+    } else if (isResolvedURLBoardCapability(capability)) {
+      if (!loader || !context) {
+        throw new Error(
+          `The "board" Capability is a URL, but no loader and/or context was supplied.`
+        );
+      }
+      const graph = await loader.load(capability.url, context);
+      if (!graph) {
+        throw new Error(
+          `Unable to load "board" Capability with the URL of ${capability.url}.`
+        );
+      }
+      return BoardRunner.fromGraphDescriptor(graph);
+    } else if (isUnresolvedPathBoardCapability(capability)) {
+      throw new Error(
+        `Integrity error: somehow, the unresolved path "board" Capability snuck through the processing of inputs`
+      );
     }
-
-    return runnableBoard;
+    throw new Error(
+      `Unsupported type of "board" Capability. Perhaps the supplied board isn't actually a GraphDescriptor?`
+    );
   }
 
   static async handlersFromBoard(

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -602,10 +602,41 @@ export interface Breadboard extends BreadboardRunner {
   addEdgeAcrossBoards(edge: Edge, from: Breadboard, to: Breadboard): void;
 }
 
-export type BreadboardCapability = Capability & {
+export type GraphDescriptorBoardCapability = {
   kind: "board";
   board: GraphDescriptor;
+  /**
+   * Unresolved path to the board. Use this field to specify the path at
+   * compose-time that needs to be resolved at run-time.
+   * The path will be resolved as the inputs are received by the board,
+   * relative to the invoking board.
+   */
 };
+
+export type ResolvedURLBoardCapability = {
+  kind: "board";
+  /**
+   * Resolved path to the board. This field is populated at run-time as a
+   * result of resolving the `path` field.
+   */
+  url: string;
+};
+
+export type UnresolvedPathBoardCapability = {
+  kind: "board";
+  /**
+   * Unresolved path to the board. Use this field to specify the path at
+   * compose-time that needs to be resolved at run-time.
+   * The path will be resolved as the inputs are received by the board,
+   * relative to the invoking board.
+   */
+  path: string;
+};
+
+export type BreadboardCapability =
+  | GraphDescriptorBoardCapability
+  | ResolvedURLBoardCapability
+  | UnresolvedPathBoardCapability;
 
 export interface NodeHandlerContext {
   readonly board?: BreadboardRunner;
@@ -718,7 +749,7 @@ export type LambdaNodeInputs = InputValues & {
    *
    * Note that (for now) each board can only be represented by one node.
    */
-  board: BreadboardCapability;
+  board: GraphDescriptorBoardCapability;
 
   /**
    * All other inputs will be bound to the board.

--- a/packages/breadboard/tests/board.ts
+++ b/packages/breadboard/tests/board.ts
@@ -6,7 +6,10 @@
 
 import test from "ava";
 import { Board } from "../src/board.js";
-import type { BreadboardCapability, GraphDescriptor } from "../src/types.js";
+import type {
+  GraphDescriptor,
+  GraphDescriptorBoardCapability,
+} from "../src/types.js";
 import { TestKit } from "./helpers/_test-kit.js";
 import breadboardSchema from "@google-labs/breadboard-schema/breadboard.schema.json" assert { type: "json" };
 
@@ -189,19 +192,19 @@ test("nested lambdas reusing kits", async (t) => {
   // kit1 wasn't used in the first lambda, so shouldn't be on the lambda board
   const lambda1 = board.nodes.find((n) => n.type === "lambda");
   const board2 = (
-    lambda1?.configuration?.board as BreadboardCapability | undefined
+    lambda1?.configuration?.board as GraphDescriptorBoardCapability | undefined
   )?.board;
   t.deepEqual(board2?.kits, [kits[1]]);
 
   // both kits were used in the second lambda
   const lambda2 = board2?.nodes.find((n) => n.type === "lambda");
   const board3 = (
-    lambda2?.configuration?.board as BreadboardCapability | undefined
+    lambda2?.configuration?.board as GraphDescriptorBoardCapability | undefined
   )?.board;
   t.deepEqual(board3?.kits, kits);
 });
 
-test("corectly invoke a lambda", async (t) => {
+test("correctly invoke a lambda", async (t) => {
   const board = new Board();
   const kit = board.addKit(TestKit);
 

--- a/packages/breadboard/tests/helpers/_test-kit.ts
+++ b/packages/breadboard/tests/helpers/_test-kit.ts
@@ -10,6 +10,7 @@ import { StreamCapability } from "../../src/stream.js";
 import {
   BreadboardCapability,
   GraphDescriptor,
+  GraphDescriptorBoardCapability,
   InputValues,
   NodeDescriberResult,
   NodeHandlerContext,
@@ -72,11 +73,11 @@ export const TestKit = new KitBuilder({
                 $board as BreadboardCapability
               )
             : typeof $board === "string"
-            ? await Board.load($board, {
-                base,
-                outerGraph: context.outerGraph,
-              })
-            : undefined;
+              ? await Board.load($board, {
+                  base,
+                  outerGraph: context.outerGraph,
+                })
+              : undefined;
 
         if (!board) throw new Error("Must provide valid $board to invoke");
 
@@ -87,11 +88,11 @@ export const TestKit = new KitBuilder({
         const runnableBoard = board
           ? await Board.fromBreadboardCapability(board)
           : path
-          ? await Board.load(path, {
-              base,
-              outerGraph: context.outerGraph,
-            })
-          : undefined;
+            ? await Board.load(path, {
+                base,
+                outerGraph: context.outerGraph,
+              })
+            : undefined;
 
         if (!runnableBoard)
           throw new Error("Must provide valid board to invoke");
@@ -107,12 +108,12 @@ export const TestKit = new KitBuilder({
         inputs?.$board &&
         (inputs?.$board as BreadboardCapability).kind === "board"
       ) {
-        graph = (inputs?.$board as BreadboardCapability).board;
+        graph = (inputs?.$board as GraphDescriptorBoardCapability).board;
       } else if (
         inputs?.board &&
         (inputs.board as BreadboardCapability).kind === "board"
       ) {
-        graph = (inputs.board as BreadboardCapability).board;
+        graph = (inputs.board as GraphDescriptorBoardCapability).board;
       } else if (inputs?.graph) {
         graph = inputs.graph as GraphDescriptor;
       }
@@ -168,7 +169,7 @@ export const TestKit = new KitBuilder({
             },
           ])
         ),
-        additonalProperties: Object.entries(inputs ?? {}).length === 0,
+        additionalProperties: Object.entries(inputs ?? {}).length === 0,
       });
 
       return {

--- a/packages/breadboard/tests/new/grammar/lambdas.ts
+++ b/packages/breadboard/tests/new/grammar/lambdas.ts
@@ -14,7 +14,7 @@ import {
   OutputValues,
   BoardRunner,
   asRuntimeKit,
-  BreadboardCapability,
+  GraphDescriptorBoardCapability,
 } from "../../../src/index.js";
 
 import { TestKit, testKit } from "../../helpers/_test-kit.js";
@@ -121,7 +121,7 @@ test("serialize closure lambda", async (t) => {
   t.deepEqual(
     (
       serialized?.nodes?.find((node) => node.type === "lambda")?.configuration
-        ?.board as BreadboardCapability
+        ?.board as GraphDescriptorBoardCapability
     )?.board,
     { kits: [], ...serialized2 }
   );

--- a/packages/core-kit/src/nodes/curry.ts
+++ b/packages/core-kit/src/nodes/curry.ts
@@ -44,12 +44,6 @@ const describe = async (
   context?: NodeDescriberContext
 ): Promise<NodeDescriberResult> => {
   const inputBuilder = new SchemaBuilder().addProperties({
-    path: {
-      title: "path",
-      behavior: ["deprecated"],
-      description: "The path to the board to invoke.",
-      type: "string",
-    },
     $board: {
       title: "board",
       behavior: ["board"],
@@ -68,20 +62,21 @@ const describe = async (
     });
   if (context?.base) {
     let board: GraphDescriptor | undefined;
-    try {
-      const { $board } = inputs || {};
-      board = await getGraphDescriptor($board, context);
-    } catch {
-      // eat any exceptions.
-      // This is a describer, so it must always return some valid value.
-    }
-    if (board) {
-      const inspectableGraph = inspect(board);
-      const { inputSchema } = await inspectableGraph.describe();
-      inputBuilder.addProperties(inputSchema?.properties);
-      inputBuilder.setAdditionalProperties(inputSchema.additionalProperties);
-    } else {
-      inputBuilder.setAdditionalProperties(true);
+    inputBuilder.setAdditionalProperties(true);
+    if (inputs) {
+      const { $board } = inputs;
+      try {
+        board = await getGraphDescriptor($board, context);
+      } catch {
+        // eat any exceptions.
+        // This is a describer, so it must always return some valid value.
+      }
+      if (board) {
+        const inspectableGraph = inspect(board);
+        const { inputSchema } = await inspectableGraph.describe();
+        inputBuilder.addProperties(inputSchema?.properties);
+        inputBuilder.setAdditionalProperties(inputSchema.additionalProperties);
+      }
     }
   }
   const inputSchema = inputBuilder.build();

--- a/packages/core-kit/src/nodes/curry.ts
+++ b/packages/core-kit/src/nodes/curry.ts
@@ -13,9 +13,9 @@ import {
   OutputValues,
   Schema,
   SchemaBuilder,
+  getGraphDescriptor,
   inspect,
 } from "@google-labs/breadboard";
-import { getGraphDescriptor } from "../utils.js";
 
 export type CurryInputs = {
   $board: unknown;

--- a/packages/core-kit/src/nodes/invoke.ts
+++ b/packages/core-kit/src/nodes/invoke.ts
@@ -79,23 +79,27 @@ const describe = async (
   const outputBuilder = new SchemaBuilder();
   if (context?.base) {
     let board: GraphDescriptor | undefined;
-    try {
-      board = (await getRunnableBoard(context, inputs || {})).board;
-    } catch {
-      // eat any exceptions.
-      // This is a describer, so it must always return some valid value.
-    }
-    if (board) {
-      const inspectableGraph = inspect(board);
-      const { inputSchema, outputSchema } = await inspectableGraph.describe();
-      inputBuilder.addProperties(inputSchema?.properties);
-      inputBuilder.setAdditionalProperties(inputSchema.additionalProperties);
-      inputSchema?.required && inputBuilder.addRequired(inputSchema?.required);
-      outputBuilder.addProperties(outputSchema?.properties);
-      outputBuilder.setAdditionalProperties(outputSchema.additionalProperties);
-    } else {
-      outputBuilder.setAdditionalProperties(true);
-      inputBuilder.setAdditionalProperties(true);
+    outputBuilder.setAdditionalProperties(true);
+    inputBuilder.setAdditionalProperties(true);
+    if (inputs) {
+      try {
+        board = (await getRunnableBoard(context, inputs)).board;
+      } catch {
+        // eat any exceptions.
+        // This is a describer, so it must always return some valid value.
+      }
+      if (board) {
+        const inspectableGraph = inspect(board);
+        const { inputSchema, outputSchema } = await inspectableGraph.describe();
+        inputBuilder.addProperties(inputSchema?.properties);
+        inputBuilder.setAdditionalProperties(inputSchema.additionalProperties);
+        inputSchema?.required &&
+          inputBuilder.addRequired(inputSchema?.required);
+        outputBuilder.addProperties(outputSchema?.properties);
+        outputBuilder.setAdditionalProperties(
+          outputSchema.additionalProperties
+        );
+      }
     }
   }
   const inputSchema = inputBuilder.build();

--- a/packages/core-kit/src/utils.ts
+++ b/packages/core-kit/src/utils.ts
@@ -6,10 +6,9 @@
 
 import {
   BoardRunner,
-  BreadboardCapability,
   BreadboardRunner,
-  GraphDescriptor,
   NodeHandlerContext,
+  getGraphDescriptor,
 } from "@google-labs/breadboard";
 
 export const loadGraphFromPath = async (
@@ -19,46 +18,6 @@ export const loadGraphFromPath = async (
   const graph = await context.loader?.load(path, context);
   if (!graph) throw new Error(`Unable to load graph from "${path}"`);
   return graph;
-};
-
-const isBreadboardCapability = (
-  candidate: unknown
-): candidate is BreadboardCapability => {
-  const board = candidate as BreadboardCapability;
-  return (
-    board &&
-    typeof board === "object" &&
-    board.kind === "board" &&
-    board.board &&
-    isGraphDescriptor(board.board)
-  );
-};
-
-const isGraphDescriptor = (
-  candidate: unknown
-): candidate is GraphDescriptor => {
-  const graph = candidate as GraphDescriptor;
-  return (
-    graph && typeof graph === "object" && graph.nodes && graph.edges && true
-  );
-};
-
-export const getGraphDescriptor = async (
-  board: unknown,
-  context: NodeHandlerContext
-): Promise<GraphDescriptor | undefined> => {
-  if (!board) return undefined;
-
-  if (typeof board === "string") {
-    const graph = await context.loader?.load(board, context);
-    if (!graph) throw new Error(`Unable to load graph from "${board}"`);
-    return graph;
-  } else if (isBreadboardCapability(board)) {
-    return board.board;
-  } else if (isGraphDescriptor(board)) {
-    return board;
-  }
-  return undefined;
 };
 
 export const getRunner = async (


### PR DESCRIPTION
- **Introduce `path` and `url` in `BreadboardCapability`.**
- **Add path resolution for BreadboardCapability.**
- **Somewhat working.**
- **Be more forgiving about UnresolvedPathBoardCapability.**
- **Take care of strings and undefined.**
- **docs(changeset): Split run-time and build-time URL resolutions for loading graphs.**
