### PR TITLE
data store

### DIFF
--- a/.changeset/silver-tigers-design.md
+++ b/.changeset/silver-tigers-design.md
@@ -1,0 +1,6 @@
+---
+"@google-labs/breadboard-ui": minor
+"@google-labs/breadboard": minor
+---
+
+Implement `DataStore` and a simple implementation.

--- a/.changeset/wet-moles-sin.md
+++ b/.changeset/wet-moles-sin.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/core-kit": minor
+---
+
+Introduce `deflate` node.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1377,18 +1377,6 @@
         "sisteransi": "^1.0.5"
       }
     },
-    "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
-      "version": "1.3.0",
-      "extraneous": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@codemirror/autocomplete": {
       "version": "6.16.0",
       "license": "MIT",
@@ -3158,6 +3146,14 @@
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.2.0",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/context": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@lit/context/-/context-1.1.1.tgz",
+      "integrity": "sha512-q/Rw7oWSJidUP43f/RUPwqZ6f5VlY8HzinTWxL/gW1Hvm2S5q2hZvV+qM8WFcC+oLNNknc3JKsd5TwxLk1hbdg==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.6.2 || ^2.0.0"
+      }
     },
     "node_modules/@lit/reactive-element": {
       "version": "2.0.4",
@@ -24604,6 +24600,7 @@
       "dependencies": {
         "@dagrejs/dagre": "^1.1.2",
         "@google-labs/breadboard": "^0.20.0",
+        "@lit/context": "^1.1.1",
         "@lit/task": "^1.0.0",
         "ajv": "^8.13.0",
         "lit": "^3.1.3",

--- a/packages/breadboard-ui/package.json
+++ b/packages/breadboard-ui/package.json
@@ -143,6 +143,7 @@
   "dependencies": {
     "@dagrejs/dagre": "^1.1.2",
     "@google-labs/breadboard": "^0.20.0",
+    "@lit/context": "^1.1.1",
     "@lit/task": "^1.0.0",
     "ajv": "^8.13.0",
     "lit": "^3.1.3",

--- a/packages/breadboard-ui/src/contexts/data-store.ts
+++ b/packages/breadboard-ui/src/contexts/data-store.ts
@@ -1,0 +1,4 @@
+import { DataStore } from "@google-labs/breadboard";
+import { createContext } from "@lit/context";
+
+export const dataStoreContext = createContext<DataStore>("datastore");

--- a/packages/breadboard-ui/src/elements/activity-log/activity-log.ts
+++ b/packages/breadboard-ui/src/elements/activity-log/activity-log.ts
@@ -11,6 +11,7 @@ import {
   InspectableRunInputs,
   InspectableRunNodeEvent,
   OutputValues,
+  createDataStore,
 } from "@google-labs/breadboard";
 import { LitElement, html, HTMLTemplateResult, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
@@ -24,6 +25,8 @@ import { markdown } from "../../directives/markdown.js";
 import { SETTINGS_TYPE, Settings } from "../../types/types.js";
 import { styles as activityLogStyles } from "./activity-log.styles.js";
 import { isArrayOfLLMContent, isLLMContent } from "../../utils/llm-content.js";
+import { provide } from "@lit/context";
+import { dataStoreContext } from "../../contexts/data-store.js";
 
 @customElement("bb-activity-log")
 export class ActivityLog extends LitElement {
@@ -47,6 +50,9 @@ export class ActivityLog extends LitElement {
 
   @property()
   settings: Settings | null = null;
+
+  @provide({ context: dataStoreContext })
+  dataStore = createDataStore();
 
   #seenItems = new Set<string>();
   #newestEntry: Ref<HTMLElement> = createRef();

--- a/packages/breadboard-ui/src/elements/input/llm-input/llm-input.ts
+++ b/packages/breadboard-ui/src/elements/input/llm-input/llm-input.ts
@@ -14,7 +14,6 @@ import {
 import { map } from "lit/directives/map.js";
 import { classMap } from "lit/directives/class-map.js";
 import { Ref, createRef, ref } from "lit/directives/ref.js";
-// import { asBase64 } from "../../../utils/as-base-64.js";
 import { until } from "lit/directives/until.js";
 import { cache } from "lit/directives/cache.js";
 import type { AudioInput } from "../audio/audio.js";
@@ -28,7 +27,6 @@ import {
   isText,
 } from "../../../utils/llm-content.js";
 import { createDataStore } from "@google-labs/breadboard";
-import { asBase64 } from "../../../utils/as-base-64.js";
 
 const inlineDataTemplate = { inlineData: { data: "", mimeType: "" } };
 

--- a/packages/breadboard-ui/src/elements/input/llm-input/llm-input.ts
+++ b/packages/breadboard-ui/src/elements/input/llm-input/llm-input.ts
@@ -9,11 +9,12 @@ import {
   AllowedLLMContentTypes,
   LLMContent,
   LLMInlineData,
+  LLMStoredData,
 } from "../../../types/types.js";
 import { map } from "lit/directives/map.js";
 import { classMap } from "lit/directives/class-map.js";
 import { Ref, createRef, ref } from "lit/directives/ref.js";
-import { asBase64 } from "../../../utils/as-base-64.js";
+// import { asBase64 } from "../../../utils/as-base-64.js";
 import { until } from "lit/directives/until.js";
 import { cache } from "lit/directives/cache.js";
 import type { AudioInput } from "../audio/audio.js";
@@ -23,10 +24,14 @@ import {
   isFunctionCall,
   isFunctionResponse,
   isInlineData,
+  isStoredData,
   isText,
 } from "../../../utils/llm-content.js";
 
 const inlineDataTemplate = { inlineData: { data: "", mimeType: "" } };
+const storedDataTemplate: LLMStoredData = {
+  storedData: { handle: "", mimeType: "" },
+};
 
 type MultiModalInput = AudioInput | DrawableInput | WebcamInput;
 
@@ -522,16 +527,31 @@ export class LLMInput extends LitElement {
     }
 
     if (!this.value.parts[partIdx]) {
-      this.value.parts[partIdx] = structuredClone(inlineDataTemplate);
+      this.value.parts[partIdx] = structuredClone(storedDataTemplate);
+    } else if (!isStoredData(this.value.parts[partIdx])) {
+      this.value.parts[partIdx] = structuredClone(storedDataTemplate);
     }
+
+    // if (!this.value.parts[partIdx]) {
+    //   this.value.parts[partIdx] = structuredClone(inlineDataTemplate);
+    // }
 
     let part = this.value.parts[partIdx];
-    if (!isInlineData(part)) {
-      part = structuredClone(inlineDataTemplate);
+    if (!isStoredData(part)) {
+      part = structuredClone(storedDataTemplate);
     }
+    // This will leak for now.
+    // TODO: Use actual DataStore for this.
+    part.storedData.handle = URL.createObjectURL(files[0]);
+    part.storedData.mimeType = files[0].type;
+    console.log("🌻 I am done", this.value.parts[partIdx]);
 
-    part.inlineData.data = await asBase64(files[0]);
-    part.inlineData.mimeType = files[0].type;
+    // if (!isInlineData(part)) {
+    //   part = structuredClone(inlineDataTemplate);
+    // }
+
+    // part.inlineData.data = await asBase64(files[0]);
+    // part.inlineData.mimeType = files[0].type;
     this.#emitUpdate();
     this.requestUpdate();
   }
@@ -663,20 +683,35 @@ export class LLMInput extends LitElement {
 
   async #getPartDataAsHTML(
     idx: number,
-    part: LLMInlineData,
+    part: LLMInlineData | LLMStoredData,
     isLastPart = false
   ) {
-    let url = this.#partDataURLs.get(idx);
-    if (!url && part.inlineData.data !== "") {
-      const dataURL = `data:${part.inlineData.mimeType};base64,${part.inlineData.data}`;
-      const response = await fetch(dataURL);
-      const data = await response.blob();
+    let mimeType;
+    let data;
+    let url;
+    console.log("🌻 getPartDataAsHTML", part);
+    if (isInlineData(part)) {
+      url = this.#partDataURLs.get(idx);
+      mimeType = part.inlineData.mimeType;
+      data = part.inlineData.data;
+      if (!url && part.inlineData.data !== "") {
+        const dataURL = `data:${part.inlineData.mimeType};base64,${part.inlineData.data}`;
+        const response = await fetch(dataURL);
+        const data = await response.blob();
 
-      url = URL.createObjectURL(data);
-      this.#partDataURLs.set(idx, url);
+        url = URL.createObjectURL(data);
+        this.#partDataURLs.set(idx, url);
+      }
+    } else {
+      console.log("🌻 I see stored part data!", part.storedData);
+      url = part.storedData.handle;
+      mimeType = part.storedData.mimeType;
+      // This is definitely wrong
+      // TODO: Fix this.
+      data = part.storedData.handle;
     }
 
-    switch (part.inlineData.mimeType) {
+    switch (mimeType) {
       case "image/png":
       case "image/jpg":
       case "image/jpeg":
@@ -702,7 +737,7 @@ export class LLMInput extends LitElement {
 
       case "text/plain": {
         // prettier-ignore
-        return cache(html`<div class="plain-text">${atob(part.inlineData.data)}</div>`);
+        return cache(html`<div class="plain-text">${atob(data)}</div>`);
       }
 
       case "file": {
@@ -883,6 +918,15 @@ export class LLMInput extends LitElement {
                 partClass = "function-response";
                 value = html`${part.functionResponse.name}
                 ${JSON.stringify(part.functionResponse.response, null, 2)}`;
+              } else if (isStoredData(part)) {
+                console.log("🌻 I see stored part data!");
+                // Steal the inline data class for now
+                partClass = "inline-data";
+
+                value = html`${until(
+                  this.#getPartDataAsHTML(idx, part, isLastPart),
+                  "Loading..."
+                )}`;
               } else if (isInlineData(part)) {
                 partClass = "inline-data";
 

--- a/packages/breadboard-ui/src/elements/llm-output/llm-output.ts
+++ b/packages/breadboard-ui/src/elements/llm-output/llm-output.ts
@@ -11,6 +11,7 @@ import {
   isFunctionCall,
   isFunctionResponse,
   isInlineData,
+  isStoredData,
   isText,
 } from "../../utils/llm-content.js";
 import { markdown } from "../../directives/markdown.js";
@@ -188,6 +189,20 @@ export class LLMOutput extends LitElement {
             value = html`${until(tmpl)}`;
           } else if (isFunctionCall(part) || isFunctionResponse(part)) {
             value = html` <bb-json-tree .json=${part}></bb-json-tree>`;
+          } else if (isStoredData(part)) {
+            const { handle: url, mimeType } = part.storedData;
+            if (mimeType.startsWith("image")) {
+              value = html`<img src="${url}" alt="LLM Image" />`;
+            }
+            if (mimeType.startsWith("audio")) {
+              return html`<audio src="${url}" controls />`;
+            }
+            if (mimeType.startsWith("video")) {
+              return html`<video src="${url}" controls />`;
+            }
+            if (mimeType.startsWith("text")) {
+              return html`<div class="plain-text">${url}</div>`;
+            }
           } else {
             value = html`Unrecognized part`;
           }

--- a/packages/breadboard-ui/src/elements/llm-output/llm-output.ts
+++ b/packages/breadboard-ui/src/elements/llm-output/llm-output.ts
@@ -191,6 +191,10 @@ export class LLMOutput extends LitElement {
             value = html` <bb-json-tree .json=${part}></bb-json-tree>`;
           } else if (isStoredData(part)) {
             const { handle: url, mimeType } = part.storedData;
+            const getData = async () => {
+              const response = await fetch(url);
+              return response.text();
+            };
             if (mimeType.startsWith("image")) {
               value = html`<img src="${url}" alt="LLM Image" />`;
             }
@@ -201,7 +205,7 @@ export class LLMOutput extends LitElement {
               return html`<video src="${url}" controls />`;
             }
             if (mimeType.startsWith("text")) {
-              return html`<div class="plain-text">${url}</div>`;
+              return html`<div class="plain-text">${until(getData())}</div>`;
             }
           } else {
             value = html`Unrecognized part`;

--- a/packages/breadboard-ui/src/types/types.ts
+++ b/packages/breadboard-ui/src/types/types.ts
@@ -98,8 +98,16 @@ export type LLMText = {
   text: string;
 };
 
+export type LLMStoredData = {
+  storedData: {
+    handle: string;
+    mimeType: string;
+  };
+};
+
 export type LLMPart =
   | LLMInlineData
+  | LLMStoredData
   | LLMFunctionCall
   | LLMFunctionResponse
   | LLMText;

--- a/packages/breadboard-ui/src/utils/llm-content.ts
+++ b/packages/breadboard-ui/src/utils/llm-content.ts
@@ -12,6 +12,7 @@ import {
   LLMFunctionResponse,
   LLMInlineData,
   LLMPart,
+  LLMStoredData,
   LLMText,
 } from "../types/types.js";
 
@@ -29,6 +30,10 @@ export function isFunctionResponse(part: LLMPart): part is LLMFunctionResponse {
 
 export function isInlineData(part: LLMPart): part is LLMInlineData {
   return "inlineData" in part;
+}
+
+export function isStoredData(part: LLMPart): part is LLMStoredData {
+  return "storedData" in part;
 }
 
 export function isLLMContent(nodeValue: unknown): nodeValue is LLMContent {

--- a/packages/breadboard/src/data.ts
+++ b/packages/breadboard/src/data.ts
@@ -25,7 +25,7 @@ export const asBlob = async (
   part: InlineDataCapabilityPart | StoredDataCapabilityPart
 ) => {
   let url: string;
-  if ("storedData" in part) {
+  if (isStoredData(part)) {
     url = part.storedData.handle;
   } else {
     url = `data:${part.inlineData.mimeType};base64,${part.inlineData.data}`;
@@ -33,4 +33,67 @@ export const asBlob = async (
   const response = await fetch(url);
   const data = await response.blob();
   return data;
+};
+
+const isStoredData = (value: unknown): value is StoredDataCapabilityPart => {
+  if (typeof value !== "object" || value === null) return false;
+  const data = value as DataCapability;
+  if (!("storedData" in data)) return false;
+  if (!data.storedData.handle) return false;
+  return true;
+};
+
+function asBase64(file: File | Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result !== "string") {
+        reject("Reader result is not a string");
+        return;
+      }
+
+      const [, content] = reader.result.split(",");
+      resolve(content);
+    };
+    reader.onerror = (err) => reject(err);
+    reader.readAsDataURL(file);
+  });
+}
+
+/**
+ * Recursively descends into the data object and inflates any
+ * `StoreDataCapabilityPart`, turning it into
+ * `InlineDataCapabilityPart`.
+ * @param data -- data to inflate
+ * @returns -- a new object with all `StoredDataCapabilityPart`
+ * replaced with `InlineDataCapabilityPart`
+ */
+export const inflateData = async (data: unknown) => {
+  const descender = async (value: unknown): Promise<unknown> => {
+    if (isStoredData(value)) {
+      const { mimeType, handle } = value.storedData;
+      const blob = await (await fetch(handle)).blob();
+      const data = await asBase64(blob);
+      return { inlineData: { data, mimeType } };
+    }
+    if (Array.isArray(value)) {
+      const result = [];
+      for (const item of value) {
+        result.push(await descender(item));
+      }
+      return result;
+    }
+    if (typeof value === "object" && value !== null) {
+      const v = value as Record<string, unknown>;
+      const result: Record<string, unknown> = {};
+      for (const key in value) {
+        result[key] = await descender(v[key]);
+      }
+      return result;
+    }
+    return value;
+  };
+
+  const result = await descender(data);
+  return result;
 };

--- a/packages/breadboard/src/data.ts
+++ b/packages/breadboard/src/data.ts
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { DataCapability, InlineDataCapabilityPart } from "./types.js";
+import {
+  DataCapability,
+  InlineDataCapabilityPart,
+  StoredDataCapabilityPart,
+} from "./types.js";
 
 // Helpers for handling DataCapability objects.
 
@@ -12,13 +16,21 @@ export const isDataCapability = (value: unknown): value is DataCapability => {
   if (typeof value !== "object" || value === null) return false;
   const data = value as DataCapability;
   if (data.kind !== "data") return false;
-  if (!("inlineData" in data)) return false;
-  return true;
+  if ("inlineData" in data) return true;
+  if ("storedData" in data) return true;
+  return false;
 };
 
-export const asBlob = async (part: InlineDataCapabilityPart) => {
-  const dataURL = `data:${part.inlineData.mimeType};base64,${part.inlineData.data}`;
-  const response = await fetch(dataURL);
+export const asBlob = async (
+  part: InlineDataCapabilityPart | StoredDataCapabilityPart
+) => {
+  let url: string;
+  if ("storedData" in part) {
+    url = part.storedData.handle;
+  } else {
+    url = `data:${part.inlineData.mimeType};base64,${part.inlineData.data}`;
+  }
+  const response = await fetch(url);
   const data = await response.blob();
   return data;
 };

--- a/packages/breadboard/src/data/common.ts
+++ b/packages/breadboard/src/data/common.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { InlineDataCapabilityPart, StoredDataCapabilityPart } from "./types.js";
+import { DataCapability } from "../types.js";
+
+// Helpers for handling DataCapability objects.
+
+export const isDataCapability = (value: unknown): value is DataCapability => {
+  if (typeof value !== "object" || value === null) return false;
+  const data = value as DataCapability;
+  if (data.kind !== "data") return false;
+  if ("inlineData" in data) return true;
+  if ("storedData" in data) return true;
+  return false;
+};
+
+export const asBlob = async (
+  part: InlineDataCapabilityPart | StoredDataCapabilityPart
+) => {
+  let url: string;
+  if (isStoredData(part)) {
+    url = part.storedData.handle;
+  } else {
+    url = `data:${part.inlineData.mimeType};base64,${part.inlineData.data}`;
+  }
+  const response = await fetch(url);
+  const data = await response.blob();
+  return data;
+};
+
+export const isStoredData = (
+  value: unknown
+): value is StoredDataCapabilityPart => {
+  if (typeof value !== "object" || value === null) return false;
+  const data = value as DataCapability;
+  if (!("storedData" in data)) return false;
+  if (!data.storedData.handle) return false;
+  return true;
+};
+
+export const isInlineData = (
+  value: unknown
+): value is InlineDataCapabilityPart => {
+  if (typeof value !== "object" || value === null) return false;
+  const data = value as DataCapability;
+  if (!("inlineData" in data)) return false;
+  if (!data.inlineData.data) return false;
+  return true;
+};
+
+export function asBase64(file: File | Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result !== "string") {
+        reject("Reader result is not a string");
+        return;
+      }
+
+      const [, content] = reader.result.split(",");
+      resolve(content);
+    };
+    reader.onerror = (err) => reject(err);
+    reader.readAsDataURL(file);
+  });
+}

--- a/packages/breadboard/src/data/data.ts
+++ b/packages/breadboard/src/data/data.ts
@@ -42,6 +42,16 @@ export const isStoredData = (
   return true;
 };
 
+export const isInlineData = (
+  value: unknown
+): value is InlineDataCapabilityPart => {
+  if (typeof value !== "object" || value === null) return false;
+  const data = value as DataCapability;
+  if (!("inlineData" in data)) return false;
+  if (!data.inlineData.data) return false;
+  return true;
+};
+
 export function asBase64(file: File | Blob): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -74,6 +84,51 @@ export const inflateData = async (data: unknown) => {
       const blob = await (await fetch(handle)).blob();
       const data = await asBase64(blob);
       return { inlineData: { data, mimeType } };
+    }
+    if (Array.isArray(value)) {
+      const result = [];
+      for (const item of value) {
+        result.push(await descender(item));
+      }
+      return result;
+    }
+    if (typeof value === "object" && value !== null) {
+      const v = value as Record<string, unknown>;
+      const result: Record<string, unknown> = {};
+      for (const key in value) {
+        result[key] = await descender(v[key]);
+      }
+      return result;
+    }
+    return value;
+  };
+
+  const result = await descender(data);
+  return result;
+};
+
+/**
+ * Recursively descends into the data object and deflates any
+ * `InlineDataCapabilityPart`, turning it into
+ * `StoredDataCapabilityPart`.
+ * @param data -- data to deflate
+ * @returns -- a new object with all `InlineDataCapabilityPart`
+ * replaced with `StoredDataCapabilityPart`
+ */
+export const deflateData = async (data: unknown) => {
+  const descender = async (value: unknown): Promise<unknown> => {
+    if (isInlineData(value)) {
+      const { mimeType, data } = value.inlineData;
+      const blob = await fetch(`data:${mimeType};base64,${data}`).then((r) =>
+        r.blob()
+      );
+      const handle = URL.createObjectURL(blob);
+      return {
+        storedData: {
+          handle,
+          mimeType,
+        },
+      };
     }
     if (Array.isArray(value)) {
       const result = [];

--- a/packages/breadboard/src/data/data.ts
+++ b/packages/breadboard/src/data/data.ts
@@ -4,11 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  DataCapability,
-  InlineDataCapabilityPart,
-  StoredDataCapabilityPart,
-} from "./types.js";
+import { InlineDataCapabilityPart, StoredDataCapabilityPart } from "./types.js";
+import { DataCapability } from "../types.js";
 
 // Helpers for handling DataCapability objects.
 
@@ -35,7 +32,9 @@ export const asBlob = async (
   return data;
 };
 
-const isStoredData = (value: unknown): value is StoredDataCapabilityPart => {
+export const isStoredData = (
+  value: unknown
+): value is StoredDataCapabilityPart => {
   if (typeof value !== "object" || value === null) return false;
   const data = value as DataCapability;
   if (!("storedData" in data)) return false;
@@ -43,7 +42,7 @@ const isStoredData = (value: unknown): value is StoredDataCapabilityPart => {
   return true;
 };
 
-function asBase64(file: File | Blob): Promise<string> {
+export function asBase64(file: File | Blob): Promise<string> {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
     reader.onload = () => {

--- a/packages/breadboard/src/data/index.ts
+++ b/packages/breadboard/src/data/index.ts
@@ -4,48 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { asBase64, isStoredData } from "./data.js";
-import {
-  DataStore,
-  InlineDataCapabilityPart,
-  StoredDataCapabilityPart,
-} from "./types.js";
+import { SimpleDataStore } from "./simple.js";
+import { DataStore } from "./types.js";
 
 export const createDataStore = (): DataStore => {
   return new SimpleDataStore();
 };
 
-class SimpleDataStore implements DataStore {
-  async store(data: Blob): Promise<StoredDataCapabilityPart> {
-    const handle = URL.createObjectURL(data);
-    const mimeType = data.type;
-    return {
-      storedData: { handle, mimeType },
-    };
-  }
-  async retrieve(
-    storedData: StoredDataCapabilityPart
-  ): Promise<InlineDataCapabilityPart> {
-    const raw = await this.retrieveAsBlob(storedData);
-    const mimeType = storedData.storedData.mimeType;
-    const data = await asBase64(raw);
-    return { inlineData: { mimeType, data } };
-  }
+export { inflateData, deflateData } from "./inflate-deflate.js";
 
-  async retrieveAsBlob(storedData: StoredDataCapabilityPart): Promise<Blob> {
-    if (!isStoredData(storedData)) {
-      throw new Error("Invalid stored data");
-    }
-    const { handle } = storedData.storedData;
-    const response = await fetch(handle);
-    return await response.blob();
-  }
-
-  async retrieveAsURL(storedData: StoredDataCapabilityPart): Promise<string> {
-    if (!isStoredData(storedData)) {
-      throw new Error("Invalid stored data");
-    }
-    const { handle } = storedData.storedData;
-    return handle;
-  }
-}
+export { isDataCapability, asBlob } from "./common.js";

--- a/packages/breadboard/src/data/index.ts
+++ b/packages/breadboard/src/data/index.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { asBase64, isStoredData } from "./data.js";
+import {
+  DataStore,
+  InlineDataCapabilityPart,
+  StoredDataCapabilityPart,
+} from "./types.js";
+
+export const createDataStore = (): DataStore => {
+  return new SimpleDataStore();
+};
+
+class SimpleDataStore implements DataStore {
+  async store(data: Blob): Promise<StoredDataCapabilityPart> {
+    const handle = URL.createObjectURL(data);
+    const mimeType = data.type;
+    return {
+      storedData: { handle, mimeType },
+    };
+  }
+  async retrieve(
+    storedData: StoredDataCapabilityPart
+  ): Promise<InlineDataCapabilityPart> {
+    const raw = await this.retrieveAsBlob(storedData);
+    const mimeType = storedData.storedData.mimeType;
+    const data = await asBase64(raw);
+    return { inlineData: { mimeType, data } };
+  }
+
+  async retrieveAsBlob(storedData: StoredDataCapabilityPart): Promise<Blob> {
+    if (!isStoredData(storedData)) {
+      throw new Error("Invalid stored data");
+    }
+    const { handle } = storedData.storedData;
+    const response = await fetch(handle);
+    return await response.blob();
+  }
+
+  async retrieveAsURL(storedData: StoredDataCapabilityPart): Promise<string> {
+    if (!isStoredData(storedData)) {
+      throw new Error("Invalid stored data");
+    }
+    const { handle } = storedData.storedData;
+    return handle;
+  }
+}

--- a/packages/breadboard/src/data/inflate-deflate.ts
+++ b/packages/breadboard/src/data/inflate-deflate.ts
@@ -4,70 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { InlineDataCapabilityPart, StoredDataCapabilityPart } from "./types.js";
-import { DataCapability } from "../types.js";
-
-// Helpers for handling DataCapability objects.
-
-export const isDataCapability = (value: unknown): value is DataCapability => {
-  if (typeof value !== "object" || value === null) return false;
-  const data = value as DataCapability;
-  if (data.kind !== "data") return false;
-  if ("inlineData" in data) return true;
-  if ("storedData" in data) return true;
-  return false;
-};
-
-export const asBlob = async (
-  part: InlineDataCapabilityPart | StoredDataCapabilityPart
-) => {
-  let url: string;
-  if (isStoredData(part)) {
-    url = part.storedData.handle;
-  } else {
-    url = `data:${part.inlineData.mimeType};base64,${part.inlineData.data}`;
-  }
-  const response = await fetch(url);
-  const data = await response.blob();
-  return data;
-};
-
-export const isStoredData = (
-  value: unknown
-): value is StoredDataCapabilityPart => {
-  if (typeof value !== "object" || value === null) return false;
-  const data = value as DataCapability;
-  if (!("storedData" in data)) return false;
-  if (!data.storedData.handle) return false;
-  return true;
-};
-
-export const isInlineData = (
-  value: unknown
-): value is InlineDataCapabilityPart => {
-  if (typeof value !== "object" || value === null) return false;
-  const data = value as DataCapability;
-  if (!("inlineData" in data)) return false;
-  if (!data.inlineData.data) return false;
-  return true;
-};
-
-export function asBase64(file: File | Blob): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => {
-      if (typeof reader.result !== "string") {
-        reject("Reader result is not a string");
-        return;
-      }
-
-      const [, content] = reader.result.split(",");
-      resolve(content);
-    };
-    reader.onerror = (err) => reject(err);
-    reader.readAsDataURL(file);
-  });
-}
+import { asBase64, isInlineData, isStoredData } from "./common.js";
 
 /**
  * Recursively descends into the data object and inflates any

--- a/packages/breadboard/src/data/simple.ts
+++ b/packages/breadboard/src/data/simple.ts
@@ -13,6 +13,8 @@ import {
 
 export class SimpleDataStore implements DataStore {
   async store(data: Blob): Promise<StoredDataCapabilityPart> {
+    // TODO: Figure out how to revoke the URLs when the data
+    // is no longer needed.
     const handle = URL.createObjectURL(data);
     const mimeType = data.type;
     return {

--- a/packages/breadboard/src/data/simple.ts
+++ b/packages/breadboard/src/data/simple.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { asBase64, isStoredData } from "./common.js";
+import {
+  DataStore,
+  InlineDataCapabilityPart,
+  StoredDataCapabilityPart,
+} from "./types.js";
+
+export class SimpleDataStore implements DataStore {
+  async store(data: Blob): Promise<StoredDataCapabilityPart> {
+    const handle = URL.createObjectURL(data);
+    const mimeType = data.type;
+    return {
+      storedData: { handle, mimeType },
+    };
+  }
+  async retrieve(
+    storedData: StoredDataCapabilityPart
+  ): Promise<InlineDataCapabilityPart> {
+    const raw = await this.retrieveAsBlob(storedData);
+    const mimeType = storedData.storedData.mimeType;
+    const data = await asBase64(raw);
+    return { inlineData: { mimeType, data } };
+  }
+
+  async retrieveAsBlob(storedData: StoredDataCapabilityPart): Promise<Blob> {
+    if (!isStoredData(storedData)) {
+      throw new Error("Invalid stored data");
+    }
+    const { handle } = storedData.storedData;
+    const response = await fetch(handle);
+    return await response.blob();
+  }
+
+  async retrieveAsURL(storedData: StoredDataCapabilityPart): Promise<string> {
+    if (!isStoredData(storedData)) {
+      throw new Error("Invalid stored data");
+    }
+    const { handle } = storedData.storedData;
+    return handle;
+  }
+}

--- a/packages/breadboard/src/data/types.ts
+++ b/packages/breadboard/src/data/types.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DataStoreHandle, InlineDataCapabilityPart } from "../types.js";
+
+export type StoredData = {
+  asInline(): Promise<InlineDataCapabilityPart>;
+};
+
+/**
+ * A provider that handles storing and retrieving data.
+ */
+export type DataStoreProvider = {
+  store(data: InlineDataCapabilityPart): Promise<StoredData>;
+  retrieve(handle: DataStoreHandle): Promise<StoredData>;
+  release(handle: DataStoreHandle): Promise<void>;
+  releaseAll(): Promise<void>;
+};

--- a/packages/breadboard/src/data/types.ts
+++ b/packages/breadboard/src/data/types.ts
@@ -4,7 +4,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { DataStoreHandle, InlineDataCapabilityPart } from "../types.js";
+/**
+ * Represents inline data, encoded as a base64 string.
+ */
+export type InlineDataCapabilityPart = {
+  inlineData: {
+    mimeType: string;
+    data: string;
+  };
+};
+
+/**
+ * Represents data that is stored by a DataStoreProvider.
+ */
+export type StoredDataCapabilityPart = {
+  storedData: {
+    handle: DataStoreHandle;
+    mimeType: string;
+  };
+};
+
+export type DataStoreHandle = string;
 
 export type StoredData = {
   asInline(): Promise<InlineDataCapabilityPart>;
@@ -18,4 +38,13 @@ export type DataStoreProvider = {
   retrieve(handle: DataStoreHandle): Promise<StoredData>;
   release(handle: DataStoreHandle): Promise<void>;
   releaseAll(): Promise<void>;
+};
+
+export type DataStore = {
+  store(data: Blob): Promise<StoredDataCapabilityPart>;
+  retrieve(
+    storedData: StoredDataCapabilityPart
+  ): Promise<InlineDataCapabilityPart>;
+  retrieveAsBlob(storedData: StoredDataCapabilityPart): Promise<Blob>;
+  retrieveAsURL(storedData: StoredDataCapabilityPart): Promise<string>;
 };

--- a/packages/breadboard/src/index.ts
+++ b/packages/breadboard/src/index.ts
@@ -91,5 +91,10 @@ export { formatGraphDescriptor } from "./formatter.js";
  */
 
 export type * from "./data/types.js";
-export { isDataCapability, asBlob, inflateData } from "./data/data.js";
+export {
+  isDataCapability,
+  asBlob,
+  inflateData,
+  deflateData,
+} from "./data/data.js";
 export { createDataStore } from "./data/index.js";

--- a/packages/breadboard/src/index.ts
+++ b/packages/breadboard/src/index.ts
@@ -90,4 +90,4 @@ export { formatGraphDescriptor } from "./formatter.js";
  * DataCapability helpers.
  */
 
-export { isDataCapability, asBlob } from "./data.js";
+export { isDataCapability, asBlob, inflateData } from "./data.js";

--- a/packages/breadboard/src/index.ts
+++ b/packages/breadboard/src/index.ts
@@ -89,12 +89,11 @@ export { formatGraphDescriptor } from "./formatter.js";
 /**
  * DataCapability helpers.
  */
-
 export type * from "./data/types.js";
 export {
-  isDataCapability,
-  asBlob,
+  createDataStore,
   inflateData,
   deflateData,
-} from "./data/data.js";
-export { createDataStore } from "./data/index.js";
+  isDataCapability,
+  asBlob,
+} from "./data/index.js";

--- a/packages/breadboard/src/index.ts
+++ b/packages/breadboard/src/index.ts
@@ -90,4 +90,6 @@ export { formatGraphDescriptor } from "./formatter.js";
  * DataCapability helpers.
  */
 
-export { isDataCapability, asBlob, inflateData } from "./data.js";
+export type * from "./data/types.js";
+export { isDataCapability, asBlob, inflateData } from "./data/data.js";
+export { createDataStore } from "./data/index.js";

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -143,7 +143,7 @@ export type ErrorCapability = Capability & {
 };
 
 /**
- * Represents an inline data capability, encoded as a base64 string.
+ * Represents inline data, encoded as a base64 string.
  */
 export type InlineDataCapabilityPart = {
   inlineData: {
@@ -153,13 +153,24 @@ export type InlineDataCapabilityPart = {
 };
 
 /**
+ * Represents data that is stored by a DataStoreProvider.
+ */
+export type StoredDataCapabilityPart = {
+  storedData: {
+    handle: DataStoreHandle;
+  };
+};
+
+export type DataStoreHandle = string;
+
+/**
  * A capability that represents a data value passed over the wire.
  * This is useful for passing inline data (base64 encoded) over the wire, as
  * well as references to external resources.
  */
 export type DataCapability = {
   kind: "data";
-} & InlineDataCapabilityPart;
+} & (InlineDataCapabilityPart | StoredDataCapabilityPart);
 
 /**
  * The Map of queues of all outputs that were sent to a given node,

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -158,6 +158,7 @@ export type InlineDataCapabilityPart = {
 export type StoredDataCapabilityPart = {
   storedData: {
     handle: DataStoreHandle;
+    mimeType: string;
   };
 };
 

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -17,6 +17,10 @@ import type {
   OutputValues,
 } from "@google-labs/breadboard-schema/graph.js";
 import { GraphLoader } from "./loader/types.js";
+import {
+  InlineDataCapabilityPart,
+  StoredDataCapabilityPart,
+} from "./data/types.js";
 
 export type {
   Capability,
@@ -141,28 +145,6 @@ export type ErrorCapability = Capability & {
   readonly inputs?: InputValues;
   readonly descriptor?: NodeDescriptor;
 };
-
-/**
- * Represents inline data, encoded as a base64 string.
- */
-export type InlineDataCapabilityPart = {
-  inlineData: {
-    mimeType: string;
-    data: string;
-  };
-};
-
-/**
- * Represents data that is stored by a DataStoreProvider.
- */
-export type StoredDataCapabilityPart = {
-  storedData: {
-    handle: DataStoreHandle;
-    mimeType: string;
-  };
-};
-
-export type DataStoreHandle = string;
 
 /**
  * A capability that represents a data value passed over the wire.

--- a/packages/core-kit/src/index.ts
+++ b/packages/core-kit/src/index.ts
@@ -191,6 +191,14 @@ export const Core = builder.build({
   runJavascript,
   secrets,
   curry,
+
+  /**
+   * Converts all inline data to stored data, saving memory.
+   * Useful when working with multimodal content. Safely passes
+   * data through if it's already stored or no inline data is
+   * present.
+   */
+  deflate,
 });
 
 export type Core = InstanceType<typeof Core>;
@@ -211,6 +219,7 @@ import {
   NewNodeFactory as NodeFactory,
 } from "@google-labs/breadboard";
 import curry, { CurryInputs, CurryOutputs } from "./nodes/curry.js";
+import deflate from "./nodes/deflate.js";
 
 export type CoreKitType = {
   passthrough: NodeFactory<InputValues, OutputValues>;

--- a/packages/core-kit/src/nodes/deflate.ts
+++ b/packages/core-kit/src/nodes/deflate.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { defineNodeType, object } from "@breadboard-ai/build";
+import { deflateData } from "@google-labs/breadboard";
+
+export default defineNodeType({
+  name: "deflate",
+  metadata: {
+    title: "Deflate",
+    description:
+      "Converts all inline data to stored data, saving memory. Useful when working with multimodal content. Safely passes data through if it's already stored or no inline data is present.",
+  },
+  inputs: {
+    data: {
+      type: object({}),
+      description: "Data to deflate.",
+    },
+  },
+  outputs: {
+    data: {
+      type: object({}),
+      description: "Deflated data.",
+    },
+  },
+  invoke: async ({ data }) => {
+    return { data: await deflateData(data) };
+  },
+});

--- a/packages/core-kit/src/nodes/fetch.ts
+++ b/packages/core-kit/src/nodes/fetch.ts
@@ -12,11 +12,10 @@ import {
 } from "@breadboard-ai/build";
 import { JsonSerializable } from "@breadboard-ai/build/internal/type-system/type.js";
 import {
-  DataCapability,
   NodeHandlerContext,
-  StoredDataCapabilityPart,
   StreamCapability,
   asBlob,
+  inflateData,
   isDataCapability,
 } from "@google-labs/breadboard";
 
@@ -42,63 +41,6 @@ const serverSentEventTransform = () =>
       }
     },
   });
-
-const isStoredData = (value: unknown): value is StoredDataCapabilityPart => {
-  if (typeof value !== "object" || value === null) return false;
-  const data = value as DataCapability;
-  if (!("storedData" in data)) return false;
-  if (!data.storedData.handle) return false;
-  return true;
-};
-
-function asBase64(file: File | Blob): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => {
-      if (typeof reader.result !== "string") {
-        reject("Reader result is not a string");
-        return;
-      }
-
-      const [, content] = reader.result.split(",");
-      resolve(content);
-    };
-    reader.onerror = (err) => reject(err);
-    reader.readAsDataURL(file);
-  });
-}
-
-const inflateData = async (data: unknown) => {
-  // Recursively descend into the data structure,
-  // replacing storedData with inlineData.
-  const descender = async (value: unknown): Promise<unknown> => {
-    if (isStoredData(value)) {
-      const { mimeType, handle } = value.storedData;
-      const blob = await (await fetch(handle)).blob();
-      const data = await asBase64(blob);
-      return { inlineData: { data, mimeType } };
-    }
-    if (Array.isArray(value)) {
-      const result = [];
-      for (const item of value) {
-        result.push(await descender(item));
-      }
-      return result;
-    }
-    if (typeof value === "object" && value !== null) {
-      const v = value as Record<string, unknown>;
-      const result: Record<string, unknown> = {};
-      for (const key in value) {
-        result[key] = await descender(v[key]);
-      }
-      return result;
-    }
-    return value;
-  };
-
-  const result = await descender(data);
-  return result;
-};
 
 const createBody = async (
   body: unknown,


### PR DESCRIPTION
- **Aspirational `DataStoreProvider` API types.**
- **Gross hacks in `llm-input` and `llm-output` to make `StoredData` show up.**
- **Sketch working end to end.**
- **Move `inflateData` to `breadboard` package.**
- **Make text files work with stored data.**
- **Very basic `DataStore`.**
- **Remove spurious imports.**
- **Add `deflate` node to Core Kit.**
- **Move files around.**
- **Add thoughtful comment.**
- **Use Lit context to provide `DataStore` only to Activity Log.**
- **docs(changeset): Introduce `deflate` node.**
- **docs(changeset): Implement `DataStore` and a simple implementation.**
