### PR TITLE
[breadboard] Clarify meaning of required output ports

### DIFF
--- a/.changeset/angry-schools-poke.md
+++ b/.changeset/angry-schools-poke.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard": minor
+---
+
+Allow output ports to be required in their schema without it turning output ports red when they are unwired

--- a/packages/breadboard/src/inspector/bubbled-node.ts
+++ b/packages/breadboard/src/inspector/bubbled-node.ts
@@ -109,6 +109,7 @@ export class BubbledInspectableNode implements InspectableNode {
           this.incoming(),
           described.inputSchema,
           false,
+          true,
           inputValues
         ),
       };
@@ -118,6 +119,7 @@ export class BubbledInspectableNode implements InspectableNode {
           EdgeType.Out,
           [],
           described.outputSchema,
+          false,
           false,
           bubbledValues
         ),

--- a/packages/breadboard/src/inspector/node.ts
+++ b/packages/breadboard/src/inspector/node.ts
@@ -121,6 +121,7 @@ class Node implements InspectableNode {
         incoming,
         described.inputSchema,
         false,
+        true,
         this.#inputsAndConfig(inputValues, this.configuration())
       ),
     };
@@ -133,6 +134,7 @@ class Node implements InspectableNode {
         outgoing,
         described.outputSchema,
         addErrorPort,
+        false,
         outputValues
       ),
     };

--- a/packages/breadboard/src/inspector/ports.ts
+++ b/packages/breadboard/src/inspector/ports.ts
@@ -38,6 +38,7 @@ export const collectPorts = (
   edges: InspectableEdge[],
   schema: Schema,
   addErrorPort: boolean,
+  allowRequired: boolean,
   values?: NodeConfiguration
 ) => {
   let wiredContainsStar = false;
@@ -94,7 +95,7 @@ export const collectPorts = (
         status: computePortStatus(
           wired || configured,
           !fixed || expected || schemaContainsStar,
-          required,
+          allowRequired && required,
           wiredContainsStar
         ),
         schema: portSchema,


### PR DESCRIPTION
Before this PR, effectively saying that an output port was required meant "you must wire this up", since it would turn red in the UI if you didn't. However, really if an output port is required, it's just saying that it won't be undefined, and it has no bearing on how the caller choses to use it or not.