### PR TITLE
[build] Serialize boards as subgraphs when passed as node inputs

### DIFF
--- a/.changeset/silly-baboons-smell.md
+++ b/.changeset/silly-baboons-smell.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": minor
+---
+
+Input ports with the "board" behavior can now receive board objects declared using the build API. This will be serialized as an embedded graph.

--- a/packages/build/src/internal/board/board.ts
+++ b/packages/build/src/internal/board/board.ts
@@ -71,6 +71,7 @@ export function board<
     description,
     version,
     metadata,
+    isBoard: true,
   });
 }
 
@@ -264,3 +265,9 @@ type ExtractPortTypes<PORTS extends BoardInputPorts | BoardOutputPorts> = {
     ? TYPE
     : never;
 };
+
+export function isBoard(value: unknown): value is GenericBoardDefinition {
+  return (
+    typeof value === "function" && "isBoard" in value && value.isBoard === true
+  );
+}

--- a/packages/build/src/internal/common/serializable.ts
+++ b/packages/build/src/internal/common/serializable.ts
@@ -4,17 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { GraphMetadata } from "@google-labs/breadboard-schema/graph.js";
+import type { GenericBoardDefinition } from "../board/board.js";
 import type { Convergence } from "../board/converge.js";
 import type {
   GenericSpecialInput,
   Input,
   InputWithDefault,
 } from "../board/input.js";
-import type { Output } from "../board/output.js";
 import type { Loopback } from "../board/loopback.js";
+import type { Output } from "../board/output.js";
 import type { BreadboardType, JsonSerializable } from "../type-system/type.js";
 import type { DefaultValue, OutputPortGetter } from "./port.js";
