### PR TITLE
[core-kit] Add unnest node

### DIFF
--- a/.changeset/neat-pandas-sniff.md
+++ b/.changeset/neat-pandas-sniff.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/core-kit": patch
+---
+
+Add unnest node, for expanding an object value with N properties into a node with N output ports

--- a/.changeset/swift-kings-arrive.md
+++ b/.changeset/swift-kings-arrive.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/core-kit": patch
+---
+
+Mark "response" as the primary output of fetch

--- a/packages/core-kit/src/index.ts
+++ b/packages/core-kit/src/index.ts
@@ -20,6 +20,7 @@ import append from "./nodes/append.js";
 import fetch from "./nodes/fetch.js";
 import runJavascript from "./nodes/run-javascript.js";
 import secrets from "./nodes/secrets.js";
+import { unnestNode } from "./nodes/unnest.js";
 
 export { code } from "./nodes/code.js";
 export { default as fetch } from "./nodes/fetch.js";
@@ -27,6 +28,7 @@ export { default as invoke } from "./nodes/invoke.js";
 export { default as passthrough } from "./nodes/passthrough.js";
 export { default as runJavascript } from "./nodes/run-javascript.js";
 export { secret, default as secrets } from "./nodes/secrets.js";
+export { unnest, unnestNode } from "./nodes/unnest.js";
 
 const builder = new KitBuilder({
   title: "Core Kit",
@@ -199,6 +201,8 @@ export const Core = builder.build({
    * present.
    */
   deflate,
+
+  unnest: unnestNode,
 });
 
 export type Core = InstanceType<typeof Core>;
@@ -220,6 +224,7 @@ import {
 } from "@google-labs/breadboard";
 import curry, { CurryInputs, CurryOutputs } from "./nodes/curry.js";
 import deflate from "./nodes/deflate.js";
+import { NodeFactoryFromDefinition } from "@breadboard-ai/build";
 
 export type CoreKitType = {
   passthrough: NodeFactory<InputValues, OutputValues>;
@@ -313,6 +318,7 @@ export type CoreKitType = {
     { result: unknown; [k: string]: unknown }
   >;
   secrets: NodeFactory<{ keys: string[] }, { [k: string]: string }>;
+  unnest: NodeFactoryFromDefinition<typeof unnestNode>;
   // TODO: Other Core nodes.
 };
 

--- a/packages/core-kit/src/nodes/fetch.ts
+++ b/packages/core-kit/src/nodes/fetch.ts
@@ -118,6 +118,7 @@ export default defineNodeType({
     response: {
       description: "The response from the fetch request",
       type: "unknown",
+      primary: true,
     },
     status: {
       description: "The HTTP status code of the response",

--- a/packages/core-kit/src/nodes/unnest.ts
+++ b/packages/core-kit/src/nodes/unnest.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  defineNodeType,
+  object,
+  toJSONSchema,
+  unsafeCast,
+  unsafeSchema,
+  unsafeType,
+} from "@breadboard-ai/build";
+import type {
+  OutputPort,
+  OutputPortReference,
+} from "@breadboard-ai/build/internal/common/port.js";
+import type { JsonSerializable } from "@breadboard-ai/build/internal/type-system/type.js";
+
+export function unnest<T extends { [K: string]: JsonSerializable }>(
+  nested: OutputPortReference<T>
+): { [K in keyof T]-?: OutputPort<T[K]> } {
+  const instance = unnestNode({ nested });
+  const type = nested["__output"].type;
+  const schema = toJSONSchema(type);
+  if (schema.type !== "object") {
+    throw new Error(
+      `Expected schema.type to be "object" but was "${schema.type}"`
+    );
+  }
+  const outputs = Object.fromEntries(
+    Object.entries(schema.properties ?? {}).map(([name, schema]) => {
+      return [
+        name,
+        unsafeCast(instance.unsafeOutput(name), unsafeType(schema)),
+      ];
+    })
+  );
+  return outputs as { [K in keyof T]-?: OutputPort<T[K]> };
+}
+
+export const unnestNode = defineNodeType({
+  name: "unnest",
+  inputs: {
+    nested: {
+      type: object({}, "unknown"),
+      description: "The nested object",
+    },
+  },
+  outputs: {
+    "*": {
+      type: "unknown",
+    },
+  },
+  describe: (_, __, context) => {
+    return {
+      outputs: context?.inputSchema ? unsafeSchema(context.inputSchema) : {},
+    };
+  },
+  invoke: ({ nested }) => {
+    return nested;
+  },
+});


### PR DESCRIPTION
Adds a new `unnest` node to `core-kit`. It takes an object with N properties, and fans them out as output ports.

<img width="1426" alt="image" src="https://github.com/breadboard-ai/breadboard/assets/48894/76e1da91-7d53-4f1b-8ef2-dd8f125405db">


Also includes a type-aware utility for the build API. Sample usage:

```ts
const fileListType = object({
  nextPageToken: optional("string"),
  incompleteSearch: "boolean",
  files: array(fileType),
});

const rawResponse = fetch({ url, headers });
const response = unsafeCast(rawResponse, fileListType);
const { files, incompleteSearch, nextPageToken } = unnest(response);
// Now we have 3 OutputPorts, which correspond to the 3 properties
// from the decoded fetch response. Types are all preserved.
```