### PR TITLE
[build] [core-kit] [template-kit] Be more explicit & verbose with generated schemas

### DIFF
--- a/.changeset/new-news-smile.md
+++ b/.changeset/new-news-smile.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/core-kit": minor
+---
+
+fetch, secrets, and run-javascript are slightly more correct in their descriptions (object vs any JSON value)

--- a/.changeset/nice-hotels-wash.md
+++ b/.changeset/nice-hotels-wash.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Generated JSON schemas are now more explicit and verbose

--- a/.changeset/wet-hounds-drum.md
+++ b/.changeset/wet-hounds-drum.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/template-kit": minor
+---
+
+prompt-template is now slightly more correct in its description (object vs any JSON value)

--- a/packages/breadboard-web/public/graphs/best-of-n.json
+++ b/packages/breadboard-web/public/graphs/best-of-n.json
@@ -309,8 +309,12 @@
               "title": "Task",
               "description": "The task to perform",
               "type": [
-                "string",
-                "object"
+                "array",
+                "boolean",
+                "null",
+                "number",
+                "object",
+                "string"
               ],
               "format": "multiline",
               "examples": [

--- a/packages/breadboard-web/public/graphs/nager.date/available-countries.json
+++ b/packages/breadboard-web/public/graphs/nager.date/available-countries.json
@@ -22,8 +22,12 @@
               "title": "response",
               "description": "The response from the fetch request",
               "type": [
-                "string",
-                "object"
+                "array",
+                "boolean",
+                "null",
+                "number",
+                "object",
+                "string"
               ]
             }
           }

--- a/packages/breadboard-web/public/graphs/nager.date/country-info.json
+++ b/packages/breadboard-web/public/graphs/nager.date/country-info.json
@@ -34,8 +34,12 @@
               "title": "response",
               "description": "The response from the fetch request",
               "type": [
-                "string",
-                "object"
+                "array",
+                "boolean",
+                "null",
+                "number",
+                "object",
+                "string"
               ]
             }
           }

--- a/packages/breadboard-web/public/graphs/nager.date/long-weekend.json
+++ b/packages/breadboard-web/public/graphs/nager.date/long-weekend.json
@@ -46,8 +46,12 @@
               "title": "response",
               "description": "The response from the fetch request",
               "type": [
-                "string",
-                "object"
+                "array",
+                "boolean",
+                "null",
+                "number",
+                "object",
+                "string"
               ]
             }
           }

--- a/packages/breadboard-web/public/graphs/tour-guide-writer.json
+++ b/packages/breadboard-web/public/graphs/tour-guide-writer.json
@@ -247,8 +247,12 @@
                         "title": "location",
                         "description": "The value to substitute for the parameter \"location\"",
                         "type": [
-                          "string",
-                          "object"
+                          "array",
+                          "boolean",
+                          "null",
+                          "number",
+                          "object",
+                          "string"
                         ]
                       },
                       "generator": {
@@ -285,8 +289,12 @@
                         "title": "activity",
                         "description": "The value to substitute for the parameter \"activity\"",
                         "type": [
-                          "string",
-                          "object"
+                          "array",
+                          "boolean",
+                          "null",
+                          "number",
+                          "object",
+                          "string"
                         ]
                       }
                     },

--- a/packages/build/src/internal/define/json-schema.ts
+++ b/packages/build/src/internal/define/json-schema.ts
@@ -7,6 +7,7 @@
 import type { JSONSchema4 } from "json-schema";
 import type { PortConfigMap } from "../common/port.js";
 import { toJSONSchema } from "../type-system/type.js";
