### PR TITLE
[breadboard-ui] Retire single node move event

### DIFF
--- a/.changeset/shiny-brooms-compete.md
+++ b/.changeset/shiny-brooms-compete.md
@@ -1,0 +1,6 @@
+---
+"@google-labs/breadboard-web": patch
+"@google-labs/breadboard-ui": patch
+---
+
+Retire the single node move event

--- a/packages/breadboard-ui/src/elements/editor/editor.ts
+++ b/packages/breadboard-ui/src/elements/editor/editor.ts
@@ -27,13 +27,11 @@ import {
   GraphNodeEdgeAttachEvent,
   GraphNodeEdgeChangeEvent,
   GraphNodeEdgeDetachEvent,
-  GraphNodeMoveEvent,
   GraphNodesMoveEvent,
   KitNodeChosenEvent,
   MultiEditEvent,
   NodeCreateEvent,
   NodeDeleteEvent,
-  NodeMoveEvent,
   SubGraphChosenEvent,
   SubGraphCreateEvent,
   SubGraphDeleteEvent,
@@ -115,7 +113,6 @@ export class Editor extends LitElement {
   #onResizeBound = this.#onResize.bind(this);
   #onPointerMoveBound = this.#onPointerMove.bind(this);
   #onPointerDownBound = this.#onPointerDown.bind(this);
-  #onGraphNodeMoveBound = this.#onGraphNodeMove.bind(this);
   #onGraphNodesMoveBound = this.#onGraphNodesMove.bind(this);
   #onGraphEdgeAttachBound = this.#onGraphEdgeAttach.bind(this);
   #onGraphEdgeDetachBound = this.#onGraphEdgeDetach.bind(this);
@@ -463,11 +460,6 @@ export class Editor extends LitElement {
     );
 
     this.#graphRenderer.addEventListener(
-      GraphNodeMoveEvent.eventName,
-      this.#onGraphNodeMoveBound
-    );
-
-    this.#graphRenderer.addEventListener(
       GraphNodesMoveEvent.eventName,
       this.#onGraphNodesMoveBound
     );
@@ -501,11 +493,6 @@ export class Editor extends LitElement {
     this.#graphRenderer.removeEventListener(
       GraphNodeDeleteEvent.eventName,
       this.#onGraphNodeDeleteBound
-    );
-
-    this.#graphRenderer.removeEventListener(
-      GraphNodeMoveEvent.eventName,
-      this.#onGraphNodeMoveBound
     );
 
     this.#graphRenderer.removeEventListener(
@@ -774,12 +761,6 @@ export class Editor extends LitElement {
     }
 
     this.#addButtonRef.value.checked = false;
-  }
-
-  #onGraphNodeMove(evt: Event) {
-    const { id, x, y } = evt as GraphNodeMoveEvent;
-    this.#ignoreNextUpdate = true;
-    this.dispatchEvent(new NodeMoveEvent(id, x, y, this.subGraphId));
   }
 
   #onGraphNodesMove(evt: Event) {

--- a/packages/breadboard-ui/src/elements/editor/graph-renderer.ts
+++ b/packages/breadboard-ui/src/elements/editor/graph-renderer.ts
@@ -13,7 +13,6 @@ import {
   GraphNodeEdgeAttachEvent,
   GraphNodeEdgeChangeEvent,
   GraphNodeEdgeDetachEvent,
-  GraphNodeMoveEvent,
   InputErrorEvent,
   GraphNodeDeselectedEvent,
   GraphNodeDeselectedAllEvent,
@@ -629,7 +628,7 @@ export class GraphRenderer extends LitElement {
     graph.on(
       GRAPH_OPERATIONS.GRAPH_NODE_MOVED,
       (id: string, x: number, y: number) => {
-        this.dispatchEvent(new GraphNodeMoveEvent(id, x, y));
+        this.dispatchEvent(new GraphNodesMoveEvent([{ id, x, y }]));
       }
     );
 

--- a/packages/breadboard-ui/src/events/events.ts
+++ b/packages/breadboard-ui/src/events/events.ts
@@ -414,19 +414,6 @@ export class EdgeChangeEvent extends Event {
   }
 }
 
-export class NodeMoveEvent extends Event {
-  static eventName = "bbnodemove";
-
-  constructor(
-    public readonly id: string,
-    public readonly x: number,
-    public readonly y: number,
-    public readonly subGraphId: string | null = null
-  ) {
-    super(NodeMoveEvent.eventName, { ...eventInit });
-  }
-}
-
 export class MultiEditEvent extends Event {
   static eventName = "bbmultiedit";
   constructor(
@@ -435,18 +422,6 @@ export class MultiEditEvent extends Event {
     public readonly subGraphId: string | null = null
   ) {
     super(MultiEditEvent.eventName, { ...eventInit });
-  }
-}
-
-export class GraphNodeMoveEvent extends Event {
-  static eventName = "bbgraphnodemove";
-
-  constructor(
-    public readonly id: string,
-    public readonly x: number,
-    public readonly y: number
-  ) {
-    super(GraphNodeMoveEvent.eventName, { ...eventInit });
   }
 }
 

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -1351,38 +1351,6 @@ export class Main extends LitElement {
               `Change metadata for "${id}"`
             );
           }}
-          @bbnodemove=${(evt: BreadboardUI.Events.NodeMoveEvent) => {
-            let editableGraph = this.#getEditor();
-            if (editableGraph && evt.subGraphId) {
-              editableGraph = editableGraph.getGraph(evt.subGraphId);
-            }
-
-            if (!editableGraph) {
-              console.warn("Unable to update node metadata; no active graph");
-              return;
-            }
-
-            const inspectableGraph = editableGraph.inspect();
-
-            const { id, x, y } = evt;
-            const existingNode = inspectableGraph.nodeById(id);
-            const metadata = existingNode?.metadata() || {};
-            let visual = metadata.visual || {};
-            if (typeof visual !== "object") {
-              visual = {};
-            }
-
-            editableGraph.edit(
-              [
-                {
-                  type: "changemetadata",
-                  id,
-                  metadata: { ...metadata, visual: { ...visual, x, y } },
-                },
-              ],
-              `Move node "${id}" to (${x}, ${y})`
-            );
-          }}
           @bbmultiedit=${(evt: BreadboardUI.Events.MultiEditEvent) => {
             const { edits, description, subGraphId } = evt;
             let editableGraph = this.#getEditor();


### PR DESCRIPTION
This is a pre-cursor to storing the collapse/expand state for nodes