### PR TITLE
[breadboard-ui] Avoid wire creation when the user clicks on a port

### DIFF
--- a/packages/breadboard-ui/src/elements/editor/graph.ts
+++ b/packages/breadboard-ui/src/elements/editor/graph.ts
@@ -347,8 +347,8 @@ export class Graph extends PIXI.Container {
       const path = evt.composedPath();
       const topTarget = path[path.length - 1] as PIXI.Graphics;
 
-      // If the user has clicked on the node, but not dragged the wire anywhere,
-      // avoid creating a wire.
+      // If the pointer target is the same at pointerdown and pointerup, the
+      // user has clicked on a node port, and we should avoid creating a wire.
       if (topTarget === nodePortBeingEdited) {
         return;
       }

--- a/packages/breadboard-ui/src/elements/editor/graph.ts
+++ b/packages/breadboard-ui/src/elements/editor/graph.ts
@@ -347,6 +347,12 @@ export class Graph extends PIXI.Container {
       const path = evt.composedPath();
       const topTarget = path[path.length - 1] as PIXI.Graphics;
 
+      // If the user has clicked on the node, but not dragged the wire anywhere,
+      // avoid creating a wire.
+      if (topTarget === nodePortBeingEdited) {
+        return;
+      }
+
       // Take a copy of the info we need.
       const targetNodePort = nodePortBeingEdited;
       const targetEdge = edgeBeingEdited;


### PR DESCRIPTION
Fixes #2060 