### PR TITLE
operations

### DIFF
--- a/.changeset/silly-moose-learn.md
+++ b/.changeset/silly-moose-learn.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard": patch
+---
+
+Switch to use edit operations machinery in Editor API internals.

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -1050,7 +1050,12 @@ export class Main extends LitElement {
                 }
 
                 editableGraph.edit([
-                  { type: "changeedge", from: evt.from, to: evt.to },
+                  {
+                    type: "changeedge",
+                    from: evt.from,
+                    to: evt.to,
+                    strict: false,
+                  },
                 ]);
                 break;
               }

--- a/packages/breadboard/src/editor/edge.ts
+++ b/packages/breadboard/src/editor/edge.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GraphDescriptor } from "@google-labs/breadboard-schema/graph.js";
+import { EditableEdgeSpec } from "./types.js";
+
+export const findEdgeIndex = (
+  graph: GraphDescriptor,
+  spec: EditableEdgeSpec
+) => {
+  return graph.edges.findIndex((edge) => {
+    return edgesEqual(spec, edge);
+  });
+};
+
+export const edgesEqual = (a: EditableEdgeSpec, b: EditableEdgeSpec) => {
+  return (
+    a.from === b.from &&
+    a.to === b.to &&
+    a.out === b.out &&
+    a.in === b.in &&
+    b.constant === b.constant
+  );
+};

--- a/packages/breadboard/src/editor/edit.ts
+++ b/packages/breadboard/src/editor/edit.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GraphDescriptor } from "@google-labs/breadboard-schema/graph.js";
+import { InspectableGraph } from "../inspector/types.js";
+import { EditSpec } from "./types.js";
+
+/**
+ * Represents an edit operation.
+ */
+export class Edit {
+  #edits: EditSpec[];
+  #graph: GraphDescriptor;
+  #inspector: InspectableGraph;
+
+  constructor(
+    edits: EditSpec[],
+    graph: GraphDescriptor,
+    inspector: InspectableGraph
+  ) {
+    this.#edits = edits;
+    this.#graph = graph;
+    this.#inspector = inspector;
+  }
+}

--- a/packages/breadboard/src/editor/operations/add-edge.ts
+++ b/packages/breadboard/src/editor/operations/add-edge.ts
@@ -5,11 +5,16 @@
  */
 
 import { GraphDescriptor } from "@google-labs/breadboard-schema/graph.js";
-import { EditResult, EditSpec, EditableEdgeSpec } from "../types.js";
+import {
+  EditOperation,
+  EditResult,
+  EditSpec,
+  EditableEdgeSpec,
+} from "../types.js";
 import { InspectableGraphWithStore } from "../../inspector/types.js";
 import { fixUpStarEdge, fixupConstantEdge } from "../../inspector/edge.js";
 
