### PR TITLE
[breadboard-web] Fix specialist testing grounds

### DIFF
--- a/packages/breadboard-ui/src/elements/input/input.ts
+++ b/packages/breadboard-ui/src/elements/input/input.ts
@@ -305,8 +305,18 @@ export class Input extends LitElement {
             let value: LLMContent | null = null;
             value = values[key] as LLMContent | null;
             if (!value) {
-              const unparsedValue = property.examples?.[0] ?? property.default;
+              const unparsedValue =
+                property.examples && property.examples.length
+                  ? property.examples[0]
+                  : property.default;
               value = unparsedValue ? JSON.parse(unparsedValue) : null;
+            }
+
+            if (Array.isArray(value)) {
+              value = value[0] as LLMContent;
+              console.warn(
+                "Default value is an array where single value is expected - using first item"
+              );
             }
 
             const allow = createAllowListFromProperty(property);

--- a/packages/breadboard-web/public/graphs/super-worker-test.json
+++ b/packages/breadboard-web/public/graphs/super-worker-test.json
@@ -44,7 +44,7 @@
               "title": "Book Specs",
               "description": "The source material for the worker",
               "examples": [
-                "[\n  {\n    \"role\": \"user\",\n    \"parts\": [\n      {\n        \"text\": \"book description: This book will be about breadboards and how awesome they are:\\n\\nchapter target: 10\\n\\npage target: 400\\n\\nfiction genre: space opera\\n\\nsetting: the planet where there are no breadboards\\n\\nstory arc: A girl named Aurora invents a breadboard on the planet where breadboards are strictly forbidden. Through struggles and determination, and with the help of trusted friends, Aurora overcomes many challenges and changes the whole planet for the better.\\n\\ntonality: futuristic struggle, but optimistic\\n\\nworking title: Aurora\\n\"\n      }\n    ]\n  }\n]"
+                "{\n  \"role\": \"user\",\n  \"parts\": [\n    {\n      \"text\": \"book description: This book will be about breadboards and how awesome they are:\\n\\nchapter target: 10\\n\\npage target: 400\\n\\nfiction genre: space opera\\n\\nsetting: the planet where there are no breadboards\\n\\nstory arc: A girl named Aurora invents a breadboard on the planet where breadboards are strictly forbidden. Through struggles and determination, and with the help of trusted friends, Aurora overcomes many challenges and changes the whole planet for the better.\\n\\ntonality: futuristic struggle, but optimistic\\n\\nworking title: Aurora\\n\"\n    }\n  ]\n}"
               ],
               "items": {
                 "type": "object",
@@ -112,7 +112,7 @@
         "task": {
           "parts": [
             {
-              "text": "Your friend, an accomplished author, has written an outline for a new book and has asked you for insightful feedback.  \n\nReview the outline that the author submitted.  Please read it very carefully.  Then, provide feedback for the author.  Give the author up to five specific suggestions to make the novel more compelling and have more chance to be a bestseller!"
+              "text": "Your friend, an accomplished author, has written an outline for a new book and has asked you for insightful feedback.\n\nReview the outline that the author submitted.  Please read it very carefully.  Then, provide feedback for the author.  Give the author up to five specific suggestions to make the novel more compelling and have more chance to be a bestseller!"
             }
           ]
         }

--- a/packages/breadboard-web/src/boards/super-worker-test.ts
+++ b/packages/breadboard-web/src/boards/super-worker-test.ts
@@ -6,9 +6,8 @@ const contextFromText = (text: string, role?: string) => {
   return role ? { role, parts } : { parts };
 };
 
-const sampleContext = [
-  contextFromText(
-    `book description: This book will be about breadboards and how awesome they are:
+const sampleContext = contextFromText(
+  `book description: This book will be about breadboards and how awesome they are:
 
 chapter target: 10
 
@@ -24,9 +23,8 @@ tonality: futuristic struggle, but optimistic
 
 working title: Aurora
 `,
-    "user"
-  ),
-];
+  "user"
+);
 
 const outlineWriterPersona =
   contextFromText(`You are a famous author.  You are writing a novel.
@@ -46,7 +44,7 @@ const outlineCriticPersona = contextFromText(
 );
 
 const outlineCriticTask =
-  contextFromText(`Your friend, an accomplished author, has written an outline for a new book and has asked you for insightful feedback.  
+  contextFromText(`Your friend, an accomplished author, has written an outline for a new book and has asked you for insightful feedback.
 
 Review the outline that the author submitted.  Please read it very carefully.  Then, provide feedback for the author.  Give the author up to five specific suggestions to make the novel more compelling and have more chance to be a bestseller!`);
 


### PR DESCRIPTION
I noticed we had an array of LLM Contents as the examples for the specialist, i.e., examples is an array and the zeroth item itself was an array of LLM Contents... whereas the input itself is set to a single LLM Content. This meant that the LLM Input received an array when it expected an object.