### PR TITLE
node type icon

### DIFF
--- a/.changeset/small-zebras-relax.md
+++ b/.changeset/small-zebras-relax.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard": minor
+---
+
+Support `icon` metadata on node types and graphs.

--- a/packages/agent-kit/agent.kit.json
+++ b/packages/agent-kit/agent.kit.json
@@ -812,6 +812,9 @@
     },
     "superWorker": {
       "title": "Super Worker",
+      "metadata": {
+        "icon": "smart-toy"
+      },
       "description": "All-in-one worker. A work in progress, incorporates all the learnings from making previous workers.",
       "edges": [
         {

--- a/packages/agent-kit/src/boards/super-worker.ts
+++ b/packages/agent-kit/src/boards/super-worker.ts
@@ -103,6 +103,9 @@ export default await board(({ in: context, persona, task }) => {
   return { out: addGenerated.context };
 }).serialize({
   title: "Super Worker",
+  metadata: {
+    icon: "smart-toy",
+  },
   description:
     "All-in-one worker. A work in progress, incorporates all the learnings from making previous workers.",
 });

--- a/packages/breadboard-web/public/agent.kit.json
+++ b/packages/breadboard-web/public/agent.kit.json
@@ -812,6 +812,9 @@
     },
     "superWorker": {
       "title": "Super Worker",
+      "metadata": {
+        "icon": "smart-toy"
+      },
       "description": "All-in-one worker. A work in progress, incorporates all the learnings from making previous workers.",
       "edges": [
         {

--- a/packages/breadboard/src/kits/load.ts
+++ b/packages/breadboard/src/kits/load.ts
@@ -40,8 +40,9 @@ class GraphDescriptorNodeHandler implements NodeHandlerObject {
     this.#graph = setBaseURL(base, type, graph);
     this.describe = this.describe.bind(this);
     this.invoke = this.invoke.bind(this);
-    const { title, description } = this.#graph;
+    const { title, description, metadata } = this.#graph;
     this.metadata = { title, description };
+    if (metadata?.icon) this.metadata.icon = metadata.icon;
   }
 
   async describe() {

--- a/packages/breadboard/src/new/grammar/board.ts
+++ b/packages/breadboard/src/new/grammar/board.ts
@@ -8,7 +8,6 @@ import {
   GraphDescriptor,
   Schema,
   NodeDescriberFunction,
-  GraphInlineMetadata,
   BreadboardCapability,
 } from "../../types.js";
 import {
@@ -23,6 +22,7 @@ import {
   InputsMaybeAsValues,
   Lambda,
   ClosureEdge,
+  GraphCombinedMetadata,
 } from "./types.js";
 import { NodeHandler, NodeHandlerFunction } from "../runner/types.js";
 
@@ -42,7 +42,7 @@ export const board: BoardFactory = (
         invoke?: NodeProxyHandlerFunction;
         describe?: NodeDescriberFunction;
         name?: string;
-      } & GraphInlineMetadata)
+      } & GraphCombinedMetadata)
     | GraphDeclarationFunction,
   maybeFn?: GraphDeclarationFunction
 ) => {
@@ -78,7 +78,7 @@ function lambdaFactory(
     invoke?: NodeProxyHandlerFunction;
     describe?: NodeDescriberFunction;
     name?: string;
-  } & GraphInlineMetadata
+  } & GraphCombinedMetadata
 ): Lambda {
   if (!options.invoke && !options.graph)
     throw new Error("Missing invoke or graph definition function");
@@ -88,7 +88,7 @@ function lambdaFactory(
 
   // Extract board metadata from config. Used in serialize().
   const { url, title, description, version } = options ?? {};
-  const configMetadata: GraphInlineMetadata = {
+  const configMetadata: GraphCombinedMetadata = {
     ...(url ? { url } : {}),
     ...(title ? { title } : {}),
     ...(description ? { description } : {}),
@@ -251,7 +251,7 @@ function lambdaFactory(
 
   // (Will be called and then overwritten by `createLambda` below
   // once this turns into a closure)
-  factory.serialize = async (metadata?: GraphInlineMetadata) => {
+  factory.serialize = async (metadata?: GraphCombinedMetadata) => {
     const node = new BuilderNode(handler, lexicalScope);
     const [singleNode, graph] = await node.serializeNode();
 
@@ -312,7 +312,7 @@ function lambdaFactory(
 
     // Replace the serialize function with one that returns a graph with that
     // lambda node and an invoke node, not the original graph.
-    factory.serialize = async (metadata?: GraphInlineMetadata) => {
+    factory.serialize = async (metadata?: GraphCombinedMetadata) => {
       // If there are no incoming wires to the lambda node, it's not a closure
       // and we can just return the original board.
       if (lambdaNode?.incoming.length === 0 && closureEdgesToWire.length === 0)

--- a/packages/breadboard/src/new/grammar/scope.ts
+++ b/packages/breadboard/src/new/grammar/scope.ts
@@ -8,12 +8,13 @@ import {
   BuilderScopeInterface,
   BuilderNodeInterface,
   ClosureEdge,
+  GraphCombinedMetadata,
 } from "./types.js";
 import { AbstractNode, ScopeConfig } from "../runner/types.js";
 
 import { Scope } from "../runner/scope.js";
 import { BuilderNode } from "./node.js";
-import { GraphInlineMetadata, GraphDescriptor } from "../../types.js";
+import { GraphDescriptor } from "../../types.js";
 
 /**
  * Adds syntactic sugar to support unproxying and serialization of nodes/graphs.
@@ -37,7 +38,7 @@ export class BuilderScope extends Scope implements BuilderScopeInterface {
   }
 
   async serialize(
-    metadata?: GraphInlineMetadata,
+    metadata?: GraphCombinedMetadata,
     node?: AbstractNode
   ): Promise<GraphDescriptor> {
     return super.serialize(

--- a/packages/breadboard/src/new/grammar/types.ts
+++ b/packages/breadboard/src/new/grammar/types.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { GraphMetadata } from "@google-labs/breadboard-schema/graph.js";
 import {
   BreadboardCapability,
   NodeDescriberFunction,
@@ -21,6 +22,10 @@ import {
   AbstractNode,
   Serializeable,
 } from "../runner/types.js";
+
+export type GraphCombinedMetadata = GraphInlineMetadata & {
+  metadata?: GraphMetadata;
+};
 
 export type NodeValue =
   | BaseNodeValue
@@ -148,7 +153,7 @@ export interface BoardFactory {
       invoke?: NodeProxyHandlerFunction;
       describe?: NodeDescriberFunction;
       name?: string;
-    } & GraphInlineMetadata
+    } & GraphCombinedMetadata
   ): Lambda<I, Required<O>>;
 
   <I extends InputValues = InputValues, O extends OutputValues = OutputValues>(
@@ -159,7 +164,7 @@ export interface BoardFactory {
       invoke?: NodeProxyHandlerFunction;
       describe?: NodeDescriberFunction;
       name?: string;
-    } & GraphInlineMetadata,
+    } & GraphCombinedMetadata,
     fn: GraphDeclarationFunction<I, O>
   ): Lambda<I, Required<O>>;
 }

--- a/packages/breadboard/src/new/runner/node.ts
+++ b/packages/breadboard/src/new/runner/node.ts
@@ -6,7 +6,6 @@
 
 import {
   GraphDescriptor,
-  GraphInlineMetadata,
   NodeDescriptor,
   InputValues as OriginalInputValues,
   Schema,
@@ -22,6 +21,7 @@ import {
   EdgeInterface,
   OptionalIdConfiguration,
   ScopeInterface,
+  GraphCombinedMetadata,
 } from "./types.js";
 
 import { Scope } from "./scope.js";
@@ -157,7 +157,7 @@ export class BaseNode<
       : undefined;
   }
 
-  async serialize(metadata?: GraphInlineMetadata): Promise<GraphDescriptor> {
+  async serialize(metadata?: GraphCombinedMetadata): Promise<GraphDescriptor> {
     return this.#scope.serialize(metadata, this as unknown as BaseNode);
   }
 

--- a/packages/breadboard/src/new/runner/scope.ts
+++ b/packages/breadboard/src/new/runner/scope.ts
@@ -6,6 +6,7 @@
 
 import {
   AbstractNode,
+  GraphCombinedMetadata,
   InputValues,
   InvokeCallbacks,
   NodeHandler,
@@ -18,7 +19,6 @@ import {
 
 import {
   GraphDescriptor,
-  GraphInlineMetadata,
   NodeDescriberResult,
   Schema,
   SubGraphs,
@@ -257,7 +257,7 @@ export class Scope implements ScopeInterface {
   }
 
   async serialize(
-    metadata?: GraphInlineMetadata,
+    metadata?: GraphCombinedMetadata,
     node?: AbstractNode
   ): Promise<GraphDescriptor> {
     const queue: AbstractNode[] = (node ? [node] : this.#pinnedNodes).flatMap(

--- a/packages/breadboard/src/new/runner/types.ts
+++ b/packages/breadboard/src/new/runner/types.ts
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { NodeMetadata } from "@google-labs/breadboard-schema/graph.js";
+import {
+  GraphMetadata,
+  NodeMetadata,
+} from "@google-labs/breadboard-schema/graph.js";
 import {
   NodeDescriptor,
   GraphDescriptor,
@@ -22,6 +25,9 @@ import {
 export type NodeValue = OriginalNodeValue | PromiseLike<NodeValue> | unknown;
 export type NodeTypeIdentifier = string;
 
+export type GraphCombinedMetadata = GraphInlineMetadata & {
+  metadata?: GraphMetadata;
+};
 export type InputValues = { [key: string]: NodeValue };
 
 export type OutputValues = { [key: string]: NodeValue };
@@ -50,7 +56,7 @@ export type NodeHandlers = Record<
 
 export interface Serializeable {
   serialize(
-    metadata?: GraphInlineMetadata
+    metadata?: GraphCombinedMetadata
   ): Promise<GraphDescriptor> | GraphDescriptor;
 }
 
@@ -103,7 +109,9 @@ export abstract class AbstractNode<
     outputSchema?: Schema
   ): Promise<NodeDescriberResult | undefined>;
 
-  abstract serialize(metadata?: GraphInlineMetadata): Promise<GraphDescriptor>;
+  abstract serialize(
+    metadata?: GraphCombinedMetadata
+  ): Promise<GraphDescriptor>;
 
   abstract serializeNode(): Promise<[NodeDescriptor, GraphDescriptor?]>;
 }
@@ -280,7 +288,7 @@ export interface ScopeInterface {
    * @param node Node to serialize, or undefined to serialize all pinned nodes
    */
   serialize(
-    metadata?: GraphInlineMetadata,
+    metadata?: GraphCombinedMetadata,
     node?: AbstractNode
   ): Promise<GraphDescriptor>;
 }

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -252,6 +252,11 @@ export type NodeHandlerMetadata = {
    */
   description?: string;
   /**
+   * An icon associated with this node type.
+   * Can be a URL or a Material Design id.
+   */
+  icon?: string;
+  /**
    * Whether or not the node is deprecated.
    */
   deprecated?: boolean;

--- a/packages/schema/breadboard.schema.json
+++ b/packages/schema/breadboard.schema.json
@@ -191,6 +191,12 @@
 		},
 		"GraphMetadata": {
 			"type": "object",
+			"properties": {
+				"icon": {
+					"type": "string",
+					"description": "The icon that identifies the graph. Can be a URL or a Material Design id."
+				}
+			},
 			"additionalProperties": {
 				"$ref": "#/definitions/NodeValue"
 			},

--- a/packages/schema/src/graph.ts
+++ b/packages/schema/src/graph.ts
@@ -210,7 +210,13 @@ export type GraphInlineMetadata = {
 /**
  * Represents graph metadata.
  */
-export type GraphMetadata = Record<string, NodeValue>;
+export type GraphMetadata = {
+  /**
+   * The icon that identifies the graph. Can be a URL or a Material Design id.
+   */
+  icon?: string;
+  [name: string]: NodeValue;
+};
 
 /**
  * Unique identifier of a graph.


### PR DESCRIPTION
- **Add `icon` to `GraphMetadata`.**
- **Plumb `GraphMetadata` to TS syntax.**
- **Add `smart-toy` icon to Super Worker.**
- **Plumb `icon` to `NodeHandlerMetadata`.**
- **docs(changeset): Support `icon` metadata on node types and graphs.**
