### PR TITLE
Add much more deps to genemanyrate:graphs

### DIFF
--- a/packages/breadboard-web/package.json
+++ b/packages/breadboard-web/package.json
@@ -207,9 +207,17 @@
     "generate:graphs": {
       "command": "tsx src/make-graphs.ts",
       "dependencies": [
-        "../build:build:tsc",
         "../breadboard:build:tsc",
-        "../manifest:build:ts"
+        "../build:build:tsc",
+        "../core-kit:build",
+        "../gemini-kit:build",
+        "../google-drive-kit:build",
+        "../json-kit:build",
+        "../manifest:build:ts",
+        "../node-nursery-web:build",
+        "../palm-kit:build",
+        "../pinecone-kit:build",
+        "../template-kit:build"
       ],
       "files": [
         "src/boards/**/*.ts"


### PR DESCRIPTION
Follow up to https://github.com/breadboard-ai/breadboard/pull/2301 to improve stability. I removed some edges in that PR, but needed to add some more which were now no longer connected transitively.