### PR TITLE
board server esbuild

### DIFF
--- a/.changeset/unlucky-pens-decide.md
+++ b/.changeset/unlucky-pens-decide.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/board-server": minor
+---
+
+Use esbuild for building the server bits to allow bundling Breadboard in.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1409,18 +1409,6 @@
         "sisteransi": "^1.0.5"
       }
     },
-    "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
-      "version": "1.3.0",
-      "extraneous": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@codemirror/autocomplete": {
       "version": "6.16.2",
       "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.16.2.tgz",
@@ -25585,6 +25573,7 @@
       "devDependencies": {
         "@types/node": "^20.14.1",
         "concurrently": "^8.2.2",
+        "esbuild": "^0.21.4",
         "eslint": "^8.57.0",
         "typescript": "^5.4.5",
         "wireit": "^0.14.4"

--- a/packages/board-server/.gcloudignore
+++ b/packages/board-server/.gcloudignore
@@ -1,17 +1,5 @@
-# This file specifies files that are *not* uploaded to Google Cloud
-# using gcloud. It follows the same syntax as .gitignore, with the addition of
-# "#!include" directives (which insert the entries of the given .gitignore-style
-# file at that point).
-#
-# For more information, run:
-#   $ gcloud topic gcloudignore
-#
 .gcloudignore
-# If you would like to upload your .git directory, .gitignore file or files
-# from your .gitignore file, remove the corresponding line
-# below:
 .git
 .gitignore
-
-# Node.js dependencies:
 node_modules/
+.wireit/

--- a/packages/board-server/README.md
+++ b/packages/board-server/README.md
@@ -8,13 +8,13 @@ One-time setup:
 
 - Login
 
-````bash
+```bash
 gcloud auth login
-```b
+```
 
 ```bash
 gcloud auth application-default login
-````
+```
 
 ```bash
 gcloud config set project <project name>
@@ -34,3 +34,11 @@ npm run s
 
 This will bring up the board server at `http://localhost:3000` and
 a breadboard-web dev server at whatever port it launches (usually `http://localhost:5173/`).
+
+To deploy:
+
+```bash
+npm run deploy
+```
+
+This will build the project and deploy it to App Engine.

--- a/packages/board-server/package.json
+++ b/packages/board-server/package.json
@@ -6,17 +6,15 @@
   "private": true,
   "version": "0.0.1",
   "description": "Board Server",
-  "main": "./dist/index.js",
-  "exports": "./dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/server/index.js",
+  "exports": "./dist/server/index.js",
   "type": "module",
   "scripts": {
     "start": "node .",
     "prepack": "npm run build",
     "build": "wireit",
+    "deploy": "npm run build && gcloud app deploy",
     "add": "tsx scripts/create-account.ts",
-    "build:tsc": "wireit",
-    "test": "wireit",
     "serve": "wireit",
     "dev": "concurrently \"npm run serve --watch\" \"(cd ../breadboard-web && npm run dev)\""
   },
@@ -37,19 +35,21 @@
         "dist/client"
       ],
       "dependencies": [
-        "build:tsc"
+        "build:esbuild"
       ],
       "clean": "if-file-deleted"
     },
-    "build:tsc": {
-      "command": "tsc --pretty",
+    "build:esbuild": {
+      "command": "tsx scripts/build.ts",
       "files": [
-        "src/",
+        "scripts/build.ts",
+        "src/index.ts",
+        "src/server/**/*.ts",
         "tsconfig.json",
         "package.json"
       ],
       "output": [
-        "dist/"
+        "dist/server/index.js"
       ],
       "dependencies": [
         "../breadboard:build",
@@ -68,14 +68,6 @@
       "dependencies": [
         "build"
       ]
-    },
-    "test": {
-      "command": "node --test --enable-source-maps --test-reporter spec dist/test/*_test.js",
-      "dependencies": [
-        "build:tsc"
-      ],
-      "files": [],
-      "output": []
     }
   },
   "repository": {
@@ -96,6 +88,7 @@
   "devDependencies": {
     "@types/node": "^20.14.1",
     "concurrently": "^8.2.2",
+    "esbuild": "^0.21.4",
     "eslint": "^8.57.0",
     "typescript": "^5.4.5",
     "wireit": "^0.14.4"

--- a/packages/board-server/scripts/build.ts
+++ b/packages/board-server/scripts/build.ts
@@ -1,0 +1,16 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as esbuild from "esbuild";
+
+await esbuild.build({
+  entryPoints: ["src/index.ts"],
+  bundle: true,
+  platform: "node",
+  external: ["@google-cloud", "import.meta", "vite"],
+  format: "esm",
+  outfile: "dist/server/index.js",
+});


### PR DESCRIPTION
- **Exclude `.wireit` from App Engine upload.**
- **Start using esbuild for building.**
- **docs(changeset): Use esbuild for building the server bits to allow bundling Breadboard in.**
