### PR TITLE
Revert "fetch body"

### DIFF
--- a/.changeset/nice-carpets-repeat.md
+++ b/.changeset/nice-carpets-repeat.md
@@ -1,5 +1,0 @@
----
-"@google-labs/core-kit": patch
----
-
-Do not stringify fetch body.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1470,7 +1470,6 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/core-kit/src/nodes/fetch.ts
+++ b/packages/core-kit/src/nodes/fetch.ts
@@ -108,7 +108,7 @@ export default defineNodeType({
     };
     // GET can not have a body.
     if (method !== "GET") {
-      init.body = body as BodyInit;
+      init.body = JSON.stringify(body);
     } else if (body) {
       throw new Error("GET requests can not have a body");
     }


### PR DESCRIPTION
Reverts breadboard-ai/breadboard#1535. I was way too hasty here -- this isn't the right fix. It looks like `fetch` doesn't actually stringify things and when this landed suddenly all fetch bodies were `[Object object]`.