### PR TITLE
[schema] Add analyzeIsJsonSubSchema function

### DIFF
--- a/.changeset/few-garlics-flow.md
+++ b/.changeset/few-garlics-flow.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard-schema": patch
+---
+
+Add analyzeIsJsonSubSchema function

--- a/package-lock.json
+++ b/package-lock.json
@@ -25257,11 +25257,13 @@
       "name": "@google-labs/breadboard-schema",
       "version": "1.5.0",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
       "devDependencies": {
         "ajv": "^8.16.0",
         "ajv-formats": "^3.0.1",
-        "ts-json-schema-generator": "^2.3.0",
-        "tsx": "^4.15.8"
+        "ts-json-schema-generator": "^2.3.0"
       }
     },
     "packages/team-kit": {
@@ -25334,7 +25336,7 @@
     },
     "packages/visual-editor": {
       "name": "@google-labs/visual-editor",
-      "version": "1.10.3",
+      "version": "1.10.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@breadboard-ai/build": "0.7.0",

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -14,6 +14,7 @@
   "files": [
     "CHANGELOG.md",
     "dist/graph.{js,js.map,d.ts,d.ts.map}",
+    "dist/subschema.{js,js.map,d.ts,d.ts.map}",
     "breadboard.schema.json"
   ],
   "type": "module",
@@ -24,6 +25,12 @@
       "import": {
         "types": "./dist/graph.d.ts",
         "default": "./dist/graph.js"
+      }
+    },
+    "./subschema.js": {
+      "import": {
+        "types": "./dist/subschema.d.ts",
+        "default": "./dist/subschema.js"
       }
     }
   },
@@ -42,7 +49,7 @@
       ]
     },
     "test": {
-      "command": "find dist -name '*.test.js' | xargs node --test",
+      "command": "find dist -name '*.test.js' | xargs node --enable-source-maps --test --test-reporter spec",
       "dependencies": [
         "build"
       ],
@@ -89,7 +96,9 @@
   "devDependencies": {
     "ajv": "^8.16.0",
     "ajv-formats": "^3.0.1",
-    "ts-json-schema-generator": "^2.3.0",
-    "tsx": "^4.15.8"
+    "ts-json-schema-generator": "^2.3.0"
+  },
+  "dependencies": {
+    "@types/json-schema": "^7.0.15"
   }
 }

