### PR TITLE
node 20.14

### DIFF
--- a/.changeset/pretty-penguins-warn.md
+++ b/.changeset/pretty-penguins-warn.md
@@ -1,0 +1,11 @@
+---
+"@google-labs/graph-playground": patch
+"@google-labs/breadboard-ui": patch
+"@google-labs/template-kit": patch
+"@google-labs/llm-starter": patch
+"@google-labs/breadboard": patch
+"@google-labs/breadboard-website": patch
+"@google-labs/breadboard-schema": patch
+---
+
+Switch to Nodejs v20.14.0 as the baseline.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This is the monorepo for Breadboard. See [DEVELOPING.md](./DEVELOPING.md) for in
 
 ## Requirements
 
-Breadboard requires [Node](https://nodejs.org/) version >=v19.0.0.
+Breadboard requires [Node](https://nodejs.org/) version >=v22.
 
 ## Packages
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This is the monorepo for Breadboard. See [DEVELOPING.md](./DEVELOPING.md) for in
 
 ## Requirements
 
-Breadboard requires [Node](https://nodejs.org/) version >=v22.
+Breadboard requires [Node](https://nodejs.org/) version >=v20.14.0.
 
 ## Packages
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25613,6 +25613,9 @@
         "typedoc": "^0.25.12",
         "typedoc-plugin-markdown": "^4.0.3",
         "typescript": "^5.4.5"
+      },
+      "engines": {
+        "node": ">=20.14.0"
       }
     },
     "packages/breadboard-cli": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1409,6 +1409,18 @@
         "sisteransi": "^1.0.5"
       }
     },
+    "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
+      "version": "1.3.0",
+      "extraneous": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@codemirror/autocomplete": {
       "version": "6.16.2",
       "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.16.2.tgz",
@@ -25601,9 +25613,6 @@
         "typedoc": "^0.25.12",
         "typedoc-plugin-markdown": "^4.0.3",
         "typescript": "^5.4.5"
-      },
-      "engines": {
-        "node": ">=19.0.0"
       }
     },
     "packages/breadboard-cli": {
@@ -25718,9 +25727,6 @@
         "typedoc": "^0.25.12",
         "typedoc-plugin-markdown": "^4.0.3",
         "typescript": "^5.4.5"
-      },
-      "engines": {
-        "node": ">=19.0.0"
       }
     },
     "packages/breadboard-web": {
@@ -26014,9 +26020,6 @@
         "ava": "^5.2.0",
         "typedoc": "^0.25.12",
         "typescript": "^5.4.5"
-      },
-      "engines": {
-        "node": ">=19.0.0"
       }
     },
     "packages/graph-runner": {
@@ -26114,9 +26117,6 @@
         "typedoc": "^0.25.12",
         "typedoc-plugin-markdown": "^4.0.3",
         "typescript": "^5.4.5"
-      },
-      "engines": {
-        "node": ">=19.0.0"
       }
     },
     "packages/node-nursery": {
@@ -26200,9 +26200,6 @@
         "firebase-functions-test": "^3.2.0",
         "rollup": "^4.18.0",
         "typescript": "^5.4.5"
-      },
-      "engines": {
-        "node": "20"
       }
     },
     "packages/palm-kit": {
@@ -26291,9 +26288,6 @@
         "@typescript-eslint/parser": "^7.12.0",
         "ava": "^5.2.0",
         "typescript": "^5.4.5"
-      },
-      "engines": {
-        "node": ">=19.0.0"
       }
     },
     "packages/website": {

--- a/packages/breadboard-ui/package.json
+++ b/packages/breadboard-ui/package.json
@@ -148,9 +148,6 @@
     "typedoc-plugin-markdown": "^4.0.3",
     "typescript": "^5.4.5"
   },
