### PR TITLE
[build] Rename assertOutput to unsafeOutput

### DIFF
--- a/.changeset/clean-schools-wait.md
+++ b/.changeset/clean-schools-wait.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": minor
+---
+
+Rename assertOutput to unsafeOutput

--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -175,17 +175,17 @@ _Static_ means there is not.)
 | Dynamic | Dynamic    | Optional        | **Required**     |
 | Dynamic | Reflective | Optional        | N/A              |
 
-### `assertOutput`
+### `unsafeOutput`
 
 When a node has dynamic outputs, but is not `reflective`, it is not possible at
 compile time for Breadboard to know what the valid output ports of a node are.
-In this case, use the `assertOutput` method to get an output port with a given
+In this case, use the `unsafeOutput` method to get an output port with a given
 name. Note that there is no guarantee this port will exist at runtime, so a
 runtime error could occur.
 
 (Note that the following example is highly contrived. It is better to find a
 way to use fully static or reflective nodes whenever possible to avoid the use
-of `assertOutput`).
+of `unsafeOutput`).
 
 ```ts
 import { defineNodeType, array } from "@breadboard-ai/build";
@@ -210,9 +210,9 @@ const lengths = weirdStringLength({ strings: ["foo", "bar"] });
 // All 3 of these variables will have type OutputPort<number> and can be wired
 // up to other nodes and boards as normal, but only `foo` and `bar` will
 // *actually* be valid at runtime.
-const foo = lengths.assertOutput("foo");
-const bar = lengths.assertOutput("bar");
-const baz = lengths.assertOutput("baz"); // Oops!
+const foo = lengths.unsafeOutput("foo");
+const bar = lengths.unsafeOutput("bar");
+const baz = lengths.unsafeOutput("baz"); // Oops!
 ```
 
 ## Adding nodes to Kits

--- a/packages/build/src/internal/define/instance.ts
+++ b/packages/build/src/internal/define/instance.ts
@@ -87,7 +87,7 @@ export class Instance<
 
   #assertedOutputs = new Map<string, OutputPort<JsonSerializable>>();
 
-  assertOutput: DO extends JsonSerializable
+  unsafeOutput: DO extends JsonSerializable
     ? R extends false
       ? <N extends string>(
           name: N extends keyof O ? never : N
@@ -96,21 +96,21 @@ export class Instance<
     : never = ((name) => {
     if (this.#dynamicOutputType === undefined) {
       throw new Error(
-        `assertOutput was called unnecessarily on a BreadboardNode. ` +
+        `unsafeOutput was called unnecessarily on a BreadboardNode. ` +
           `Type "${this.type}" has entirely static outputs. ` +
           `Use "<node>.outputs.${name}" instead.`
       );
     }
     if (this.#reflective) {
       throw new Error(
-        `assertOutput was called unnecessarily on a BreadboardNode. ` +
+        `unsafeOutput was called unnecessarily on a BreadboardNode. ` +
           `Type "${this.type}" is reflective. ` +
           `Use "<node>.outputs.${name}" instead.`
       );
     }
     if (this.outputs[name] !== undefined) {
       throw new Error(
-        `assertOutput was called unnecessarily on a BreadboardNode. ` +
+        `unsafeOutput was called unnecessarily on a BreadboardNode. ` +
           `Type "${this.type}" already has a static port called "${name}". ` +
           `Use "<node>.outputs.${name}" instead.`
       );
@@ -122,7 +122,7 @@ export class Instance<
     port = new OutputPort(this.#dynamicOutputType, name, this);
     this.#assertedOutputs.set(name, port);
     return port;
-  }) as (typeof this)["assertOutput"];
+  }) as (typeof this)["unsafeOutput"];
 
   #processInputs(
     staticInputs: { [K: string]: StaticInputPortConfig },

--- a/packages/build/src/test/define_test.ts
+++ b/packages/build/src/test/define_test.ts
@@ -453,7 +453,7 @@ test("poly/poly", async () => {
 
   assert.ok(
     // $ExpectType OutputPort<number>
-    i.assertOutput("do1")
+    i.unsafeOutput("do1")
   );
 
   assert.equal(
@@ -1732,7 +1732,7 @@ test("error: reflective poly/poly should not return outputs", () => {
   });
 });
 
-test("error: assertOutput with entirely static outputs", () => {
+test("error: unsafeOutput with entirely static outputs", () => {
   const d = defineNodeType({
     name: "foo",
     inputs: {},
@@ -1745,12 +1745,12 @@ test("error: assertOutput with entirely static outputs", () => {
   assert.throws(
     () =>
       // @ts-expect-error
-      i.assertOutput("do1"),
-    /assertOutput was called unnecessarily on a BreadboardNode. Type "foo" has entirely static outputs. Use "<node>.outputs.do1" instead./
+      i.unsafeOutput("do1"),
+    /unsafeOutput was called unnecessarily on a BreadboardNode. Type "foo" has entirely static outputs. Use "<node>.outputs.do1" instead./
   );
 });
 
-test("error: assertOutput on reflective node", () => {
+test("error: unsafeOutput on reflective node", () => {
   const d = defineNodeType({
     name: "foo",
     inputs: {
@@ -1766,12 +1766,12 @@ test("error: assertOutput on reflective node", () => {
   assert.throws(
     () =>
       // @ts-expect-error
-      i.assertOutput("do1"),
-    /assertOutput was called unnecessarily on a BreadboardNode. Type "foo" is reflective. Use "<node>.outputs.do1" instead./
+      i.unsafeOutput("do1"),
+    /unsafeOutput was called unnecessarily on a BreadboardNode. Type "foo" is reflective. Use "<node>.outputs.do1" instead./
   );
 });
 
-test("error: assertOutput on existing static output", () => {
+test("error: unsafeOutput on existing static output", () => {
   const d = defineNodeType({
     name: "foo",
     inputs: {},
@@ -1785,11 +1785,11 @@ test("error: assertOutput on existing static output", () => {
   const i = d({});
   assert.throws(
     () =>
-      i.assertOutput(
+      i.unsafeOutput(
         // @ts-expect-error
         "so1"
       ),
-    /assertOutput was called unnecessarily on a BreadboardNode. Type "foo" already has a static port called "so1". Use "<node>.outputs.so1" instead./
+    /unsafeOutput was called unnecessarily on a BreadboardNode. Type "foo" already has a static port called "so1". Use "<node>.outputs.so1" instead./
   );
 });
 

--- a/packages/build/src/test/serialize_test.ts
+++ b/packages/build/src/test/serialize_test.ts
@@ -927,9 +927,9 @@ test("polymorphic outputs", () => {
     board({
       inputs: {},
       outputs: {
-        boardOut1: myNode.assertOutput("asserted1"),
-        boardOut2: myNode.assertOutput("asserted2"),
-        boardOut3: myNode.assertOutput("asserted1"),
+        boardOut1: myNode.unsafeOutput("asserted1"),
+        boardOut2: myNode.unsafeOutput("asserted2"),
+        boardOut3: myNode.unsafeOutput("asserted1"),
       },
     }),
     {


### PR DESCRIPTION
We have a few other "unsafe" functions which help identify escape hatches from strict typing. So, just keeping the naming scheme consistent.