--- a/packages/schema/src/subschema.ts
+++ b/packages/schema/src/subschema.ts
@@ -1,0 +1,613 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { JSONSchema4, JSONSchema4TypeName } from "json-schema";
+
+export type JsonSubSchemaAnalysis =
+  | { isSubSchema: true; details?: never }
+  | { isSubSchema: false; details: JsonSubSchemaAnalysisDetail[] };
+
+export interface JsonSubSchemaAnalysisDetail {
+  pathA: Array<string | number>;
+  pathB: Array<string | number>;
+}
+
+interface Context {
+  pathA: Array<string | number>;
+  pathB: Array<string | number>;
+  details: JsonSubSchemaAnalysisDetail[];
+}
+
+const PASS_AND_SKIP_REMAINING_CHECKS = Symbol();
+const FAIL_AND_SKIP_REMAINING_CHECKS = Symbol();
+
+type Checker = (
+  a: JSONSchema4,
+  b: JSONSchema4,
+  context: Context
+) =>
+  | boolean
+  | typeof PASS_AND_SKIP_REMAINING_CHECKS
+  | typeof FAIL_AND_SKIP_REMAINING_CHECKS;
+
+const CHECKERS: Checker[] = [
+  // IMPORTANT: anyOf must come first because it can skip the other checks.
+  checkAnyOf,
+  checkType,
+  checkEnum,
+
+  // string
+  checkStringLength,
+  checkStringPattern,
+  checkStringFormat,
+
+  // number
+  checkNumberRange,
+
+  // array
+  checkArrayItems,
+
+  // object
+  checkObjectProperties,
+  checkObjectAdditionalProperties,
+  checkObjectRequiredProperties,
+];
+
+/**
+ * {@link https://json-schema.org/understanding-json-schema/reference/type}
+ */
+const ALL_TYPES = new Set<JSONSchema4TypeName>([
+  "string",
+  "number",
+  "integer",
+  "object",
+  "array",
+  "boolean",
+  "null",
+]);
+
+const ALL_TYPES_SCHEMA = { type: [...ALL_TYPES] };
+
+/**
+ * Given the JSON Schemas `a` and `b`, determine whether `a` is a sub-schema of
+ * `b`, and if not explain why.
+ *
+ * We say that `a` is a sub-schema of `b` if every JSON Schema constraint in `b`
+ * is also present in `a` at an equal or higher strictness. Examples:
+ *
+ * - If `b` enforces type `string OR number`, then `a` must enforce either
+ *   `string`, `number`, or `string OR number`.
+ * - If `b` enforces `maxLength` 4, then `a` must enforce `maxLength <= 4` .
+ *
+ * Note that the following JSON Schema features are NOT yet implemented by this
+ * function:
+ *
+ *   - ~~$ref~~
+ *   - ~~allOf / oneOf / not~~
+ *   - ~~const~~
+ *   - ~~contains~~
+ *   - ~~contentEncoding / contentMediaType~~
+ *   - ~~dependentRequired / dependentSchemas / dependencies~~
+ *   - ~~exclusiveMinimum / exclusiveMaximum~~
+ *   - ~~if / then / else~~
+ *   - ~~minContains / maxContains~~
+ *   - ~~minItems / maxItems~~
+ *   - ~~minProperties / maxProperties~~
+ *   - ~~multipleOf~~
+ *   - ~~prefixItems / uniqueItems / unevaluatedItems~~
+ *   - ~~propertyNames / patternProperties / unevaluatedProperties~~
+ *   - ~~tuple~~
+ *
+ * @param a The JSON Schema that is potentially a subset of `b`.
+ * @param b The JSON Schema that is potentially a superset of `a`.
+ *
+ * @returns A {@link JsonSubSchemaAnalysis} object. Use the
+ * {@link JsonSubSchemaAnalysis.isSubSchema} property to check whether `a` is a
+ * subschema of `b`. When {@link JsonSubSchemaAnalysis.isSubSchema} is `false`,
+ * use the {@link JsonSubSchemaAnalysis.details} property to get a detailed
+ * explanation of why `a` is not a subschema of `b`.
+ */
+export function analyzeIsJsonSubSchema(
+  // TODO(aomarks) Should we be using something newer like JSONSchema7? Maybe we
+  // accept multiple versions?
+  a: JSONSchema4,
+  b: JSONSchema4,
+  context: Context = { pathA: [], pathB: [], details: [] }
+): JsonSubSchemaAnalysis {
+  let anyChecksFailed = false;
+  for (const checker of CHECKERS) {
+    const result = checker(a, b, context);
+    if (result === true) {
+      // N/A
+    } else if (result === false) {
+      anyChecksFailed = true;
+      // Continue because we want to accumulate multiple errors.
+    } else if (result === PASS_AND_SKIP_REMAINING_CHECKS) {
+      break;
+    } else if (result === FAIL_AND_SKIP_REMAINING_CHECKS) {
+      anyChecksFailed = true;
+      break;
+    } else {
+      result satisfies never;
+    }
+  }
+  if (anyChecksFailed) {
+    return { isSubSchema: false, details: context.details };
+  }
+  return { isSubSchema: true };
+}
+
+/**
+ * {@link https://json-schema.org/understanding-json-schema/reference/type}
+ */
+function checkType(a: JSONSchema4, b: JSONSchema4, context: Context): boolean {
+  if (a.type === b.type) {
+    // Fast path to avoid Set allocations for very common simple case of e.g.
+    // `{type: "string"} vs `{type: "number"}.
+    return true;
+  }
+  const aTypes = normalizedTypes(a);
+  const bTypes = normalizedTypes(b);
+  if (aTypes.has("integer") && bTypes.has("number")) {
+    // All integers are numbers, but not all numbers are integers. So, here is
+    // special handling to allow the case where A is an integer and B is a
+    // number (but not vice-versa).
+    aTypes.delete("integer");
+    aTypes.add("number");
+  }
+  if (!isSubsetOf(aTypes, bTypes)) {
+    context.details.push({
+      pathA: [...context.pathA, "type"],
+      pathB: [...context.pathB, "type"],
+    });
+    return false;
+  }
+  return true;
+}
+
+function normalizedTypes(schema: JSONSchema4): Set<JSONSchema4TypeName> {
+  if (schema.type === undefined) {
+    // No type means all types.
+    return ALL_TYPES;
+  }
+  return coerceSet(schema.type);
+}
+
+/**
+ * {@link https://json-schema.org/understanding-json-schema/reference/enum}
+ */
+function checkEnum(a: JSONSchema4, b: JSONSchema4, context: Context): boolean {
+  if (b.enum === undefined) {
+    return true;
+  }
+  if (
+    a.enum === undefined ||
+    (a.enum.length === 0 && b.enum.length > 0) ||
+    !isSubsetOf(coerceSet(a.enum), coerceSet(b.enum))
+  ) {
+    context.details.push({
+      pathA: [...context.pathA, "enum"],
+      pathB: [...context.pathB, "enum"],
+    });
+    return false;
+  }
+  return true;
+}
+
+/**
+ * {@link https://json-schema.org/understanding-json-schema/reference/string#length}
+ */
+function checkStringLength(
+  a: JSONSchema4,
+  b: JSONSchema4,
+  context: Context
+): boolean {
+  if (b.minLength === undefined && b.maxLength === undefined) {
+    return true;
+  }
+
+  let ok = true;
+
+  const aMin = a.minLength ?? 0;
+  const bMin = b.minLength ?? 0;
+  if (aMin < bMin) {
+    ok = false;
+    context.details.push({
+      pathA: [...context.pathA, "minLength"],
+      pathB: [...context.pathB, "minLength"],
+    });
+  }
+
+  const aMax = a.maxLength ?? Number.MAX_VALUE;
+  const bMax = b.maxLength ?? Number.MAX_VALUE;
+  if (aMax > bMax) {
+    ok = false;
+    context.details.push({
+      pathA: [...context.pathA, "maxLength"],
+      pathB: [...context.pathB, "maxLength"],
+    });
+  }
+
+  return ok;
+}
+
+/**
+ * {@link https://json-schema.org/understanding-json-schema/reference/string#regexp}
+ */
+function checkStringPattern(
+  a: JSONSchema4,
+  b: JSONSchema4,
+  context: Context
+): boolean {
+  if (b.pattern === undefined) {
+    return true;
+  }
+  if (a.pattern !== b.pattern) {
+    context.details.push({
+      pathA: [...context.pathA, "pattern"],
+      pathB: [...context.pathB, "pattern"],
+    });
+    return false;
+  }
+  return true;
+}
+
+/**
+ * {@link https://json-schema.org/understanding-json-schema/reference/string#format}
+ */
+function checkStringFormat(
+  a: JSONSchema4,
+  b: JSONSchema4,
+  context: Context
+): boolean {
+  if (b.format === undefined) {
+    return true;
+  }
+  if (a.format !== b.format) {
+    context.details.push({
+      pathA: [...context.pathA, "format"],
+      pathB: [...context.pathB, "format"],
+    });
+    return false;
+  }
+  return true;
+}
+
+/**
+ * {@link https://json-schema.org/understanding-json-schema/reference/numeric#range}
+ */
+function checkNumberRange(
+  a: JSONSchema4,
+  b: JSONSchema4,
+  context: Context
+): boolean {
+  if (b.minimum === undefined && b.maximum === undefined) {
+    return true;
+  }
+
+  const aMin = a.minimum ?? 0;
+  const bMin = b.minimum ?? 0;
+  if (aMin < bMin) {
+    context.details.push({
+      pathA: [...context.pathA, "minimum"],
+      pathB: [...context.pathB, "minimum"],
+    });
+    return false;
+  }
+  const aMax = a.maximum ?? Number.MAX_VALUE;
+  const bMax = b.maximum ?? Number.MAX_VALUE;
+  if (aMax > bMax) {
+    context.details.push({
+      pathA: [...context.pathA, "maximum"],
+      pathB: [...context.pathB, "maximum"],
+    });
+    return false;
+  }
+  return true;
+}
+
+/**
+ * {@link https://json-schema.org/understanding-json-schema/reference/array#items}
+ */
+function checkArrayItems(
+  a: JSONSchema4,
+  b: JSONSchema4,
+  context: Context
+): boolean {
+  if (b.items === undefined) {
+    return true;
+  }
+  if (Array.isArray(a.items) || Array.isArray(b.items)) {
+    // TODO(aomarks) Implement tuple support.
+    return true;
+  }
+  // TODO(aomarks) Recurse in a way that won't lose context (once context is
+  // actually used for anything).
+  context.pathA.push("items");
+  context.pathB.push("items");
+  const ok = analyzeIsJsonSubSchema(
+    a.items ?? ALL_TYPES_SCHEMA,
+    b.items,
+    context
+  ).isSubSchema;
+  context.pathA.pop();
+  context.pathB.pop();
+  return ok;
+}
+
+/**
+ * {@link https://json-schema.org/understanding-json-schema/reference/object#properties}
+ */
+function checkObjectProperties(
+  a: JSONSchema4,
+  b: JSONSchema4,
+  context: Context
+): boolean {
+  if (a.properties === undefined || b.properties === undefined) {
+    return true;
+  }
+  for (const [name, bProperty] of Object.entries(b.properties)) {
+    const aProperty = a.properties[name];
+    if (aProperty === undefined) {
+      continue;
+    }
+    context.pathA.push("properties", name);
+    context.pathB.push("properties", name);
+    const ok = analyzeIsJsonSubSchema(
+      aProperty,
+      bProperty,
+      context
+    ).isSubSchema;
+    context.pathA.pop();
+    context.pathA.pop();
+    context.pathB.pop();
+    context.pathB.pop();
+    if (!ok) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * {@link https://json-schema.org/understanding-json-schema/reference/object#additionalproperties}
+ */
+function checkObjectAdditionalProperties(
+  a: JSONSchema4,
+  b: JSONSchema4,
+  context: Context
+): boolean {
+  if (b.additionalProperties ?? true) {
+    return true;
+  }
+  if (a.additionalProperties ?? true) {
+    context.details.push({
+      pathA: [...context.pathA, "additionalProperties"],
+      pathB: [...context.pathB, "additionalProperties"],
+    });
+    return false;
+  }
+  const aPropertyNames = new Set(Object.keys(a.properties ?? {}));
+  const bPropertyNames = new Set(Object.keys(b.properties ?? {}));
+  let ok = true;
+  for (const name of aPropertyNames) {
+    if (!bPropertyNames.has(name)) {
+      ok = false;
+      context.details.push({
+        pathA: [...context.pathA, "properties", name],
+        pathB: [...context.pathB, "additionalProperties"],
+      });
+    }
+  }
+  return ok;
+}
+
+/**
+ * {@link https://json-schema.org/understanding-json-schema/reference/object#required}
+ */
+function checkObjectRequiredProperties(
+  a: JSONSchema4,
+  b: JSONSchema4,
+  context: Context
+): boolean {
+  if (typeof a.required === "boolean" || typeof b.required === "boolean") {
+    // TODO(aomarks) Validate that required can't actually be a boolean. The
+    // `json-schema` types package say that it can be, but the docs don't
+    // mention this, so it doesn't seem right.
+    return true;
+  }
+  if (b.required === undefined || b.required.length === 0) {
+    return true;
+  }
+  const aRequired = new Set(a.required ?? []);
+  let ok = true;
+  for (let i = 0; i < b.required.length; i++) {
+    const name = b.required[i];
+    if (!aRequired.has(name)) {
+      ok = false;
+      context.details.push({
+        pathA: [...context.pathA, "required"],
+        pathB: [...context.pathB, "required", i],
+      });
+    }
+  }
+  return ok;
+}
+
+/**
+ * {@link https://json-schema.org/understanding-json-schema/reference/combining#anyOf}
+ */
+function checkAnyOf(
+  a: JSONSchema4,
+  b: JSONSchema4,
+  context: Context
+):
+  | boolean
+  | typeof PASS_AND_SKIP_REMAINING_CHECKS
+  | typeof FAIL_AND_SKIP_REMAINING_CHECKS {
+  if (a.anyOf !== undefined) {
+    // ALL possibilities from A must satisfy B.
+    for (let idxA = 0; idxA < a.anyOf.length; idxA++) {
+      const originalSubA = a.anyOf[idxA];
+      const modifiedSubA = inheritParentConstraintsIntoAnyOfEntry(
+        a,
+        originalSubA
+      );
+      if (b.anyOf === undefined) {
+        // B is NOT an `anyOf`, so check each A directly against B.
+        //
+        // We need to be a bit clever here, because we ARE passing down the
+        // context, but we're doing so with "fake" paths (see
+        // `inheritParentConstraintsIntoAnyOfEntry`). So we do this:
+        //
+        // 1. Make a temporary context so that we can easily isolate the details
+        //    from this recursion from any other details we might already have.
+        // 2. Undo the effect of `inheritParentConstraintsIntoAnyOfEntry` using
+        //    `repairDetailPathsForInheritedProperties`.
+        // 3. Merge back in the details we temporarily excluded in (1).
+        const tempDetails: JsonSubSchemaAnalysisDetail[] = [];
+        const tempContext = { ...context, details: tempDetails };
+        context.pathA.push("anyOf", idxA);
+        const ok = analyzeIsJsonSubSchema(
+          modifiedSubA,
+          b,
+          tempContext
+        ).isSubSchema;
+        context.pathA.pop();
+        context.pathA.pop();
+        if (!ok) {
+          context.details.push(
+            ...repairDetailPathsForInheritedProperties(
+              tempDetails,
+              idxA,
+              originalSubA
+            )
+          );
+          return FAIL_AND_SKIP_REMAINING_CHECKS;
+        }
+      } else {
+        // B is also an `anyOf`, so check that ALL possibilities from A
+        // satisfies AT LEAST ONE posibility from B.
+        //
+        // PERFORMANCE WARNING: O(n^2) comparisons!
+        let found = false;
+        for (const subB of b.anyOf) {
+          if (
+            analyzeIsJsonSubSchema(
+              modifiedSubA,
+              inheritParentConstraintsIntoAnyOfEntry(b, subB)
+              // Note we do NOT pass down context here because we don't want to
+              // accumulate details, because we're _searching_ for a match, not
+              // asserting a match.
+            ).isSubSchema
+          ) {
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          context.details.push({
+            pathA: [...context.pathA, "anyOf", idxA],
+            pathB: [...context.pathB, "anyOf"],
+          });
+          return FAIL_AND_SKIP_REMAINING_CHECKS;
+        }
+      }
+    }
+    return PASS_AND_SKIP_REMAINING_CHECKS;
+  } else if (b.anyOf !== undefined) {
+    // Only B is an `anyOf`. Ensure that A satisfies AT LEAST ONE possibility
+    // from B.
+    for (const subB of b.anyOf) {
+      if (
+        analyzeIsJsonSubSchema(
+          a,
+          inheritParentConstraintsIntoAnyOfEntry(b, subB)
+          // Note we do NOT pass down context here because we don't want to
+          // accumulate details, because we're _searching_ for a match, not
+          // asserting a match.
+        ).isSubSchema
+      ) {
+        return PASS_AND_SKIP_REMAINING_CHECKS;
+      }
+    }
+    context.details.push({
+      pathA: [...context.pathA],
+      pathB: [...context.pathB, "anyOf"],
+    });
+    return FAIL_AND_SKIP_REMAINING_CHECKS;
+  } else {
+    return true;
+  }
+}
+
+/**
+ * If you have e.g. `{ maxLength: 4, anyOf: { A, B } }` then the `maxLength`
+ * constraint implicitly applies to both `A` and `B`. This function copies any
+ * such constraints from a parent JSON schema object into one of its given
+ * `anyOf` entries so that it can more easily be analyzed.
+ *
+ * See
+ * {@link https://json-schema.org/understanding-json-schema/reference/combining#factoringschemas}.
+ */
+function inheritParentConstraintsIntoAnyOfEntry(
+  parentSchema: JSONSchema4,
+  anyOfEntry: JSONSchema4
+): JSONSchema4 {
+  if (Object.keys(parentSchema).length === 1) {
+    // We assume `parent` has `anyOf`, so if there's only 1 property then it
+    // must be `anyOf`, which we can ignore and save a copy.
+    return anyOfEntry;
+  }
+  return { ...parentSchema, anyOf: undefined, ...anyOfEntry };
+}
+
+function repairDetailPathsForInheritedProperties(
+  details: JsonSubSchemaAnalysisDetail[],
+  idxA: number,
+  anyOfEntry: JSONSchema4
+): JsonSubSchemaAnalysisDetail[] {
+  return details.map((detail) => {
+    const { pathA, pathB } = detail;
+    // If we see a path that's within the anyOf entry, but it's a property that
+    // doesn't exist on the original anyOf entry, then it must have been
+    // inherited, so we should trim off the first 2 path components because
+    // really they came from the parent.
+    if (
+      pathA[0] === "anyOf" &&
+      pathA[1] === idxA &&
+      anyOfEntry[pathA[2]] === undefined
+    ) {
+      return {
+        pathA: pathA.slice(2),
+        pathB,
+      };
+    } else {
+      return detail;
+    }
+  });
+}
+
+function coerceSet<T>(value: T | T[] | undefined): Set<T> {
+  return new Set(
+    value === undefined ? [] : Array.isArray(value) ? value : [value]
+  );
+}
+
+// Replace with
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/isSubsetOf
+// when Node 22 is our minimum version.
+function isSubsetOf(a: Set<unknown>, b: Set<unknown>): boolean {
+  if (a.size > b.size) {
+    return false;
+  }
+  for (const item of a) {
+    if (!b.has(item)) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/packages/schema/src/tests/subschema.test.ts
+++ b/packages/schema/src/tests/subschema.test.ts
@@ -1,0 +1,966 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { type JSONSchema4 } from "json-schema";
+import * as assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import {
+  analyzeIsJsonSubSchema,
+  type JsonSubSchemaAnalysisDetail,
+} from "../subschema.js";
+
+function ok(testName: string, a: JSONSchema4, b: JSONSchema4) {
+  test(testName, () => {
+    assert.equal(analyzeIsJsonSubSchema(a, b).isSubSchema, true);
+  });
+}
+
+function notOk(testName: string, a: JSONSchema4, b: JSONSchema4) {
+  test(testName, () => {
+    assert.equal(analyzeIsJsonSubSchema(a, b).isSubSchema, false);
+  });
+}
+
+function detail(
+  testName: string,
+  a: JSONSchema4,
+  b: JSONSchema4,
+  expectedDetails: JsonSubSchemaAnalysisDetail[] | undefined
+) {
+  test(testName, () => {
+    assert.deepEqual(analyzeIsJsonSubSchema(a, b).details, expectedDetails);
+  });
+}
+
+const EXHAUSTIVE_SCHEMA: JSONSchema4 = {
+  type: ["string", "number", "integer", "object", "array", "boolean", "null"],
+};
+
+describe("type", () => {
+  ok("string vs string", { type: "string" }, { type: "string" });
+  ok("string vs [string]", { type: "string" }, { type: ["string"] });
+  ok(
+    "string vs [number, string]",
+    { type: "string" },
+    { type: ["number", "string"] }
+  );
+  ok("string vs missing", { type: "string" }, {});
+  ok("missing vs missing", {}, {});
+  ok("exhaustive vs exhaustive", EXHAUSTIVE_SCHEMA, EXHAUSTIVE_SCHEMA);
+  ok("exhaustive vs missing", EXHAUSTIVE_SCHEMA, {});
+  ok(
+    "missing vs exhaustive",
+    {},
+    {
+      type: [
+        "string",
+        "number",
+        "integer",
+        "object",
+        "array",
+        "boolean",
+        "null",
+      ],
+    }
+  );
+
+  notOk("string vs number", { type: "string" }, { type: "number" });
+  notOk("number vs string", { type: "number" }, { type: "string" });
+  notOk("string vs [number]", { type: "string" }, { type: ["number"] });
+  notOk("[string] vs number", { type: ["string"] }, { type: "number" });
+  notOk(
+    "[number, string] vs string",
+    { type: ["number", "string"] },
+    { type: "string" }
+  );
+  notOk("missing vs string", {}, { type: "string" });
+  notOk("object vs array", { type: "object" }, { type: "array" });
+
+  // Note type=number vs type=integer is an interesting case, but that's tested
+  // in the "number" suite later.
+});
+
+describe("string", () => {
+  describe("length", () => {
+    ok(
+      "equal",
+      { type: "string", minLength: 3, maxLength: 6 },
+      { type: "string", minLength: 3, maxLength: 6 }
+    );
+    ok(
+      "inside left",
+      { type: "string", minLength: 4, maxLength: 6 },
+      { type: "string", minLength: 3, maxLength: 6 }
+    );
+    ok(
+      "inside right",
+      { type: "string", minLength: 3, maxLength: 5 },
+      { type: "string", minLength: 3, maxLength: 6 }
+    );
+    ok(
+      "inside both",
+      { type: "string", minLength: 4, maxLength: 5 },
+      { type: "string", minLength: 3, maxLength: 6 }
+    );
+
+    notOk(
+      "outside left",
+      { type: "string", minLength: 2, maxLength: 6 },
+      { type: "string", minLength: 3, maxLength: 6 }
+    );
+    notOk(
+      "outside right",
+      { type: "string", minLength: 3, maxLength: 7 },
+      { type: "string", minLength: 3, maxLength: 6 }
+    );
+    notOk(
+      "outside both",
+      { type: "string", minLength: 2, maxLength: 7 },
+      { type: "string", minLength: 3, maxLength: 6 }
+    );
+
+    ok("both missing", { type: "string" }, { type: "string" });
+    ok(
+      "b missing",
+      { type: "string", minLength: 2, maxLength: 7 },
+      { type: "string" }
+    );
+    notOk(
+      "a missing",
+      { type: "string" },
+      { type: "string", minLength: 2, maxLength: 7 }
+    );
+  });
+
+  describe("pattern", () => {
+    ok(
+      "equal",
+      { type: "string", pattern: "[0-9]+" },
+      { type: "string", pattern: "[0-9]+" }
+    );
+    notOk(
+      "not equal",
+      { type: "string", pattern: "[0-9]+" },
+      { type: "string", pattern: "[a-z]+" }
+    );
+
+    ok("both missing", { type: "string" }, { type: "string" });
+    ok("b missing", { type: "string", pattern: "[0-9]+" }, { type: "string" });
+    notOk(
+      "a missing",
+      { type: "string" },
+      { type: "string", pattern: "[a-z]+" }
+    );
+  });
+
+  describe("format", () => {
+    ok(
+      "equal",
+      { type: "string", format: "uri" },
+      { type: "string", format: "uri" }
+    );
+    notOk(
+      "not equal",
+      { type: "string", format: "uri" },
+      { type: "string", format: "email" }
+    );
+
+    ok("both missing", { type: "string" }, { type: "string" });
+    ok("b missing", { type: "string", format: "uri" }, { type: "string" });
+    notOk("a missing", { type: "string" }, { type: "string", format: "email" });
+  });
+});
+
+describe("number", () => {
+  describe("number/integer", () => {
+    ok("number vs number", { type: "number" }, { type: "number" });
+    ok("integer vs number", { type: "integer" }, { type: "number" });
+    notOk("number vs integer", { type: "number" }, { type: "integer" });
+  });
+
+  describe("inclusive range", () => {
+    ok(
+      "equal",
+      { type: "number", minimum: 3, maximum: 6 },
+      { type: "number", minimum: 3, maximum: 6 }
+    );
+    ok(
+      "inside left",
+      { type: "number", minimum: 4, maximum: 6 },
+      { type: "number", minimum: 3, maximum: 6 }
+    );
+    ok(
+      "inside right",
+      { type: "number", minimum: 3, maximum: 5 },
+      { type: "number", minimum: 3, maximum: 6 }
+    );
+    ok(
+      "inside both",
+      { type: "number", minimum: 4, maximum: 5 },
+      { type: "number", minimum: 3, maximum: 6 }
+    );
+    notOk(
+      "outside left",
+      { type: "number", minimum: 2, maximum: 6 },
+      { type: "number", minimum: 3, maximum: 6 }
+    );
+    notOk(
+      "outside right",
+      { type: "number", minimum: 3, maximum: 7 },
+      { type: "number", minimum: 3, maximum: 6 }
+    );
+    notOk(
+      "outside both",
+      { type: "number", minimum: 2, maximum: 7 },
+      { type: "number", minimum: 3, maximum: 6 }
+    );
+    ok("both missing", { type: "number" }, { type: "number" });
+    ok(
+      "b missing",
+      { type: "number", minimum: 2, maximum: 7 },
+      { type: "number" }
+    );
+    notOk(
+      "a missing",
+      { type: "number" },
+      { type: "number", minimum: 2, maximum: 7 }
+    );
+  });
+
+  describe("exclusive range", () => {
+    // TODO(aomarks) Implement this.
+  });
+
+  describe("multipleOf", () => {
+    // TODO(aomarks) Implement this.
+  });
+});
+
+describe("array", () => {
+  describe("items.type", () => {
+    ok(
+      "string vs string",
+      { type: "array", items: { type: "string" } },
+      { type: "array", items: { type: "string" } }
+    );
+    notOk(
+      "string vs number",
+      { type: "array", items: { type: "string" } },
+      { type: "array", items: { type: "number" } }
+    );
+    notOk(
+      "number vs string",
+      { type: "array", items: { type: "number" } },
+      { type: "array", items: { type: "string" } }
+    );
+
+    ok(
+      "string[] vs string[]",
+      { type: "array", items: { type: "array", items: { type: "string" } } },
+      { type: "array", items: { type: "array", items: { type: "string" } } }
+    );
+    ok(
+      "string[][] vs string[][]",
+      {
+        type: "array",
+        items: {
+          type: "array",
+          items: { type: "array", items: { type: "string" } },
+        },
+      },
+      {
+        type: "array",
+        items: {
+          type: "array",
+          items: { type: "array", items: { type: "string" } },
+        },
+      }
+    );
+    notOk(
+      "string[] vs number[]",
+      { type: "array", items: { type: "array", items: { type: "string" } } },
+      { type: "array", items: { type: "array", items: { type: "number" } } }
+    );
+    notOk(
+      "number[] vs string[]",
+      { type: "array", items: { type: "array", items: { type: "number" } } },
+      { type: "array", items: { type: "array", items: { type: "string" } } }
+    );
+    notOk(
+      "string[] vs string[][]",
+      { type: "array", items: { type: "array", items: { type: "string" } } },
+      {
+        type: "array",
+        items: {
+          type: "array",
+          items: { type: "array", items: { type: "string" } },
+        },
+      }
+    );
+    notOk(
+      "string[4] vs string[3]",
+      {
+        type: "array",
+        items: { type: "array", items: { type: "string", maxLength: 4 } },
+      },
+      {
+        type: "array",
+        items: { type: "array", items: { type: "string", maxLength: 3 } },
+      }
+    );
+
+    ok("missing vs missing", { type: "array" }, { type: "array" });
+    ok(
+      "string vs missing",
+      { type: "array", items: { type: "string" } },
+      { type: "array" }
+    );
+
+    ok(
+      "string vs any",
+      { type: "array", items: { type: "string" } },
+      {
+        type: "array",
+        items: {
+          type: [
+            "string",
+            "number",
+            "integer",
+            "object",
+            "array",
+            "boolean",
+            "null",
+          ],
+        },
+      }
+    );
+    ok(
+      "missing vs exhaustive",
+      { type: "array" },
+      {
+        type: "array",
+        items: EXHAUSTIVE_SCHEMA,
+      }
+    );
+    ok(
+      "exhaustive vs missing",
+      {
+        type: "array",
+        items: EXHAUSTIVE_SCHEMA,
+      },
+      { type: "array" }
+    );
+    notOk(
+      "missing vs string",
+      { type: "array" },
+      { type: "array", items: { type: "number" } }
+    );
+  });
+});
+
+describe("object", () => {
+  describe("properties", () => {
+    ok(
+      "string vs string",
+      { type: "object", properties: { foo: { type: "string" } } },
+      { type: "object", properties: { foo: { type: "string" } } }
+    );
+    notOk(
+      "string vs number",
+      { type: "object", properties: { foo: { type: "string" } } },
+      { type: "object", properties: { foo: { type: "number" } } }
+    );
+    notOk(
+      "number vs string",
+      { type: "object", properties: { foo: { type: "number" } } },
+      { type: "object", properties: { foo: { type: "string" } } }
+    );
+
+    ok(
+      "string<3> vs string<4>",
+      { type: "object", properties: { foo: { type: "string", maxLength: 3 } } },
+      { type: "object", properties: { foo: { type: "string", maxLength: 4 } } }
+    );
+    notOk(
+      "string<4> vs string<3>",
+      { type: "object", properties: { foo: { type: "string", maxLength: 4 } } },
+      { type: "object", properties: { foo: { type: "string", maxLength: 3 } } }
+    );
+
+    ok(
+      "string vs missing",
+      { type: "object", properties: { foo: { type: "string" } } },
+      { type: "object" }
+    );
+    ok(
+      "missing vs string",
+      { type: "object" },
+      { type: "object", properties: { foo: { type: "string" } } }
+    );
+  });
+
+  describe("additionalProperties", () => {
+    describe("no properties", () => {
+      ok(
+        "false vs false",
+        { type: "object", additionalProperties: false },
+        { type: "object", additionalProperties: false }
+      );
+      ok(
+        "true vs true",
+        { type: "object", additionalProperties: true },
+        { type: "object", additionalProperties: true }
+      );
+      ok(
+        "false vs true",
+        { type: "object", additionalProperties: false },
+        { type: "object", additionalProperties: true }
+      );
+      notOk(
+        "true vs false",
+        { type: "object", additionalProperties: true },
+        { type: "object", additionalProperties: false }
+      );
+    });
+
+    describe("both false", () => {
+      ok(
+        "{} vs {}",
+        {
+          type: "object",
+          additionalProperties: false,
+        },
+        {
+          type: "object",
+          additionalProperties: false,
+        }
+      );
+
+      notOk(
+        "{foo} vs {}",
+        {
+          type: "object",
+          additionalProperties: false,
+          properties: { foo: { type: "string" } },
+        },
+        {
+          type: "object",
+          additionalProperties: false,
+        }
+      );
+
+      ok(
+        "{} vs {foo}",
+        {
+          type: "object",
+          additionalProperties: false,
+        },
+        {
+          type: "object",
+          additionalProperties: false,
+          properties: { foo: { type: "string" } },
+        }
+      );
+
+      ok(
+        "{foo} vs {foo}",
+        {
+          type: "object",
+          additionalProperties: false,
+          properties: { foo: { type: "string" } },
+        },
+        {
+          type: "object",
+          additionalProperties: false,
+          properties: { foo: { type: "string" } },
+        }
+      );
+
+      notOk(
+        "{foo} vs {bar}",
+        {
+          type: "object",
+          additionalProperties: false,
+          properties: { foo: { type: "string" } },
+        },
+        {
+          type: "object",
+          additionalProperties: false,
+          properties: { bar: { type: "string" } },
+        }
+      );
+
+      notOk(
+        "{foo,bar} vs {foo}",
+        {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            foo: { type: "string" },
+            bar: { type: "string" },
+          },
+        },
+        {
+          type: "object",
+          additionalProperties: false,
+          properties: { foo: { type: "string" } },
+        }
+      );
+
+      ok(
+        "{foo} vs {foo,bar}",
+        {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            foo: { type: "string" },
+          },
+        },
+        {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            foo: { type: "string" },
+            bar: { type: "string" },
+          },
+        }
+      );
+    });
+  });
+
+  describe("requiredProperties", () => {
+    ok(
+      "{} vs {}",
+      { type: "object", required: [] },
+      { type: "object", required: [] }
+    );
+    ok(
+      "{foo} vs {foo}",
+      { type: "object", required: ["foo"] },
+      { type: "object", required: ["foo"] }
+    );
+    ok(
+      "{foo} vs {}",
+      { type: "object", required: ["foo"] },
+      { type: "object", required: [] }
+    );
+    ok(
+      "{foo,bar} vs {foo}",
+      { type: "object", required: ["foo", "bar"] },
+      { type: "object", required: ["bar"] }
+    );
+    notOk(
+      "{} vs {foo}",
+      { type: "object", required: [] },
+      { type: "object", required: ["foo"] }
+    );
+    notOk(
+      "{foo} vs {bar}",
+      { type: "object", required: ["foo"] },
+      { type: "object", required: ["bar"] }
+    );
+    notOk(
+      "{foo} vs {foo,bar}",
+      { type: "object", required: ["foo"] },
+      { type: "object", required: ["foo", "bar"] }
+    );
+  });
+});
+
+describe("enum", () => {
+  ok("[foo] vs [foo]", { enum: ["foo"] }, { enum: ["foo"] });
+  ok("[42] vs [42]", { enum: [42] }, { enum: [42] });
+  ok("[foo] vs [foo, 42]", { enum: ["foo"] }, { enum: ["foo", 42] });
+  ok("[] vs []", { enum: [] }, { enum: [] });
+  ok("[foo] vs missing", { enum: ["foo"] }, {});
+
+  notOk("[foo, 42] vs [42]", { enum: ["foo", 42] }, { enum: [42] });
+  notOk("[foo] vs [42]", { enum: ["foo"] }, { enum: [42] });
+  notOk("[foo] vs []", { enum: ["foo"] }, { enum: [] });
+  notOk("[] vs [foo]", { enum: [] }, { enum: ["foo"] });
+  notOk("missing vs [foo]", {}, { enum: ["foo"] });
+  notOk("['42'] vs [42]", { enum: ["42"] }, { enum: [42] });
+});
+
+describe("anyOf", () => {
+  describe("with / with", () => {
+    ok(
+      "[str, num, bool] vs [str, num, bool]",
+      { anyOf: [{ type: "string" }, { type: "number" }, { type: "boolean" }] },
+      { anyOf: [{ type: "string" }, { type: "number" }, { type: "boolean" }] }
+    );
+    ok(
+      "[str, num, bool] vs [bool, str, num]",
+      { anyOf: [{ type: "string" }, { type: "number" }, { type: "boolean" }] },
+      { anyOf: [{ type: "boolean" }, { type: "string" }, { type: "number" }] }
+    );
+    ok(
+      "[str, num] vs [str, num, bool]",
+      { anyOf: [{ type: "string" }, { type: "number" }] },
+      { anyOf: [{ type: "string" }, { type: "number" }, { type: "boolean" }] }
+    );
+    ok(
+      "[str:email, str:uri]:3 vs [str:email, str:uri]:4",
+      {
+        maxLength: 3,
+        anyOf: [
+          { type: "string", format: "email" },
+          { type: "string", format: "uri" },
+        ],
+      },
+      {
+        maxLength: 4,
+        anyOf: [
+          { type: "string", format: "email" },
+          { type: "string", format: "uri" },
+        ],
+      }
+    );
+    ok(
+      "[str:email:3, str:uri:3] vs [str:email, str:uri]:4",
+      {
+        anyOf: [
+          { type: "string", format: "email", maxLength: 3 },
+          { type: "string", format: "uri", maxLength: 3 },
+        ],
+      },
+      {
+        maxLength: 4,
+        anyOf: [
+          { type: "string", format: "email" },
+          { type: "string", format: "uri" },
+        ],
+      }
+    );
+    ok(
+      "[] vs [str, num]",
+      { anyOf: [] },
+      { anyOf: [{ type: "string" }, { type: "number" }] }
+    );
+    ok(
+      "anyOf[str, num] vs type[str, num]",
+      {
+        anyOf: [{ type: "string" }, { type: "number" }],
+      },
+      {
+        type: ["string", "number"],
+      }
+    );
+
+    notOk(
+      "[str, num, bool] vs [str, num]",
+      { anyOf: [{ type: "string" }, { type: "number" }, { type: "boolean" }] },
+      { anyOf: [{ type: "string" }, { type: "number" }] }
+    );
+    notOk(
+      "[str:email, str:uri]:4 vs [str:email, str:uri]:3",
+      {
+        maxLength: 4,
+        anyOf: [
+          { type: "string", format: "email" },
+          { type: "string", format: "uri" },
+        ],
+      },
+      {
+        maxLength: 3,
+        anyOf: [
+          { type: "string", format: "email" },
+          { type: "string", format: "uri" },
+        ],
+      }
+    );
+    notOk(
+      "[str, num] vs []",
+      { anyOf: [{ type: "string" }, { type: "number" }] },
+      { anyOf: [] }
+    );
+    notOk(
+      "anyOf[str, bool] vs type[str, num]",
+      {
+        anyOf: [{ type: "string" }, { type: "boolean" }],
+      },
+      {
+        type: ["string", "number"],
+      }
+    );
+  });
+
+  describe("with / without", () => {
+    ok(
+      "[str:email, str:uri] vs str",
+      {
+        anyOf: [
+          { type: "string", format: "email" },
+          { type: "string", format: "uri" },
+        ],
+      },
+      { type: "string" }
+    );
+    ok(
+      "[str, num] vs empty",
+      { anyOf: [{ type: "string" }, { type: "number" }] },
+      {}
+    );
+    ok(
+      "[str:email, str:uri]:3 vs str:4",
+      {
+        maxLength: 3,
+        anyOf: [
+          { type: "string", format: "email" },
+          { type: "string", format: "uri" },
+        ],
+      },
+      { type: "string", maxLength: 4 }
+    );
+    notOk(
+      "[str, num] vs bool",
+      { anyOf: [{ type: "string" }, { type: "number" }] },
+      { type: "boolean" }
+    );
+    notOk(
+      "[str, num] vs str",
+      { anyOf: [{ type: "string" }, { type: "number" }] },
+      { type: "string" }
+    );
+    notOk(
+      "[str:email, str:uri] vs str:date",
+      {
+        anyOf: [
+          { type: "string", format: "email" },
+          { type: "string", format: "uri" },
+        ],
+      },
+      { type: "string", format: "date" }
+    );
+    notOk(
+      "[str:email, str:uri]:4 vs str:3",
+      {
+        maxLength: 4,
+        anyOf: [
+          { type: "string", format: "email" },
+          { type: "string", format: "uri" },
+        ],
+      },
+      { type: "string", maxLength: 3 }
+    );
+  });
+
+  describe("without / with", () => {
+    ok(
+      "str vs [str, num]",
+      { type: "string" },
+      { anyOf: [{ type: "string" }, { type: "number" }] }
+    );
+    ok(
+      "anyOf[str, num] vs type[str, num]",
+      { anyOf: [{ type: "string" }, { type: "number" }] },
+      { type: ["string", "number"] }
+    );
+
+    notOk(
+      "bool vs [str, num]",
+      { type: "boolean" },
+      { anyOf: [{ type: "string" }, { type: "number" }] }
+    );
+    notOk(
+      "str vs [str:email, str:uri]",
+      { type: "string" },
+      {
+        anyOf: [
+          { type: "string", format: "email" },
+          { type: "string", format: "uri" },
+        ],
+      }
+    );
+    notOk(
+      "empty vs [str, num]",
+      {},
+      { anyOf: [{ type: "string" }, { type: "number" }] }
+    );
+    notOk(
+      "string vs [str]:3",
+      { type: "string" },
+      {
+        maxLength: 3,
+        anyOf: [{ type: "string" }],
+      }
+    );
+    notOk(
+      "type[str, num] vs anyOf[str, bool]",
+      { type: ["string", "number"] },
+      { anyOf: [{ type: "string" }, { type: "boolean" }] }
+    );
+  });
+});
+
+describe("details", () => {
+  detail("type", { type: "string" }, { type: "number" }, [
+    { pathA: ["type"], pathB: ["type"] },
+  ]);
+
+  describe("string", () => {
+    detail(
+      "pattern",
+      { type: "string", pattern: "[0-9]+" },
+      { type: "string", pattern: "[a-z]+" },
+      [{ pathA: ["pattern"], pathB: ["pattern"] }]
+    );
+    detail(
+      "format",
+      { type: "string", format: "email" },
+      { type: "string", format: "uri" },
+      [{ pathA: ["format"], pathB: ["format"] }]
+    );
+    detail(
+      "length",
+      { type: "string", minLength: 2, maxLength: 5 },
+      { type: "string", minLength: 3, maxLength: 4 },
+      [
+        { pathA: ["minLength"], pathB: ["minLength"] },
+        { pathA: ["maxLength"], pathB: ["maxLength"] },
+      ]
+    );
+  });
+
+  describe("number", () => {
+    detail(
+      "minimum",
+      { type: "number", minimum: 3 },
+      { type: "number", minimum: 4 },
+      [{ pathA: ["minimum"], pathB: ["minimum"] }]
+    );
+    detail(
+      "maximum",
+      { type: "number", maximum: 4 },
+      { type: "number", maximum: 3 },
+      [{ pathA: ["maximum"], pathB: ["maximum"] }]
+    );
+  });
+
+  detail("enum", { enum: ["foo"] }, { enum: [42] }, [
+    { pathA: ["enum"], pathB: ["enum"] },
+  ]);
+
+  describe("array", () => {
+    detail(
+      "items.type",
+      { type: "array", items: { type: "string" } },
+      { type: "array", items: { type: "number" } },
+      [{ pathA: ["items", "type"], pathB: ["items", "type"] }]
+    );
+  });
+
+  describe("object", () => {
+    detail(
+      "properties",
+      { type: "object", properties: { foo: { type: "string" } } },
+      { type: "object", properties: { foo: { type: "number" } } },
+      [
+        {
+          pathA: ["properties", "foo", "type"],
+          pathB: ["properties", "foo", "type"],
+        },
+      ]
+    );
+
+    detail(
+      "additionalProperties (setting)",
+      { type: "object" },
+      { type: "object", additionalProperties: false },
+      [
+        {
+          pathA: ["additionalProperties"],
+          pathB: ["additionalProperties"],
+        },
+      ]
+    );
+
+    detail(
+      "additionalProperties (extra property)",
+      {
+        type: "object",
+        additionalProperties: false,
+        properties: { foo: { type: "string" } },
+      },
+      {
+        type: "object",
+        additionalProperties: false,
+      },
+      [
+        {
+          pathA: ["properties", "foo"],
+          pathB: ["additionalProperties"],
+        },
+      ]
+    );
+
+    detail(
+      "requiredProperties",
+      {
+        type: "object",
+        required: ["foo", "baz"],
+      },
+      {
+        type: "object",
+        required: ["foo", "bar", "baz", "qux"],
+      },
+      [
+        {
+          pathA: ["required"],
+          pathB: ["required", 1],
+        },
+        {
+          pathA: ["required"],
+          pathB: ["required", 3],
+        },
+      ]
+    );
+  });
+
+  describe("anyOf", () => {
+    detail(
+      "with/with",
+      { anyOf: [{ type: "string" }, { type: "boolean" }, { type: "number" }] },
+      { anyOf: [{ type: "string" }, { type: "number" }] },
+      [{ pathA: ["anyOf", 1], pathB: ["anyOf"] }]
+    );
+    detail(
+      "with/without",
+      { anyOf: [{ type: "string" }, { type: "number" }] },
+      { type: "string" },
+      [{ pathA: ["anyOf", 1, "type"], pathB: ["type"] }]
+    );
+    detail(
+      "with/without (inherited constraint)",
+      {
+        maxLength: 4,
+        anyOf: [
+          { type: "string", format: "email" },
+          { type: "string", format: "uri" },
+        ],
+      },
+      { type: "string", maxLength: 3 },
+      [{ pathA: ["maxLength"], pathB: ["maxLength"] }]
+    );
+    detail(
+      "with/without (own constraint)",
+      {
+        anyOf: [
+          { type: "string", format: "email", maxLength: 4 },
+          { type: "string", format: "uri", maxLength: 4 },
+        ],
+      },
+      { type: "string", maxLength: 3 },
+      [{ pathA: ["anyOf", 0, "maxLength"], pathB: ["maxLength"] }]
+    );
+    detail(
+      "without/with",
+      { type: "boolean" },
+      { anyOf: [{ type: "string" }, { type: "number" }] },
+      [{ pathA: [], pathB: ["anyOf"] }]
+    );
+  });
+});


### PR DESCRIPTION
Given the JSON Schemas `a` and `b`, determine whether `a` is a sub-schema of `b`, and if not explain why.

We say that `a` is a sub-schema of `b` if every JSON Schema constraint in `b` is also present in `a` at an equal or higher strictness. Examples:

 - If `b` enforces type `string OR number`, then `a` must enforce either `string`, `number`, or `string OR number`.
 - If `b` enforces `maxLength` 4, then `a` must enforce `maxLength <= 4` .