### PR TITLE
[build] Support multiple output nodes

### DIFF
--- a/.changeset/dirty-mice-begin.md
+++ b/.changeset/dirty-mice-begin.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Board outputs can now be an array of output node configurations

--- a/packages/build/src/internal/board/board.ts
+++ b/packages/build/src/internal/board/board.ts
@@ -6,6 +6,7 @@
 
 import {
   InputPort,
+  OutputPort,
   type OutputPortReference,
   type ValuesOrOutputPorts,
 } from "../common/port.js";
@@ -43,27 +44,68 @@ export function board<
   // directly here? The only way to not have already initialized it to something
   // was to have used an input(), so only inputs should be allowed, right?
   IPORTS extends BoardInputPorts,
-  OPORTS extends BoardOutputPorts,
+  OPORTS extends BoardOutputShape,
 >({
   inputs,
   outputs,
   title,
   description,
   version,
-}: BoardParameters<IPORTS, OPORTS>): BoardDefinition<IPORTS, OPORTS> {
-  const def = new BoardDefinitionImpl(inputs, outputs);
+}: BoardParameters<IPORTS, OPORTS>): BoardDefinition<
+  IPORTS,
+  FlattenMultiOutputs<OPORTS>
+> {
+  const flatOutputs = flattenOutputs(outputs);
+  const def = new BoardDefinitionImpl(inputs, flatOutputs);
   return Object.assign(def.instantiate.bind(def), {
     inputs,
-    outputs,
+    outputs: flatOutputs,
+    outputsForSerialization: outputs as
+      | BoardOutputPorts
+      | Array<BoardOutputPorts>,
     title,
     description,
     version,
   });
 }
 
+function flattenOutputs<OPORTS extends BoardOutputShape>(
+  outputs: OPORTS
+): FlattenMultiOutputs<OPORTS> {
+  if (!Array.isArray(outputs)) {
+    return outputs as FlattenMultiOutputs<OPORTS>;
+  }
+  const ports = {} as FlattenMultiOutputs<OPORTS>;
+  for (const outputNode of outputs as Array<BoardOutputPorts>) {
+    for (const [name, port] of Object.entries(outputNode)) {
+      // TODO(aomarks) This is wrong. We're just clobbering. Doesn't matter up
+      // until we try to invoke a board, which we don't yet support.
+      ports[name] = port;
+    }
+  }
+  return ports;
+}
+
+type FlattenMultiOutputs<O extends BoardOutputShape> =
+  O extends Array<BoardOutputPortsWithUndefined>
+    ? {
+        [K in keyof O[number] as K extends "$id" | "$metadata"
+          ? never
+          : K]-?: O[number][K] extends OutputPort<infer T> | undefined
+          ? undefined extends O[number][K]
+            ? OutputPort<T | undefined>
+            : OutputPort<T>
+          : O[number][K] extends OutputPortReference<infer T> | undefined
+            ? undefined extends O[number][K]
+              ? OutputPortReference<T | undefined>
+              : OutputPortReference<T>
+            : never;
+      }
+    : O;
+
 export interface BoardParameters<
   IPORTS extends BoardInputPorts,
