### PR TITLE
[breadboard] Interactive secrets option on `RunConfig`.

### DIFF
--- a/.changeset/little-turtles-relax.md
+++ b/.changeset/little-turtles-relax.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard": minor
+---
+
+Add support for `interactiveSecrets` option on `RunConfig`.

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -963,6 +963,7 @@ export class Main extends LitElement {
                     loader: this.#loader,
                     signal: this.#abortController?.signal,
                     inputs: inputsFromSettings(this.#settings),
+                    interactiveSecrets: true,
                   },
                   this.#settings
                 )

--- a/packages/breadboard-web/src/preview-run.ts
+++ b/packages/breadboard-web/src/preview-run.ts
@@ -203,6 +203,7 @@ export class PreviewRun extends LitElement {
       kits: this.kits,
       diagnostics: true,
       loader: this.#loader,
+      interactiveSecrets: true,
     };
 
     this.status = BreadboardUI.Types.STATUS.RUNNING;


### PR DESCRIPTION
Make asking for secrets interactively an option. This used to be the default for breadboard-web.