### PR TITLE
[breadboard-ui] Only show history when focused on renderer

### DIFF
--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -481,6 +481,15 @@ export class Main extends LitElement {
     }
 
     if (evt.key === "h" && !evt.metaKey && !evt.shiftKey) {
+      const isFocusedOnRenderer = evt
+        .composedPath()
+        .find(
+          (target) => target instanceof BreadboardUI.Elements.GraphRenderer
+        );
+      if (!isFocusedOnRenderer) {
+        return;
+      }
+
       this.showHistory = !this.showHistory;
     }
 


### PR DESCRIPTION
Fixes #1874 