### PR TITLE
[build] Add `unsafeCast` function

### DIFF
--- a/.changeset/modern-actors-worry.md
+++ b/.changeset/modern-actors-worry.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Add unsafeCast function as an escape hatch for when an output doesn't match a type but you're really really sure it's ok

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -14,6 +14,7 @@ export { input } from "./internal/board/input.js";
 export { output } from "./internal/board/output.js";
 export { placeholder } from "./internal/board/placeholder.js";
 export { serialize } from "./internal/board/serialize.js";
+export { unsafeCast } from "./internal/board/unsafe-cast.js";
 export type {
   // TODO(aomarks) Not quite sure about exporting and/or the name of
   // SerializableBoard.

--- a/packages/build/src/internal/board/unsafe-cast.ts
+++ b/packages/build/src/internal/board/unsafe-cast.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  OutputPort,
+  OutputPortGetter,
+  type OutputPortReference,
+} from "../common/port.js";
+import type {
+  BreadboardType,
+  ConvertBreadboardType,
+  JsonSerializable,
+} from "../type-system/type.js";
+
+export function unsafeCast<
+  O extends JsonSerializable,
+  B extends BreadboardType,
+>(
+  output: OutputPortReference<O>,
+  type: B
+): OutputPortReference<ConvertBreadboardType<B>> {
+  const actualOutput = output[OutputPortGetter];
+  return new OutputPort(type, actualOutput.name, actualOutput.node);
+}


### PR DESCRIPTION
Add unsafeCast function as an escape hatch for when an output doesn't match a type but you're really really sure it's ok.