### PR TITLE
[build] Fix type behavior of annotate function

### DIFF
--- a/packages/build/src/internal/type-system/annotate.ts
+++ b/packages/build/src/internal/type-system/annotate.ts
@@ -11,7 +11,7 @@ import { toJSONSchema, type BreadboardType } from "./type.js";
  * Add Breadboard-specific annotations to a schema.
  */
 export function annotate<T extends BreadboardType>(
-  value: BreadboardType,
+  value: T,
   annotations: {
     behavior: BehaviorSchema[];
   }

--- a/packages/build/src/test/type_test.ts
+++ b/packages/build/src/test/type_test.ts
@@ -366,6 +366,7 @@ describe("array", () => {
 test("can annotate a nested object with a behavior", () => {
   assert.deepEqual(
     toJSONSchema(
+      // $ExpectType AdvancedBreadboardType<{ foo: number; }[]>
       array(
         annotate(object({ foo: "number" }), {
           behavior: ["llm-content"],
@@ -390,6 +391,7 @@ test("can annotate a nested object with a behavior", () => {
 test("can annotate basic type with behavior", () => {
   assert.deepEqual(
     toJSONSchema(
+      // $ExpectType "string"
       annotate("string", {
         behavior: ["llm-content"],
       })


### PR DESCRIPTION
Forgot to test that the types were preserved correctly in https://github.com/breadboard-ai/breadboard/pull/1703. They weren't!