### PR TITLE
[connections] Fix bug with refreshing oauth token

### DIFF
--- a/packages/breadboard-ui/src/elements/connection/connection-input.ts
+++ b/packages/breadboard-ui/src/elements/connection/connection-input.ts
@@ -193,7 +193,7 @@ export class ConnectionInput extends LitElement {
       name: connectionId,
       value: JSON.stringify(updatedGrant),
     });
-    this.#broadcastSecret(grant.access_token);
+    this.#broadcastSecret(updatedGrant.access_token);
   }
 
   #broadcastSecret(secret: string) {


### PR DESCRIPTION
After a refreshing an OAuth token automatically, we were returning the original token instead of the new one. We still saved the new one to local storage, so trying again would work, but now you don't need to.