### PR TITLE
rollback

### DIFF
--- a/.changeset/shiny-mayflies-lie.md
+++ b/.changeset/shiny-mayflies-lie.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard": minor
+---
+
+Teach Editor API to properly roll back multiple graph changes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1471,6 +1471,7 @@
     },
     "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "extraneous": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {

--- a/packages/breadboard/src/editor/graph.ts
+++ b/packages/breadboard/src/editor/graph.ts
@@ -150,21 +150,21 @@ export class Graph implements EditableGraph {
         error: "Unsupported edit type",
       };
     }
-    const can = await operation.do(edit, {
+    const result = await operation.do(edit, {
       graph: this.#graph,
       inspector: this.#inspector,
       store: this.#inspector,
     });
-    if (!can.success) {
-      this.#dispatchNoChange(can.error);
-      return can;
+    if (!result.success) {
+      this.#dispatchNoChange(result.error);
+      return result;
     }
-    if (can.nochange) {
+    if (result.noChange) {
       this.#dispatchNoChange();
-      return can;
+      return result;
     }
-    this.#updateGraph(!!can.visualOnly);
-    return can;
+    this.#updateGraph(!!result.visualOnly);
+    return result;
   }
 
   async #canEdit(edits: EditSpec[]): Promise<EdgeEditResult> {

--- a/packages/breadboard/src/editor/operations/add-edge.ts
+++ b/packages/breadboard/src/editor/operations/add-edge.ts
@@ -7,9 +7,9 @@
 import {
   EditOperation,
   EditOperationContext,
-  EditResult,
   EditSpec,
   EditableEdgeSpec,
+  SingleEditResult,
 } from "../types.js";
 import { InspectableGraph } from "../../inspector/types.js";
 import { fixUpStarEdge, fixupConstantEdge } from "../../inspector/edge.js";
@@ -18,7 +18,7 @@ export class AddEdge implements EditOperation {
   async can(
     edge: EditableEdgeSpec,
     inspector: InspectableGraph
-  ): Promise<EditResult> {
+  ): Promise<SingleEditResult> {
     if (inspector.hasEdge(edge)) {
       return {
         success: false,
@@ -84,7 +84,10 @@ export class AddEdge implements EditOperation {
     return { success: true };
   }
 
-  async do(spec: EditSpec, context: EditOperationContext): Promise<EditResult> {
+  async do(
+    spec: EditSpec,
+    context: EditOperationContext
+  ): Promise<SingleEditResult> {
     if (spec.type !== "addedge") {
       throw new Error(
         `Editor API integrity error: expected type "addedge", received "${spec.type}" instead.`

--- a/packages/breadboard/src/editor/operations/change-edge.ts
+++ b/packages/breadboard/src/editor/operations/change-edge.ts
@@ -6,7 +6,6 @@
 
 import { InspectableGraph } from "../../inspector/types.js";
 import {
-  EdgeEditResult,
   EditOperation,
   EditOperationContext,
   EditSpec,
@@ -23,7 +22,7 @@ export class ChangeEdge implements EditOperation {
     from: EditableEdgeSpec,
     to: EditableEdgeSpec,
     inspector: InspectableGraph
-  ): Promise<EdgeEditResult> {
+  ): Promise<SingleEditResult> {
     if (edgesEqual(from, to)) {
       return { success: true };
     }

--- a/packages/breadboard/src/editor/operations/change-edge.ts
+++ b/packages/breadboard/src/editor/operations/change-edge.ts
@@ -67,7 +67,7 @@ export class ChangeEdge implements EditOperation {
           error,
         };
       }
-      return { success: true, nochange: true };
+      return { success: true, noChange: true };
     }
     const fixedUpEdge = fixUpStarEdge(from);
     const edges = graph.edges;

--- a/packages/breadboard/src/editor/operations/change-metadata.ts
+++ b/packages/breadboard/src/editor/operations/change-metadata.ts
@@ -49,12 +49,6 @@ export class ChangeMetadata implements EditOperation {
       );
     }
     const { id, metadata } = spec;
-    if (!metadata) {
-      return {
-        success: false,
-        error: "Metadata wasn't supplied.",
-      };
-    }
     const { inspector } = context;
     const can = await this.can(id, inspector);
     if (!can.success) return can;

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -136,7 +136,6 @@ export type EditSpec =
   | ChangeConfigurationSpec
   | ChangeMetadataSpec
   | ChangeGraphMetadataSpec;
-export type EditResult = SingleEditResult;
 
 export type EditableGraph = {
   addEventListener<Key extends keyof EditableGraphEventMap>(
@@ -231,5 +230,25 @@ export type SingleEditResult =
        */
       visualOnly?: boolean;
     };
+
+export type EditResultLogEntry = {
+  edit: EditSpec["type"];
+  result: SingleEditResult;
+};
+
+/**
+ * Multi-edit result.
+ */
+export type EditResult = {
+  log: EditResultLogEntry[];
+} & (
+  | {
+      success: true;
+    }
+  | {
+      success: false;
+      error: string;
+    }
+);
 
 export type EditableEdgeSpec = Edge;

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -86,13 +86,13 @@ export type ChangeEdgeSpec = {
 export type ChangeConfigurationSpec = {
   type: "changeconfiguration";
   id: NodeIdentifier;
-  configuration?: NodeConfiguration;
+  configuration: NodeConfiguration;
 };
 
 export type ChangeMetadataSpec = {
   type: "changemetadata";
   id: NodeIdentifier;
-  metadata?: NodeMetadata;
+  metadata: NodeMetadata;
 };
 
 export type ChangeGraphMetadataSpec = {

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -136,7 +136,7 @@ export type EditSpec =
   | ChangeConfigurationSpec
   | ChangeMetadataSpec
   | ChangeGraphMetadataSpec;
-export type EditResult = EdgeEditResult;
+export type EditResult = SingleEditResult;
 
 export type EditableGraph = {
   addEventListener<Key extends keyof EditableGraphEventMap>(
@@ -212,6 +212,11 @@ export type SingleEditResult =
   | {
       success: false;
       error: string;
+      /**
+       * Only used when editing edges, provides an
+       * alternative that could be used for the operation to still succeed.
+       */
+      alternative?: EditableEdgeSpec;
     }
   | {
       success: true;
@@ -225,16 +230,6 @@ export type SingleEditResult =
        * changes.
        */
       visualOnly?: boolean;
-    };
-
-export type EdgeEditResult =
-  | {
-      success: true;
-    }
-  | {
-      success: false;
-      error: string;
-      alternative?: EditableEdgeSpec;
     };
 
 export type EditableEdgeSpec = Edge;

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -219,7 +219,7 @@ export type SingleEditResult =
        * Indicates that the edit was successful, and
        * resulted in no change.
        */
-      nochange?: boolean;
+      noChange?: boolean;
       /**
        * Indicates that this edit only involved visual
        * changes.

--- a/packages/breadboard/src/inspector/graph.ts
+++ b/packages/breadboard/src/inspector/graph.ts
@@ -227,6 +227,15 @@ class Graph implements InspectableGraphWithStore {
     this.#graph = graph;
   }
 
+  resetGraph(graph: GraphDescriptor): void {
+    this.#graph = graph;
+    const nodes = new NodeCache(this);
+    const edges = new EdgeCache(nodes);
+    edges.populate(graph);
+    this.#cache = { edges, nodes };
+    this.#graphs = null;
+  }
+
   #populateSubgraphs(): InspectableSubgraphs {
     const subgraphs = this.#graph.graphs;
     if (!subgraphs) return {};

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -455,6 +455,9 @@ export type GraphStoreMutator = {
   // TODO: This is probably wrong. A new version of the graph should likely
   // create a new instance of an `InspectableGraph`.
   updateGraph(graph: GraphDescriptor): void;
+  // Destroys all caches.
+  // TODO: Maybe too much machinery here? Just get a new instance of inspector?
+  resetGraph(graph: GraphDescriptor): void;
   nodeStore: NodeStoreMutator;
   edgeStore: EdgeStoreMutator;
 };

--- a/packages/breadboard/tests/editor/graph.ts
+++ b/packages/breadboard/tests/editor/graph.ts
@@ -9,7 +9,7 @@ import test from "ava";
 import { editGraph } from "../../src/editor/index.js";
 import { NodeHandler } from "../../src/types.js";
 
-const testEditGraph = () => {
+export const testEditGraph = () => {
   return editGraph(
     structuredClone({
       nodes: [
@@ -532,7 +532,12 @@ test("editor API allows using 'star` ports as drop zones", async (t) => {
     if (result.success) {
       t.fail();
     } else {
-      t.deepEqual(result.alternative, {
+      const singleEdit = result.log[0].result;
+      if (singleEdit.success) {
+        t.fail();
+        return;
+      }
+      t.deepEqual(singleEdit.alternative, {
         from: "node0",
         out: "out",
         to: "node2",

--- a/packages/breadboard/tests/editor/graph.ts
+++ b/packages/breadboard/tests/editor/graph.ts
@@ -474,7 +474,7 @@ test("editor API does not allow connecting a specific output port to a star port
 
   const edgeSpec = { from: "node0", out: "out", to: "node2", in: "*" };
   const result = await graph.edit(
-    [{ type: "addedge", edge: edgeSpec, strict: false }],
+    [{ type: "addedge", edge: edgeSpec, strict: true }],
     true
   );
   t.false(result.success);
@@ -526,7 +526,7 @@ test("editor API allows using 'star` ports as drop zones", async (t) => {
   {
     const graph = testEditGraph();
     const result = await graph.edit(
-      [{ type: "addedge", edge: edgeSpec, strict: false }],
+      [{ type: "addedge", edge: edgeSpec, strict: true }],
       true
     );
     if (result.success) {

--- a/packages/breadboard/tests/editor/metadata.ts
+++ b/packages/breadboard/tests/editor/metadata.ts
@@ -34,9 +34,10 @@ test("editGraph correctly edits node metadata", async (t) => {
   t.is(metadata, undefined);
 
   const result = await graph.edit(
-    [{ type: "changemetadata", id: "node0" }],
+    [{ type: "changemetadata", id: "node0", metadata: {} }],
     true
   );
+  console.log(result);
   t.is(result.success, true);
 
   const newMetadata = { title: "bar" };
@@ -67,7 +68,7 @@ test("editGraph correctly edits visual node metadata", async (t) => {
   t.is(metadata, undefined);
 
   const result = await graph.edit(
-    [{ type: "changemetadata", id: "node0" }],
+    [{ type: "changemetadata", id: "node0", metadata: {} }],
     true
   );
   t.is(result.success, true);

--- a/packages/breadboard/tests/editor/multi.ts
+++ b/packages/breadboard/tests/editor/multi.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import test from "ava";
+import { testEditGraph } from "./graph.js";
+
+test("Multi-edit returns a last failed edit's error message", async (t) => {
+  const graph = testEditGraph();
+  const result = await graph.edit(
+    [
+      {
+        type: "addnode",
+        node: {
+          id: "node0",
+          type: "foo",
+        },
+      },
+    ],
+    true
+  );
+
+  if (result.success) {
+    t.fail();
+    return;
+  }
+  t.true(result.log.length === 1);
+  const singleEdit = result.log[0].result;
+  if (singleEdit.success) {
+    t.fail();
+    return;
+  }
+  t.assert(result.error === singleEdit.error);
+});

--- a/packages/breadboard/tests/editor/multi.ts
+++ b/packages/breadboard/tests/editor/multi.ts
@@ -10,15 +10,7 @@ import { testEditGraph } from "./graph.js";
 test("Multi-edit returns a last failed edit's error message", async (t) => {
   const graph = testEditGraph();
   const result = await graph.edit(
-    [
-      {
-        type: "addnode",
-        node: {
-          id: "node0",
-          type: "foo",
-        },
-      },
-    ],
+    [{ type: "addnode", node: { id: "node0", type: "foo" } }],
     true
   );
 
@@ -33,4 +25,60 @@ test("Multi-edit returns a last failed edit's error message", async (t) => {
     return;
   }
   t.assert(result.error === singleEdit.error);
+});
+
+test("Multi-edit can do multiple successful edits", async (t) => {
+  {
+    const graph = testEditGraph();
+    const result = await graph.edit([
+      { type: "addnode", node: { id: "node-1", type: "foo" } },
+      { type: "addnode", node: { id: "node-2", type: "foo" } },
+      { type: "addnode", node: { id: "node-3", type: "foo" } },
+    ]);
+    t.true(result.success);
+    const inspector = graph.inspect();
+    t.assert(inspector.nodeById("node-1"));
+    t.assert(inspector.nodeById("node-2"));
+    t.assert(inspector.nodeById("node-3"));
+  }
+  {
+    const graph = testEditGraph();
+    const result = await graph.edit(
+      [
+        { type: "addnode", node: { id: "node-1", type: "foo" } },
+        { type: "addnode", node: { id: "node-2", type: "foo" } },
+        { type: "addnode", node: { id: "node-3", type: "foo" } },
+      ],
+      true
+    );
+    t.true(result.success);
+    const inspector = graph.inspect();
+    t.assert(!inspector.nodeById("node-1"));
+    t.assert(!inspector.nodeById("node-2"));
+    t.assert(!inspector.nodeById("node-3"));
+  }
+});
+
+test("Multi-edit gracefully fails", async (t) => {
+  {
+    const graph = testEditGraph();
+    const result = await graph.edit([
+      { type: "addnode", node: { id: "node-1", type: "foo" } },
+      { type: "addnode", node: { id: "node0", type: "foo" } },
+      { type: "addnode", node: { id: "node-3", type: "foo" } },
+    ]);
+    if (result.success) {
+      t.fail();
+      return;
+    }
+    const failedEdit = result.log[1];
+    t.is(failedEdit.edit, "addnode");
+    if (failedEdit.result.success) {
+      t.fail();
+      return;
+    }
+    const inspector = graph.inspect();
+    t.assert(!inspector.nodeById("node-1"));
+    t.assert(!inspector.nodeById("node-3"));
+  }
 });


### PR DESCRIPTION
- **Tweak naming for clarity.**
- **Implement dryRun as a throw-away run.**
- **Cohere all single edit results into `SingleEditResult`.**
- **Make `EditResult` multi-edit-aware.**
- **Support multi-edit under covers.**
- **Loosely working multi-edit.**
- **Add tests for event dispatch.**
- **docs(changeset): Teach Editor API to properly roll back multiple graph changes.**
