### PR TITLE
Convert fetch to @breadboard-ai/build

### DIFF
--- a/.changeset/fast-mice-judge.md
+++ b/.changeset/fast-mice-judge.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+JSON schema for outputs no longer sets any required properties

--- a/.changeset/hot-bugs-deny.md
+++ b/.changeset/hot-bugs-deny.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/core-kit": minor
+---
+
+The fetch node is now implemented with @breadboard-ai/build. This should not affect any board behavior.

--- a/package-lock.json
+++ b/package-lock.json
@@ -27734,6 +27734,7 @@
       "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@breadboard-ai/build": "^0.4.0",
         "@google-labs/breadboard": "^0.17.0"
       },
       "devDependencies": {

--- a/packages/build/src/internal/define/definition.ts
+++ b/packages/build/src/internal/define/definition.ts
@@ -228,31 +228,46 @@ export class DefinitionImpl<
     };
     if (this.#dynamicOutputs === undefined) {
       // All outputs are static.
-      outputSchema = portConfigMapToJSONSchema(this.#staticOutputs);
+      outputSchema = portConfigMapToJSONSchema(
+        this.#staticOutputs,
+        // TODO(aomarks) The Breadboard visual editor interprets JSON schema
+        // "required" on an output as "the user must wire this to something"
+        // (shows up as a red port). That might be not quite right, it seems
+        // like "required" here should describe the expectations of the node
+        // implementation's return object, not the way the user choses to use
+        // the output.
+        true
+      );
     } else if (this.#reflective) {
       // We're reflective, so our outputs are determined by our dynamic inputs.
       const dynamicInputNames = Object.keys(inputSchema.properties).filter(
         (name) => this.#staticInputs[name] === undefined
       );
       const d = this.#dynamicOutputs;
-      outputSchema = portConfigMapToJSONSchema({
-        ...Object.fromEntries(dynamicInputNames.map((name) => [name, d])),
-        ...this.#staticOutputs,
-      });
+      outputSchema = portConfigMapToJSONSchema(
+        {
+          ...Object.fromEntries(dynamicInputNames.map((name) => [name, d])),
+          ...this.#staticOutputs,
+        },
+        true
+      );
     } else if (user?.outputs !== undefined) {
       // The definition author has provided the outputs.
       const d = this.#dynamicOutputs;
-      outputSchema = portConfigMapToJSONSchema({
-        ...Object.fromEntries(
-          parseDynamicPorts(user.outputs).map(([name, config]) => [
-            name,
-            { ...d, ...config },
-          ])
-        ),
-        ...this.#staticOutputs,
-      });
+      outputSchema = portConfigMapToJSONSchema(
+        {
+          ...Object.fromEntries(
+            parseDynamicPorts(user.outputs).map(([name, config]) => [
+              name,
+              { ...d, ...config },
+            ])
+          ),
+          ...this.#staticOutputs,
+        },
+        true
+      );
     } else {
-      outputSchema = portConfigMapToJSONSchema(this.#staticOutputs);
+      outputSchema = portConfigMapToJSONSchema(this.#staticOutputs, true);
     }
 
     return {

--- a/packages/build/src/internal/define/json-schema.ts
+++ b/packages/build/src/internal/define/json-schema.ts
@@ -9,7 +9,8 @@ import type { PortConfigMap } from "../common/port.js";
 import { toJSONSchema } from "../type-system/type.js";
 
 export function portConfigMapToJSONSchema(
-  config: PortConfigMap
+  config: PortConfigMap,
+  omitRequired = false
 ): JSONSchema4 & {
   properties: { [k: string]: JSONSchema4 };
 } {
@@ -45,11 +46,13 @@ export function portConfigMapToJSONSchema(
       })
     ),
   };
-  const required = sortedEntries
-    .filter(([, config]) => config.default === undefined)
-    .map(([name]) => name);
-  if (required.length > 0) {
-    schema.required = required;
+  if (!omitRequired) {
+    const required = sortedEntries
+      .filter(([, config]) => config.default === undefined)
+      .map(([name]) => name);
+    if (required.length > 0) {
+      schema.required = required;
+    }
   }
   return schema;
 }

--- a/packages/build/src/test/compatibility_test.ts
+++ b/packages/build/src/test/compatibility_test.ts
@@ -114,6 +114,7 @@ function setupKits<
     const descriptor = descriptors[0]!;
     assert.deepEqual(await descriptor.describe(), {
       inputSchema: {
+        type: "object",
         properties: {
           str: {
             title: "str",
@@ -121,17 +122,15 @@ function setupKits<
           },
         },
         required: ["str"],
-        type: "object",
       },
       outputSchema: {
+        type: "object",
         properties: {
           len: {
             title: "len",
             type: "number",
           },
         },
-        required: ["len"],
-        type: "object",
       },
     });
   });
