### PR TITLE
[build] Allow inputs to be optional

### DIFF
--- a/.changeset/quick-steaks-search.md
+++ b/.changeset/quick-steaks-search.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Allow inputs to be optional

--- a/packages/build/src/internal/board/input.ts
+++ b/packages/build/src/internal/board/input.ts
@@ -106,6 +106,7 @@ export function input(
     description: params?.description,
     default: params?.default,
     examples: params?.examples,
+    optional: params?.optional,
   } satisfies
     | Omit<Input<JsonSerializable>, "__type">
     | InputWithDefault<JsonSerializable> as
@@ -120,6 +121,7 @@ interface LooseParams {
   description?: string;
   default?: JsonSerializable;
   examples?: JsonSerializable[];
+  optional?: true;
 }
 
 export interface Input<T extends JsonSerializable | undefined> {
@@ -131,6 +133,7 @@ export interface Input<T extends JsonSerializable | undefined> {
   readonly description?: string;
   readonly default: undefined;
   readonly examples?: T[];
+  readonly optional?: boolean;
 }
 
 export interface InputWithDefault<T extends JsonSerializable | undefined> {
@@ -161,6 +164,7 @@ type CheckParams<T extends LooseParams> = (T["type"] extends Defined
           : JsonSerializable
       >;
       description?: string;
+      optional?: T["default"] extends Defined ? never : true;
     }
   : T["default"] extends Defined
     ? {
@@ -170,6 +174,7 @@ type CheckParams<T extends LooseParams> = (T["type"] extends Defined
         default: string | number | boolean;
         examples?: Array<T["default"]>;
         description?: string;
+        optional?: never;
       }
     : T["examples"] extends Defined
       ? {
@@ -179,6 +184,7 @@ type CheckParams<T extends LooseParams> = (T["type"] extends Defined
           default?: never;
           examples?: string[] | number[] | boolean[];
           description?: string;
+          optional?: true;
         }
       : never) & {
   [K in keyof T]: K extends
@@ -188,6 +194,7 @@ type CheckParams<T extends LooseParams> = (T["type"] extends Defined
     | "default"
     | "examples"
     | "description"
+    | "optional"
     ? unknown
     : never;
 };

--- a/packages/build/src/internal/board/serialize.ts
+++ b/packages/build/src/internal/board/serialize.ts
@@ -107,6 +107,7 @@ export function serialize(board: SerializableBoard): GraphDescriptor {
       });
       unconnectedInputs.add(input);
       const schema = toJSONSchema(input.type);
+      let isSpecialOptional = false;
       if (isSpecialInput(input)) {
         if (input.title !== undefined) {
           schema.title = input.title;
@@ -130,6 +131,9 @@ export function serialize(board: SerializableBoard): GraphDescriptor {
                 // requires it, but seems like it should be real JSON.
                 JSON.stringify(example, null, 2)
           );
+        }
+        if ("optional" in input && input.optional) {
+          isSpecialOptional = true;
         }
       }
       let inputNode = inputNodes.get(inputNodeId);
@@ -171,7 +175,7 @@ export function serialize(board: SerializableBoard): GraphDescriptor {
           "additionalProperties",
         ]
       );
-      if (schema.default === undefined) {
+      if (schema.default === undefined && !isSpecialOptional) {
         inputNode.configuration.schema.required.push(mainInputName);
       }
     }


### PR DESCRIPTION
Optional inputs are sort of interesting. They don't mean that the value can be undefined, they mean that the user will be prompted for the value if it's undefined.