### PR TITLE
[template-kit] Add prompt tagged template literal function

### DIFF
--- a/.changeset/eight-pigs-dream.md
+++ b/.changeset/eight-pigs-dream.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/template-kit": patch
+---
+
+Add a prompt`...` tagged template literal function to more safely/concisely instantiate promptTemplate nodes.

--- a/packages/breadboard-web/src/boards/build-example.ts
+++ b/packages/breadboard-web/src/boards/build-example.ts
@@ -5,7 +5,8 @@
  */
 
 import { board, input } from "@breadboard-ai/build";
-import { reverseString, prompt } from "../build-example-kit.js";
+import { prompt } from "@google-labs/template-kit";
+import { reverseString } from "../build-example-kit.js";
 
 const word = input({ description: "The word to reverse" });
 const reversed = reverseString({ forwards: word });

--- a/packages/breadboard-web/src/boards/math.ts
+++ b/packages/breadboard-web/src/boards/math.ts
@@ -6,7 +6,7 @@
 
 import { board, input, output, unsafeCast } from "@breadboard-ai/build";
 import { invoke, runJavascript } from "@google-labs/core-kit";
-import { promptTemplate } from "@google-labs/template-kit";
+import { prompt, promptPlaceholder } from "@google-labs/template-kit";
 
 const question = input({
   $id: "math-question",
@@ -22,26 +22,21 @@ const generator = input({
   default: "text-generator.json",
 });
 
-// TODO(aomarks) Implement a prompt`...` template literal function that enforces
-// placeholders.
-const prompt = promptTemplate({
-  $id: "math-function",
-  template: `Translate the math problem below into a self-contained,
+const instructions =
+  prompt`Translate the math problem below into a self-contained,
 zero-argument JavaScript function named \`compute\` that can be executed
 to provide the answer to the problem.
 
 Do not use any dependencies or libraries.
 
-Math Problem: {{question}}
+Math Problem: ${promptPlaceholder(question, { name: "question" })}
 
-Solution:`,
-  question,
-});
+Solution:`.configure({ id: "math-function" });
 
 const generatedCode = invoke({
   $id: "generator",
   $board: generator,
-  text: prompt,
+  text: instructions,
   // TODO(aomarks) Some kind of helper that can abstract over multiple boards
   // (need to convert all underyling boards to the new API first).
 }).unsafeOutput("text");

--- a/packages/breadboard-web/src/build-example-kit.ts
+++ b/packages/breadboard-web/src/build-example-kit.ts
@@ -6,12 +6,10 @@
 
 import {
   defineNodeType,
-  type Value,
   type NodeFactoryFromDefinition,
 } from "@breadboard-ai/build";
 import { addKit } from "@google-labs/breadboard";
 import { KitBuilder } from "@google-labs/breadboard/kits";
-import { promptTemplate } from "@google-labs/template-kit";
 
 export const reverseString = defineNodeType({
   name: "reverseString",
@@ -34,32 +32,6 @@ export const reverseString = defineNodeType({
     };
   },
 });
-
-/**
- * An example of a sugar function which wraps instantiation of a node (in this
- * case, a template), in a more convenient syntax (in this case, a tagged
- * template literal function).
- */
-export function prompt(
-  strings: TemplateStringsArray,
-  ...values: Value<string>[]
-) {
-  let template = "";
-  const placeholders: Record<string, Value<string>> = {};
-  for (let i = 0; i < strings.length; i++) {
-    if (i > 0) {
-      template += "}}";
-    }
-    template += strings[i];
-    if (i < strings.length - 1) {
-      template += `{{`;
-      const name = `p${i}`;
-      template += name;
-      placeholders[name] = values[i]!;
-    }
-  }
-  return promptTemplate({ template, ...placeholders });
-}
 
 const BuildExampleKit = new KitBuilder({
   title: "Example Kit",

--- a/packages/template-kit/package.json
+++ b/packages/template-kit/package.json
@@ -5,10 +5,19 @@
   },
   "version": "0.2.6",
   "description": "Breadboard Kit that contains nodes for various sorts of templating",
-  "main": "./dist/src/index.js",
-  "exports": "./dist/src/index.js",
-  "types": "dist/src/index.d.ts",
   "type": "module",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
+    },
+    "./*.js": {
+      "types": "./*.d.ts",
+      "default": null
+    }
+  },
   "scripts": {
     "prepack": "npm run build",
     "generate:docs": "wireit",

--- a/packages/template-kit/src/index.ts
+++ b/packages/template-kit/src/index.ts
@@ -9,6 +9,7 @@ import { addKit } from "@google-labs/breadboard";
 import { KitBuilder } from "@google-labs/breadboard/kits";
 import promptTemplate from "./nodes/prompt-template.js";
 import urlTemplate from "./nodes/url-template.js";
+export { prompt, promptPlaceholder } from "./nodes/prompt-template-tag.js";
 export { default as promptTemplate } from "./nodes/prompt-template.js";
 export { default as urlTemplate } from "./nodes/url-template.js";
 

--- a/packages/template-kit/src/nodes/prompt-template-tag.ts
+++ b/packages/template-kit/src/nodes/prompt-template-tag.ts
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { JsonSerializable } from "@breadboard-ai/build/internal/type-system/type.js";
+import promptTemplate from "./prompt-template.js";
+import { Value } from "@breadboard-ai/build";
+
+/**
+ * A utility that makes it safer and more convenient to instantiate a
+ * {@link promptTemplate} node using JavaScript template string literals.
+ *
+ * Usage:
+ *
+ * ```ts
+ * import {prompt} from '@google-labs/template-kit';
+ * import {input} from '@breadboard-ai/build';
+ *
+ * const dish = input();
+ * const steps = input({default: 10});
+ * const instructions = prompt`Write a ${dish} recipe in under ${steps} steps`;
+ * ```
+ *
+ * To customize the node id of the `promptTemplate` node that this function will
+ * create, you can use the `configure` method:
+ *
+ * ```ts
+ * const instructions =
+ *   prompt`Write a ${dish} recipe in under ${steps} steps`.configure({
+ *     id: "recipe-template",
+ * });
+ * ```
+ *
+ * To customize the name of a parameter within the template, use the
+ * {@link promptPlaceholder} function to wrap the value:
+ *
+ * ```ts
+ * import {prompt, promptPlaceholder} from '@google-labs/template-kit';
+ *
+ * const instructions = prompt`Write a ${promptPlaceholder(dish, {
+ *   name: "dish",
+ * })} recipe in under ${promptPlaceholder(steps, {
+ *   name: "steps",
+ * })} steps`;
+ * ```
+ */
+export function prompt(
+  strings: TemplateStringsArray,
+  ...values: Array<Value<JsonSerializable> | PromptPlaceholder>
+): ReturnType<typeof promptTemplate> & {
+  configure(config: { id: string }): ReturnType<typeof promptTemplate>;
+} {
+  let template = "";
+  const placeholders: Record<string, Value<JsonSerializable>> = {};
+  const uniqueNames = new Set<string>();
+  for (let i = 0; i < strings.length; i++) {
+    if (i > 0) {
+      template += "}}";
+    }
+    template += strings[i];
+    if (i < strings.length - 1) {
+      const value = values[i]!;
+      const { name, actualValue } = isPromptPlaceholder(value)
+        ? { name: value.name, actualValue: value.value }
+        : { name: `p${i}`, actualValue: value };
+      if (uniqueNames.has(name)) {
+        throw new Error(
+          `Prompt placeholder ${JSON.stringify(name)} has already been used ` +
+            `in template starting with ` +
+            JSON.stringify(strings.join("...").slice(0, 32))
+        );
+      }
+      uniqueNames.add(name);
+      template += `{{`;
+      template += name;
+      placeholders[name] = actualValue;
+    }
+  }
+  return Object.assign(
+    promptTemplate({
+      template,
+      ...placeholders,
+    }),
+    {
+      configure: ({ id }: { id: string }) =>
+        promptTemplate({
+          $id: id,
+          template,
+          ...placeholders,
+        }),
+    }
+  );
+}
+
+const PromptPlaceholderBrand = Symbol();
+
+export function promptPlaceholder(
+  value: Value<JsonSerializable>,
+  { name }: { name: string }
+): PromptPlaceholder {
+  return { [PromptPlaceholderBrand]: true, value, name };
+}
+
+interface PromptPlaceholder {
+  [PromptPlaceholderBrand]: true;
+  value: Value<JsonSerializable>;
+  name: string;
+}
+
+function isPromptPlaceholder(value: unknown): value is PromptPlaceholder {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    PromptPlaceholderBrand in value
+  );
+}

--- a/packages/template-kit/src/nodes/prompt-template.ts
+++ b/packages/template-kit/src/nodes/prompt-template.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { anyOf, defineNodeType, object } from "@breadboard-ai/build";
+import { defineNodeType } from "@breadboard-ai/build";
 import type { InputValues } from "@google-labs/breadboard";
 
 export const stringify = (value: unknown): string => {

--- a/packages/template-kit/tests/prompt-template-tag_test.ts
+++ b/packages/template-kit/tests/prompt-template-tag_test.ts
@@ -1,0 +1,203 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+
+import { board, input, serialize } from "@breadboard-ai/build";
+import { prompt, promptPlaceholder } from "@google-labs/template-kit";
+import test from "ava";
+
+test("usage", (t) => {
+  const dish = input();
+  const steps = input({ default: 10 });
+
+  prompt`No placeholders`;
+  prompt`Write a ${dish} recipe in under ${steps} steps`;
+  prompt`Invalid placeholder: ${
+    // @ts-expect-error
+    undefined
+  }`;
+
+  t.pass();
+});
+
+test("serialization with automatic ID", (t) => {
+  const dish = input();
+  const steps = input({ default: 10 });
+  const instructions = prompt`Write a ${dish} recipe in under ${steps} steps`;
+  const bgl = serialize(
+    board({
+      inputs: { dish, steps },
+      outputs: { instructions },
+    })
+  );
+  t.deepEqual(bgl, {
+    edges: [
+      {
+        from: "input-0",
+        to: "promptTemplate-0",
+        in: "p0",
+        out: "dish",
+      },
+      {
+        from: "input-0",
+        to: "promptTemplate-0",
+        in: "p1",
+        out: "steps",
+      },
+      {
+        from: "promptTemplate-0",
+        to: "output-0",
+        in: "instructions",
+        out: "prompt",
+      },
+    ],
+    nodes: [
+      {
+        id: "input-0",
+        type: "input",
+        configuration: {
+          schema: {
+            type: "object",
+            properties: {
+              dish: {
+                type: "string",
+              },
+              steps: {
+                type: "number",
+                default: 10,
+              },
+            },
+            required: ["dish", "steps"],
+          },
+        },
+      },
+      {
+        id: "output-0",
+        type: "output",
+        configuration: {
+          schema: {
+            type: "object",
+            properties: {
+              instructions: {
+                type: "string",
+              },
+            },
+            required: ["instructions"],
+          },
+        },
+      },
+      {
+        id: "promptTemplate-0",
+        type: "promptTemplate",
+        configuration: {
+          template: "Write a {{p0}} recipe in under {{p1}} steps",
+        },
+      },
+    ],
+  });
+});
+
+test("serialization with custom node id and placeholder names", (t) => {
+  const dish = input();
+  const steps = input({ default: 10 });
+  const instructions = prompt`Write a ${promptPlaceholder(dish, {
+    name: "dish",
+  })} recipe in under ${promptPlaceholder(steps, { name: "steps" })} steps`.configure(
+    {
+      id: "recipe-template",
+    }
+  );
+  const bgl = serialize(
+    board({
+      inputs: { dish, steps },
+      outputs: { instructions },
+    })
+  );
+  t.deepEqual(bgl, {
+    edges: [
+      {
+        from: "input-0",
+        to: "recipe-template",
+        in: "dish",
+        out: "dish",
+      },
+      {
+        from: "input-0",
+        to: "recipe-template",
+        in: "steps",
+        out: "steps",
+      },
+      {
+        from: "recipe-template",
+        to: "output-0",
+        in: "instructions",
+        out: "prompt",
+      },
+    ],
+    nodes: [
+      {
+        id: "input-0",
+        type: "input",
+        configuration: {
+          schema: {
+            type: "object",
+            properties: {
+              dish: {
+                type: "string",
+              },
+              steps: {
+                type: "number",
+                default: 10,
+              },
+            },
+            required: ["dish", "steps"],
+          },
+        },
+      },
+      {
+        id: "output-0",
+        type: "output",
+        configuration: {
+          schema: {
+            type: "object",
+            properties: {
+              instructions: {
+                type: "string",
+              },
+            },
+            required: ["instructions"],
+          },
+        },
+      },
+      {
+        id: "recipe-template",
+        type: "promptTemplate",
+        configuration: {
+          template: "Write a {{dish}} recipe in under {{steps}} steps",
+        },
+      },
+    ],
+  });
+});
+
+test("error if prompt placeholder name collides with a default one", (t) => {
+  const dish = input();
+  const steps = input({ default: 10 });
+  t.throws(
+    () =>
+      prompt`Write a ${promptPlaceholder(dish, {
+        name: "p1",
+      })} recipe in under ${steps} steps`.configure({
+        id: "recipe-template",
+      }),
+    {
+      message:
+        `Prompt placeholder "p1" has already been used ` +
+        `in template starting with "Write a ... recipe in under ... "`,
+    }
+  );
+});


### PR DESCRIPTION
Adds a utility that makes it safer and more convenient to instantiate a `promptTemplate` node using JavaScript template string literals.

Usage:

```ts
import {prompt} from '@google-labs/template-kit';
import {input} from '@breadboard-ai/build';

const dish = input();
const steps = input({default: 10});
const instructions = prompt`Write a ${dish} recipe in under ${steps} steps`;
```

To customize the node id of the `promptTemplate` node that this function will create, you can use the `configure` method:

```ts
const instructions =
   prompt`Write a ${dish} recipe in under ${steps} steps`.configure({
     id: "recipe-template",
 });
 ```

To customize the name of a parameter within the template, use the `promptPlaceholder` function to wrap the value:

```ts
import {prompt, promptPlaceholder} from '@google-labs/template-kit';

const instructions = prompt`Write a ${promptPlaceholder(dish, {
  name: "dish",
})} recipe in under ${promptPlaceholder(steps, {
  name: "steps",
})} steps`;
```