### PR TITLE
[core-kit] Add secret helper function

### DIFF
--- a/.changeset/tame-guests-flash.md
+++ b/.changeset/tame-guests-flash.md
@@ -1,0 +1,7 @@
+---
+"@google-labs/core-kit": patch
+---
+
+Add a `secret` function which creates and configures a `secrets` node for just
+one secret, and returns the corresponding output port. A simpler way to get
+secrets in the API.

--- a/packages/core-kit/src/index.ts
+++ b/packages/core-kit/src/index.ts
@@ -25,7 +25,7 @@ export { code } from "./nodes/code.js";
 export { default as fetch } from "./nodes/fetch.js";
 export { default as invoke } from "./nodes/invoke.js";
 export { default as runJavascript } from "./nodes/run-javascript.js";
-export { default as secrets } from "./nodes/secrets.js";
+export { default as secrets, secret } from "./nodes/secrets.js";
 
 const builder = new KitBuilder({
   title: "Core Kit",

--- a/packages/core-kit/src/nodes/secrets.ts
+++ b/packages/core-kit/src/nodes/secrets.ts
@@ -69,7 +69,7 @@ const getKeys = (
   return keys;
 };
 
-export default defineNodeType({
+const secrets = defineNodeType({
   name: "secrets",
   metadata: {
     title: "Secrets",
@@ -98,3 +98,17 @@ export default defineNodeType({
       ])
     ),
 });
+export default secrets;
+
+/**
+ * Create and configure a {@link secrets} node for one secret, and return the
+ * corresponding output port.
+ */
+export function secret(name: string) {
+  // TODO(aomarks) Should we replace the `secrets` node with a `secret` node
+  // that is monomorphic? Seems simpler.
+  return secrets({
+    $id: `${name}-secret`,
+    keys: [name],
+  }).unsafeOutput(name);
+}


### PR DESCRIPTION
Adds a `secret` function which creates and configures a `secrets` node for just one secret, and returns the corresponding output port. A simpler way to get secrets in the API.

```ts
import {secret} from '@breadboard-ai/core-kit';

// OutputPort<string>
const geminiKey = secret('GEMINI_KEY');
```