### PR TITLE
[template-kit] Convert template-kit to use @breadboard-ai/build

### DIFF
--- a/.changeset/curvy-ties-shake.md
+++ b/.changeset/curvy-ties-shake.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/template-kit": minor
+---
+
+Convert template-kit to new @breadboard-ai/build package. Should be a no-op.

--- a/package-lock.json
+++ b/package-lock.json
@@ -28093,6 +28093,7 @@
       "version": "0.2.6",
       "license": "Apache-2.0",
       "dependencies": {
+        "@breadboard-ai/build": "^0.4.0",
         "@google-labs/breadboard": "^0.17.0",
         "url-template": "^3.1.0"
       },
@@ -28104,6 +28105,17 @@
         "@typescript-eslint/parser": "^7.0.0",
         "ava": "^5.2.0",
         "typescript": "^5.4.5"
+      },
+      "engines": {
+        "node": ">=19.0.0"
+      }
+    },
+    "packages/template-kit/node_modules/@breadboard-ai/build/node_modules/@google-labs/breadboard": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@google-labs/breadboard/-/breadboard-0.16.0.tgz",
+      "integrity": "sha512-DcH0dHlLNQWWDBIRu1zUO3e+g3pBdDrfbV7SAleXPAmbO00VvVpK14DmjmRA5hVPzo+dqSNu3qZA59P6oTT44Q==",
+      "dependencies": {
+        "@google-labs/breadboard-schema": "^1.4.0"
       },
       "engines": {
         "node": ">=19.0.0"

--- a/packages/breadboard-web/public/graphs/build-example.json
+++ b/packages/breadboard-web/public/graphs/build-example.json
@@ -36,19 +36,25 @@
       }
     },
     {
-      "id": "reverseString-0",
-      "type": "reverseString",
-      "configuration": {}
-    },
-    {
-      "id": "templater-0",
-      "type": "templater",
+      "id": "promptTemplate-0",
+      "type": "promptTemplate",
       "configuration": {
         "template": "The word \"{{p0}}\" is \"{{p1}}\" in reverse"
       }
+    },
+    {
+      "id": "reverseString-0",
+      "type": "reverseString",
+      "configuration": {}
     }
   ],
   "edges": [
+    {
+      "from": "input-0",
+      "out": "word",
+      "to": "promptTemplate-0",
+      "in": "p0"
+    },
     {
       "from": "input-0",
       "out": "word",
@@ -56,22 +62,16 @@
       "in": "forwards"
     },
     {
-      "from": "input-0",
-      "out": "word",
-      "to": "templater-0",
-      "in": "p0"
+      "from": "promptTemplate-0",
+      "out": "prompt",
+      "to": "output-0",
+      "in": "result"
     },
     {
       "from": "reverseString-0",
       "out": "backwards",
-      "to": "templater-0",
+      "to": "promptTemplate-0",
       "in": "p1"
-    },
-    {
-      "from": "templater-0",
-      "out": "result",
-      "to": "output-0",
-      "in": "result"
     }
   ]
 }

--- a/packages/breadboard-web/src/build-example-kit.ts
+++ b/packages/breadboard-web/src/build-example-kit.ts
@@ -11,6 +11,7 @@ import {
 } from "@breadboard-ai/build";
 import { addKit } from "@google-labs/breadboard";
 import { KitBuilder } from "@google-labs/breadboard/kits";
+import { promptTemplate } from "@google-labs/template-kit";
 
 export const reverseString = defineNodeType({
   name: "reverseString",
@@ -33,52 +34,6 @@ export const reverseString = defineNodeType({
     };
   },
 });
