### PR TITLE
[breadboard-ui/website] UI fixes for mobile

### DIFF
--- a/.changeset/kind-cows-sip.md
+++ b/.changeset/kind-cows-sip.md
@@ -1,0 +1,6 @@
+---
+"@google-labs/breadboard-ui": patch
+"@google-labs/breadboard-website": patch
+---
+
+Minor UX fixes for mobile

--- a/packages/breadboard-ui/src/elements/editor/graph-comment.ts
+++ b/packages/breadboard-ui/src/elements/editor/graph-comment.ts
@@ -338,24 +338,27 @@ export class GraphComment extends PIXI.Container {
         hitArea.fill({ color: 0xff00ff, alpha: 0 });
       }
 
-      hitArea.on("click", (evt: PIXI.FederatedPointerEvent) => {
-        const url = evt.target.label;
-        if (url.startsWith("board:")) {
-          this.emit(
-            GRAPH_OPERATIONS.GRAPH_BOARD_LINK_CLICKED,
-            url.replace(/board:/, "")
-          );
-          return;
-        }
+      hitArea.addEventListener(
+        "pointerup",
+        (evt: PIXI.FederatedPointerEvent) => {
+          const url = evt.target.label;
+          if (url.startsWith("board:")) {
+            this.emit(
+              GRAPH_OPERATIONS.GRAPH_BOARD_LINK_CLICKED,
+              url.replace(/board:/, "")
+            );
+            return;
+          }
 
-        try {
-          const parsedUrl = new URL(url);
-          window.open(parsedUrl.href, "_blank", "noopener");
-        } catch (err) {
-          console.warn(`Unable to parse URL from comment: ${url}`);
-          console.warn(err);
+          try {
+            const parsedUrl = new URL(url);
+            window.open(parsedUrl.href, "_blank", "noopener");
+          } catch (err) {
+            console.warn(`Unable to parse URL from comment: ${url}`);
+            console.warn(err);
+          }
         }
-      });
+      );
 
       this.#hitAreas.addChild(hitArea);
     }

--- a/packages/breadboard-ui/src/elements/editor/graph-renderer.ts
+++ b/packages/breadboard-ui/src/elements/editor/graph-renderer.ts
@@ -161,7 +161,7 @@ export class GraphRenderer extends LitElement {
     }
 
     :host([readonly="true"]) canvas {
-      touch-action: pan-y !important;
+      touch-action: manipulation !important;
     }
 
     canvas {
@@ -461,7 +461,6 @@ export class GraphRenderer extends LitElement {
 
     const onWheel = (evt: PIXI.FederatedWheelEvent) => {
       if (this.readOnly) {
-        console.log("Removing wheel behavior");
         this.#app.stage.off("wheel", onWheel);
       }
 

--- a/packages/website/src/js/board-embed.ts
+++ b/packages/website/src/js/board-embed.ts
@@ -5,6 +5,7 @@
  */
 import { LitElement, html, css, TemplateResult, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
+import { cache } from "lit/directives/cache.js";
 
 import Core from "@google-labs/core-kit";
 import JSONKit from "@google-labs/json-kit";
@@ -36,7 +37,22 @@ export class BoardEmbed extends LitElement {
   @property({ reflect: true })
   collapseNodesByDefault = "true";
 
+  @property({ reflect: true })
+  active = false;
+
   #data: Promise<TemplateResult> | null = null;
+  #observer = new IntersectionObserver(
+    (entries) => {
+      this.active = false;
+
+      if (entries.length === 0) {
+        return;
+      }
+
+      this.active = entries[0].isIntersecting;
+    },
+    { rootMargin: "80px", threshold: 0 }
+  );
 
   static styles = css`
     :host {
@@ -76,7 +92,14 @@ export class BoardEmbed extends LitElement {
   connectedCallback(): void {
     super.connectedCallback();
 
+    this.#observer.observe(this);
     this.#data = this.loadBoard();
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+
+    this.#observer.unobserve(this);
   }
 
   async loadBoard() {
@@ -125,6 +148,8 @@ export class BoardEmbed extends LitElement {
       setTimeout(r, UPDATE_USER_TIMEOUT)
     ).then(() => html`🤖 Getting there... Hang on...`);
 
-    return html`${until(this.#data, updateUser)}`;
+    return this.active
+      ? cache(html`${until(this.#data, updateUser)}`)
+      : nothing;
   }
 }


### PR DESCRIPTION
Three fixes in one:

1. Uses an IntersectionObserver to handle rendering the embed. Fixes #2273.
2. Enables clicking on links on mobile devices. Fixes #2262.
3. Allows pinch-zoom and other, similar behaviors when in readOnly mode.