### PR TITLE
[build] Various improvements needed while converting an existing node definition

### DIFF
--- a/.changeset/blue-lemons-kneel.md
+++ b/.changeset/blue-lemons-kneel.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+The breadboard type expression object({}) is now more strictly constrained to plain objects (rather than anything).

--- a/.changeset/curly-laws-behave.md
+++ b/.changeset/curly-laws-behave.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Simpler JSON schema serialization for array

--- a/.changeset/slow-wombats-shop.md
+++ b/.changeset/slow-wombats-shop.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+The describe function can now return objects with new descriptions

--- a/.changeset/spicy-flowers-hide.md
+++ b/.changeset/spicy-flowers-hide.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Add multiline option to port config

--- a/.changeset/tasty-dots-vanish.md
+++ b/.changeset/tasty-dots-vanish.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Simpler JSON schema serialization for anyOf

--- a/.changeset/witty-books-build.md
+++ b/.changeset/witty-books-build.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard": patch
+---
+
+Better compatibility with @breadboard-ai/build

--- a/packages/breadboard/src/new/grammar/node.ts
+++ b/packages/breadboard/src/new/grammar/node.ts
@@ -253,7 +253,11 @@ export class BuilderNode<
         //    - execute the graph, and return the output node's outputs
         //  - otherwise return the handler's return value as result.
         const handlerFn =