-
-export const templater = defineNodeType({
-  name: "templater",
-  inputs: {
-    template: {
-      type: "string",
-      description: "A template with {{placeholders}}.",
-    },
-    "*": {
-      type: "string",
-      description: "Values to fill into template's {{placeholders}}.",
-    },
-  },
-  outputs: {
-    result: {
-      type: "string",
-      description: "The template with {{placeholders}} substituted.",
-      primary: true,
-    },
-  },
-  describe: ({ template }) => ({
-    inputs: extractPlaceholders(template ?? ""),
-  }),
-  invoke: ({ template }, placeholders) => ({
-    result: substituteTemplatePlaceholders(template, placeholders),
-  }),
-});
-
-function extractPlaceholders(template: string): string[] {
-  const matches = template.matchAll(/{{(?<name>[\w-]+)}}/g);
-  const parameters = Array.from(matches).map(
-    (match) => match.groups?.name || ""
-  );
-  const unique = Array.from(new Set(parameters));
-  return unique;
-}
-
-function substituteTemplatePlaceholders(
-  template: string,
-  values: Record<string, string | number>
-) {
-  return Object.entries(values).reduce(
-    (acc, [key, value]) => acc.replace(`{{${key}}}`, String(value)),
-    template
-  );
-}
 
 /**
  * An example of a sugar function which wraps instantiation of a node (in this
@@ -103,7 +58,7 @@ export function prompt(
       placeholders[name] = values[i]!;
     }
   }
-  return templater({ template, ...placeholders });
+  return promptTemplate({ template, ...placeholders });
 }
 
 const BuildExampleKit = new KitBuilder({
@@ -111,10 +66,9 @@ const BuildExampleKit = new KitBuilder({
   description: "An example kit",
   version: "0.1.0",
   url: "npm:@breadboard-ai/example-kit",
-}).build({ reverseString, templater });
+}).build({ reverseString });
 export default BuildExampleKit;
 
 export const buildExampleKit = addKit(BuildExampleKit) as {
   reverseString: NodeFactoryFromDefinition<typeof reverseString>;
-  templater: NodeFactoryFromDefinition<typeof templater>;
 };

--- a/packages/template-kit/package.json
+++ b/packages/template-kit/package.json
@@ -21,6 +21,7 @@
     "build": {
       "dependencies": [
         "../breadboard:build",
+        "../build:build",
         "build:tsc"
       ]
     },
@@ -30,6 +31,7 @@
         "FORCE_COLOR": "1"
       },
       "dependencies": [
+        "../build:build:tsc",
         "../breadboard:build:tsc"
       ],
       "files": [
@@ -111,14 +113,15 @@
   "homepage": "https://github.com/breadboard-ai/breadboard/tree/main/packages/template-kit#readme",
   "devDependencies": {
     "@ava/typescript": "^4.0.0",
+    "@google-labs/tsconfig": "^0.0.1",
+    "@types/node": "^20.12.7",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
-    "@types/node": "^20.12.7",
     "ava": "^5.2.0",
-    "typescript": "^5.4.5",
-    "@google-labs/tsconfig": "^0.0.1"
+    "typescript": "^5.4.5"
   },
   "dependencies": {
+    "@breadboard-ai/build": "^0.4.0",
     "@google-labs/breadboard": "^0.17.0",
     "url-template": "^3.1.0"
   },

--- a/packages/template-kit/src/index.ts
+++ b/packages/template-kit/src/index.ts
@@ -4,10 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { NodeFactoryFromDefinition } from "@breadboard-ai/build";
+import { addKit } from "@google-labs/breadboard";
 import { KitBuilder } from "@google-labs/breadboard/kits";
 import promptTemplate from "./nodes/prompt-template.js";
-
 import urlTemplate from "./nodes/url-template.js";
+export { default as promptTemplate } from "./nodes/prompt-template.js";
+export { default as urlTemplate } from "./nodes/url-template.js";
 
 const builder = new KitBuilder({
   title: "Template Kit",
@@ -25,78 +28,9 @@ export type TemplateKit = InstanceType<typeof TemplateKit>;
 
 export default TemplateKit;
 
-/**
- * This is a wrapper around existing kits for the new syntax to add types.
- *
- * This should transition to a codegen step, with typescript types constructed
- * from .describe() calls.
- */
-import {
-  addKit,
-  NewNodeValue as NodeValue,
-  NewNodeFactory as NodeFactory,
-} from "@google-labs/breadboard";
-
 export type TemplateKitType = {
-  /**
-   * Use this node to populate simple handlebar-style templates. A required
-   * input is `template`, which is a string that contains the template prompt
-   * template. The template can contain zero or more placeholders that will be
-   * replaced with values from inputs. Specify placeholders as `{{inputName}}`
-   * in the template. The placeholders in the template must match the inputs
-   * wired into this node. The node will replace all placeholders with values
-   * from the input property bag and pass the result along as the `prompt`
-   * output property.
-   */
-  promptTemplate: NodeFactory<
-    {
-      /**
-       * The template to use for the prompt.
-       */
-      template: string;
-      /**
-       * The values to fill in the template.
-       */
-      [key: string]: NodeValue;
-    },
-    | {
-        /**
-         * The result of template with placeholders being replaced with values.
-         */
-        prompt: string;
-      }
-    | {
-        /**
-         * The result of template with placeholders being replaced with values.
-         */
-        text: string;
-      }
-  >;
-  /**
-   * Use this node to safely construct URLs. This node relies on the
-   * [URI template specification](https://tools.ietf.org/html/rfc6570) to
-   * construct URLs, so the syntax is using single curly braces instead of
-   * double curly braces.
-   */
-  urlTemplate: NodeFactory<
-    {
-      /**
-       * The URL template to use for the URL.
-       */
-      template: string;
-      /**
-       * Values for the template placeholders.
-       */
-      [key: string]: NodeValue;
-    },
-    {
-      /**
-       * The result of the URL template with placeholders being replaced with
-       * values.
-       */
-      url: string;
-    }
-  >;
+  promptTemplate: NodeFactoryFromDefinition<typeof promptTemplate>;
+  urlTemplate: NodeFactoryFromDefinition<typeof urlTemplate>;
 };
 
 /**
@@ -106,6 +40,5 @@ export type TemplateKitType = {
  *
  * The `promptTemplate` creates nodes for simple handlebar-style templates and
  * the `urlTemplate` creates nodes for safely constructing URLs.
- *
  */
