### PR TITLE
fix event rerender

### DIFF
--- a/.changeset/proud-crabs-breathe.md
+++ b/.changeset/proud-crabs-breathe.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard": patch
+---
+
+Don't update events when looking up event data.

--- a/packages/breadboard/src/inspector/run/path-registry.ts
+++ b/packages/breadboard/src/inspector/run/path-registry.ts
@@ -139,7 +139,7 @@ class Entry implements PathRegistryEntry {
   ): PathRegistryEntry | null {
     // Marking events dirty, because we're about to mutate something within
     // this swath of the registry.
-    this.#eventsIsDirty = true;
+    if (!readonly) this.#eventsIsDirty = true;
     const [head, ...tail] = path;
     if (head === undefined) {
       return null;


### PR DESCRIPTION
- **Only mark `events` as dirty when mutating path registry.**
- **docs(changeset): Don't update events when looking up event data.**