-export class AddEdge {
+export class AddEdge implements EditOperation {
   #graph: GraphDescriptor;
   #inspector: InspectableGraphWithStore;
 
@@ -96,13 +101,11 @@ export class AddEdge {
     const can = await this.can(edge);
     if (!can.success) {
       if (!can.alternative || strict) {
-        // this.#dispatchNoChange(can.error);
         return can;
       }
       if (can.alternative) {
         const canAlternative = await this.can(can.alternative);
         if (!canAlternative.success) {
-          // this.#dispatchNoChange(canAlternative.error);
           return canAlternative;
         }
         edge = can.alternative;

--- a/packages/breadboard/src/editor/operations/add-node.ts
+++ b/packages/breadboard/src/editor/operations/add-node.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GraphDescriptor } from "@google-labs/breadboard-schema/graph.js";
+import {
+  EdgeEditResult,
+  EditOperation,
+  EditSpec,
+  EditableNodeSpec,
+  SingleEditResult,
+} from "../types.js";
+import { InspectableGraphWithStore } from "../../inspector/types.js";
+
+export class AddNode implements EditOperation {
+  #graph: GraphDescriptor;
+  #inspector: InspectableGraphWithStore;
+
+  constructor(graph: GraphDescriptor, inspector: InspectableGraphWithStore) {
+    this.#graph = graph;
+    this.#inspector = inspector;
+  }
+  async can(spec: EditableNodeSpec): Promise<SingleEditResult> {
+    const duplicate = !!this.#inspector.nodeById(spec.id);
+    if (duplicate) {
+      return {
+        success: false,
+        error: `Unable to add node: a node with id "${spec.id}" already exists`,
+      };
+    }
+
+    const validType = !!this.#inspector.typeById(spec.type);
+    if (!validType) {
+      return {
+        success: false,
+        error: `Unable to add node: node type "${spec.type}" is not a known type`,
+      };
+    }
+
+    return { success: true };
+  }
+
+  async do(spec: EditSpec): Promise<SingleEditResult> {
+    if (spec.type !== "addnode") {
+      throw new Error(
+        `Editor API integrity error: expected type "addnode", received "${spec.type}" instead.`
+      );
+    }
+    const node = spec.node;
+    const can = await this.can(node);
+    if (!can.success) {
+      return can;
+    }
+
+    this.#graph.nodes.push(node);
+    this.#inspector.nodeStore.add(node);
+    return { success: true };
+  }
+}

--- a/packages/breadboard/src/editor/operations/add-node.ts
+++ b/packages/breadboard/src/editor/operations/add-node.ts
@@ -6,7 +6,6 @@
 
 import { GraphDescriptor } from "@google-labs/breadboard-schema/graph.js";
 import {
-  EdgeEditResult,
   EditOperation,
   EditSpec,
   EditableNodeSpec,

--- a/packages/breadboard/src/editor/operations/addedge.ts
+++ b/packages/breadboard/src/editor/operations/addedge.ts
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GraphDescriptor } from "@google-labs/breadboard-schema/graph.js";
+import { EditResult, EditSpec, EditableEdgeSpec } from "../types.js";
+import { InspectableGraphWithStore } from "../../inspector/types.js";
+import { fixUpStarEdge, fixupConstantEdge } from "../../inspector/edge.js";
+
+export class AddEdge {
+  #graph: GraphDescriptor;
+  #inspector: InspectableGraphWithStore;
+
+  constructor(graph: GraphDescriptor, inspector: InspectableGraphWithStore) {
+    this.#graph = graph;
+    this.#inspector = inspector;
+  }
+
+  async can(edge: EditableEdgeSpec): Promise<EditResult> {
+    const inspector = this.#inspector;
+    if (inspector.hasEdge(edge)) {
+      return {
+        success: false,
+        error: `Edge from "${edge.from}:${edge.out}" to "${edge.to}:${edge.in}" already exists`,
+      };
+    }
+    const from = inspector.nodeById(edge.from);
+    if (!from) {
+      return {
+        success: false,
+        error: `Node with id "${edge.from}" does not exist, but is required as the "from" part of the edge`,
+      };
+    }
+    const to = inspector.nodeById(edge.to);
+    if (!to) {
+      return {
+        success: false,
+        error: `Node with id "${edge.to}" does not exist, but is required as the "to" part of the edge`,
+      };
+    }
+
+    let error: string | null = null;
+    if (edge.out === "*" && edge.in !== "*") {
+      if (edge.in !== "") {
+        edge = { ...edge, out: edge.in };
+      }
+      error = `A "*" output port cannot be connected to a named or control input port`;
+    } else if (edge.out === "" && edge.in !== "") {
+      error = `A control input port cannot be connected to a named or "*" output part`;
+    } else if (edge.in === "*" && edge.out !== "*") {
+      if (edge.out !== "") {
+        edge = { ...edge, in: edge.out };
+      }
+      error = `A named input port cannot be connected to a "*" output port`;
+    } else if (edge.in === "" && edge.out !== "") {
+      error = `A named input port cannot be connected to a control output port`;
+    }
+    const fromPorts = (await from.ports()).outputs;
+    if (fromPorts.fixed) {
+      const found = fromPorts.ports.find((port) => port.name === edge.out);
+      if (!found) {
+        error ??= `Node with id "${edge.from}" does not have an output port named "${edge.out}"`;
+        return {
+          success: false,
+          error,
+        };
+      }
+    }
+    const toPorts = (await to.ports()).inputs;
+    if (toPorts.fixed) {
+      const found = toPorts.ports.find((port) => port.name === edge.in);
+      if (!found) {
+        error ??= `Node with id "${edge.to}" does not have an input port named "${edge.in}"`;
+        return {
+          success: false,
+          error,
+        };
+      }
+    }
+    if (error) {
+      return { success: false, error, alternative: edge };
+    }
+    return { success: true };
+  }
+
+  async do(spec: EditSpec): Promise<EditResult> {
+    if (spec.type !== "addedge") {
+      throw new Error(
+        `Editor API integrity error: expected type "addedge", received "${spec.type}" instead.`
+      );
+    }
+    let edge = spec.edge;
+    const strict = spec.strict;
+    const can = await this.can(edge);
+    if (!can.success) {
+      if (!can.alternative || strict) {
+        // this.#dispatchNoChange(can.error);
+        return can;
+      }
+      if (can.alternative) {
+        const canAlternative = await this.can(can.alternative);
+        if (!canAlternative.success) {
+          // this.#dispatchNoChange(canAlternative.error);
+          return canAlternative;
+        }
+        edge = can.alternative;
+      }
+    }
+    edge = fixUpStarEdge(edge);
+    edge = fixupConstantEdge(edge);
+    // TODO: Figure out how to make this work in multi-edit mode.
+    this.#inspector.edgeStore.add(edge);
+    this.#graph.edges.push(edge);
+    return { success: true };
+  }
+}

--- a/packages/breadboard/src/editor/operations/change-configuration.ts
+++ b/packages/breadboard/src/editor/operations/change-configuration.ts
@@ -38,6 +38,12 @@ export class ChangeConfiguration implements EditOperation {
       );
     }
     const { id, configuration } = spec;
+    if (!configuration) {
+      return {
+        success: false,
+        error: "Configuration wasn't supplied.",
+      };
+    }
     const can = await this.can(id);
     if (!can.success) {
       return can;

--- a/packages/breadboard/src/editor/operations/change-configuration.ts
+++ b/packages/breadboard/src/editor/operations/change-configuration.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  GraphDescriptor,
+  NodeIdentifier,
+} from "@google-labs/breadboard-schema/graph.js";
+import { EditOperation, EditSpec, SingleEditResult } from "../types.js";
+import { InspectableGraphWithStore } from "../../inspector/types.js";
+
+export class ChangeConfiguration implements EditOperation {
+  #graph: GraphDescriptor;
+  #inspector: InspectableGraphWithStore;
+
+  constructor(graph: GraphDescriptor, inspector: InspectableGraphWithStore) {
+    this.#graph = graph;
+    this.#inspector = inspector;
+  }
+
+  async can(id: NodeIdentifier): Promise<SingleEditResult> {
+    const node = this.#inspector.nodeById(id);
+    if (!node) {
+      return {
+        success: false,
+        error: `Unable to update configuration: node with id "${id}" does not exist`,
+      };
+    }
+    return { success: true };
+  }
+
+  async do(spec: EditSpec): Promise<SingleEditResult> {
+    if (spec.type !== "changeconfiguration") {
+      throw new Error(
+        `Editor API integrity error: expected type "changeconfiguration", received "${spec.type}" instead.`
+      );
+    }
+    const { id, configuration } = spec;
+    const can = await this.can(id);
+    if (!can.success) {
+      return can;
+    }
+    const node = this.#inspector.nodeById(id);
+    if (node) {
+      node.descriptor.configuration = configuration;
+    }
+    return { success: true };
+  }
+}

--- a/packages/breadboard/src/editor/operations/change-edge.ts
+++ b/packages/breadboard/src/editor/operations/change-edge.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GraphDescriptor } from "@google-labs/breadboard-schema/graph.js";
+import { InspectableGraphWithStore } from "../../inspector/types.js";
+import {
+  EdgeEditResult,
+  EditOperation,
+  EditSpec,
+  EditableEdgeSpec,
+  SingleEditResult,
+} from "../types.js";
+import { RemoveEdge } from "./remove-edge.js";
+import { AddEdge } from "./add-edge.js";
+import { edgesEqual, findEdgeIndex } from "../edge.js";
+import { fixUpStarEdge } from "../../inspector/edge.js";
+
+export class ChangeEdge implements EditOperation {
+  #graph: GraphDescriptor;
+  #inspector: InspectableGraphWithStore;
+
+  constructor(graph: GraphDescriptor, inspector: InspectableGraphWithStore) {
+    this.#graph = graph;
+    this.#inspector = inspector;
+  }
+
+  async can(
+    from: EditableEdgeSpec,
+    to: EditableEdgeSpec
+  ): Promise<EdgeEditResult> {
+    if (edgesEqual(from, to)) {
+      return { success: true };
+    }
+    const canRemoveOp = new RemoveEdge(this.#graph, this.#inspector);
+    const canRemove = await canRemoveOp.can(from);
+    if (!canRemove.success) return canRemove;
+    const canAddOp = new AddEdge(this.#graph, this.#inspector);
+    const canAdd = await canAddOp.can(to);
+    if (!canAdd.success) return canAdd;
+    return { success: true };
+  }
+
+  async do(spec: EditSpec): Promise<SingleEditResult> {
+    if (spec.type !== "changeedge") {
+      throw new Error(
+        `Editor API integrity error: expected type "changeedge", received "${spec.type}" instead.`
+      );
+    }
+    const from = spec.from;
+    let to = spec.to;
+    const strict = spec.strict;
+
+    const can = await this.can(from, to);
+    let alternativeChosen = false;
+    if (!can.success) {
+      if (!can.alternative || strict) {
+        return can;
+      }
+      to = can.alternative;
+      alternativeChosen = true;
+    }
+    if (edgesEqual(from, to)) {
+      if (alternativeChosen) {
+        const error = `Edge from ${from.from}:${from.out}" to "${to.to}:${to.in}" already exists`;
+        return {
+          success: false,
+          error,
+        };
+      }
+      return { success: true, nochange: true };
+    }
+    const fixedUpEdge = fixUpStarEdge(from);
+    const edges = this.#graph.edges;
+    const index = findEdgeIndex(this.#graph, fixedUpEdge);
+    const edge = edges[index];
+    edge.from = to.from;
+    edge.out = to.out;
+    edge.to = to.to;
+    edge.in = to.in;
+    if (to.constant === true) {
+      edge.constant = to.constant;
+    }
+    return { success: true };
+  }
+}

--- a/packages/breadboard/src/editor/operations/change-graph-metadata.ts
+++ b/packages/breadboard/src/editor/operations/change-graph-metadata.ts
@@ -4,27 +4,26 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GraphDescriptor } from "@google-labs/breadboard-schema/graph.js";
-import { EditOperation, EditSpec, SingleEditResult } from "../types.js";
-import { InspectableGraphWithStore } from "../../inspector/types.js";
+import {
+  EditOperation,
+  EditOperationContext,
+  EditSpec,
+  SingleEditResult,
+} from "../types.js";
 
 export class ChangeGraphMetadata implements EditOperation {
-  #graph: GraphDescriptor;
-  #inspector: InspectableGraphWithStore;
-
-  constructor(graph: GraphDescriptor, inspector: InspectableGraphWithStore) {
-    this.#graph = graph;
-    this.#inspector = inspector;
-  }
-
-  async do(spec: EditSpec): Promise<SingleEditResult> {
+  async do(
+    spec: EditSpec,
+    context: EditOperationContext
+  ): Promise<SingleEditResult> {
     if (spec.type !== "changegraphmetadata") {
       throw new Error(
         `Editor API integrity error: expected type "changegraphmetadata", received "${spec.type}" instead.`
       );
     }
     const { metadata } = spec;
-    this.#graph.metadata = metadata;
+    const { graph } = context;
+    graph.metadata = metadata;
     return { success: true };
   }
 }

--- a/packages/breadboard/src/editor/operations/change-graph-metadata.ts
+++ b/packages/breadboard/src/editor/operations/change-graph-metadata.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GraphDescriptor } from "@google-labs/breadboard-schema/graph.js";
+import { EditOperation, EditSpec, SingleEditResult } from "../types.js";
+import { InspectableGraphWithStore } from "../../inspector/types.js";
+
+export class ChangeGraphMetadata implements EditOperation {
+  #graph: GraphDescriptor;
+  #inspector: InspectableGraphWithStore;
+
+  constructor(graph: GraphDescriptor, inspector: InspectableGraphWithStore) {
+    this.#graph = graph;
+    this.#inspector = inspector;
+  }
+
+  async do(spec: EditSpec): Promise<SingleEditResult> {
+    if (spec.type !== "changegraphmetadata") {
+      throw new Error(
+        `Editor API integrity error: expected type "changegraphmetadata", received "${spec.type}" instead.`
+      );
+    }
+    const { metadata } = spec;
+    this.#graph.metadata = metadata;
+    return { success: true };
+  }
+}

--- a/packages/breadboard/src/editor/operations/change-metadata.ts
+++ b/packages/breadboard/src/editor/operations/change-metadata.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  GraphDescriptor,
+  NodeIdentifier,
+  NodeMetadata,
+} from "@google-labs/breadboard-schema/graph.js";
+import { EditOperation, EditSpec, SingleEditResult } from "../types.js";
+import { InspectableGraphWithStore } from "../../inspector/types.js";
+
+export class ChangeMetadata implements EditOperation {
+  #graph: GraphDescriptor;
+  #inspector: InspectableGraphWithStore;
+
+  constructor(graph: GraphDescriptor, inspector: InspectableGraphWithStore) {
+    this.#graph = graph;
+    this.#inspector = inspector;
+  }
+
+  async can(id: NodeIdentifier): Promise<SingleEditResult> {
+    const node = this.#inspector.nodeById(id);
+    if (!node) {
+      return {
+        success: false,
+        error: `Node with id "${id}" does not exist`,
+      };
+    }
+    return { success: true };
+  }
+
+  #isVisualOnly(incoming: NodeMetadata, existing: NodeMetadata): boolean {
+    return (
+      existing.title === incoming.title &&
+      existing.description === incoming.description &&
+      existing.logLevel === incoming.logLevel
+    );
+  }
+
+  async do(spec: EditSpec): Promise<SingleEditResult> {
+    if (spec.type !== "changemetadata") {
+      throw new Error(
+        `Editor API integrity error: expected type "changemetadata", received "${spec.type}" instead.`
+      );
+    }
+    const { id, metadata } = spec;
+    if (!metadata) {
+      return {
+        success: false,
+        error: "Metadata wasn't supplied.",
+      };
+    }
+    const can = await this.can(id);
+    if (!can.success) return can;
+    const node = this.#inspector.nodeById(id);
+    if (!node) {
+      const error = `Unknown node with id "${id}"`;
+      return { success: false, error };
+    }
+    const visualOnly = this.#isVisualOnly(
+      metadata,
+      node.descriptor.metadata || {}
+    );
+    node.descriptor.metadata = metadata;
+    return { success: true, visualOnly };
+  }
+}

--- a/packages/breadboard/src/editor/operations/remove-edge.ts
+++ b/packages/breadboard/src/editor/operations/remove-edge.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GraphDescriptor } from "@google-labs/breadboard-schema/graph.js";
+import {
+  EditOperation,
+  EditSpec,
+  EditableEdgeSpec,
+  SingleEditResult,
+} from "../types.js";
+import { InspectableGraphWithStore } from "../../inspector/types.js";
+import { fixUpStarEdge } from "../../inspector/edge.js";
+import { findEdgeIndex } from "../edge.js";
+
+export class RemoveEdge implements EditOperation {
+  #graph: GraphDescriptor;
+  #inspector: InspectableGraphWithStore;
+
+  constructor(graph: GraphDescriptor, inspector: InspectableGraphWithStore) {
+    this.#graph = graph;
+    this.#inspector = inspector;
+  }
+
+  async can(spec: EditableEdgeSpec): Promise<SingleEditResult> {
+    if (!this.#inspector.hasEdge(spec)) {
+      return {
+        success: false,
+        error: `Edge from "${spec.from}:${spec.out}" to "${spec.to}:${spec.in}" does not exist`,
+      };
+    }
+    return { success: true };
+  }
+
+  async do(spec: EditSpec): Promise<SingleEditResult> {
+    if (spec.type !== "removeedge") {
+      throw new Error(
+        `Editor API integrity error: expected type "removeedge", received "${spec.type}" instead.`
+      );
+    }
+    let edge = spec.edge;
+    const can = await this.can(edge);
+    if (!can.success) {
+      return can;
+    }
+    edge = fixUpStarEdge(edge);
+    const edges = this.#graph.edges;
+    const index = findEdgeIndex(this.#graph, edge);
+    const foundEdge = edges.splice(index, 1)[0];
+    this.#inspector.edgeStore.remove(foundEdge);
+    return { success: true };
+  }
+}

--- a/packages/breadboard/src/editor/operations/remove-node.ts
+++ b/packages/breadboard/src/editor/operations/remove-node.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  GraphDescriptor,
+  NodeIdentifier,
+} from "@google-labs/breadboard-schema/graph.js";
+import { EditOperation, EditSpec, SingleEditResult } from "../types.js";
+import { InspectableGraphWithStore } from "../../inspector/types.js";
+
+export class RemoveNode implements EditOperation {
+  #graph: GraphDescriptor;
+  #inspector: InspectableGraphWithStore;
+
+  constructor(graph: GraphDescriptor, inspector: InspectableGraphWithStore) {
+    this.#graph = graph;
+    this.#inspector = inspector;
+  }
+
+  async can(id: NodeIdentifier): Promise<SingleEditResult> {
+    const exists = !!this.#inspector.nodeById(id);
+    if (!exists) {
+      return {
+        success: false,
+        error: `Unable to remove node: node with id "${id}" does not exist`,
+      };
+    }
+    return { success: true };
+  }
+
+  async do(spec: EditSpec): Promise<SingleEditResult> {
+    if (spec.type !== "removenode") {
+      throw new Error(
+        `Editor API integrity error: expected type "removenode", received "${spec.type}" instead.`
+      );
+    }
+    const id = spec.id;
+    const can = await this.can(id);
+    if (!can.success) {
+      return can;
+    }
+
+    // Remove any edges that are connected to the removed node.
+    this.#graph.edges = this.#graph.edges.filter((edge) => {
+      const shouldRemove = edge.from === id || edge.to === id;
+      if (shouldRemove) {
+        this.#inspector.edgeStore.remove(edge);
+      }
+      return !shouldRemove;
+    });
+    // Remove the node from the graph.
+    this.#graph.nodes = this.#graph.nodes.filter((node) => node.id != id);
+    this.#inspector.nodeStore.remove(id);
+    return { success: true };
+  }
+}

