### PR TITLE
Revert "[breadboard] Add `credentials: include` to default loader's fetch."

### DIFF
--- a/.changeset/plenty-ads-hunt.md
+++ b/.changeset/plenty-ads-hunt.md
@@ -1,5 +1,0 @@
----
-"@google-labs/breadboard": patch
----
-
-Add `credentials: include` to default loader's fetch.

--- a/packages/breadboard/src/loader/default.ts
+++ b/packages/breadboard/src/loader/default.ts
@@ -33,7 +33,7 @@ export const loadFromFile = async (path: string) => {
 };
 
 export const loadWithFetch = async (url: string | URL) => {
-  const response = await fetch(url, { credentials: "include" });
+  const response = await fetch(url);
   return await response.json();
 };
 


### PR DESCRIPTION
This reverts commit 2411056c3080b2e192a98a55be7884b2fcd48f76.
