### PR TITLE
[breadboard-python] Add run-python-kit to define run-python node

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "./packages/import:build",
         "./packages/json-kit:build",
         "./packages/template-kit:build",
+        "./packages/run-python-kit:build",
         "./packages/node-nursery:build",
         "./packages/node-nursery-web:build",
         "./packages/palm-kit:build",
@@ -78,6 +79,7 @@
         "./packages/import:test",
         "./packages/json-kit:test",
         "./packages/template-kit:test",
+        "./packages/run-python-kit:test",
         "./packages/node-nursery:test",
         "./packages/node-nursery-web:test",
         "./packages/palm-kit:test",
@@ -108,6 +110,7 @@
         "./packages/import:lint",
         "./packages/json-kit:lint",
         "./packages/template-kit:lint",
+        "./packages/run-python-kit:lint",
         "./packages/node-nursery:lint",
         "./packages/node-nursery-web:lint",
         "./packages/palm-kit:lint",
@@ -133,6 +136,7 @@
         "./packages/graph-playground:generate:docs",
         "./packages/graph-runner:generate:docs",
         "./packages/template-kit:generate:docs",
+        "./packages/run-python-kit:generate:docs",
         "./packages/node-nursery:generate:docs"
       ]
     },

--- a/packages/breadboard-web/package.json
+++ b/packages/breadboard-web/package.json
@@ -53,6 +53,7 @@
         "../gemini-kit:build",
         "../json-kit:build",
         "../template-kit:build",
+        "../run-python-kit:build",
         "../node-nursery-web:build",
         "../palm-kit:build",
         "../pinecone-kit:build",
@@ -73,6 +74,7 @@
         "../gemini-kit:build:tsc",
         "../json-kit:build:tsc",
         "../template-kit:build:tsc",
+        "../run-python-kit:build:tsc",
         "../node-nursery-web:build:tsc",
         "../palm-kit:build:tsc",
         "../pinecone-kit:build:tsc",
@@ -234,6 +236,7 @@
     "typedoc": "^0.25.12",
     "typedoc-plugin-markdown": "^4.0.3",
     "typescript": "^5.4.5",
+    "universal-websocket-client": "^1.0.2",
     "vite": "^5.2.13",
     "vite-plugin-full-reload": "^1.1.0",
     "vite-plugin-watch-and-run": "^1.7.0",
@@ -254,12 +257,16 @@
     "@google-labs/node-nursery-web": "^1.1.3",
     "@google-labs/palm-kit": "^0.0.14",
     "@google-labs/pinecone-kit": "^0.1.12",
+    "@google-labs/run-python-kit": "^0.1.0",
     "@google-labs/team-kit": "^0.1.0",
     "@google-labs/template-kit": "^0.3.2",
     "@lit/context": "^1.1.2",
     "codemirror": "^6.0.1",
     "idb": "^8.0.0",
     "idb-keyval": "^6.2.1",
-    "lit": "^3.1.4"
+    "lit": "^3.1.4",
+    "uuid": "^9.0.1",
+    "websocket": "^1.0.34",
+    "ws": "^8.17.0"
   }
 }

--- a/packages/breadboard-web/src/run-python-kit.ts
+++ b/packages/breadboard-web/src/run-python-kit.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import RunPythonKit from "@google-labs/run-python-kit";
+
+export default RunPythonKit;