-export const templates = addKit(TemplateKit) as unknown as TemplateKitType;
+export const templates = addKit(TemplateKit) as TemplateKitType;

--- a/packages/template-kit/tests/nodes/prompt-template.ts
+++ b/packages/template-kit/tests/nodes/prompt-template.ts
@@ -6,8 +6,7 @@
 
 import test from "ava";
 
-import {
-  computeInputSchema,
+import promptTemplate, {
   parametersFromTemplate,
   stringify,
   substitute,
@@ -93,9 +92,9 @@ test("substitute replaces parameters with stringified values", (t) => {
   );
 });
 
-test("`generateInputSchema` correctly generates schema for a template with no parameters", (t) => {
+test("`generateInputSchema` correctly generates schema for a template with no parameters", async (t) => {
   const inputs = { template: "foo" };
-  const result = computeInputSchema(inputs);
+  const result = (await promptTemplate.describe(inputs)).inputSchema;
   t.deepEqual(result, {
     type: "object",
     properties: {
@@ -110,9 +109,9 @@ test("`generateInputSchema` correctly generates schema for a template with no pa
   });
 });
 
-test("`generateInputSchema` correctly generates schema for a template with parameters", (t) => {
+test("`generateInputSchema` correctly generates schema for a template with parameters", async (t) => {
   const inputs = { template: "{{foo}} {{bar}}" };
-  const result = computeInputSchema(inputs);
+  const result = (await promptTemplate.describe(inputs)).inputSchema;
   t.deepEqual(result, {
     type: "object",
     properties: {
@@ -133,6 +132,6 @@ test("`generateInputSchema` correctly generates schema for a template with param
         format: "multiline",
       },
     },
-    required: ["template", "foo", "bar"],
+    required: ["bar", "foo", "template"],
   });
 });

--- a/packages/template-kit/tests/nodes/url-template.ts
+++ b/packages/template-kit/tests/nodes/url-template.ts
@@ -6,9 +6,8 @@
 
 import test from "ava";
 
-import {
+import urlTemplate, {
   getUrlTemplateParameters,
-  urlTemplateDescriber,
 } from "../../src/nodes/url-template.js";
 
 test("getUrlTemplateParameters produces valid results", (t) => {
@@ -57,7 +56,7 @@ test("getUrlTemplateParameters produces valid results", (t) => {
 
 test("`urlTemplateDescriber` produces valid results", async (t) => {
   {
-    const description = await urlTemplateDescriber({
+    const description = await urlTemplate.describe({
       template: "https://example.com/{path}",
     });
     t.like(description, {
@@ -79,7 +78,7 @@ test("`urlTemplateDescriber` produces valid results", async (t) => {
     });
   }
   {
-    const description = await urlTemplateDescriber({
+    const description = await urlTemplate.describe({
       template: "https://example.com/{/path}",
     });
     t.like(description, {


### PR DESCRIPTION
Converts `template-kit` to the new `@breadboard-ai/build` library. This shouldn't change any compatibility with existing boards, but has these advantages:

- The implementation of the template nodes are now more strictly type checked
- The implementation of the template nodes are quite a bit more concise
- template-kit can now be used with boards using the new syntax in `@breadboard-ai/build`
 