### PR TITLE
[breadboard-ui] Allow box selection; change controls

### DIFF
--- a/.changeset/strange-tables-refuse.md
+++ b/.changeset/strange-tables-refuse.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard-ui": minor
+---
+
+Teach editor about box selection; update controls

--- a/packages/breadboard-ui/src/elements/editor/graph.ts
+++ b/packages/breadboard-ui/src/elements/editor/graph.ts
@@ -550,6 +550,33 @@ export class Graph extends PIXI.Container {
     this.emit(GRAPH_OPERATIONS.GRAPH_NODE_DESELECTED_ALL);
   }
 
+  selectInRect(rect: PIXI.Rectangle) {
+    for (const child of this.children) {
+      if (!(child instanceof GraphNode)) {
+        continue;
+      }
+
+      const isSelected = child.selected;
+      child.selected = rect.intersects(child.getBounds(true).rectangle);
+      if (isSelected !== child.selected) {
+        this.emit(
+          child.selected
+            ? GRAPH_OPERATIONS.GRAPH_NODE_SELECTED
+            : GRAPH_OPERATIONS.GRAPH_NODE_DESELECTED,
+          child.label
+        );
+      }
+    }
+
+    for (const edge of this.#edgeContainer.children) {
+      if (!(edge instanceof GraphEdge)) {
+        continue;
+      }
+
+      edge.selected = rect.intersects(edge.getBounds(true).rectangle);
+    }
+  }
+
   getSelectedChildren(): Array<GraphNode | GraphEdge> {
     const selected = [];
     for (const node of this.children) {


### PR DESCRIPTION
You can now:

1. Click and drag the cursor to select nodes and edges
2. Use the mouse wheel to move around the canvas
3. Use cmd/ctrl + mouse wheel to zoom in / out of the canvas

This brings the controls more in line with other canvas-centric apps