### PR TITLE
[build] Stringify all defaults and examples

### DIFF
--- a/.changeset/fuzzy-months-hear.md
+++ b/.changeset/fuzzy-months-hear.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Stringify all defaults and examples

--- a/packages/build/src/internal/board/serialize.ts
+++ b/packages/build/src/internal/board/serialize.ts
@@ -115,10 +115,21 @@ export function serialize(board: SerializableBoard): GraphDescriptor {
           schema.description = input.description;
         }
         if (input.default !== undefined) {
-          schema.default = input.default;
+          schema.default =
+            typeof input.default === "string"
+              ? input.default
+              : // TODO(aomarks) Why is default JSON stringified? The UI currently
+                // requires it, but seems like it should be real JSON.
+                JSON.stringify(input.default, null, 2);
         }
         if (input.examples !== undefined && input.examples.length > 0) {
-          schema.examples = input.examples;
+          schema.examples = input.examples.map((example) =>
+            typeof example === "string"
+              ? example
+              : // TODO(aomarks) Why is examples JSON stringified? The UI currently
+                // requires it, but seems like it should be real JSON.
+                JSON.stringify(example, null, 2)
+          );
         }
       }
       let inputNode = inputNodes.get(inputNodeId);

--- a/packages/build/src/test/serialize_test.ts
+++ b/packages/build/src/test/serialize_test.ts
@@ -2096,7 +2096,7 @@ test("constant input", () => {
             schema: {
               type: "object",
               properties: {
-                inputWithDefault: { type: "number", default: 123 },
+                inputWithDefault: { type: "number", default: "123" },
                 stringInput: { type: "string" },
               },
               required: ["stringInput"],

--- a/packages/template-kit/tests/prompt-template-tag_test.ts
+++ b/packages/template-kit/tests/prompt-template-tag_test.ts
@@ -68,7 +68,7 @@ test("serialization with automatic ID", (t) => {
               },
               steps: {
                 type: "number",
-                default: 10,
+                default: "10",
               },
             },
             required: ["dish"],
@@ -151,7 +151,7 @@ test("serialization with custom node id and placeholder names", (t) => {
               },
               steps: {
                 type: "number",
-                default: 10,
+                default: "10",
               },
             },
             required: ["dish"],


### PR DESCRIPTION
Pretty sure we don't want this ultimately, but mimicking the current serialization behavior for now to ensure we're compatible. The UI currently seems not to be able to read non-string values out of defaults/examples (at least in some cases).