### PR TITLE
[visual-editor] Null out the editor earlier

### DIFF
--- a/.changeset/stupid-clocks-sleep.md
+++ b/.changeset/stupid-clocks-sleep.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/visual-editor": patch
+---
+
+Null out the editor property sooner

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -849,10 +849,11 @@ export class Main extends LitElement {
     this.graph = null;
     this.subGraphId = null;
 
+    // TODO: Figure out how to avoid needing to null this out.
+    this.#editor = null;
+
     if (startEvent.descriptor) {
       this.graph = startEvent.descriptor;
-      // TODO: Figure out how to avoid needing to null this out.
-      this.#editor = null;
     }
     this.status = BreadboardUI.Types.STATUS.STOPPED;
     this.#runObserver = null;
@@ -896,13 +897,9 @@ export class Main extends LitElement {
         this.graph = graph;
         this.#setPageTitle();
         await this.#trackRecentBoard();
-        // TODO: Figure out how to avoid needing to null this out.
-        this.#editor = null;
       } catch (err) {
         this.url = null;
         this.graph = null;
-        // TODO: Figure out how to avoid needing to null this out.
-
         this.#editor = null;
         this.#failedGraphLoad = true;
       }


### PR DESCRIPTION
I noticed we were using a stale editor instance on occasion, which meant we'd get errors about non-existent nodes. This PR nulls out the editor instance as soon as we start a board.