-          typeof handler === "function" ? handler : handler?.invoke;
+          handler && "invoke" in handler && handler.invoke
+            ? handler.invoke
+            : typeof handler === "function"
+              ? handler
+              : undefined;
         if (handlerFn) {
           result = (await handlerFn(inputs, this)) as O;
         } else if (handler && typeof handler !== "function" && handler.graph) {
@@ -350,7 +354,11 @@ export class BuilderNode<
     } else {
       // Else, serialize the handler itself and return a runJavascript node.
       const handlerFn =
-        typeof handler === "function" ? handler : handler?.invoke;
+        handler && "invoke" in handler && handler.invoke
+          ? handler.invoke
+          : typeof handler === "function"
+            ? handler
+            : undefined;
       if (!handlerFn)
         throw new Error(`Handler for ${this.type} in ${this.id} not found`);
 

--- a/packages/breadboard/src/new/runner/kits.ts
+++ b/packages/breadboard/src/new/runner/kits.ts
@@ -5,7 +5,11 @@
  */
 
 import { OutputValues, NodeHandlers } from "./types.js";
-import { Kit, InputValues as OriginalInputValues } from "../../types.js";
+import {
+  Kit,
+  NodeHandlerFunction,
+  InputValues as OriginalInputValues,
+} from "../../types.js";
 
 // TODO: This is wraps classic handlers that expected resolved inputs into
 // something that accepts promises. We should either change all handlers to
@@ -15,9 +19,13 @@ export function handlersFromKit(kit: Kit): NodeHandlers {
   return Object.fromEntries(
     Object.entries(kit.handlers).map(([name, handler]) => {
       const handlerFunction =
-        handler instanceof Function ? handler : handler.invoke;
+        "invoke" in handler && handler.invoke
+          ? handler.invoke
+          : (handler as NodeHandlerFunction);
       const describeFunction =
-        handler instanceof Function ? undefined : handler.describe;
+        "describe" in handler && handler.describe
+          ? handler.describe
+          : undefined;
       const describe = describeFunction ? { describe: describeFunction } : {};
 
       return [

--- a/packages/breadboard/src/new/runner/node.ts
+++ b/packages/breadboard/src/new/runner/node.ts
@@ -35,7 +35,7 @@ const nodeIdVendor = new IdVendor();
 // methods that should be base as "TODO:BASE" below, including complications.
 export class BaseNode<
     I extends InputValues = InputValues,
-    O extends OutputValues = OutputValues
+    O extends OutputValues = OutputValues,
   >
   extends AbstractNode<I, O>
   implements Serializeable
@@ -103,7 +103,7 @@ export class BaseNode<
 
   #getHandlerDescribe(scope: ScopeInterface) {
     const handler = this.#handler ?? scope.getHandler(this.type);
-    return handler && typeof handler !== "function"
+    return handler && "describe" in handler && handler.describe
       ? handler.describe
       : undefined;
   }
@@ -122,7 +122,12 @@ export class BaseNode<
 
     let result;
 
-    const handlerFn = typeof handler === "function" ? handler : handler?.invoke;
+    const handlerFn =
+      handler && "invoke" in handler && handler.invoke
+        ? handler.invoke
+        : typeof handler === "function"
+          ? handler
+          : undefined;
 
     if (handlerFn) {
       result = (await handlerFn(inputs, this)) as O;

--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -140,8 +140,10 @@ values.
 
 A `describe` function will be passed a set of values (in the same way as
 `invoke`), and should return an object containing either or both of `inputs` and
-`outputs`, each an array of strings, the names for the input and/or output ports
-that should be dynamically opened.
+`outputs`, which can either be an array of strings or an object. When an array
+of strings, the strings are the names of the ports to open. When an object, the
+keys are the names of the ports to open, and the values are an object matching
+`{description: string}`.
 
 For example, in `templater` above, the `describe` function parses the static
 `template` input and opens a port for each of the template's placeholders.

--- a/packages/build/src/internal/common/port.ts
+++ b/packages/build/src/internal/common/port.ts
@@ -17,6 +17,7 @@ import type {
   SerializableOutputPort,
 } from "./serializable.js";
 
+// TODO(aomarks) Combine with PortConfig from define.ts
 export type PortConfig = StaticPortConfig | DynamicPortConfig;
 
 /**
@@ -58,6 +59,8 @@ interface StaticPortConfig {
    * concise.
    */
   primary?: boolean;
+
+  multiline?: true;
 }
 
 /**

--- a/packages/build/src/internal/define/config.ts
+++ b/packages/build/src/internal/define/config.ts
@@ -15,6 +15,7 @@ export type OutputPortConfig = StaticOutputPortConfig | DynamicOutputPortConfig;
 interface BaseConfig {
   type: BreadboardType;
   description?: string;
+  multiline?: true;
 }
 
 export interface StaticInputPortConfig extends BaseConfig {

--- a/packages/build/src/internal/define/define.ts
+++ b/packages/build/src/internal/define/define.ts
@@ -311,6 +311,10 @@ type Convert<C extends PortConfig> = ConvertBreadboardType<C["type"]>;
 
 type LooseDescribeFn = Function;
 
+export type DynamicInputPorts =
+  | string[]
+  | { [K: string]: { description: string } };
+
 type StrictDescribeFn<
   I extends Record<string, InputPortConfig>,
   O extends Record<string, OutputPortConfig>,
@@ -323,7 +327,7 @@ type StrictDescribeFn<
             staticInputs: Expand<StaticInvokeParams<I>>,
             dynamicInputs: Expand<DynamicInvokeParams<I>>
           ) => {
-            inputs: string[];
+            inputs: DynamicInputPorts;
             outputs?: never;
           };
         }
@@ -333,8 +337,8 @@ type StrictDescribeFn<
             staticInputs: Expand<StaticInvokeParams<I>>,
             dynamicInputs: Expand<DynamicInvokeParams<I>>
           ) => {
-            inputs?: string[];
-            outputs: string[];
+            inputs?: DynamicInputPorts;
+            outputs: DynamicInputPorts;
           };
         }
     : {
@@ -343,7 +347,7 @@ type StrictDescribeFn<
           staticInputs: Expand<StaticInvokeParams<I>>,
           dynamicInputs: Expand<DynamicInvokeParams<I>>
         ) => {
-          inputs: string[];
+          inputs: DynamicInputPorts;
           outputs?: never;
         };
       }
@@ -355,7 +359,7 @@ type StrictDescribeFn<
           dynamicInputs: Expand<DynamicInvokeParams<I>>
         ) => {
           inputs?: never;
-          outputs: string[];
+          outputs: DynamicInputPorts;
         };
       }
     : {

--- a/packages/build/src/internal/define/json-schema.ts
+++ b/packages/build/src/internal/define/json-schema.ts
@@ -19,11 +19,13 @@ export function portConfigMapToJSONSchema(
       Object.entries(config)
         .sort(([nameA], [nameB]) => nameA.localeCompare(nameB))
         .map(([name, { description, type, multiline }]) => {
-          const schema = toJSONSchema(type);
-          schema.title = name;
-          if (description !== undefined) {
+          const schema: JSONSchema4 = {
+            title: name,
+          };
+          if (description) {
             schema.description = description;
           }
+          Object.assign(schema, toJSONSchema(type));
           if (multiline === true) {
             // TODO(aomarks) This is not a valid use of the JSON Schema format
             // keyword according to

--- a/packages/build/src/internal/define/json-schema.ts
+++ b/packages/build/src/internal/define/json-schema.ts
@@ -18,11 +18,19 @@ export function portConfigMapToJSONSchema(
     properties: Object.fromEntries(
       Object.entries(config)
         .sort(([nameA], [nameB]) => nameA.localeCompare(nameB))
-        .map(([name, { description, type }]) => {
+        .map(([name, { description, type, multiline }]) => {
           const schema = toJSONSchema(type);
           schema.title = name;
           if (description !== undefined) {
             schema.description = description;
+          }
+          if (multiline === true) {
+            // TODO(aomarks) This is not a valid use of the JSON Schema format
+            // keyword according to
+            // https://opis.io/json-schema/2.x/formats.html. We should probably put
+            // Breadboard specific stuff somewhere else (e.g. in a breadboard
+            // property).
+            schema.format = "multiline";
           }
           return [name, schema];
         })

--- a/packages/build/src/internal/define/node-factory.ts
+++ b/packages/build/src/internal/define/node-factory.ts
@@ -4,10 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { NewNodeFactory } from "@google-labs/breadboard";
+import type { NewNodeFactory, NewNodeValue } from "@google-labs/breadboard";
 import type { Definition } from "./definition.js";
 import type { JsonSerializable } from "../type-system/type.js";
 import type { Expand } from "../common/type-util.js";
+
+/* eslint-disable @typescript-eslint/ban-types */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 /**
  * `NodeFactoryFromDefinition` takes a {@link NodeDefinition} type (as returned
@@ -15,17 +18,17 @@ import type { Expand } from "../common/type-util.js";
  * for use with {@link KitBuilder}.
  */
 export type NodeFactoryFromDefinition<
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   D extends Definition<any, any, any, any, any, any, any>,
 > =
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   D extends Definition<infer SI, infer SO, infer DI, infer DO, any, any, any>
     ? NewNodeFactory<
         Expand<
-          SI & (DI extends JsonSerializable ? { [K: string]: DI } : object)
+          SI &
+            (DI extends JsonSerializable ? { [K: string]: NewNodeValue } : {})
         >,
         Expand<
-          SO & (DO extends JsonSerializable ? { [K: string]: DO } : object)
+          SO &
+            (DO extends JsonSerializable ? { [K: string]: NewNodeValue } : {})
         >
       >
     : never;

--- a/packages/build/src/internal/type-system/any-of.ts
+++ b/packages/build/src/internal/type-system/any-of.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { JSONSchema4TypeName } from "json-schema";
 import {
   toJSONSchema,
   type BreadboardType,
@@ -20,9 +21,14 @@ import {
 export function anyOf<
   T extends [BreadboardType, BreadboardType, ...BreadboardType[]],
 >(...members: T): AdvancedBreadboardType<ConvertBreadboardType<T[number]>> {
+  const types = members.map(toJSONSchema);
+  const allTypesAreBasic = types.every(
+    (member) =>
+      typeof member.type === "string" && Object.keys(member).length === 1
+  );
   return {
-    jsonSchema: {
-      anyOf: members.map(toJSONSchema),
-    },
+    jsonSchema: allTypesAreBasic
+      ? { type: types.map((member) => member.type as JSONSchema4TypeName) }
+      : { anyOf: types },
   };
 }

--- a/packages/build/src/internal/type-system/object.ts
+++ b/packages/build/src/internal/type-system/object.ts
@@ -9,6 +9,7 @@ import {
   type AdvancedBreadboardType,
   type BreadboardType,
   type ConvertBreadboardType,
+  type JsonSerializable,
 } from "./type.js";
 
 /**
@@ -18,9 +19,11 @@ import {
  */
 export function object<T extends Record<string, BreadboardType>>(
   properties: T
-): AdvancedBreadboardType<{
-  [P in keyof T]: ConvertBreadboardType<T[P]>;
-}> {
+): AdvancedBreadboardType<
+  keyof T extends never
+    ? object & JsonSerializable
+    : { [P in keyof T]: ConvertBreadboardType<T[P]> }
+> {
   if (Object.keys(properties).length === 0) {
     return {
       jsonSchema: {

--- a/packages/build/src/internal/type-system/object.ts
+++ b/packages/build/src/internal/type-system/object.ts
@@ -21,6 +21,13 @@ export function object<T extends Record<string, BreadboardType>>(
 ): AdvancedBreadboardType<{
   [P in keyof T]: ConvertBreadboardType<T[P]>;
 }> {
+  if (Object.keys(properties).length === 0) {
+    return {
+      jsonSchema: {
+        type: "object",
+      },
+    };
+  }
   return {
     jsonSchema: {
       type: "object",

--- a/packages/build/src/internal/type-system/type.ts
+++ b/packages/build/src/internal/type-system/type.ts
@@ -73,7 +73,10 @@ export type ConvertBreadboardType<BT extends BreadboardType> =
  */
 export function toJSONSchema(type: BreadboardType): JSONSchema4 {
   if (typeof type === "object" && "jsonSchema" in type) {
-    return type.jsonSchema;
+    // Make a copy because it's not uncommon for callers to mutate this object,
+    // (e.g. adding a description to a port schema), and 2 ports might share an
+    // advanced breadboard type instance (e.g. dynamic ports).
+    return structuredClone(type.jsonSchema);
   }
   switch (type) {
     case "string":

--- a/packages/build/src/test/compatibility_test.ts
+++ b/packages/build/src/test/compatibility_test.ts
@@ -164,7 +164,7 @@ function setupKits<
   const { kit: adderKit, runtimeKit: adderRuntimeKit } = setupKits({
     adder,
   });
-  // $ExpectType { adder: NodeFactory<{ [x: string]: number; base: number; }, { sum: number; }>; }
+  // $ExpectType { adder: NodeFactory<{ [x: string]: unknown; base: number; }, { sum: number; }>; }
   adderKit;
   // $ExpectType Lambda<InputValues, Required<{ boardSum: number; }>>
   const adderBoard = await board(({ num1, num2, num3 }) => {

--- a/packages/build/src/test/compatibility_test.ts
+++ b/packages/build/src/test/compatibility_test.ts
@@ -98,7 +98,7 @@ function setupKits<
         additionalProperties: false,
         properties: {
           boardLen: {
-            title: "boardLen",
+            title: "len",
             type: "number",
           },
         },
@@ -213,7 +213,7 @@ function setupKits<
         additionalProperties: false,
         properties: {
           boardSum: {
-            title: "boardSum",
+            title: "sum",
             type: "number",
           },
         },

--- a/packages/build/src/test/define_test.ts
+++ b/packages/build/src/test/define_test.ts
@@ -10,6 +10,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { defineNodeType } from "../internal/define/define.js";
+import { object } from "../internal/type-system/object.js";
 
 test("mono/mono", async () => {
   const values = { si1: "foo", si2: 123 };
@@ -1528,4 +1529,28 @@ test("error: assertOutput on existing static output", () => {
       ),
     /assertOutput was called unnecessarily on a BreadboardNode. Type "foo" already has a static port called "so1". Use "<node>.outputs.so1" instead./
   );
+});
+
+test("error: object types must be plain objects at initialization", () => {
+  const d = defineNodeType({
+    name: "foo",
+    inputs: {
+      "*": { type: object({}) },
+    },
+    outputs: {},
+    invoke: () => ({}),
+  });
+  const i = d({
+    ok1: {},
+    ok2: { foo: 123 },
+
+    // @ts-expect-error
+    bad1: 123,
+    // @ts-expect-error
+    bad1: "foo",
+    // @ts-expect-error
+    bad1: globalThis,
+    // @ts-expect-error
+    bad1: Object,
+  });
 });

--- a/packages/build/src/test/define_test.ts
+++ b/packages/build/src/test/define_test.ts
@@ -852,16 +852,50 @@ test("primary input + output", () => {
   );
 });
 
-test("sync invoke", async () => {
+test("multiline", async () => {
   const d = defineNodeType({
     name: "foo",
-    inputs: {},
-    outputs: {
-      so1: { type: "string" },
+    inputs: {
+      si1: {
+        type: "string",
+        multiline: true,
+      },
     },
-    invoke: () => ({ so1: "foo" }),
+    outputs: {
+      so1: {
+        type: "string",
+        multiline: true,
+      },
+    },
+    invoke: () => {
+      return { so1: "foo" };
+    },
   });
-  assert.deepEqual(await d.invoke({}, null as never), { so1: "foo" });
+
+  assert.deepEqual(await d.describe(), {
+    inputSchema: {
+      type: "object",
+      properties: {
+        si1: {
+          title: "si1",
+          type: "string",
+          format: "multiline",
+        },
+      },
+      required: ["si1"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        so1: {
+          title: "so1",
+          type: "string",
+          format: "multiline",
+        },
+      },
+      required: ["so1"],
+    },
+  });
 });
 
 test("dynamic port descriptions", async () => {

--- a/packages/build/src/test/define_test.ts
+++ b/packages/build/src/test/define_test.ts
@@ -864,6 +864,58 @@ test("sync invoke", async () => {
   assert.deepEqual(await d.invoke({}, null as never), { so1: "foo" });
 });
 
+test("dynamic port descriptions", async () => {
+  const d = defineNodeType({
+    name: "foo",
+    inputs: {
+      "*": { type: "string" },
+    },
+    outputs: {
+      "*": { type: "string" },
+    },
+    describe: (_, inputs) => ({
+      inputs: Object.fromEntries(
+        Object.keys(inputs).map((name) => [
+          name,
+          { description: `input "${name}"` },
+        ])
+      ),
+      outputs: Object.fromEntries(
+        Object.keys(inputs).map((name) => [
+          name,
+          { description: `output "${name}"` },
+        ])
+      ),
+    }),
+    invoke: () => ({}),
+  });
+
+  assert.deepEqual(await d.describe({ foo: "foo" }), {
+    inputSchema: {
+      type: "object",
+      properties: {
+        foo: {
+          title: "foo",
+          type: "string",
+          description: 'input "foo"',
+        },
+      },
+      required: ["foo"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        foo: {
+          title: "foo",
+          type: "string",
+          description: 'output "foo"',
+        },
+      },
+      required: ["foo"],
+    },
+  });
+});
+
 test("error: missing name", () => {
   assert.throws(
     () =>

--- a/packages/build/src/test/type_test.ts
+++ b/packages/build/src/test/type_test.ts
@@ -75,14 +75,14 @@ test("anyOf", () => {
   // $ExpectType number | boolean
   type t2 = ConvertBreadboardType<typeof with2>;
   assert.deepEqual(toJSONSchema(with2), {
-    anyOf: [{ type: "number" }, { type: "boolean" }],
+    type: ["number", "boolean"],
   });
 
   const with3 = anyOf("number", "boolean", "string") satisfies BreadboardType;
   // $ExpectType string | number | boolean
   type t3 = ConvertBreadboardType<typeof with3>;
   assert.deepEqual(toJSONSchema(with3), {
-    anyOf: [{ type: "number" }, { type: "boolean" }, { type: "string" }],
+    type: ["number", "boolean", "string"],
   });
 
   /* eslint-enable @typescript-eslint/no-unused-vars */
@@ -153,7 +153,7 @@ describe("object", () => {
     assert.deepEqual(toJSONSchema(obj4), {
       type: "object",
       properties: {
-        foo: { anyOf: [{ type: "string" }, { type: "number" }] },
+        foo: { type: ["string", "number"] },
       },
       required: ["foo"],
     });
@@ -268,7 +268,7 @@ describe("array", () => {
     type arrayType = ConvertBreadboardType<typeof arr>;
     assert.deepEqual(toJSONSchema(arr), {
       type: "array",
-      items: { anyOf: [{ type: "string" }, { type: "number" }] },
+      items: { type: ["string", "number"] },
     });
   });
 

--- a/packages/build/src/test/type_test.ts
+++ b/packages/build/src/test/type_test.ts
@@ -98,7 +98,7 @@ describe("object", () => {
 
   test("empty object", () => {
     const obj1 = object({});
-    // $ExpectType {}
+    // $ExpectType object & JsonSerializable
     type t1 = ConvertBreadboardType<typeof obj1>;
     assert.deepEqual(toJSONSchema(obj1), {
       type: "object",
@@ -194,7 +194,7 @@ describe("object", () => {
 
   test("object no known properties", () => {
     const obj = object({});
-    // $ExpectType {}
+    // $ExpectType object & JsonSerializable
     type objType = ConvertBreadboardType<typeof obj>;
     assert.deepEqual(toJSONSchema(obj), {
       type: "object",

--- a/packages/build/src/test/type_test.ts
+++ b/packages/build/src/test/type_test.ts
@@ -102,8 +102,6 @@ describe("object", () => {
     type t1 = ConvertBreadboardType<typeof obj1>;
     assert.deepEqual(toJSONSchema(obj1), {
       type: "object",
-      properties: {},
-      required: [],
     });
   });
 
@@ -200,8 +198,6 @@ describe("object", () => {
     type objType = ConvertBreadboardType<typeof obj>;
     assert.deepEqual(toJSONSchema(obj), {
       type: "object",
-      properties: {},
-      required: [],
     });
   });
 


### PR DESCRIPTION
- Support returning dynamic port descriptions
- Simplify anyOf when all members are basic
- Simplify object when it has no properties
- Clone schemas so they can be mutated
- Add support for multiline string format hint
- Make the order of JSON schema properties a bit more natural
- Require that ports with type object({}) are plain objects, not number etc.
- Slightly loosen the constraints on NodeFactoryFromDefinition for better compatibility
- Update a few more spots where the breadboard package was confused about @breadboard-ai/build definitions