### PR TITLE
[breadboard-ui] Unhook CodeMirror before DOM removal

### DIFF
--- a/.changeset/silver-chicken-fix.md
+++ b/.changeset/silver-chicken-fix.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard-ui": patch
+---
+
+Unhook CodeMirror before DOM removal

--- a/packages/breadboard-ui/src/elements/input/code-editor/code-editor.ts
+++ b/packages/breadboard-ui/src/elements/input/code-editor/code-editor.ts
@@ -113,16 +113,18 @@ export class CodeEditor extends LitElement {
     super.disconnectedCallback();
 
     this.removeEventListener("keydown", this.#onKeyDownBound);
+  }
 
+  render() {
+    return html`<div ${ref(this.#content)}></div>`;
+  }
+
+  unhookSafely() {
     if (!this.#editor) {
       return;
     }
 
     this.#editor.destroy();
     this.#editor = null;
-  }
-
-  render() {
-    return html`<div ${ref(this.#content)}></div>`;
   }
 }

--- a/packages/breadboard-ui/src/elements/node-info/node-configuration.ts
+++ b/packages/breadboard-ui/src/elements/node-info/node-configuration.ts
@@ -404,6 +404,36 @@ export class NodeConfigurationInfo extends LitElement {
     }
   }
 
+  protected willUpdate(
+    changedProperties:
+      | PropertyValueMap<{
+          graph: GraphDescriptor | null;
+          subGraphId: number;
+          selectedNodeIds: string[];
+        }>
+      | Map<PropertyKey, unknown>
+  ): void {
+    if (
+      changedProperties.has("graph") ||
+      changedProperties.has("subGraphId") ||
+      changedProperties.has("selectedNodeIds")
+    ) {
+      if (!this.#nodeConfigurationFormRef.value) {
+        return;
+      }
+
+      // Here we must unhook the editor *before* it is removed from the DOM,
+      // otherwise CodeMirror will hold onto focus if it has it.
+      const editors =
+        this.#nodeConfigurationFormRef.value.querySelectorAll<CodeEditor>(
+          "bb-code-editor"
+        );
+      for (const editor of editors) {
+        editor.unhookSafely();
+      }
+    }
+  }
+
   #assertIsValidBehavior(
     behavior: string | undefined
   ): behavior is BehaviorSchema {


### PR DESCRIPTION
Hopefully this fixes the remaining issues with CM's focus retention.