### PR TITLE
Ensure textures have loaded before graph data is sent through

### DIFF
--- a/.changeset/chilly-cobras-suffer.md
+++ b/.changeset/chilly-cobras-suffer.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard-ui": patch
+---
+
+Ensure textures have loaded before graph data is sent through

--- a/packages/breadboard-ui/src/elements/editor/editor.ts
+++ b/packages/breadboard-ui/src/elements/editor/editor.ts
@@ -380,6 +380,12 @@ export class Editor extends LitElement {
   `;
 
   async #processGraph(): Promise<GraphRenderer> {
+    if (GraphAssets.assetPrefix !== this.assetPrefix) {
+      GraphAssets.assetPrefix = this.assetPrefix;
+    }
+
+    await this.#graphRenderer.loadTexturesAndInitializeRenderer();
+
     if (!this.graph) {
       this.#graphRenderer.deleteGraphs();
       return this.#graphRenderer;
@@ -527,8 +533,6 @@ export class Editor extends LitElement {
     this.addEventListener("pointerdown", this.#onPointerDownBound);
     this.addEventListener("dragover", this.#onDragOverBound);
     this.addEventListener("drop", this.#onDropBound);
-
-    GraphAssets.assetPrefix = this.assetPrefix;
   }
 
   disconnectedCallback(): void {

--- a/packages/breadboard-ui/src/elements/editor/graph-assets.ts
+++ b/packages/breadboard-ui/src/elements/editor/graph-assets.ts
@@ -27,7 +27,7 @@ export class GraphAssets {
     return this.#instance;
   }
 
-  #assets!: AssetMap;
+  #assets: AssetMap = new Map();
   #loaded: Promise<void>;
 
   // Not to be instantiated directly.

--- a/packages/breadboard-ui/src/elements/editor/graph-renderer.ts
+++ b/packages/breadboard-ui/src/elements/editor/graph-renderer.ts
@@ -1108,7 +1108,7 @@ export class GraphRenderer extends LitElement {
     this.removeEventListener("wheel", this.#onWheelBound);
   }
 
-  async loadTexturesAndRender() {
+  async loadTexturesAndInitializeRenderer() {
     if (this.#appInitialized) {
       return this.#app.canvas;
     }
@@ -1506,7 +1506,7 @@ export class GraphRenderer extends LitElement {
       : nothing;
 
     return html`${until(
-      this.loadTexturesAndRender()
+      this.loadTexturesAndInitializeRenderer()
     )}${overflowMenu}${edgeSelectDisambiguationMenu}${edgeMenu}`;
   }
 }


### PR DESCRIPTION
Working on #2264

We weren't ensuring that the textures were loaded before the graph data was sent through. This meant that the icons were being assessed before the textures had loaded, the net result being nodes without icons.

This change largely involves awaiting the Pixijs app startup and texture loading code before sending any updated graph data through. The initialization code early exits on subsequent calls so it shouldn't cause multiple initializations.