### PR TITLE
[core-kit] Add `code` function

### DIFF
--- a/.changeset/clever-carrots-exercise.md
+++ b/.changeset/clever-carrots-exercise.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/core-kit": patch
+---
+
+Add a `code` function which creates a `runJavascript` node in a type-safe way.

--- a/packages/breadboard-web/public/graphs/build-example.json
+++ b/packages/breadboard-web/public/graphs/build-example.json
@@ -1,7 +1,7 @@
 {
   "title": "Example of @breadboard-ai/build",
   "description": "A simple example of using the @breadboard-ai/build API",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "edges": [
     {
       "from": "input-0",
@@ -16,6 +16,12 @@
       "in": "forwards"
     },
     {
+      "from": "input-0",
+      "to": "runJavascript-0",
+      "out": "word",
+      "in": "str"
+    },
+    {
       "from": "promptTemplate-0",
       "to": "output-0",
       "out": "prompt",
@@ -26,6 +32,12 @@
       "to": "promptTemplate-0",
       "out": "backwards",
       "in": "p1"
+    },
+    {
+      "from": "runJavascript-0",
+      "to": "promptTemplate-0",
+      "out": "capitalized",
+      "in": "p2"
     }
   ],
   "nodes": [
@@ -68,13 +80,21 @@
       "id": "promptTemplate-0",
       "type": "promptTemplate",
       "configuration": {
-        "template": "The word \"{{p0}}\" is \"{{p1}}\" in reverse"
+        "template": "The word \"{{p0}}\" is \"{{p1}}\" in reverse\nand \"{{p2}}\" when capitalized."
       }
     },
     {
       "id": "reverseString-0",
       "type": "reverseString",
       "configuration": {}
+    },
+    {
+      "id": "runJavascript-0",
+      "type": "runJavascript",
+      "configuration": {
+        "code": "({str})=>({capitalized:str.toUpperCase()})",
+        "raw": true
+      }
     }
   ]
 }