--- a/packages/breadboard-web/vite.config.ts
+++ b/packages/breadboard-web/vite.config.ts
@@ -31,6 +31,7 @@ export default defineConfig((_) => {
           "json-kit": "src/json-kit.ts",
           "template-kit": "src/template-kit.ts",
           "python-wasm-kit": "src/python-wasm-kit.ts",
+          "run-python-kit": "src/run-python-kit.ts",
           "node-nursery-web-kit": "src/node-nursery-web-kit.ts",
         },
         name: "Breadboard Web Runtime",

--- a/packages/run-python-kit/.npmignore
+++ b/packages/run-python-kit/.npmignore
@@ -1,0 +1,2 @@
+.env
+tsconfig.tsbuildinfo

--- a/packages/run-python-kit/README.md
+++ b/packages/run-python-kit/README.md
@@ -1,0 +1,3 @@
+# Run Python Kit
+
+Defines Schema for run-python nodes. These nodes aren't actually implemented directly. Instead, they are meant to be handled by proxy.

--- a/packages/run-python-kit/package.json
+++ b/packages/run-python-kit/package.json
@@ -1,0 +1,111 @@
+{
+  "name": "@google-labs/run-python-kit",
+  "publishConfig": {
+    "registry": "https://wombat-dressing-room.appspot.com"
+  },
+  "version": "0.1.0",
+  "description": "Breadboard Kit that contains nodes for running Python",
+  "main": "./dist/src/index.js",
+  "exports": "./dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "type": "module",
+  "scripts": {
+    "prepack": "npm run build",
+    "test": "wireit",
+    "build": "wireit",
+    "build:tsc": "wireit",
+    "lint": "wireit"
+  },
+  "wireit": {
+    "build": {
+      "dependencies": [
+        "../breadboard:build",
+        "build:tsc"
+      ]
+    },
+    "build:tsc": {
+      "command": "tsc -b",
+      "env": {
+        "FORCE_COLOR": "1"
+      },
+      "dependencies": [
+        "../breadboard:build:tsc"
+      ],
+      "files": [
+        "src/**/*.ts",
+        "tests/**/*.ts",
+        "tsconfig.json",
+        "../../core/tsconfig/base.json"
+      ],
+      "output": [
+        "dist/"
+      ],
+      "clean": "if-file-deleted"
+    },
+    "test": {
+      "command": "ava",
+      "env": {
+        "FORCE_COLOR": "1"
+      },
+      "dependencies": [
+        "build:tsc"
+      ],
+      "files": [],
+      "output": []
+    },
+    "lint": {
+      "command": "eslint . --ext .ts",
+      "env": {
+        "FORCE_COLOR": "1"
+      },
+      "files": [
+        "src/**/*.ts",
+        "tests/**/*.ts",
+        "../../.eslintrc.json"
+      ],
+      "output": []
+    }
+  },
+  "repository": {
+    "directory": "packages/run-python-kit",
+    "type": "git",
+    "url": "https://github.com/breadboard-ai/breadboard.git"
+  },
+  "files": [
+    "dist/src"
+  ],
+  "ava": {
+    "timeout": "30s",
+    "files": [
+      "tests/**/*.ts"
+    ],
+    "workerThreads": false,
+    "typescript": {
+      "rewritePaths": {
+        "./": "dist/"
+      },
+      "compile": false
+    }
+  },
+  "keywords": [],
+  "author": "Google Labs Team",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/breadboard-ai/breadboard/issues"
+  },
+  "devDependencies": {
+    "@ava/typescript": "^4.0.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/parser": "^6.20.0",
+    "@types/node": "^20.11.30",
+    "ava": "^5.2.0",
+    "typescript": "^5.3.3",
+    "@google-labs/tsconfig": "^0.0.1"
+  },
+  "dependencies": {
+    "@google-labs/breadboard": "^0.15.0"
+  },
+  "engines": {
+    "node": ">=19.0.0"
+  }
+}

--- a/packages/run-python-kit/src/index.ts
+++ b/packages/run-python-kit/src/index.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { KitBuilder } from "@google-labs/breadboard/kits";
+import runPython from "./nodes/run-python.js";
+
+const builder = new KitBuilder({
+  title: "Python Kit",
+  description: "A kit that contains nodes for running Python.",
+  version: "0.0.1",
+  url: "npm:@google-labs/run-python-kit",
+});
+
+export const RunPythonKit = builder.build({
+  runPython,
+});
+
+export type RunPythonKit = InstanceType<typeof RunPythonKit>;
+
+export default RunPythonKit;
+
+/**
+ * This is a wrapper around existing kits for the new syntax to add types.
+ *
+ * This should transition to a codegen step, with typescript types constructed
+ * from .describe() calls.
+ */
+import {
+  addKit,
+  NewNodeValue as NodeValue,
+  NewNodeFactory as NodeFactory,
+} from "@google-labs/breadboard";
+
+export type RunPythonKitType = {
+  /**
+   * Use this node to populate simple handlebar-style templates. A required
+   * input is `template`, which is a string that contains the template prompt
+   * template. The template can contain zero or more placeholders that will be
+   * replaced with values from inputs. Specify placeholders as `{{inputName}}`
+   * in the template. The placeholders in the template must match the inputs
+   * wired into this node. The node will replace all placeholders with values
+   * from the input property bag and pass the result along as the `prompt`
+   * output property.
+   */
+  runPython: NodeFactory<
+    {
+      /**
+       * The Python code to run.
+       */
+      code: string;
+      /**
+       * The values to provide to the code.
+       */
+      [key: string]: NodeValue;
+    },
+    {
+      /**
+       * The result of code being ran.
+       */
+      text: string;
+    }
+  >;
+};
+
+export const runpythons = addKit(RunPythonKit) as unknown as RunPythonKitType;

