### PR TITLE
Add a Python proxy client for integrating with Python node proxy servers

### DIFF
--- a/packages/breadboard-web/src/config.ts
+++ b/packages/breadboard-web/src/config.ts
@@ -15,6 +15,7 @@ import GeminiKit from "@google-labs/gemini-kit";
 import { loadKits } from "./utils/kit-loader";
 
 const PROXY_NODES = ["secrets", "fetch"];
+const PYTHON_NODES = ["runPython"];
 
 const WORKER_URL =
   import.meta.env.MODE === "development" ? "/src/worker.ts" : "/worker.js";
@@ -49,6 +50,12 @@ export const createRunConfig = async (url: string): Promise<RunConfig> => {
         url: proxyServerURL,
         nodes: PROXY_NODES,
       });
+      proxy.push({
+        location: "python",
+        url: proxyServerURL,
+        nodes: PYTHON_NODES,
+      });
+      console.log(proxy);
     }
   } else if (harness === WORKER_HARNESS_VALUE) {
     proxy.push({ location: "main", nodes: PROXY_NODES });

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -393,6 +393,7 @@ export class Main extends LitElement {
       align-items: center;
     }
   `;
+  proxyFromUrl: string | undefined;
 
   #load: Promise<void>;
   constructor(config: MainArguments) {
@@ -413,6 +414,11 @@ export class Main extends LitElement {
 
     if (firstRunFromUrl && firstRunFromUrl === "true") {
       this.showFirstRun = true;
+    }
+    const proxyFromUrl = currentUrl.searchParams.get("python_proxy");
+    if (proxyFromUrl) {
+      console.log("Setting python_proxy: %s", proxyFromUrl);
+      this.proxyFromUrl = proxyFromUrl;
     }
 
     this.embed = embedFromUrl !== null && embedFromUrl !== "false";
@@ -1341,7 +1347,8 @@ export class Main extends LitElement {
                     inputs: inputsFromSettings(this.#settings),
                     interactiveSecrets: true,
                   },
-                  this.#settings
+                  this.#settings,
+                  this.proxyFromUrl
                 )
               )
             );

--- a/packages/breadboard/tests/remote/proxy.ts
+++ b/packages/breadboard/tests/remote/proxy.ts
@@ -63,7 +63,8 @@ test("End-to-end proxy works with HTTP transports", async (t) => {
   );
   const result = await client.proxy(
     { id: "id", type: "reverser" },
-    { hello: "world" }
+    { hello: "world" },
+    {}
   );
   t.deepEqual(result, { hello: "dlrow" });
 });


### PR DESCRIPTION
Adds a parameter proxy_url that allows a proxy url to be passed in.

This proxy url is used as an endpoint for proxy client.

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
