### PR TITLE
[breadboard-web] Unblock UI on providers

### DIFF
--- a/.changeset/seven-donkeys-smoke.md
+++ b/.changeset/seven-donkeys-smoke.md
@@ -1,0 +1,7 @@
+---
+"@google-labs/breadboard-web": patch
+"@google-labs/breadboard-ui": patch
+"@google-labs/breadboard": patch
+---
+
+Unblock UI on Providers

--- a/packages/breadboard-cli/src/debugger/provider.ts
+++ b/packages/breadboard-cli/src/debugger/provider.ts
@@ -46,6 +46,11 @@ export class DebuggerGraphProvider implements GraphProvider {
 
   #blank: URL | null = null;
   #items: Map<string, GraphProviderStore> = new Map();
+  #ready = Promise.resolve();
+
+  ready() {
+    return this.#ready;
+  }
 
   items(): Map<string, GraphProviderStore> {
     return this.#items;

--- a/packages/breadboard-web/src/index.ts
+++ b/packages/breadboard-web/src/index.ts
@@ -856,6 +856,15 @@ export class Main extends LitElement {
     if (this.url) {
       try {
         const base = new URL(window.location.href);
+        const provider = this.#getProviderForURL(new URL(this.url));
+        if (!provider) {
+          throw new Error(`Unable to find provider: ${this.url}`);
+        }
+
+        // Ensure the the provider has actually loaded fully before requesting
+        // the graph file from it.
+        await provider.ready();
+
         const graph = await this.#loader.load(this.url, { base });
         if (!graph) {
           throw new Error(`Unable to load graph: ${this.url}`);

--- a/packages/breadboard-web/src/providers/examples.ts
+++ b/packages/breadboard-web/src/providers/examples.ts
@@ -19,6 +19,11 @@ export class ExamplesGraphProvider implements GraphProvider {
   #blank: URL | null = null;
   #items: Map<string, GraphProviderStore> = new Map();
 
+  #ready = Promise.resolve();
+  ready() {
+    return this.#ready;
+  }
+
   constructor(manifest: BreadboardManifest) {
     const boards = manifest.boards || [];
     const blank = boards.find((board) => {

--- a/packages/breadboard-web/src/providers/file-system.ts
+++ b/packages/breadboard-web/src/providers/file-system.ts
@@ -89,6 +89,7 @@ export class FileSystemGraphProvider implements GraphProvider {
     }
   >();
   #locations = new Map<string, FileSystemDirectoryHandle>();
+  #ready = Promise.resolve();
 
   name = "FileSystemGraphProvider";
 
@@ -96,6 +97,10 @@ export class FileSystemGraphProvider implements GraphProvider {
 
   async createURL(location: string, fileName: string) {
     return `${FILE_SYSTEM_PROTOCOL}//${FILE_SYSTEM_HOST_PREFIX}~${location}/${fileName}`;
+  }
+
+  ready() {
+    return this.#ready;
   }
 
   parseURL(url: URL) {
@@ -422,7 +427,7 @@ export class FileSystemGraphProvider implements GraphProvider {
 
     const entries = await KeyVal.entries<string, FileSystemDirectoryHandle>();
     this.#locations = new Map(entries);
-    return this.#refreshAllItems();
+    this.#ready = this.#refreshAllItems();
   }
 
   async createGraphURL(location: string, fileName: string) {

--- a/packages/breadboard-web/src/providers/indexed-db.ts
+++ b/packages/breadboard-web/src/providers/indexed-db.ts
@@ -54,6 +54,7 @@ export class IDBGraphProvider implements GraphProvider {
     return this.#instance;
   }
 
+  #ready = Promise.resolve();
   #storeLocations: GraphDBStore[] = [];
   #stores: Map<string, GraphProviderStore<void>> = new Map<
     string,
@@ -67,6 +68,10 @@ export class IDBGraphProvider implements GraphProvider {
   name = "IDBGraphProvider";
 
   private constructor() {}
+
+  ready() {
+    return this.#ready;
+  }
 
   isSupported() {
     return "IDBOpenDBRequest" in window;
@@ -127,7 +132,7 @@ export class IDBGraphProvider implements GraphProvider {
     }
 
     this.#storeLocations = storeList;
-    return this.#refreshAllItems();
+    this.#ready = this.#refreshAllItems();
   }
 
   canProvide(url: URL): false | GraphProviderCapabilities {

--- a/packages/breadboard-web/src/providers/remote.ts
+++ b/packages/breadboard-web/src/providers/remote.ts
@@ -93,6 +93,7 @@ export class RemoteGraphProvider implements GraphProvider {
   readonly name = "RemoteGraphProvider";
   title = "Remote";
 
+  #ready = Promise.resolve();
   #locations: GraphDBStore[] = [];
   #stores: Map<string, GraphProviderStore<void>> = new Map<
     string,
@@ -104,6 +105,10 @@ export class RemoteGraphProvider implements GraphProvider {
   >();
 
   private constructor() {}
+
+  ready() {
+    return this.#ready;
+  }
 
   #getApiKey(location: string) {
     const store = this.#locations.find((store) => store.url === location);
@@ -290,7 +295,7 @@ export class RemoteGraphProvider implements GraphProvider {
     );
 
     this.#locations = await storeDb.getAll("stores");
-    return this.#refreshAllItems();
+    this.#ready = this.#refreshAllItems();
   }
 
   async #storeLocations() {

--- a/packages/breadboard/src/loader/default.ts
+++ b/packages/breadboard/src/loader/default.ts
@@ -40,6 +40,11 @@ export const loadWithFetch = async (url: string | URL) => {
 export class DefaultGraphProvider implements GraphProvider {
   name = "DefaultGraphProvider";
 
+  #ready = Promise.resolve();
+  ready() {
+    return this.#ready;
+  }
+
   isSupported(): boolean {
     return true;
   }

--- a/packages/breadboard/src/loader/types.ts
+++ b/packages/breadboard/src/loader/types.ts
@@ -84,6 +84,10 @@ export type GraphProvider = {
    */
   name: string;
   /**
+   * An indicator that the Provider is ready to serve graphs.
+   */
+  ready(): Promise<void>;
+  /**
    * Whether the provider is supported or not in the current environment.
    */
   isSupported(): boolean;


### PR DESCRIPTION
We were waiting on board lists being restored before rendering the UI, which was slowing things down in the case of Board Servers particularly. This PR changes things so it eagerly renders while the Providers are restoring. To accommodate that change the main loader awaits the selected Provider's `ready` `Promise` before loading a board, and the nav similarly awaits the same before trying to render the item list.