### PR TITLE
[inspector] Add a validate method to InspectableEdge

### DIFF
--- a/.changeset/strange-files-deliver.md
+++ b/.changeset/strange-files-deliver.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard": minor
+---
+
+Add validate() method to InspectableEdge

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -168,7 +168,24 @@ export type InspectableEdge = {
    * The type of the edge.
    */
   type: InspectableEdgeType;
+
+  /**
+   * Check if the input and output schemas are compatible (meaning that the
+   * output port type is a subtype of the input port type).
+   */
+  validate(): Promise<ValidateResult>;
 };
+
+export type ValidateResult =
+  | { status: "unknown"; errors?: never }
+  | { status: "valid"; errors?: never }
+  | { status: "invalid"; errors: ValidateError[] };
+
+export interface ValidateError {
+  message: string;
+  // TODO(aomarks) Could add more data here in future, e.g. a path to the part
+  // of the schema which is invalid for fancy highlighting, etc.
+}
 
 export type InspectableSubgraphs = Record<GraphIdentifier, InspectableGraph>;
 


### PR DESCRIPTION
Adds a `validate` method to `InspectableEdge`. It grabs the schema for the from/to sides of the edge and calls `canConnect` to determine whether they are compatible. Includes a new Validation type so that we can add more structured data, detailed error messages, etc.

Part of https://github.com/breadboard-ai/breadboard/issues/2298