### PR TITLE
[build] A bunch of improvements needed for migrating runJavascript

### DIFF
--- a/.changeset/dry-suits-accept.md
+++ b/.changeset/dry-suits-accept.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+additionalProperties is now set on generated port JSON schemas

--- a/.changeset/honest-pens-tap.md
+++ b/.changeset/honest-pens-tap.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": minor
+---
+
+Replace multiline field with format, which can be multiline or javascript

--- a/.changeset/mighty-gifts-talk.md
+++ b/.changeset/mighty-gifts-talk.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Inbound edges, even if they don't have a value, now inform the auto generated input schema

--- a/.changeset/perfect-shoes-complain.md
+++ b/.changeset/perfect-shoes-complain.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Fix some incorrect type errors from certain describe functions.

--- a/.changeset/smooth-badgers-hug.md
+++ b/.changeset/smooth-badgers-hug.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Automatically detected input ports are no longer required. Only static ones.

--- a/.changeset/strange-keys-watch.md
+++ b/.changeset/strange-keys-watch.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Allow specifying behaviors

--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ packages/breadboard-web/build
 
 # User-specific configuration
 .vscode/settings.json
+
+lcov.info

--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -62,6 +62,13 @@ the following fields:
 
 - `default`: (Optional) A default value for this input.
 
+- `format`: (Optional) Additional information about the format of the value.
+  Primarily used to determine how strings are displayed in the Breadboard Visual
+  Editor. Valid values:
+
+  - `multiline`: A string that is likely to contain multiple lines.
+  - `javascript`: A string that is JavaScript code.
+
 - `primary`: (Optional) Enables a syntactic sugar feature for an output port to
   make wiring nodes more concise. When a node has a `primary` output port, then
   it becomes possible to use the node itself in API positions where an output

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -45,6 +45,7 @@
     "build:tsc": "wireit",
     "test": "wireit",
     "test:only": "wireit",
+    "coverage": "wireit",
     "lint": "wireit",
     "test-and-lint": "wireit",
     "dev": "npm run test-and-lint --watch"
@@ -86,6 +87,16 @@
       ],
       "files": [],
       "output": []
