### PR TITLE
[core-kit] Convert passthrough to new API

### DIFF
--- a/.changeset/polite-masks-fly.md
+++ b/.changeset/polite-masks-fly.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/core-kit": minor
+---
+
+Convert passthrough to new API. The output schema of passthrough is now taken from the connected inputSchema instead of just using the values. This preserves more information about the ports that are being passed-through.

--- a/packages/core-kit/src/nodes/passthrough.ts
+++ b/packages/core-kit/src/nodes/passthrough.ts
@@ -4,38 +4,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {
-  InputValues,
-  NodeHandlerObject,
-  OutputValues,
-} from "@google-labs/breadboard";
-import { SchemaBuilder } from "@google-labs/breadboard/kits";
+import { defineNodeType } from "@breadboard-ai/build";
 
-export default {
+export default defineNodeType({
+  name: "passthrough",
   metadata: {
     title: "Passthrough",
     description:
       "Takes all inputs and passes them through as outputs. Effectively, a no-op node in Breadboard.",
   },
-  describe: async (inputs?: InputValues) => {
-    if (!inputs) {
-      return {
-        inputSchema: SchemaBuilder.empty(true),
-        outputSchema: SchemaBuilder.empty(true),
-      };
-    }
-    return {
-      inputSchema: new SchemaBuilder()
-        .addInputs(inputs)
-        .setAdditionalProperties(true)
-        .build(),
-      outputSchema: new SchemaBuilder()
-        .addInputs(inputs)
-        .setAdditionalProperties(true)
-        .build(),
-    };
+  inputs: {
+    "*": {
+      type: "unknown",
+    },
   },
-  invoke: async (inputs: InputValues): Promise<OutputValues> => {
-    return inputs;
+  outputs: {
+    "*": {
+      type: "unknown",
+      reflective: true,
+    },
   },
-} satisfies NodeHandlerObject;
+  invoke: (_, inputs) => inputs,
+});

--- a/packages/core-kit/tests/passthrough.ts
+++ b/packages/core-kit/tests/passthrough.ts
@@ -6,7 +6,6 @@
 
 import test from "ava";
 
-import type { NodeHandlerObject } from "@google-labs/breadboard";
 import passthrough from "../src/nodes/passthrough.js";
 
 test("pass through all values", async (t) => {
@@ -15,7 +14,7 @@ test("pass through all values", async (t) => {
     num: 123,
     arr: [{ bool: true }],
   };
-  const actual = await passthrough.invoke(inputs);
+  const actual = await passthrough.invoke(inputs, null as never);
   const expected = inputs;
   t.deepEqual(actual, expected);
 });
@@ -26,17 +25,21 @@ test("describe with no parameters returns empty schemas", async (t) => {
     inputSchema: {
       type: "object",
       properties: {},
+      required: [],
+      additionalProperties: true,
     },
     outputSchema: {
       type: "object",
       properties: {},
+      required: [],
+      additionalProperties: false,
     },
   };
   t.deepEqual(actual, expected);
 });
 
 test("describe uses input values to generate output schema", async (t) => {
-  const actual = await (passthrough as NodeHandlerObject).describe?.(
+  const actual = await passthrough.describe(
     {
       str: "foo",
       num: 123,
@@ -63,18 +66,46 @@ test("describe uses input values to generate output schema", async (t) => {
     inputSchema: {
       type: "object",
       properties: {
-        str: { type: "string" },
-        num: { type: "number" },
-        arr: { type: "array" },
+        str: {
+          title: "str",
+          type: "string",
+        },
+        num: {
+          title: "num",
+          type: "number",
+        },
+        arr: {
+          title: "arr",
+          type: "array",
+          items: {
+            type: "boolean",
+          },
+        },
       },
+      required: [],
+      additionalProperties: true,
     },
     outputSchema: {
       type: "object",
       properties: {
-        str: { type: "string" },
-        num: { type: "number" },
-        arr: { type: "array" },
+        str: {
+          title: "str",
+          type: "string",
+        },
+        num: {
+          title: "num",
+          type: "number",
+        },
+        arr: {
+          title: "arr",
+          type: "array",
+          items: {
+            type: "boolean",
+          },
+        },
       },
+      required: [],
+      additionalProperties: false,
     },
   };
   t.deepEqual(actual, expected);


### PR DESCRIPTION
There is a change here, as shown by the tests, which I think is for the better. The output schema of `passthrough` is now taken from the connected `inputSchema` instead of just using the values. This preserves more information about the ports that are being passed-through.