@@ -229,6 +228,7 @@ function setupKits<
     const descriptor = descriptors[0]!;
     assert.deepEqual(await descriptor.describe(), {
       inputSchema: {
+        type: "object",
         properties: {
           base: {
             title: "base",
@@ -237,17 +237,15 @@ function setupKits<
           // TODO(aomarks) Shouldn't num1, num2, num3 show up here?
         },
         required: ["base"],
-        type: "object",
       },
       outputSchema: {
+        type: "object",
         properties: {
           sum: {
             title: "sum",
             type: "number",
           },
         },
-        required: ["sum"],
-        type: "object",
       },
     });
   });

--- a/packages/build/src/test/define_test.ts
+++ b/packages/build/src/test/define_test.ts
@@ -122,7 +122,6 @@ test("mono/mono", async () => {
           type: "null",
         },
       },
-      required: ["so1", "so2"],
     },
   };
   assert.deepEqual(await d.describe(), expectedSchema);
@@ -235,7 +234,6 @@ test("poly/mono", async () => {
           type: "boolean",
         },
       },
-      required: ["so1"],
     },
   });
 
@@ -266,7 +264,6 @@ test("poly/mono", async () => {
           type: "boolean",
         },
       },
-      required: ["so1"],
     },
   });
 });
@@ -363,7 +360,6 @@ test("mono/poly", async () => {
           type: "number",
         },
       },
-      required: ["do1", "so1"],
     },
   };
   assert.deepEqual(await d.describe(), expectedSchema);
@@ -487,7 +483,6 @@ test("poly/poly", async () => {
           type: "number",
         },
       },
-      required: ["do1", "so1"],
     },
   });
 
@@ -522,7 +517,6 @@ test("poly/poly", async () => {
           type: "number",
         },
       },
-      required: ["do1", "so1"],
     },
   });
 });
@@ -648,7 +642,6 @@ test("reflective", async () => {
       properties: {
         so1: { type: "boolean", title: "so1" },
       },
-      required: ["so1"],
     },
   });
 
@@ -669,7 +662,6 @@ test("reflective", async () => {
         di2: { type: "string", title: "di2" },
         so1: { type: "boolean", title: "so1" },
       },
-      required: ["di1", "di2", "so1"],
     },
   });
 });
@@ -896,7 +888,6 @@ test("multiline", async () => {
           format: "multiline",
         },
       },
-      required: ["so1"],
     },
   });
 });
@@ -948,7 +939,6 @@ test("dynamic port descriptions", async () => {
           description: 'output "foo"',
         },
       },
-      required: ["foo"],
     },
   });
 });
@@ -1031,7 +1021,6 @@ test("defaults", async () => {
           items: { type: "number" },
         },
       },
-      required: ["a", "b"],
     },
   };
   assert.deepEqual(await d.describe(), expectedSchema);

--- a/packages/core-kit/package.json
+++ b/packages/core-kit/package.json
@@ -20,6 +20,7 @@
       "dependencies": [
         "../breadboard:build",
         "../template-kit:build",
+        "../build:build",
         "build:tsc"
       ]
     },
