### PR TITLE
[breadboard-ui] Use GPU for transforms

### DIFF
--- a/packages/breadboard-ui/src/elements/editor/graph-node.ts
+++ b/packages/breadboard-ui/src/elements/editor/graph-node.ts
@@ -82,7 +82,9 @@ export class GraphNode extends PIXI.Container {
   #iconSprite: PIXI.Sprite | null = null;
 
   constructor(id: string, type: string, title: string) {
-    super();
+    super({
+      isRenderGroup: true,
+    });
 
     this.title = title;
     this.id = id;

--- a/packages/breadboard-ui/src/elements/editor/graph-node.ts
+++ b/packages/breadboard-ui/src/elements/editor/graph-node.ts
@@ -89,6 +89,7 @@ export class GraphNode extends PIXI.Container {
     this.title = title;
     this.id = id;
     this.type = type;
+    this.isRenderGroup = true;
 
     switch (type) {
       case "input":

--- a/packages/breadboard-ui/src/elements/editor/graph-renderer.ts
+++ b/packages/breadboard-ui/src/elements/editor/graph-renderer.ts
@@ -36,7 +36,9 @@ export class GraphRenderer extends LitElement {
   #overflowMenuRef: Ref<HTMLDivElement> = createRef();
   #overflowMenuGraphNode: GraphNode | null = null;
   #padding = 50;
-  #container = new PIXI.Container();
+  #container = new PIXI.Container({
+    isRenderGroup: true,
+  });
   #background: PIXI.TilingSprite | null = null;
   #lastContentRect: DOMRectReadOnly | null = null;
   #resizeObserver = new ResizeObserver((entries) => {

--- a/packages/breadboard-ui/src/elements/editor/graph.ts
+++ b/packages/breadboard-ui/src/elements/editor/graph.ts
@@ -59,6 +59,7 @@ export class Graph extends PIXI.Container {
       isRenderGroup: true,
     });
 
+    this.isRenderGroup = true;
     this.eventMode = "static";
     this.sortableChildren = true;
 

--- a/packages/breadboard-ui/src/elements/editor/graph.ts
+++ b/packages/breadboard-ui/src/elements/editor/graph.ts
@@ -36,7 +36,9 @@ const highlightedNodeColor = getGlobalColor("--bb-output-600");
 
 export class Graph extends PIXI.Container {
   #isDirty = true;
-  #edgeContainer = new PIXI.Container();
+  #edgeContainer = new PIXI.Container({
+    isRenderGroup: true,
+  });
   #edgeGraphics = new Map<string, GraphEdge>();
   #edges: InspectableEdge[] | null = null;
   #nodes: InspectableNode[] | null = null;
@@ -53,7 +55,9 @@ export class Graph extends PIXI.Container {
   layoutRect: DOMRectReadOnly | null = null;
 
   constructor() {
-    super();
+    super({
+      isRenderGroup: true,
+    });
 
     this.eventMode = "static";
     this.sortableChildren = true;


### PR DESCRIPTION
Per https://pixijs.com/blog/pixi-v8-launches#-scene-upgrades we can use GPU for Container transforms... so why not?