### PR TITLE
[ui] [web] New setting that displays wires in red if they are invalid

### DIFF
--- a/packages/breadboard-ui/src/elements/editor/editor.ts
+++ b/packages/breadboard-ui/src/elements/editor/editor.ts
@@ -137,6 +137,9 @@ export class Editor extends LitElement {
   readOnly = false;
 
   @property()
+  highlightInvalidWires = false;
+
+  @property()
   set showPortTooltips(value: boolean) {
     this.#graphRenderer.showPortTooltips = value;
   }
@@ -398,6 +401,7 @@ export class Editor extends LitElement {
 
     this.#graphVersion++;
     this.#graphRenderer.readOnly = this.readOnly;
+    this.#graphRenderer.highlightInvalidWires = this.highlightInvalidWires;
 
     let breadboardGraph = inspect(this.graph, {
       kits: this.kits,

--- a/packages/breadboard-ui/src/elements/editor/graph-edge.ts
+++ b/packages/breadboard-ui/src/elements/editor/graph-edge.ts
@@ -15,6 +15,7 @@ const edgeColorOrdinary = getGlobalColor("--bb-neutral-300");
 const edgeColorConstant = getGlobalColor("--bb-ui-200");
 const edgeColorControl = getGlobalColor("--bb-boards-200");
 const edgeColorStar = getGlobalColor("--bb-inputs-200");
+const edgeColorInvalid = getGlobalColor("--bb-warning-500");
 
 /**
  * Calculates an [x,y] pair of points from start to end via the control point.
@@ -105,6 +106,7 @@ export class GraphEdge extends PIXI.Graphics {
   #overrideOutLocation: PIXI.ObservablePoint | null = null;
   #type: InspectableEdgeType | null = null;
   #selected = false;
+  #invalid = false;
   #hitAreaSpacing = 6;
 
   readOnly = false;
@@ -148,6 +150,15 @@ export class GraphEdge extends PIXI.Graphics {
 
   set selected(selected: boolean) {
     this.#selected = selected;
+    this.#isDirty = true;
+  }
+
+  get invalid() {
+    return this.#invalid;
+  }
+
+  set invalid(invalid: boolean) {
+    this.#invalid = invalid;
     this.#isDirty = true;
   }
 
@@ -258,6 +269,10 @@ export class GraphEdge extends PIXI.Graphics {
         edgeColor = edgeColorStar;
         break;
       }
+    }
+
+    if (this.invalid) {
+      edgeColor = edgeColorInvalid;
     }
 
     if (this.#overrideColor) {

--- a/packages/breadboard-ui/src/elements/editor/graph-renderer.ts
+++ b/packages/breadboard-ui/src/elements/editor/graph-renderer.ts
@@ -78,6 +78,9 @@ export class GraphRenderer extends LitElement {
   @property({ reflect: true })
   readOnly = false;
 
+  @property({ reflect: true })
+  highlightInvalidWires = false;
+
   @property()
   showPortTooltips = false;
 
@@ -647,6 +650,7 @@ export class GraphRenderer extends LitElement {
     }
 
     graph.readOnly = this.readOnly;
+    graph.highlightInvalidWires = this.highlightInvalidWires;
 
     return true;
   }

--- a/packages/breadboard-ui/src/elements/editor/graph.ts
+++ b/packages/breadboard-ui/src/elements/editor/graph.ts
@@ -59,6 +59,7 @@ export class Graph extends PIXI.Container {
   layoutRect: DOMRectReadOnly | null = null;
 
   readOnly = false;
+  highlightInvalidWires = false;
 
   constructor() {
     super({
@@ -1413,7 +1414,11 @@ export class Graph extends PIXI.Container {
 
       edgeGraphic.edge = edge;
       edgeGraphic.readOnly = this.readOnly;
-      this.#scheduleValidation(edge, edgeGraphic);
+      if (this.highlightInvalidWires) {
+        this.#scheduleValidation(edge, edgeGraphic);
+      } else {
+        edgeGraphic.invalid = false;
+      }
     }
 
     this.#removeStaleEdges();

--- a/packages/breadboard-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/breadboard-ui/src/elements/ui-controller/ui-controller.ts
@@ -331,6 +331,12 @@ export class UI extends LitElement {
           ?.value
       : false;
 
+    const highlightInvalidWires = this.settings
+      ? this.settings[SETTINGS_TYPE.GENERAL].items.get(
+          "Highlight Invalid Wires"
+        )?.value
+      : false;
+
     /**
      * Create all the elements we need.
      */
@@ -348,6 +354,7 @@ export class UI extends LitElement {
         showNodeTypeDescriptions,
         invertZoomScrollDirection,
         showPortTooltips,
+        highlightInvalidWires,
       ],
       () => {
         return html`<bb-editor
@@ -365,6 +372,7 @@ export class UI extends LitElement {
           .showNodeTypeDescriptions=${showNodeTypeDescriptions}
           .invertZoomScrollDirection=${invertZoomScrollDirection}
           .showPortTooltips=${showPortTooltips}
+          .highlightInvalidWires=${highlightInvalidWires}
           @bbmultiedit=${(evt: MultiEditEvent) => {
             const deletedNodes: RemoveNodeSpec[] = evt.edits.filter(
               (edit) => edit.type === "removenode"

--- a/packages/breadboard-web/src/data/settings-store.ts
+++ b/packages/breadboard-web/src/data/settings-store.ts
@@ -93,6 +93,15 @@ export class SettingsStore {
           },
         ],
         [
+          "Highlight Invalid Wires",
+          {
+            name: "Highlight Invalid Wires",
+            description:
+              "Toggles whether wires that have incompatible schema will be shown in red.",
+            value: false,
+          },
+        ],
+        [
           "Invert Zoom Scroll Direction",
           {
             name: "Invert Zoom Scroll Direction",


### PR DESCRIPTION
Adds a new setting that displays wires in red if they are invalid. Wires are invalid if their from->to schemas are incompatible according to `canConnect` from the inspector API.

Defaults to OFF for now because I've seen some false-positives looking through example boards. After this PR I'll work on making sure `canConnect` covers all the cases, and then we can switch the default to ON after checking out a bunch of boards. There's probably also some things to fix in popular nodes & boards where we're actually configuring slightly wrong types.

<img width="412" alt="image" src="https://github.com/breadboard-ai/breadboard/assets/48894/30392727-f14b-4817-b9f1-5a5dbcbc331b">

<img width="563" alt="image" src="https://github.com/breadboard-ai/breadboard/assets/48894/ed40e237-64ac-4c1a-ac7f-6481965ec0f9">