+    },
+    "coverage": {
+      "command": "node --test --enable-source-maps --experimental-test-coverage --test-reporter lcov --test-reporter-destination=lcov.info dist/test/*_test.js",
+      "dependencies": [
+        "build:tsc"
+      ],
+      "files": [],
+      "output": [
+        "lcov.info"
+      ]
     },
     "lint": {
       "command": "eslint src/ --ext .ts",

--- a/packages/build/src/internal/common/port.ts
+++ b/packages/build/src/internal/common/port.ts
@@ -6,6 +6,7 @@
 
 import type { Input, InputWithDefault } from "../board/input.js";
 import type { Placeholder } from "../board/placeholder.js";
+import type { PortConfig } from "../define/config.js";
 import type {
   BreadboardType,
   ConvertBreadboardType,
@@ -16,74 +17,6 @@ import type {
   SerializableNode,
   SerializableOutputPort,
 } from "./serializable.js";
-
-// TODO(aomarks) Combine with PortConfig from define.ts
-export type PortConfig = StaticPortConfig | DynamicPortConfig;
-
-/**
- * Configuration parameters for a static Breadboard node port. A port is static
- * if it always exists for all instances of a node type.
- */
-interface StaticPortConfig {
-  /**
-   * The {@link BreadboardType} that values sent or received on this port will
-   * be required to conform to.
-   */
-  type: BreadboardType;
-
-  /**
-   * An optional title for the port. Defaults to the name of the port.
-   */
-  title?: string;
-
-  /**
-   * An optional brief description of this port. Useful when introspecting and
-   * debugging.
-   */
-  description?: string;
-
-  /**
-   * If true, this port is is the `primary` input or output port of the node it
-   * belongs to.
-   *
-   * When a node definition has one primary input port, and/or one primary
-   * output port, then instances of that node will themselves behave like that
-   * primary input and/or output ports, depending on the context. Note that it
-   * is an error for a node to have more than 1 primary input ports, or more
-   * than 1 primary output ports.
-   *
-   * For example, an LLM node might have a primary input for `prompt`, and a
-   * primary output for `completion`. This would mean that in API locations
-   * where an input port is expected, instead of writing `llm.inputs.prompt`,
-   * one could simply write `llm`, and the `prompt` port will be selected
-   * automatically. Likewise for `completion`, where `llm` would be equivalent
-   * to `llm.outputs.completion` where an output port is expected.
-   *
-   * Note this has no effect on Breadboard runtime behavior, it is purely a hint
-   * to the JavaScript/TypeScript API to help make board construction more
-   * concise.
-   */
-  primary?: boolean;
-
-  multiline?: true;
-
-  default?: JsonSerializable;
-}
-
-/**
- * Configuration parameters that apply to all dynamic Breadboard ports on a
- * node.
- *
- * A port is dynamic if its existence, name, type, or other metadata can be
- * different across different instances of a node type.
- */
-interface DynamicPortConfig extends StaticPortConfig {
-  /**
-   * The `primary` property should never be set on a dynamic port config,
-   * because it is not possible for a dynamic port to be primary.
-   */
-  primary?: never;
-}
 
 // TODO(aomarks) Just make this a normal property, no need to export (it was
 // originally a symbol to try and make a package-private API).

--- a/packages/build/src/internal/define/config.ts
+++ b/packages/build/src/internal/define/config.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { BehaviorSchema } from "@google-labs/breadboard";
 import type { BreadboardType, JsonSerializable } from "../type-system/type.js";
 
 export type PortConfig = InputPortConfig | OutputPortConfig;
@@ -43,6 +44,13 @@ interface BaseConfig {
    * visual editor.
    */
   format?: Format;
+
+  /**
+   * Can be used to provide additional hints to the UI or to other parts of
+   * the system about behavior of this particular input/output or input/output
+   * port.
+   */
+  behavior?: BehaviorSchema[];
 }
 
 interface StaticBase {

--- a/packages/build/src/internal/define/config.ts
+++ b/packages/build/src/internal/define/config.ts
@@ -12,6 +12,14 @@ export type PortConfigs = Record<string, PortConfig>;
 export type InputPortConfig = StaticInputPortConfig | DynamicInputPortConfig;
 export type OutputPortConfig = StaticOutputPortConfig | DynamicOutputPortConfig;
 
+/**
+ * Additional information about the format of the value. Primarily used to
+ * determine how strings are displayed in the Breadboard Visual Editor.
+ */
+export type Format =
+  | /* A string that is likely to contain multiple lines. */ "multiline"
+  | /* A string that is JavaScript code. */ "javascript";
+
 interface BaseConfig {
   /**
    * The {@link BreadboardType} that values sent or received on this port will
@@ -31,13 +39,13 @@ interface BaseConfig {
   description?: string;
 
   /**
-   * A hint for the Breadboard visual editor to indicate that the text is likely
-   * to contain multiple lines.
+   * Special format annotations. Primarily used as hints for the Breadboard
+   * visual editor.
    */
-  multiline?: true;
+  format?: Format;
 }
 
-interface WithPrimary {
+interface StaticBase {
   /**
    * If true, this port is is the `primary` input or output port of the node it
    * belongs to.
@@ -65,7 +73,7 @@ interface WithPrimary {
 /**
  * Configuration for a static import ports of a Breadboard node.
  */
-export interface StaticInputPortConfig extends BaseConfig, WithPrimary {
+export interface StaticInputPortConfig extends BaseConfig, StaticBase {
   /**
    * A default value for this port.
    */
@@ -80,7 +88,7 @@ export interface DynamicInputPortConfig extends BaseConfig {}
 /**
  * Configuration for a static output port of a Breadboard node.
  */
-export interface StaticOutputPortConfig extends BaseConfig, WithPrimary {}
+export interface StaticOutputPortConfig extends BaseConfig, StaticBase {}
 
 /**
  * Configuration for the dynamic output ports of a Breadboard node.

--- a/packages/build/src/internal/define/config.ts
+++ b/packages/build/src/internal/define/config.ts
@@ -13,23 +13,83 @@ export type InputPortConfig = StaticInputPortConfig | DynamicInputPortConfig;
 export type OutputPortConfig = StaticOutputPortConfig | DynamicOutputPortConfig;
 
 interface BaseConfig {
+  /**
+   * The {@link BreadboardType} that values sent or received on this port will
+   * be required to conform to.
+   */
   type: BreadboardType;
+
+  /**
+   * An optional title for the port. Defaults to the name of the port.
+   */
   title?: string;
+
+  /**
+   * An optional brief description of this port. Useful when introspecting and
+   * debugging.
+   */
   description?: string;
+
+  /**
+   * A hint for the Breadboard visual editor to indicate that the text is likely
+   * to contain multiple lines.
+   */
   multiline?: true;
 }
 
-export interface StaticInputPortConfig extends BaseConfig {
+interface WithPrimary {
+  /**
+   * If true, this port is is the `primary` input or output port of the node it
+   * belongs to.
+   *
+   * When a node definition has one primary input port, and/or one primary
+   * output port, then instances of that node will themselves behave like that
+   * primary input and/or output ports, depending on the context. Note that it
+   * is an error for a node to have more than 1 primary input ports, or more
+   * than 1 primary output ports.
+   *
+   * For example, an LLM node might have a primary input for `prompt`, and a
+   * primary output for `completion`. This would mean that in API locations
+   * where an input port is expected, instead of writing `llm.inputs.prompt`,
+   * one could simply write `llm`, and the `prompt` port will be selected
+   * automatically. Likewise for `completion`, where `llm` would be equivalent
+   * to `llm.outputs.completion` where an output port is expected.
+   *
+   * Note this has no effect on Breadboard runtime behavior, it is purely a hint
+   * to the JavaScript/TypeScript API to help make board construction more
+   * concise.
+   */
   primary?: true;
+}
+
+/**
+ * Configuration for a static import ports of a Breadboard node.
+ */
+export interface StaticInputPortConfig extends BaseConfig, WithPrimary {
+  /**
+   * A default value for this port.
+   */
   default?: JsonSerializable;
 }
 
+/**
+ * Configuration for the dynamic import ports of a Breadboard node.
+ */
 export interface DynamicInputPortConfig extends BaseConfig {}
 
-export interface StaticOutputPortConfig extends BaseConfig {
-  primary?: true;
-}
+/**
+ * Configuration for a static output port of a Breadboard node.
+ */
+export interface StaticOutputPortConfig extends BaseConfig, WithPrimary {}
 
+/**
+ * Configuration for the dynamic output ports of a Breadboard node.
+ */
 export interface DynamicOutputPortConfig extends BaseConfig {
+  /**
+   * If true, for each dynamic input that an instance of this node type is
+   * instantiated with, an output port with the same name will be automatically
+   * created.
+   */
   reflective?: true;
 }

--- a/packages/build/src/internal/define/define.ts
+++ b/packages/build/src/internal/define/define.ts
@@ -326,7 +326,24 @@ type LooseDescribeFn = Function;
 
 export type DynamicInputPorts =
   | string[]
-  | { [K: string]: { description: string } };
+  | {
+      [K: string]:
+        | { description?: string }
+        // We include undefined here because TypeScript sometimes generates a
+        // type which would otherwise not match our constraint. For example,
+        // the expression:
+        //
+        //   outputFoo ? { foo: { description: "foo" } } : {}
+        //
+        // Gets assigned this type:
+        //
+        //   { foo: { description:"foo" } } | { foo?: undefined }
+        //
+        // Instead of:
+        //
+        //   { foo: { description:"foo" } } | {}
+        | undefined;
+    };
 
 type StrictDescribeFn<
   I extends Record<string, InputPortConfig>,

--- a/packages/build/src/internal/define/definition.ts
+++ b/packages/build/src/internal/define/definition.ts
@@ -194,7 +194,7 @@ export class DefinitionImpl<
     }
 
     let inputSchema: JSONSchema4 & {
-      properties: { [k: string]: JSONSchema4 };
+      properties?: { [k: string]: JSONSchema4 };
     };
     if (this.#dynamicInputs === undefined) {
       // All inputs are static.
@@ -224,7 +224,7 @@ export class DefinitionImpl<
     }
 
     let outputSchema: JSONSchema4 & {
-      properties: { [k: string]: JSONSchema4 };
+      properties?: { [k: string]: JSONSchema4 };
     };
     if (this.#dynamicOutputs === undefined) {
       // All outputs are static.
@@ -240,9 +240,9 @@ export class DefinitionImpl<
       );
     } else if (this.#reflective) {
       // We're reflective, so our outputs are determined by our dynamic inputs.
-      const dynamicInputNames = Object.keys(inputSchema.properties).filter(
-        (name) => this.#staticInputs[name] === undefined
-      );
+      const dynamicInputNames = Object.keys(
+        inputSchema.properties ?? {}
+      ).filter((name) => this.#staticInputs[name] === undefined);
       const d = this.#dynamicOutputs;
       outputSchema = portConfigMapToJSONSchema(
         {

--- a/packages/build/src/internal/define/definition.ts
+++ b/packages/build/src/internal/define/definition.ts
@@ -282,7 +282,10 @@ function parseDynamicPorts(
 ): Array<[string, { description?: string }]> {
   return Array.isArray(ports)
     ? ports.map((name) => [name, {}])
-    : Object.entries(ports);
+    : (Object.entries(ports).filter(
+        /** See {@link DynamicInputPorts} for why undefined is possible here. */
+        ([, config]) => config !== undefined
+      ) as Array<[string, { description?: string }]>);
 }
 
 type LooseInstantiateArgs = object;

--- a/packages/build/src/internal/define/json-schema.ts
+++ b/packages/build/src/internal/define/json-schema.ts
@@ -23,7 +23,7 @@ export function portConfigMapToJSONSchema(
     type: "object",
     properties: Object.fromEntries(
       sortedEntries.map(([name, config]) => {
-        const { description, type } = config;
+        const { description, type, behavior } = config;
         const schema: JSONSchema4 = {
           title: config.title ?? name,
         };
@@ -36,6 +36,9 @@ export function portConfigMapToJSONSchema(
         Object.assign(schema, toJSONSchema(type));
         if ("format" in config && config.format !== undefined) {
           schema.format = config.format;
+        }
+        if (behavior !== undefined && behavior.length > 0) {
+          schema.behavior = behavior;
         }
         return [name, schema];
       })

--- a/packages/build/src/internal/define/json-schema.ts
+++ b/packages/build/src/internal/define/json-schema.ts
@@ -10,19 +10,19 @@ import { toJSONSchema } from "../type-system/type.js";
 
 export function portConfigMapToJSONSchema(
   config: PortConfigMap,
-  omitRequired = false
+  omitRequired: boolean
 ): JSONSchema4 & {
   properties?: { [k: string]: JSONSchema4 };
 } {
   const schema: JSONSchema4 & { properties?: { [k: string]: JSONSchema4 } } = {
     type: "object",
   };
-  const sortedEntries = Object.entries(config).sort(([nameA], [nameB]) =>
+  const sortedProperties = Object.entries(config).sort(([nameA], [nameB]) =>
     nameA.localeCompare(nameB)
   );
-  if (sortedEntries.length > 0) {
+  if (sortedProperties.length > 0) {
     schema.properties = Object.fromEntries(
-      sortedEntries.map(([name, config]) => {
+      sortedProperties.map(([name, config]) => {
         const { description, type, behavior } = config;
         const schema: JSONSchema4 = {
           title: config.title ?? name,
@@ -44,7 +44,7 @@ export function portConfigMapToJSONSchema(
       })
     );
     if (!omitRequired) {
-      const required = sortedEntries
+      const required = sortedProperties
         .filter(
           ([, config]) => !("default" in config) || config.default === undefined
         )

--- a/packages/build/src/internal/define/json-schema.ts
+++ b/packages/build/src/internal/define/json-schema.ts
@@ -12,16 +12,16 @@ export function portConfigMapToJSONSchema(
   config: PortConfigMap,
   omitRequired = false
 ): JSONSchema4 & {
-  properties: { [k: string]: JSONSchema4 };
+  properties?: { [k: string]: JSONSchema4 };
 } {
+  const schema: JSONSchema4 & { properties?: { [k: string]: JSONSchema4 } } = {
+    type: "object",
+  };
   const sortedEntries = Object.entries(config).sort(([nameA], [nameB]) =>
     nameA.localeCompare(nameB)
   );
-  const schema: JSONSchema4 & {
-    properties: { [k: string]: JSONSchema4 };
-  } = {
-    type: "object",
-    properties: Object.fromEntries(
+  if (sortedEntries.length > 0) {
+    schema.properties = Object.fromEntries(
       sortedEntries.map(([name, config]) => {
         const { description, type, behavior } = config;
         const schema: JSONSchema4 = {
@@ -42,16 +42,16 @@ export function portConfigMapToJSONSchema(
         }
         return [name, schema];
       })
-    ),
-  };
-  if (!omitRequired) {
-    const required = sortedEntries
-      .filter(
-        ([, config]) => !("default" in config) || config.default === undefined
-      )
-      .map(([name]) => name);
-    if (required.length > 0) {
-      schema.required = required;
+    );
+    if (!omitRequired) {
+      const required = sortedEntries
+        .filter(
+          ([, config]) => !("default" in config) || config.default === undefined
+        )
+        .map(([name]) => name);
+      if (required.length > 0) {
+        schema.required = required;
+      }
     }
   }
   return schema;

--- a/packages/build/src/internal/define/json-schema.ts
+++ b/packages/build/src/internal/define/json-schema.ts
@@ -23,7 +23,7 @@ export function portConfigMapToJSONSchema(
     type: "object",
     properties: Object.fromEntries(
       sortedEntries.map(([name, config]) => {
-        const { description, type, multiline } = config;
+        const { description, type } = config;
         const schema: JSONSchema4 = {
           title: config.title ?? name,
         };
@@ -34,13 +34,8 @@ export function portConfigMapToJSONSchema(
           schema.default = config.default;
         }
         Object.assign(schema, toJSONSchema(type));
-        if (multiline === true) {
-          // TODO(aomarks) This is not a valid use of the JSON Schema format
-          // keyword according to
-          // https://opis.io/json-schema/2.x/formats.html. We should probably put
-          // Breadboard specific stuff somewhere else (e.g. in a breadboard
-          // property).
-          schema.format = "multiline";
+        if ("format" in config && config.format !== undefined) {
+          schema.format = config.format;
         }
         return [name, schema];
       })

--- a/packages/build/src/internal/define/json-schema.ts
+++ b/packages/build/src/internal/define/json-schema.ts
@@ -30,7 +30,7 @@ export function portConfigMapToJSONSchema(
         if (description) {
           schema.description = description;
         }
-        if (config.default !== undefined) {
+        if ("default" in config && config.default !== undefined) {
           schema.default = config.default;
         }
         Object.assign(schema, toJSONSchema(type));
@@ -48,7 +48,9 @@ export function portConfigMapToJSONSchema(
   };
   if (!omitRequired) {
     const required = sortedEntries
-      .filter(([, config]) => config.default === undefined)
+      .filter(
+        ([, config]) => !("default" in config) || config.default === undefined
+      )
       .map(([name]) => name);
     if (required.length > 0) {
       schema.required = required;

--- a/packages/build/src/test/compatibility_test.ts
+++ b/packages/build/src/test/compatibility_test.ts
@@ -236,7 +236,18 @@ function setupKits<
             title: "base",
             type: "number",
           },
-          // TODO(aomarks) Shouldn't num1, num2, num3 show up here?
+          num1: {
+            title: "num1",
+            type: "number",
+          },
+          num2: {
+            title: "num2",
+            type: "number",
+          },
+          num3: {
+            title: "num3",
+            type: "number",
+          },
         },
         required: ["base"],
         additionalProperties: { type: "number" },

--- a/packages/build/src/test/compatibility_test.ts
+++ b/packages/build/src/test/compatibility_test.ts
@@ -122,6 +122,7 @@ function setupKits<
           },
         },
         required: ["str"],
+        additionalProperties: false,
       },
       outputSchema: {
         type: "object",
@@ -131,6 +132,7 @@ function setupKits<
             type: "number",
           },
         },
+        additionalProperties: false,
       },
     });
   });
@@ -237,6 +239,7 @@ function setupKits<
           // TODO(aomarks) Shouldn't num1, num2, num3 show up here?
         },
         required: ["base"],
+        additionalProperties: { type: "number" },
       },
       outputSchema: {
         type: "object",
@@ -246,6 +249,7 @@ function setupKits<
             type: "number",
           },
         },
+        additionalProperties: false,
       },
     });
   });

--- a/packages/build/src/test/define_test.ts
+++ b/packages/build/src/test/define_test.ts
@@ -910,6 +910,53 @@ test("multiline/javascript", async () => {
   });
 });
 
+test("behavior", async () => {
+  const d = defineNodeType({
+    name: "foo",
+    inputs: {
+      si1: {
+        type: "string",
+        behavior: ["config"],
+      },
+    },
+    outputs: {
+      so1: {
+        type: "string",
+        behavior: ["image", "code"],
+      },
+    },
+    invoke: () => {
+      return { so1: "foo" };
+    },
+  });
+
+  assert.deepEqual(await d.describe(), {
+    inputSchema: {
+      type: "object",
+      properties: {
+        si1: {
+          title: "si1",
+          type: "string",
+          behavior: ["config"],
+        },
+      },
+      required: ["si1"],
+      additionalProperties: false,
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        so1: {
+          title: "so1",
+          type: "string",
+          behavior: ["image", "code"],
+        },
+      },
+      additionalProperties: false,
+    },
+  });
+});
+
 test("dynamic port descriptions", async () => {
   const d = defineNodeType({
     name: "foo",

--- a/packages/build/src/test/define_test.ts
+++ b/packages/build/src/test/define_test.ts
@@ -847,23 +847,31 @@ test("primary input + output", () => {
   );
 });
 
-test("multiline", async () => {
+test("multiline/javascript", async () => {
   const d = defineNodeType({
     name: "foo",
     inputs: {
       si1: {
         type: "string",
-        multiline: true,
+        format: "multiline",
+      },
+      si2: {
+        type: "string",
+        format: "javascript",
       },
     },
     outputs: {
       so1: {
         type: "string",
-        multiline: true,
+        format: "multiline",
+      },
+      so2: {
+        type: "string",
+        format: "javascript",
       },
     },
     invoke: () => {
-      return { so1: "foo" };
+      return { so1: "foo", so2: "foo" };
     },
   });
 
@@ -876,8 +884,13 @@ test("multiline", async () => {
           type: "string",
           format: "multiline",
         },
+        si2: {
+          title: "si2",
+          type: "string",
+          format: "javascript",
+        },
       },
-      required: ["si1"],
+      required: ["si1", "si2"],
     },
     outputSchema: {
       type: "object",
@@ -886,6 +899,11 @@ test("multiline", async () => {
           title: "so1",
           type: "string",
           format: "multiline",
+        },
+        so2: {
+          title: "so2",
+          type: "string",
+          format: "javascript",
         },
       },
     },

--- a/packages/build/src/test/define_test.ts
+++ b/packages/build/src/test/define_test.ts
@@ -512,7 +512,7 @@ test("poly/poly", async () => {
           type: "number",
         },
       },
-      required: ["di1", "di2", "si1"],
+      required: ["si1"],
       additionalProperties: { type: "number" },
     },
     outputSchema: {
@@ -666,7 +666,7 @@ test("reflective", async () => {
         di2: { type: "number", title: "di2" },
         si1: { type: "string", title: "si1" },
       },
-      required: ["di1", "di2", "si1"],
+      required: ["si1"],
       additionalProperties: { type: "number" },
     },
     outputSchema: {

--- a/packages/build/src/test/define_test.ts
+++ b/packages/build/src/test/define_test.ts
@@ -11,7 +11,6 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { defineNodeType } from "../internal/define/define.js";
 import { object } from "../internal/type-system/object.js";
-import { anyOf } from "../internal/type-system/any-of.js";
 import { array } from "../internal/type-system/array.js";
 
 test("mono/mono", async () => {
@@ -1134,25 +1133,8 @@ test("override title", async () => {
           type: "null",
         },
       },
-      type: "object",
+      additionalProperties: false,
     },
-  });
-});
-
-test("describe is lenient with odd TypeScript types", () => {
-  defineNodeType({
-    name: "foo",
-    inputs: {
-      outputFoo: { type: "boolean" },
-    },
-    outputs: {
-      "*": { type: "unknown" },
-    },
-    describe: ({ outputFoo }) => ({
-      /** See {@link DynamicInputPorts} for why this is an interesting case. */
-      outputs: outputFoo ? { foo: { description: "foo" } } : {},
-    }),
-    invoke: () => ({}),
   });
 });
 
@@ -1580,36 +1562,6 @@ test("error: excess instantiate input", () => {
   );
 });
 
-test("error: mono/mono should not have describe", () => {
-  const d = defineNodeType({
-    name: "foo",
-    inputs: {
-      si1: { type: "string" },
-    },
-    outputs: {
-      so1: { type: "string" },
-    },
-    // @ts-expect-error
-    describe: () => ({ inputs: [], outputs: [] }),
-    invoke: () => ({ so1: "so1" }),
-  });
-});
-
-test("error: mono/poly must have describe", () => {
-  // @ts-expect-error
-  const d = defineNodeType({
-    name: "foo",
-    inputs: {
-      si1: { type: "string" },
-    },
-    outputs: {
-      so1: { type: "string" },
-      "*": { type: "number" },
-    },
-    invoke: () => ({ so1: "so1" }),
-  });
-});
-
 test("error: mono/poly should not return inputs", () => {
   const d = defineNodeType({
     name: "foo",
@@ -1638,22 +1590,6 @@ test("error: poly/mono should not return outputs", () => {
     },
     // @ts-expect-error
     describe: () => ({ inputs: [], outputs: [] }),
-    invoke: () => ({ so1: "so1" }),
-  });
-});
-
-test("error: non-reflective poly/poly must have describe", () => {
-  // @ts-expect-error
-  const d = defineNodeType({
-    name: "foo",
-    inputs: {
-      si1: { type: "string" },
-      "*": { type: "string" },
-    },
-    outputs: {
-      so1: { type: "string" },
-      "*": { type: "string" },
-    },
     invoke: () => ({ so1: "so1" }),
   });
 });

--- a/packages/build/src/test/define_test.ts
+++ b/packages/build/src/test/define_test.ts
@@ -108,6 +108,7 @@ test("mono/mono", async () => {
         },
       },
       required: ["si1", "si2"],
+      additionalProperties: false,
     },
     outputSchema: {
       type: "object",
@@ -121,6 +122,7 @@ test("mono/mono", async () => {
           type: "null",
         },
       },
+      additionalProperties: false,
     },
   };
   assert.deepEqual(await d.describe(), expectedSchema);
@@ -224,6 +226,7 @@ test("poly/mono", async () => {
         },
       },
       required: ["si1"],
+      additionalProperties: false,
     },
     outputSchema: {
       type: "object",
@@ -233,6 +236,7 @@ test("poly/mono", async () => {
           type: "boolean",
         },
       },
+      additionalProperties: false,
     },
   });
 
@@ -254,6 +258,7 @@ test("poly/mono", async () => {
         },
       },
       required: ["di1", "di2", "si1"],
+      additionalProperties: false,
     },
     outputSchema: {
       type: "object",
@@ -263,6 +268,7 @@ test("poly/mono", async () => {
           type: "boolean",
         },
       },
+      additionalProperties: false,
     },
   });
 });
@@ -346,6 +352,7 @@ test("mono/poly", async () => {
         },
       },
       required: ["si1"],
+      additionalProperties: false,
     },
     outputSchema: {
       type: "object",
@@ -359,6 +366,7 @@ test("mono/poly", async () => {
           type: "number",
         },
       },
+      additionalProperties: false,
     },
   };
   assert.deepEqual(await d.describe(), expectedSchema);
@@ -469,6 +477,7 @@ test("poly/poly", async () => {
         },
       },
       required: ["si1"],
+      additionalProperties: { type: "number" },
     },
     outputSchema: {
       type: "object",
@@ -482,6 +491,7 @@ test("poly/poly", async () => {
           type: "number",
         },
       },
+      additionalProperties: false,
     },
   });
 
