### PR TITLE
[breadboard-ui] Reverse the scroll to zoom behavior

### DIFF
--- a/packages/breadboard-ui/src/elements/editor/graph-renderer.ts
+++ b/packages/breadboard-ui/src/elements/editor/graph-renderer.ts
@@ -182,7 +182,6 @@ export class GraphRenderer extends LitElement {
     this.#app.stage.addEventListener(
       "pointerdown",
       (evt: PIXI.FederatedPointerEvent) => {
-        console.log(evt);
         for (const graph of this.#container.children) {
           if (!(graph instanceof Graph)) {
             continue;
@@ -234,7 +233,7 @@ export class GraphRenderer extends LitElement {
     this.#app.stage.on(
       "wheel",
       function (this: GraphRenderer, evt) {
-        let delta = 1 + evt.deltaY / this.zoomFactor;
+        let delta = 1 - evt.deltaY / this.zoomFactor;
         const newScale = this.#container.scale.x * delta;
         if (newScale < this.minScale || newScale > this.maxScale) {
           delta = 1;


### PR DESCRIPTION
This brings it more in line with other tools, like the Chrome DevTools perf panel or Google Maps, inasmuch as scrolling down zooms out, and scrolling up zooms in. This is guaranteed to confuse me for a few days until I adjust! 😂 