--- a/packages/breadboard/src/editor/operations/remove-node.ts
+++ b/packages/breadboard/src/editor/operations/remove-node.ts
@@ -4,24 +4,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { NodeIdentifier } from "@google-labs/breadboard-schema/graph.js";
 import {
-  GraphDescriptor,
-  NodeIdentifier,
-} from "@google-labs/breadboard-schema/graph.js";
-import { EditOperation, EditSpec, SingleEditResult } from "../types.js";
-import { InspectableGraphWithStore } from "../../inspector/types.js";
+  EditOperation,
+  EditOperationContext,
+  EditSpec,
+  SingleEditResult,
+} from "../types.js";
+import { InspectableGraph } from "../../inspector/types.js";
 
 export class RemoveNode implements EditOperation {
-  #graph: GraphDescriptor;
-  #inspector: InspectableGraphWithStore;
-
-  constructor(graph: GraphDescriptor, inspector: InspectableGraphWithStore) {
-    this.#graph = graph;
-    this.#inspector = inspector;
-  }
-
-  async can(id: NodeIdentifier): Promise<SingleEditResult> {
-    const exists = !!this.#inspector.nodeById(id);
+  async can(
+    id: NodeIdentifier,
+    inspector: InspectableGraph
+  ): Promise<SingleEditResult> {
+    const exists = !!inspector.nodeById(id);
     if (!exists) {
       return {
         success: false,
@@ -31,29 +28,33 @@ export class RemoveNode implements EditOperation {
     return { success: true };
   }
 
-  async do(spec: EditSpec): Promise<SingleEditResult> {
+  async do(
+    spec: EditSpec,
+    context: EditOperationContext
+  ): Promise<SingleEditResult> {
     if (spec.type !== "removenode") {
       throw new Error(
         `Editor API integrity error: expected type "removenode", received "${spec.type}" instead.`
       );
     }
     const id = spec.id;
-    const can = await this.can(id);
+    const { graph, inspector, store } = context;
+    const can = await this.can(id, inspector);
     if (!can.success) {
       return can;
     }
 
     // Remove any edges that are connected to the removed node.
-    this.#graph.edges = this.#graph.edges.filter((edge) => {
+    graph.edges = graph.edges.filter((edge) => {
       const shouldRemove = edge.from === id || edge.to === id;
       if (shouldRemove) {
-        this.#inspector.edgeStore.remove(edge);
+        store.edgeStore.remove(edge);
       }
       return !shouldRemove;
     });
     // Remove the node from the graph.
-    this.#graph.nodes = this.#graph.nodes.filter((node) => node.id != id);
-    this.#inspector.nodeStore.remove(id);
+    graph.nodes = graph.nodes.filter((node) => node.id != id);
+    store.nodeStore.remove(id);
     return { success: true };
   }
 }

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -117,7 +117,7 @@ export type RemoveGraphSpec = {
 };
 
 export type EditOperation = {
-  do(edit: EditSpec): Promise<EditResult>;
+  do(edit: EditSpec): Promise<SingleEditResult>;
 };
 
 export type EditSpec =

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -10,6 +10,7 @@ import {
   NodeMetadata,
 } from "@google-labs/breadboard-schema/graph.js";
 import {
+  GraphStoreMutator,
   InspectableGraph,
   InspectableGraphOptions,
 } from "../inspector/types.js";
@@ -116,8 +117,14 @@ export type RemoveGraphSpec = {
   id: GraphIdentifier;
 };
 
+export type EditOperationContext = {
+  graph: GraphDescriptor;
+  inspector: InspectableGraph;
+  store: GraphStoreMutator;
+};
+
 export type EditOperation = {
-  do(edit: EditSpec): Promise<SingleEditResult>;
+  do(edit: EditSpec, context: EditOperationContext): Promise<SingleEditResult>;
 };
 
 export type EditSpec =

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -115,6 +115,10 @@ export type RemoveGraphSpec = {
   id: GraphIdentifier;
 };
 
+export type EditOperation = {
+  do(edit: EditSpec): Promise<EditResult>;
+};
+
 export type EditSpec =
   | AddNodeSpec
   | RemoveNodeSpec

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -79,6 +79,7 @@ export type ChangeEdgeSpec = {
   type: "changeedge";
   from: EditableEdgeSpec;
   to: EditableEdgeSpec;
+  strict: boolean;
 };
 
 export type ChangeConfigurationSpec = {
@@ -207,6 +208,11 @@ export type SingleEditResult =
     }
   | {
       success: true;
+      /**
+       * Indicates that the edit was successful, and
+       * resulted in no change.
+       */
+      nochange?: boolean;
     };
 
 export type EdgeEditResult =

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -213,6 +213,11 @@ export type SingleEditResult =
        * resulted in no change.
        */
       nochange?: boolean;
+      /**
+       * Indicates that this edit only involved visual
+       * changes.
+       */
+      visualOnly?: boolean;
     };
 
 export type EdgeEditResult =

--- a/packages/breadboard/src/inspector/graph.ts
+++ b/packages/breadboard/src/inspector/graph.ts
@@ -149,16 +149,20 @@ class Graph implements InspectableGraphWithStore {
     return (this.#kits ??= collectKits(this.#options.kits || []));
   }
 
-  typeForNode(id: string): InspectableNodeType | undefined {
-    const kits = this.kits();
+  typeForNode(id: NodeIdentifier): InspectableNodeType | undefined {
     const node = this.nodeById(id);
     if (!node) {
       return undefined;
     }
+    return this.typeById(node.descriptor.type);
+  }
+
+  typeById(id: NodeTypeIdentifier): InspectableNodeType | undefined {
+    const kits = this.kits();
     this.#nodeTypes ??= new Map(
       kits.flatMap((kit) => kit.nodeTypes.map((type) => [type.type(), type]))
     );
-    return this.#nodeTypes.get(node.descriptor.type);
+    return this.#nodeTypes.get(id);
   }
 
   incomingForNode(id: NodeIdentifier): InspectableEdge[] {

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -213,6 +213,11 @@ export type InspectableGraph = {
    */
   typeForNode(id: NodeIdentifier): InspectableNodeType | undefined;
   /**
+   * Returns the `InspectableNodeType` for a given type or undefined if the type
+   * does not exist.
+   */
+  typeById(id: NodeTypeIdentifier): InspectableNodeType | undefined;
+  /**
    * Describe a given type of the node
    */
   describeType(

--- a/packages/breadboard/tests/editor/graph.ts
+++ b/packages/breadboard/tests/editor/graph.ts
@@ -453,6 +453,7 @@ test("editor API allows changing edge", async (t) => {
       type: "changeedge",
       from: { from: "node0", out: "out", to: "node0", in: "in" },
       to: { from: "node0", out: "out", to: "node2", in: "in" },
+      strict: false,
     },
   ]);
 


### PR DESCRIPTION
- **Migrate `AddEdge` to an operation.**
- **Introduce `InspectableGraph.typeById`.**
- **Introduce `AddNode` operation.**
- **Introduce `RemoveNode` operation.**
- **Introduce `RemoveEdge` operation.**
- **Introduce `ChangeEdge` operation.**
- **Introduce `ChangeConfiguration` operation.**
- **Introduce `ChangeMetadata` operation.**
- **Introduce `ChangeGraphMetadata` operation.**
- **Remove helper methods.**
- **Use a routing map.**
- **docs(changeset): Switch to use edit operations machinery in Editor API internals.**
