### PR TITLE
[breadboard-ui] Teach visual metadata about collapsed state

### DIFF
--- a/.changeset/grumpy-plums-help.md
+++ b/.changeset/grumpy-plums-help.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard-ui": minor
+---
+
+Node metadata contains collapsed state

--- a/packages/breadboard-ui/src/events/events.ts
+++ b/packages/breadboard-ui/src/events/events.ts
@@ -425,7 +425,7 @@ export class MultiEditEvent extends Event {
   }
 }
 
-export class GraphNodesMoveEvent extends Event {
+export class GraphNodesVisualUpdateEvent extends Event {
   static eventName = "bbgraphnodesmove";
 
   constructor(
@@ -433,9 +433,10 @@ export class GraphNodesMoveEvent extends Event {
       readonly id: string;
       readonly x: number;
       readonly y: number;
+      readonly collapsed: boolean;
     }>
   ) {
-    super(GraphNodesMoveEvent.eventName, { ...eventInit });
+    super(GraphNodesVisualUpdateEvent.eventName, { ...eventInit });
   }
 }
 


### PR DESCRIPTION
Working on #1753

Because this is now part of the metadata it also gets tracked as part of the undo/redo stack and also allows for some nodes being collapsed, and others being open.