### PR TITLE
examples

### DIFF
--- a/.changeset/few-cooks-argue.md
+++ b/.changeset/few-cooks-argue.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard-ui": patch
+---
+
+Treat schema.examples as an array, rather than single value.

--- a/packages/breadboard-ui/src/elements/input/input.ts
+++ b/packages/breadboard-ui/src/elements/input/input.ts
@@ -299,11 +299,9 @@ export class Input extends LitElement {
             input = html`${multipart}`;
           } else {
             // Text inputs: multi line and single line.
+            const examples = property.examples?.[0];
             const value =
-              (values[key] as string) ??
-              property.examples ??
-              property.default ??
-              "";
+              (values[key] as string) ?? examples ?? property.default ?? "";
             if (isMultiline(property)) {
               // Multi line input.
               input = html`<div class="multiline">


### PR DESCRIPTION
- **Treat schema examples as an array, rather than one value.**
- **docs(changeset): Treat schema.examples as an array, rather than single value.**
