### PR TITLE
[json-kit] Adding an option strict schema config to validateJson

### DIFF
--- a/.changeset/twelve-paws-impress.md
+++ b/.changeset/twelve-paws-impress.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/json-kit": minor
+---
+
+validateJson node can now accept invalid schemas at the users discression

--- a/package-lock.json
+++ b/package-lock.json
@@ -1277,6 +1277,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/json-kit/src/nodes/validate-json.ts
+++ b/packages/json-kit/src/nodes/validate-json.ts
@@ -23,9 +23,13 @@ export type ValidateJsonInputs = InputValues & {
    * Optional schema to validate against.
    */
   schema?: NodeValue;
+  /**
+   * Optional boolean to enforce or turn off strict validation of the supplied schema.
+   */
+  strictSchema?: boolean;
 };
 
-export type ValidationErrorType = "parsing" | "validation";
+export type ValidationErrorType = "parsing" | "schema" | "validation";
 
 export type InvalidJsonOutputs = OutputValues & {
   /**
@@ -74,12 +78,27 @@ export const tryParseJson = (json: string): InvalidJsonOutputs | NodeValue => {
 
 export const validateJson = (
   parsed: NodeValue,
-  schema: Schema
+  schema: Schema,
+  strictSchema: boolean | undefined = undefined
 ): ValidateJsonOutputs => {
   const result = { json: parsed };
   if (!schema) return result;
-  const validator = new Ajv.default();
-  const validate = validator.compile(schema);
+  const validator = new Ajv.default({ strict: strictSchema });
+  let validate: Ajv.ValidateFunction;
+  try {
+    validate = validator.compile(schema);
+  } catch (e) {
+    return {
+      $error: {
+        kind: "error",
+        error: {
+          type: "schema",
+          message: (e as Error).message,
+        },
+      },
+    };
+  }
+
   const valid = validate(parsed);
   if (!valid) {
     return {
@@ -92,12 +111,19 @@ export const validateJson = (
       },
     };
   }
+
   return result;
 };
 
 const invoke = async (inputs: InputValues): Promise<OutputValues> => {
-  const { json, schema } = inputs as ValidateJsonInputs;
+  const { json, schema, strictSchema } = inputs as ValidateJsonInputs;
   if (!json) throw new Error("The `json` input is required.");
+
+  if (!schema && strictSchema) {
+    throw new Error(
+      "The `schema` input is required when `strictSchema` is true."
+    );
+  }
 
   // First, let's try to parse JSON.
   const parsed = tryParseJson(json);
@@ -115,7 +141,7 @@ const invoke = async (inputs: InputValues): Promise<OutputValues> => {
   }
 
   // Now, let's try to validate JSON.
-  return validateJson(parsed, parsedSchema as Schema);
+  return validateJson(parsed, parsedSchema as Schema, strictSchema);
 };
 
 const describe: NodeDescriberFunction = async () => {
@@ -129,6 +155,12 @@ const describe: NodeDescriberFunction = async () => {
       title: "schema",
       description: "Optional schema to validate against.",
       type: "object",
+    })
+    .addProperty("strictSchema", {
+      title: "strictSchema",
+      description:
+        "Optional boolean to enforce or turn off strict validation of the supplied schema.",
+      type: "boolean",
     })
     .addRequired(["json"])
     .build();

--- a/packages/json-kit/src/nodes/validate-json.ts
+++ b/packages/json-kit/src/nodes/validate-json.ts
@@ -119,7 +119,7 @@ const invoke = async (inputs: InputValues): Promise<OutputValues> => {
   const { json, schema, strictSchema } = inputs as ValidateJsonInputs;
   if (!json) throw new Error("The `json` input is required.");
 
-  if (!schema && strictSchema) {
+  if (!schema && strictSchema == true) {
     throw new Error(
       "The `schema` input is required when `strictSchema` is true."
     );

--- a/packages/json-kit/tests/validate-json.ts
+++ b/packages/json-kit/tests/validate-json.ts
@@ -61,6 +61,84 @@ describe("validate-json", () => {
     });
   });
 
+  test("validateJson fails when strictSchema is true and the schema is invalid", (t) => {
+    const parsed = { foo: 1 };
+    const schema = {
+      type: "object",
+      properties: { foo: { type: "number", example: "Test" } }, // Using "example" because the OpenAI OpenAPI schema uses it
+    };
+    const result = validateJson(parsed, schema, true);
+    deepStrictEqual(result, {
+      $error: {
+        kind: "error",
+        error: {
+          type: "schema",
+          message: 'strict mode: unknown keyword: "example"',
+        },
+      },
+    });
+  });
+
+  test("validateJson passes when strictSchema is true and the schema is valid", (t) => {
+    const parsed = { foo: 1 };
+    const schema = {
+      type: "object",
+      properties: { foo: { type: "number" } }, // Using "example" because the OpenAI OpenAPI schema uses it
+    };
+    const result = validateJson(parsed, schema, true);
+    deepStrictEqual(result, {
+      $error: {
+        kind: "error",
+        error: {
+          type: "schema",
+          message: 'strict mode: unknown keyword: "example"',
+        },
+      },
+    });
+  });
+
+  test("validateJson fails when strictSchema is undefined and the schema is invalid", (t) => {
+    const parsed = { foo: 1 };
+    const schema = {
+      type: "object",
+      properties: { foo: { type: "number", example: "Test" } },
+    };
+    const result = validateJson(parsed, schema);
+    deepStrictEqual(result, {
+      $error: {
+        kind: "error",
+        error: {
+          type: "schema",
+          message: 'strict mode: unknown keyword: "example"',
+        },
+      },
+    });
+  });
+
+  test("validateJson passes when strictSchema is undefined and the schema is valid", (t) => {
+    const parsed = { foo: 1 };
+    const schema = {
+      type: "object",
+      properties: { foo: { type: "number" } },
+    };
+    const result = validateJson(parsed, schema);
+    deepStrictEqual(result, {
+      json: { foo: 1 },
+    });
+  });
+
+  test("validateJson passes when strictSchema is false and the schema is invalid", (t) => {
+    const parsed = { foo: 1 };
+    const schema = {
+      type: "object",
+      properties: { foo: { type: "number", example: "Test" } },
+    };
+    const result = validateJson(parsed, schema, false);
+    deepStrictEqual(result, {
+      json: { foo: 1 },
+    });
+  });
+
   test("stripCodeBlock correctly strips Markdown only if present", (t) => {
     deepStrictEqual(stripCodeBlock('```json\n"json"\n```'), '"json"');
     deepStrictEqual(stripCodeBlock('```\n"json"\n```'), '"json"');

--- a/packages/json-kit/tests/validate-json.ts
+++ b/packages/json-kit/tests/validate-json.ts
@@ -87,13 +87,7 @@ describe("validate-json", () => {
     };
     const result = validateJson(parsed, schema, true);
     deepStrictEqual(result, {
-      $error: {
-        kind: "error",
-        error: {
-          type: "schema",
-          message: 'strict mode: unknown keyword: "example"',
-        },
-      },
+      json: { foo: 1 },
     });
   });
 


### PR DESCRIPTION
Fixes #1427

This will enable `validateJson`'s schema to be technically "invalid" - see https://ajv.js.org/options.html#strict (we just enable true/false/undefined, ignore log)