-  OPORTS extends BoardOutputPorts,
+  OPORTS extends BoardOutputShape,
 > {
   inputs: IPORTS;
   outputs: OPORTS;
@@ -77,10 +119,26 @@ export type BoardInputPorts = Record<
   InputPort<JsonSerializable> | GenericSpecialInput
 >;
 
+export type BoardOutputShape =
+  | BoardOutputPorts
+  | Array<BoardOutputPortsWithUndefined>;
+
 export type BoardOutputPorts = Record<
   string,
   OutputPortReference<JsonSerializable> | Output<JsonSerializable>
 >;
+
+export type BoardOutputPortsWithUndefined = Record<
+  string,
+  | OutputPortReference<JsonSerializable>
+  | Output<JsonSerializable>
+  | string
+  | { title?: string; description?: string }
+  | undefined
+> & {
+  $id?: string | undefined;
+  $metadata?: { title?: string; description?: string };
+};
 
 export type BoardDefinition<
   IPORTS extends BoardInputPorts,
@@ -88,6 +146,7 @@ export type BoardDefinition<
 > = BoardInstantiateFunction<IPORTS, OPORTS> & {
   readonly inputs: IPORTS;
   readonly outputs: OPORTS;
+  readonly outputsForSerialization: BoardOutputPorts | Array<BoardOutputPorts>;
   readonly title?: string;
   readonly description?: string;
   readonly version?: string;

--- a/packages/build/src/internal/board/board.ts
+++ b/packages/build/src/internal/board/board.ts
@@ -9,7 +9,6 @@ import {
   type OutputPortReference,
   type ValuesOrOutputPorts,
 } from "../common/port.js";
-import type { SerializableBoard } from "../common/serializable.js";
 import type { JsonSerializable } from "../type-system/type.js";
 import type { GenericSpecialInput } from "./input.js";
 import type { Output } from "./output.js";
@@ -127,8 +126,7 @@ class BoardDefinitionImpl<
 class BoardInstance<
   IPORTS extends BoardInputPorts,
   OPORTS extends BoardOutputPorts,
-> implements SerializableBoard
-{
+> {
   readonly inputs: IPORTS;
   readonly outputs: OPORTS;
   // TODO(aomarks) This should get used somewhere.

--- a/packages/build/src/internal/board/output.ts
+++ b/packages/build/src/internal/board/output.ts
@@ -24,7 +24,7 @@ export function output<T extends JsonSerializable>(
   };
 }
 
-export interface Output<T extends JsonSerializable> {
+export interface Output<T extends JsonSerializable | undefined> {
   readonly __SpecialOutputBrand: true;
   readonly id?: string;
   readonly title?: string;

--- a/packages/build/src/internal/board/serialize.ts
+++ b/packages/build/src/internal/board/serialize.ts
@@ -23,12 +23,11 @@ import type {
   SerializableOutputPortReference,
 } from "../common/serializable.js";
 import { toJSONSchema, type JsonSerializable } from "../type-system/type.js";
-import type { GenericSpecialInput } from "./input.js";
-import type { Output } from "./output.js";
-import { isLoopback, type Loopback } from "./loopback.js";
 import { ConstantVersionOf, isConstant } from "./constant.js";
-import { isConvergence, type Convergence } from "./converge.js";
-import type { Value } from "../../index.js";
+import { isConvergence } from "./converge.js";
+import type { GenericSpecialInput } from "./input.js";
+import { isLoopback } from "./loopback.js";
+import type { Output } from "./output.js";
 
 /**
  * Serialize a Breadboard board to Breadboard Graph Language (BGL) so that it

--- a/packages/build/src/internal/board/serialize.ts
+++ b/packages/build/src/internal/board/serialize.ts
@@ -107,55 +107,81 @@ export function serialize(board: SerializableBoard): GraphDescriptor {
     inputNode.configuration.schema.required.push(mainInputName);
   }
 
-  // Recursively traverse the graph starting from outputs.
-  const sortedBoardOutputs = Object.entries(board.outputs).sort(
-    // Sort so that mainOutputSchema will also be sorted.
-    ([nameA], [nameB]) => nameA.localeCompare(nameB)
-  );
-  for (const [name, output] of sortedBoardOutputs) {
-    const port = isSpecialOutput(output)
-      ? output.port[OutputPortGetter]
-      : output[OutputPortGetter];
-    const outputNodeId = isSpecialOutput(output)
-      ? output.id ?? "output-0"
-      : "output-0";
-    let outputNode = outputNodes.get(outputNodeId);
-    if (outputNode === undefined) {
-      outputNode = {
-        id: outputNodeId,
-        type: "output",
-        configuration: {
-          schema: {
-            type: "object",
-            properties: {},
-            required: [],
-            // TODO(aomarks) Disallow extra properties?
-          },
-        },
-      };
-      outputNodes.set(outputNodeId, outputNode);
-    }
-    const schema = toJSONSchema(port.type);
-    if (isSpecialOutput(output)) {
-      if (output.title !== undefined) {
-        schema.title = output.title;
-      }
-      if (output.description !== undefined) {
-        schema.description = output.description;
-      }
-    }
-    outputNode.configuration.schema.properties[name] = schema;
-    outputNode.configuration.schema.required.push(name);
-    addEdge(
-      visitNodeAndReturnItsId(port.node),
-      port.name,
-      outputNodeId,
-      name,
-      isConstant(
-        // TODO(aomarks) Should not need this cast.
-        output as OutputPortReference<JsonSerializable>
-      )
+  const outputsArray = Array.isArray(board.outputsForSerialization)
+    ? board.outputsForSerialization
+    : [board.outputsForSerialization];
+  let i = 0;
+  for (const outputs of outputsArray) {
+    // Recursively traverse the graph starting from outputs.
+    const sortedBoardOutputs = Object.entries(outputs).sort(
+      // Sort so that mainOutputSchema will also be sorted.
+      ([nameA], [nameB]) => nameA.localeCompare(nameB)
     );
+    let iterationOutputId: string | undefined = undefined;
+    const autoId = () => {
+      if (iterationOutputId == undefined) {
+        iterationOutputId;
+        iterationOutputId = `output-${i}`;
+        i++;
+      }
+      return iterationOutputId;
+    };
+    for (const [name, output] of sortedBoardOutputs) {
+      if (name === "$id" || name === "$metadata") {
+        continue;
+      }
+      const port = isSpecialOutput(output)
+        ? output.port[OutputPortGetter]
+        : output[OutputPortGetter];
+      const outputNodeId =
+        (outputs.$id as string | undefined) ??
+        (isSpecialOutput(output) ? output.id : undefined) ??
+        autoId();
+      let outputNode = outputNodes.get(outputNodeId);
+      if (outputNode === undefined) {
+        outputNode = {
+          id: outputNodeId,
+          type: "output",
+          configuration: {
+            schema: {
+              type: "object",
+              properties: {},
+              required: [],
+              // TODO(aomarks) Disallow extra properties?
+            },
+          },
+        };
+        const metadata = outputs.$metadata as {
+          title?: string;
+          description?: string;
+        };
+        if (metadata !== undefined) {
+          outputNode.metadata = metadata;
+        }
+        outputNodes.set(outputNodeId, outputNode);
+      }
+      const schema = toJSONSchema(port.type);
+      if (isSpecialOutput(output)) {
+        if (output.title !== undefined) {
+          schema.title = output.title;
+        }
+        if (output.description !== undefined) {
+          schema.description = output.description;
+        }
+      }
+      outputNode.configuration.schema.properties[name] = schema;
+      outputNode.configuration.schema.required.push(name);
+      addEdge(
+        visitNodeAndReturnItsId(port.node),
+        port.name,
+        outputNodeId,
+        name,
+        isConstant(
+          // TODO(aomarks) Should not need this cast.
+          output as OutputPortReference<JsonSerializable>
+        )
+      );
+    }
   }
 
   if (unconnectedInputs.size > 0) {

--- a/packages/build/src/internal/common/port.ts
+++ b/packages/build/src/internal/common/port.ts
@@ -52,7 +52,7 @@ export class InputPort<T extends JsonSerializable>
 /**
  * A Breadboard node port which sends values.
  */
-export class OutputPort<T extends JsonSerializable>
+export class OutputPort<T extends JsonSerializable | undefined>
   implements OutputPortReference<T>, SerializableOutputPort
 {
   readonly [OutputPortGetter] = this;
@@ -68,7 +68,7 @@ export class OutputPort<T extends JsonSerializable>
   }
 }
 
-export interface OutputPortReference<T extends JsonSerializable> {
+export interface OutputPortReference<T extends JsonSerializable | undefined> {
   readonly [OutputPortGetter]: OutputPort<T>;
 }
 

--- a/packages/build/src/internal/common/serializable.ts
+++ b/packages/build/src/internal/common/serializable.ts
@@ -17,6 +17,14 @@ export interface SerializableBoard {
     string,
     SerializableOutputPortReference | Output<JsonSerializable>
   >;
+  outputsForSerialization:
+    | Record<string, SerializableOutputPortReference | Output<JsonSerializable>>
+    | Array<
+        Record<
+          string,
+          SerializableOutputPortReference | Output<JsonSerializable>
+        >
+      >;
   title?: string;
   description?: string;
   version?: string;

--- a/packages/build/src/internal/define/definition.ts
+++ b/packages/build/src/internal/define/definition.ts
@@ -435,7 +435,10 @@ type StrictInstantiateArgs<
 } & {
   [K in keyof Omit<SI, OI | "$id" | "$metadata">]: InstantiateArg<SI[K]>;
 } & {
-  [K in OI]?: InstantiateArg<SI[K]> | undefined;
+  [K in OI]?:
+    | InstantiateArg<SI[K]>
+    | OutputPortReference<SI[K] | undefined>
+    | undefined;
 } & {
   [K in keyof Omit<
     A,

--- a/packages/build/src/internal/define/instance.ts
+++ b/packages/build/src/internal/define/instance.ts
@@ -192,12 +192,13 @@ export class Instance<
       [K: string]: JsonSerializable | OutputPortReference<JsonSerializable>;
     }
   ) {
-    const ports: { [K: string]: OutputPort<JsonSerializable> } & {
-      assert?: (name: string) => OutputPort<JsonSerializable>;
+    const ports: { [K: string]: OutputPort<JsonSerializable | undefined> } & {
+      assert?: (name: string) => OutputPort<JsonSerializable | undefined>;
     } = {
       $error: new OutputPort(breadboardErrorType, "$error", this),
     };
-    let primary: OutputPort<JsonSerializable> | undefined = undefined;
+    let primary: OutputPort<JsonSerializable | undefined> | undefined =
+      undefined;
 
     for (const [name, config] of Object.entries(staticOutputs)) {
       const port = new OutputPort(config.type, name, this);
@@ -234,7 +235,9 @@ export class Instance<
         // create the OutputPort any time there is a property access. But, we
         // want to make it clear to see when a port is being asserted, since the
         // type system has absolutely no idea if this is a valid port or not.
-        ports.assert = (name: string): OutputPort<JsonSerializable> => {
+        ports.assert = (
+          name: string
+        ): OutputPort<JsonSerializable | undefined> => {
           let port = ports[name];
           if (port !== undefined) {
             return port;


### PR DESCRIPTION
When defining a board, you can now pass an array of objects. Previously you could only pass one object. When there are multiple outputs, that means multiple output nodes will be serialized, one each. The ID can be set with `$id`, or else it defaults to the `output-1`, `output-2`, etc. scheme.

```ts
export default board({
  title: "My Board",
  inputs: { ... }
  },
  outputs: [
    {
      $id: "my-output-node-1",
      out1,
      out2,
    },
    {
      $id: "my-output-node-2",
      $metadata: {
        title: "My Title",
      },
      out2,
      out3,
    },
  ],