@@ -503,6 +513,7 @@ test("poly/poly", async () => {
         },
       },
       required: ["di1", "di2", "si1"],
+      additionalProperties: { type: "number" },
     },
     outputSchema: {
       type: "object",
@@ -516,6 +527,7 @@ test("poly/poly", async () => {
           type: "number",
         },
       },
+      additionalProperties: false,
     },
   });
 });
@@ -635,12 +647,14 @@ test("reflective", async () => {
         si1: { type: "string", title: "si1" },
       },
       required: ["si1"],
+      additionalProperties: { type: "number" },
     },
     outputSchema: {
       type: "object",
       properties: {
         so1: { type: "boolean", title: "so1" },
       },
+      additionalProperties: false,
     },
   });
 
@@ -653,6 +667,7 @@ test("reflective", async () => {
         si1: { type: "string", title: "si1" },
       },
       required: ["di1", "di2", "si1"],
+      additionalProperties: { type: "number" },
     },
     outputSchema: {
       type: "object",
@@ -661,6 +676,7 @@ test("reflective", async () => {
         di2: { type: "string", title: "di2" },
         so1: { type: "boolean", title: "so1" },
       },
+      additionalProperties: false,
     },
   });
 });
@@ -890,6 +906,7 @@ test("multiline/javascript", async () => {
         },
       },
       required: ["si1", "si2"],
