### PR TITLE
[breadboard-ui] Add "invert scroll to zoom" setting

### DIFF
--- a/packages/breadboard-ui/src/elements/editor/editor.ts
+++ b/packages/breadboard-ui/src/elements/editor/editor.ts
@@ -91,6 +91,9 @@ export class Editor extends LitElement {
   @state()
   defaultConfiguration: NodeConfiguration | null = null;
 
+  @property({ reflect: true })
+  invertZoomScrollDirection = false;
+
   #graph = new Graph();
   #graphRenderer = new GraphRenderer();
   // Incremented each time a graph is updated, used to avoid extra work
@@ -746,6 +749,8 @@ export class Editor extends LitElement {
 
     if (this.#graphRenderer) {
       this.#graphRenderer.editable = this.editable;
+      this.#graphRenderer.invertZoomScrollDirection =
+        this.invertZoomScrollDirection;
     }
 
     const subGraphs: SubGraphs | null =

--- a/packages/breadboard-ui/src/elements/editor/graph-renderer.ts
+++ b/packages/breadboard-ui/src/elements/editor/graph-renderer.ts
@@ -49,6 +49,9 @@ export class GraphRenderer extends LitElement {
   @property({ reflect: true })
   editable = false;
 
+  @property({ reflect: true })
+  invertZoomScrollDirection = false;
+
   #app = new PIXI.Application();
   #appInitialized = false;
 
@@ -419,7 +422,10 @@ export class GraphRenderer extends LitElement {
       "wheel",
       function (this: GraphRenderer, evt) {
         if (evt.metaKey) {
-          let delta = 1 - evt.deltaY / this.zoomFactor;
+          let delta =
+            1 -
+            (evt.deltaY / this.zoomFactor) *
+              (this.invertZoomScrollDirection ? -1 : 1);
           const newScale = this.#container.scale.x * delta;
           if (newScale < this.minScale || newScale > this.maxScale) {
             delta = 1;

--- a/packages/breadboard-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/breadboard-ui/src/elements/ui-controller/ui-controller.ts
@@ -302,6 +302,12 @@ export class UI extends LitElement {
         )?.value
       : false;
 
+    const invertZoomScrollDirection = this.settings
+      ? this.settings[SETTINGS_TYPE.GENERAL].items.get(
+          "Invert Zoom Scroll Direction"
+        )?.value
+      : false;
+
     const editorMode = hideAdvancedPortsOnNodes
       ? EditorMode.MINIMAL
       : EditorMode.ADVANCED;
@@ -326,6 +332,7 @@ export class UI extends LitElement {
       .hideSubboardSelectorWhenEmpty=${hideSubboardSelectorWhenEmpty}
       .mode=${editorMode}
       .showNodeShortcuts=${showNodeShortcuts}
+      .invertZoomScrollDirection=${invertZoomScrollDirection}
       @bbnodedelete=${(evt: NodeDeleteEvent) => {
         if (!this.selectedNodeIds) {
           return;

--- a/packages/breadboard-web/src/data/settings-store.ts
+++ b/packages/breadboard-web/src/data/settings-store.ts
@@ -82,6 +82,14 @@ export class SettingsStore {
             value: true,
           },
         ],
+        [
+          "Invert Zoom Scroll Direction",
+          {
+            name: "Invert Zoom Scroll Direction",
+            description: "Inverts the board zoom scroll direction",
+            value: false,
+          },
+        ],
       ]),
     },
     [BreadboardUI.Types.SETTINGS_TYPE.SECRETS]: {


### PR DESCRIPTION
For whatever reason I like my scroll-to-zoom direction to be the opposite to the default, so here's a setting that allows the user to choose.