--- a/packages/breadboard-web/public/local-boards.json
+++ b/packages/breadboard-web/public/local-boards.json
@@ -57,7 +57,7 @@
   {
     "title": "Example of @breadboard-ai/build",
     "url": "/graphs/build-example.json",
-    "version": "1.0.0"
+    "version": "1.1.0"
   },
   {
     "title": "Chat bot 2.0",

--- a/packages/breadboard-web/src/boards/build-example.ts
+++ b/packages/breadboard-web/src/boards/build-example.ts
@@ -5,17 +5,24 @@
  */
 
 import { board, input } from "@breadboard-ai/build";
+import { code } from "@google-labs/core-kit";
 import { prompt } from "@google-labs/template-kit";
 import { reverseString } from "../build-example-kit.js";
 
 const word = input({ description: "The word to reverse" });
 const reversed = reverseString({ forwards: word });
-const result = prompt`The word "${word}" is "${reversed}" in reverse`;
+const capitalizer = code(
+  { str: word },
+  { capitalized: "string" },
+  ({ str }) => ({ capitalized: str.toUpperCase() })
+);
+const result = prompt`The word "${word}" is "${reversed}" in reverse
+and "${capitalizer.outputs.capitalized}" when capitalized.`;
 
 export default board({
   title: "Example of @breadboard-ai/build",
   description: "A simple example of using the @breadboard-ai/build API",
-  version: "1.0.0",
+  version: "1.1.0",
   inputs: { word },
   outputs: { result },
 });

--- a/packages/core-kit/src/index.ts
+++ b/packages/core-kit/src/index.ts
@@ -21,6 +21,7 @@ import fetch from "./nodes/fetch.js";
 import runJavascript from "./nodes/run-javascript.js";
 import secrets from "./nodes/secrets.js";
 
+export { code } from "./nodes/code.js";
 export { default as fetch } from "./nodes/fetch.js";
 export { default as invoke } from "./nodes/invoke.js";
 export { default as runJavascript } from "./nodes/run-javascript.js";

--- a/packages/core-kit/src/nodes/code.ts
+++ b/packages/core-kit/src/nodes/code.ts
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Value } from "@breadboard-ai/build";
+import type { OutputPort } from "@breadboard-ai/build/internal/common/port.js";
+import type { Expand } from "@breadboard-ai/build/internal/common/type-util.js";
+import type { Instance } from "@breadboard-ai/build/internal/define/instance.js";
+import type {
+  BreadboardType,
+  ConvertBreadboardType,
+  JsonSerializable,
+} from "@breadboard-ai/build/internal/type-system/type.js";
+import runJavascript from "./run-javascript.js";
+
+/**
+ * The `code` function creates a {@link runJavascript} Breadboard node in a
+ * type-safe manner. Usage:
+ *
+ * ```ts
+ * import {code} from "@google-labs/core-kit";
+ * import {board, input} from "@breadboard-ai/build";
+ *
+ * const forwards = input({ description: "A string to reverse" });
+ *
+ * const reversed = code({ forwards }, { reversed: "string" }, ({ forwards }) => ({
+ *   reversed: str.split("").reverse().join(""),
+ * }));
+ *
+ * export board({forwards}, {reversed: reversed.outputs.reversed});
+ * ```
+ */
+export function code<
+  I extends Record<string, Value<JsonSerializable>>,
+  O extends Record<string, BreadboardType>,
+>(
+  inputs: I,
+  // TODO(aomarks) We could make the `outputs` parameter optional, but we'd have
+  // to be careful with schema. What we'd need to do if `outputs` is missing is:
+  //
+  // 1. Infer the output ports from `ReturnType<fn>` instead of from `outputs`.
+  //
+  // 2. Return a node that has a magic `outputs` object. This `outputs` object
+  //    would be a proxy that overloads `get` to automatically create output
+  //    ports as they are accessed (same as what we do below, except deferred).
+  //
+  // 3. Deal with the fact that the runtime `type` of those ports will be too
+  //    broad. It will be the base dynamic output type of `runJavascript`, which
+  //    is any JSON serializable value.
+  //
+  //    This is OK when wiring to an input port because input ports already know
+  //    their schema, and TypeScript will take care of making sure we only wire
+  //    it to the right place.
+  //
+  //    However, if we want to use one of these outputs as a _board output_, we
+  //    have a problem, since we need to write the schema to the output node
+  //    configuration. So, we'll probably want to introduce a "weak typed"
+  //    version of an `OutputPortReference`, which is accepted when wiring
+  //    nodes, but NOT accepted when configuring board outputs. Then, we can
+  //    update the `output` utility function to only take weak
+  //    `OutputPortReferences` if the `output` has had its type explicitly
+  //    specified.
+  //
+  outputs: O,
+  fn: (params: Expand<StrictCodeFunctionParams<I>>) => ConvertBreadboardTypes<O>
+): CodeNode<
+  Expand<CodeNodeInputs<I>>,
+  { [K in keyof O]: ConvertBreadboardType<O[K]> }
+> {
+  const node = runJavascript({
+    code: fn.toString(),
+    raw: true,
+    ...(inputs as Record<string, JsonSerializable>),
+  }) as CodeNode<Expand<CodeNodeInputs<I>>, ConvertBreadboardTypes<O>>;
+  for (const [name, type] of Object.entries(outputs)) {
+    // TODO(aomarks) This is a bit of a hacky way to materialize the dynamic
+    // ports. Node definitions should probably have a more elegant way to
+    // configure dynamic ports at instantiation time.
+    const port = node.unsafeOutput(name);
+    (port as Writable<typeof port>).type = type;
+    (node.outputs as Record<string, OutputPort<JsonSerializable>>)[name] = port;
+  }
+  return node;
+}
+
+export type CodeNode<
+  I extends Record<string, JsonSerializable>,
+  O extends Record<string, JsonSerializable>,
+> = ReturnType<typeof runJavascript> &
+  Instance<
+    { code: string; name: string; raw: boolean } & I,
+    O,
+    JsonSerializable,
+    undefined,
+    never,
+    false
+  >;
+
+type CodeNodeInputs<I extends Record<string, Value<JsonSerializable>>> = {
+  [K in keyof I]: I[K] extends Value<infer T> ? T : never;
+};
+
+type StrictCodeFunctionParams<
+  I extends Record<string, Value<JsonSerializable>>,
+> = {
+  [K in keyof I]: I[K] extends Value<infer T> ? T : never;
+};
+
+type ConvertBreadboardTypes<T extends Record<string, BreadboardType>> = {
+  [K in keyof T]: ConvertBreadboardType<T[K]>;
+};
+
+type Writable<T> = { -readonly [P in keyof T]: T[P] };

