### PR TITLE
[build] Add unsafeSchema function

### DIFF
--- a/.changeset/tough-kings-yell.md
+++ b/.changeset/tough-kings-yell.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Add unsafeSchema function which allows returning raw arbitrary JSON schema from a describe function

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -20,6 +20,7 @@ export type {
 } from "./internal/common/serializable.js";
 export { defineNodeType } from "./internal/define/define.js";
 export type { NodeFactoryFromDefinition } from "./internal/define/node-factory.js";
+export { unsafeSchema } from "./internal/define/unsafe-schema.js";
 export { anyOf } from "./internal/type-system/any-of.js";
 export { array } from "./internal/type-system/array.js";
 export { enumeration } from "./internal/type-system/enumeration.js";

--- a/packages/build/src/internal/define/define.ts
+++ b/packages/build/src/internal/define/define.ts
@@ -1,9 +1,10 @@
-/* eslint-disable @typescript-eslint/ban-types */
 /**
  * @license
  * Copyright 2024 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
+
+/* eslint-disable @typescript-eslint/ban-types */
 
 import type {
   NodeDescriberContext,
@@ -15,6 +16,7 @@ import type {
   ConvertBreadboardType,
   JsonSerializable,
 } from "../type-system/type.js";
+import type { UnsafeSchema } from "./unsafe-schema.js";
 import type {
   DynamicInputPortConfig,
   DynamicOutputPortConfig,
@@ -352,7 +354,8 @@ export type DynamicInputPorts =
         //
         //   { foo: { description:"foo" } } | {}
         | undefined;
-    };
+    }
+  | UnsafeSchema;
 
 type StrictDescribeFn<
   I extends Record<string, InputPortConfig>,

--- a/packages/build/src/internal/define/unsafe-schema.ts
+++ b/packages/build/src/internal/define/unsafe-schema.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Schema } from "@google-labs/breadboard";
+import type { JSONSchema4 } from "json-schema";
+
+/**
+ * Can be used in a node definition's `describe` function to directly specify
+ * some raw JSON schema, instead of a normal `@breadboard-ai/build` port
+ * configuration.
+ *
+ * Useful for cases like the `invoke` node where we need to trust that the
+ * schema returned by some dynamically loaded board is valid.
+ */
+export function unsafeSchema(schema: JSONSchema4 | Schema): UnsafeSchema {
+  return { [unsafeSchemaAccessor]: schema as JSONSchema4 };
+}
+
+/** Checks whether an object was created by {@link unsafeSchema}. */
+export function isUnsafeSchema(value: unknown): value is UnsafeSchema {
+  return (
+    typeof value === "object" && value !== null && unsafeSchemaAccessor in value
+  );
+}
+
+/** The interface for {@link unsafeSchema}. */
+export interface UnsafeSchema {
+  [unsafeSchemaAccessor]: JSONSchema4;
+}
+
+/** A package-private accessor for {@link unsafeSchema}. */
+export const unsafeSchemaAccessor = Symbol();


### PR DESCRIPTION
Can be used in a node definition's `describe` function to directly specify some raw JSON schema, instead of a normal `@breadboard-ai/build` port configuration.

Useful for cases like the `invoke` node where we need to trust that the schema returned by some dynamically loaded board is valid.