### PR TITLE
[runJavascript schema] Adds Schema support to runJavascript

### DIFF
--- a/.changeset/spotty-worms-reflect.md
+++ b/.changeset/spotty-worms-reflect.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/core-kit": minor
+---
+
+Teachs runJavaScript to accept a schema

--- a/packages/core-kit/tests/run-javascript.ts
+++ b/packages/core-kit/tests/run-javascript.ts
@@ -80,6 +80,32 @@ test("runJavascript understands `raw` input", async (t) => {
   t.deepEqual(result, { hello: "world" });
 });
 
+test("describe outputs when raw = true and schema defined", async (t) => {
+  const result = (
+    await handler.describe({
+      raw: true,
+      schema: {
+        type: "object",
+        properties: {
+          hello: { type: "string" },
+        },
+      },
+    })
+  ).outputSchema;
+  t.deepEqual(result, {
+    type: "object",
+    properties: {
+      hello: {
+        type: "string",
+        title: "hello",
+        description: 'output "hello"',
+      },
+    },
+    required: [],
+    additionalProperties: false,
+  });
+});
+
 test("describe outputs when raw = true", async (t) => {
   const result = (await handler.describe({ raw: true })).outputSchema;
   t.deepEqual(result, {
@@ -145,6 +171,16 @@ test("describe inputs", async (t) => {
           "Whether or not to return use the result of execution as raw output (true) or as a port called `result` (false). Default is false.",
         title: "raw",
         type: "boolean",
+      },
+      schema: {
+        additionalProperties: true,
+        behavior: ["config"],
+        description:
+          "The schema of the output data. This is used to validate the output data before running the code.",
+        properties: {},
+        required: [],
+        title: "schema",
+        type: "object",
       },
       what: {
         title: "what",


### PR DESCRIPTION
There is now an optional port called `schema` it accepts JSON schema. When populated it will create output ports of the correct name and type. There is no validation on the result of the `runJavascript`

Fixes #1930 

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
