### PR TITLE
[build] Add converge function for ports with multiple incoming edges

### DIFF
--- a/.changeset/old-birds-pay.md
+++ b/.changeset/old-birds-pay.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Add converge function which allows wiring multiple edges to the same input port

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { Convergence } from "./internal/board/converge.js";
 import type { Input, InputWithDefault } from "./internal/board/input.js";
 import type { Placeholder } from "./internal/board/placeholder.js";
 import type { OutputPortReference } from "./internal/common/port.js";
@@ -11,6 +12,7 @@ import type { JsonSerializable } from "./internal/type-system/type.js";
 
 export { board } from "./internal/board/board.js";
 export { constant } from "./internal/board/constant.js";
+export { converge } from "./internal/board/converge.js";
 export { input } from "./internal/board/input.js";
 export { output } from "./internal/board/output.js";
 export { placeholder } from "./internal/board/placeholder.js";
@@ -47,4 +49,5 @@ export type Value<T extends JsonSerializable> =
   | OutputPortReference<T>
   | Input<T>
   | InputWithDefault<T>
-  | Placeholder<T>;
+  | Placeholder<T>
+  | Convergence<T>;

--- a/packages/build/src/internal/board/converge.ts
+++ b/packages/build/src/internal/board/converge.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { OutputPortReference } from "../common/port.js";
+import type { BroadenBasicType } from "../common/type-util.js";
+import type { JsonSerializable } from "../type-system/type.js";
+import type { Input, InputWithDefault } from "./input.js";
+import type { Placeholder } from "./placeholder.js";
+
+type Convergable<T extends JsonSerializable> =
+  | OutputPortReference<T>
+  | Input<T>
+  | InputWithDefault<T>
+  | Placeholder<T>;
+
+export function converge<
+  A extends Convergable<JsonSerializable>,
+  B extends Convergable<JsonSerializable>,
+  C extends Array<Convergable<JsonSerializable>>,
+>(
+  first: A,
+  second: B,
+  ...rest: C
+): Convergence<ExtractType<A | B | C[number]>> {
+  return {
+    __isDistribute: true,
+    ports: [first, second, ...rest] as Array<
+      Convergable<ExtractType<A | B | C[number]>>
+    >,
+  };
+}
+type ExtractType<T extends Convergable<JsonSerializable>> =
+  T extends Convergable<infer X>
+    ? X extends string | number | boolean
+      ? BroadenBasicType<X>
+      : X
+    : never;
+
+export interface Convergence<T extends JsonSerializable> {
+  __isDistribute: true;
+  ports: Array<Convergable<T>>;
+}
+
+export function isConvergence(
+  value: unknown
+): value is Convergence<JsonSerializable> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as Partial<Convergence<JsonSerializable>>).__isDistribute === true
+  );
+}

--- a/packages/build/src/internal/common/serializable.ts
+++ b/packages/build/src/internal/common/serializable.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { Convergence } from "../board/converge.js";
 import type { GenericSpecialInput } from "../board/input.js";
 import type { Output } from "../board/output.js";
 import type { Placeholder } from "../board/placeholder.js";
@@ -37,6 +38,7 @@ export interface SerializableInputPort {
     | SerializableOutputPortReference
     | GenericSpecialInput
     | Placeholder<JsonSerializable>
+    | Convergence<JsonSerializable>
     | typeof DefaultValue;
 }
 

--- a/packages/build/src/internal/define/definition.ts
+++ b/packages/build/src/internal/define/definition.ts
@@ -50,6 +50,7 @@ import { unsafeType } from "../type-system/unsafe.js";
 import { array } from "../type-system/array.js";
 import { object } from "../type-system/object.js";
 import { normalizeBreadboardError } from "../common/error.js";
+import type { Convergence } from "../board/converge.js";
 
 export interface Definition<
   /* Static Inputs   */ SI extends { [K: string]: JsonSerializable },
@@ -467,7 +468,8 @@ type InstantiateArg<T extends JsonSerializable> =
   | OutputPortReference<T>
   | Input<T>
   | InputWithDefault<T>
