### PR TITLE
[build] Allow declaring objects with optional properties

### DIFF
--- a/.changeset/modern-mugs-think.md
+++ b/.changeset/modern-mugs-think.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Allow declaring objects with optional properties

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -27,7 +27,7 @@ export { unsafeSchema } from "./internal/define/unsafe-schema.js";
 export { anyOf } from "./internal/type-system/any-of.js";
 export { array } from "./internal/type-system/array.js";
 export { enumeration } from "./internal/type-system/enumeration.js";
-export { object } from "./internal/type-system/object.js";
+export { object, optional } from "./internal/type-system/object.js";
 export { unsafeType } from "./internal/type-system/unsafe.js";
 
 /**

--- a/packages/build/src/test/type_test.ts
+++ b/packages/build/src/test/type_test.ts
@@ -4,7 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { anyOf, array, object, unsafeType } from "@breadboard-ai/build";
+import {
+  anyOf,
+  array,
+  object,
+  optional,
+  unsafeType,
+} from "@breadboard-ai/build";
 
 import {
   toJSONSchema,
@@ -255,6 +261,24 @@ describe("object", () => {
       properties: {},
       required: [],
       additionalProperties: true,
+    });
+  });
+
+  test("object with optional property", () => {
+    const obj = object({
+      req: "number",
+      opt: optional("number"),
+    });
+    // $ExpectType { req: number; opt?: number | undefined; }
+    type objType = ConvertBreadboardType<typeof obj>;
+    assert.deepEqual(toJSONSchema(obj), {
+      type: "object",
+      properties: {
+        opt: { type: "number" },
+        req: { type: "number" },
+      },
+      required: ["req"],
+      additionalProperties: false,
     });
   });
 


### PR DESCRIPTION
Example, the TypeScript:

```ts
import {object, optional} from "@breadboard-ai/build";

const obj = object({
  req: "number",
  opt: optional("number"),
});
```

... creates the TypeScript type:

```ts
{ req: number; opt?: number | undefined; }
```

... and the JSON Schema:

```json
{
  "type": "object",
  "properties": {
    "opt": { "type": "number" },
    "req": { "type": "number" }
  },
  "required": ["req"],
  "additionalProperties": false
}
```