### PR TITLE
[build] Set the "type" field when an enumeration is all of the same type

### DIFF
--- a/.changeset/few-feet-hunt.md
+++ b/.changeset/few-feet-hunt.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Set the "type" field when an enumeration is all of one type.

--- a/packages/build/src/internal/type-system/enumeration.ts
+++ b/packages/build/src/internal/type-system/enumeration.ts
@@ -21,14 +21,31 @@ export function enumeration<T extends [Enumable, ...Enumable[]]>(
   if (values.length === 0) {
     throw new Error("enumeration needs at least one value");
   }
-  for (const value of values) {
-    const t = typeof value;
-    if (t !== "string" && t !== "number" && t !== "boolean" && value !== null) {
+  const types = new Set<"string" | "number" | "boolean" | "null">(
+    values.map((value) => {
+      const t = typeof value;
+      switch (t) {
+        case "string":
+        case "number":
+        case "boolean":
+          return t;
+      }
+      if (value === null) {
+        return "null";
+      }
       throw new Error(
         `enumeration values must be string, number, boolean, or null. ` +
-          `Got ${typeof value}.`
+          `Got ${t}.`
       );
-    }
+    })
+  );
+  if (types.size === 1) {
+    return {
+      jsonSchema: {
+        type: [...types][0]!,
+        enum: values,
+      },
+    };
   }
   return {
     jsonSchema: {

--- a/packages/build/src/test/enumeration_test.ts
+++ b/packages/build/src/test/enumeration_test.ts
@@ -18,7 +18,7 @@ test("1 string", () => {
       // $ExpectType AdvancedBreadboardType<"foo">
       enumeration("foo")
     ),
-    { enum: ["foo"] }
+    { type: "string", enum: ["foo"] }
   );
 });
 
@@ -28,7 +28,7 @@ test("3 strings", () => {
       // $ExpectType AdvancedBreadboardType<"foo" | "bar" | "baz">
       enumeration("foo", "bar", "baz")
     ),
-    { enum: ["foo", "bar", "baz"] }
+    { type: "string", enum: ["foo", "bar", "baz"] }
   );
 });
 
@@ -38,7 +38,7 @@ test("2 numbers", () => {
       // $ExpectType AdvancedBreadboardType<123 | 456>
       enumeration(123, 456)
     ),
-    { enum: [123, 456] }
+    { type: "number", enum: [123, 456] }
   );
 });
 
@@ -48,7 +48,7 @@ test("boolean", () => {
       // $ExpectType AdvancedBreadboardType<true>
       enumeration(true)
     ),
-    { enum: [true] }
+    { type: "boolean", enum: [true] }
   );
 });
 
@@ -58,7 +58,7 @@ test("null", () => {
       // $ExpectType AdvancedBreadboardType<null>
       enumeration(null)
     ),
-    { enum: [null] }
+    { type: "null", enum: [null] }
   );
 });
 


### PR DESCRIPTION
Not technically needed, but we have tended to do this in our manually written schema so it helps when comparing.