+import type { StaticInputPortConfig } from "./config.js";
 
 export function portConfigMapToJSONSchema(
   config: PortConfigMap,
@@ -14,50 +15,43 @@ export function portConfigMapToJSONSchema(
 ): JSONSchema4 & {
   properties?: { [k: string]: JSONSchema4 };
 } {
-  const schema: JSONSchema4 & { properties?: { [k: string]: JSONSchema4 } } = {
-    type: "object",
-  };
-  const sortedProperties = Object.entries(config).sort(([nameA], [nameB]) =>
-    nameA.localeCompare(nameB)
+  const sortedPropertyEntries = Object.entries(config).sort(
+    ([nameA], [nameB]) => nameA.localeCompare(nameB)
   );
-  if (sortedProperties.length > 0) {
-    const optional = new Set(
-      forceOptional === true ? Object.keys(config) : forceOptional
-    );
-    schema.properties = Object.fromEntries(
-      sortedProperties.map(([name, config]) => {
-        const { description, type, behavior } = config;
-        const schema: JSONSchema4 = {
-          title: config.title ?? name,
-        };
-        if (description) {
-          schema.description = description;
+  const forceOptionalSet = new Set(
+    forceOptional === true ? Object.keys(config) : forceOptional
+  );
+  return {
+    type: "object",
+    properties: Object.fromEntries(
+      sortedPropertyEntries.map(
+        ([name, { title, description, type, behavior, ...config }]) => {
+          const schema: JSONSchema4 = { title: title ?? name };
+          if (description) {
+            schema.description = description;
+          }
+          Object.assign(schema, toJSONSchema(type));
+          const defaultValue = (config as StaticInputPortConfig).default;
+          if (defaultValue !== undefined) {
+            schema.default = defaultValue;
+          }
+          if (config.format !== undefined) {
+            schema.format = config.format;
+          }
+          if (behavior !== undefined && behavior.length > 0) {
+            schema.behavior = behavior;
+          }
+          return [name, schema];
         }
-        if ("default" in config && config.default !== undefined) {
-          schema.default = config.default;
-        }
-        Object.assign(schema, toJSONSchema(type));
-        if ("format" in config && config.format !== undefined) {
-          schema.format = config.format;
-        }
-        if (behavior !== undefined && behavior.length > 0) {
-          schema.behavior = behavior;
-        }
-        if ("optional" in config && config.optional === true) {
-          optional.add(name);
-        }
-        return [name, schema];
-      })
-    );
-    const required = sortedProperties
+      )
+    ),
+    required: sortedPropertyEntries
       .filter(([name, config]) => {
-        const hasDefault = "default" in config && config.default !== undefined;
-        return !hasDefault && !optional.has(name);
+        const isOptional = (config as StaticInputPortConfig).optional === true;
+        const hasDefault =
+          (config as StaticInputPortConfig).default !== undefined;
+        return !isOptional && !hasDefault && !forceOptionalSet.has(name);
       })
-      .map(([name]) => name);
-    if (required.length > 0) {
-      schema.required = required;
-    }
-  }
-  return schema;
+      .map(([name]) => name),
+  };
 }

--- a/packages/build/src/internal/type-system/object.ts
+++ b/packages/build/src/internal/type-system/object.ts
@@ -48,20 +48,20 @@ export function object(
   properties: Record<string, BreadboardType>,
   additional?: BreadboardType
 ): AdvancedBreadboardType<JsonSerializable> {
-  const jsonSchema: JSONSchema4 = { type: "object" };
-  if (Object.keys(properties).length > 0) {
-    jsonSchema.properties = Object.fromEntries(
+  const jsonSchema: JSONSchema4 = {
+    type: "object",
+    properties: Object.fromEntries(
       Object.entries(properties).map(([name, type]) => [
         name,
         toJSONSchema(type),
       ])
-    );
-    jsonSchema.required = Object.keys(properties);
-  }
+    ),
+  };
+  jsonSchema.required = Object.keys(properties);
   if (additional === undefined) {
     jsonSchema.additionalProperties = false;
   } else if (additional === "unknown") {
-    // This is the JSON Schema default if you omit additionalProperties.
+    jsonSchema.additionalProperties = true;
   } else {
     jsonSchema.additionalProperties = toJSONSchema(additional);
   }

--- a/packages/build/src/internal/type-system/type.ts
+++ b/packages/build/src/internal/type-system/type.ts
@@ -86,9 +86,15 @@ export function toJSONSchema(type: BreadboardType): JSONSchema4 {
       return { type };
     }
     case "unknown": {
-      // {} is our equivalent to TypeScript's `unknown` in JSON Schema, since it
-      // enforces no type constraints at all.
-      return {};
+      // All possible JSON schema data types.
+      //
+      // We could return {} here, but returning all possible types is a bit more
+      // explicit. Also, there is some other Breadboard code which assumes when
+      // there is no type, that the type is string (this is a bug, since no type
+      // actually means anything).
+      return {
+        type: ["array", "boolean", "null", "number", "object", "string"],
+      };
     }
     default: {
       throw new Error(

--- a/packages/build/src/test/compatibility_test.ts
+++ b/packages/build/src/test/compatibility_test.ts
@@ -132,6 +132,7 @@ function setupKits<
             type: "number",
           },
         },
+        required: [],
         additionalProperties: false,
       },
     });
@@ -260,6 +261,7 @@ function setupKits<
             type: "number",
           },
         },
