### PR TITLE
[breadboard-web/-ui] Various small UI tweaks

### DIFF
--- a/.changeset/flat-mirrors-love.md
+++ b/.changeset/flat-mirrors-love.md
@@ -1,0 +1,6 @@
+---
+"@google-labs/breadboard-web": patch
+"@google-labs/breadboard-ui": patch
+---
+
+Various small tweaks

--- a/packages/breadboard-ui/src/elements/overflow-menu/overflow-menu.ts
+++ b/packages/breadboard-ui/src/elements/overflow-menu/overflow-menu.ts
@@ -23,6 +23,9 @@ export class OverflowMenu extends LitElement {
   @property()
   actions: Action[] = [];
 
+  @property()
+  disabled = true;
+
   #onKeyDownBound = this.#onKeyDown.bind(this);
   #onPointerDownBound = this.#onPointerDown.bind(this);
 
@@ -54,6 +57,7 @@ export class OverflowMenu extends LitElement {
       border: none;
       text-align: left;
       border-bottom: 1px solid var(--bb-neutral-300);
+      cursor: pointer;
     }
 
     button:first-of-type {
@@ -65,8 +69,13 @@ export class OverflowMenu extends LitElement {
       border-bottom: none;
     }
 
-    button:hover,
-    button:focus {
+    button[disabled] {
+      opacity: 0.5;
+      cursor: auto;
+    }
+
+    button:not([disabled]):hover,
+    button:not([disabled]):focus {
       background-color: var(--bb-neutral-50);
     }
 
@@ -84,6 +93,10 @@ export class OverflowMenu extends LitElement {
 
     button.settings {
       background-image: var(--bb-icon-settings);
+    }
+
+    button.delete {
+      background-image: var(--bb-icon-delete);
     }
   `;
 
@@ -126,6 +139,7 @@ export class OverflowMenu extends LitElement {
         @click=${() => {
           this.dispatchEvent(new OverflowMenuActionEvent(action.name));
         }}
+        ?disabled=${this.disabled}
       >
         ${action.title}
       </button>`;

--- a/packages/breadboard-ui/src/elements/ui-controller/ui-controller.styles.ts
+++ b/packages/breadboard-ui/src/elements/ui-controller/ui-controller.styles.ts
@@ -180,6 +180,7 @@ export const styles = css`
     flex-direction: column;
     align-items: center;
     justify-content: center;
+    height: 100%;
   }
 
   .failed-to-load h1 {

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -642,12 +642,13 @@ export class Main extends LitElement {
     const boardUrl = new URL(this.graph.url);
     const provider = this.#getProviderForURL(boardUrl);
     if (!provider) {
-      this.toast("Unable to save board", BreadboardUI.Events.ToastType.ERROR);
+      this.showSaveAsDialog = true;
       return;
     }
 
     const capabilities = provider.canProvide(boardUrl);
     if (!capabilities || !capabilities.save) {
+      this.showSaveAsDialog = true;
       return;
     }
 
@@ -710,6 +711,7 @@ export class Main extends LitElement {
       return;
     }
 
+    this.#setBoardPendingSaveState(false);
     this.#persistProviderAndLocation(providerName, location);
 
     // Trigger a re-render.
@@ -721,6 +723,55 @@ export class Main extends LitElement {
       false,
       id
     );
+  }
+
+  async #attemptBoardDelete(
+    providerName: string,
+    url: string,
+    isActive: boolean
+  ) {
+    if (
+      !confirm(
+        "Are you sure you want to delete this board? This cannot be undone"
+      )
+    ) {
+      return;
+    }
+
+    const provider = this.#getProviderByName(providerName);
+    if (!provider) {
+      this.toast("Unable to delete file", BreadboardUI.Events.ToastType.ERROR);
+      return;
+    }
+
+    const id = this.toast(
+      "Deleting board...",
+      BreadboardUI.Events.ToastType.PENDING,
+      true
+    );
+
+    const { result, error } = await provider.delete(new URL(url));
+
+    this.toast(
+      "Board deleted",
+      BreadboardUI.Events.ToastType.INFORMATION,
+      false,
+      id
+    );
+
+    if (!result) {
+      this.toast(
+        error || "Unexpected error",
+        BreadboardUI.Events.ToastType.ERROR
+      );
+    }
+
+    if (isActive) {
+      this.#startFromProviderDefault();
+    }
+
+    // Trigger a re-render.
+    this.providerOps++;
   }
 
   get status() {
@@ -887,7 +938,7 @@ export class Main extends LitElement {
   }
 
   #getProviderForURL(url: URL) {
-    return this.#providers.find((provider) => provider.canProvide(url));
+    return this.#providers.find((provider) => provider.canProvide(url)) || null;
   }
 
   #confirmUnloadWithUserFirstIfNeeded(evt: Event) {
@@ -1194,37 +1245,7 @@ export class Main extends LitElement {
         @bbgraphproviderdeleterequest=${async (
           evt: BreadboardUI.Events.GraphProviderDeleteRequestEvent
         ) => {
-          if (
-            !confirm(
-              "Are you sure you want to delete this board? This cannot be undone"
-            )
-          ) {
-            return;
-          }
-
-          const provider = this.#getProviderByName(evt.providerName);
-          if (!provider) {
-            this.toast(
-              "Unable to delete file",
-              BreadboardUI.Events.ToastType.ERROR
-            );
-            return;
-          }
-
-          const { result, error } = await provider.delete(new URL(evt.url));
-          if (!result) {
-            this.toast(
-              error || "Unexpected error",
-              BreadboardUI.Events.ToastType.ERROR
-            );
-          }
-
-          if (evt.isActive) {
-            this.#startFromProviderDefault();
-          }
-
-          // Trigger a re-render.
-          this.providerOps++;
+          this.#attemptBoardDelete(evt.providerName, evt.url, evt.isActive);
         }}
         @bbstart=${(evt: BreadboardUI.Events.StartEvent) => {
           if (this.status !== BreadboardUI.Types.STATUS.STOPPED) {
@@ -2003,7 +2024,7 @@ export class Main extends LitElement {
     if (this.showOverflowMenu) {
       const actions = [
         {
-          title: "Download board",
+          title: "Download Board",
           name: "download",
           icon: "download",
         },
@@ -2014,12 +2035,22 @@ export class Main extends LitElement {
           const url = new URL(this.graph.url);
           const provider = this.#getProviderForURL(url);
           const capabilities = provider?.canProvide(url);
-          if (provider && capabilities && capabilities.save) {
-            actions.push({
-              title: "Save As...",
-              name: "save-as",
-              icon: "save-as",
-            });
+          if (provider && capabilities) {
+            if (capabilities.save) {
+              actions.push({
+                title: "Save As...",
+                name: "save-as",
+                icon: "save-as",
+              });
+            }
+
+            if (capabilities.delete) {
+              actions.push({
+                title: "Delete Board",
+                name: "delete",
+                icon: "delete",
+              });
+            }
           }
         } catch (err) {
           // If there are any problems with the URL, etc, don't offer the save button.
@@ -2034,6 +2065,7 @@ export class Main extends LitElement {
 
       overflowMenu = html`<bb-overflow-menu
         .actions=${actions}
+        .disabled=${this.graph === null}
         @bboverflowmenudismissed=${() => {
           this.showOverflowMenu = false;
         }}
@@ -2073,6 +2105,20 @@ export class Main extends LitElement {
 
             case "save": {
               await this.#attemptBoardSave();
+              break;
+            }
+
+            case "delete": {
+              if (!this.graph || !this.graph.url) {
+                return;
+              }
+
+              const provider = this.#getProviderForURL(new URL(this.graph.url));
+              if (!provider) {
+                return;
+              }
+
+              this.#attemptBoardDelete(provider.name, this.graph.url, true);
               break;
             }
 

--- a/packages/breadboard-web/src/providers/indexed-db.ts
+++ b/packages/breadboard-web/src/providers/indexed-db.ts
@@ -109,6 +109,21 @@ export class IDBGraphProvider implements GraphProvider {
     if (storeList.length === 0) {
       await storeDb.put("stores", DEFAULT_STORE);
       storeList = await storeDb.getAll("stores");
+    } else {
+      // TODO: Remove this eventually. For now, it's a useful way of updating
+      // the title of the default store when it's changed.
+      for (const store of storeList) {
+        if (
+          store.name === DEFAULT_STORE.name &&
+          store.title !== DEFAULT_STORE.title
+        ) {
+          console.warn(
+            `Updating "Board Store" title to ${DEFAULT_STORE.title}`
+          );
+          store.title = DEFAULT_STORE.title;
+          await storeDb.put("stores", store);
+        }
+      }
     }
 
     this.#storeLocations = storeList;

--- a/packages/breadboard-web/src/providers/remote.ts
+++ b/packages/breadboard-web/src/providers/remote.ts
@@ -254,9 +254,7 @@ export class RemoteGraphProvider implements GraphProvider {
   }
 
   async createBlank(url: URL): Promise<{ result: boolean; error?: string }> {
-    // TODO: Remove "published" by default once we have UI to flip the
-    // "published" / "draft" flag.
-    return this.create(url, blankLLMContent("published"));
+    return this.create(url, blankLLMContent());
   }
 
   async create(


### PR DESCRIPTION
Including:

- Disabling overflow menu items when there is no loaded graph.
- Pointer cursor for overflow menu items.
- "Unable to load board" panel now fills the space.
- When pressing Cmd/Ctrl+S for a board without write permissions, we show the "Save as..." dialog.
- Added a "Delete Board..." option to the overflow menu.
- Provide a status update toast when deleting a board.
- Renaming of "Board Store" to "Browser Storage" for a bit of clarity.