### PR TITLE
[connections] Adds a Connections settings panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1409,18 +1409,6 @@
         "sisteransi": "^1.0.5"
       }
     },
-    "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
-      "version": "1.3.0",
-      "extraneous": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@codemirror/autocomplete": {
       "version": "6.16.0",
       "license": "MIT",
@@ -25925,6 +25913,7 @@
         "@google-labs/pinecone-kit": "^0.1.12",
         "@google-labs/team-kit": "^0.1.0",
         "@google-labs/template-kit": "^0.3.2",
+        "@lit/context": "^1.1.1",
         "codemirror": "^6.0.1",
         "idb": "^8.0.0",
         "idb-keyval": "^6.2.1",
@@ -26029,6 +26018,7 @@
       }
     },
     "packages/connection-server": {
+      "name": "@breadboard-ai/connection-server",
       "version": "0.1.0",
       "license": "Apache-2.0",
       "devDependencies": {

--- a/packages/breadboard-ui/src/contexts/contexts.ts
+++ b/packages/breadboard-ui/src/contexts/contexts.ts
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { dataStoreContext } from "./data-store.js";
+export { environmentContext } from "./environment.js";

--- a/packages/breadboard-ui/src/contexts/environment.ts
+++ b/packages/breadboard-ui/src/contexts/environment.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createContext } from "@lit/context";
+
+export interface Environment {
+  connectionServerUrl?: string;
+}
+
+export const environmentContext = createContext<Environment>("bb-environment");

--- a/packages/breadboard-ui/src/elements/connection/connection-server.ts
+++ b/packages/breadboard-ui/src/elements/connection/connection-server.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Task } from "@lit/task";
+import type { ReactiveControllerHost } from "lit";
+import type { Environment } from "../../contexts/environment.js";
+
+export function fetchAvailableConnections(
+  host: ReactiveControllerHost,
+  environment: () => Environment | undefined
+): Task<readonly unknown[], Connection[]> {
+  return new Task(host, {
+    args: () => [environment()?.connectionServerUrl],
+    task: async ([connectionServerUrl], { signal }) => {
+      if (!connectionServerUrl) {
+        return [];
+      }
+      const httpRes = await fetch(new URL("list", connectionServerUrl), {
+        signal,
+      });
+      if (!httpRes.ok) {
+        throw new Error(String(httpRes.status));
+      }
+      const jsonRes = (await httpRes.json()) as ListConnectionsResponse;
+      return jsonRes.connections;
+    },
+  });
+}
+
+// IMPORTANT: Keep in sync with
+// breadboard/packages/connection-server/src/api/list.ts
+interface ListConnectionsResponse {
+  connections: Connection[];
+}
+
+export interface Connection {
+  id: string;
+  authUrl: string;
+  title: string;
+  description?: string;
+  icon?: string;
+}

--- a/packages/breadboard-ui/src/elements/connection/connection-settings.ts
+++ b/packages/breadboard-ui/src/elements/connection/connection-settings.ts
@@ -4,13 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { consume } from "@lit/context";
 import { LitElement, html } from "lit";
 import { customElement, property } from "lit/decorators.js";
+import {
+  environmentContext,
+  type Environment,
+} from "../../contexts/environment.js";
 import type {
   CustomSettingsElement,
   SETTINGS_TYPE,
   Settings,
 } from "../../types/types.js";
+import {
+  fetchAvailableConnections as fetchAvailableConnectionsTask,
+  type Connection,
+} from "./connection-server.js";
 
 /**
  * Custom settings panel for signing in and out of connections to third party
@@ -27,7 +36,38 @@ export class ConnectionSettings
   @property({ attribute: false })
   settingsItems: Settings[SETTINGS_TYPE]["items"] | undefined;
 
+  @consume({ context: environmentContext })
+  environment?: Environment;
+
+  /**
+   * The available connections vary across deployment environments, so we fetch
+   * them from the Breadboard Connection Server dynamically.
+   */
+  #availableConnections = fetchAvailableConnectionsTask(
+    this,
+    () => this.environment
+  );
+
   render() {
-    return html`<p>(Not yet implemented)</p>`;
+    const connectionServerUrl = this.environment?.connectionServerUrl;
+    if (!connectionServerUrl) {
+      return html`No connection server URL configured.`;
+    }
+    return this.#availableConnections.render({
+      pending: () => html`<p>Loading connections ...</p>`,
+      error: (e) => html`<p>Error loading connections: ${e}</p>`,
+      complete: (connections: Connection[]) => {
+        if (connections.length === 0) {
+          return html`<p>No connections available</p>`;
+        }
+        return html`<ul>
+          ${connections.map(
+            (connection) =>
+              // TODO(aomarks) Render a sign in/out widget.
+              html`<li>${connection.id}</li>`
+          )}
+        </ul>`;
+      },
+    });
   }
 }

