### PR TITLE
[template-kit] Expand the exports to allow internal types to be referenced

### DIFF
--- a/.changeset/wild-trains-deliver.md
+++ b/.changeset/wild-trains-deliver.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/template-kit": minor
+---
+
+Expand the exports of template-kit to allow internal types to be referenced (but still prevent JS from actually being imported at runtime)

--- a/packages/template-kit/package.json
+++ b/packages/template-kit/package.json
@@ -5,10 +5,19 @@
   },
   "version": "0.2.6",
   "description": "Breadboard Kit that contains nodes for various sorts of templating",
-  "main": "./dist/src/index.js",
-  "exports": "./dist/src/index.js",
-  "types": "dist/src/index.d.ts",
   "type": "module",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
+    },
+    "./*.js": {
+      "types": "./*.d.ts",
+      "default": null
+    }
+  },
   "scripts": {
     "prepack": "npm run build",
     "generate:docs": "wireit",


### PR DESCRIPTION
Still prevents JS from actually being imported at runtime.