--- a/packages/core-kit/tests/code_test.ts
+++ b/packages/core-kit/tests/code_test.ts
@@ -1,0 +1,210 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+
+import { board, defineNodeType, input, serialize } from "@breadboard-ai/build";
+import test from "ava";
+import { code } from "@google-labs/core-kit";
+
+test("usage", (t) => {
+  const str = input();
+  const num = input({ type: "number" });
+
+  t.throws(() =>
+    // @ts-expect-error
+    code()
+  );
+
+  // $ExpectType CodeNode<{ str: string; num: number; }, { fwdStr: string; fwdNum: number; newBool: boolean; }>
+  const c = code(
+    { str, num },
+    { fwdStr: "string", fwdNum: "number", newBool: "boolean" },
+    (
+      // $ExpectType { str: string; num: number; }
+      params
+    ) => {
+      return {
+        fwdStr:
+          // $ExpectType string
+          params.str,
+        fwdNum:
+          // $ExpectType number
+          params.num,
+        newBool: true,
+      };
+    }
+  );
+
+  code(
+    { str, num },
+    { fwdStr: "string", fwdNum: "number", newBool: "boolean" },
+    // @ts-expect-error
+    () => {
+      return {};
+    }
+  );
+
+  code(
+    { str, num },
+    { fwdStr: "string", fwdNum: "number", newBool: "boolean" },
+    // @ts-expect-error
+    () => {
+      return {
+        fwdStr: "foo",
+        fwdNum: 123,
+        newBool: "true",
+      };
+    }
+  );
+
+  t.truthy(
+    // $ExpectType InputPort<string>
+    c.inputs.code
+  );
+  t.truthy(
+    // $ExpectType InputPort<string>
+    c.inputs.str
+  );
+  t.truthy(
+    // $ExpectType InputPort<number>
+    c.inputs.num
+  );
+
+  t.truthy(
+    // $ExpectType OutputPort<string>
+    c.outputs.fwdStr
+  );
+  t.truthy(
+    // $ExpectType OutputPort<number>
+    c.outputs.fwdNum
+  );
+  t.truthy(
+    // $ExpectType OutputPort<boolean>
+    c.outputs.newBool
+  );
+
+  t.is(
+    // @ts-expect-error
+    c.outputs.notReal,
+    undefined
+  );
+
+  t.pass();
+});
+
+test("serialization", (t) => {
+  const str = input();
+  const num = input({ type: "number" });
+
+  // $ExpectType Definition<{ num: number; }, { halfNum: number; }, undefined, undefined, never, false, never, never>
+  const otherNodeDef = defineNodeType({
+    name: "other",
+    inputs: {
+      num: { type: "number" },
+    },
+    outputs: {
+      halfNum: { type: "number" },
+    },
+    invoke: ({ num }) => ({ halfNum: num / 2 }),
+  });
+
+  const codeResult = code(
+    { str, num, bool: false },
+    {
+      strLen: "number",
+      strReversed: "string",
+      doubleNum: "number",
+      not: "boolean",
+    },
+    ({ str, num, bool }) => ({
+      strLen: str.length,
+      strReversed: str.split("").reverse().join(""),
+      doubleNum: num * 2,
+      not: !bool,
+    })
+  );
+
+  // $ExpectType OutputPort<string>
+  codeResult.outputs.strReversed;
+
+  otherNodeDef({
+    // TODO(aomarks) This should be an error!
+    num: codeResult.outputs.strReversed,
+  });
+
+  const otherNode = otherNodeDef({ num: codeResult.outputs.doubleNum });
+
+  const bgl = serialize(
+    board({
+      inputs: { str, num },
+      outputs: {
+        out1: codeResult.outputs.strLen,
+        out2: codeResult.outputs.strReversed,
+        out3: codeResult.outputs.doubleNum,
+        out4: codeResult.outputs.not,
+        out5: otherNode.outputs.halfNum,
+      },
+    })
+  );
+  t.deepEqual(bgl, {
+    edges: [
+      { from: "input-0", to: "runJavascript-0", out: "num", in: "num" },
+      { from: "input-0", to: "runJavascript-0", out: "str", in: "str" },
+      { from: "other-0", to: "output-0", out: "halfNum", in: "out5" },
+      { from: "runJavascript-0", to: "other-0", out: "doubleNum", in: "num" },
+      { from: "runJavascript-0", to: "output-0", out: "doubleNum", in: "out3" },
+      { from: "runJavascript-0", to: "output-0", out: "not", in: "out4" },
+      { from: "runJavascript-0", to: "output-0", out: "strLen", in: "out1" },
+      {
+        from: "runJavascript-0",
+        to: "output-0",
+        out: "strReversed",
+        in: "out2",
+      },
+    ],
+    nodes: [
+      {
+        id: "input-0",
+        type: "input",
+        configuration: {
+          schema: {
+            type: "object",
+            properties: { num: { type: "number" }, str: { type: "string" } },
+            required: ["num", "str"],
+          },
+        },
+      },
+      {
+        id: "output-0",
+        type: "output",
+        configuration: {
+          schema: {
+            type: "object",
+            properties: {
+              out1: { type: "number" },
+              out2: { type: "string" },
+              out3: { type: "number" },
+              out4: { type: "boolean" },
+              out5: { type: "number" },
+            },
+            required: ["out1", "out2", "out3", "out4", "out5"],
+          },
+        },
+      },
+      { id: "other-0", type: "other", configuration: {} },
+      {
+        id: "runJavascript-0",
+        type: "runJavascript",
+        configuration: {
+          bool: false,
+          code: '({ str, num, bool }) => ({\n        strLen: str.length,\n        strReversed: str.split("").reverse().join(""),\n        doubleNum: num * 2,\n        not: !bool,\n    })',
+          raw: true,
+        },
+      },
+    ],
+  });
+});


