### PR TITLE
[build] Pass inputSchema and outputSchema to describe functions

### DIFF
--- a/packages/build/src/internal/define/define.ts
+++ b/packages/build/src/internal/define/define.ts
@@ -359,7 +359,7 @@ type Convert<C extends PortConfig> = ConvertBreadboardType<C["type"]>;
 
 type VeryLooseDescribeFn = Function;
 
-export type DynamicInputPorts =
+export type CustomDescribePortManifest =
   | string[]
   | {
       [K: string]:

--- a/packages/build/src/internal/define/definition.ts
+++ b/packages/build/src/internal/define/definition.ts
@@ -33,7 +33,10 @@ import type {
 } from "./define.js";
 import type { LooseDescribeFn } from "./describe.js";
 import { Instance } from "./instance.js";
-import { portConfigMapToJSONSchema } from "./json-schema.js";
+import {
+  jsonSchemaToPortConfigMap,
+  portConfigMapToJSONSchema,
+} from "./json-schema.js";
 import {
   isUnsafeSchema,
   unsafeSchemaAccessor,
@@ -183,7 +186,7 @@ export class DefinitionImpl<
   async describe(
     values?: InputValues,
     inboundEdges?: Schema,
-    _outboundEdges?: Schema,
+    outboundEdges?: Schema,
     context?: NodeDescriberContext
   ): Promise<NodeDescriberResult> {
     let user:
@@ -197,8 +200,12 @@ export class DefinitionImpl<
         this.#applyDefaultsAndPartitionRuntimeInputValues(values ?? {});
       user = await this.#describe(staticValues, dynamicValues, {
         ...(context ?? { outerGraph: { nodes: [], edges: [] } }),
-        inputSchema: {},
-        outputSchema: {},
+        inputSchema: jsonSchemaToPortConfigMap(
+          (inboundEdges as JSONSchema4) ?? {}
+        ),
+        outputSchema: jsonSchemaToPortConfigMap(
+          (outboundEdges as JSONSchema4) ?? {}
+        ),
       });
     }
 

