### PR TITLE
[visual-editor] Fix subgraph metadata/comments bug

### DIFF
--- a/.changeset/nasty-wombats-roll.md
+++ b/.changeset/nasty-wombats-roll.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/visual-editor": patch
+---
+
+Fix subgraph metadata bug

--- a/packages/visual-editor/src/ui/elements/editor/editor.ts
+++ b/packages/visual-editor/src/ui/elements/editor/editor.ts
@@ -1123,14 +1123,18 @@ export class Editor extends LitElement {
     }
 
     // Remove comments.
-    if (this.graph && this.graph.metadata) {
-      this.graph.metadata.comments ??= [];
-      this.graph.metadata.comments = this.graph.metadata.comments.filter(
+    let graph = this.graph;
+    if (this.subGraphId && this.graph?.graphs) {
+      graph = this.graph?.graphs[this.subGraphId];
+    }
+    if (graph && graph.metadata) {
+      graph.metadata.comments ??= [];
+      graph.metadata.comments = graph.metadata.comments.filter(
         (comment) => !comments.includes(comment.id)
       );
       edits.push({
         type: "changegraphmetadata",
-        metadata: this.graph.metadata,
+        metadata: graph.metadata,
       });
     }
 


### PR DESCRIPTION
Noticed that comments from the parent graph were appearing after multi-edits on subgraphs. This PR fixes that.