+        required: [],
         additionalProperties: false,
       },
     });

--- a/packages/build/src/test/define_test.ts
+++ b/packages/build/src/test/define_test.ts
@@ -122,6 +122,7 @@ test("mono/mono", async () => {
           type: "null",
         },
       },
+      required: [],
       additionalProperties: false,
     },
   };
@@ -236,6 +237,7 @@ test("poly/mono", async () => {
           type: "boolean",
         },
       },
+      required: [],
       additionalProperties: false,
     },
   });
@@ -268,6 +270,7 @@ test("poly/mono", async () => {
           type: "boolean",
         },
       },
+      required: [],
       additionalProperties: false,
     },
   });
@@ -366,6 +369,7 @@ test("mono/poly", async () => {
           type: "number",
         },
       },
+      required: [],
       additionalProperties: false,
     },
   };
@@ -491,6 +495,7 @@ test("poly/poly", async () => {
           type: "number",
         },
       },
+      required: [],
       additionalProperties: false,
     },
   });
@@ -527,6 +532,7 @@ test("poly/poly", async () => {
           type: "number",
         },
       },
+      required: [],
       additionalProperties: false,
     },
   });
@@ -654,6 +660,7 @@ test("reflective", async () => {
       properties: {
         so1: { type: "boolean", title: "so1" },
       },
+      required: [],
       additionalProperties: false,
     },
   });
@@ -676,6 +683,7 @@ test("reflective", async () => {
         di2: { type: "string", title: "di2" },
         so1: { type: "boolean", title: "so1" },
       },
+      required: [],
       additionalProperties: false,
     },
   });
@@ -922,6 +930,7 @@ test("multiline/javascript", async () => {
           format: "javascript",
         },
       },
+      required: [],
       additionalProperties: false,
     },
   });
@@ -969,6 +978,7 @@ test("behavior", async () => {
           behavior: ["image", "code"],
         },
       },
+      required: [],
       additionalProperties: false,
     },
   });
@@ -1022,6 +1032,7 @@ test("dynamic port descriptions", async () => {
           description: 'output "foo"',
         },
       },
+      required: [],
       additionalProperties: false,
     },
   });
@@ -1091,6 +1102,7 @@ test("defaults", async () => {
           default: [12, 34],
         },
       },
+      required: [],
       additionalProperties: false,
     },
     outputSchema: {
@@ -1106,6 +1118,7 @@ test("defaults", async () => {
           items: { type: "number" },
         },
       },
+      required: [],
       additionalProperties: false,
     },
   };
@@ -1188,6 +1201,7 @@ test("optional", async () => {
         },
       },
       additionalProperties: false,
+      required: [],
     },
   };
   assert.deepEqual(await d.describe(), expectedSchema);
@@ -1238,6 +1252,7 @@ test("override title", async () => {
           type: "null",
         },
       },
+      required: [],
       additionalProperties: false,
     },
   });

--- a/packages/build/src/test/describe_test.ts
+++ b/packages/build/src/test/describe_test.ts
@@ -282,6 +282,7 @@ test("static output schema", async () => {
       // TODO(aomarks) I think this should be required, but currently the visual
       // editor will show this in red, which doesn't seem right.
       // required: ["foo"],
+      required: [],
       additionalProperties: false,
     }
   );
