### PR TITLE
[visual-editor] Change edit board to close board

### DIFF
--- a/.changeset/cold-parrots-behave.md
+++ b/.changeset/cold-parrots-behave.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/visual-editor": patch
+---
+
+Change edit board to close

--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://wombat-dressing-room.appspot.com"
   },
-  "version": "1.10.3",
+  "version": "1.10.4",
   "description": "The Web runtime for Breadboard",
   "main": "./build/index.js",
   "exports": {

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -226,11 +226,11 @@ export class Main extends LitElement {
       cursor: pointer;
     }
 
-    #edit-board-info {
+    #close-board {
       font-size: 0;
       width: 20px;
       height: 20px;
-      background: var(--bb-icon-edit) center center no-repeat;
+      background: var(--bb-icon-close) center center no-repeat;
       background-size: 16px 16px;
       border: 2px solid transparent;
       margin-left: calc(var(--bb-grid-size) * 2);
@@ -239,11 +239,11 @@ export class Main extends LitElement {
       border-radius: 50%;
     }
 
-    #edit-board-info:not([disabled]) {
+    #close-board:not([disabled]) {
       cursor: pointer;
     }
 
-    #edit-board-info:not([disabled]):hover {
+    #close-board:not([disabled]):hover {
       transition-duration: 0.1s;
       opacity: 1;
       background-color: var(--bb-neutral-300);
@@ -1455,27 +1455,15 @@ export class Main extends LitElement {
                   : nothing}
                 <button
                   @click=${() => {
-                    let graph = this.graph;
-                    if (graph && graph.graphs && this.subGraphId) {
-                      graph = graph.graphs[this.subGraphId];
-                    }
-
-                    this.boardEditOverlayInfo = {
-                      title: graph?.title ?? "No Title",
-                      version: graph?.version ?? "0.0.1",
-                      description: graph?.description ?? "No Description",
-                      published: this.subGraphId
-                        ? null
-                        : graph?.metadata?.tags?.includes("published") ?? false,
-                      isTool: graph?.metadata?.tags?.includes("tool") ?? false,
-                      subGraphId: this.subGraphId,
-                    };
+                    this.#attemptBoardStart(
+                      new BreadboardUI.Events.StartEvent(null, null)
+                    );
                   }}
                   ?disabled=${this.graph === null}
-                  id="edit-board-info"
-                  title="Edit Board Information"
+                  id="close-board"
+                  title="Close Board"
                 >
-                  Edit
+                  Close
                 </button>
               </h1>`
             : nothing}


### PR DESCRIPTION
Since we have the dedicated "Board details" pane on the right hand side of the UI we no longer really need the edit button in the tab. So this PR changes the button to close the current board and return the user back to the Welcome Pane.