### PR TITLE
[breadboard-web] Add vite preview option to scripts

### DIFF
--- a/packages/breadboard-web/package.json
+++ b/packages/breadboard-web/package.json
@@ -35,6 +35,7 @@
     "prepack": "npm run build",
     "dev": "npm run serve --watch",
     "serve": "wireit",
+    "preview": "wireit",
     "deploy": "npm run build:vite && firebase deploy",
     "build": "wireit",
     "build:vite": "wireit",
@@ -126,6 +127,32 @@
       ],
       "output": [
         "dist/"
+      ]
+    },
+    "preview": {
+      "command": "vite preview",
+      "service": true,
+      "dependencies": [
+        {
+          "script": "typescript-files-and-deps",
+          "cascade": false
+        },
+        {
+          "script": "generate:graphs",
+          "cascade": false
+        },
+        {
+          "script": "copy-light-kits",
+          "cascade": false
+        },
+        {
+          "script": "../connection-server:dev:nowatch",
+          "cascade": false
+        }
+      ],
+      "files": [
+        "vite.config.ts",
+        ".env"
       ]
     },
     "serve": {


### PR DESCRIPTION
Adds option so that breadboard-web can be served with "npm run preview", using vite preview instead of vite dev.

preview serves the website from dist, which is more similar to how it will be served when deployed.

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
