### PR TITLE
[build] Improve handling of defaults in describe functions

### DIFF
--- a/.changeset/early-lamps-switch.md
+++ b/.changeset/early-lamps-switch.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/core-kit": patch
+---
+
+Handle the case in secrets describe where there are no input keys yet

--- a/.changeset/grumpy-drinks-dance.md
+++ b/.changeset/grumpy-drinks-dance.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Improve handling of defaults in describe functions. Defaults are now always passed into the describe function, and types will be optional or not based on whether there is a default (default means it can never be undefined).

--- a/packages/build/src/internal/define/definition.ts
+++ b/packages/build/src/internal/define/definition.ts
@@ -187,13 +187,9 @@ export class DefinitionImpl<
       | { inputs?: DynamicInputPorts; outputs?: DynamicInputPorts }
       | undefined = undefined;
     if (this.#describe !== undefined) {
-      if (values !== undefined) {
-        const { staticValues, dynamicValues } =
-          this.#applyDefaultsAndPartitionRuntimeInputValues(values);
-        user = await this.#describe(staticValues, dynamicValues, context);
-      } else {
-        user = await this.#describe({}, {}, context);
-      }
+      const { staticValues, dynamicValues } =
+        this.#applyDefaultsAndPartitionRuntimeInputValues(values ?? {});
+      user = await this.#describe(staticValues, dynamicValues, context);
     }
 
     let inputSchema: JSONSchema4 & {

--- a/packages/build/src/internal/define/definition.ts
+++ b/packages/build/src/internal/define/definition.ts
@@ -27,11 +27,8 @@ import type {
   StaticInputPortConfig,
   StaticOutputPortConfig,
 } from "./config.js";
-import type {
-  DynamicInputPorts,
-  LooseDescribeFn,
-  VeryLooseInvokeFn,
-} from "./define.js";
+import type { DynamicInputPorts, VeryLooseInvokeFn } from "./define.js";
+import type { LooseDescribeFn } from "./describe.js";
 import { Instance } from "./instance.js";
 import { portConfigMapToJSONSchema } from "./json-schema.js";
 import {

--- a/packages/build/src/internal/define/describe.ts
+++ b/packages/build/src/internal/define/describe.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { NodeDescriberContext } from "@google-labs/breadboard";
+import type { Expand, MaybePromise } from "../common/type-util.js";
+import type { JsonSerializable } from "../type-system/type.js";
+import type {
+  DynamicInputPortConfig,
+  DynamicOutputPortConfig,
+  InputPortConfig,
+  OutputPortConfig,
+} from "./config.js";
+import type {
+  DynamicInputPorts,
+  DynamicInvokeParams,
+  StaticInvokeParams,
+} from "./define.js";
+
+export type LooseDescribeFn = (
+  staticParams: Record<string, JsonSerializable>,
+  dynamicParams: Record<string, JsonSerializable>,
+  context?: NodeDescriberContext
+) => MaybePromise<{
+  inputs?: DynamicInputPorts;
+  outputs?: DynamicInputPorts;
+}>;
+
+export type StrictDescribeFn<
+  I extends Record<string, InputPortConfig>,
+  O extends Record<string, OutputPortConfig>,
+> = I["*"] extends DynamicInputPortConfig
+  ? O["*"] extends DynamicOutputPortConfig
+    ? O["*"]["reflective"] extends true
+      ? {
+          // poly/poly reflective
+          describe?: (
+            staticInputs: Expand<StaticInvokeParams<I>>,
+            dynamicInputs: Expand<DynamicInvokeParams<I>>,
+            context?: NodeDescriberContext
+          ) => MaybePromise<{
+            inputs: DynamicInputPorts;
+            outputs?: never;
+          }>;
+        }
+      : {
+          // poly/poly non-reflective
+          describe: (
+            staticInputs: Expand<StaticInvokeParams<I>>,
+            dynamicInputs: Expand<DynamicInvokeParams<I>>,
+            context?: NodeDescriberContext
+          ) => MaybePromise<{
+            inputs?: DynamicInputPorts;
+            outputs: DynamicInputPorts;
+          }>;
+        }
+    : {
+        // poly/mono
+        describe?: (
+          staticInputs: Expand<StaticInvokeParams<I>>,
+          dynamicInputs: Expand<DynamicInvokeParams<I>>,
+          context?: NodeDescriberContext
+        ) => MaybePromise<{
+          inputs: DynamicInputPorts;
+          outputs?: never;
+        }>;
+      }
+  : O["*"] extends DynamicOutputPortConfig
+    ? {
+        // mono/poly
+        describe: (
+          staticInputs: Expand<StaticInvokeParams<I>>,
+          dynamicInputs: Expand<DynamicInvokeParams<I>>,
+          context?: NodeDescriberContext
+        ) => MaybePromise<{
+          inputs?: never;
+          outputs: DynamicInputPorts;
+        }>;
+      }
+    : {
+        // mono/mono
+        describe?: never;
+      };

--- a/packages/build/src/test/define_test.ts
+++ b/packages/build/src/test/define_test.ts
@@ -145,7 +145,7 @@ test("poly/mono", async () => {
       so1: { type: "boolean" },
     },
     describe: (
-      // $ExpectType { si1: string; }
+      // $ExpectType { si1: string | undefined; }
       staticInputs,
       // $ExpectType { [x: string]: number; }
       dynamicInputs
@@ -291,7 +291,7 @@ test("mono/poly", async () => {
       "*": { type: "number" },
     },
     describe: (
-      // $ExpectType { si1: string; }
+      // $ExpectType { si1: string | undefined; }
       staticInputs,
       // $ExpectType {}
       dynamicInputs
@@ -393,7 +393,7 @@ test("poly/poly", async () => {
       "*": { type: "number" },
     },
     describe: (
-      // $ExpectType { si1: string; }
+      // $ExpectType { si1: string | undefined; }
       staticInputs,
       // $ExpectType { [x: string]: number; }
       dynamicInputs

--- a/packages/build/src/test/describe_test.ts
+++ b/packages/build/src/test/describe_test.ts
@@ -426,6 +426,93 @@ test("describe receives context", async () => {
   assert.deepEqual(actual, expected);
 });
 
+test("describe receives defaults with undefined values", async () => {
+  let describeRan = false;
+  defineNodeType({
+    name: "foo",
+    inputs: {
+      withDefault: { type: "string", default: "DEFAULT1" },
+      withoutDefault: { type: "string" },
+      "*": { type: "string" },
+    },
+    outputs: {},
+    describe: ({ withDefault, withoutDefault }) => {
+      assert.equal(
+        // $ExpectType string
+        withDefault,
+        "DEFAULT1"
+      );
+      assert.equal(
+        // $ExpectType string | undefined
+        withoutDefault,
+        undefined
+      );
+      describeRan = true;
+      return {
+        inputs: [],
+      };
+    },
+    invoke: () => ({}),
+  }).describe(undefined, {}, null as never);
+  assert.equal(describeRan, true);
+});
+
+test("describe receives defaults with overrides", async () => {
+  let describeRan = false;
+  defineNodeType({
+    name: "foo",
+    inputs: {
+      withDefault: { type: "string", default: "DEFAULT1" },
+      withDefaultOverride: { type: "string", default: "DEFAULT2" },
+      withoutDefault: { type: "string" },
+      withoutDefaultOverride: { type: "string" },
+      "*": { type: "string" },
+    },
+    outputs: {},
+    describe: ({
+      withDefault,
+      withDefaultOverride,
+      withoutDefault,
+      withoutDefaultOverride,
+    }) => {
+      assert.equal(
+        // $ExpectType string
+        withDefault,
+        "DEFAULT1"
+      );
+      assert.equal(
+        // $ExpectType string
+        withDefaultOverride,
+        "OVERRIDE1"
+      );
+      assert.equal(
+        // $ExpectType string | undefined
+        withoutDefault,
+        undefined
+      );
+      assert.equal(
+        // $ExpectType string | undefined
+        withoutDefaultOverride,
+        "OVERRIDE2"
+      );
+      describeRan = true;
+      return {
+        inputs: [],
+      };
+    },
+    invoke: () => ({}),
+  }).describe(
+    {
+      withDefaultOverride: "OVERRIDE1",
+      withoutDefaultOverride: "OVERRIDE2",
+    },
+    {},
+    {},
+    null as never
+  );
+  assert.equal(describeRan, true);
+});
+
 test("unsafeSchema can be used to force a raw JSON schema", async () => {
   assert.deepEqual(
     await defineNodeType({

--- a/packages/core-kit/src/nodes/secrets.ts
+++ b/packages/core-kit/src/nodes/secrets.ts
@@ -88,7 +88,7 @@ const secrets = defineNodeType({
     },
   },
   describe: (inputs) => ({
-    outputs: inputs.keys,
+    outputs: inputs.keys ?? [],
   }),
   invoke: (inputs) =>
     Object.fromEntries(

--- a/packages/core-kit/tests/secrets.ts
+++ b/packages/core-kit/tests/secrets.ts
@@ -30,7 +30,7 @@ test("describer correctly responds to no inputs", async (t) => {
       type: "object",
       properties: {},
       required: [],
-      additionalProperties: { type: "string" },
+      additionalProperties: false,
     },
   });
 });
@@ -63,32 +63,6 @@ test("describer correctly responds to inputs", async (t) => {
       },
       required: [],
       additionalProperties: false,
-    },
-  });
-});
-
-test("describer correctly responds to unknown inputs", async (t) => {
-  t.deepEqual(await secrets.describe(), {
-    inputSchema: {
-      type: "object",
-      properties: {
-        keys: {
-          title: "secrets",
-          description: "The array of secrets to retrieve from the node.",
-          type: "array",
-          items: {
-            type: "string",
-          },
-        },
-      },
-      required: ["keys"],
-      additionalProperties: false,
-    },
-    outputSchema: {
-      type: "object",
-      properties: {},
-      required: [],
-      additionalProperties: { type: "string" },
     },
   });
 });


### PR DESCRIPTION
Defaults are now always passed into the describe function, and types will be optional or not based on whether there is a default (default means it can never be undefined).

Also factors out a `describe.ts` file for better readability.