-  "engines": {
-    "node": ">=19.0.0"
-  },
   "dependencies": {
     "@dagrejs/dagre": "^1.1.2",
     "@google-labs/breadboard": "^0.20.0",

--- a/packages/breadboard-ui/rollup.config.js
+++ b/packages/breadboard-ui/rollup.config.js
@@ -1,7 +1,7 @@
 import { nodeResolve } from "@rollup/plugin-node-resolve";
 import terser from "@rollup/plugin-terser";
 
-import config from "./package.json" assert { type: "json" };
+import config from "./package.json" with { type: "json" };
 
 const makeAllTargets = Object.entries(config.exports).map(([name, input]) => {
   name = name === "." ? "index" : name;

--- a/packages/breadboard/README.md
+++ b/packages/breadboard/README.md
@@ -42,7 +42,7 @@ This library's design emphasizes two key properties:
 
 ## Installation
 
-Breadboard requires [Node.js](https://nodejs.org/) version 19 or higher. Before installing, [download and install Node.js](https://nodejs.org/en/download/).
+Breadboard requires [Node.js](https://nodejs.org/) version 22 or higher. Before installing, [download and install Node.js](https://nodejs.org/en/download/).
 
 - Check what version of Node.js you're running with `node -v`.
 - In your workspace, make sure to create a `package.json` first with the [`npm init` command](https://docs.npmjs.com/creating-a-package-json-file).
@@ -132,16 +132,18 @@ console.log(await echo({ say: "Hello Breadboard!" })); // { hear: 'Hello Breadbo
 Attributes can be passed between nodes by wiring them together.
 
 Using `to`, attributes can be wired from left-to-right.
+
 ```typescript
 board<{ message: string }>(({ message }, { output }) => {
-	return message.as("response").to(output());
+  return message.as("response").to(output());
 });
 ```
 
 Alternatively, `in` can be used to pass attributes from right-to-left.
+
 ```typescript
 board<{ message: string }>(({ message }, { output }) => {
-	return output().in(message.as("response"))
+  return output().in(message.as("response"));
 });
 ```
 
@@ -330,7 +332,13 @@ When running a serialized board that uses kits or `code`, all the kits it uses m
 Each of the kits must be wrapped with `asRuntimeKit` and passed in together in an array.
 
 ```typescript
-import { addKit, asRuntimeKit, board, BoardRunner, code } from "@google-labs/breadboard";
+import {
+  addKit,
+  asRuntimeKit,
+  board,
+  BoardRunner,
+  code,
+} from "@google-labs/breadboard";
 import Core from "@google-labs/core-kit";
 import TemplateKit from "@google-labs/template-kit";
 
@@ -511,7 +519,7 @@ export default await board(() => {
       required: ["greeting", "subject"],
     },
   });
-  
+
   const result = concatStrings({
     greeting: inputs.greeting.isString(),
     subject: inputs.subject.isString(),

--- a/packages/breadboard/README.md
+++ b/packages/breadboard/README.md
@@ -42,7 +42,7 @@ This library's design emphasizes two key properties:
 
 ## Installation
 
-Breadboard requires [Node.js](https://nodejs.org/) version 22 or higher. Before installing, [download and install Node.js](https://nodejs.org/en/download/).
+Breadboard requires [Node.js](https://nodejs.org/) version 20.14.0 or higher. Before installing, [download and install Node.js](https://nodejs.org/en/download/).
 
 - Check what version of Node.js you're running with `node -v`.
 - In your workspace, make sure to create a `package.json` first with the [`npm init` command](https://docs.npmjs.com/creating-a-package-json-file).

--- a/packages/breadboard/docs/fodder/happy-path.md
+++ b/packages/breadboard/docs/fodder/happy-path.md
@@ -20,7 +20,7 @@ Go to Breadboard Replit Project (TOOD: URL) and click "Fork". This will create r
 
 ### Install locally
 
-1. Install [Node.js >=v22](https://nodejs.org/en). If you already have an earlier version of Node installed, you can use [nvm](https://github.com/nvm-sh/nvm) to get to the version that Breadboard needs.
+1. Install [Node.js >=v20.14.0](https://nodejs.org/en). If you already have an earlier version of Node installed, you can use [nvm](https://github.com/nvm-sh/nvm) to get to the version that Breadboard needs.
 
 2. Run `npm init @google-labs/breadboard` to set up the project. (TODO: make sure this works)
 

--- a/packages/breadboard/docs/fodder/happy-path.md
+++ b/packages/breadboard/docs/fodder/happy-path.md
@@ -9,9 +9,7 @@ If you're eager to start making boards with Breadboard as quickly as possible, h
 > Neither onboarding via Replit nor installing locally are ready yet. While they are baking, follow these steps for an in-tree setup:
 >
 > - Check out and set up the monorepo following steps in [DEVELOPING.md](https://github.com/breadboard-ai/breadboard/blob/main/DEVELOPING.md#getting-started)
->
 > - Navigate to `packages/breadboard-web` from the root of the repo
->
 > - Pick back up at "Set up the environment".
 
 There are two ways to get started with Breadboard: fork a Replit project or install Breadboard locally.
@@ -22,7 +20,7 @@ Go to Breadboard Replit Project (TOOD: URL) and click "Fork". This will create r
 
 ### Install locally
 
-1. Install [Node.js >=v19](https://nodejs.org/en). If you already have an earlier version of Node installed, you can use [nvm](https://github.com/nvm-sh/nvm) to get to the version that Breadboard needs.
+1. Install [Node.js >=v22](https://nodejs.org/en). If you already have an earlier version of Node installed, you can use [nvm](https://github.com/nvm-sh/nvm) to get to the version that Breadboard needs.
 
 2. Run `npm init @google-labs/breadboard` to set up the project. (TODO: make sure this works)
 
@@ -81,15 +79,10 @@ export default await board(({ text }) => {
 > It might be worth going over this code to orient ourselves a little bit:
 >
 > - The `board` call is how we tell Breadboard to create a new board. It takes a function as an argument. This function (let's call it a "board function") is where we describe the board.
->
 > - The board function itself takes a single argument (let's call it "inputs") and returns a single argument, which we'll call "outputs". These arguments are the objects that describe the inputs and outputs of our new board.
->
 > - Both input and output are of the same shape: they are property bags that contain named properties. Each property is a "port" -- one value that the board takes in as input or passes as output. For example, the blank board has a single input port called `text` and a single output port called `text` -- and that input port is passed right through to the output port.
->
 > - The `serialize` function is then called on the result of the `board` invocation. This will serialize the board into Breadboard Graph Language (BGL). BGL is the [common format](./hourglass.md) that Breadboard uses to represent boards.
->
 > - The `serialize` function also takes a single argument: some metadata that describes the board. This is where we can set the title, description, and version of the board. Since we'll be making many boards in the future, it's a good practice to give meaningful values to these properties.
->
 > - Behind the scenes, debugger scans for all the files in `src/boards`, looks for the `default` export in each file, serializes it as BGL, and then renders the BGL in the debugger. This is why we see the "Blank" board in the debugger window.
 
 In the debugger window, we can see that the board asks for the `text` input. If we enter something there, and hit "Run", we'll see that what we entered gets passed through to the output.
@@ -228,13 +221,9 @@ We will also need to update TypeScript imports in this file to include the `code
 > Just like before, we will go over this bit of code to orient ourselves:
 >
 > - the `code` function is how we ask Breadboard to create a new type of node.
->
 > - just like the `board` function, it takes a single input: the "node function" that describes what the node will do.
->
 > - The node function takes in the inputs bag of ports and returns the output ports. In our node, there's one input port named `text` and one output port named `reversed`.
->
 > - the one-liner that actually does the work reverses the value of the `text` port. Note that we need to typecast it as `string`. By default, the type ports are unknown.
->
 > - finally, we return the `reversed` value as part of the outputs.
 
 It looks like creating new node types is pretty straightforward. Let's see if we can add it to the board.

--- a/packages/breadboard/docs/tutorial/README.md
+++ b/packages/breadboard/docs/tutorial/README.md
@@ -8,7 +8,7 @@ If you like learning by starting with simple examples that get more complex with
 Pre-requisites:
 
 - Familiarity with JavaScript and Node.
-- Node v19.0.0 or higher
+- Node v22 or higher
 - PaLM API key (go [here](https://developers.generativeai.google/tutorials/setup) to obtain one)
 - Spirit of adventure
 

--- a/packages/breadboard/docs/tutorial/README.md
+++ b/packages/breadboard/docs/tutorial/README.md
@@ -8,7 +8,7 @@ If you like learning by starting with simple examples that get more complex with
 Pre-requisites:
 
 - Familiarity with JavaScript and Node.
-- Node v22 or higher
+- Node v20.14.0 or higher
 - PaLM API key (go [here](https://developers.generativeai.google/tutorials/setup) to obtain one)
 - Spirit of adventure
 

--- a/packages/breadboard/package.json
+++ b/packages/breadboard/package.json
@@ -165,6 +165,9 @@
     "typedoc-plugin-markdown": "^4.0.3",
     "typescript": "^5.4.5"
   },
+  "engines": {
+    "node": ">=20.14.0"
+  },
   "dependencies": {
     "@google-labs/breadboard-schema": "^1.4.1"
   }

--- a/packages/breadboard/package.json
+++ b/packages/breadboard/package.json
@@ -165,9 +165,6 @@
     "typedoc-plugin-markdown": "^4.0.3",
     "typescript": "^5.4.5"
   },
-  "engines": {
-    "node": ">=19.0.0"
-  },
   "dependencies": {
     "@google-labs/breadboard-schema": "^1.4.1"
   }

--- a/packages/breadboard/rollup.config.js
+++ b/packages/breadboard/rollup.config.js
@@ -1,7 +1,7 @@
 import json from "@rollup/plugin-json";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
 import terser from "@rollup/plugin-terser";
-import config from "./package.json" assert { type: "json" };
+import config from "./package.json" with { type: "json" };
 
 const makeAllTargets = Object.entries(config.exports).map(([name, input]) => {
   name = name === "." ? "index" : name;

--- a/packages/breadboard/src/runner.ts
+++ b/packages/breadboard/src/runner.ts
@@ -38,7 +38,7 @@ import {
 import { asyncGen } from "./utils/async-gen.js";
 import { StackManager } from "./stack.js";
 import { timestamp } from "./timestamp.js";
-import breadboardSchema from "@google-labs/breadboard-schema/breadboard.schema.json" assert { type: "json" };
+import breadboardSchema from "@google-labs/breadboard-schema/breadboard.schema.json" with { type: "json" };
 import { GraphLoader, GraphProvider } from "./loader/types.js";
 import { SENTINEL_BASE_URL, createLoader } from "./loader/index.js";
 import {

--- a/packages/breadboard/tests/board.ts
+++ b/packages/breadboard/tests/board.ts
@@ -12,7 +12,7 @@ import type {
   InputValues,
 } from "../src/types.js";
 import { TestKit } from "./helpers/_test-kit.js";
-import breadboardSchema from "@google-labs/breadboard-schema/breadboard.schema.json" assert { type: "json" };
+import breadboardSchema from "@google-labs/breadboard-schema/breadboard.schema.json" with { type: "json" };
 
 test("correctly passes inputs and outputs to included boards", async (t) => {
   const nestedBoard = new Board();

--- a/packages/graph-playground/package.json
+++ b/packages/graph-playground/package.json
@@ -181,8 +181,5 @@
     "@google-labs/pinecone-kit": "^0.1.12",
     "@google-labs/template-kit": "^0.3.2",
     "dotenv": "^16.4.5"
-  },
-  "engines": {
-    "node": ">=19.0.0"
   }
 }

--- a/packages/llm-starter/package.json
+++ b/packages/llm-starter/package.json
@@ -124,8 +124,5 @@
   "dependencies": {
     "@google-labs/breadboard": "^0.20.0",
     "url-template": "^3.1.0"
-  },
-  "engines": {
-    "node": ">=19.0.0"
   }
 }

--- a/packages/node-proxy-server/functions/package.json
+++ b/packages/node-proxy-server/functions/package.json
@@ -71,9 +71,6 @@
       ]
     }
   },
-  "engines": {
-    "node": "20"
-  },
   "main": "lib/bundle.js",
   "dependencies": {
     "firebase-admin": "^12.1.1",

--- a/packages/schema/src/scripts/generate-schema-id.ts
+++ b/packages/schema/src/scripts/generate-schema-id.ts
@@ -5,11 +5,11 @@
  */
 
 import * as path from "path";
-import packageJson from "../../package.json" assert { type: "json" };
+import packageJson from "../../package.json" with { type: "json" };
 import { ascendToPackageDir } from "./util/ascend-to-package-dir.js";
 
 export function generateSchemaId() {
-  const PACKAGE_ROOT = ascendToPackageDir(packageJson.name)
+  const PACKAGE_ROOT = ascendToPackageDir(packageJson.name);
   const SCHEMA_PATH = path.relative(PACKAGE_ROOT, "breadboard.schema.json");
 
   const GITHUB_OWNER = "breadboard-ai";

--- a/packages/schema/src/tests/main.test.ts
+++ b/packages/schema/src/tests/main.test.ts
@@ -12,10 +12,10 @@ import * as path from "path";
 import { ascendToPackageDir } from "../scripts/util/ascend-to-package-dir.js";
 import { getBoardFiles } from "./util/get-board-files.js";
 
-let ajv = new Ajv();
+const ajv = new Ajv();
 let validate: ValidateFunction;
 
-import schema from "../../breadboard.schema.json" assert { type: "json" };
+import schema from "../../breadboard.schema.json" with { type: "json" };
 
 test.before(() => {
   validate = ajv.compile(schema);

--- a/packages/template-kit/README.md
+++ b/packages/template-kit/README.md
@@ -6,7 +6,7 @@ The Template Kit is a collection of [Breadboard](https://github.com/breadboard-a
 
 ## Installing
 
-The Template Kit requires Node version >=v19.0.0. To install:
+The Template Kit requires Node version >= v22. To install:
 
 ```sh
 npm install @google-labs/template-kit

--- a/packages/template-kit/README.md
+++ b/packages/template-kit/README.md
@@ -6,7 +6,7 @@ The Template Kit is a collection of [Breadboard](https://github.com/breadboard-a
 
 ## Installing
 
-The Template Kit requires Node version >= v22. To install:
+The Template Kit requires Node version >= v20.14.0. To install:
 
 ```sh
 npm install @google-labs/template-kit

--- a/packages/template-kit/docs/README.md
+++ b/packages/template-kit/docs/README.md
@@ -8,7 +8,7 @@ The Template Kit is a collection of [Breadboard](https://github.com/breadboard-a
 
 ## Installing
 
-The Template Kit requires Node version >=v19.0.0. To install:
+The Template Kit requires Node version >=22. To install:
 
 ```sh
 npm install @google-labs/template-kit

--- a/packages/template-kit/package.json
+++ b/packages/template-kit/package.json
@@ -134,8 +134,5 @@
     "@breadboard-ai/build": "^0.6.0",
     "@google-labs/breadboard": "^0.20.0",
     "url-template": "^3.1.0"
-  },
-  "engines": {
-    "node": ">=19.0.0"
   }
 }

--- a/packages/website/src/docs/happy-path.md
+++ b/packages/website/src/docs/happy-path.md
@@ -22,7 +22,7 @@ Go to the [Breadboard Starter Project](https://replit.com/@dglazkov/Breadboard-S
 
 Alternatively, you can install Breadboard locally:
 
-1. Install [Node.js >=v22](https://nodejs.org/en) if needed. Type `node -v` in your CLI to find out which node version you're currently using. If you already have an earlier version of Node installed, you can use [nvm](https://github.com/nvm-sh/nvm) to get to the version that Breadboard needs.
+1. Install [Node.js >=20.14.0](https://nodejs.org/en) if needed. Type `node -v` in your CLI to find out which node version you're currently using. If you already have an earlier version of Node installed, you can use [nvm](https://github.com/nvm-sh/nvm) to get to the version that Breadboard needs.
 
 2. Run the following command:
 

--- a/packages/website/src/docs/happy-path.md
+++ b/packages/website/src/docs/happy-path.md
@@ -22,7 +22,7 @@ Go to the [Breadboard Starter Project](https://replit.com/@dglazkov/Breadboard-S
 
 Alternatively, you can install Breadboard locally:
 
-1. Install [Node.js >=v19](https://nodejs.org/en) if needed. Type `node -v` in your CLI to find out which node version you're currently using. If you already have an earlier version of Node installed, you can use [nvm](https://github.com/nvm-sh/nvm) to get to the version that Breadboard needs.
+1. Install [Node.js >=v22](https://nodejs.org/en) if needed. Type `node -v` in your CLI to find out which node version you're currently using. If you already have an earlier version of Node installed, you can use [nvm](https://github.com/nvm-sh/nvm) to get to the version that Breadboard needs.
 
 2. Run the following command:
 


### PR DESCRIPTION
- **Update all mentions of Node v19 to v22.**
- **Replace import assertions with import attributes.**
- **Update docs/etc. to 20.14.0**
- **docs(changeset): Switch to Nodejs v20.14.0 as the baseline.**