@@ -30,7 +31,8 @@
       },
       "dependencies": [
         "../breadboard:build:tsc",
-        "../template-kit:build:tsc"
+        "../template-kit:build:tsc",
+        "../build:build:tsc"
       ],
       "files": [
         "src/**/*.ts",
@@ -99,15 +101,16 @@
   "homepage": "https://github.com/breadboard-ai/breadboard/tree/main/packages/core-kit#readme",
   "devDependencies": {
     "@ava/typescript": "^4.0.0",
+    "@google-labs/template-kit": "^0.2.6",
+    "@google-labs/tsconfig": "^0.0.1",
+    "@types/node": "^20.12.7",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.7.0",
-    "@types/node": "^20.12.7",
     "ava": "^5.2.0",
-    "typescript": "^5.4.5",
-    "@google-labs/tsconfig": "^0.0.1",
-    "@google-labs/template-kit": "^0.2.6"
+    "typescript": "^5.4.5"
   },
   "dependencies": {
+    "@breadboard-ai/build": "^0.4.0",
     "@google-labs/breadboard": "^0.17.0"
   }
 }

--- a/packages/core-kit/src/nodes/fetch.ts
+++ b/packages/core-kit/src/nodes/fetch.ts
@@ -5,11 +5,12 @@
  */
 
 import {
-  StreamCapability,
-  type InputValues,
-  type NodeDescriberFunction,
-  type NodeHandler,
-} from "@google-labs/breadboard";
+  anyOf,
+  defineNodeType,
+  enumeration,
+  object,
+} from "@breadboard-ai/build";
+import { StreamCapability } from "@google-labs/breadboard";
 
 const serverSentEventTransform = () =>
   new TransformStream({
@@ -34,125 +35,68 @@ const serverSentEventTransform = () =>
     },
   });
 
