### PR TITLE
[build] Support for $error

### DIFF
--- a/.changeset/lazy-birds-smile.md
+++ b/.changeset/lazy-birds-smile.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/json-kit": patch
+---
+
+Update jsonata node for new $error behavior

--- a/.changeset/small-news-report.md
+++ b/.changeset/small-news-report.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Node invoke functions can now return $error. All node instances now automatically have an outputs.$error. Throwing from an invoke function will now convert the exception to an $error result; the stack trace is logged to the server, but not shown to the end-user.

--- a/packages/build/src/internal/common/error.ts
+++ b/packages/build/src/internal/common/error.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { object } from "../type-system/object.js";
+import type { ConvertBreadboardType } from "../type-system/type.js";
+
+export const breadboardErrorType = object({ message: "string" });
+
+export type BreadboardError = ConvertBreadboardType<typeof breadboardErrorType>;
+
+export function normalizeBreadboardError(value: unknown): BreadboardError {
+  if (typeof value === "object" && value !== null && "message" in value) {
+    console.log("$error", value, 0);
+    return value as BreadboardError;
+  }
+  console.log("$error", value, 1);
+  return { message: typeof value === "string" ? value : JSON.stringify(value) };
+}

--- a/packages/build/src/internal/common/error.ts
+++ b/packages/build/src/internal/common/error.ts
@@ -12,10 +12,7 @@ export const breadboardErrorType = object({ message: "string" });
 export type BreadboardError = ConvertBreadboardType<typeof breadboardErrorType>;
 
 export function normalizeBreadboardError(value: unknown): BreadboardError {
-  if (typeof value === "object" && value !== null && "message" in value) {
-    console.log("$error", value, 0);
-    return value as BreadboardError;
-  }
-  console.log("$error", value, 1);
-  return { message: typeof value === "string" ? value : JSON.stringify(value) };
+  return typeof value === "object" && value !== null && "message" in value
+    ? (value as BreadboardError)
+    : { message: typeof value === "string" ? value : JSON.stringify(value) };
 }

--- a/packages/build/src/internal/define/define.ts
+++ b/packages/build/src/internal/define/define.ts
@@ -287,17 +287,26 @@ type StrictInvokeFnReturn<
   I extends Record<string, InputPortConfig>,
   O extends Record<string, OutputPortConfig>,
   F extends LooseInvokeFn<I>,
-> = {
-  [K in keyof Omit<O, "*">]: Convert<O[K]>;
-} & {
-  [K in keyof ReturnType<
-    F extends (...args: unknown[]) => unknown ? F : never
-  >]: K extends keyof O
-    ? Convert<O[K]>
-    : O["*"] extends DynamicOutputPortConfig
-      ? Convert<O["*"]>
-      : never;
-};
+> =
+  ReturnType<F extends (...args: unknown[]) => unknown ? F : never> extends {
+    $error: unknown;
+  }
+    ? {
+        [K in keyof ReturnType<
+          F extends (...args: unknown[]) => unknown ? F : never
+        >]: K extends "$error" ? string | { message: string } : never;
+      }
+    : {
+        [K in keyof Omit<O, "*">]: Convert<O[K]>;
+      } & {
+        [K in keyof ReturnType<
+          F extends (...args: unknown[]) => unknown ? F : never
+        >]: K extends keyof O
+          ? Convert<O[K]>
+          : O["*"] extends DynamicOutputPortConfig
+            ? Convert<O["*"]>
+            : never;
+      };
 
 export type StaticInvokeParams<I extends Record<string, InputPortConfig>> = {
   [K in keyof Omit<I, "*">]: I[K] extends StaticInputPortConfig

--- a/packages/build/src/internal/define/definition.ts
+++ b/packages/build/src/internal/define/definition.ts
@@ -49,6 +49,8 @@ import {
 import { unsafeType } from "../type-system/unsafe.js";
 import { array } from "../type-system/array.js";
 import { object } from "../type-system/object.js";
+import { normalizeBreadboardError } from "../common/error.js";
+import { normalize } from "path";
 
 export interface Definition<
   /* Static Inputs   */ SI extends { [K: string]: JsonSerializable },
@@ -148,13 +150,35 @@ export class DefinitionImpl<
     );
   }
 