--- a/packages/breadboard-ui/src/elements/connection/connection-settings.ts
+++ b/packages/breadboard-ui/src/elements/connection/connection-settings.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { LitElement, html } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import type {
+  CustomSettingsElement,
+  SETTINGS_TYPE,
+  Settings,
+} from "../../types/types.js";
+
+/**
+ * Custom settings panel for signing in and out of connections to third party
+ * apps/services.
+ */
+@customElement("bb-connection-settings")
+export class ConnectionSettings
+  extends LitElement
+  implements CustomSettingsElement
+{
+  @property({ attribute: false })
+  settingsType: SETTINGS_TYPE | undefined;
+
+  @property({ attribute: false })
+  settingsItems: Settings[SETTINGS_TYPE]["items"] | undefined;
+
+  render() {
+    return html`<p>(Not yet implemented)</p>`;
+  }
+}

--- a/packages/breadboard-ui/src/elements/elements.ts
+++ b/packages/breadboard-ui/src/elements/elements.ts
@@ -10,6 +10,7 @@ export { BoardDetails } from "./board-details/board-details.js";
 export { BoardEditOverlay } from "./overlay/board-edit.js";
 export { BoardSelector } from "./node-info/board-selector.js";
 export { CodeEditor } from "./input/code-editor/code-editor.js";
+export { ConnectionSettings } from "./connection/connection-settings.js";
 export { DrawableInput } from "./input/drawable/drawable.js";
 export { Editor } from "./editor/editor.js";
 export { EventDetails } from "./event-details/event-details.js";

--- a/packages/breadboard-ui/src/index.ts
+++ b/packages/breadboard-ui/src/index.ts
@@ -8,3 +8,4 @@ export * as Types from "./types/types.js";
 export * as Events from "./events/events.js";
 export * as Elements from "./elements/elements.js";
 export * as Constants from "./constants/constants.js";
+export * as Contexts from "./contexts/contexts.js";

--- a/packages/breadboard-ui/src/types/types.ts
+++ b/packages/breadboard-ui/src/types/types.ts
@@ -160,7 +160,18 @@ export type Settings = {
       description: string;
       nameEditable: boolean;
       nameVisible: boolean;
+      /**
+       * Render an instance of the custom element with this name, instead of
+       * generic setting entries. The element must match the
+       * {@link CustomSettingsElement} interface.
+       */
+      customElement?: string;
     };
     items: Map<SettingEntry["value"]["name"], SettingEntry["value"]>;
   };
+};
+
+export type CustomSettingsElement = HTMLElement & {
+  settingsType: SETTINGS_TYPE | undefined;
+  settingsItems: Settings[SETTINGS_TYPE]["items"] | undefined;
 };

