### PR TITLE
provide data store

### DIFF
--- a/.changeset/short-falcons-appear.md
+++ b/.changeset/short-falcons-appear.md
@@ -1,0 +1,8 @@
+---
+"@google-labs/breadboard-web": minor
+"@google-labs/breadboard-ui": minor
+"@google-labs/breadboard": minor
+"@google-labs/core-kit": minor
+---
+
+Plumb `DataStore` throuh to `NodeHandlerContext`.

--- a/packages/breadboard-ui/src/contexts/data-store.ts
+++ b/packages/breadboard-ui/src/contexts/data-store.ts
@@ -1,4 +1,8 @@
 import { DataStore } from "@google-labs/breadboard";
 import { createContext } from "@lit/context";
 
-export const dataStoreContext = createContext<DataStore>("datastore");
+export type DataStoreContext = {
+  instance: DataStore | null;
+};
+
+export const dataStoreContext = createContext<DataStoreContext>("datastore");

--- a/packages/breadboard-ui/src/elements/activity-log/activity-log.ts
+++ b/packages/breadboard-ui/src/elements/activity-log/activity-log.ts
@@ -11,7 +11,6 @@ import {
   InspectableRunInputs,
   InspectableRunNodeEvent,
   OutputValues,
-  createDataStore,
 } from "@google-labs/breadboard";
 import { LitElement, html, HTMLTemplateResult, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
@@ -25,8 +24,6 @@ import { markdown } from "../../directives/markdown.js";
 import { SETTINGS_TYPE, Settings } from "../../types/types.js";
 import { styles as activityLogStyles } from "./activity-log.styles.js";
 import { isArrayOfLLMContent, isLLMContent } from "../../utils/llm-content.js";
-import { provide } from "@lit/context";
-import { dataStoreContext } from "../../contexts/data-store.js";
 
 @customElement("bb-activity-log")
 export class ActivityLog extends LitElement {
@@ -50,9 +47,6 @@ export class ActivityLog extends LitElement {
 
   @property()
   settings: Settings | null = null;
-
-  @provide({ context: dataStoreContext })
-  dataStore = createDataStore();
 
   #seenItems = new Set<string>();
   #newestEntry: Ref<HTMLElement> = createRef();

--- a/packages/breadboard-ui/src/elements/input/llm-input/llm-input.ts
+++ b/packages/breadboard-ui/src/elements/input/llm-input/llm-input.ts
@@ -73,7 +73,7 @@ export class LLMInput extends LitElement {
 
   @consume({ context: dataStoreContext })
   @property({ attribute: false })
-  public dataStore?: DataStore;
+  public dataStore?: { instance: DataStore | null };
 
   static styles = css`
     * {
@@ -530,8 +530,9 @@ export class LLMInput extends LitElement {
       this.value = { role: "user", parts: [] };
     }
 
-    if (this.dataStore) {
-      this.value.parts[partIdx] = await this.dataStore.store(files[0]);
+    if (this.dataStore?.instance) {
+      const store = this.dataStore.instance;
+      this.value.parts[partIdx] = await store.store(files[0]);
     } else {
       if (!this.value.parts[partIdx]) {
         this.value.parts[partIdx] = structuredClone(inlineDataTemplate);
@@ -696,7 +697,7 @@ export class LLMInput extends LitElement {
       url = part.storedData.handle;
       mimeType = part.storedData.mimeType;
       getData = async () => {
-        const response = await this.dataStore?.retrieve(part);
+        const response = await this.dataStore?.instance?.retrieve(part);
         if (!response) {
           return "Unable to retrieve data";
         }

--- a/packages/breadboard-ui/src/elements/llm-output/llm-output.ts
+++ b/packages/breadboard-ui/src/elements/llm-output/llm-output.ts
@@ -17,7 +17,9 @@ import {
 import { markdown } from "../../directives/markdown.js";
 import { until } from "lit/directives/until.js";
 import { cache } from "lit/directives/cache.js";
-import { createDataStore } from "@google-labs/breadboard";
+import { DataStore } from "@google-labs/breadboard";
+import { consume } from "@lit/context";
+import { dataStoreContext } from "../../contexts/data-store.js";
 
 @customElement("bb-llm-output")
 export class LLMOutput extends LitElement {
@@ -26,7 +28,8 @@ export class LLMOutput extends LitElement {
 
   #partDataURLs = new Map<number, string>();
 
-  #dataStore = createDataStore();
+  @consume({ context: dataStoreContext })
+  dataStore?: { instance: DataStore | null };
 
   static styles = css`
     :host {
@@ -193,27 +196,33 @@ export class LLMOutput extends LitElement {
           } else if (isFunctionCall(part) || isFunctionResponse(part)) {
             value = html` <bb-json-tree .json=${part}></bb-json-tree>`;
           } else if (isStoredData(part)) {
-            const storedData = this.#dataStore.retrieveAsURL(part);
-            const tmpl = storedData.then((url) => {
-              const { mimeType } = part.storedData;
-              const getData = async () => {
-                const response = await fetch(url);
-                return response.text();
-              };
-              if (mimeType.startsWith("image")) {
-                return html`<img src="${url}" alt="LLM Image" />`;
-              }
-              if (mimeType.startsWith("audio")) {
-                return html`<audio src="${url}" controls />`;
-              }
-              if (mimeType.startsWith("video")) {
-                return html`<video src="${url}" controls />`;
-              }
-              if (mimeType.startsWith("text")) {
-                return html`<div class="plain-text">${until(getData())}</div>`;
-              }
-            });
-            value = html`${until(tmpl)}`;
+            const storedData = this.dataStore?.instance?.retrieveAsURL(part);
+            if (!storedData) {
+              value = html`<div>Failed to retrieve stored data</div>`;
+            } else {
+              const tmpl = storedData.then((url) => {
+                const { mimeType } = part.storedData;
+                const getData = async () => {
+                  const response = await fetch(url);
+                  return response.text();
+                };
+                if (mimeType.startsWith("image")) {
+                  return html`<img src="${url}" alt="LLM Image" />`;
+                }
+                if (mimeType.startsWith("audio")) {
+                  return html`<audio src="${url}" controls />`;
+                }
+                if (mimeType.startsWith("video")) {
+                  return html`<video src="${url}" controls />`;
+                }
+                if (mimeType.startsWith("text")) {
+                  return html`<div class="plain-text">
+                    ${until(getData())}
+                  </div>`;
+                }
+              });
+              value = html`${until(tmpl)}`;
+            }
           } else {
             value = html`Unrecognized part`;
           }

--- a/packages/breadboard-ui/src/elements/node-info/node-configuration.ts
+++ b/packages/breadboard-ui/src/elements/node-info/node-configuration.ts
@@ -37,6 +37,8 @@ import { CodeEditor } from "../input/code-editor/code-editor.js";
 import { LLMInput } from "../input/llm-input/llm-input.js";
 import { EditorMode, filterConfigByMode } from "../../utils/mode.js";
 import { classMap } from "lit/directives/class-map.js";
+import { dataStoreContext } from "../../contexts/data-store.js";
+import { provide } from "@lit/context";
 
 function isLLMContent(port: InspectablePort) {
   return port.schema.behavior?.includes("llm-content") || false;
@@ -75,6 +77,9 @@ export class NodeConfigurationInfo extends LitElement {
 
   @state()
   inputsExpanded = true;
+
+  @provide({ context: dataStoreContext })
+  dataStore = { instance: null };
 
   #ignoreNextUpdate = false;
 

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -14,7 +14,9 @@ import { InputResolveRequest } from "@google-labs/breadboard/remote";
 import {
   blank,
   BoardRunner,
+  createDataStore,
   createLoader,
+  DataStore,
   edit,
   EditableGraph,
   GraphDescriptor,
@@ -39,6 +41,7 @@ import {
   Environment,
   environmentContext,
 } from "@google-labs/breadboard-ui/contexts/environment.js";
+import { dataStoreContext } from "@google-labs/breadboard-ui/contexts/data-store.js";
 
 type MainArguments = {
   boards: BreadboardUI.Types.Board[];
@@ -107,6 +110,9 @@ export class Main extends LitElement {
         : undefined,
     connectionRedirectUrl: "/oauth/",
   };
+
+  @provide({ context: dataStoreContext })
+  dataStore: { instance: DataStore | null } = { instance: createDataStore() };
 
   #abortController: AbortController | null = null;
   #uiRef: Ref<BreadboardUI.Elements.UI> = createRef();

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -1311,6 +1311,7 @@ export class Main extends LitElement {
                     diagnostics: true,
                     kits: this.kits,
                     loader: this.#loader,
+                    store: this.dataStore.instance!,
                     signal: this.#abortController?.signal,
                     inputs: inputsFromSettings(this.#settings),
                     interactiveSecrets: true,

--- a/packages/breadboard/src/harness/local.ts
+++ b/packages/breadboard/src/harness/local.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Board, asyncGen } from "../index.js";
+import { Board, asyncGen, createDataStore } from "../index.js";
 import { createLoader } from "../loader/index.js";
 import { timestamp } from "../timestamp.js";
 import {
@@ -100,6 +100,7 @@ export async function* runLocally(config: RunConfig, kits: Kit[]) {
   yield* asyncGen<HarnessRunResult>(async (next) => {
     const runner = config.runner || (await load(config));
     const loader = config.loader || createLoader();
+    const store = config.store || createDataStore();
 
     try {
       const probe = config.diagnostics
@@ -112,6 +113,7 @@ export async function* runLocally(config: RunConfig, kits: Kit[]) {
         probe,
         kits,
         loader,
+        store,
         base: config.base,
         signal: config.signal,
         inputs: config.inputs,

--- a/packages/breadboard/src/harness/run.ts
+++ b/packages/breadboard/src/harness/run.ts
@@ -4,7 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { BreadboardRunner, InputValues, Kit, asyncGen } from "../index.js";
+import {
+  BreadboardRunner,
+  DataStore,
+  InputValues,
+  Kit,
+  asyncGen,
+} from "../index.js";
 import { NodeProxyConfig } from "../remote/config.js";
 import { HTTPClientTransport } from "../remote/http.js";
 import { ProxyClient } from "../remote/proxy.js";
@@ -97,6 +103,10 @@ export type RunConfig = {
    * the secrets on its own.
    */
   interactiveSecrets?: boolean;
+  /**
+   * The data store to use for storing data.
+   */
+  store?: DataStore;
 };
 
 const configureKits = (config: RunConfig) => {

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -18,6 +18,7 @@ import type {
 } from "@google-labs/breadboard-schema/graph.js";
 import { GraphLoader } from "./loader/types.js";
 import {
+  DataStore,
   InlineDataCapabilityPart,
   StoredDataCapabilityPart,
 } from "./data/types.js";
@@ -714,6 +715,10 @@ export interface NodeHandlerContext {
    * The `AbortSignal` that can be used to stop the board run.
    */
   readonly signal?: AbortSignal;
+  /**
+   * The data store that can be used to store data across nodes.
+   */
+  readonly store?: DataStore;
 }
 
 export type RunArguments = NodeHandlerContext & {

--- a/packages/core-kit/src/nodes/deflate.ts
+++ b/packages/core-kit/src/nodes/deflate.ts
@@ -5,7 +5,7 @@
  */
 
 import { defineNodeType, object } from "@breadboard-ai/build";
-import { deflateData } from "@google-labs/breadboard";
+import { NodeHandlerContext, deflateData } from "@google-labs/breadboard";
 
 export default defineNodeType({
   name: "deflate",
@@ -26,7 +26,12 @@ export default defineNodeType({
       description: "Deflated data.",
     },
   },
-  invoke: async ({ data }) => {
-    return { data: await deflateData(data) };
+  invoke: async ({ data }, { store }: NodeHandlerContext) => {
+    if (!store) {
+      throw new Error(
+        "Data store was not specified in run configuration, but is required for deflation."
+      );
+    }
+    return { data: await deflateData(store, data) };
   },
 });

--- a/packages/core-kit/src/nodes/deflate.ts
+++ b/packages/core-kit/src/nodes/deflate.ts
@@ -26,7 +26,7 @@ export default defineNodeType({
       description: "Deflated data.",
     },
   },
-  invoke: async ({ data }, { store }: NodeHandlerContext) => {
+  invoke: async ({ data }, _, { store }: NodeHandlerContext) => {
     if (!store) {
       throw new Error(
         "Data store was not specified in run configuration, but is required for deflation."

--- a/packages/core-kit/src/nodes/fetch.ts
+++ b/packages/core-kit/src/nodes/fetch.ts
@@ -137,6 +137,7 @@ export default defineNodeType({
   },
   invoke: async (
     { url, method, body, headers, raw, stream },
+    _, // No dynamic inputs.
     { signal, store }: NodeHandlerContext
   ) => {
     if (!url) throw new Error("Fetch requires `url` input");

--- a/packages/core-kit/src/nodes/fetch.ts
+++ b/packages/core-kit/src/nodes/fetch.ts
@@ -12,10 +12,10 @@ import {
 } from "@breadboard-ai/build";
 import { JsonSerializable } from "@breadboard-ai/build/internal/type-system/type.js";
 import {
+  DataStore,
   NodeHandlerContext,
   StreamCapability,
   asBlob,
-  createDataStore,
   inflateData,
   isDataCapability,
 } from "@google-labs/breadboard";
@@ -45,7 +45,8 @@ const serverSentEventTransform = () =>
 
 const createBody = async (
   body: unknown,
-  headers: Record<string, string | undefined>
+  headers: Record<string, string | undefined>,
+  store: DataStore
 ) => {
   if (!body) return undefined;
   const contentType = headers["Content-Type"];
@@ -70,7 +71,7 @@ const createBody = async (
     }
     return formData;
   }
-  return JSON.stringify(await inflateData(body));
+  return JSON.stringify(await inflateData(store, body));
 };
 
 export default defineNodeType({
@@ -136,13 +137,18 @@ export default defineNodeType({
   },
   invoke: async (
     { url, method, body, headers, raw, stream },
-    { signal }: NodeHandlerContext
+    { signal, store }: NodeHandlerContext
   ) => {
     if (!url) throw new Error("Fetch requires `url` input");
     const init: RequestInit = { method, headers, signal };
     // GET can not have a body.
     if (method !== "GET") {
-      init.body = await createBody(body, headers);
+      if (!store) {
+        throw new Error(
+          "No store provided in run configuration to store the request."
+        );
+      }
+      init.body = await createBody(body, headers, store);
     } else if (body) {
       throw new Error("GET requests can not have a body");
     }
@@ -192,8 +198,12 @@ export default defineNodeType({
         } else if (isText) {
           response = await data.text();
         } else {
+          if (!store) {
+            throw new Error(
+              "No store provided in run configuration to store the response."
+            );
+          }
           const blob = await data.blob();
-          const store = createDataStore();
           response = await store.store(blob);
         }
       }


### PR DESCRIPTION
- **Plumb `DataStore` through `NodeHandlerContext`.**
- **Make it actually work.**
- **Use a single DataStore instance in the UI.**
- **Use a single DataStore instance in Breadboard Web.**
- **docs(changeset): Plumb `DataStore` throuh to `NodeHandlerContext`.**
