### PR TITLE
[build] Don't make inputs with defaults required

### DIFF
--- a/packages/build/src/test/define_test.ts
+++ b/packages/build/src/test/define_test.ts
@@ -1017,7 +1017,6 @@ test("defaults", async () => {
           default: [12, 34],
         },
       },
-      required: ["a", "b"],
     },
     outputSchema: {
       type: "object",


### PR DESCRIPTION
Small followup to https://github.com/breadboard-ai/breadboard/pull/1446. If an input port has a default, then it shouldn't be `required` in the JSON schema.