-  | Placeholder<T>;
+  | Placeholder<T>
+  | Convergence<T>;
 
 function mergeStaticsAndUnsafeUserSchema(
   statics: JSONSchema4,

--- a/packages/build/src/test/converge_test.ts
+++ b/packages/build/src/test/converge_test.ts
@@ -1,0 +1,172 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { converge } from "../internal/board/converge.js";
+import { input } from "../internal/board/input.js";
+import { placeholder } from "../internal/board/placeholder.js";
+import { defineNodeType } from "../internal/define/define.js";
+import { serialize } from "../internal/board/serialize.js";
+import { board } from "../internal/board/board.js";
+import { array } from "../internal/type-system/array.js";
+import { object } from "../internal/type-system/object.js";
+
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+
+test("converge must have 2 or more arguments", () => {
+  // @ts-expect-error
+  converge();
+  // @ts-expect-error
+  converge(input());
+
+  converge(input(), input());
+  converge(input(), input(), input());
+  converge(input(), input(), input(), input());
+});
+
+test("converge must be a valid non-basic value", () => {
+  // @ts-expect-error
+  converge(undefined, undefined);
+  // @ts-expect-error
+  converge(converge, converge);
+  // @ts-expect-error
+  converge("foo", "bar");
+  // @ts-expect-error
+  converge(123, 456);
+  // @ts-expect-error
+  converge(null, null);
+});
+
+test("nested converge is not allowed", () => {
+  // @ts-expect-error
+  converge(converge(input(), input()), input());
+});
+
+test("converge creates a union of types", () => {
+  // $ExpectType Convergence<string | number>
+  converge(input(), input({ type: "number" }));
+  // $ExpectType Convergence<string | number>
+  converge(placeholder(), placeholder({ type: "number" }));
+  // $ExpectType Convergence<string | number | { foo: number; }[] | { bar: boolean; }[]>
+  converge(
+    input(),
+    placeholder({ type: "number" }),
+    input({ type: array(object({ foo: "number" })) }),
+    placeholder({ type: array(object({ bar: "boolean" })) })
+  );
+});
+
+test("converge stores the ports in order", () => {
+  const str = input();
+  const num = input({ type: "number" });
+  const bool = placeholder({ type: "boolean" });
+  assert.deepEqual(converge(str, num, bool).ports, [str, num, bool]);
+  assert.deepEqual(converge(num, bool, str).ports, [num, bool, str]);
+});
+
+test("converge can be passed as node input", () => {
+  const def = defineNodeType({
+    name: "test",
+    inputs: { foo: { type: "number" } },
+    outputs: {},
+    invoke: () => ({}),
+  });
+  def({
+    foo: converge(input({ type: "number" }), input({ type: "number" })),
+  });
+});
+
+test("converge of wrong type can't be passed as node input", () => {
+  const def = defineNodeType({
+    name: "test",
+    inputs: { foo: { type: "number" } },
+    outputs: {},
+    invoke: () => ({}),
+  });
+  def({
+    // @ts-expect-error
+    foo: converge(123, "bar"),
+  });
+});
+
+test("convergences are serialized as multiple edges", () => {
+  const def = defineNodeType({
+    name: "test",
+    inputs: { foo: { type: "number" } },
+    outputs: { bar: { type: "number" } },
+    invoke: ({ foo }) => ({ bar: foo + 1 }),
+  });
+  const a = input({ type: "number" });
+  const b = input({ type: "number" });
+  const { bar } = def({
+    foo: converge(a, b),
+  }).outputs;
+  const brd = board({ inputs: { a, b }, outputs: { bar } });
+  const bgl = serialize(brd);
+  assert.deepEqual(bgl, {
+    edges: [
+      {
+        from: "input-0",
+        to: "test-0",
+        out: "a",
+        in: "foo",
+      },
+      {
+        from: "input-0",
+        to: "test-0",
+        out: "b",
+        in: "foo",
+      },
+      {
+        from: "test-0",
+        to: "output-0",
+        in: "bar",
+        out: "bar",
+      },
+    ],
+    nodes: [
+      {
+        configuration: {
+          schema: {
+            properties: {
+              a: {
+                type: "number",
+              },
+              b: {
+                type: "number",
+              },
+            },
+            required: ["a", "b"],
+            type: "object",
+          },
+        },
+        id: "input-0",
+        type: "input",
+      },
+      {
+        configuration: {
+          schema: {
+            properties: {
+              bar: {
+                type: "number",
+              },
+            },
+            required: ["bar"],
+            type: "object",
+          },
+        },
+        id: "output-0",
+        type: "output",
+      },
+      {
+        id: "test-0",
+        type: "test",
+        configuration: {},
+      },
+    ],
+  });
+});


### PR DESCRIPTION
Previously, nodes could only be instantiated with a single input, meaning an input port could only have one incoming edge. Now using the `converge` function, you can pass multiple edges.

```ts
def({ foo: converge(a, b) }
```

The type of a convergence is the union of the input values, so `converge(input({type: "string"}), input({type: "number"}))` gives the type `string|number`. This is good because it  enforces that the invoke function you wire it up to can handle all of the possible value types from all of the possible incoming edges.

The alternative to this syntax was accepting arrays of input values. However, I think it's useful to have a clearly distinctive signature to remove any ambiguity between *an array of values intended to each be separately wired* (the convergence case), from *an array of values that is a single input for that port* (the case where a port accepts an array).