+      additionalProperties: false,
     },
     outputSchema: {
       type: "object",
@@ -905,6 +922,7 @@ test("multiline/javascript", async () => {
           format: "javascript",
         },
       },
+      additionalProperties: false,
     },
   });
 });
@@ -993,6 +1011,7 @@ test("dynamic port descriptions", async () => {
         },
       },
       required: ["foo"],
+      additionalProperties: false,
     },
     outputSchema: {
       type: "object",
@@ -1003,6 +1022,7 @@ test("dynamic port descriptions", async () => {
           description: 'output "foo"',
         },
       },
+      additionalProperties: false,
     },
   });
 });
@@ -1071,6 +1091,7 @@ test("defaults", async () => {
           default: [12, 34],
         },
       },
+      additionalProperties: false,
     },
     outputSchema: {
       type: "object",
@@ -1085,6 +1106,7 @@ test("defaults", async () => {
           items: { type: "number" },
         },
       },
+      additionalProperties: false,
     },
   };
   assert.deepEqual(await d.describe(), expectedSchema);
@@ -1109,6 +1131,7 @@ test("override title", async () => {
   });
   assert.deepEqual(await d.describe(), {
     inputSchema: {
+      type: "object",
       properties: {
         si1: {
           title: "custom1",
@@ -1120,9 +1143,10 @@ test("override title", async () => {
         },
       },
       required: ["si1", "si2"],
-      type: "object",
+      additionalProperties: false,
     },
     outputSchema: {
+      type: "object",
       properties: {
         so1: {
           title: "so1",

--- a/packages/build/src/test/define_test.ts
+++ b/packages/build/src/test/define_test.ts
@@ -1074,6 +1074,23 @@ test("override title", async () => {
   });
 });
 
+test("describe is lenient with odd TypeScript types", () => {
+  defineNodeType({
+    name: "foo",
+    inputs: {
+      outputFoo: { type: "boolean" },
+    },
+    outputs: {
+      "*": { type: "unknown" },
+    },
+    describe: ({ outputFoo }) => ({
+      /** See {@link DynamicInputPorts} for why this is an interesting case. */
+      outputs: outputFoo ? { foo: { description: "foo" } } : {},
+    }),
+    invoke: () => ({}),
+  });
+});
+
 test("error: missing name", () => {
   assert.throws(
     () =>

--- a/packages/build/src/test/describe_test.ts
+++ b/packages/build/src/test/describe_test.ts
@@ -157,7 +157,7 @@ test("dynamic input schema with custom describe (open)", async () => {
   );
 });
 
-test("dynamic input schema with default describe and no values", async () => {
+test("dynamic input schema with default describe passed nothing", async () => {
   assert.deepEqual(
     (
       await defineNodeType({
@@ -184,7 +184,7 @@ test("dynamic input schema with default describe and no values", async () => {
   );
 });
 
-test("dynamic input schema with default describe and values", async () => {
+test("dynamic input schema with default describe passed values", async () => {
   assert.deepEqual(
     (
       await defineNodeType({
@@ -213,7 +213,48 @@ test("dynamic input schema with default describe and values", async () => {
           type: "number",
         },
       },
-      required: ["a", "b", "foo"],
+      required: ["foo"],
+      additionalProperties: { type: "number" },
+    }
+  );
+});
+
+test("dynamic input schema with default describe passed inbound edges", async () => {
+  assert.deepEqual(
+    (
+      await defineNodeType({
+        name: "foo",
+        inputs: {
+          foo: { type: "string" },
+          "*": { type: "number" },
+        },
+        outputs: {},
+        invoke: () => ({}),
+      }).describe(undefined, {
+        type: "object",
+        properties: {
+          a: { type: "number" },
+          b: { type: "string" },
+        },
+      })
+    ).inputSchema,
+    {
+      type: "object",
+      properties: {
+        foo: {
+          title: "foo",
+          type: "string",
+        },
+        a: {
+          title: "a",
+          type: "number",
+        },
+        b: {
+          title: "b",
+          type: "number",
+        },
+      },
+      required: ["foo"],
       additionalProperties: { type: "number" },
     }
   );

--- a/packages/build/src/test/describe_test.ts
+++ b/packages/build/src/test/describe_test.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import assert from "node:assert/strict";
 import { test } from "node:test";
 import { defineNodeType } from "../internal/define/define.js";
 
@@ -70,4 +71,240 @@ test("describe is lenient with odd TypeScript types", () => {
     }),
     invoke: () => ({}),
   });
+});
+
+test("static input schema", async () => {
+  assert.deepEqual(
+    (
+      await defineNodeType({
+        name: "foo",
+        inputs: { foo: { type: "string" } },
+        outputs: {},
+        invoke: () => ({}),
+      }).describe()
+    ).inputSchema,
+    {
+      type: "object",
+      properties: {
+        foo: {
+          title: "foo",
+          type: "string",
+        },
+      },
+      required: ["foo"],
+      additionalProperties: false,
+    }
+  );
+});
+
+test("dynamic input schema with custom describe (closed)", async () => {
+  assert.deepEqual(
+    (
+      await defineNodeType({
+        name: "foo",
+        inputs: {
+          foo: { type: "string" },
+          "*": { type: "number" },
+        },
+        outputs: {},
+        describe: () => ({ inputs: ["bar"] }),
+        invoke: () => ({}),
+      }).describe()
+    ).inputSchema,
+    {
+      type: "object",
+      properties: {
+        foo: {
+          title: "foo",
+          type: "string",
+        },
+        bar: {
+          title: "bar",
+          type: "number",
+        },
+      },
+      required: ["bar", "foo"],
+      additionalProperties: false,
+    }
+  );
+});
+
+test("dynamic input schema with custom describe (open)", async () => {
+  assert.deepEqual(
+    (
+      await defineNodeType({
+        name: "foo",
+        inputs: {
+          foo: { type: "string" },
+          "*": { type: "number" },
+        },
+        outputs: {},
+        describe: () => ({ inputs: { "*": {} } }),
+        invoke: () => ({}),
+      }).describe()
+    ).inputSchema,
+    {
+      type: "object",
+      properties: {
+        foo: {
+          title: "foo",
+          type: "string",
+        },
+      },
+      required: ["foo"],
+      additionalProperties: { type: "number" },
+    }
+  );
+});
+
+test("dynamic input schema with default describe and no values", async () => {
+  assert.deepEqual(
+    (
+      await defineNodeType({
+        name: "foo",
+        inputs: {
+          foo: { type: "string" },
+          "*": { type: "number" },
+        },
+        outputs: {},
+        invoke: () => ({}),
+      }).describe()
+    ).inputSchema,
+    {
+      type: "object",
+      properties: {
+        foo: {
+          title: "foo",
+          type: "string",
+        },
+      },
+      required: ["foo"],
+      additionalProperties: { type: "number" },
+    }
+  );
+});
+
+test("dynamic input schema with default describe and values", async () => {
+  assert.deepEqual(
+    (
+      await defineNodeType({
+        name: "foo",
+        inputs: {
+          foo: { type: "string" },
+          "*": { type: "number" },
+        },
+        outputs: {},
+        invoke: () => ({}),
+      }).describe({ a: 1, b: 2 })
+    ).inputSchema,
+    {
+      type: "object",
+      properties: {
+        foo: {
+          title: "foo",
+          type: "string",
+        },
+        a: {
+          title: "a",
+          type: "number",
+        },
+        b: {
+          title: "b",
+          type: "number",
+        },
+      },
+      required: ["a", "b", "foo"],
+      additionalProperties: { type: "number" },
+    }
+  );
+});
+
+test("static output schema", async () => {
+  assert.deepEqual(
+    (
+      await defineNodeType({
+        name: "foo",
+        inputs: {},
+        outputs: { foo: { type: "string" } },
+        invoke: () => ({ foo: "foo" }),
+      }).describe()
+    ).outputSchema,
+    {
+      type: "object",
+      properties: {
+        foo: {
+          title: "foo",
+          type: "string",
+        },
+      },
+      // TODO(aomarks) I think this should be required, but currently the visual
+      // editor will show this in red, which doesn't seem right.
+      // required: ["foo"],
+      additionalProperties: false,
+    }
+  );
+});
+
+test("dynamic output schema with custom describe (closed)", async () => {
+  assert.deepEqual(
+    (
+      await defineNodeType({
+        name: "foo",
+        inputs: {},
+        outputs: {
+          foo: { type: "string" },
+          "*": { type: "number" },
+        },
+        describe: () => ({ outputs: ["bar"] }),
+        invoke: () => ({ foo: "foo" }),
+      }).describe()
+    ).outputSchema,
+    {
+      type: "object",
+      properties: {
+        foo: {
+          title: "foo",
+          type: "string",
+        },
+        bar: {
+          title: "bar",
+          type: "number",
+        },
+      },
+      // TODO(aomarks) I think this should be required, but currently the visual
+      // editor will show this in red, which doesn't seem right.
+      // required: ["bar", "foo"],
+      additionalProperties: false,
+    }
+  );
+});
+
+test("dynamic output schema with custom describe (open)", async () => {
+  assert.deepEqual(
+    (
+      await defineNodeType({
+        name: "foo",
+        inputs: {},
+        outputs: {
+          foo: { type: "string" },
+          "*": { type: "number" },
+        },
+        describe: () => ({ outputs: { "*": {} } }),
+        invoke: () => ({ foo: "foo" }),
+      }).describe()
+    ).outputSchema,
+    {
+      type: "object",
+      properties: {
+        foo: {
+          title: "foo",
+          type: "string",
+        },
+      },
+      // TODO(aomarks) I think this should be required, but currently the visual
+      // editor will show this in red, which doesn't seem right.
+      // required: ["foo"],
+      additionalProperties: { type: "number" },
+    }
+  );
 });

--- a/packages/build/src/test/describe_test.ts
+++ b/packages/build/src/test/describe_test.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { test } from "node:test";
+import { defineNodeType } from "../internal/define/define.js";
+
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+
+test("error: mono/mono should not have describe", () => {
+  defineNodeType({
+    name: "foo",
+    inputs: {
+      si1: { type: "string" },
+    },
+    outputs: {
+      so1: { type: "string" },
+    },
+    // @ts-expect-error
+    describe: () => ({ inputs: [], outputs: [] }),
+    invoke: () => ({ so1: "so1" }),
+  });
+});
+
+test("error: mono/poly must have describe", () => {
+  // @ts-expect-error
+  defineNodeType({
+    name: "foo",
+    inputs: {
+      si1: { type: "string" },
+    },
+    outputs: {
+      so1: { type: "string" },
+      "*": { type: "number" },
+    },
+    invoke: () => ({ so1: "so1" }),
+  });
+});
+
+test("error: non-reflective poly/poly must have describe", () => {
+  // @ts-expect-error
+  defineNodeType({
+    name: "foo",
+    inputs: {
+      si1: { type: "string" },
+      "*": { type: "string" },
+    },
+    outputs: {
+      so1: { type: "string" },
+      "*": { type: "string" },
+    },
+    invoke: () => ({ so1: "so1" }),
+  });
+});
+
+test("describe is lenient with odd TypeScript types", () => {
+  defineNodeType({
+    name: "foo",
+    inputs: {
+      outputFoo: { type: "boolean" },
+    },
+    outputs: {
+      "*": { type: "unknown" },
+    },
+    describe: ({ outputFoo }) => ({
+      /** See {@link DynamicInputPorts} for why this is an interesting case. */
+      outputs: outputFoo ? { foo: { description: "foo" } } : {},
+    }),
+    invoke: () => ({}),
+  });
+});

--- a/packages/core-kit/tests/secrets.ts
+++ b/packages/core-kit/tests/secrets.ts
@@ -23,9 +23,11 @@ test("describer correctly responds to no inputs", async (t) => {
         },
       },
       required: ["keys"],
+      additionalProperties: false,
     },
     outputSchema: {
       type: "object",
+      additionalProperties: { type: "string" },
     },
   });
 });
@@ -48,6 +50,7 @@ test("describer correctly responds to inputs", async (t) => {
         },
       },
       required: ["keys"],
+      additionalProperties: false,
     },
     outputSchema: {
       type: "object",
@@ -55,6 +58,7 @@ test("describer correctly responds to inputs", async (t) => {
         SECRET1: { title: "SECRET1", type: "string" },
         SECRET2: { title: "SECRET2", type: "string" },
       },
+      additionalProperties: false,
     },
   });
 });
@@ -74,9 +78,11 @@ test("describer correctly responds to unknown inputs", async (t) => {
         },
       },
       required: ["keys"],
+      additionalProperties: false,
     },
     outputSchema: {
       type: "object",
+      additionalProperties: { type: "string" },
     },
   });
 });

--- a/packages/core-kit/tests/secrets.ts
+++ b/packages/core-kit/tests/secrets.ts
@@ -26,7 +26,6 @@ test("describer correctly responds to no inputs", async (t) => {
     },
     outputSchema: {
       type: "object",
-      properties: {},
     },
   });
 });