### PR DESCRIPTION
The `code` function creates a `runJavascript` Breadboard node in a
type-safe manner. Usage:

```ts
import {code} from "@google-labs/core-kit";
import {board, input} from "@breadboard-ai/build";

const forwards = input({ description: "A string to reverse" });

const reversed = code({ forwards }, { reversed: "string" }, ({ forwards }) => ({
  reversed: str.split("").reverse().join(""),
}));

export board({forwards}, {reversed: reversed.outputs.reversed});
```

As a future improvement, we could make the `outputs` parameter optional, but we'd
have to be careful with schema. What we'd need to do if `outputs` is missing is:
  
  1. Infer the output ports from `ReturnType<fn>` instead of from `outputs`.
  
  2. Return a node that has a magic `outputs` object. This `outputs` object
     would be a proxy that overloads `get` to automatically create output
     ports as they are accessed (same as what we do below, except deferred).
  
  3. Deal with the fact that the runtime `type` of those ports will be too
     broad. It will be the base dynamic output type of `runJavascript`, which
     is any JSON serializable value.
  
     This is OK when wiring to an input port because input ports already know
     their schema, and TypeScript will take care of making sure we only wire
     it to the right place.
  
     However, if we want to use one of these outputs as a _board output_, we
     have a problem, since we need to write the schema to the output node
     configuration. So, we'll probably want to introduce a "weak typed"
     version of an `OutputPortReference`, which is accepted when wiring
     nodes, but NOT accepted when configuring board outputs. Then, we can
     update the `output` utility function to only take weak
     `OutputPortReferences` if the `output` has had its type explicitly
     specified.