### PR TITLE
[devx] Optimize breadboard-web build graph

### DIFF
--- a/packages/breadboard-web/package.json
+++ b/packages/breadboard-web/package.json
@@ -189,6 +189,7 @@
       "dependencies": [
         "../agent-kit:build"
       ],
+      "files": [],
       "output": [
         "public/*.kit.json"
       ]
@@ -205,10 +206,9 @@
     },
     "generate:graphs": {
       "command": "tsx src/make-graphs.ts",
-      "dependencies": [
-        "typescript-files-and-deps"
+      "files": [
+        "src/boards/**/*.ts"
       ],
-      "files": [],
       "output": [
         "public/local-boards.json",
         "public/graphs/**/*.json",

--- a/packages/breadboard-web/package.json
+++ b/packages/breadboard-web/package.json
@@ -206,6 +206,9 @@
     },
     "generate:graphs": {
       "command": "tsx src/make-graphs.ts",
+      "dependencies": [
+        "../build:build:tsc"
+      ],
       "files": [
         "src/boards/**/*.ts"
       ],

--- a/packages/breadboard-web/package.json
+++ b/packages/breadboard-web/package.json
@@ -207,7 +207,9 @@
     "generate:graphs": {
       "command": "tsx src/make-graphs.ts",
       "dependencies": [
-        "../build:build:tsc"
+        "../build:build:tsc",
+        "../breadboard:build:tsc",
+        "../manifest:build:ts"
       ],
       "files": [
         "src/boards/**/*.ts"

--- a/packages/manifest/package.json
+++ b/packages/manifest/package.json
@@ -64,12 +64,27 @@
         "../schema:build",
         "validate"
       ],
+      "files": [
+        "src/**/*.ts",
+        "tsconfig.json",
+        "../../core/tsconfig/base.json"
+      ],
       "output": [
         "bbm.schema.json"
       ]
     },
     "build:ts": {
-      "command": "tsc -b -v",
+      "command": "tsc -b -v --pretty",
+      "clean": "if-file-deleted",
+      "files": [
+        "src/**/*.ts",
+        "tsconfig.json",
+        "../../core/tsconfig/base.json"
+      ],
+      "output": [
+        "dist/**",
+        "tsconfig.tsbuildinfo"
+      ],
       "dependencies": [
         "build:schema",
         "../breadboard:build",
@@ -81,6 +96,8 @@
       "dependencies": [
         "build"
       ],
+      "files": [],
+      "output": [],
       "env": {
         "FORCE_COLOR": "1"
       }
@@ -90,7 +107,13 @@
       "dependencies": [
         "../breadboard:build",
         "../schema:build"
-      ]
+      ],
+      "files": [
+        "src/**/*.ts",
+        "tsconfig.json",
+        "../../core/tsconfig/base.json"
+      ],
+      "output": []
     }
   }
 }


### PR DESCRIPTION
This improves caching in a few spots in the transitive build graph of the `npm run dev` command in `breadboard-web`. Changes to TypeScript files should usually now only trigger a single refresh instead of 2-3.