### PR TITLE
[visual-editor] Clean up recent boards on delete

### DIFF
--- a/.changeset/rude-bananas-repair.md
+++ b/.changeset/rude-bananas-repair.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/visual-editor": patch
+---
+
+Clean up recent boards on delete

--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://wombat-dressing-room.appspot.com"
   },
-  "version": "1.10.5",
+  "version": "1.10.6",
   "description": "The Web runtime for Breadboard",
   "main": "./build/index.js",
   "exports": {

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -778,6 +778,7 @@ export class Main extends LitElement {
     );
 
     const { result, error } = await provider.delete(new URL(url));
+    await this.#removeRecentUrl(url);
 
     this.toast(
       "Board deleted",
@@ -794,7 +795,7 @@ export class Main extends LitElement {
     }
 
     if (isActive) {
-      this.showWelcomePanel = true;
+      this.#attemptBoardStart(new BreadboardUI.Events.StartEvent(null, null));
     }
 
     // Trigger a re-render.
@@ -945,6 +946,21 @@ export class Main extends LitElement {
 
     if (this.#recentBoards.length > 5) {
       this.#recentBoards.length = 5;
+    }
+
+    await this.#recentBoardStore.store(this.#recentBoards);
+  }
+
+  async #removeRecentUrl(url: string) {
+    url = url.replace(window.location.origin, "");
+    const count = this.#recentBoards.length;
+
+    this.#recentBoards = this.#recentBoards.filter(
+      (board) => board.url !== url
+    );
+
+    if (count === this.#recentBoards.length) {
+      return;
     }
 
     await this.#recentBoardStore.store(this.#recentBoards);


### PR DESCRIPTION
I noticed that when we delete a board we don't remove the board from the "Recent Boards" list, and the UI shows the tab _and_ the Welcome Pane.

This PR fixes both.