--- a/packages/breadboard-ui/src/types/types.ts
+++ b/packages/breadboard-ui/src/types/types.ts
@@ -134,6 +134,7 @@ export enum SETTINGS_TYPE {
   GENERAL = "General",
   INPUTS = "Inputs",
   NODE_PROXY_SERVERS = "Node Proxy Servers",
+  CONNECTIONS = "Connections",
 }
 
 export interface SettingEntry {
@@ -151,6 +152,7 @@ export interface SettingsList {
   [SETTINGS_TYPE.SECRETS]: SettingEntry;
   [SETTINGS_TYPE.INPUTS]: SettingEntry;
   [SETTINGS_TYPE.NODE_PROXY_SERVERS]: SettingEntry;
+  [SETTINGS_TYPE.CONNECTIONS]: SettingEntry;
 }
 
 export type Settings = {

--- a/packages/breadboard-web/package.json
+++ b/packages/breadboard-web/package.json
@@ -243,6 +243,7 @@
     "@google-labs/pinecone-kit": "^0.1.12",
     "@google-labs/team-kit": "^0.1.0",
     "@google-labs/template-kit": "^0.3.2",
+    "@lit/context": "^1.1.1",
     "codemirror": "^6.0.1",
     "idb": "^8.0.0",
     "idb-keyval": "^6.2.1",

--- a/packages/breadboard-web/src/data/settings-store.ts
+++ b/packages/breadboard-web/src/data/settings-store.ts
@@ -10,7 +10,7 @@ import * as BreadboardUI from "@google-labs/breadboard-ui";
 interface SettingsDB extends BreadboardUI.Types.SettingsList, idb.DBSchema {}
 
 const SETTINGS_NAME = "settings";
-const SETTINGS_VERSION = 5;
+const SETTINGS_VERSION = 6;
 
 export class SettingsStore {
   static #instance: SettingsStore;
@@ -118,6 +118,17 @@ export class SettingsStore {
           "Node proxy servers to use when running boards. Put the URL of the node proxy server in the first field and a comma-separated list of nodes to proxy in the second field.",
         nameEditable: true,
         nameVisible: true,
+      },
+      items: new Map([]),
+    },
+    [BreadboardUI.Types.SETTINGS_TYPE.CONNECTIONS]: {
+      configuration: {
+        extensible: false,
+        description:
+          "Third-party services boards can access. When you are signed into a service, any board can access and modify your data on that service.",
+        nameEditable: false,
+        nameVisible: false,
+        customElement: "bb-connection-settings",
       },
       items: new Map([]),
     },

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -33,6 +33,11 @@ import BuildExampleKit from "./build-example-kit";
 import { SettingsStore } from "./data/settings-store";
 import { inputsFromSettings } from "./data/inputs";
 import { addNodeProxyServerConfig } from "./data/node-proxy-servers";
+import { provide } from "@lit/context";
+import {
+  Environment,
+  environmentContext,
+} from "../../breadboard-ui/dist/src/contexts/environment";
 
 type MainArguments = {
   boards: BreadboardUI.Types.Board[];
@@ -91,6 +96,15 @@ export class Main extends LitElement {
 
   @state()
   providerOps = 0;
+
+  @provide({ context: environmentContext })
+  environment: Environment = {
+    connectionServerUrl:
+      // TODO(aomarks) Read this from a global stamped into the HTML somehow.
+      new URL(window.location.href).origin === "http://localhost:5173"
+        ? "http://localhost:5555"
+        : undefined,
+  };
 
   #abortController: AbortController | null = null;
   #uiRef: Ref<BreadboardUI.Elements.UI> = createRef();

--- a/packages/connection-server/src/api/list.ts
+++ b/packages/connection-server/src/api/list.ts
@@ -10,6 +10,8 @@ import { okJson } from "../responses.js";
 import type { OAuthClientSecretData } from "../secrets.js";
 import type { OurSpecialOAuthState } from "../state.js";
 
+// IMPORTANT: Keep in sync with
+// breadboard/packages/breadboard-ui/src/elements/connection/connection-server.ts
 interface ListConnectionsResponse {
   connections: Connection[];
 }


### PR DESCRIPTION
Adds a "Connections" settings panel which talks to the Breadboard Connections Server and displays the list of available OAuth endpoints. It is not yet possible to actually *connect*, that will come in followups.

<img src="https://github.com/breadboard-ai/breadboard/assets/48894/a06341c7-c70a-4dbe-ad10-48bc2e3fa1ff" height="250px">

<hr>

I added two general-purpose features to facilitate this:

1. You can now render a completely custom settings panel UI. The connections panel is quite specialized, so it's nice to have full control over the UI instead of using the generic settings form/widgets.

    ```js
    [BreadboardUI.Types.SETTINGS_TYPE.CONNECTIONS]: {
      configuration: {
        extensible: false,
        description:
          "Third-party services boards can access. When you are signed into a service, any board can access and modify your data on that service.",
        nameEditable: false,
        nameVisible: false,
        customElement: "bb-connection-settings",
      }
    ```

2. Added an `Environment` object which can be consumed by any element under `bb-main` like this:
   
   ```js
   @consume({ context: environmentContext })
   environment?: Environment;
   ```

    The idea is for `Environment` to contain deployment-environment-specific configuration. In this case, I need the URL of a Breadboard Connection Server:
  
    ```js
    export interface Environment {
      connectionServerUrl?: string;
    }
    ```
  
    Currently this value is provided by `bb-main` with some hard-coded logic that will work for local development (if we're on localhost:5173, then return `localhost:5555` as the connection server).