--- a/packages/run-python-kit/src/nodes/run-python.ts
+++ b/packages/run-python-kit/src/nodes/run-python.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  InputValues,
+  NodeDescriberFunction,
+  NodeHandler,
+  NodeHandlerFunction,
+  Schema,
+} from "@google-labs/breadboard";
+
+export type PropmtTemplateOutputs = {
+  text: string;
+  prompt: string; // Deprecated
+};
+
+export type PromptTemplateInputs = {
+  template: string;
+};
+
+export const stringify = (value: unknown): string => {
+  if (typeof value === "string") return value;
+  if (value === undefined) return "undefined";
+  return JSON.stringify(value, null, 2);
+};
+
+export const substitute = (template: string, values: InputValues) => {
+  return Object.entries(values).reduce(
+    (acc, [key, value]) => acc.replace(`{{${key}}}`, stringify(value)),
+    template
+  );
+};
+
+export const parametersFromTemplate = (template: string): string[] => {
+  const matches = template.matchAll(/{{(?<name>[\w-]+)}}/g);
+  const parameters = Array.from(matches).map(
+    (match) => match.groups?.name || ""
+  );
+  const unique = Array.from(new Set(parameters));
+  return unique;
+};
+
+export const promptTemplateHandler: NodeHandlerFunction = async (
+  inputs: InputValues
+) => {
+  const template = inputs.template as string;
+  const parameters = parametersFromTemplate(template);
+  if (!parameters.length) return { prompt: template, text: template };
+
+  const substitutes = parameters.reduce((acc, parameter) => {
+    if (inputs[parameter] === undefined)
+      throw new Error(`Input is missing parameter "${parameter}"`);
+    return { ...acc, [parameter]: inputs[parameter] };
+  }, {});
+
+  const prompt = substitute(template, substitutes);
+  // log.info(`Prompt: ${prompt}`);
+  return { prompt, text: prompt };
+};
+
+export const computeInputSchema = (inputs: InputValues): Schema => {
+  const parameters = parametersFromTemplate((inputs.template ?? "") as string);
+  const properties: Schema["properties"] = parameters.reduce(
+    (acc, parameter) => {
+      const schema = {
+        title: parameter,
+        description: `The value to substitute for the parameter "${parameter}"`,
+        type: ["string", "object"],
+      };
+      return { ...acc, [parameter]: schema };
+    },
+    {}
+  );
+  properties["template"] = {
+    title: "template",
+    description: "The template with placeholders to fill in.",
+    type: "string",
+  };
+  return {
+    type: "object",
+    properties,
+    required: ["template", ...parameters],
+  };
+};
+
+export const promptTemplateDescriber: NodeDescriberFunction = async (
+  inputs?: InputValues
+) => {
+  return {
+    inputSchema: computeInputSchema(inputs || {}),
+    outputSchema: {
+      type: "object",
+      properties: {
+        prompt: {
+          title: "prompt",
+          description:
+            "The resulting prompt that was produced by filling in the placeholders in the template.",
+          type: "string",
+        },
+        text: {
+          title: "text",
+          description:
+            "The resulting prompt that was produced by filling in the placeholders in the template.",
+          type: "string",
+        },
+      },
+    },
+  };
+};
+
+export default {
+  describe: promptTemplateDescriber,
+  invoke: promptTemplateHandler,
+} satisfies NodeHandler;

--- a/packages/run-python-kit/tests/index.ts
+++ b/packages/run-python-kit/tests/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2023 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import test from "ava";
+
+test("run-python-kit", async (t) => {
+  t.pass();
+});

--- a/packages/run-python-kit/tsconfig.json
+++ b/packages/run-python-kit/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*", "tests/**/*"],
+  "extends": "@google-labs/tsconfig/base.json"
+}


### PR DESCRIPTION
Adds a run-python-kit, which defines the schema for a single run-python node.

This doesn't actually implement the node because it's meant to be handled by proxy.

This can probably be merged with the python-wasm kit, which does have an implementation.

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