-  invoke(
+  async invoke(
     values: InputValues,
     context: NodeHandlerContext
   ): Promise<OutputValues> {
     const { staticValues, dynamicValues } =
       this.#applyDefaultsAndPartitionRuntimeInputValues(values);
-    return Promise.resolve(this.#invoke(staticValues, dynamicValues, context));
+    let result;
+    try {
+      result = await this.#invoke(staticValues, dynamicValues, context);
+    } catch (e) {
+      console.error(
+        `
+A node's invoke function raised an exception. This indicates an internal error.
+Expected errors should always be returned as a value on the $error port.
+
+Node type: ${this.#name}
+
+Error: ${String(e instanceof Error ? e.stack : e).replace(/^Error:\s*/, "")}
+
+Values: ${JSON.stringify(values, null, 2)}`
+      );
+      return {
+        $error: { message: "Internal error (see server logs for details)" },
+      };
+    }
+    if (result.$error !== undefined) {
+      result.$error = normalizeBreadboardError(result.$error);
+    }
+    return result;
   }
 
   /**

--- a/packages/build/src/internal/define/definition.ts
+++ b/packages/build/src/internal/define/definition.ts
@@ -50,7 +50,6 @@ import { unsafeType } from "../type-system/unsafe.js";
 import { array } from "../type-system/array.js";
 import { object } from "../type-system/object.js";
 import { normalizeBreadboardError } from "../common/error.js";
-import { normalize } from "path";
 
 export interface Definition<
   /* Static Inputs   */ SI extends { [K: string]: JsonSerializable },

--- a/packages/build/src/test/define_test.ts
+++ b/packages/build/src/test/define_test.ts
@@ -13,6 +13,8 @@ import { defineNodeType } from "../internal/define/define.js";
 import { object } from "../internal/type-system/object.js";
 import { array } from "../internal/type-system/array.js";
 import { input } from "../internal/board/input.js";
+import type { OutputPort } from "../internal/common/port.js";
+import type { BreadboardError } from "../internal/common/error.js";
 
 test("mono/mono", async () => {
   const values = { si1: "foo", si2: 123 };
@@ -62,8 +64,11 @@ test("mono/mono", async () => {
   );
 
   assert.ok(
-    // $ExpectType { so1: OutputPort<boolean>; so2: OutputPort<null>; }
-    i.outputs
+    i.outputs satisfies {
+      so1: OutputPort<boolean>;
+      so2: OutputPort<null>;
+      $error: OutputPort<BreadboardError>;
+    }
   );
   assert.ok(
     // $ExpectType OutputPort<boolean>
@@ -190,8 +195,10 @@ test("poly/mono", async () => {
   );
 
   assert.ok(
-    // $ExpectType { so1: OutputPort<boolean>; }
-    i.outputs
+    i.outputs satisfies {
+      so1: OutputPort<boolean>;
+      $error: OutputPort<BreadboardError>;
+    }
   );
   assert.ok(
     // $ExpectType OutputPort<boolean>
@@ -326,8 +333,10 @@ test("mono/poly", async () => {
   );
 
   assert.ok(
-    // $ExpectType { so1: OutputPort<boolean>; }
-    i.outputs
+    i.outputs satisfies {
+      so1: OutputPort<boolean>;
+      $error: OutputPort<BreadboardError>;
+    }
   );
   assert.ok(
     // $ExpectType OutputPort<boolean>
@@ -438,8 +447,10 @@ test("poly/poly", async () => {
   );
 
   assert.ok(
-    // $ExpectType { so1: OutputPort<boolean>; }
-    i.outputs
+    i.outputs satisfies {
+      so1: OutputPort<boolean>;
+      $error: OutputPort<BreadboardError>;
+    }
   );
   assert.ok(
     // $ExpectType OutputPort<boolean>
@@ -611,8 +622,12 @@ test("reflective", async () => {
   );
 
   assert.ok(
-    // $ExpectType { so1: OutputPort<boolean>; di1: OutputPort<string>; di2: OutputPort<string>; }
-    i.outputs
+    i.outputs satisfies {
+      so1: OutputPort<boolean>;
+      di1: OutputPort<string>;
+      di2: OutputPort<string>;
+      $error: OutputPort<BreadboardError>;
+    }
   );
   assert.ok(
     // $ExpectType OutputPort<boolean>
@@ -728,8 +743,10 @@ test("primary input with no other inputs", () => {
   );
 
   assert.ok(
-    // $ExpectType { so1: OutputPort<boolean>; }
-    i.outputs
+    i.outputs satisfies {
+      so1: OutputPort<boolean>;
+      $error: OutputPort<BreadboardError>;
+    }
   );
   assert.ok(
     // $ExpectType OutputPort<boolean>
@@ -791,8 +808,10 @@ test("primary input with another input", () => {
   );
 
   assert.ok(
-    // $ExpectType { so1: OutputPort<boolean>; }
-    i.outputs
+    i.outputs satisfies {
+      so1: OutputPort<boolean>;
+      $error: OutputPort<BreadboardError>;
+    }
   );
   assert.ok(
     // $ExpectType OutputPort<boolean>
@@ -851,8 +870,10 @@ test("primary output with no other outputs", () => {
   );
 
   assert.ok(
-    // $ExpectType { so1: OutputPort<boolean>; }
-    i.outputs
+    i.outputs satisfies {
+      so1: OutputPort<boolean>;
+      $error: OutputPort<BreadboardError>;
+    }
   );
   assert.ok(
     // $ExpectType OutputPort<boolean>
@@ -912,8 +933,11 @@ test("primary output with other outputs", () => {
   );
 
   assert.ok(
-    // $ExpectType { so1: OutputPort<boolean>; so2: OutputPort<number>; }
-    i.outputs
+    i.outputs satisfies {
+      so1: OutputPort<boolean>;
+      so2: OutputPort<number>;
+      $error: OutputPort<BreadboardError>;
+    }
   );
   assert.ok(
     // $ExpectType OutputPort<boolean>
@@ -972,8 +996,10 @@ test("primary input + output", () => {
   );
 
   assert.ok(
-    // $ExpectType { so1: OutputPort<boolean>; }
-    i.outputs
+    i.outputs satisfies {
+      so1: OutputPort<boolean>;
+      $error: OutputPort<BreadboardError>;
+    }
   );
   assert.ok(
     // $ExpectType OutputPort<boolean>
@@ -2054,7 +2080,7 @@ test("$id should not show up as an instance input", () => {
   const i = d({ $id: "foo" });
   // $ExpectType {}
   i.inputs;
-  // $ExpectType {}
+  // $ExpectType { $error: OutputPort<{ message: string; }>; }
   i.outputs;
   assert.equal(
     // @ts-expect-error
@@ -2083,8 +2109,10 @@ test("$id should not show up as a reflective output", () => {
   const i = d({ $id: "foo", notId: "foo" });
   // $ExpectType { notId: InputPort<string>; }
   i.inputs;
-  // $ExpectType { notId: OutputPort<string>; }
-  i.outputs;
+  i.outputs satisfies {
+    notId: OutputPort<string>;
+    $error: OutputPort<BreadboardError>;
+  };
   assert.equal(
     // @ts-expect-error
     i.outputs.$id,

--- a/packages/build/src/test/error_test.ts
+++ b/packages/build/src/test/error_test.ts
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+
+import { defineNodeType } from "@breadboard-ai/build";
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+test("can return $error as {message}", async () => {
+  const def = defineNodeType({
+    name: "test",
+    inputs: {},
+    outputs: {},
+    invoke: () => ({ $error: { message: "oh no" } }),
+  });
+  assert.deepEqual(await def.invoke({}, null as never), {
+    $error: { message: "oh no" },
+  });
+});
+
+test("can return $error as string and it gets normalized", async () => {
+  const def = defineNodeType({
+    name: "test",
+    inputs: {},
+    outputs: {},
+    invoke: () => ({ $error: "oh no" }),
+  });
+  assert.deepEqual(await def.invoke({}, null as never), {
+    $error: { message: "oh no" },
+  });
+});
+
+test("throwing returns an $error without leaking internal stack", async () => {
+  const def = defineNodeType({
+    name: "test",
+    inputs: {},
+    outputs: {},
+    invoke: () => {
+      throw new Error("private internal details the user shouldn't see");
+    },
+  });
+  assert.deepEqual(await def.invoke({}, null as never), {
+    $error: { message: "Internal error (see server logs for details)" },
+  });
+});
+
+test("must include message in $error object", () => {
+  defineNodeType({
+    name: "test",
+    inputs: {},
+    outputs: {},
+    // @ts-expect-error
+    invoke: () => ({ $error: { notmessage: "oh no" } }),
+  });
+});
+
+test("can't return other properties when returning $error", () => {
+  defineNodeType({
+    name: "test",
+    inputs: {},
+    outputs: {
+      foo: { type: "number" },
+    },
+    // @ts-expect-error
+    invoke: () => ({
+      $error: "oh no",
+      foo: 123,
+    }),
+  });
+});
+
+test("nodes that return $error have an $error output", () => {
+  const def = defineNodeType({
+    name: "test",
+    inputs: {},
+    outputs: {},
+    invoke: () => ({ $error: "oh no" }),
+  });
+  const inst = def({});
+  assert.ok(
+    // $ExpectType OutputPort<{ message: string; }>
+    inst.outputs.$error
+  );
+});
+
+test("all nodes have an $error output even if they don't return $error", () => {
+  const def = defineNodeType({
+    name: "test",
+    inputs: {},
+    outputs: {},
+    invoke: () => ({}),
+  });
+  const inst = def({});
+  assert.ok(
+    // $ExpectType OutputPort<{ message: string; }>
+    inst.outputs.$error
+  );
+});

--- a/packages/json-kit/src/nodes/jsonata.ts
+++ b/packages/json-kit/src/nodes/jsonata.ts
@@ -64,7 +64,7 @@ export default defineNodeType({
     if (!expression) {
       // TODO(aomarks) We shouldn't need this if we ensure that invoke isn't
       // called unless all required properties are set.
-      throw new Error("Jsonata node requires `expression` input");
+      return { $error: "Jsonata node requires `expression` input" };
     }
     // TODO(aomarks) Error if both json and rest are set.
     const result: JsonSerializable = await jsonata(expression).evaluate(
@@ -72,9 +72,10 @@ export default defineNodeType({
     );
     if (raw) {
       if (typeof result !== "object" || result === null) {
-        throw new Error(
-          "jsonata node in raw mode but expression did not return an object"
-        );
+        return {
+          $error:
+            "jsonata node in raw mode but expression did not return an object",
+        };
       }
       return result;
     }

--- a/packages/json-kit/tests/jsonata.ts
+++ b/packages/json-kit/tests/jsonata.ts
@@ -191,17 +191,21 @@ describe("jsonata", () => {
   });
 
   test("invoke in raw mode and doesn't return object", async () => {
-    assert.rejects(
-      () =>
-        jsonata.invoke(
-          {
-            raw: true,
-            expression: "foo.bar",
-            json: { foo: { bar: "baz" } },
-          },
-          null as never
-        ),
-      /jsonata node in raw mode but expression did not return an object/
+    assert.deepEqual(
+      await jsonata.invoke(
+        {
+          raw: true,
+          expression: "foo.bar",
+          json: { foo: { bar: "baz" } },
+        },
+        null as never
+      ),
+      {
+        $error: {
+          message:
+            "jsonata node in raw mode but expression did not return an object",
+        },
+      }
     );
   });
 });


### PR DESCRIPTION
Node invoke functions can now return `{$error}`.

All node instances now automatically have an `outputs.$error`.

Throwing from an invoke function will now convert the exception to an `$error` result; the stack trace is logged to the server, but not shown to the end-user.