### PR TITLE
[visual-editor] Fix the wireit config for copy-pyoide-assets

### DIFF
--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -196,11 +196,9 @@
     "copy-pyoide-assets": {
       "command": "tsx src/copy-pyodide-assets.ts",
       "files": [],
-      "dependencies": [
-        "../agent-kit:build"
-      ],
       "output": [
-        "public/*.kit.json"
+        "public/python_stdlib.zip",
+        "public/pyodide*"
       ]
     },
     "generate:graphs": {


### PR DESCRIPTION
Likely to fix https://github.com/breadboard-ai/breadboard/issues/2402. I copied this script from another one, and forgot to fix the output files, so it's possible this was causing a race condition, clobbering the output of another script.