### PR TITLE
board server proxy

### DIFF
--- a/.changeset/clever-stingrays-work.md
+++ b/.changeset/clever-stingrays-work.md
@@ -1,0 +1,7 @@
+---
+"@breadboard-ai/board-server": minor
+"@google-labs/breadboard": minor
+"@google-labs/core-kit": minor
+---
+
+Teach Board Server to use Node Proxy Server

--- a/package-lock.json
+++ b/package-lock.json
@@ -2484,6 +2484,17 @@
         "node": ">=14"
       }
     },
+    "node_modules/@google-cloud/secret-manager": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/secret-manager/-/secret-manager-5.6.0.tgz",
+      "integrity": "sha512-0daW/OXQEVc6VQKPyJTQNyD+563I/TYQ7GCQJx4dq3lB666R9FUPvqHx9b/o/qQtZ5pfuoCbGZl3krpxgTSW8Q==",
+      "dependencies": {
+        "google-gax": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@google-cloud/storage": {
       "version": "7.9.0",
       "license": "Apache-2.0",
@@ -25576,6 +25587,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@google-cloud/firestore": "^7.8.0",
+        "@google-cloud/secret-manager": "^5.6.0",
         "@google-labs/breadboard": "^0.20.0",
         "@google-labs/breadboard-web": "^1.9.0",
         "@lit/context": "^1.1.2",

--- a/packages/board-server/package.json
+++ b/packages/board-server/package.json
@@ -16,7 +16,7 @@
     "deploy": "npm run build && gcloud app deploy",
     "add": "tsx scripts/create-account.ts",
     "serve": "wireit",
-    "dev": "concurrently \"npm run serve --watch\" \"(cd ../breadboard-web && npm run dev)\""
+    "dev": "export GOOGLE_CLOUD_PROJECT=$(gcloud config get-value project) &&concurrently \"npm run serve --watch\" \"(cd ../breadboard-web && npm run dev)\""
   },
   "wireit": {
     "build": {

--- a/packages/board-server/package.json
+++ b/packages/board-server/package.json
@@ -95,6 +95,7 @@
   },
   "dependencies": {
     "@google-cloud/firestore": "^7.8.0",
+    "@google-cloud/secret-manager": "^5.6.0",
     "@google-labs/breadboard": "^0.20.0",
     "@google-labs/breadboard-web": "^1.9.0",
     "@lit/context": "^1.1.2",

--- a/packages/board-server/src/app/app.ts
+++ b/packages/board-server/src/app/app.ts
@@ -473,6 +473,14 @@ export class App extends LitElement {
       },
     };
 
+    const base = new URL(window.location.href);
+    if (base.searchParams.has("proxy")) {
+      config.proxy = [
+        { location: "http", url: "/proxy", nodes: ["fetch", "secrets"] },
+      ];
+      config.interactiveSecrets = false;
+    }
+
     this.status = STATUS.RUNNING;
     this.#outputs.clear();
     for await (const result of run(config)) {
@@ -891,7 +899,12 @@ export class App extends LitElement {
           }
 
           const typeInfo = formData.get(`${key}-data-type`);
-          if (typeInfo && typeInfo === "object" && typeof value === "string") {
+          console.log("typeInfo", typeInfo, typeof value, value);
+          if (
+            typeInfo &&
+            (typeInfo === "object" || typeInfo === "array") &&
+            typeof value === "string"
+          ) {
             try {
               value = JSON.parse(value);
             } catch (err) {

--- a/packages/board-server/src/app/app.ts
+++ b/packages/board-server/src/app/app.ts
@@ -895,7 +895,6 @@ export class App extends LitElement {
           }
 
           const typeInfo = formData.get(`${key}-data-type`);
-          console.log("typeInfo", typeInfo, typeof value, value);
           if (
             typeInfo &&
             (typeInfo === "object" || typeInfo === "array") &&

--- a/packages/board-server/src/app/app.ts
+++ b/packages/board-server/src/app/app.ts
@@ -109,7 +109,6 @@ export class App extends LitElement {
     title: string | undefined;
     description: string | undefined;
   }> | null = null;
-  #partDataURLs = new Map<number, string>();
   #contentRef: Ref<HTMLDivElement> = createRef();
   #outputs = new Map<string, InputValues>();
   #secrets: Record<string, string> = {};
@@ -699,9 +698,7 @@ export class App extends LitElement {
             } else if (isInlineData(part)) {
               const key = idx;
               let partDataURL: Promise<string> = Promise.resolve("No source");
-              if (this.#partDataURLs.has(key)) {
-                partDataURL = Promise.resolve(this.#partDataURLs.get(key)!);
-              } else if (
+              if (
                 part.inlineData.data !== "" &&
                 !part.inlineData.mimeType.startsWith("text")
               ) {
@@ -710,7 +707,6 @@ export class App extends LitElement {
                   .then((response) => response.blob())
                   .then((data) => {
                     const url = URL.createObjectURL(data);
-                    this.#partDataURLs.set(key, url);
                     return url;
                   });
               }

--- a/packages/board-server/src/index.ts
+++ b/packages/board-server/src/index.ts
@@ -8,7 +8,7 @@ import { createServer } from "http";
 import { createServer as createViteServer } from "vite";
 import { env } from "process";
 import { cors } from "./server/cors.js";
-import { serveWithVite } from "./server/common.js";
+import { serveContent } from "./server/common.js";
 import { serveBoardsAPI } from "./server/boards/index.js";
 import { serveProxyAPI } from "./server/proxy/index.js";
 
@@ -40,7 +40,7 @@ const server = createServer(async (req, res) => {
     return;
   }
 
-  serveWithVite(vite, req, res);
+  serveContent(vite, req, res);
 });
 
 server.listen(PORT, () => {

--- a/packages/board-server/src/index.ts
+++ b/packages/board-server/src/index.ts
@@ -30,7 +30,9 @@ const server = createServer(async (req, res) => {
     return;
   }
 
-  if (!(await serveBoardsAPI(vite, req, res))) {
+  const url = new URL(req.url || "", HOSTNAME);
+
+  if (!(await serveBoardsAPI(url, vite, req, res))) {
     if (!(await serveProxyAPI(req, res))) {
       serveWithVite(vite, req, res);
     }

--- a/packages/board-server/src/index.ts
+++ b/packages/board-server/src/index.ts
@@ -26,17 +26,21 @@ const vite = IS_PROD
     });
 
 const server = createServer(async (req, res) => {
+  const url = new URL(req.url || "", HOSTNAME);
+
+  if (await serveProxyAPI(req, res)) {
+    return;
+  }
+
   if (!cors(req, res)) {
     return;
   }
 
-  const url = new URL(req.url || "", HOSTNAME);
-
-  if (!(await serveBoardsAPI(url, vite, req, res))) {
-    if (!(await serveProxyAPI(req, res))) {
-      serveWithVite(vite, req, res);
-    }
+  if (await serveBoardsAPI(url, vite, req, res)) {
+    return;
   }
+
+  serveWithVite(vite, req, res);
 });
 
 server.listen(PORT, () => {

--- a/packages/board-server/src/index.ts
+++ b/packages/board-server/src/index.ts
@@ -10,6 +10,7 @@ import { env } from "process";
 import { cors } from "./server/cors.js";
 import { serveWithVite } from "./server/common.js";
 import { serveBoardsAPI } from "./server/boards/index.js";
+import { serveProxyAPI } from "./server/proxy.js";
 
 const PORT = env.PORT || 3000;
 const HOST = env.HOST || "localhost";
@@ -30,7 +31,9 @@ const server = createServer(async (req, res) => {
   }
 
   if (!(await serveBoardsAPI(vite, req, res))) {
-    serveWithVite(vite, req, res);
+    if (!(await serveProxyAPI(req, res))) {
+      serveWithVite(vite, req, res);
+    }
   }
 });
 

--- a/packages/board-server/src/index.ts
+++ b/packages/board-server/src/index.ts
@@ -10,7 +10,7 @@ import { env } from "process";
 import { cors } from "./server/cors.js";
 import { serveWithVite } from "./server/common.js";
 import { serveBoardsAPI } from "./server/boards/index.js";
-import { serveProxyAPI } from "./server/proxy.js";
+import { serveProxyAPI } from "./server/proxy/index.js";
 
 const PORT = env.PORT || 3000;
 const HOST = env.HOST || "localhost";

--- a/packages/board-server/src/server/boards/index.ts
+++ b/packages/board-server/src/server/boards/index.ts
@@ -24,15 +24,12 @@ const getApiPath = (path: string) => {
 };
 
 export const serveBoardsAPI = async (
+  url: URL,
   vite: ViteDevServer | null,
   req: IncomingMessage,
   res: ServerResponse
 ): Promise<boolean> => {
-  const pathname = req.url;
-  if (!pathname) {
-    serverError(res, "Empty url");
-    return true;
-  }
+  const { pathname } = url;
 
   const isBoardServer = pathname.startsWith(API_ENTRY);
   const isApp = pathname.endsWith(".app");

--- a/packages/board-server/src/server/common.ts
+++ b/packages/board-server/src/server/common.ts
@@ -47,7 +47,7 @@ export const serveFile = async (
   }
 };
 
-export const serveWithVite = async (
+export const serveContent = async (
   vite: ViteDevServer | null,
   req: IncomingMessage,
   res: ServerResponse

--- a/packages/board-server/src/server/errors.ts
+++ b/packages/board-server/src/server/errors.ts
@@ -11,6 +11,11 @@ export const serverError = (res: ServerResponse, error: string) => {
   res.end(error);
 };
 
+export const methodNotAllowed = (res: ServerResponse, error: string) => {
+  res.writeHead(405, "Method Not Allowed");
+  res.end(error);
+};
+
 export const notFound = (res: ServerResponse, error: string) => {
   res.writeHead(404, "Page not found");
   res.end(error);

--- a/packages/board-server/src/server/proxy.ts
+++ b/packages/board-server/src/server/proxy.ts
@@ -1,0 +1,105 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IncomingMessage, ServerResponse } from "http";
+import { methodNotAllowed, serverError } from "./errors.js";
+import {
+  ProxyServer,
+  type ServerResponse as ProxyServerResponse,
+  type AnyProxyRequestMessage,
+  HTTPServerTransport,
+  type ProxyServerConfig,
+  hasOrigin,
+} from "@google-labs/breadboard/remote";
+import { asRuntimeKit } from "@google-labs/breadboard";
+import Core from "@google-labs/core-kit";
+
+const config: ProxyServerConfig = {
+  kits: [asRuntimeKit(Core)],
+  proxy: [
+    "fetch",
+    {
+      node: "secrets",
+      tunnel: {
+        GEMINI_KEY: {
+          to: "fetch",
+          when: {
+            url: hasOrigin("https://generativelanguage.googleapis.com"),
+          },
+        },
+        SCRAPING_BEE_KEY: {
+          to: "fetch",
+          when: {
+            url: hasOrigin("https://app.scrapingbee.com/"),
+          },
+        },
+      },
+    },
+  ],
+};
+
+class ResponseAdapter implements ProxyServerResponse {
+  #response: ServerResponse;
+
+  constructor(response: ServerResponse) {
+    this.#response = response;
+  }
+
+  header(field: string, value: string): unknown {
+    this.#response.setHeader(field, value);
+    return this;
+  }
+
+  write(chunk: unknown): boolean {
+    return this.#response.write(chunk);
+  }
+
+  end(): unknown {
+    this.#response.end();
+    return this;
+  }
+}
+
+const extractRequestBody = async (request: IncomingMessage) => {
+  return new Promise<AnyProxyRequestMessage>((resolve, reject) => {
+    let body = "";
+    request.on("data", (chunk) => {
+      body += chunk.toString();
+    });
+    request.on("end", () => {
+      resolve(JSON.parse(body) as AnyProxyRequestMessage);
+    });
+    request.on("error", reject);
+  });
+};
+
+export const serveProxyAPI = async (
+  req: IncomingMessage,
+  res: ServerResponse
+) => {
+  const path = req.url;
+  const isProxy = path === "/proxy" || path === "/proxy/";
+  if (!isProxy) {
+    return false;
+  }
+
+  if (req.method !== "POST") {
+    methodNotAllowed(res, "Use POST method");
+    return true;
+  }
+
+  const body = await extractRequestBody(req);
+  const server = new ProxyServer(
+    new HTTPServerTransport({ body }, new ResponseAdapter(res))
+  );
+  try {
+    await server.serve(config);
+  } catch (e) {
+    serverError(res, (e as Error).message);
+  }
+
+  return true;
+};

--- a/packages/board-server/src/server/proxy/secrets.ts
+++ b/packages/board-server/src/server/proxy/secrets.ts
@@ -39,7 +39,7 @@ const getKey = async (key: string) => {
 };
 
 /**
- * An simplest possible Kit that contains a "secrets" node that talks to the
+ * The simplest possible Kit that contains a "secrets" node that talks to the
  * Google Cloud Secret Manager.
  */
 export const secretsKit: Kit = {

--- a/packages/board-server/src/server/proxy/secrets.ts
+++ b/packages/board-server/src/server/proxy/secrets.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SecretManagerServiceClient } from "@google-cloud/secret-manager";
+import type { Kit } from "@google-labs/breadboard";
+
+const url = import.meta.url;
+
+const PROJECT_ID = process.env.GOOGLE_CLOUD_PROJECT;
+
+if (!PROJECT_ID) {
+  throw new Error("Please set GOOGLE_CLOUD_PROJECT environment variable.");
+}
+
+type SecretInputs = {
+  keys: string[];
+};
+
+const secretManager = new SecretManagerServiceClient();
+
+const secretsMap = new Map<string, string>();
+
+const getKey = async (key: string) => {
+  if (secretsMap.has(key)) {
+    return [key, secretsMap.get(key)];
+  }
+  const name = secretManager.secretVersionPath(PROJECT_ID, key, "latest");
+  const [version] = await secretManager.accessSecretVersion({ name });
+  const payload = version?.payload?.data;
+  if (!payload) {
+    throw new Error(`Missing secret: ${key}`);
+  }
+  const value = payload.toString();
+  secretsMap.set(key, value);
+  return [key, value];
+};
+
+/**
+ * An simplest possible Kit that contains a "secrets" node that talks to the
+ * Google Cloud Secret Manager.
+ */
+export const secretsKit: Kit = {
+  url,
+  handlers: {
+    secrets: async (inputs) => {
+      const { keys } = inputs as SecretInputs;
+      const entries = await Promise.all(keys.map(getKey));
+      return Object.fromEntries(entries);
+    },
+  },
+};

--- a/packages/breadboard/src/data/common.ts
+++ b/packages/breadboard/src/data/common.ts
@@ -52,19 +52,23 @@ export const isInlineData = (
   return true;
 };
 
-export function asBase64(file: File | Blob): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => {
-      if (typeof reader.result !== "string") {
-        reject("Reader result is not a string");
-        return;
-      }
+export async function asBase64(file: File | Blob): Promise<string> {
+  if ("Buffer" in globalThis) {
+    return Buffer.from(await file.arrayBuffer()).toString("base64");
+  } else {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        if (typeof reader.result !== "string") {
+          reject("Reader result is not a string");
+          return;
+        }
 
-      const [, content] = reader.result.split(",");
-      resolve(content);
-    };
-    reader.onerror = (err) => reject(err);
-    reader.readAsDataURL(file);
-  });
+        const [, content] = reader.result.split(",");
+        resolve(content);
+      };
+      reader.onerror = (err) => reject(err);
+      reader.readAsDataURL(file);
+    });
+  }
 }

--- a/packages/breadboard/src/data/common.ts
+++ b/packages/breadboard/src/data/common.ts
@@ -54,6 +54,7 @@ export const isInlineData = (
 
 export async function asBase64(file: File | Blob): Promise<string> {
   if ("Buffer" in globalThis) {
+    // Node.js implementation, since Node.js doesn't have FileReader.
     return Buffer.from(await file.arrayBuffer()).toString("base64");
   } else {
     return new Promise((resolve, reject) => {

--- a/packages/breadboard/src/remote/config.ts
+++ b/packages/breadboard/src/remote/config.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { DataStore } from "../data/types.js";
 import { Kit, NodeTypeIdentifier } from "../types.js";
 
 /**
@@ -99,6 +100,10 @@ export type ProxyServerConfig = {
    * @see NodeProxySpec for more details.
    */
   proxy?: NodeProxyConfig;
+  /**
+   * The data store to use for storing data.
+   */
+  store?: DataStore;
 };
 
 export const defineConfig = (config: ProxyServerConfig) => config;

--- a/packages/core-kit/src/nodes/fetch.ts
+++ b/packages/core-kit/src/nodes/fetch.ts
@@ -46,7 +46,7 @@ const serverSentEventTransform = () =>
 const createBody = async (
   body: unknown,
   headers: Record<string, string | undefined>,
-  store: DataStore
+  store?: DataStore
 ) => {
   if (!body) return undefined;
   const contentType = headers["Content-Type"];
@@ -71,7 +71,8 @@ const createBody = async (
     }
     return formData;
   }
-  return JSON.stringify(await inflateData(store, body));
+  const data = store ? await inflateData(store, body) : body;
+  return JSON.stringify(data);
 };
 
 export default defineNodeType({
@@ -144,11 +145,6 @@ export default defineNodeType({
     const init: RequestInit = { method, headers, signal };
     // GET can not have a body.
     if (method !== "GET") {
-      if (!store) {
-        throw new Error(
-          "No store provided in run configuration to store the request."
-        );
-      }
       init.body = await createBody(body, headers, store);
     } else if (body) {
       throw new Error("GET requests can not have a body");


### PR DESCRIPTION
- **First sketch of Proxy Server API.**
- **Teach `fetch` to be more forgiving about the lack of data store.**
- **Teach NodeProxyConfig about DataStore.**
- **Teach app about URL search params.**
- **Teach data store to turn blobs into base64 in Nodejs.**
- **Loosely working node proxy server.**
- **Make app.ts forget about partDataURL cache (for now).**
- **Update package-lock.json.**
- **Remove spurious logging.**
- **Create a `secrets` node that uses Cloud Secret Manager.**
- **Grammar.**
- **Restrict access to proxy API via CORS for now.**
- **Better naming.**
- **docs(changeset): Teach Board Server to use Node Proxy Server**