@@ -316,6 +317,7 @@ test("dynamic output schema with custom describe (closed)", async () => {
       // TODO(aomarks) I think this should be required, but currently the visual
       // editor will show this in red, which doesn't seem right.
       // required: ["bar", "foo"],
+      required: [],
       additionalProperties: false,
     }
   );
@@ -346,6 +348,7 @@ test("dynamic output schema with custom describe (open)", async () => {
       // TODO(aomarks) I think this should be required, but currently the visual
       // editor will show this in red, which doesn't seem right.
       // required: ["foo"],
+      required: [],
       additionalProperties: { type: "number" },
     }
   );
@@ -390,6 +393,7 @@ test("async describe", async () => {
             type: "number",
           },
         },
+        required: [],
         additionalProperties: false,
       },
     }
@@ -482,6 +486,7 @@ test("unsafeSchema can be used to force a raw JSON schema", async () => {
             type: "string",
           },
         },
+        required: [],
       },
     }
   );

--- a/packages/build/src/test/type_test.ts
+++ b/packages/build/src/test/type_test.ts
@@ -52,7 +52,9 @@ test("unknown", () => {
   "unknown" satisfies BreadboardType;
   // @ts-expect-error not a valid basic type
   "xunknown" satisfies BreadboardType;
-  assert.deepEqual(toJSONSchema("unknown"), {});
+  assert.deepEqual(toJSONSchema("unknown"), {
+    type: ["array", "boolean", "null", "number", "object", "string"],
+  });
   /* eslint-disable @typescript-eslint/no-unused-vars */
   // $ExpectType JsonSerializable
   type t = ConvertBreadboardType<"unknown">;
@@ -102,6 +104,8 @@ describe("object", () => {
     type t1 = ConvertBreadboardType<typeof obj1>;
     assert.deepEqual(toJSONSchema(obj1), {
       type: "object",
+      properties: {},
+      required: [],
       additionalProperties: false,
     });
   });
@@ -193,7 +197,9 @@ describe("object", () => {
     assert.deepEqual(toJSONSchema(obj), {
       type: "object",
       properties: {
-        foo: {},
+        foo: {
+          type: ["array", "boolean", "null", "number", "object", "string"],
+        },
       },
       required: ["foo"],
       additionalProperties: false,
@@ -206,6 +212,8 @@ describe("object", () => {
     type objType = ConvertBreadboardType<typeof obj>;
     assert.deepEqual(toJSONSchema(obj), {
       type: "object",
+      properties: {},
+      required: [],
       additionalProperties: false,
     });
   });
@@ -216,6 +224,8 @@ describe("object", () => {
     type objType = ConvertBreadboardType<typeof obj>;
     assert.deepEqual(toJSONSchema(obj), {
       type: "object",
+      properties: {},
+      required: [],
       additionalProperties: { type: "string" },
     });
   });
@@ -242,6 +252,9 @@ describe("object", () => {
     type objType = ConvertBreadboardType<typeof obj>;
     assert.deepEqual(toJSONSchema(obj), {
       type: "object",
+      properties: {},
+      required: [],
+      additionalProperties: true,
     });
   });
 
@@ -318,7 +331,9 @@ describe("array", () => {
     // $ExpectType JsonSerializable[]
     type arrayType = ConvertBreadboardType<typeof arr>;
     assert.deepEqual(toJSONSchema(arr), {
-      items: {},
+      items: {
+        type: ["array", "boolean", "null", "number", "object", "string"],
+      },
       type: "array",
     });
   });

--- a/packages/core-kit/src/nodes/fetch.ts
+++ b/packages/core-kit/src/nodes/fetch.ts
@@ -59,8 +59,8 @@ export default defineNodeType({
     },
     body: {
       description: "The body of the request",
-      type: anyOf("string", object({}, "unknown"), "null"),
-      default: null,
+      type: "unknown",
+      optional: true,
     },
     raw: {
       description:
@@ -77,12 +77,7 @@ export default defineNodeType({
   outputs: {
     response: {
       description: "The response from the fetch request",
-      type: anyOf(
-        "string",
-        // TODO(aomarks) Is this right? Technically it could be any JSON, right?
-        // So number, null, array, are also possible.
-        object({}, "unknown")
-      ),
+      type: "unknown",
     },
     status: {
       description: "The HTTP status code of the response",

--- a/packages/core-kit/tests/run-javascript.ts
+++ b/packages/core-kit/tests/run-javascript.ts
@@ -84,6 +84,8 @@ test("describe outputs when raw = true", async (t) => {
   const result = (await handler.describe({ raw: true })).outputSchema;
   t.deepEqual(result, {
     type: "object",
+    properties: {},
+    required: [],
     additionalProperties: true,
   });
 });
@@ -96,8 +98,10 @@ test("describe outputs when raw = false", async (t) => {
       result: {
         title: "result",
         description: "The result of running the JavaScript code",
+        type: ["array", "boolean", "null", "number", "object", "string"],
       },
     },
+    required: [],
     additionalProperties: false,
   });
 });
@@ -144,6 +148,7 @@ test("describe inputs", async (t) => {
       },
       what: {
         title: "what",
+        type: ["array", "boolean", "null", "number", "object", "string"],
       },
     },
     required: ["code"],

--- a/packages/core-kit/tests/secrets.ts
+++ b/packages/core-kit/tests/secrets.ts
@@ -27,6 +27,8 @@ test("describer correctly responds to no inputs", async (t) => {
     },
     outputSchema: {
       type: "object",
+      properties: {},
+      required: [],
       additionalProperties: { type: "string" },
     },
   });
@@ -58,6 +60,7 @@ test("describer correctly responds to inputs", async (t) => {
         SECRET1: { title: "SECRET1", type: "string" },
         SECRET2: { title: "SECRET2", type: "string" },
       },
+      required: [],
       additionalProperties: false,
     },
   });
@@ -82,6 +85,8 @@ test("describer correctly responds to unknown inputs", async (t) => {
     },
     outputSchema: {
       type: "object",
+      properties: {},
+      required: [],
       additionalProperties: { type: "string" },
     },
   });

--- a/packages/template-kit/src/nodes/prompt-template.ts
+++ b/packages/template-kit/src/nodes/prompt-template.ts
@@ -34,7 +34,7 @@ export const parametersFromTemplate = (
 
 const promptTemplateHandler = (
   template: string,
-  inputs: { [K: string]: string | object }
+  inputs: { [K: string]: unknown }
 ) => {
   const parameters = parametersFromTemplate(template);
   if (!parameters.length) return { prompt: template, text: template };
@@ -74,7 +74,7 @@ export default defineNodeType({
       description: "The template with placeholders to fill in.",
     },
     "*": {
-      type: anyOf("string", object({}, "unknown")),
+      type: "unknown",
     },
   },
   outputs: {

--- a/packages/template-kit/tests/nodes/prompt-template.ts
+++ b/packages/template-kit/tests/nodes/prompt-template.ts
@@ -123,12 +123,12 @@ test("`generateInputSchema` correctly generates schema for a template with param
       foo: {
         title: "foo",
         description: 'The value to substitute for the parameter "foo"',
-        type: ["string", "object"],
+        type: ["array", "boolean", "null", "number", "object", "string"],
       },
       bar: {
         title: "bar",
         description: 'The value to substitute for the parameter "bar"',
-        type: ["string", "object"],
+        type: ["array", "boolean", "null", "number", "object", "string"],
       },
       template: {
         title: "template",


### PR DESCRIPTION
- For `unknown`, we previously emitted `{}`, but now we emit `{type: ["array", "boolean", "null", "number", "object", "string"]}`. These are technically equivalent according to JSON schema, but since there is some other Breadboard code that treats `{}` as `string`, doing the verbose thing is a bit more compatible.

- Updated some `core-kit` and `template-kit` nodes to use `unknown` instead of `object`. In JSON Schema, `object` means a JSON object like `{foo}`, but not a basic type like `"foo"`. In these nodes, some inputs/outputs can be any kind of JSON, so this is now the more correct broader type.