--- a/packages/build/src/internal/define/definition.ts
+++ b/packages/build/src/internal/define/definition.ts
@@ -195,7 +195,11 @@ export class DefinitionImpl<
     if (this.#describe !== undefined) {
       const { staticValues, dynamicValues } =
         this.#applyDefaultsAndPartitionRuntimeInputValues(values ?? {});
-      user = await this.#describe(staticValues, dynamicValues, context);
+      user = await this.#describe(staticValues, dynamicValues, {
+        ...(context ?? { outerGraph: { nodes: [], edges: [] } }),
+        inputSchema: {},
+        outputSchema: {},
+      });
     }
 
     let inputSchema: JSONSchema4 & {

--- a/packages/build/src/internal/define/definition.ts
+++ b/packages/build/src/internal/define/definition.ts
@@ -27,7 +27,10 @@ import type {
   StaticInputPortConfig,
   StaticOutputPortConfig,
 } from "./config.js";
-import type { DynamicInputPorts, VeryLooseInvokeFn } from "./define.js";
+import type {
+  CustomDescribePortManifest,
+  VeryLooseInvokeFn,
+} from "./define.js";
 import type { LooseDescribeFn } from "./describe.js";
 import { Instance } from "./instance.js";
 import { portConfigMapToJSONSchema } from "./json-schema.js";
@@ -184,7 +187,10 @@ export class DefinitionImpl<
     context?: NodeDescriberContext
   ): Promise<NodeDescriberResult> {
     let user:
-      | { inputs?: DynamicInputPorts; outputs?: DynamicInputPorts }
+      | {
+          inputs?: CustomDescribePortManifest;
+          outputs?: CustomDescribePortManifest;
+        }
       | undefined = undefined;
     if (this.#describe !== undefined) {
       const { staticValues, dynamicValues } =
@@ -329,7 +335,7 @@ export class DefinitionImpl<
 }
 
 function parseDynamicPorts(
-  ports: Exclude<DynamicInputPorts, UnsafeSchema>,
+  ports: Exclude<CustomDescribePortManifest, UnsafeSchema>,
   base: DynamicInputPortConfig | DynamicOutputPortConfig
 ): {
   newStatic: Record<string, StaticInputPortConfig | StaticOutputPortConfig>;
@@ -341,7 +347,7 @@ function parseDynamicPorts(
   const newStatic = Object.fromEntries(
     Object.entries(ports)
       .filter(
-        /** See {@link DynamicInputPorts} for why undefined is possible here. */
+        /** See {@link CustomDescribePortManifest} for why undefined is possible here. */
         ([name, config]) => config !== undefined && name !== "*"
       )
       .map(([name, config]) => [name, { ...base, ...config }])

--- a/packages/build/src/internal/define/describe.ts
+++ b/packages/build/src/internal/define/describe.ts
@@ -38,7 +38,7 @@ export interface NodeDescriberContextWithSchemas extends NodeDescriberContext {
 export type LooseDescribeFn = (
   staticParams: Record<string, JsonSerializable>,
   dynamicParams: Record<string, JsonSerializable>,
-  context?: NodeDescriberContext
+  context?: NodeDescriberContextWithSchemas
 ) => MaybePromise<{
   inputs?: CustomDescribePortManifest;
   outputs?: CustomDescribePortManifest;
@@ -65,7 +65,7 @@ export type StrictDescribeFn<
           describe?: (
             staticInputs: Expand<StaticDescribeValues<I>>,
             dynamicInputs: Expand<DynamicInvokeParams<I>>,
-            context?: NodeDescriberContext
+            context?: NodeDescriberContextWithSchemas
           ) => MaybePromise<{
             inputs: CustomDescribePortManifest;
             outputs?: never;
@@ -76,7 +76,7 @@ export type StrictDescribeFn<
           describe: (
             staticInputs: Expand<StaticDescribeValues<I>>,
             dynamicInputs: Expand<DynamicInvokeParams<I>>,
-            context?: NodeDescriberContext
+            context?: NodeDescriberContextWithSchemas
           ) => MaybePromise<{
             inputs?: CustomDescribePortManifest;
             outputs: CustomDescribePortManifest;
@@ -87,7 +87,7 @@ export type StrictDescribeFn<
         describe?: (
           staticInputs: Expand<StaticDescribeValues<I>>,
           dynamicInputs: Expand<DynamicInvokeParams<I>>,
-          context?: NodeDescriberContext
+          context?: NodeDescriberContextWithSchemas
         ) => MaybePromise<{
           inputs: CustomDescribePortManifest;
           outputs?: never;
@@ -99,7 +99,7 @@ export type StrictDescribeFn<
         describe: (
           staticInputs: Expand<StaticDescribeValues<I>>,
           dynamicInputs: Expand<DynamicInvokeParams<I>>,
-          context?: NodeDescriberContext
+          context?: NodeDescriberContextWithSchemas
         ) => MaybePromise<{
           inputs?: never;
           outputs: CustomDescribePortManifest;

--- a/packages/build/src/internal/define/describe.ts
+++ b/packages/build/src/internal/define/describe.ts
@@ -17,11 +17,23 @@ import type {
   OutputPortConfig,
   PortConfig,
   StaticInputPortConfig,
+  StaticOutputPortConfig,
 } from "./config.js";
 import type {
   CustomDescribePortManifest,
   DynamicInvokeParams,
 } from "./define.js";
+
+/**
+ * The same as {@link NodeDescriberContext} but with `inputSchema ` and
+ * `outputSchema` added in, to simplify the signature of `describe`.
+ *
+ * TODO(aomarks) Roll this into {@link NodeDescriberContext}.
+ */
+export interface NodeDescriberContextWithSchemas extends NodeDescriberContext {
+  inputSchema: { [k: string]: StaticInputPortConfig };
+  outputSchema: { [k: string]: StaticOutputPortConfig };
+}
 
 export type LooseDescribeFn = (
   staticParams: Record<string, JsonSerializable>,

--- a/packages/build/src/internal/define/describe.ts
+++ b/packages/build/src/internal/define/describe.ts
@@ -18,15 +18,18 @@ import type {
   PortConfig,
   StaticInputPortConfig,
 } from "./config.js";
-import type { DynamicInputPorts, DynamicInvokeParams } from "./define.js";
+import type {
+  CustomDescribePortManifest,
+  DynamicInvokeParams,
+} from "./define.js";
 
 export type LooseDescribeFn = (
   staticParams: Record<string, JsonSerializable>,
   dynamicParams: Record<string, JsonSerializable>,
   context?: NodeDescriberContext
 ) => MaybePromise<{
-  inputs?: DynamicInputPorts;
-  outputs?: DynamicInputPorts;
+  inputs?: CustomDescribePortManifest;
+  outputs?: CustomDescribePortManifest;
 }>;
 
 export type StaticDescribeValues<I extends Record<string, InputPortConfig>> = {
@@ -52,7 +55,7 @@ export type StrictDescribeFn<
             dynamicInputs: Expand<DynamicInvokeParams<I>>,
             context?: NodeDescriberContext
           ) => MaybePromise<{
-            inputs: DynamicInputPorts;
+            inputs: CustomDescribePortManifest;
             outputs?: never;
           }>;
         }
@@ -63,8 +66,8 @@ export type StrictDescribeFn<
             dynamicInputs: Expand<DynamicInvokeParams<I>>,
             context?: NodeDescriberContext
           ) => MaybePromise<{
-            inputs?: DynamicInputPorts;
-            outputs: DynamicInputPorts;
+            inputs?: CustomDescribePortManifest;
+            outputs: CustomDescribePortManifest;
           }>;
         }
     : {
@@ -74,7 +77,7 @@ export type StrictDescribeFn<
           dynamicInputs: Expand<DynamicInvokeParams<I>>,
           context?: NodeDescriberContext
         ) => MaybePromise<{
-          inputs: DynamicInputPorts;
+          inputs: CustomDescribePortManifest;
           outputs?: never;
         }>;
       }
@@ -87,7 +90,7 @@ export type StrictDescribeFn<
           context?: NodeDescriberContext
         ) => MaybePromise<{
           inputs?: never;
-          outputs: DynamicInputPorts;
+          outputs: CustomDescribePortManifest;
         }>;
       }
     : {

--- a/packages/build/src/internal/define/json-schema.ts
+++ b/packages/build/src/internal/define/json-schema.ts
@@ -55,3 +55,7 @@ export function portConfigMapToJSONSchema(
       .map(([name]) => name),
   };
 }
+
+export function jsonSchemaToPortConfigMap(_schema: JSONSchema4): PortConfigMap {
+  return {};
+}

--- a/packages/build/src/internal/define/json-schema.ts
+++ b/packages/build/src/internal/define/json-schema.ts
@@ -7,7 +7,8 @@
 import type { JSONSchema4 } from "json-schema";
 import type { PortConfigMap } from "../common/port.js";
 import { toJSONSchema } from "../type-system/type.js";
-import type { StaticInputPortConfig } from "./config.js";
+import type { PortConfig, StaticInputPortConfig } from "./config.js";
+import { unsafeType } from "../type-system/unsafe.js";
 
 export function portConfigMapToJSONSchema(
   config: PortConfigMap,
@@ -56,6 +57,16 @@ export function portConfigMapToJSONSchema(
   };
 }
 
-export function jsonSchemaToPortConfigMap(_schema: JSONSchema4): PortConfigMap {
-  return {};
+export function jsonSchemaToPortConfigMap(
+  ioSchema: JSONSchema4
+): PortConfigMap {
+  return Object.fromEntries(
+    Object.entries(ioSchema.properties ?? {}).map(([portName, portSchema]) => [
+      portName,
+      {
+        ...portSchema,
+        type: unsafeType(portSchema),
+      } as PortConfig,
+    ])
+  );
 }

--- a/packages/build/src/internal/define/json-schema.ts
+++ b/packages/build/src/internal/define/json-schema.ts
@@ -27,11 +27,13 @@ export function portConfigMapToJSONSchema(
     properties: Object.fromEntries(
       sortedPropertyEntries.map(
         ([name, { title, description, type, behavior, ...config }]) => {
-          const schema: JSONSchema4 = { title: title ?? name };
+          const schema: JSONSchema4 = {
+            ...toJSONSchema(type),
+            title: title ?? name,
+          };
           if (description) {
             schema.description = description;
           }
-          Object.assign(schema, toJSONSchema(type));
           const defaultValue = (config as StaticInputPortConfig).default;
           if (defaultValue !== undefined) {
             schema.default = defaultValue;

--- a/packages/build/src/test/describe_test.ts
+++ b/packages/build/src/test/describe_test.ts
@@ -402,6 +402,38 @@ test("async describe", async () => {
 });
 
 test("describe receives context", async () => {
+  const input: NodeDescriberContext = {
+    base: new URL("http://example.com/"),
+    outerGraph: { nodes: [], edges: [] },
+  };
+  const expected: NodeDescriberContextWithSchemas = {
+    base: new URL("http://example.com/"),
+    outerGraph: { nodes: [], edges: [] },
+    inputSchema: {},
+    outputSchema: {},
+  };
+  let actual: NodeDescriberContext | undefined;
+  defineNodeType({
+    name: "foo",
+    inputs: {
+      "*": { type: "number" },
+    },
+    outputs: {
+      "*": { type: "number" },
+    },
+    describe: (_staticInputs, _dynamicInputs, context) => {
+      actual = context;
+      return {
+        inputs: [],
+        outputs: [],
+      };
+    },
+    invoke: () => ({}),
+  }).describe({}, {}, {}, input);
+  assert.deepEqual(actual, expected);
+});
+
+test("describe receives converted inputSchema and outputSchema and can return it", async () => {
   let actualContext: NodeDescriberContextWithSchemas | undefined;
   const testDefinition = defineNodeType({
     name: "foo",

--- a/packages/build/src/test/describe_test.ts
+++ b/packages/build/src/test/describe_test.ts
@@ -5,7 +5,7 @@
  */
 
 import { array, defineNodeType, unsafeSchema } from "@breadboard-ai/build";
-import type { NodeDescriberContext } from "@google-labs/breadboard";
+import type { NodeDescriberContext, Schema } from "@google-labs/breadboard";
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import type { NodeDescriberContextWithSchemas } from "../internal/define/describe.js";
@@ -402,68 +402,6 @@ test("async describe", async () => {
 });
 
 test("describe receives context", async () => {
-  const testContext: NodeDescriberContext = {
-    base: new URL("http://example.com/"),
-    outerGraph: { nodes: [], edges: [] },
-  };
-
-  const testInputSchema = {
-    type: "object",
-    properties: {
-      foo: { type: "string", default: "foo", weirdThing: 123 },
-    },
-  };
-  const testOutputSchema = {
-    type: "object",
-    properties: {
-      bar: { type: "number", anotherWeirdThing: 456 },
-    },
-  };
-
-  const expectedContext: NodeDescriberContextWithSchemas = {
-    base: new URL("http://example.com/"),
-    outerGraph: { nodes: [], edges: [] },
-    inputSchema: {
-      foo: {
-        type: {
-          jsonSchema: {
-            type: "string",
-            default: "foo",
-            weirdThing: 123,
-          },
-        },
-        default: "foo",
-        ["weirdThing" as never]: 123,
-      },
-    },
-    outputSchema: {
-      bar: {
-        type: {
-          jsonSchema: {
-            type: "number",
-            anotherWeirdThing: 456,
-          },
-        },
-        ["anotherWeirdThing" as never]: 456,
-      },
-    },
-  };
-
-  const expectedDescription = {
-    inputSchema: {
-      additionalProperties: false,
-      properties: {},
-      required: [],
-      type: "object",
-    },
-    outputSchema: {
-      additionalProperties: false,
-      properties: {},
-      required: [],
-      type: "object",
-    },
-  };
-
   let actualContext: NodeDescriberContextWithSchemas | undefined;
   const testDefinition = defineNodeType({
     name: "foo",
@@ -476,12 +414,122 @@ test("describe receives context", async () => {
     describe: (_staticInputs, _dynamicInputs, context) => {
       actualContext = context;
       return {
-        inputs: {},
-        outputs: {},
+        // Solidfy that the actual input/output ports are valid by returning
+        // them here so they show up in the description
+        inputs: {
+          ...context?.inputSchema,
+          // Also continue to allow additional ports.
+          "*": {},
+        },
+        outputs: {
+          ...context?.outputSchema,
+          // Stop allowing additional ports (no "*").
+          // But do add some specific other property for some reason.
+          new: {
+            type: array("boolean"),
+          },
+        },
       };
     },
     invoke: () => ({}),
   });
+
+  const testContext: NodeDescriberContext = {
+    base: new URL("http://example.com/"),
+    outerGraph: { nodes: [], edges: [] },
+  };
+
+  const testInputSchema: Schema = {
+    type: "object",
+    properties: {
+      foo: {
+        type: "string",
+        default: "foo",
+        format: "javascript",
+        behavior: ["bubble"],
+        ["weirdThing" as never]: 123,
+      },
+    },
+  };
+  const testOutputSchema: Schema = {
+    type: "object",
+    properties: {
+      bar: {
+        type: "number",
+        ["anotherWeirdThing" as never]: 456,
+      },
+    },
+  };
+
+  const expectedContext: NodeDescriberContextWithSchemas = {
+    base: new URL("http://example.com/"),
+    outerGraph: { nodes: [], edges: [] },
+    inputSchema: {
+      foo: {
+        type: {
+          jsonSchema: {
+            behavior: ["bubble"],
+            default: "foo",
+            format: "javascript",
+            type: "string",
+            weirdThing: 123,
+          },
+        },
+        default: "foo",
+        format: "javascript",
+        behavior: ["bubble"],
+      },
+    },
+    outputSchema: {
+      bar: {
+        type: {
+          jsonSchema: {
+            anotherWeirdThing: 456,
+            type: "number",
+          },
+        },
+      },
+    },
+  };
+
+  const expectedDescription = {
+    inputSchema: {
+      type: "object",
+      properties: {
+        foo: {
+          title: "foo",
+          type: "string",
+          default: "foo",
+          behavior: ["bubble"],
+          format: "javascript",
+          weirdThing: 123,
+        },
+      },
+      required: [],
+      additionalProperties: {
+        type: "number",
+      },
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        bar: {
+          title: "bar",
+          type: "number",
+          anotherWeirdThing: 456,
+        },
+        new: {
+          title: "new",
+          type: "array",
+          items: {
+            type: "boolean",
+          },
+        },
+      },
+      required: [],
+      additionalProperties: false,
+    },
+  };
 
   const actualDescription = await testDefinition.describe(
     {},

--- a/packages/build/src/test/describe_test.ts
+++ b/packages/build/src/test/describe_test.ts
@@ -8,6 +8,7 @@ import { array, defineNodeType, unsafeSchema } from "@breadboard-ai/build";
 import type { NodeDescriberContext } from "@google-labs/breadboard";
 import assert from "node:assert/strict";
 import { test } from "node:test";
+import type { NodeDescriberContextWithSchemas } from "../internal/define/describe.js";
 
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
@@ -401,11 +402,17 @@ test("async describe", async () => {
 });
 
 test("describe receives context", async () => {
-  const expected: NodeDescriberContext = {
+  const input: NodeDescriberContext = {
     base: new URL("http://example.com/"),
     outerGraph: { nodes: [], edges: [] },
   };
-  let actual: NodeDescriberContext | undefined;
+  const expected: NodeDescriberContextWithSchemas = {
+    base: new URL("http://example.com/"),
+    outerGraph: { nodes: [], edges: [] },
+    inputSchema: {},
+    outputSchema: {},
+  };
+  let actual: NodeDescriberContextWithSchemas | undefined;
   defineNodeType({
     name: "foo",
     inputs: {
@@ -422,7 +429,7 @@ test("describe receives context", async () => {
       };
     },
     invoke: () => ({}),
-  }).describe({}, {}, {}, expected);
+  }).describe({}, {}, {}, input);
   assert.deepEqual(actual, expected);
 });
 

--- a/packages/build/src/test/describe_test.ts
+++ b/packages/build/src/test/describe_test.ts
@@ -402,9 +402,21 @@ test("async describe", async () => {
 });
 
 test("describe receives context", async () => {
-  const input: NodeDescriberContext = {
+  const testContext: NodeDescriberContext = {
     base: new URL("http://example.com/"),
     outerGraph: { nodes: [], edges: [] },
+  };
+  const testInputSchema = {
+    type: "object",
+    properties: {
+      foo: { type: "string", default: "foo" },
+    },
+  };
+  const testOutputSchema = {
+    type: "object",
+    properties: {
+      bar: { type: "number" },
+    },
   };
   const expected: NodeDescriberContextWithSchemas = {
     base: new URL("http://example.com/"),
@@ -429,7 +441,7 @@ test("describe receives context", async () => {
       };
     },
     invoke: () => ({}),
-  }).describe({}, {}, {}, input);
+  }).describe({}, testInputSchema, testOutputSchema, testContext);
   assert.deepEqual(actual, expected);
 });
 


### PR DESCRIPTION
`describe` functions are now passed `inputSchema` and `outputSchema`. Unlike the previous `describe` signature, though, now those two properties are part of the `context`. This just makes the signature easier a bit easier to read, instead of passing those properties as their own parameters.

The schemas are converted to `PortConfig` objects, which are very similar, but use Breadboard Type Expressions as the `type` field, instead of JSON. The original schema is bundled into a special `unsafeType` wrapper so that it's preserved exactly if the describe-author decides to return the incoming schema unchanged.