-import type { GraphMetadata } from "@google-labs/breadboard-schema/graph.js";
 
 export interface SerializableBoard {
   inputs: Record<
@@ -71,6 +72,7 @@ export interface SerializableInputPort {
     | GenericSpecialInput
     | Loopback<JsonSerializable>
     | Convergence<JsonSerializable>
+    | GenericBoardDefinition
     | typeof DefaultValue;
 }
 

--- a/packages/build/src/internal/define/define.ts
+++ b/packages/build/src/internal/define/define.ts
@@ -211,7 +211,7 @@ export function defineNodeType<
 }
 
 type ExtractInputMetadata<I extends Record<string, InputPortConfig>> = {
-  [K in keyof I]: {
+  [K in keyof I as K extends "*" ? never : K]: {
     board: I[K]["behavior"] extends Array<unknown>
       ? "board" extends I[K]["behavior"][number]
         ? true

--- a/packages/build/src/internal/define/define.ts
+++ b/packages/build/src/internal/define/define.ts
@@ -156,7 +156,8 @@ export function defineNodeType<
   GetOptionalInputs<I> & keyof Expand<GetStaticTypes<I>>,
   GetReflective<O>,
   Expand<GetPrimary<I>>,
-  Expand<GetPrimary<O>>
+  Expand<GetPrimary<O>>,
+  Expand<ExtractInputMetadata<I>>
 > {
   if (!params.name) {
     throw new Error("params.name is required");
@@ -178,7 +179,8 @@ export function defineNodeType<
     GetOptionalInputs<I> & keyof Expand<GetStaticTypes<I>>,
     GetReflective<O>,
     Expand<GetPrimary<I>>,
-    Expand<GetPrimary<O>>
+    Expand<GetPrimary<O>>,
+    Expand<ExtractInputMetadata<I>>
   >(
     params.name,
     omitDynamic(params.inputs),
@@ -194,8 +196,29 @@ export function defineNodeType<
     invoke: impl.invoke.bind(impl),
     describe: impl.describe.bind(impl),
     metadata: params.metadata || {},
-  });
+    // TODO(aomarks) Should not need cast.
+  }) as Definition<
+    Expand<GetStaticTypes<I>>,
+    Expand<GetStaticTypes<O>>,
+    GetDynamicTypes<I>,
+    GetDynamicTypes<O>,
+    GetOptionalInputs<I> & keyof Expand<GetStaticTypes<I>>,
+    GetReflective<O>,
+    Expand<GetPrimary<I>>,
+    Expand<GetPrimary<O>>,
+    Expand<ExtractInputMetadata<I>>
+  >;
 }
+
+type ExtractInputMetadata<I extends Record<string, InputPortConfig>> = {
+  [K in keyof I]: {
+    board: I[K]["behavior"] extends Array<unknown>
+      ? "board" extends I[K]["behavior"][number]
+        ? true
+        : false
+      : false;
+  };
+};
 
 function omitDynamic(configs: PortConfigs): PortConfigs {
   return Object.fromEntries(

--- a/packages/build/src/internal/define/node-factory.ts
+++ b/packages/build/src/internal/define/node-factory.ts
@@ -18,7 +18,7 @@ import type { Expand } from "../common/type-util.js";
  * for use with {@link KitBuilder}.
  */
 export type NodeFactoryFromDefinition<
-  D extends Definition<any, any, any, any, any, any, any, any>,
+  D extends Definition<any, any, any, any, any, any, any, any, any>,
 > =
   D extends Definition<
     infer SI,
@@ -26,6 +26,7 @@ export type NodeFactoryFromDefinition<
     infer DI,
     infer DO,
     infer OI,
+    any,
     any,
     any,
     any

--- a/packages/build/src/test/compatibility_test.ts
+++ b/packages/build/src/test/compatibility_test.ts
@@ -26,7 +26,7 @@ function setupKits<
     // TODO(aomarks) See TODO about `any` at {@link NodeFactoryFromDefinition}.
     //
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    Definition<any, any, any, any, any, any, any, any>
+    Definition<any, any, any, any, any, any, any, any, any>
   >,
 >(definitions: DEFS) {
   const ctr = new KitBuilder({ url: "N/A" }).build(definitions);

--- a/packages/build/src/test/define_test.ts
+++ b/packages/build/src/test/define_test.ts
@@ -19,7 +19,7 @@ import type { BreadboardError } from "../internal/common/error.js";
 test("mono/mono", async () => {
   const values = { si1: "foo", si2: 123 };
 
-  // $ExpectType Definition<{ si1: string; si2: number; }, { so1: boolean; so2: null; }, undefined, undefined, never, false, false, false>
+  // $ExpectType Definition<{ si1: string; si2: number; }, { so1: boolean; so2: null; }, undefined, undefined, never, false, false, false, { si1: { board: false; }; si2: { board: false; }; }>
   const d = defineNodeType({
     name: "foo",
     inputs: {
@@ -139,7 +139,7 @@ test("mono/mono", async () => {
 test("poly/mono", async () => {
   const values = { si1: "si1", di1: 1, di2: 2 };
 
-  // $ExpectType Definition<{ si1: string; }, { so1: boolean; }, number, undefined, never, false, false, false>
+  // $ExpectType Definition<{ si1: string; }, { so1: boolean; }, number, undefined, never, false, false, false, { si1: { board: false; }; }>
   const d = defineNodeType({
     name: "foo",
     inputs: {
@@ -287,7 +287,7 @@ test("poly/mono", async () => {
 test("mono/poly", async () => {
   const values = { si1: "si1" };
 
-  // $ExpectType Definition<{ si1: string; }, { so1: boolean; }, undefined, number, never, false, false, false>
+  // $ExpectType Definition<{ si1: string; }, { so1: boolean; }, undefined, number, never, false, false, false, { si1: { board: false; }; }>
   const d = defineNodeType({
     name: "foo",
     inputs: {
@@ -390,7 +390,7 @@ test("mono/poly", async () => {
 test("poly/poly", async () => {
   const values = { si1: "si1", di1: 1, di2: 2 };
 
-  // $ExpectType Definition<{ si1: string; }, { so1: boolean; }, number, number, never, false, false, false>
+  // $ExpectType Definition<{ si1: string; }, { so1: boolean; }, number, number, never, false, false, false, { si1: { board: false; }; }>
   const d = defineNodeType({
     name: "foo",
     inputs: {
@@ -573,7 +573,7 @@ test("async invoke function", async () => {
 test("reflective", async () => {
   const values = { si1: "si1", di1: 1, di2: 2 };
 
-  // $ExpectType Definition<{ si1: string; }, { so1: boolean; }, number, string, never, true, false, false>
+  // $ExpectType Definition<{ si1: string; }, { so1: boolean; }, number, string, never, true, false, false, { si1: { board: false; }; }>
   const d = defineNodeType({
     name: "foo",
     inputs: {
@@ -708,7 +708,7 @@ test("reflective", async () => {
 test("primary input with no other inputs", () => {
   const values = { si1: 123 };
 
-  // $ExpectType Definition<{ si1: number; }, { so1: boolean; }, undefined, undefined, never, false, "si1", false>
+  // $ExpectType Definition<{ si1: number; }, { so1: boolean; }, undefined, undefined, never, false, "si1", false, { si1: { board: false; }; }>
   const d = defineNodeType({
     name: "foo",
     inputs: {
@@ -772,7 +772,7 @@ test("primary input with no other inputs", () => {
 test("primary input with another input", () => {
   const values = { si1: 123, si2: true };
 
-  // $ExpectType Definition<{ si1: number; si2: boolean; }, { so1: boolean; }, undefined, undefined, never, false, "si1", false>
+  // $ExpectType Definition<{ si1: number; si2: boolean; }, { so1: boolean; }, undefined, undefined, never, false, "si1", false, { si1: { board: false; }; si2: { board: false; }; }>
   const d = defineNodeType({
     name: "foo",
     inputs: {
@@ -835,7 +835,7 @@ test("primary input with another input", () => {
 });
 
 test("primary output with no other outputs", () => {
-  // $ExpectType Definition<{ si1: number; }, { so1: boolean; }, undefined, undefined, never, false, false, "so1">
+  // $ExpectType Definition<{ si1: number; }, { so1: boolean; }, undefined, undefined, never, false, false, "so1", { si1: { board: false; }; }>
   const d = defineNodeType({
     name: "foo",
     inputs: {
@@ -897,7 +897,7 @@ test("primary output with no other outputs", () => {
 });
 
 test("primary output with other outputs", () => {
-  // $ExpectType Definition<{ si1: number; }, { so1: boolean; so2: number; }, undefined, undefined, never, false, false, "so1">
+  // $ExpectType Definition<{ si1: number; }, { so1: boolean; so2: number; }, undefined, undefined, never, false, false, "so1", { si1: { board: false; }; }>
   const d = defineNodeType({
     name: "foo",
     inputs: {
@@ -961,7 +961,7 @@ test("primary output with other outputs", () => {
 });
 
 test("primary input + output", () => {
-  // $ExpectType Definition<{ si1: number; }, { so1: boolean; }, undefined, undefined, never, false, "si1", "so1">
+  // $ExpectType Definition<{ si1: number; }, { so1: boolean; }, undefined, undefined, never, false, "si1", "so1", { si1: { board: false; }; }>
   const d = defineNodeType({
     name: "foo",
     inputs: {

--- a/packages/build/src/test/nested-boards_test.ts
+++ b/packages/build/src/test/nested-boards_test.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+
+import { anyOf, board, defineNodeType, object } from "@breadboard-ai/build";
+import { test } from "node:test";
+
+test("board behavior", () => {
+  const def = defineNodeType({
+    name: "test",
+    inputs: {
+      board: {
+        type: anyOf("string", object({}, "unknown")),
+        behavior: ["board"],
+      },
+    },
+    outputs: {},
+    invoke: () => ({}),
+  });
+
+  def({ board: "local.bgl.json" });
+
+  def({ board: board({ inputs: {}, outputs: {} }) });
+
+  // @ts-expect-error
+  def({ board: 123 });
+
+  // @ts-expect-error
+  def({ board: ["local.bgl.json"] });
+});

--- a/packages/build/src/test/nested-boards_test.ts
+++ b/packages/build/src/test/nested-boards_test.ts
@@ -6,29 +6,239 @@
 
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
-import { anyOf, board, defineNodeType, object } from "@breadboard-ai/build";
+import {
+  anyOf,
+  board,
+  defineNodeType,
+  input,
+  object,
+  serialize,
+} from "@breadboard-ai/build";
+import assert from "node:assert/strict";
 import { test } from "node:test";
 
-test("board behavior", () => {
-  const def = defineNodeType({
-    name: "test",
+const nodeThatTakesBoard = defineNodeType({
+  name: "boardnode",
+  inputs: {
+    board: {
+      type: anyOf("string", object({}, "unknown")),
+      behavior: ["board"],
+    },
+  },
+  outputs: {
+    result: {
+      type: "unknown",
+    },
+  },
+  invoke: () => ({ result: 123 }),
+});
+
+const nestedBoard = (() => {
+  const strToNumNode = defineNodeType({
+    name: "str2num",
     inputs: {
-      board: {
-        type: anyOf("string", object({}, "unknown")),
-        behavior: ["board"],
+      str: {
+        type: "string",
       },
     },
-    outputs: {},
-    invoke: () => ({}),
+    outputs: {
+      num: {
+        type: "number",
+      },
+    },
+    invoke: ({ str }) => ({ num: Number(str) }),
   });
+  const str = input();
+  const { num } = strToNumNode({ str }).outputs;
+  return board({ inputs: { str }, outputs: { num } });
+})();
 
-  def({ board: "local.bgl.json" });
+test("can pass board path string", () => {
+  const { result } = nodeThatTakesBoard({ board: "local.bgl.json" }).outputs;
+  const boardDef = board({ inputs: {}, outputs: { result } });
+  assert.deepEqual(serialize(boardDef), {
+    edges: [
+      {
+        from: "boardnode-0",
+        in: "result",
+        out: "result",
+        to: "output-0",
+      },
+    ],
+    nodes: [
+      {
+        configuration: {
+          schema: {
+            properties: {
+              result: {
+                type: [
+                  "array",
+                  "boolean",
+                  "null",
+                  "number",
+                  "object",
+                  "string",
+                ],
+              },
+            },
+            required: ["result"],
+            type: "object",
+          },
+        },
+        id: "output-0",
+        type: "output",
+      },
+      {
+        configuration: {
+          board: "local.bgl.json",
+        },
+        id: "boardnode-0",
+        type: "boardnode",
+      },
+    ],
+  });
+});
 
-  def({ board: board({ inputs: {}, outputs: {} }) });
+test("can pass nested board", () => {
+  const { result: result1 } = nodeThatTakesBoard({
+    board: nestedBoard,
+  }).outputs;
+  const { result: result2 } = nodeThatTakesBoard({
+    board: nestedBoard,
+  }).outputs;
+  const boardDef = board({ inputs: {}, outputs: { result1, result2 } });
+  const serialized = serialize(boardDef);
+  console.log(JSON.stringify(serialized, null));
+  assert.deepEqual(serialized, {
+    edges: [
+      { from: "boardnode-0", to: "output-0", out: "result", in: "result1" },
+      { from: "boardnode-1", to: "output-0", out: "result", in: "result2" },
+    ],
+    nodes: [
+      {
+        id: "output-0",
+        type: "output",
+        configuration: {
+          schema: {
+            type: "object",
+            properties: {
+              result1: {
+                type: [
+                  "array",
+                  "boolean",
+                  "null",
+                  "number",
+                  "object",
+                  "string",
+                ],
+              },
+              result2: {
+                type: [
+                  "array",
+                  "boolean",
+                  "null",
+                  "number",
+                  "object",
+                  "string",
+                ],
+              },
+            },
+            required: ["result1", "result2"],
+          },
+        },
+      },
+      {
+        id: "boardnode-0",
+        type: "boardnode",
+        configuration: {
+          board: {
+            kind: "board",
+            path: "#subgraph-0",
+          },
+        },
+      },
+      {
+        id: "boardnode-1",
+        type: "boardnode",
+        configuration: {
+          board: {
+            kind: "board",
+            path: "#subgraph-1",
+          },
+        },
+      },
+    ],
+    graphs: {
+      "subgraph-0": {
+        edges: [
+          { from: "input-0", to: "str2num-0", out: "str", in: "str" },
+          { from: "str2num-0", to: "output-0", out: "num", in: "num" },
+        ],
+        nodes: [
+          {
+            id: "input-0",
+            type: "input",
+            configuration: {
+              schema: {
+                type: "object",
+                properties: { str: { type: "string" } },
+                required: ["str"],
+              },
+            },
+          },
+          {
+            id: "output-0",
+            type: "output",
+            configuration: {
+              schema: {
+                type: "object",
+                properties: { num: { type: "number" } },
+                required: ["num"],
+              },
+            },
+          },
+          { id: "str2num-0", type: "str2num", configuration: {} },
+        ],
+      },
+      "subgraph-1": {
+        edges: [
+          { from: "input-0", to: "str2num-0", out: "str", in: "str" },
+          { from: "str2num-0", to: "output-0", out: "num", in: "num" },
+        ],
+        nodes: [
+          {
+            id: "input-0",
+            type: "input",
+            configuration: {
+              schema: {
+                type: "object",
+                properties: { str: { type: "string" } },
+                required: ["str"],
+              },
+            },
+          },
+          {
+            id: "output-0",
+            type: "output",
+            configuration: {
+              schema: {
+                type: "object",
+                properties: { num: { type: "number" } },
+                required: ["num"],
+              },
+            },
+          },
+          { id: "str2num-0", type: "str2num", configuration: {} },
+        ],
+      },
+    },
+  });
+});
+
+test("error passing invalid types as boards", () => {
+  // @ts-expect-error
+  nodeThatTakesBoard({ board: 123 });
 
   // @ts-expect-error
-  def({ board: 123 });
-
-  // @ts-expect-error
-  def({ board: ["local.bgl.json"] });
+  nodeThatTakesBoard({ board: ["local.bgl.json"] });
 });

--- a/packages/build/src/test/nested-boards_test.ts
+++ b/packages/build/src/test/nested-boards_test.ts
@@ -17,6 +17,7 @@ import {
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
+// $ExpectType Definition<{ board: string | { [x: string]: JsonSerializable; }; }, { result: JsonSerializable; }, undefined, undefined, never, false, false, false, { board: { board: true; }; }>
 const nodeThatTakesBoard = defineNodeType({
   name: "boardnode",
   inputs: {

--- a/packages/core-kit/tests/code_test.ts
+++ b/packages/core-kit/tests/code_test.ts
@@ -100,7 +100,7 @@ test("serialization", (t) => {
   const str = input();
   const num = input({ type: "number" });
 
-  // $ExpectType Definition<{ num: number; }, { halfNum: number; }, undefined, undefined, never, false, false, false>
+  // $ExpectType Definition<{ num: number; }, { halfNum: number; }, undefined, undefined, never, false, false, false, { num: { board: false; }; }>
   const otherNodeDef = defineNodeType({
     name: "other",
     inputs: {


### PR DESCRIPTION
Input ports with the "board" behavior can now receive board objects declared using the build API. This will be serialized as an embedded graph.