### PR TITLE
[visual-editor] Tweak the board selector to only show tools

### DIFF
--- a/.changeset/sharp-zebras-battle.md
+++ b/.changeset/sharp-zebras-battle.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/visual-editor": patch
+---
+
+Tweak the board selector to only show tools

--- a/packages/visual-editor/src/ui/elements/node-info/array-editor.ts
+++ b/packages/visual-editor/src/ui/elements/node-info/array-editor.ts
@@ -33,9 +33,6 @@ export class ArrayEditor extends LitElement {
   behavior: BehaviorSchema | null = null;
 
   @property()
-  subGraphId: string | null = null;
-
-  @property()
   providers: GraphProvider[] = [];
 
   @property()
@@ -400,9 +397,7 @@ export class ArrayEditor extends LitElement {
                   ? html`<bb-board-selector
                       name="item-${idx}"
                       id="item-${idx}"
-                      .subGraphIds=${this.graph && this.graph.graphs
-                        ? Object.keys(this.graph.graphs)
-                        : []}
+                      .subGraphs=${this.graph?.graphs ?? null}
                       .providers=${this.providers}
                       .providerOps=${this.providerOps}
                       .value=${value || ""}

--- a/packages/visual-editor/src/ui/elements/node-info/node-configuration.ts
+++ b/packages/visual-editor/src/ui/elements/node-info/node-configuration.ts
@@ -880,9 +880,11 @@ export class NodeConfigurationInfo extends LitElement {
                               if (port.edges.length === 0) {
                                 switch (type) {
                                   case "object": {
-                                    // Only show the schema editor for inputs & outputs
+                                    // The port spec schema editor is shown
+                                    // separately, so skip over the port and
+                                    // render nothing.
                                     if (port.type.hasBehavior("ports-spec")) {
-                                      input = html``;
+                                      input = nothing;
                                     } else if (isBoard(port, value)) {
                                       const selectorValue = value
                                         ? typeof value === "string"
@@ -891,10 +893,7 @@ export class NodeConfigurationInfo extends LitElement {
                                         : "";
                                       input = html`<bb-board-selector
                                         .graph=${this.graph}
-                                        .subGraphIds=${this.graph &&
-                                        this.graph.graphs
-                                          ? Object.keys(this.graph.graphs)
-                                          : []}
+                                        .subGraphs=${this.graph?.graphs ?? null}
                                         .providers=${this.providers}
                                         .providerOps=${this.providerOps}
                                         .value=${selectorValue || ""}
@@ -1021,10 +1020,7 @@ export class NodeConfigurationInfo extends LitElement {
                                             : port.schema.items
                                           : port.schema
                                       )}
-                                      .subGraphIds=${this.graph &&
-                                      this.graph.graphs
-                                        ? Object.keys(this.graph.graphs)
-                                        : []}
+                                      .graph=${this.graph}
                                       .providers=${this.providers}
                                       .providerOps=${this.providerOps}
                                     ></bb-array-editor>`;


### PR DESCRIPTION
Fixes #2332 
Fixes #2331 

We now only show tools in the board selector, and the embedded sub-boards show their title not their ID.