### PR TITLE
[breadboard-web] Add setting for port hover tooltip (default off)

### DIFF
--- a/packages/breadboard-ui/src/elements/editor/editor.ts
+++ b/packages/breadboard-ui/src/elements/editor/editor.ts
@@ -136,6 +136,11 @@ export class Editor extends LitElement {
   @property()
   readOnly = false;
 
+  @property()
+  set showPortTooltips(value: boolean) {
+    this.#graphRenderer.showPortTooltips = value;
+  }
+
   #graphRenderer = new GraphRenderer();
   // Incremented each time a graph is updated, used to avoid extra work
   // inspecting ports when the graph is updated.

--- a/packages/breadboard-ui/src/elements/editor/graph-node.ts
+++ b/packages/breadboard-ui/src/elements/editor/graph-node.ts
@@ -463,6 +463,21 @@ export class GraphNode extends PIXI.Container {
 
         portItem = { label, port, nodePort };
         this.#inPortsData.set(port.name, portItem);
+
+        nodePort.addEventListener("mouseover", (event) => {
+          this.emit(
+            GRAPH_OPERATIONS.GRAPH_NODE_PORT_MOUSEENTER,
+            port,
+            event.client
+          );
+        });
+        nodePort.addEventListener("mouseleave", (event) => {
+          this.emit(
+            GRAPH_OPERATIONS.GRAPH_NODE_PORT_MOUSELEAVE,
+            port,
+            event.client
+          );
+        });
       }
 
       if (portItem.label.text !== port.title) {
@@ -535,6 +550,21 @@ export class GraphNode extends PIXI.Container {
 
         portItem = { label, port, nodePort };
         this.#outPortsData.set(port.name, portItem);
+
+        nodePort.addEventListener("mouseover", (event) => {
+          this.emit(
+            GRAPH_OPERATIONS.GRAPH_NODE_PORT_MOUSEENTER,
+            port,
+            event.client
+          );
+        });
+        nodePort.addEventListener("mouseleave", (event) => {
+          this.emit(
+            GRAPH_OPERATIONS.GRAPH_NODE_PORT_MOUSELEAVE,
+            port,
+            event.client
+          );
+        });
       }
 
       if (portItem.label.text !== port.title) {

--- a/packages/breadboard-ui/src/elements/editor/graph.ts
+++ b/packages/breadboard-ui/src/elements/editor/graph.ts
@@ -1244,6 +1244,18 @@ export class Graph extends PIXI.Container {
         this.emit(GRAPH_OPERATIONS.GRAPH_NODE_EXPAND_COLLAPSE);
       });
 
+      graphNode.on(
+        GRAPH_OPERATIONS.GRAPH_NODE_PORT_MOUSEENTER,
+        (...args: unknown[]) =>
+          this.emit(GRAPH_OPERATIONS.GRAPH_NODE_PORT_MOUSEENTER, ...args)
+      );
+
+      graphNode.on(
+        GRAPH_OPERATIONS.GRAPH_NODE_PORT_MOUSELEAVE,
+        (...args: unknown[]) =>
+          this.emit(GRAPH_OPERATIONS.GRAPH_NODE_PORT_MOUSELEAVE, ...args)
+      );
+
       this.addChild(graphNode);
     }
 

--- a/packages/breadboard-ui/src/elements/editor/port-tooltip.ts
+++ b/packages/breadboard-ui/src/elements/editor/port-tooltip.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { type Schema } from "@google-labs/breadboard";
+import { LitElement, css, html } from "lit";
+import { customElement, property } from "lit/decorators.js";
+
+@customElement("pp-port-tooltip")
+export class PortTooltip extends LitElement {
+  @property({ reflect: false, type: Object })
+  schema?: Schema;
+
+  static styles = css`
+    pre {
+      font-size: 12px;
+      padding: 2px 12px;
+      text-wrap: wrap;
+      width: 350px;
+    }
+  `;
+
+  override render() {
+    // TODO(aomarks) Make a nicely styled version of this.
+    return html`<pre>${JSON.stringify(this.schema, null, 2)}</pre>`;
+  }
+}

--- a/packages/breadboard-ui/src/elements/editor/types.ts
+++ b/packages/breadboard-ui/src/elements/editor/types.ts
@@ -25,6 +25,8 @@ export enum GRAPH_OPERATIONS {
   GRAPH_NODE_EXPAND_COLLAPSE = "graphnodeexpandcollapse",
   GRAPH_NODE_MENU_CLICKED = "graphnodemenuclicked",
   GRAPH_NODE_MENU_REQUESTED = "graphnodemenurequested",
+  GRAPH_NODE_PORT_MOUSEENTER = "graphnodeportmouseenter",
+  GRAPH_NODE_PORT_MOUSELEAVE = "graphnodeportmouseleave",
 }
 
 export enum GraphNodePortType {

--- a/packages/breadboard-ui/src/elements/elements.ts
+++ b/packages/breadboard-ui/src/elements/elements.ts
@@ -22,6 +22,7 @@ export { GraphHistory } from "./graph-history/graph-history.js";
 export { GraphRenderer } from "./editor/graph-renderer.js";
 export { Input } from "./input/input.js";
 export { JSONTree } from "./json-tree/json-tree.js";
+export { PortTooltip } from "./editor/port-tooltip.js";
 export { LLMInput } from "./input/llm-input/llm-input.js";
 export { LLMInputArray } from "./input/llm-input/llm-input-array.js";
 export { LLMOutput } from "./llm-output/llm-output.js";

--- a/packages/breadboard-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/breadboard-ui/src/elements/ui-controller/ui-controller.ts
@@ -326,6 +326,11 @@ export class UI extends LitElement {
           ?.value
       : false;
 
+    const showPortTooltips = this.settings
+      ? this.settings[SETTINGS_TYPE.GENERAL].items.get("Show Port Tooltips")
+          ?.value
+      : false;
+
     /**
      * Create all the elements we need.
      */
@@ -342,6 +347,7 @@ export class UI extends LitElement {
         showNodeShortcuts,
         showNodeTypeDescriptions,
         invertZoomScrollDirection,
+        showPortTooltips,
       ],
       () => {
         return html`<bb-editor
@@ -358,6 +364,7 @@ export class UI extends LitElement {
           .showNodeShortcuts=${showNodeShortcuts}
           .showNodeTypeDescriptions=${showNodeTypeDescriptions}
           .invertZoomScrollDirection=${invertZoomScrollDirection}
+          .showPortTooltips=${showPortTooltips}
           @bbmultiedit=${(evt: MultiEditEvent) => {
             const deletedNodes: RemoveNodeSpec[] = evt.edits.filter(
               (edit) => edit.type === "removenode"

--- a/packages/breadboard-web/src/data/settings-store.ts
+++ b/packages/breadboard-web/src/data/settings-store.ts
@@ -10,7 +10,7 @@ import * as BreadboardUI from "@google-labs/breadboard-ui";
 interface SettingsDB extends BreadboardUI.Types.SettingsList, idb.DBSchema {}
 
 const SETTINGS_NAME = "settings";
-const SETTINGS_VERSION = 6;
+const SETTINGS_VERSION = 7;
 
 export class SettingsStore {
   static #instance: SettingsStore;
@@ -80,6 +80,15 @@ export class SettingsStore {
             name: "Show Node Type Descriptions",
             description:
               "Toggles the visibility of node type descriptions in graph nodes",
+            value: false,
+          },
+        ],
+        [
+          "Show Port Tooltips",
+          {
+            name: "Show Port Tooltips",
+            description:
+              "Toggles whether hovering over a port shows a tooltip with advanced port details",
             value: false,
           },
         ],


### PR DESCRIPTION
Adds a new setting under General (off by default):

<img width="468" alt="image" src="https://github.com/breadboard-ai/breadboard/assets/48894/d019a544-0873-4167-bb94-3aae825a4f8a">

When checked, it enables a new tooltip that displays the raw schema when you hover over a port:

<img width="600" alt="image" src="https://github.com/breadboard-ai/breadboard/assets/48894/b0fa8d67-8af1-4c86-9844-f9fcd6b71403">

This makes it easy to see the low-level schema directly, so there's a bit more detail than you get on the RHS, and it's quicker since it pops up right where you're already looking with dense text. (Useful for me while I'm working on better schema validation).

Ugly since it's just for debugging (though could evolve into a prettier version potentially).