### PR TITLE
kit polish

### DIFF
--- a/.changeset/green-apes-act.md
+++ b/.changeset/green-apes-act.md
@@ -1,0 +1,13 @@
+---
+"@google-labs/node-nursery-web": patch
+"@google-labs/breadboard-ui": patch
+"@google-labs/template-kit": patch
+"@google-labs/breadboard": patch
+"@google-labs/core-kit": patch
+"@google-labs/json-kit": patch
+"@google-labs/palm-kit": patch
+"@google-labs/breadboard-schema": patch
+"@breadboard-ai/build": patch
+---
+
+Introduce `metadata` for `NodeHandler` entries, teaching node types in Kits to describe themselves.

--- a/packages/breadboard-ui/src/elements/editor/node-selector.ts
+++ b/packages/breadboard-ui/src/elements/editor/node-selector.ts
@@ -1,7 +1,7 @@
 import {
   GraphDescriptor,
-  InspectableNodeTypeMetadata,
   Kit,
+  NodeHandlerMetadata,
   inspect,
 } from "@google-labs/breadboard";
 import { LitElement, html, css, nothing } from "lit";
@@ -237,7 +237,7 @@ export class NodeSelector extends LitElement {
     const kits = graph.kits() || [];
     const kitList = new Map<
       string,
-      { id: string; metadata: InspectableNodeTypeMetadata }[]
+      { id: string; metadata: NodeHandlerMetadata }[]
     >();
     kits.sort((kit1, kit2) =>
       (kit1.descriptor.title || "") > (kit2.descriptor.title || "") ? 1 : -1
@@ -250,6 +250,7 @@ export class NodeSelector extends LitElement {
 
       let kitNodes = kit.nodeTypes;
       kitNodes = kit.nodeTypes.filter((node) => {
+        if (node.metadata().deprecated) return false;
         if (!this.filter) {
           return true;
         }

--- a/packages/breadboard/src/inspector/kits.ts
+++ b/packages/breadboard/src/inspector/kits.ts
@@ -9,6 +9,7 @@ import {
   NodeHandlers,
   NodeHandler,
   NodeDescriberResult,
+  NodeHandlerMetadata,
 } from "../types.js";
 import { collectPortsForType } from "./ports.js";
 import { describeInput, describeOutput } from "./schemas.js";
@@ -16,7 +17,6 @@ import {
   InspectableKit,
   InspectableNodePorts,
   InspectableNodeType,
-  InspectableNodeTypeMetadata,
   NodeTypeDescriberOptions,
 } from "./types.js";
 
@@ -61,26 +61,20 @@ export const collectKits = (kits: Kit[]): InspectableKit[] => {
 const collectNodeTypes = (handlers: NodeHandlers): InspectableNodeType[] => {
   return Object.entries(handlers)
     .sort()
-    .map(([type, handler]) => new NodeType(type, handler, {}));
+    .map(([type, handler]) => new NodeType(type, handler));
 };
 
 class NodeType implements InspectableNodeType {
   #type: string;
   #handler: NodeHandler;
-  #metadata: InspectableNodeTypeMetadata;
 
-  constructor(
-    type: string,
-    handler: NodeHandler,
-    metadata: InspectableNodeTypeMetadata
-  ) {
+  constructor(type: string, handler: NodeHandler) {
     this.#type = type;
     this.#handler = handler;
-    this.#metadata = metadata;
   }
 
-  metadata(): InspectableNodeTypeMetadata {
-    return this.#metadata;
+  metadata(): NodeHandlerMetadata {
+    return "metadata" in this.#handler ? this.#handler.metadata || {} : {};
   }
 
   type() {
@@ -114,18 +108,15 @@ class BuiltInNodeType extends NodeType {
   constructor(
     type: string,
     describer: (options: NodeTypeDescriberOptions) => NodeDescriberResult,
-    metadata: InspectableNodeTypeMetadata
+    metadata: NodeHandlerMetadata
   ) {
-    super(
-      type,
-      {
-        invoke: async () => {},
-        describe: async () => {
-          return describer({});
-        },
+    super(type, {
+      invoke: async () => {},
+      describe: async () => {
+        return describer({});
       },
-      metadata
-    );
+      metadata,
+    });
   }
 }
 

--- a/packages/breadboard/src/inspector/kits.ts
+++ b/packages/breadboard/src/inspector/kits.ts
@@ -16,6 +16,7 @@ import {
   InspectableKit,
   InspectableNodePorts,
   InspectableNodeType,
+  InspectableNodeTypeMetadata,
   NodeTypeDescriberOptions,
 } from "./types.js";
 
@@ -27,8 +28,15 @@ const createBuiltInKit = (): InspectableKit => {
       url: "",
     },
     nodeTypes: [
-      new BuiltInNodeType("input", describeInput),
-      new BuiltInNodeType("output", describeOutput),
+      new BuiltInNodeType("input", describeInput, {
+        title: "Input",
+        description: "The input node. Use it to request inputs for your board.",
+      }),
+      new BuiltInNodeType("output", describeOutput, {
+        title: "Output",
+        description:
+          "The output node. Use it to provide outputs from your board.",
+      }),
     ],
   };
 };
@@ -51,18 +59,28 @@ export const collectKits = (kits: Kit[]): InspectableKit[] => {
 };
 
 const collectNodeTypes = (handlers: NodeHandlers): InspectableNodeType[] => {
-  return Object.entries(handlers).map(
-    ([type, handler]) => new NodeType(type, handler)
-  );
+  return Object.entries(handlers)
+    .sort()
+    .map(([type, handler]) => new NodeType(type, handler, {}));
 };
 
 class NodeType implements InspectableNodeType {
   #type: string;
   #handler: NodeHandler;
+  #metadata: InspectableNodeTypeMetadata;
 
-  constructor(type: string, handler: NodeHandler) {
+  constructor(
+    type: string,
+    handler: NodeHandler,
+    metadata: InspectableNodeTypeMetadata
+  ) {
     this.#type = type;
     this.#handler = handler;
+    this.#metadata = metadata;
+  }
+
+  metadata(): InspectableNodeTypeMetadata {
+    return this.#metadata;
   }
 
   type() {
@@ -95,14 +113,19 @@ class NodeType implements InspectableNodeType {
 class BuiltInNodeType extends NodeType {
   constructor(
     type: string,
-    describer: (options: NodeTypeDescriberOptions) => NodeDescriberResult
+    describer: (options: NodeTypeDescriberOptions) => NodeDescriberResult,
+    metadata: InspectableNodeTypeMetadata
   ) {
-    super(type, {
-      invoke: async () => {},
-      describe: async () => {
-        return describer({});
+    super(
+      type,
+      {
+        invoke: async () => {},
+        describe: async () => {
+          return describer({});
+        },
       },
-    });
+      metadata
+    );
   }
 }
 

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -20,6 +20,7 @@ import {
   NodeConfiguration,
   NodeDescriberResult,
   NodeDescriptor,
+  NodeHandlerMetadata,
   NodeIdentifier,
   NodeTypeIdentifier,
   NodeValue,
@@ -387,29 +388,11 @@ export type InspectableKit = {
   nodeTypes: InspectableNodeType[];
 };
 
-/**
- * Represents metadata for a node type.
- */
-export type InspectableNodeTypeMetadata = {
-  /**
-   * Title of the node type.
-   */
-  title?: string;
-  /**
-   * Description of the node type.
-   */
-  description?: string;
-  /**
-   * Whether or not the node is deprecated.
-   */
-  deprecated?: boolean;
-};
-
 export type InspectableNodeType = {
   /**
    * Returns the metadata, associated with this node type.
    */
-  metadata(): InspectableNodeTypeMetadata;
+  metadata(): NodeHandlerMetadata;
   /**
    * Returns the type of the node.
    */

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -387,7 +387,29 @@ export type InspectableKit = {
   nodeTypes: InspectableNodeType[];
 };
 
+/**
+ * Represents metadata for a node type.
+ */
+export type InspectableNodeTypeMetadata = {
+  /**
+   * Title of the node type.
+   */
+  title?: string;
+  /**
+   * Description of the node type.
+   */
+  description?: string;
+  /**
+   * Whether or not the node is deprecated.
+   */
+  deprecated?: boolean;
+};
+
 export type InspectableNodeType = {
+  /**
+   * Returns the metadata, associated with this node type.
+   */
+  metadata(): InspectableNodeTypeMetadata;
   /**
    * Returns the type of the node.
    */

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -242,10 +242,26 @@ export type NodeDescriberFunction = (
   context?: NodeDescriberContext
 ) => Promise<NodeDescriberResult>;
 
+export type NodeHandlerMetadata = {
+  /**
+   * Title of the node type.
+   */
+  title?: string;
+  /**
+   * Description of the node type.
+   */
+  description?: string;
+  /**
+   * Whether or not the node is deprecated.
+   */
+  deprecated?: boolean;
+};
+
 export type NodeHandler =
   | {
       invoke: NodeHandlerFunction;
       describe?: NodeDescriberFunction;
+      metadata?: NodeHandlerMetadata;
     }
   | NodeHandlerFunction;
 

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -257,13 +257,13 @@ export type NodeHandlerMetadata = {
   deprecated?: boolean;
 };
 
-export type NodeHandler =
-  | {
-      invoke: NodeHandlerFunction;
-      describe?: NodeDescriberFunction;
-      metadata?: NodeHandlerMetadata;
-    }
-  | NodeHandlerFunction;
+export type NodeHandlerObject = {
+  invoke: NodeHandlerFunction;
+  describe?: NodeDescriberFunction;
+  metadata?: NodeHandlerMetadata;
+};
+
+export type NodeHandler = NodeHandlerObject | NodeHandlerFunction;
 
 /**
  * All known node handlers.

--- a/packages/build/src/internal/define/define.ts
+++ b/packages/build/src/internal/define/define.ts
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { NodeHandlerMetadata } from "@google-labs/breadboard";
 import type { CountUnion, Expand } from "../common/type-util.js";
 import type {
   ConvertBreadboardType,
@@ -128,6 +129,7 @@ export function defineNodeType<
     outputs: O;
     invoke: F;
     describe?: D;
+    metadata?: NodeHandlerMetadata;
   } & {
     // Then narrow down the types with further constraints. This 2-step
     // approach lets us generate additional and more precise errors.
@@ -189,6 +191,7 @@ export function defineNodeType<
   return Object.assign(impl.instantiate.bind(impl), {
     invoke: impl.invoke.bind(impl),
     describe: impl.describe.bind(impl),
+    metadata: params.metadata || {},
   });
 }
 

--- a/packages/core-kit/src/nodes/append.ts
+++ b/packages/core-kit/src/nodes/append.ts
@@ -102,6 +102,9 @@ export const appendDescriber: NodeDescriberFunction = async (
 };
 
 export default {
+  metadata: {
+    deprecated: true,
+  },
   describe: appendDescriber,
   invoke: async (inputs: InputValues): Promise<OutputValues> => {
     const { accumulator, ...values } = inputs as AppendInputs;

--- a/packages/core-kit/src/nodes/batch.ts
+++ b/packages/core-kit/src/nodes/batch.ts
@@ -4,7 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { InputValues, NodeValue, OutputValues } from "@google-labs/breadboard";
+import {
+  InputValues,
+  NodeHandlerObject,
+  NodeValue,
+  OutputValues,
+} from "@google-labs/breadboard";
 
 export type BatcherInputs = InputValues & {
   /**
@@ -24,14 +29,19 @@ export type BatcherOutputs = InputValues & {
   list: NodeValue[];
 };
 
-export default async (inputs: InputValues): Promise<OutputValues> => {
-  const { list, size } = inputs as BatcherInputs;
-  if (!list) throw new Error("Batcher requires `list` input");
-  if (!size) throw new Error("Batcher requires `size` input");
-  if (!list.length) return { list: [[]] };
-  const batches = [];
-  for (let i = 0; i < list.length; i += size) {
-    batches.push(list.slice(i, i + size));
-  }
-  return { list: batches };
-};
+export default {
+  metadata: {
+    deprecated: true,
+  },
+  invoke: async (inputs: InputValues): Promise<OutputValues> => {
+    const { list, size } = inputs as BatcherInputs;
+    if (!list) throw new Error("Batcher requires `list` input");
+    if (!size) throw new Error("Batcher requires `size` input");
+    if (!list.length) return { list: [[]] };
+    const batches = [];
+    for (let i = 0; i < list.length; i += size) {
+      batches.push(list.slice(i, i + size));
+    }
+    return { list: batches };
+  },
+} satisfies NodeHandlerObject;

--- a/packages/core-kit/src/nodes/curry.ts
+++ b/packages/core-kit/src/nodes/curry.ts
@@ -10,6 +10,7 @@ import {
   NodeDescriberContext,
   NodeDescriberResult,
   NodeHandlerContext,
+  NodeHandlerMetadata,
   OutputValues,
   Schema,
   SchemaBuilder,
@@ -84,4 +85,10 @@ const describe = async (
   return { inputSchema, outputSchema };
 };
 
-export default { invoke, describe };
+const metadata = {
+  title: "Curry",
+  description:
+    "Takes a board and bakes in (curries) supplied arguments into it. Very useful when we want to invoke a board with the same arguments many times (like with `map`).",
+} satisfies NodeHandlerMetadata;
+
+export default { metadata, invoke, describe };

--- a/packages/core-kit/src/nodes/fetch.ts
+++ b/packages/core-kit/src/nodes/fetch.ts
@@ -37,6 +37,11 @@ const serverSentEventTransform = () =>
 
 export default defineNodeType({
   name: "fetch",
+  metadata: {
+    title: "Fetch",
+    description:
+      "A wrapper around `fetch` API. Use this node to fetch content from the Web.",
+  },
   inputs: {
     url: {
       description: "The URL to fetch",

--- a/packages/core-kit/src/nodes/import.ts
+++ b/packages/core-kit/src/nodes/import.ts
@@ -22,6 +22,9 @@ export type ImportNodeInputs = InputValues & {
 };
 
 export default {
+  metadata: {
+    deprecated: true,
+  },
   describe: async (inputs?: InputValues) => {
     return {
       inputSchema: new SchemaBuilder()

--- a/packages/core-kit/src/nodes/include.ts
+++ b/packages/core-kit/src/nodes/include.ts
@@ -26,6 +26,9 @@ export type IncludeNodeInputs = InputValues & {
 };
 
 export default {
+  metadata: {
+    deprecated: true,
+  },
   describe: async (inputs?: InputValues) => ({
     inputSchema: new SchemaBuilder()
       .setAdditionalProperties(true)

--- a/packages/core-kit/src/nodes/invoke.ts
+++ b/packages/core-kit/src/nodes/invoke.ts
@@ -12,6 +12,7 @@ import type {
   GraphDescriptor,
   Schema,
   NodeDescriberContext,
+  NodeHandlerObject,
 } from "@google-labs/breadboard";
 import { BoardRunner, inspect } from "@google-labs/breadboard";
 import { SchemaBuilder } from "@google-labs/breadboard/kits";
@@ -108,6 +109,11 @@ const describe = async (
 };
 
 export default {
+  metadata: {
+    title: "Invoke",
+    description:
+      "Invokes (runOnce) specified board, supplying remaining incoming wires as inputs for that board. Returns the outputs of the board.",
+  },
   describe,
   invoke: async (
     inputs: InputValues,
@@ -130,4 +136,4 @@ export default {
 
     return await board.runOnce(args, invocationContext);
   },
-};
+} satisfies NodeHandlerObject;

--- a/packages/core-kit/src/nodes/map.ts
+++ b/packages/core-kit/src/nodes/map.ts
@@ -11,6 +11,7 @@ import {
   OutputValues,
   NodeHandlerContext,
   SchemaBuilder,
+  NodeHandlerMetadata,
 } from "@google-labs/breadboard";
 import { getRunner } from "../utils.js";
 
@@ -110,4 +111,10 @@ const describe = async () => {
   return { inputSchema, outputSchema };
 };
 
-export default { invoke, describe };
+const metadata = {
+  title: "Map",
+  description:
+    "Given a list and a board, iterates over this list (just like your usual JavaScript `map` function), invoking (runOnce) the supplied board for each item.",
+} satisfies NodeHandlerMetadata;
+
+export default { metadata, invoke, describe };

--- a/packages/core-kit/src/nodes/passthrough.ts
+++ b/packages/core-kit/src/nodes/passthrough.ts
@@ -4,10 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { InputValues, OutputValues } from "@google-labs/breadboard";
+import type {
+  InputValues,
+  NodeHandlerObject,
+  OutputValues,
+} from "@google-labs/breadboard";
 import { SchemaBuilder } from "@google-labs/breadboard/kits";
 
 export default {
+  metadata: {
+    title: "Passthrough",
+    description:
+      "Takes all inputs and passes them through as outputs. Effectively, a no-op node in Breadboard.",
+  },
   describe: async (inputs?: InputValues) => {
     if (!inputs) {
       return {
@@ -26,4 +35,4 @@ export default {
   invoke: async (inputs: InputValues): Promise<OutputValues> => {
     return inputs;
   },
-};
+} satisfies NodeHandlerObject;

--- a/packages/core-kit/src/nodes/reduce.ts
+++ b/packages/core-kit/src/nodes/reduce.ts
@@ -7,6 +7,7 @@
 import {
   InputValues,
   NodeHandlerContext,
+  NodeHandlerMetadata,
   NodeValue,
   OutputValues,
   SchemaBuilder,
@@ -104,4 +105,10 @@ const describe = async () => {
   return { inputSchema, outputSchema };
 };
 
-export default { invoke, describe };
+const metadata = {
+  title: "Reduce",
+  description:
+    "Given a list, an initial accumulator value, and a board, invokes a board (runOnce) for each item and accumulator in the list and returns the final accumulator value. Loosely, same logic as the `reduce` function in JavaScript.",
+} satisfies NodeHandlerMetadata;
+
+export default { metadata, invoke, describe };

--- a/packages/core-kit/src/nodes/reflect.ts
+++ b/packages/core-kit/src/nodes/reflect.ts
@@ -17,6 +17,9 @@ const deepCopy = (graph: GraphDescriptor): GraphDescriptor => {
 };
 
 export default {
+  metadata: {
+    deprecated: true,
+  },
   describe: async () => {
     return {
       inputSchema: SchemaBuilder.empty(),

--- a/packages/core-kit/src/nodes/resolve.ts
+++ b/packages/core-kit/src/nodes/resolve.ts
@@ -7,34 +7,40 @@
 import type {
   InputValues,
   NodeHandlerContext,
+  NodeHandlerObject,
   OutputValues,
 } from "@google-labs/breadboard";
 
-export default async (
-  inputs: InputValues,
-  context: NodeHandlerContext
-): Promise<OutputValues> => {
-  const base = inputs.$base ?? context.base?.href;
-  if (!base) {
-    throw new Error(
-      `Resolve could not find a base URL. The $base input was undefined, ` +
-        `and so was the handler context base.`
-    );
-  }
-  if (typeof base !== "string") {
-    throw new Error(`Resolve base must be a string, got ${typeof base}.`);
-  }
-  const resolved: Record<string, string> = {};
-  for (const [name, value] of Object.entries(inputs)) {
-    if (name === "$base") {
-      continue;
-    }
-    if (typeof value !== "string") {
+export default {
+  metadata: {
+    deprecated: true,
+  },
+  invoke: async (
+    inputs: InputValues,
+    context: NodeHandlerContext
+  ): Promise<OutputValues> => {
+    const base = inputs.$base ?? context.base?.href;
+    if (!base) {
       throw new Error(
-        `Resolve requires string inputs. Input "${name}" had type "${typeof value}".`
+        `Resolve could not find a base URL. The $base input was undefined, ` +
+          `and so was the handler context base.`
       );
     }
-    resolved[name] = new URL(value, base).href;
-  }
-  return resolved;
-};
+    if (typeof base !== "string") {
+      throw new Error(`Resolve base must be a string, got ${typeof base}.`);
+    }
+    const resolved: Record<string, string> = {};
+    for (const [name, value] of Object.entries(inputs)) {
+      if (name === "$base") {
+        continue;
+      }
+      if (typeof value !== "string") {
+        throw new Error(
+          `Resolve requires string inputs. Input "${name}" had type "${typeof value}".`
+        );
+      }
+      resolved[name] = new URL(value, base).href;
+    }
+    return resolved;
+  },
+} satisfies NodeHandlerObject;

--- a/packages/core-kit/src/nodes/run-javascript.ts
+++ b/packages/core-kit/src/nodes/run-javascript.ts
@@ -262,6 +262,10 @@ export const runJavascriptDescriber: NodeDescriberFunction = async (
 };
 
 export default {
+  metadata: {
+    title: "Run Javascript",
+    description: "Runs supplied `code` input as Javascript.",
+  },
   describe: runJavascriptDescriber,
   invoke: runJavascriptHandler,
 } satisfies NodeHandler;

--- a/packages/core-kit/src/nodes/secrets.ts
+++ b/packages/core-kit/src/nodes/secrets.ts
@@ -69,12 +69,12 @@ const getKeys = (
   return keys;
 };
 
-/**
- * A kind of input node that provides secret values, such as API keys.
- * Currently, it simply reads them from environment.
- */
 export default defineNodeType({
   name: "secrets",
+  metadata: {
+    title: "Secrets",
+    description: "Retrieves secret values, such as API keys.",
+  },
   inputs: {
     keys: {
       title: "secrets",

--- a/packages/core-kit/src/nodes/slot.ts
+++ b/packages/core-kit/src/nodes/slot.ts
@@ -19,6 +19,9 @@ export type SlotNodeInputs = {
 };
 
 export default {
+  metadata: {
+    deprecated: true,
+  },
   describe: async (inputs?: InputValues) => ({
     inputSchema: new SchemaBuilder()
       .setAdditionalProperties(true)

--- a/packages/core-kit/tests/batch.ts
+++ b/packages/core-kit/tests/batch.ts
@@ -13,7 +13,7 @@ test("works with reasonable arguments", async (t) => {
     list: [1, 2, 3],
     size: 2,
   };
-  const outputs = await batcher(inputs);
+  const outputs = await batcher.invoke(inputs);
   t.deepEqual(outputs, {
     list: [[1, 2], [3]],
   });
@@ -25,7 +25,7 @@ test("handles unreasonable arguments", async (t) => {
       list: [],
       size: 2,
     };
-    const outputs = await batcher(inputs);
+    const outputs = await batcher.invoke(inputs);
     t.deepEqual(outputs, {
       list: [[]],
     });
@@ -35,16 +35,16 @@ test("handles unreasonable arguments", async (t) => {
       list: [1, 2],
       size: 0,
     };
-    await t.throwsAsync(async () => await batcher(inputs));
+    await t.throwsAsync(async () => await batcher.invoke(inputs));
   }
   {
     const inputs = {};
-    await t.throwsAsync(async () => await batcher(inputs));
+    await t.throwsAsync(async () => await batcher.invoke(inputs));
   }
   {
     const inputs = {
       size: 100,
     };
-    await t.throwsAsync(async () => await batcher(inputs));
+    await t.throwsAsync(async () => await batcher.invoke(inputs));
   }
 });

--- a/packages/core-kit/tests/resolve.ts
+++ b/packages/core-kit/tests/resolve.ts
@@ -12,7 +12,7 @@ import resolve from "../src/nodes/resolve.js";
 
 test("resolve resolves paths relative to the board base by default", async (t) => {
   t.deepEqual(
-    await resolve(
+    await resolve.invoke(
       { path: "./bar.json" },
       { base: new URL("http://example.com/graphs/foo.json") }
     ),
@@ -22,7 +22,7 @@ test("resolve resolves paths relative to the board base by default", async (t) =
 
 test("resolve resolves paths relative to the $base input when provided", async (t) => {
   t.deepEqual(
-    await resolve(
+    await resolve.invoke(
       {
         path: "./bar.json",
         $base: "file://not/the/default/foo.json",
@@ -35,7 +35,7 @@ test("resolve resolves paths relative to the $base input when provided", async (
 
 test("resolve resolves multiple input properties", async (t) => {
   t.deepEqual(
-    await resolve(
+    await resolve.invoke(
       {
         bar: "./bar.json",
         abc123: "./abc123.json",
@@ -51,7 +51,10 @@ test("resolve resolves multiple input properties", async (t) => {
 
 test("resolve does nothing with no inputs", async (t) => {
   t.deepEqual(
-    await resolve({}, { base: new URL("http://example.com/graphs/foo.json") }),
+    await resolve.invoke(
+      {},
+      { base: new URL("http://example.com/graphs/foo.json") }
+    ),
     {}
   );
 });

--- a/packages/json-kit/src/nodes/jsonata.ts
+++ b/packages/json-kit/src/nodes/jsonata.ts
@@ -10,8 +10,8 @@ import {
   NodeHandlerFunction,
   NodeHandlerContext,
   Schema,
-  NodeHandler,
   SchemaBuilder,
+  NodeHandlerObject,
 } from "@google-labs/breadboard";
 
 import jsonata from "jsonata";
@@ -111,6 +111,11 @@ export const jsonataDescriber: NodeDescriberFunction = async (
 };
 
 export default {
+  metadata: {
+    title: "JSONata",
+    description:
+      "Uses JSONata (a kind of SQL for JSON) to transform incoming JSON object. See https://jsonata.org/ for details on the language.",
+  },
   describe: jsonataDescriber,
   invoke: jsonataHandler,
-} satisfies NodeHandler;
+} satisfies NodeHandlerObject;

--- a/packages/json-kit/src/nodes/object-to-schema.ts
+++ b/packages/json-kit/src/nodes/object-to-schema.ts
@@ -7,6 +7,7 @@
 import {
   InputValues,
   Lambda,
+  NodeHandlerObject,
   OutputValues,
   Schema,
   code,
@@ -97,6 +98,10 @@ export const describe = async () => {
 };
 
 export default {
+  metadata: {
+    title: "Object to Schema",
+    description: "Creates a JSON Schema from a given object",
+  },
   describe,
   invoke,
-};
+} as NodeHandlerObject;

--- a/packages/json-kit/src/nodes/schemish.ts
+++ b/packages/json-kit/src/nodes/schemish.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  NodeHandlerObject,
   SchemaBuilder,
   type InputValues,
   type NodeValue,
@@ -89,6 +90,11 @@ const describe = async () => {
 };
 
 export default {
+  metadata: {
+    title: "Schemish",
+    description:
+      "Converts a JSON schema to Schemish (https://glazkov.com/2023/05/06/schemish/)",
+  },
   invoke,
   describe,
-};
+} as NodeHandlerObject;

--- a/packages/json-kit/src/nodes/validate-json.ts
+++ b/packages/json-kit/src/nodes/validate-json.ts
@@ -5,6 +5,7 @@
  */
 
 import {
+  NodeHandlerObject,
   SchemaBuilder,
   type InputValues,
   type NodeDescriberFunction,
@@ -194,6 +195,11 @@ const describe: NodeDescriberFunction = async () => {
 };
 
 export default {
+  metadata: {
+    title: "Validate JSON",
+    description:
+      "Validates given text as JSON, trying its best to parse it first.",
+  },
   invoke,
   describe,
-};
+} as NodeHandlerObject;

--- a/packages/json-kit/src/nodes/xml-to-json.ts
+++ b/packages/json-kit/src/nodes/xml-to-json.ts
@@ -71,6 +71,10 @@ const toAltJson = (
 };
 
 export default {
+  metadata: {
+    title: "XML to JSON",
+    description: "Creates a JSON representation of a given XML input.",
+  },
   describe: async () => {
     return {
       inputSchema: {

--- a/packages/node-nursery-web/src/nodes/list-to-stream.ts
+++ b/packages/node-nursery-web/src/nodes/list-to-stream.ts
@@ -6,11 +6,15 @@
 
 import {
   InputValues,
+  NodeHandler,
   OutputValues,
   StreamCapability,
 } from "@google-labs/breadboard";
 
 export default {
+  metadata: {
+    deprecated: true,
+  },
   invoke: async (inputs: InputValues): Promise<OutputValues> => {
     const { list } = inputs;
     if (!list) throw new Error("The `list` input is required");
@@ -27,4 +31,4 @@ export default {
     });
     return { stream: new StreamCapability(stream) };
   },
-};
+} satisfies NodeHandler;

--- a/packages/node-nursery-web/src/nodes/transform-stream.ts
+++ b/packages/node-nursery-web/src/nodes/transform-stream.ts
@@ -9,6 +9,7 @@ import {
   BreadboardCapability,
   InputValues,
   NodeHandlerContext,
+  NodeHandlerObject,
   OutputValues,
   StreamCapability,
   StreamCapabilityType,
@@ -53,6 +54,9 @@ const getTransformer = async (
 };
 
 export default {
+  metadata: {
+    deprecated: true,
+  },
   invoke: async (
     inputs: InputValues,
     context?: NodeHandlerContext
@@ -69,4 +73,4 @@ export default {
       .pipeThrough(new TransformStream(transformer));
     return { stream: new StreamCapability<object>(outputStream) };
   },
-};
+} satisfies NodeHandlerObject;

--- a/packages/palm-kit/src/nodes/embed-text.ts
+++ b/packages/palm-kit/src/nodes/embed-text.ts
@@ -62,6 +62,11 @@ export const embedTextDescriber: NodeDescriberFunction = async () => {
 };
 
 export default {
+  metadata: {
+    title: "Embed Text",
+    description:
+      "Uses `embedding-gecko-001` model to generate an embedding of a given text",
+  },
   describe: embedTextDescriber,
   invoke: async (inputs: InputValues): Promise<OutputValues> => {
     const values = inputs as EmbedTextInputs;

--- a/packages/palm-kit/src/nodes/generate-text.ts
+++ b/packages/palm-kit/src/nodes/generate-text.ts
@@ -141,6 +141,9 @@ export const generateTextDescriber: NodeDescriberFunction = async () => {
 };
 
 export default {
+  metadata: {
+    deprecated: true,
+  },
   describe: generateTextDescriber,
   invoke: async (inputs: InputValues) => {
     return await prepareResponse(await fetch(prepareRequest(inputs)));

--- a/packages/schema/src/graph.ts
+++ b/packages/schema/src/graph.ts
@@ -169,11 +169,11 @@ export type KitDescriptor = KitReference & {
 export type KitManifest = KitDescriptor & {
   /**
    * A map of nodes. Each key in this object is the node that is provided by
-   * the kit. Each value is the URL (string) pointing to the graph or the
-   * `GraphDescriptor` containing the graph. This graph will be run (runOnce)
-   * when the `invoke` of the node's `NodeHandler` is called.
+   * the kit. Each value the `GraphDescriptor` containing the graph. This
+   * graph will be run (runOnce) when the `invoke` of the node's `NodeHandler`
+   * is called.
    */
-  nodes: Record<NodeIdentifier, string | GraphDescriptor>;
+  nodes: Record<NodeIdentifier, GraphDescriptor>;
 };
 
 /**

--- a/packages/template-kit/src/nodes/prompt-template.ts
+++ b/packages/template-kit/src/nodes/prompt-template.ts
@@ -49,7 +49,7 @@ const promptTemplateHandler = (
 
 /**
  * Use this node to populate simple handlebar-style templates. A required
- * input is `template`, which is a string that conains the template prompt
+ * input is `template`, which is a string that contains the template prompt
  * template. The template can contain zero or more placeholders that will be
  * replaced with values from inputs. Specify placeholders as `{{inputName}}`
  * in the template. The placeholders in the template must match the inputs
@@ -59,6 +59,11 @@ const promptTemplateHandler = (
  */
 export default defineNodeType({
   name: "promptTemplate",
+  metadata: {
+    title: "Prompt Template",
+    description:
+      "Use this node to populate simple handlebar-style templates. A required input is `template`, which is a string that contains the template prompt template. The template can contain zero or more placeholders that will be replaced with values from inputs. Specify placeholders as `{{inputName}}` in the template. The placeholders in the template must match the inputs wired into this node. The node will replace all placeholders with values from the input property bag and pass the result along as the `prompt` output property.",
+  },
   inputs: {
     template: {
       type: "string",

--- a/packages/template-kit/src/nodes/url-template.ts
+++ b/packages/template-kit/src/nodes/url-template.ts
@@ -48,6 +48,11 @@ export const getUrlTemplateParameters = (
  */
 export default defineNodeType({
   name: "urlTemplate",
+  metadata: {
+    title: "URL Template",
+    description:
+      "Use this node to safely construct URLs. This node relies on the [URI template specification](https://tools.ietf.org/html/rfc6570) to construct URLs, so the syntax is using single curly braces instead of double curly braces.",
+  },
   inputs: {
     template: {
       type: "string",


### PR DESCRIPTION
- **Sort nodes in `InspectableKit` and add kit metadata.**
- **Plumb node type info to selector.**
- **Add `NodeHandlerMetadata`.**
- **Mark a few node types as deprecated.**
- **Deprecate a PaLM generate text.**
- **Implement `GraphDescriptorNodeHandler`.**
- **Teach KitManifest about node type metadata.**
- **Add support for metadata in `defineNodeType`.**
- **Teach Core kit about node handler metadata.**
- **Teach JSON Kit about node handler metadata.**
- **Deprecate nodes in Node Nursery Web.**
- **Teach PaLM Kit about node handler metadata.**
- **Teach Templates Kit about node handler metadata.**
- **docs(changeset): Introduce `metadata` for `NodeHandler` entries, teaching node types in Kits to describe themselves.**