-export type FetchOutputs = {
-  response: string | object;
-};
-
-export type FetchInputs = {
-  /**
-   * The URL to fetch
-   */
-  url: string;
-  /*
-   * The HTTP method to use
-   */
-  method?: "GET" | "POST" | "PUT" | "DELETE";
-  /**
-   * Headers to send with the request
-   */
-  headers?: Record<string, string>;
-  /**
-   * The body of the request
-   */
-  body?: string;
-  /**
-   * Whether or not to return raw text (as opposed to parsing JSON). Has no
-   * effect when `stream` is true.
-   */
-  raw?: boolean;
-  /**
-   * Whether or not to return a stream. Currently, fetch presumes that the
-   * streaming response is sent as [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format).
-   */
-  stream?: boolean;
-};
-
-export const fetchDescriber: NodeDescriberFunction = async () => {
-  return {
-    inputSchema: {
-      type: "object",
-      properties: {
-        url: {
-          title: "url",
-          description: "The URL to fetch",
-          type: "string",
-        },
-        method: {
-          title: "method",
-          description: "The HTTP method to use",
-          type: "string",
-          enum: ["GET", "POST", "PUT", "DELETE"],
-        },
-        headers: {
-          title: "headers",
-          description: "Headers to send with the request",
-          type: "object",
-          additionalProperties: {
-            type: "string",
-          },
-        },
-        body: {
-          title: "body",
-          description: "The body of the request",
-          type: ["string", "object"],
-        },
-        raw: {
-          title: "raw",
-          description:
-            "Whether or not to return raw text (as opposed to parsing JSON)",
-          type: "boolean",
-        },
-      },
-      required: ["url"],
+export default defineNodeType({
+  name: "fetch",
+  inputs: {
+    url: {
+      description: "The URL to fetch",
+      type: "string",
     },
-    outputSchema: {
-      type: "object",
-      properties: {
-        response: {
-          title: "response",
-          description: "The response from the fetch request",
-          type: ["string", "object"],
-        },
-        status: {
-          title: "status",
-          description: "The HTTP status code of the response",
-          type: "number",
-        },
-        statusText: {
-          title: "statusText",
-          description: "The status text of the response",
-          type: "string",
-        },
-        contentType: {
-          title: "contentType",
-          description: "The content type of the response",
-          type: "string",
-        },
-        responseHeaders: {
-          title: "responseHeaders",
-          description: "The headers of the response",
-          type: "object",
-          additionalProperties: {
-            type: "string",
-          },
-        },
-      },
-      required: ["response"],
+    method: {
+      description: "The HTTP method to use",
+      type: enumeration("GET", "POST", "PUT", "DELETE"),
+      default: "GET",
     },
-  };
-};
-
-export default {
-  describe: fetchDescriber,
-  invoke: async (inputs: InputValues) => {
-    const {
-      url,
-      method = "GET",
-      body,
-      headers = {},
-      raw,
-      stream,
-    } = inputs as FetchInputs;
+    headers: {
+      description: "Headers to send with the request",
+      type: object({}, "string"),
+      default: {},
+    },
+    body: {
+      description: "The body of the request",
+      type: anyOf("string", object({}, "unknown"), "null"),
+      default: null,
+    },
+    raw: {
+      description:
+        "Whether or not to return raw text (as opposed to parsing JSON)",
+      type: "boolean",
+      default: false,
+    },
+    stream: {
+      description: "Whether or not to return a stream",
+      type: "boolean",
+      default: false,
+    },
+  },
+  outputs: {
+    response: {
+      description: "The response from the fetch request",
+      type: anyOf(
+        "string",
+        // TODO(aomarks) Is this right? Technically it could be any JSON, right?
+        // So number, null, array, are also possible.
+        object({}, "unknown")
+      ),
+    },
+    status: {
+      description: "The HTTP status code of the response",
+      type: "number",
+    },
+    statusText: {
+      description: "The status text of the response",
+      type: "string",
+    },
+    contentType: {
+      description: "The content type of the response",
+      type: anyOf("string", "null"),
+    },
+    responseHeaders: {
+      description: "The headers of the response",
+      type: object({}, "string"),
+    },
+  },
+  invoke: async ({ url, method, body, headers, raw, stream }) => {
     if (!url) throw new Error("Fetch requires `url` input");
     const init: RequestInit = {
       method,
@@ -164,7 +108,7 @@ export default {
     } else if (body) {
       throw new Error("GET requests can not have a body");
     }
-    const data: Response = await fetch(url, init);
+    const data = await fetch(url, init);
     const status = data.status;
     const responseHeaders: { [key: string]: string } = {};
     data.headers.forEach((value, name) => {
@@ -174,12 +118,14 @@ export default {
     const statusText = data.statusText;
     if (!data.ok)
       return {
+        // TODO(aomarks) Figure out how to model errors better.
         $error: await data.json(),
         status,
         statusText,
         contentType,
         responseHeaders,
-      };
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any;
     if (stream) {
       if (!data.body) {
         throw new Error("Response is not streamable.");
@@ -190,7 +136,12 @@ export default {
             .pipeThrough(new TextDecoderStream())
             .pipeThrough(serverSentEventTransform())
         ),
-      };
+        // TODO(aomarks) Figure out how to model streaming responses better.
+        // For now we just cast the problem away and assume the runtime knows
+        // what to do.
+        //
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any;
     } else {
       let response;
       if (raw || !contentType || !contentType.includes("application/json")) {
@@ -201,4 +152,4 @@ export default {
       return { response, status, statusText, contentType, responseHeaders };
     }
   },
-} satisfies NodeHandler;
+});


### PR DESCRIPTION
Support for type-safety around `$error` and `stream` is not quite there yet. Those two features will need some additional handling in `build` (and I need to understand them a bit better before figuring out the API for that), but we can just cast for now.