### PR TITLE
[breadboard,-ui,-web] Improve multimodal support

### DIFF
--- a/.changeset/odd-ghosts-smoke.md
+++ b/.changeset/odd-ghosts-smoke.md
@@ -1,0 +1,7 @@
+---
+"@google-labs/breadboard-web": minor
+"@google-labs/breadboard-ui": minor
+"@google-labs/breadboard": minor
+---
+
+Change all multi-modal inputs to be a format of llm-content

--- a/packages/breadboard-ui/src/elements/input/audio/audio.ts
+++ b/packages/breadboard-ui/src/elements/input/audio/audio.ts
@@ -85,10 +85,14 @@ export class AudioInput extends LitElement {
   `;
 
   get value() {
-    const value = {
-      inline_data: { data: this.#output || "", mime_type: this.#mimeType },
+    return {
+      role: "user",
+      parts: [
+        {
+          inline_data: { data: this.#output || "", mime_type: this.#mimeType },
+        },
+      ],
     };
-    return value;
   }
 
   async #requestPermission() {

--- a/packages/breadboard-ui/src/elements/input/drawable/drawable.ts
+++ b/packages/breadboard-ui/src/elements/input/drawable/drawable.ts
@@ -7,7 +7,6 @@
 import { LitElement, html, css } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { createRef, ref, type Ref } from "lit/directives/ref.js";
-import { CanvasData } from "../../../types/types.js";
 
 @customElement("bb-drawable-input")
 export class DrawableInput extends LitElement {
@@ -288,19 +287,20 @@ export class DrawableInput extends LitElement {
   }
 
   get value() {
-    const value = { inline_data: { data: "", mime_type: this.type } };
-    const inlineData = this.#canvasRef.value?.toDataURL(this.type, 80);
-    if (!inlineData) {
-      return value;
-    }
-
+    const inlineData = this.#canvasRef.value?.toDataURL(this.type, 80) || "";
     const preamble = `data:${this.type};base64,`;
-    value.inline_data.data = inlineData.substring(preamble.length);
-    return value;
-  }
 
-  set value(_v: CanvasData) {
-    console.warn("Value set on drawable, but values are not supported");
+    return {
+      role: "user",
+      parts: [
+        {
+          inline_data: {
+            data: inlineData.substring(preamble.length),
+            mime_type: this.type,
+          },
+        },
+      ],
+    };
   }
 
   render() {

--- a/packages/breadboard-ui/src/elements/input/input.ts
+++ b/packages/breadboard-ui/src/elements/input/input.ts
@@ -11,13 +11,12 @@ import {
   isMultipart,
 } from "./input-multipart/input-multipart.js";
 import {
-  isAudio,
+  isMicrophoneAudio,
   isBoolean,
-  isDrawable,
-  isMultipartImage,
+  isDrawableImage,
   isMultiline,
   isSelect,
-  isWebcam,
+  isWebcamImage,
 } from "../../utils/index.js";
 import { LitElement, html, css } from "lit";
 import { customElement, property } from "lit/decorators.js";
@@ -196,7 +195,11 @@ export class Input extends LitElement {
     for (const [key, property] of Object.entries(properties)) {
       if (isMultipart(property)) {
         const values = await getMultipartValue(form, key);
-        data[key] = values.value;
+        if (property.type && property.type === "array") {
+          data[key] = [{ parts: values.value }];
+        } else {
+          data[key] = values.value;
+        }
       } else {
         const input = form[key];
         if (input && input.value) {
@@ -264,17 +267,12 @@ export class Input extends LitElement {
             >${property.title || key}</label
           >`;
           let input;
-          if (isAudio(property)) {
+          if (isMicrophoneAudio(property)) {
             input = html`<bb-audio-capture id="${key}"></bb-audio-capture>`;
-          } else if (isMultipartImage(property)) {
-            // Webcam input.
-            if (isWebcam(property)) {
-              input = html`<bb-webcam-input id="${key}"></bb-webcam-input>`;
-            } else if (isDrawable(property)) {
-              input = html`<bb-drawable-input id="${key}"></bb-drawable-input>`;
-            } else {
-              input = html`Image type not supported yet.`;
-            }
+          } else if (isWebcamImage(property)) {
+            input = html`<bb-webcam-input id="${key}"></bb-webcam-input>`;
+          } else if (isDrawableImage(property)) {
+            input = html`<bb-drawable-input id="${key}"></bb-drawable-input>`;
           } else if (isSelect(property)) {
             // Select input.
             const options = property.enum || [];

--- a/packages/breadboard-ui/src/elements/input/webcam/webcam.ts
+++ b/packages/breadboard-ui/src/elements/input/webcam/webcam.ts
@@ -7,7 +7,6 @@
 import { LitElement, html, css } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { createRef, ref, type Ref } from "lit/directives/ref.js";
-import { CanvasData } from "../../../types/types.js";
 
 @customElement("bb-webcam-input")
 export class WebcamInput extends LitElement {
@@ -105,19 +104,20 @@ export class WebcamInput extends LitElement {
   }
 
   get value() {
-    const value = { inline_data: { data: "", mime_type: this.type } };
-    const inlineData = this.#canvasRef.value?.toDataURL(this.type, 80);
-    if (!inlineData) {
-      return value;
-    }
-
+    const inlineData = this.#canvasRef.value?.toDataURL(this.type, 80) || "";
     const preamble = `data:${this.type};base64,`;
-    value.inline_data.data = inlineData.substring(preamble.length);
-    return value;
-  }
 
-  set value(_v: CanvasData) {
-    console.warn("Value set on webcam, but values are not supported");
+    return {
+      role: "user",
+      parts: [
+        {
+          inline_data: {
+            data: inlineData.substring(preamble.length),
+            mime_type: this.type,
+          },
+        },
+      ],
+    };
   }
 
   disconnectedCallback(): void {

--- a/packages/breadboard-ui/src/types/types.ts
+++ b/packages/breadboard-ui/src/types/types.ts
@@ -41,13 +41,6 @@ export interface ImageHandler {
   stop(): void;
 }
 
-export interface CanvasData {
-  inline_data: {
-    data: string;
-    mime_type: string;
-  };
-}
-
 export type HistoryEntry = HarnessRunResult & {
   id: string;
   guid: string;
@@ -84,7 +77,7 @@ export type OutputArgs = {
 };
 
 type InlineData = {
-  inlineData: { data: string; mime_type: string };
+  inline_data: { data: string; mime_type: string };
 };
 
 type FunctionCall = {
@@ -104,6 +97,7 @@ type FunctionResponse = {
 type Part = InlineData | FunctionCall | FunctionResponse;
 
 export type LLMContent = {
+  role?: string;
   parts: Part[];
 };
 

--- a/packages/breadboard-ui/src/utils/index.ts
+++ b/packages/breadboard-ui/src/utils/index.ts
@@ -22,22 +22,30 @@ export function isBoolean(schema: Schema) {
   return schema.type == "boolean";
 }
 
-export function isAudio(schema: Schema) {
-  return typeof schema.type === "string" && schema.type.startsWith("audio");
-}
-
-export function isMultipartImage(schema: Schema) {
-  return typeof schema.type === "string" && schema.type.startsWith("image");
+export function isMicrophoneAudio(schema: Schema) {
+  return (
+    schema.type === "object" &&
+    schema.behavior?.includes("llm-content") &&
+    schema.format === "audio-microphone"
+  );
 }
 
 export function isMultipartText(schema: Schema) {
   return schema.type === "object" && schema.format?.startsWith("text");
 }
 
-export function isWebcam(schema: Schema) {
-  return schema.format === "webcam";
+export function isWebcamImage(schema: Schema) {
+  return (
+    schema.type === "object" &&
+    schema.behavior?.includes("llm-content") &&
+    schema.format === "image-webcam"
+  );
 }
 
-export function isDrawable(schema: Schema) {
-  return schema.format === "drawable";
+export function isDrawableImage(schema: Schema) {
+  return (
+    schema.type === "object" &&
+    schema.behavior?.includes("llm-content") &&
+    schema.format === "image-drawable"
+  );
 }

--- a/packages/breadboard-ui/src/utils/schema.ts
+++ b/packages/breadboard-ui/src/utils/schema.ts
@@ -88,17 +88,17 @@ export function resolveArrayType(value: Schema) {
     const valueItems = value.items as Items;
     if (valueItems.type) {
       return valueItems.type;
-    } else if (resolveBehaviorType(valueItems) === "llm-content") {
-      return "object";
     }
-  } else if (resolveBehaviorType(value) === "llm-content") {
-    return "object";
   }
 
   return "string";
 }
 
-export function resolveBehaviorType(value: Schema | Items) {
+export function resolveBehaviorType(value: Schema | Schema[] | undefined) {
+  if (!value || Array.isArray(value)) {
+    return null;
+  }
+
   if (value.behavior) {
     if (Array.isArray(value.behavior) && value.behavior.length > 0) {
       return value.behavior[0];

--- a/packages/breadboard-web/public/graphs/audio.json
+++ b/packages/breadboard-web/public/graphs/audio.json
@@ -10,22 +10,16 @@
       "in": "text"
     },
     {
-      "from": "combineAudioAndPrompt",
+      "from": "contextify",
       "to": "describeAudio",
       "out": "context",
       "in": "context"
     },
     {
       "from": "input-1",
-      "to": "combineAudioAndPrompt",
+      "to": "contextify",
       "out": "audio",
       "in": "audio"
-    },
-    {
-      "from": "input-1",
-      "to": "combineAudioAndPrompt",
-      "out": "prompt",
-      "in": "prompt"
     }
   ],
   "nodes": [
@@ -51,16 +45,21 @@
       "type": "text",
       "configuration": {
         "model": "gemini-1.5-pro-latest",
-        "text": "unused"
+        "text": "unused",
+        "systemInstruction": "Describe what you hear in the audio. Please respond in markdown"
       }
     },
     {
-      "id": "combineAudioAndPrompt",
+      "id": "contextify",
       "type": "runJavascript",
       "configuration": {
-        "code": "const combineAudioAndPrompt = ({audio,prompt})=>{return{context:{parts:[audio,{text:prompt}]}}};",
-        "name": "combineAudioAndPrompt",
+        "code": "const contextify = ({audio})=>{return{context:[audio]}};",
+        "name": "contextify",
         "raw": true
+      },
+      "metadata": {
+        "title": "Wrap audio",
+        "description": "Wraps the audio in a context object for Gemini"
       }
     },
     {
@@ -71,21 +70,16 @@
           "type": "object",
           "properties": {
             "audio": {
-              "type": "audio/webm",
-              "title": "Audio",
-              "format": "microphone"
-            },
-            "prompt": {
-              "type": "string",
-              "title": "Prompt",
-              "examples": [
-                "Describe what you hear in the audio. Please respond in markdown"
-              ]
+              "type": "object",
+              "behavior": [
+                "llm-content"
+              ],
+              "format": "audio-microphone",
+              "title": "Audio"
             }
           },
           "required": [
-            "audio",
-            "prompt"
+            "audio"
           ]
         }
       }

--- a/packages/breadboard-web/public/graphs/drawable.json
+++ b/packages/breadboard-web/public/graphs/drawable.json
@@ -53,7 +53,7 @@
       "id": "combinePictureAndPrompt",
       "type": "runJavascript",
       "configuration": {
-        "code": "const combinePictureAndPrompt = ({picture,prompt})=>{return{parts:[picture,{text:prompt}]}};",
+        "code": "const combinePictureAndPrompt = ({picture,prompt})=>{const picturePart=picture.parts[0];return{parts:[picturePart,{text:prompt}]}};",
         "name": "combinePictureAndPrompt",
         "raw": true
       }
@@ -66,9 +66,12 @@
           "type": "object",
           "properties": {
             "picture": {
-              "type": "image/png",
+              "type": "object",
+              "behavior": [
+                "llm-content"
+              ],
               "title": "Image",
-              "format": "drawable"
+              "format": "image-drawable"
             },
             "prompt": {
               "type": "string",

--- a/packages/breadboard-web/public/graphs/gemini-pro-vision.json
+++ b/packages/breadboard-web/public/graphs/gemini-pro-vision.json
@@ -127,29 +127,15 @@
           "properties": {
             "parts": {
               "type": "array",
-              "format": "multipart",
               "title": "Content",
               "description": "Add content here",
               "minItems": 1,
-              "items": [
-                {
-                  "type": "object",
-                  "title": "Text",
-                  "format": "text_part",
-                  "description": "A text part, which consists of plain text",
-                  "properties": {
-                    "text": {
-                      "type": "string"
-                    }
-                  }
-                },
-                {
-                  "type": "object",
-                  "title": "Image",
-                  "format": "image_part",
-                  "description": "An image part. Can be a JPEG or PNG image"
-                }
-              ]
+              "items": {
+                "type": "object",
+                "behavior": [
+                  "llm-content"
+                ]
+              }
             },
             "useStreaming": {
               "type": "boolean",

--- a/packages/breadboard-web/public/graphs/webcam.json
+++ b/packages/breadboard-web/public/graphs/webcam.json
@@ -53,7 +53,7 @@
       "id": "combinePictureAndPrompt",
       "type": "runJavascript",
       "configuration": {
-        "code": "const combinePictureAndPrompt = ({picture,prompt})=>{return{parts:[picture,{text:prompt}]}};",
+        "code": "const combinePictureAndPrompt = ({picture,prompt})=>{const picturePart=picture.parts[0];return{parts:[picturePart,{text:prompt}]}};",
         "name": "combinePictureAndPrompt",
         "raw": true
       }
@@ -66,9 +66,12 @@
           "type": "object",
           "properties": {
             "picture": {
-              "type": "image/png",
+              "type": "object",
+              "behavior": [
+                "llm-content"
+              ],
               "title": "Image",
-              "format": "webcam"
+              "format": "image-webcam"
             },
             "prompt": {
               "type": "string",

--- a/packages/breadboard-web/src/boards/drawable.ts
+++ b/packages/breadboard-web/src/boards/drawable.ts
@@ -11,11 +11,16 @@ import { gemini } from "@google-labs/gemini-kit";
 // Note, this one is a bit "in the weeds": it literally formats the Gemini Pro
 // API request to include the picture as part of the prompt.
 const partsMaker = code(({ picture, prompt }) => {
-  return { parts: [picture, { text: prompt }] };
+  const picturePart = (picture as { parts: unknown[] }).parts[0];
+  return { parts: [picturePart, { text: prompt }] };
 });
 
 export default await board(({ picture, prompt }) => {
-  picture.isImage().title("Image").format("drawable");
+  picture
+    .isObject()
+    .behavior("llm-content")
+    .title("Image")
+    .format("image-drawable");
   prompt
     .isString()
     .title("Prompt")

--- a/packages/breadboard-web/src/boards/gemini-pro-vision.ts
+++ b/packages/breadboard-web/src/boards/gemini-pro-vision.ts
@@ -27,29 +27,13 @@ const inputSchema = {
   properties: {
     parts: {
       type: "array",
-      format: "multipart",
       title: "Content",
       description: "Add content here",
       minItems: 1,
-      items: [
-        {
-          type: "object",
-          title: "Text",
-          format: "text_part",
-          description: "A text part, which consists of plain text",
-          properties: {
-            text: {
-              type: "string",
-            },
-          },
-        },
-        {
-          type: "object",
-          title: "Image",
-          format: "image_part",
-          description: "An image part. Can be a JPEG or PNG image",
-        },
-      ],
+      items: {
+        type: "object",
+        behavior: ["llm-content"],
+      },
     },
     useStreaming: {
       type: "boolean",

--- a/packages/breadboard-web/src/boards/webcam.ts
+++ b/packages/breadboard-web/src/boards/webcam.ts
@@ -11,11 +11,16 @@ import { gemini } from "@google-labs/gemini-kit";
 // Note, this one is a bit "in the weeds": it literally formats the Gemini Pro
 // API request to include the picture as part of the prompt.
 const partsMaker = code(({ picture, prompt }) => {
-  return { parts: [picture, { text: prompt }] };
+  const picturePart = (picture as { parts: unknown[] }).parts[0];
+  return { parts: [picturePart, { text: prompt }] };
 });
 
 export default await board(({ picture, prompt }) => {
-  picture.isImage().title("Image").format("webcam");
+  picture
+    .isObject()
+    .behavior("llm-content")
+    .title("Image")
+    .format("image-webcam");
   prompt
     .isString()
     .title("Prompt")

--- a/packages/breadboard/src/new/grammar/types.ts
+++ b/packages/breadboard/src/new/grammar/types.ts
@@ -268,8 +268,6 @@ export abstract class AbstractValue<T extends NodeValue = NodeValue>
   abstract isBoolean(): AbstractValue<boolean>;
   abstract isArray(): AbstractValue<NodeValue[]>;
   abstract isObject(): AbstractValue<{ [key: string]: NodeValue }>;
-  abstract isImage(mimeType?: string): AbstractValue<unknown>;
-  abstract isAudio(mimeType?: string): AbstractValue<unknown>;
 
   abstract title(title: string): AbstractValue<T>;
   abstract format(format: string): AbstractValue<T>;

--- a/packages/breadboard/src/new/grammar/value.ts
+++ b/packages/breadboard/src/new/grammar/value.ts
@@ -230,16 +230,6 @@ export class Value<T extends NodeValue = NodeValue>
     return this as unknown as AbstractValue<NodeValue[]>;
   }
 
-  isImage(mimeType = "image/png"): AbstractValue<unknown> {
-    this.#schema.type = mimeType;
-    return this;
-  }
-
-  isAudio(mimeType = "audio/webm"): AbstractValue<unknown> {
-    this.#schema.type = mimeType;
-    return this;
-  }
-
   isObject(): AbstractValue<{ [key: string]: NodeValue }> {
     this.#schema.type = "object";
     return this as unknown as AbstractValue<{


### PR DESCRIPTION
I have retired `isImage` and `isAudio`. Now everything is of type `object` with a behavior of `['llm-content']` and a format that indicates the subtype.