@@ -78,7 +77,6 @@ test("describer correctly responds to unknown inputs", async (t) => {
     },
     outputSchema: {
       type: "object",
-      properties: {},
     },
   });
 });

--- a/packages/template-kit/src/nodes/prompt-template.ts
+++ b/packages/template-kit/src/nodes/prompt-template.ts
@@ -70,7 +70,7 @@ export default defineNodeType({
   inputs: {
     template: {
       type: "string",
-      multiline: true,
+      format: "multiline",
       description: "The template with placeholders to fill in.",
     },
     "*": {

--- a/packages/template-kit/src/nodes/url-template.ts
+++ b/packages/template-kit/src/nodes/url-template.ts
@@ -56,7 +56,7 @@ export default defineNodeType({
   inputs: {
     template: {
       type: "string",
-      multiline: true,
+      format: "multiline",
       description: "The URL template to use",
     },
     "*": {

--- a/packages/template-kit/tests/nodes/prompt-template.ts
+++ b/packages/template-kit/tests/nodes/prompt-template.ts
@@ -110,6 +110,7 @@ test("`generateInputSchema` correctly generates schema for a template with no pa
       },
     },
     required: ["template"],
+    additionalProperties: false,
   });
 });
 
@@ -137,5 +138,6 @@ test("`generateInputSchema` correctly generates schema for a template with param
       },
     },
     required: ["bar", "foo", "template"],
+    additionalProperties: false,
   });
 });


### PR DESCRIPTION
- Unify the config interfaces
- Fix some incorrect type errors from certain describe functions.
- Replace `multiline` field with `format`, which can be `multiline` or `javascript`
- Allow specifying behaviors
- Don't set properties on schema when it would be an empty object (just for cleaner formatting)
- Factor out `describe` tests
- `additionalProperties` is now set on generated port JSON schemas
- Add a coverage target
- Inbound edges, even if they don't have a value, now inform the auto generated input schema. 
- Automatically detected input ports are no longer `required`. Only static ones.
