### PR TITLE
[core-kit] Process function name in code helper

### DIFF
--- a/.changeset/chatty-moons-buy.md
+++ b/.changeset/chatty-moons-buy.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/gemini-kit": patch
+---
+
+The core-kit code helper function now behaves exactly like the one in breadboard-ai in terms of the function name it selects for the code.

--- a/packages/breadboard-web/public/graphs/build-example.json
+++ b/packages/breadboard-web/public/graphs/build-example.json
@@ -92,7 +92,8 @@
       "id": "runJavascript-0",
       "type": "runJavascript",
       "configuration": {
-        "code": "({str})=>({capitalized:str.toUpperCase()})",
+        "code": "const run = ({str})=>({capitalized:str.toUpperCase()});",
+        "name": "run",
         "raw": true
       }
     }

--- a/packages/core-kit/tests/code_test.ts
+++ b/packages/core-kit/tests/code_test.ts
@@ -204,7 +204,8 @@ test("serialization", (t) => {
         type: "runJavascript",
         configuration: {
           bool: false,
-          code: '({ str, num, bool }) => ({\n        strLen: str.length,\n        strReversed: str.split("").reverse().join(""),\n        doubleNum: num * 2,\n        not: !bool,\n    })',
+          code: 'const customId = ({ str, num, bool }) => ({\n        strLen: str.length,\n        strReversed: str.split("").reverse().join(""),\n        doubleNum: num * 2,\n        not: !bool,\n    });',
+          name: "customId",
           raw: true,
         },
         metadata: { title: "Custom title", description: "Custom description" },


### PR DESCRIPTION
The core-kit code helper function now behaves exactly like the one in breadboard-ai in terms of the function name it selects for the code.

I'm not actually sure this is necessary, since I think we can just wrap any function (arrow or traditional) in parens and call it immediately (`(<fn>)()`); but in the immediate term matching the serialization behavior is nice because it makes comparing board conversions easier.