### PR TITLE
[build] Fix type bug relating to instances acting as outputs even when they have no primary port

### DIFF
--- a/.changeset/shaggy-seas-add.md
+++ b/.changeset/shaggy-seas-add.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Fix a bug in the @breadboard-ai/build type system that allowed node instances to be passed as board outputs even if they did not have a primary port.

--- a/packages/build/src/internal/common/type-util.ts
+++ b/packages/build/src/internal/common/type-util.ts
@@ -59,3 +59,8 @@ export type BroadenBasicType<T extends string | number | boolean> =
       : T extends boolean
         ? boolean
         : never;
+
+/**
+ * See https://github.com/microsoft/TypeScript/issues/31751#issuecomment-498526919
+ */
+export type IsNever<T> = [T] extends [never] ? true : false;

--- a/packages/build/src/internal/define/define.ts
+++ b/packages/build/src/internal/define/define.ts
@@ -11,7 +11,12 @@ import type {
   NodeHandlerContext,
   NodeHandlerMetadata,
 } from "@google-labs/breadboard";
-import type { CountUnion, Expand, MaybePromise } from "../common/type-util.js";
+import type {
+  CountUnion,
+  Expand,
+  IsNever,
+  MaybePromise,
+} from "../common/type-util.js";
 import type {
   ConvertBreadboardType,
   JsonSerializable,
@@ -325,16 +330,23 @@ type GetOptionalInputs<I extends Record<string, InputPortConfig>> = {
 type GetDynamicTypes<C extends Record<string, PortConfig>> =
   C["*"] extends PortConfig ? Convert<C["*"]> : undefined;
 
-type GetPrimary<C extends Record<string, PortConfig>> = {
-  [K in keyof Omit<C, "*">]: C[K] extends
-    | StaticInputPortConfig
-    | StaticOutputPortConfig
-    ? C[K]["primary"] extends true
-      ? K
-      : never
-    : never;
-}[keyof Omit<C, "*">] &
-  string;
+type GetPrimary<C extends Record<string, PortConfig>> = ReplaceNever<
+  Extract<
+    {
+      [K in keyof Omit<C, "*">]: C[K] extends
+        | StaticInputPortConfig
+        | StaticOutputPortConfig
+        ? C[K]["primary"] extends true
+          ? K
+          : false
+        : false;
+    }[keyof Omit<C, "*">],
+    string
+  >,
+  false
+>;
+
+type ReplaceNever<T, R> = IsNever<T> extends true ? R : T;
 
 type GetReflective<O extends Record<string, OutputPortConfig>> =
   O["*"] extends DynamicOutputPortConfig

--- a/packages/build/src/internal/define/definition.ts
+++ b/packages/build/src/internal/define/definition.ts
@@ -47,8 +47,8 @@ export interface Definition<
   /* Dynamic Outputs */ DO extends JsonSerializable | undefined,
   /* Optional Inputs */ OI extends keyof SI,
   /* Reflective?     */ R extends boolean,
-  /* Primary Input   */ PI extends string | undefined,
-  /* Primary Output  */ PO extends string | undefined,
+  /* Primary Input   */ PI extends string | false,
+  /* Primary Output  */ PO extends string | false,
 > extends StrictNodeHandler {
   <A extends LooseInstantiateArgs>(
     args: A & StrictInstantiateArgs<SI, OI, DI, A>
@@ -69,8 +69,8 @@ export class DefinitionImpl<
   /* Dynamic Outputs */ DO extends JsonSerializable | undefined,
   /* Optional Inputs */ OI extends keyof SI,
   /* Reflective?     */ R extends boolean,
-  /* Primary Input   */ PI extends string | undefined,
-  /* Primary Output  */ PO extends string | undefined,
+  /* Primary Input   */ PI extends string | false,
+  /* Primary Output  */ PO extends string | false,
 > implements StrictNodeHandler
 {
   readonly #name: string;

--- a/packages/build/src/internal/define/instance.ts
+++ b/packages/build/src/internal/define/instance.ts
@@ -26,8 +26,8 @@ export class Instance<
   /* Inputs         */ I extends { [K: string]: JsonSerializable },
   /* Outputs        */ O extends { [K: string]: JsonSerializable },
   /* Dynamic Output */ DO extends JsonSerializable | undefined,
-  /* Primary Input  */ PI extends string | undefined,
-  /* Primary Output */ PO extends string | undefined,
+  /* Primary Input  */ PI extends string | false,
+  /* Primary Output */ PO extends string | false,
   /* Reflective     */ R extends boolean,
 > implements SerializableNode
 {

--- a/packages/build/src/test/board_test.ts
+++ b/packages/build/src/test/board_test.ts
@@ -4,9 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+
 import { defineNodeType } from "@breadboard-ai/build";
 import { test } from "node:test";
 import { board } from "../internal/board/board.js";
+import assert from "node:assert/strict";
 
 const testNode = defineNodeType({
   name: "example",
@@ -90,6 +93,44 @@ test("expect type error: missing instantiate param", () => {
   definition({ inNum: 123 });
   // @ts-expect-error missing inNum
   definition({ inStr: "inStr" });
+});
+
+test("expect type error: board input/output types", () => {
+  const noPrimary = defineNodeType({
+    name: "noPrimary",
+    inputs: {
+      in: { type: "string" },
+    },
+    outputs: {
+      out: { type: "string" },
+    },
+    invoke: () => ({ out: "foo" }),
+  });
+
+  assert.throws(() =>
+    board({
+      inputs: {
+        // @ts-expect-error
+        in1: undefined,
+        // @ts-expect-error
+        in2: null,
+        // @ts-expect-error
+        in3: "foo",
+        // @ts-expect-error
+        in4: noPrimary({}),
+      },
+      outputs: {
+        // @ts-expect-error
+        out1: undefined,
+        // @ts-expect-error
+        out2: null,
+        // @ts-expect-error
+        out3: "foo",
+        // @ts-expect-error
+        out4: noPrimary({}),
+      },
+    })
+  );
 });
 
 test("expect type error: incorrect make instance param type", () => {

--- a/packages/build/src/test/define_test.ts
+++ b/packages/build/src/test/define_test.ts
@@ -17,7 +17,7 @@ import { input } from "../internal/board/input.js";
 test("mono/mono", async () => {
   const values = { si1: "foo", si2: 123 };
 
-  // $ExpectType Definition<{ si1: string; si2: number; }, { so1: boolean; so2: null; }, undefined, undefined, never, false, never, never>
+  // $ExpectType Definition<{ si1: string; si2: number; }, { so1: boolean; so2: null; }, undefined, undefined, never, false, false, false>
   const d = defineNodeType({
     name: "foo",
     inputs: {
@@ -40,7 +40,7 @@ test("mono/mono", async () => {
     },
   });
 
-  // $ExpectType Instance<{ si1: string; si2: number; }, { so1: boolean; so2: null; }, undefined, never, never, false>
+  // $ExpectType Instance<{ si1: string; si2: number; }, { so1: boolean; so2: null; }, undefined, false, false, false>
   const i = d(values);
 
   assert.ok(
@@ -80,12 +80,12 @@ test("mono/mono", async () => {
   );
 
   assert.equal(
-    // $ExpectType never
+    // $ExpectType undefined
     i.primaryInput,
     undefined
   );
   assert.equal(
-    // $ExpectType never
+    // $ExpectType undefined
     i.primaryOutput,
     undefined
   );
@@ -134,7 +134,7 @@ test("mono/mono", async () => {
 test("poly/mono", async () => {
   const values = { si1: "si1", di1: 1, di2: 2 };
 
-  // $ExpectType Definition<{ si1: string; }, { so1: boolean; }, number, undefined, never, false, never, never>
+  // $ExpectType Definition<{ si1: string; }, { so1: boolean; }, number, undefined, never, false, false, false>
   const d = defineNodeType({
     name: "foo",
     inputs: {
@@ -164,7 +164,7 @@ test("poly/mono", async () => {
     },
   });
 
-  // $ExpectType Instance<{ si1: string; di1: number; di2: number; }, { so1: boolean; }, undefined, never, never, false>
+  // $ExpectType Instance<{ si1: string; di1: number; di2: number; }, { so1: boolean; }, undefined, false, false, false>
   const i = d(values);
 
   assert.ok(
@@ -204,12 +204,12 @@ test("poly/mono", async () => {
   );
 
   assert.equal(
-    // $ExpectType never
+    // $ExpectType undefined
     i.primaryInput,
     undefined
   );
   assert.equal(
-    // $ExpectType never
+    // $ExpectType undefined
     i.primaryOutput,
     undefined
   );
@@ -280,7 +280,7 @@ test("poly/mono", async () => {
 test("mono/poly", async () => {
   const values = { si1: "si1" };
 
-  // $ExpectType Definition<{ si1: string; }, { so1: boolean; }, undefined, number, never, false, never, never>
+  // $ExpectType Definition<{ si1: string; }, { so1: boolean; }, undefined, number, never, false, false, false>
   const d = defineNodeType({
     name: "foo",
     inputs: {
@@ -308,7 +308,7 @@ test("mono/poly", async () => {
     },
   });
 
-  // $ExpectType Instance<{ si1: string; }, { so1: boolean; }, number, never, never, false>
+  // $ExpectType Instance<{ si1: string; }, { so1: boolean; }, number, false, false, false>
   const i = d(values);
 
   assert.ok(
@@ -336,9 +336,9 @@ test("mono/poly", async () => {
   // @ts-expect-error
   i.outputs.do1;
 
-  // $ExpectType never
+  // $ExpectType undefined
   i.primaryInput;
-  // $ExpectType never
+  // $ExpectType undefined
   i.primaryOutput;
 
   assert.deepEqual(await d.invoke(values, null as never), {
@@ -381,7 +381,7 @@ test("mono/poly", async () => {
 test("poly/poly", async () => {
   const values = { si1: "si1", di1: 1, di2: 2 };
 
-  // $ExpectType Definition<{ si1: string; }, { so1: boolean; }, number, number, never, false, never, never>
+  // $ExpectType Definition<{ si1: string; }, { so1: boolean; }, number, number, never, false, false, false>
   const d = defineNodeType({
     name: "foo",
     inputs: {
@@ -410,7 +410,7 @@ test("poly/poly", async () => {
     },
   });
 
-  // $ExpectType Instance<{ si1: string; di1: number; di2: number; }, { so1: boolean; }, number, never, never, false>
+  // $ExpectType Instance<{ si1: string; di1: number; di2: number; }, { so1: boolean; }, number, false, false, false>
   const i = d(values);
 
   assert.ok(
@@ -457,12 +457,12 @@ test("poly/poly", async () => {
   );
 
   assert.equal(
-    // $ExpectType never
+    // $ExpectType undefined
     i.primaryInput,
     undefined
   );
   assert.equal(
-    // $ExpectType never
+    // $ExpectType undefined
     i.primaryOutput,
     undefined
   );
@@ -562,7 +562,7 @@ test("async invoke function", async () => {
 test("reflective", async () => {
   const values = { si1: "si1", di1: 1, di2: 2 };
 
-  // $ExpectType Definition<{ si1: string; }, { so1: boolean; }, number, string, never, true, never, never>
+  // $ExpectType Definition<{ si1: string; }, { so1: boolean; }, number, string, never, true, false, false>
   const d = defineNodeType({
     name: "foo",
     inputs: {
@@ -585,7 +585,7 @@ test("reflective", async () => {
     },
   });
 
-  // $ExpectType Instance<{ si1: string; di1: number; di2: number; }, { so1: boolean; di1: string; di2: string; }, undefined, never, never, true>
+  // $ExpectType Instance<{ si1: string; di1: number; di2: number; }, { so1: boolean; di1: string; di2: string; }, undefined, false, false, true>
   const i = d(values);
 
   assert.ok(
@@ -633,12 +633,12 @@ test("reflective", async () => {
   );
 
   assert.equal(
-    // $ExpectType never
+    // $ExpectType undefined
     i.primaryInput,
     undefined
   );
   assert.equal(
-    // $ExpectType never
+    // $ExpectType undefined
     i.primaryOutput,
     undefined
   );
@@ -693,7 +693,7 @@ test("reflective", async () => {
 test("primary input with no other inputs", () => {
   const values = { si1: 123 };
 
-  // $ExpectType Definition<{ si1: number; }, { so1: boolean; }, undefined, undefined, never, false, "si1", never>
+  // $ExpectType Definition<{ si1: number; }, { so1: boolean; }, undefined, undefined, never, false, "si1", false>
   const d = defineNodeType({
     name: "foo",
     inputs: {
@@ -710,7 +710,7 @@ test("primary input with no other inputs", () => {
     ) => ({ so1: true }),
   });
 
-  // $ExpectType Instance<{ si1: number; }, { so1: boolean; }, undefined, "si1", never, false>
+  // $ExpectType Instance<{ si1: number; }, { so1: boolean; }, undefined, "si1", false, false>
   const i = d(values);
 
   assert.ok(
@@ -746,7 +746,7 @@ test("primary input with no other inputs", () => {
     i.primaryInput
   );
   assert.equal(
-    // $ExpectType never
+    // $ExpectType undefined
     i.primaryOutput,
     undefined
   );
@@ -755,7 +755,7 @@ test("primary input with no other inputs", () => {
 test("primary input with another input", () => {
   const values = { si1: 123, si2: true };
 
-  // $ExpectType Definition<{ si1: number; si2: boolean; }, { so1: boolean; }, undefined, undefined, never, false, "si1", never>
+  // $ExpectType Definition<{ si1: number; si2: boolean; }, { so1: boolean; }, undefined, undefined, never, false, "si1", false>
   const d = defineNodeType({
     name: "foo",
     inputs: {
@@ -773,7 +773,7 @@ test("primary input with another input", () => {
     ) => ({ so1: true }),
   });
 
-  // $ExpectType Instance<{ si1: number; si2: boolean; }, { so1: boolean; }, undefined, "si1", never, false>
+  // $ExpectType Instance<{ si1: number; si2: boolean; }, { so1: boolean; }, undefined, "si1", false, false>
   const i = d(values);
 
   assert.ok(
@@ -809,14 +809,14 @@ test("primary input with another input", () => {
     i.primaryInput
   );
   assert.equal(
-    // $ExpectType never
+    // $ExpectType undefined
     i.primaryOutput,
     undefined
   );
 });
 
 test("primary output with no other outputs", () => {
-  // $ExpectType Definition<{ si1: number; }, { so1: boolean; }, undefined, undefined, never, false, never, "so1">
+  // $ExpectType Definition<{ si1: number; }, { so1: boolean; }, undefined, undefined, never, false, false, "so1">
   const d = defineNodeType({
     name: "foo",
     inputs: {
@@ -833,7 +833,7 @@ test("primary output with no other outputs", () => {
     ) => ({ so1: true }),
   });
 
-  // $ExpectType Instance<{ si1: number; }, { so1: boolean; }, undefined, never, "so1", false>
+  // $ExpectType Instance<{ si1: number; }, { so1: boolean; }, undefined, false, "so1", false>
   const i = d({ si1: 123 });
 
   assert.ok(
@@ -865,7 +865,7 @@ test("primary output with no other outputs", () => {
   );
 
   assert.equal(
-    // $ExpectType never
+    // $ExpectType undefined
     i.primaryInput,
     undefined
   );
@@ -876,7 +876,7 @@ test("primary output with no other outputs", () => {
 });
 
 test("primary output with other outputs", () => {
-  // $ExpectType Definition<{ si1: number; }, { so1: boolean; so2: number; }, undefined, undefined, never, false, never, "so1">
+  // $ExpectType Definition<{ si1: number; }, { so1: boolean; so2: number; }, undefined, undefined, never, false, false, "so1">
   const d = defineNodeType({
     name: "foo",
     inputs: {
@@ -894,7 +894,7 @@ test("primary output with other outputs", () => {
     ) => ({ so1: true, so2: 123 }),
   });
 
-  // $ExpectType Instance<{ si1: number; }, { so1: boolean; so2: number; }, undefined, never, "so1", false>
+  // $ExpectType Instance<{ si1: number; }, { so1: boolean; so2: number; }, undefined, false, "so1", false>
   const i = d({ si1: 123 });
 
   assert.ok(
@@ -926,7 +926,7 @@ test("primary output with other outputs", () => {
   );
 
   assert.equal(
-    // $ExpectType never
+    // $ExpectType undefined
     i.primaryInput,
     undefined
   );

--- a/packages/core-kit/src/nodes/code.ts
+++ b/packages/core-kit/src/nodes/code.ts
@@ -93,7 +93,7 @@ export type CodeNode<
     { code: string; name: string; raw: boolean } & I,
     O,
     JsonSerializable,
-    undefined,
+    false,
     never,
     false
   >;

--- a/packages/core-kit/tests/code_test.ts
+++ b/packages/core-kit/tests/code_test.ts
@@ -100,7 +100,7 @@ test("serialization", (t) => {
   const str = input();
   const num = input({ type: "number" });
 
-  // $ExpectType Definition<{ num: number; }, { halfNum: number; }, undefined, undefined, never, false, never, never>
+  // $ExpectType Definition<{ num: number; }, { halfNum: number; }, undefined, undefined, never, false, false, false>
   const otherNodeDef = defineNodeType({
     name: "other",
     inputs: {


### PR DESCRIPTION
Fix a bug in the @breadboard-ai/build type system that allowed node instances to be passed as board outputs even if they did not have a primary port.