### PR TITLE
[breadboard-ui] Support drag and drop of run data

### DIFF
--- a/.changeset/swift-colts-rhyme.md
+++ b/.changeset/swift-colts-rhyme.md
@@ -1,0 +1,6 @@
+---
+"@google-labs/breadboard-web": patch
+"@google-labs/breadboard-ui": patch
+---
+
+Support drag and drop of run data

--- a/packages/breadboard-ui/src/elements/editor/editor.ts
+++ b/packages/breadboard-ui/src/elements/editor/editor.ts
@@ -21,7 +21,6 @@ import {
 } from "@google-labs/breadboard";
 import {
   EdgeChangeEvent,
-  FileDropEvent,
   GraphInitialDrawEvent,
   GraphNodeDeleteEvent,
   GraphNodeEdgeAttachEvent,
@@ -874,26 +873,12 @@ export class Editor extends LitElement {
   }
 
   #onDrop(evt: DragEvent) {
-    evt.preventDefault();
-
     const [top] = evt.composedPath();
     if (!(top instanceof HTMLCanvasElement)) {
       return;
     }
 
-    if (evt.dataTransfer?.files && evt.dataTransfer.files.length) {
-      const fileDropped = evt.dataTransfer.files[0];
-      try {
-        fileDropped.text().then((data) => {
-          const descriptor = JSON.parse(data) as GraphDescriptor;
-          this.dispatchEvent(new FileDropEvent(fileDropped.name, descriptor));
-        });
-      } catch (err) {
-        console.warn(err);
-      }
-      return;
-    }
-
+    evt.preventDefault();
     const data = evt.dataTransfer?.getData(DATA_TYPE);
     if (!data || !this.#graphRenderer) {
       console.warn("No data in dropped node");

--- a/packages/breadboard-ui/src/events/events.ts
+++ b/packages/breadboard-ui/src/events/events.ts
@@ -30,17 +30,6 @@ export enum ToastType {
  * Board Management
  */
 
-export class FileDropEvent extends Event {
-  static eventName = "bbfiledrop";
-
-  constructor(
-    public readonly url: string,
-    public readonly descriptor: GraphDescriptor
-  ) {
-    super(FileDropEvent.eventName, { ...eventInit });
-  }
-}
-
 export class StartEvent extends Event {
   static eventName = "bbstart";
 


### PR DESCRIPTION
You can drop bgl.json files as before, but now you can also drop serialized runs from the Activity Log and they will load in 👍🏻 