### PR TITLE
[build] Allow setting id on inputs

### DIFF
--- a/.changeset/sweet-spoons-drive.md
+++ b/.changeset/sweet-spoons-drive.md
@@ -1,0 +1,8 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Allow setting id on inputs, which can be used to customize the input node id,
+or to create multiple input nodes. If two input objects reference the same
+id, then they will both be placed into a BGL input node with that ID. If no
+id is specified, the usual "input-0" is used.

--- a/packages/build/src/internal/board/input.ts
+++ b/packages/build/src/internal/board/input.ts
@@ -44,19 +44,11 @@ export function input<T extends Record<string, unknown>>(
     : JsonSerializable
 >;
 
-// just description
+// nothing we can use for types means string
 export function input(params: {
-  description: string;
-  title?: string;
-  type?: undefined;
-  default?: undefined;
-  examples?: undefined;
-}): Input<string>;
-
-// just title
-export function input(params: {
+  $id?: string;
   description?: string;
-  title: string;
+  title?: string;
   type?: undefined;
   default?: undefined;
   examples?: undefined;
@@ -108,6 +100,7 @@ export function input(
   }
   return {
     __SpecialInputBrand: true,
+    id: params?.$id,
     type,
     title: params?.title,
     description: params?.description,
@@ -121,6 +114,7 @@ export function input(
 }
 
 interface LooseParams {
+  $id?: string;
   type?: BreadboardType;
   title?: string;
   description?: string;
@@ -131,6 +125,7 @@ interface LooseParams {
 export interface Input<T extends JsonSerializable> {
   readonly __SpecialInputBrand: true;
   readonly __type: T;
+  readonly id?: string;
   readonly type: BreadboardType;
   readonly title?: string;
   readonly description?: string;
@@ -140,6 +135,7 @@ export interface Input<T extends JsonSerializable> {
 
 export interface InputWithDefault<T extends JsonSerializable> {
   readonly __SpecialInputBrand: true;
+  readonly id?: string;
   readonly title?: string;
   readonly type: BreadboardType;
   readonly description?: string;
@@ -153,6 +149,7 @@ export type GenericSpecialInput =
 
 type CheckParams<T extends LooseParams> = (T["type"] extends Defined
   ? {
+      $id?: string;
       type: BreadboardType;
       title?: string;
       default?: T["type"] extends BreadboardType
@@ -167,6 +164,7 @@ type CheckParams<T extends LooseParams> = (T["type"] extends Defined
     }
   : T["default"] extends Defined
     ? {
+        $id?: string;
         type?: never;
         title?: string;
         default: string | number | boolean;
@@ -175,6 +173,7 @@ type CheckParams<T extends LooseParams> = (T["type"] extends Defined
       }
     : T["examples"] extends Defined
       ? {
+          $id?: string;
           type?: never;
           title?: string;
           default?: never;
@@ -183,6 +182,7 @@ type CheckParams<T extends LooseParams> = (T["type"] extends Defined
         }
       : never) & {
   [K in keyof T]: K extends
+    | "$id"
     | "type"
     | "title"
     | "default"

--- a/packages/build/src/test/input_test.ts
+++ b/packages/build/src/test/input_test.ts
@@ -193,9 +193,6 @@ test("examples don't match type", () => {
 
 test("invalid types", () => {
   // @ts-expect-error
-  input({ type: undefined });
-
-  // @ts-expect-error
   input({ type: null });
 
   // @ts-expect-error
@@ -203,9 +200,6 @@ test("invalid types", () => {
 });
 
 test("invalid defaults", () => {
-  // @ts-expect-error
-  input({ default: undefined });
-
   // @ts-expect-error
   assert.throws(() => input({ default: null }), /Unknown default type: null/);
 
@@ -217,9 +211,6 @@ test("invalid defaults", () => {
 });
 
 test("invalid examples", () => {
-  // @ts-expect-error
-  input({ examples: undefined });
-
   // @ts-expect-error
   input({ examples: null });
 

--- a/packages/build/src/test/serialize_test.ts
+++ b/packages/build/src/test/serialize_test.ts
@@ -51,17 +51,6 @@ test("0 inputs, 1 output", () => {
       ],
       nodes: [
         {
-          id: "input-0",
-          type: "input",
-          configuration: {
-            schema: {
-              type: "object",
-              properties: {},
-              required: [],
-            },
-          },
-        },
-        {
           id: "output-0",
           type: "output",
           configuration: {
@@ -108,17 +97,6 @@ test("monomorphic node with primary output can itself act as that output", () =>
         },
       ],
       nodes: [
-        {
-          id: "input-0",
-          type: "input",
-          configuration: {
-            schema: {
-              type: "object",
-              properties: {},
-              required: [],
-            },
-          },
-        },
         {
           id: "output-0",
           type: "output",
@@ -171,17 +149,6 @@ test("polymorphic node with primary output can itself act as that output", () =>
       ],
       nodes: [
         {
-          id: "input-0",
-          type: "input",
-          configuration: {
-            schema: {
-              type: "object",
-              properties: {},
-              required: [],
-            },
-          },
-        },
-        {
           id: "output-0",
           type: "output",
           configuration: {
@@ -224,17 +191,6 @@ test("raw value input is serialized to configuration", () => {
         { from: "myNode-0", to: "output-0", out: "myNodeOut", in: "boardOut" },
       ],
       nodes: [
-        {
-          id: "input-0",
-          type: "input",
-          configuration: {
-            schema: {
-              type: "object",
-              properties: {},
-              required: [],
-            },
-          },
-        },
         {
           id: "output-0",
           type: "output",
@@ -285,17 +241,6 @@ test("default value input is omitted from configuration", () => {
       edges: [{ from: "myNode-0", to: "output-0", out: "out", in: "boardOut" }],
       nodes: [
         {
-          id: "input-0",
-          type: "input",
-          configuration: {
-            schema: {
-              type: "object",
-              properties: {},
-              required: [],
-            },
-          },
-        },
-        {
           id: "output-0",
           type: "output",
           configuration: {
@@ -332,17 +277,6 @@ test("default value input is omitted from configuration", () => {
     {
       edges: [{ from: "myNode-0", to: "output-0", out: "out", in: "boardOut" }],
       nodes: [
-        {
-          id: "input-0",
-          type: "input",
-          configuration: {
-            schema: {
-              type: "object",
-              properties: {},
-              required: [],
-            },
-          },
-        },
         {
           id: "output-0",
           type: "output",
@@ -885,13 +819,6 @@ test("triangle", () => {
       ],
       nodes: [
         {
-          id: "input-0",
-          type: "input",
-          configuration: {
-            schema: { type: "object", properties: {}, required: [] },
-          },
-        },
-        {
           id: "output-0",
           type: "output",
           configuration: {
@@ -1006,17 +933,6 @@ test("polymorphic outputs", () => {
       ],
       nodes: [
         {
-          id: "input-0",
-          type: "input",
-          configuration: {
-            schema: {
-              type: "object",
-              properties: {},
-              required: [],
-            },
-          },
-        },
-        {
           id: "output-0",
           type: "output",
           configuration: {
@@ -1070,13 +986,6 @@ test("placeholder", () => {
         { from: "myNode-1", to: "output-0", out: "bar", in: "outB" },
       ],
       nodes: [
-        {
-          id: "input-0",
-          type: "input",
-          configuration: {
-            schema: { type: "object", properties: {}, required: [] },
-          },
-        },
         {
           id: "output-0",
           type: "output",
@@ -1234,13 +1143,6 @@ test("board title, description, and version", () => {
       edges: [{ from: "foo-0", to: "output-0", out: "foo", in: "foo" }],
       nodes: [
         {
-          id: "input-0",
-          type: "input",
-          configuration: {
-            schema: { type: "object", properties: {}, required: [] },
-          },
-        },
-        {
           id: "output-0",
           type: "output",
           configuration: {
@@ -1289,17 +1191,6 @@ test("node can have IDs", () => {
     ],
     nodes: [
       {
-        id: "input-0",
-        type: "input",
-        configuration: {
-          schema: {
-            type: "object",
-            properties: {},
-            required: [],
-          },
-        },
-      },
-      {
         id: "output-0",
         type: "output",
         configuration: {
@@ -1314,4 +1205,227 @@ test("node can have IDs", () => {
       { id: "myCustomId2", type: "d2", configuration: {} },
     ],
   });
+});
+
+test("custom input id", () => {
+  const passthru = defineNodeType({
+    name: "passthru",
+    inputs: {
+      value: { type: "string" },
+    },
+    outputs: {
+      value: { type: "string", primary: true },
+    },
+    invoke: ({ value }) => ({ value }),
+  });
+
+  const in1 = input({ $id: "custom-input" });
+
+  checkSerialization(
+    board({
+      inputs: {
+        in1,
+      },
+      outputs: {
+        result: passthru({ value: in1 }),
+      },
+    }),
+    {
+      edges: [
+        { from: "custom-input", to: "passthru-0", out: "in1", in: "value" },
+        { from: "passthru-0", to: "output-0", out: "value", in: "result" },
+      ],
+      nodes: [
+        {
+          id: "custom-input",
+          type: "input",
+          configuration: {
+            schema: {
+              type: "object",
+              properties: { in1: { type: "string" } },
+              required: ["in1"],
+            },
+          },
+        },
+        {
+          id: "output-0",
+          type: "output",
+          configuration: {
+            schema: {
+              type: "object",
+              properties: { result: { type: "string" } },
+              required: ["result"],
+            },
+          },
+        },
+        { id: "passthru-0", type: "passthru", configuration: {} },
+      ],
+    }
+  );
+});
+
+test("two custom input ids", () => {
+  const passthru = defineNodeType({
+    name: "passthru",
+    inputs: {
+      value1: { type: "string" },
+      value2: { type: "string" },
+    },
+    outputs: {
+      value1: { type: "string" },
+      value2: { type: "string" },
+    },
+    invoke: ({ value1, value2 }) => ({ value1, value2 }),
+  });
+
+  const in1 = input({ $id: "custom-input-1" });
+  const in2 = input({ $id: "custom-input-2" });
+  const pt = passthru({ value1: in1, value2: in2 });
+
+  checkSerialization(
+    board({
+      inputs: {
+        in1,
+        in2,
+      },
+      outputs: {
+        result1: pt.outputs.value1,
+        result2: pt.outputs.value2,
+      },
+    }),
+    {
+      edges: [
+        { from: "custom-input-1", to: "passthru-0", out: "in1", in: "value1" },
+        { from: "custom-input-2", to: "passthru-0", out: "in2", in: "value2" },
+        { from: "passthru-0", to: "output-0", out: "value1", in: "result1" },
+        { from: "passthru-0", to: "output-0", out: "value2", in: "result2" },
+      ],
+      nodes: [
+        {
+          id: "custom-input-1",
+          type: "input",
+          configuration: {
+            schema: {
+              type: "object",
+              properties: {
+                in1: { type: "string" },
+              },
+              required: ["in1"],
+            },
+          },
+        },
+        {
+          id: "custom-input-2",
+          type: "input",
+          configuration: {
+            schema: {
+              type: "object",
+              properties: {
+                in2: { type: "string" },
+              },
+              required: ["in2"],
+            },
+          },
+        },
+        {
+          id: "output-0",
+          type: "output",
+          configuration: {
+            schema: {
+              type: "object",
+              properties: {
+                result1: { type: "string" },
+                result2: { type: "string" },
+              },
+              required: ["result1", "result2"],
+            },
+          },
+        },
+        { id: "passthru-0", type: "passthru", configuration: {} },
+      ],
+    }
+  );
+});
+
+test("custom and default input id", () => {
+  const passthru = defineNodeType({
+    name: "passthru",
+    inputs: {
+      value1: { type: "string" },
+      value2: { type: "string" },
+    },
+    outputs: {
+      value1: { type: "string" },
+      value2: { type: "string" },
+    },
+    invoke: ({ value1, value2 }) => ({ value1, value2 }),
+  });
+
+  const in1 = input({ $id: "custom-input" });
+  const in2 = input({});
+  const pt = passthru({ value1: in1, value2: in2 });
+
+  checkSerialization(
+    board({
+      inputs: {
+        in1,
+        in2,
+      },
+      outputs: {
+        result1: pt.outputs.value1,
+        result2: pt.outputs.value2,
+      },
+    }),
+    {
+      edges: [
+        { from: "custom-input", to: "passthru-0", out: "in1", in: "value1" },
+        { from: "input-0", to: "passthru-0", out: "in2", in: "value2" },
+        { from: "passthru-0", to: "output-0", out: "value1", in: "result1" },
+        { from: "passthru-0", to: "output-0", out: "value2", in: "result2" },
+      ],
+      nodes: [
+        {
+          id: "custom-input",
+          type: "input",
+          configuration: {
+            schema: {
+              type: "object",
+              properties: {
+                in1: { type: "string" },
+              },
+              required: ["in1"],
+            },
+          },
+        },
+        {
+          id: "input-0",
+          type: "input",
+          configuration: {
+            schema: {
+              type: "object",
+              properties: {
+                in2: { type: "string" },
+              },
+              required: ["in2"],
+            },
+          },
+        },
+        {
+          id: "output-0",
+          type: "output",
+          configuration: {
+            schema: {
+              type: "object",
+              properties: {
+                result1: { type: "string" },
+                result2: { type: "string" },
+              },
+              required: ["result1", "result2"],
+            },
+          },
+        },
+        { id: "passthru-0", type: "passthru", configuration: {} },
+      ],
+    }
+  );
 });


### PR DESCRIPTION
Inputs can now be used like this:

```ts
import {input} from "@breadboard-ai/build";

// These two inputs will end up on the same, default input node called "input-0":
const default1 = input();
const default2 = input({type: "number"})

// These two inputs will end up on the same custom input node called "my-special-input":
const custom1 = input({$id: "my-special-input");
const custom2 = input({$id: "my-special-input", type: "number"})
```

So, in this way, the `$id` field works kind of like the `name` field on HTML's `<input>`.

This lets you control exactly how many input nodes you get and how they are wired.