### PR TITLE
[core] Allow converge function to take raw values

### DIFF
--- a/.changeset/green-yaks-visit.md
+++ b/.changeset/green-yaks-visit.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Allow converge function to take raw values

--- a/packages/build/src/internal/board/converge.ts
+++ b/packages/build/src/internal/board/converge.ts
@@ -11,6 +11,7 @@ import type { Input, InputWithDefault } from "./input.js";
 import type { Loopback } from "./loopback.js";
 
 type Convergable<T extends JsonSerializable> =
+  | T
   | OutputPortReference<T>
   | Input<T>
   | InputWithDefault<T>

--- a/packages/build/src/test/converge_test.ts
+++ b/packages/build/src/test/converge_test.ts
@@ -108,7 +108,7 @@ test("convergences are serialized as multiple edges", () => {
   const a = input({ type: "number" });
   const b = input({ type: "number" });
   const { bar } = def({
-    foo: converge(a, b),
+    foo: converge(a, 123, b),
   }).outputs;
   const brd = board({ inputs: { a, b }, outputs: { bar } });
   const bgl = serialize(brd);
@@ -170,7 +170,9 @@ test("convergences are serialized as multiple edges", () => {
       {
         id: "test-0",
         type: "test",
-        configuration: {},
+        configuration: {
+          foo: 123,
+        },
       },
     ],
   });

--- a/packages/build/src/test/converge_test.ts
+++ b/packages/build/src/test/converge_test.ts
@@ -28,17 +28,22 @@ test("converge must have 2 or more arguments", () => {
   converge(input(), input(), input(), input());
 });
 
-test("converge must be a valid non-basic value", () => {
+test("cannot converge undefined or something weird", () => {
   // @ts-expect-error
   converge(undefined, undefined);
   // @ts-expect-error
   converge(converge, converge);
-  // @ts-expect-error
+});
+
+test("can converge basic types", () => {
+  // $ExpectType Convergence<string>
   converge("foo", "bar");
-  // @ts-expect-error
+  // $ExpectType Convergence<number>
   converge(123, 456);
-  // @ts-expect-error
+  // $ExpectType Convergence<null>
   converge(null, null);
+  // $ExpectType Convergence<{ foo: string; } | {}>
+  converge({}, input({ type: object({ foo: "string" }) }));
 });
 
 test("nested converge is not allowed", () => {


### PR DESCRIPTION
Useful for defaults:

```ts
foo({
  foo: converge({}, someOtherOutput)
});
```