### PR TITLE
[core-kit] Improve schema handling for runJavascript nodes

### DIFF
--- a/.changeset/metal-hairs-smash.md
+++ b/.changeset/metal-hairs-smash.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/core-kit": patch
+---
+
+Added inputSchema and outputSchema properties. The old "schema" property is now deprecated in favor of "outputSchema" (though will fall back to "schema").

--- a/.changeset/neat-trains-work.md
+++ b/.changeset/neat-trains-work.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/core-kit": patch
+---
+
+Add extractTypeFromValue function.

--- a/.changeset/real-yaks-provide.md
+++ b/.changeset/real-yaks-provide.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Fix bug relating to directly returning JSON Schema from describe function instead of wrapping with unsafeSchema.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "./packages/node-proxy-server/functions"
       ],
       "dependencies": {
+        "@google-labs/core-kit": "^0.10.1",
+        "json-schema": "^0.4.0",
         "litegraph.js": "^0.7.18",
         "prettier": "^3.3.2"
       },
@@ -25336,7 +25338,7 @@
     },
     "packages/visual-editor": {
       "name": "@google-labs/visual-editor",
-      "version": "1.10.6",
+      "version": "1.10.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@breadboard-ai/build": "0.7.0",

--- a/package.json
+++ b/package.json
@@ -174,6 +174,8 @@
     "@rollup/rollup-linux-x64-gnu": "^4.17.1"
   },
   "dependencies": {
+    "@google-labs/core-kit": "^0.10.1",
+    "json-schema": "^0.4.0",
     "litegraph.js": "^0.7.18",
     "prettier": "^3.3.2"
   },

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -4,11 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Convergence } from "./internal/board/converge.js";
-import type { Input, InputWithDefault } from "./internal/board/input.js";
-import type { Loopback } from "./internal/board/loopback.js";
-import type { OutputPortReference } from "./internal/common/port.js";
-import type { JsonSerializable } from "./internal/type-system/type.js";
+import { isConvergence, type Convergence } from "./internal/board/converge.js";
+import {
+  isSpecialInput,
+  type Input,
+  type InputWithDefault,
+} from "./internal/board/input.js";
+import { isLoopback, type Loopback } from "./internal/board/loopback.js";
+import {
+  isOutputPortReference,
+  OutputPortGetter,
+  type OutputPortReference,
+} from "./internal/common/port.js";
+import { anyOf } from "./internal/type-system/any-of.js";
+import type {
+  BreadboardType,
+  JsonSerializable,
+} from "./internal/type-system/type.js";
 
 export { board } from "./internal/board/board.js";
 export { constant } from "./internal/board/constant.js";
@@ -53,3 +65,42 @@ export type Value<T extends JsonSerializable> =
   | InputWithDefault<T>
   | Loopback<T>
   | Convergence<T>;
+
+/**
+ * Given a Breadboard {@link Value}, determine its JSON Schema type.
+ */
+export function extractTypeFromValue(
+  value: Value<JsonSerializable>
+): BreadboardType {
+  if (typeof value === "string") {
+    return "string";
+  }
+  if (typeof value === "number") {
+    return "number";
+  }
+  if (typeof value === "boolean") {
+    return "boolean";
+  }
+  if (value === null) {
+    return "null";
+  }
+  if (isOutputPortReference(value)) {
+    return value[OutputPortGetter].type;
+  }
+  if (isSpecialInput(value)) {
+    return value.type;
+  }
+  if (isLoopback(value)) {
+    return value.type;
+  }
+  if (isConvergence(value)) {
+    return anyOf(
+      ...(value.ports.map((port) => extractTypeFromValue(port)) as [
+        BreadboardType,
+        BreadboardType,
+        ...BreadboardType[],
+      ])
+    );
+  }
+  return "unknown";
+}

--- a/packages/build/src/internal/board/input.ts
+++ b/packages/build/src/internal/board/input.ts
@@ -198,3 +198,11 @@ type CheckParams<T extends LooseParams> = (T["type"] extends Defined
     ? unknown
     : never;
 };
+
+export function isSpecialInput(value: unknown): value is GenericSpecialInput {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "__SpecialInputBrand" in value
+  );
+}

--- a/packages/build/src/internal/board/serialize.ts
+++ b/packages/build/src/internal/board/serialize.ts
@@ -19,13 +19,13 @@ import type {
   SerializableOutputPortReference,
 } from "../common/serializable.js";
 import { toJSONSchema, type JsonSerializable } from "../type-system/type.js";
+import { isBoard, type GenericBoardDefinition } from "./board.js";
 import { ConstantVersionOf, isConstant } from "./constant.js";
 import { isConvergence } from "./converge.js";
-import type { GenericSpecialInput, Input, InputWithDefault } from "./input.js";
+import { isSpecialInput, type Input, type InputWithDefault } from "./input.js";
 import { isLoopback } from "./loopback.js";
 import { OptionalVersionOf, isOptional } from "./optional.js";
 import type { Output } from "./output.js";
-import { isBoard, type GenericBoardDefinition } from "./board.js";
 
 /**
  * Serialize a Breadboard board to Breadboard Graph Language (BGL) so that it
@@ -512,14 +512,6 @@ export function serialize(board: SerializableBoard): GraphDescriptor {
     graphs.set(id, serialize(board));
     return id;
   }
-}
-
-function isSpecialInput(value: unknown): value is GenericSpecialInput {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "__SpecialInputBrand" in value
-  );
 }
 
 function isSpecialOutput(value: unknown): value is Output<JsonSerializable> {

--- a/packages/core-kit/src/nodes/code.ts
+++ b/packages/core-kit/src/nodes/code.ts
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Value } from "@breadboard-ai/build";
+import {
+  extractTypeFromValue,
+  toJSONSchema,
+  type Value,
+} from "@breadboard-ai/build";
 import type { OutputPort } from "@breadboard-ai/build/internal/common/port.js";
 import type { Expand } from "@breadboard-ai/build/internal/common/type-util.js";
 import type { Instance } from "@breadboard-ai/build/internal/define/instance.js";
@@ -81,6 +85,25 @@ export function code<
     code,
     name,
     raw: true,
+    inputSchema: {
+      type: "object",
+      properties: Object.fromEntries(
+        Object.entries(inputs)
+          .filter(([name]) => name !== "$id" && name !== "$metadata")
+          .map(([name, value]) => [
+            name,
+            toJSONSchema(extractTypeFromValue(value)),
+          ])
+      ),
+    },
+    outputSchema: Object.fromEntries(
+      Object.entries(outputs).map(([name, output]) => [
+        name,
+        toJSONSchema(
+          typeof output === "object" && "type" in output ? output.type : output
+        ),
+      ])
+    ),
     ...(inputs as Record<string, JsonSerializable>),
   }) as CodeNode<Expand<CodeNodeInputs<I>>, ConvertBreadboardTypes<O>>;
   for (const [name, type] of Object.entries(outputs)) {

--- a/packages/core-kit/src/nodes/run-javascript.ts
+++ b/packages/core-kit/src/nodes/run-javascript.ts
@@ -285,12 +285,6 @@ export default defineNodeType({
     },
   },
   describe: ({ raw, inputSchema, ...rest }) => {
-    console.log({
-      raw,
-      inputSchema,
-      outputSchema: rest.outputSchema,
-      schema: rest.schema,
-    });
     // "schema" is the deprecated name for "outputSchema", so fall back to that.
     const outputSchema: JSONSchema4 | undefined =
       rest.outputSchema ?? rest.schema;

--- a/packages/core-kit/src/nodes/run-javascript.ts
+++ b/packages/core-kit/src/nodes/run-javascript.ts
@@ -4,9 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { defineNodeType, object } from "@breadboard-ai/build";
+import {
+  defineNodeType,
+  object,
+  unsafeSchema,
+  unsafeType,
+} from "@breadboard-ai/build";
 import { JsonSerializable } from "@breadboard-ai/build/internal/type-system/type.js";
 import type { InputValues, Schema } from "@google-labs/breadboard";
+import { JSONSchema4 } from "json-schema";
 
 // https://regex101.com/r/PeEmEW/1
 const stripCodeBlock = (code: string) =>
@@ -246,7 +252,19 @@ export default defineNodeType({
     schema: {
       behavior: ["config", "ports-spec"],
       description:
-        "The schema of the output data. This is used to validate the output data before running the code.",
+        "Deprecated! Please use inputSchema/outputSchema instead. The schema of the output data.",
+      type: object({}, "unknown"),
+      optional: true,
+    },
+    inputSchema: {
+      behavior: ["config", "ports-spec"],
+      description: "The schema of the input data.",
+      type: object({}, "unknown"),
+      optional: true,
+    },
+    outputSchema: {
+      behavior: ["config", "ports-spec"],
+      description: "The schema of the output data.",
       type: object({}, "unknown"),
       optional: true,
     },
@@ -266,35 +284,31 @@ export default defineNodeType({
       type: "unknown",
     },
   },
-  describe: (inputs) => {
-    if (inputs.raw && inputs.schema && inputs.schema.properties) {
-      const schema: Schema = inputs.schema;
-
-      const outputEntries = Object.entries(schema.properties as object).map(
-        ([name, val]) => [
-          name,
-          {
-            type: val.type,
-            description: `output "${name}"`,
+  describe: ({ raw, inputSchema, ...rest }) => {
+    console.log({
+      raw,
+      inputSchema,
+      outputSchema: rest.outputSchema,
+      schema: rest.schema,
+    });
+    // "schema" is the deprecated name for "outputSchema", so fall back to that.
+    const outputSchema: JSONSchema4 | undefined =
+      rest.outputSchema ?? rest.schema;
+    return {
+      inputs: inputSchema ? unsafeSchema(inputSchema) : { "*": "unknown" },
+      outputs: raw
+        ? outputSchema
+          ? unsafeSchema(outputSchema)
+          : { "*": "unknown" }
+        : {
+            result: {
+              description: "The result of running the JavaScript code",
+              type: outputSchema?.properties?.result
+                ? unsafeType(outputSchema.properties.result)
+                : "unknown",
+            },
           },
-        ]
-      );
-      return {
-        outputs: Object.fromEntries(outputEntries),
-      };
-    }
-
-    if (inputs.raw == false) {
-      return {
-        outputs: {
-          result: {
-            description: "The result of running the JavaScript code",
-          },
-        },
-      };
-    }
-
-    return { outputs: { "*": {} } };
+    };
   },
   invoke: (config, args) => runJavascriptHandler(config, args),
 });

--- a/packages/core-kit/tests/code_test.ts
+++ b/packages/core-kit/tests/code_test.ts
@@ -207,6 +207,34 @@ test("serialization", (t) => {
           code: 'const customId = ({ str, num, bool }) => ({\n        strLen: str.length,\n        strReversed: str.split("").reverse().join(""),\n        doubleNum: num * 2,\n        not: !bool,\n    });',
           name: "customId",
           raw: true,
+          inputSchema: {
+            properties: {
+              bool: {
+                type: "boolean",
+              },
+              num: {
+                type: "number",
+              },
+              str: {
+                type: "string",
+              },
+            },
+            type: "object",
+          },
+          outputSchema: {
+            doubleNum: {
+              type: "number",
+            },
+            not: {
+              type: "boolean",
+            },
+            strLen: {
+              type: "number",
+            },
+            strReversed: {
+              type: "string",
+            },
+          },
         },
         metadata: { title: "Custom title", description: "Custom description" },
       },

--- a/packages/core-kit/tests/run-javascript.ts
+++ b/packages/core-kit/tests/run-javascript.ts
@@ -80,116 +80,318 @@ test("runJavascript understands `raw` input", async (t) => {
   t.deepEqual(result, { hello: "world" });
 });
 
-test("describe outputs when raw = true and schema defined", async (t) => {
-  const result = (
-    await handler.describe({
-      raw: true,
-      schema: {
-        type: "object",
-        properties: {
-          hello: { type: "string" },
+test("raw=true with provided schemas", async (t) => {
+  const result = await handler.describe({
+    raw: true,
+    inputSchema: {
+      type: "object",
+      properties: { foo: { type: "string" } },
+    },
+    outputSchema: {
+      type: "object",
+      properties: { bar: { type: "number" } },
+    },
+  });
+  t.deepEqual(result, {
+    inputSchema: {
+      type: "object",
+      properties: {
+        code: {
+          type: "string",
+          title: "code",
+          description: "The JavaScript code to run",
+          format: "javascript",
+          behavior: ["config", "code"],
+        },
+        foo: {
+          type: "string",
+        },
+        inputSchema: {
+          type: "object",
+          properties: {},
+          required: [],
+          additionalProperties: true,
+          title: "inputSchema",
+          description: "The schema of the input data.",
+          behavior: ["config", "ports-spec"],
+        },
+        name: {
+          type: "string",
+          title: "name",
+          description:
+            'The name of the function to invoke in the supplied code. Default value is "run".',
+          default: "run",
+        },
+        outputSchema: {
+          type: "object",
+          properties: {},
+          required: [],
+          additionalProperties: true,
+          title: "outputSchema",
+          description: "The schema of the output data.",
+          behavior: ["config", "ports-spec"],
+        },
+        raw: {
+          type: "boolean",
+          title: "raw",
+          description:
+            "Whether or not to return use the result of execution as raw output (true) or as a port called `result` (false). Default is false.",
+          default: false,
+          behavior: ["config"],
+        },
+        schema: {
+          type: "object",
+          properties: {},
+          required: [],
+          additionalProperties: true,
+          title: "schema",
+          description:
+            "Deprecated! Please use inputSchema/outputSchema instead. The schema of the output data.",
+          behavior: ["config", "ports-spec"],
         },
       },
-    })
-  ).outputSchema;
-  t.deepEqual(result, {
-    type: "object",
-    properties: {
-      hello: {
-        type: "string",
-        title: "hello",
-        description: 'output "hello"',
-      },
+      required: ["code"],
     },
-    required: [],
-    additionalProperties: false,
-  });
-});
-
-test("describe outputs when raw = true", async (t) => {
-  const result = (await handler.describe({ raw: true })).outputSchema;
-  t.deepEqual(result, {
-    type: "object",
-    properties: {},
-    required: [],
-    additionalProperties: true,
-  });
-});
-
-test("describe outputs when raw = false", async (t) => {
-  const result = (await handler.describe({ raw: false })).outputSchema;
-  t.deepEqual(result, {
-    type: "object",
-    properties: {
-      result: {
-        title: "result",
-        description: "The result of running the JavaScript code",
-        type: ["array", "boolean", "null", "number", "object", "string"],
-      },
-    },
-    required: [],
-    additionalProperties: false,
-  });
-});
-
-test("describe inputs", async (t) => {
-  const result = (
-    await handler.describe(
-      {},
-      {
-        type: "object",
-        properties: {
-          code: { title: "code" },
-          name: { title: "name" },
-          raw: { title: "raw" },
-          what: { title: "what", type: "array", items: { type: "number" } },
+    outputSchema: {
+      type: "object",
+      properties: {
+        bar: {
+          type: "number",
         },
-      }
-    )
-  ).inputSchema;
-  t.deepEqual(result, {
-    type: "object",
-    properties: {
-      code: {
-        behavior: ["config", "code"],
-        description: "The JavaScript code to run",
-        format: "javascript",
-        title: "code",
-        type: "string",
       },
-      name: {
-        default: "run",
-        description:
-          'The name of the function to invoke in the supplied code. Default value is "run".',
-        title: "name",
-        type: "string",
-      },
-      raw: {
-        behavior: ["config"],
-        default: false,
-        description:
-          "Whether or not to return use the result of execution as raw output (true) or as a port called `result` (false). Default is false.",
-        title: "raw",
-        type: "boolean",
-      },
-      schema: {
-        additionalProperties: true,
-        behavior: ["config", "ports-spec"],
-        description:
-          "The schema of the output data. This is used to validate the output data before running the code.",
-        properties: {},
-        required: [],
-        title: "schema",
-        type: "object",
-      },
-      what: {
-        title: "what",
-        type: "array",
-        items: { type: "number" },
-      },
+      required: [],
     },
-    required: ["code"],
-    additionalProperties: true,
+  });
+});
+
+test("raw=true without provided schemas", async (t) => {
+  const result = await handler.describe({ raw: true });
+  t.deepEqual(result, {
+    inputSchema: {
+      type: "object",
+      properties: {
+        code: {
+          type: "string",
+          title: "code",
+          description: "The JavaScript code to run",
+          format: "javascript",
+          behavior: ["config", "code"],
+        },
+        inputSchema: {
+          type: "object",
+          properties: {},
+          required: [],
+          additionalProperties: true,
+          title: "inputSchema",
+          description: "The schema of the input data.",
+          behavior: ["config", "ports-spec"],
+        },
+        name: {
+          type: "string",
+          title: "name",
+          description:
+            'The name of the function to invoke in the supplied code. Default value is "run".',
+          default: "run",
+        },
+        outputSchema: {
+          type: "object",
+          properties: {},
+          required: [],
+          additionalProperties: true,
+          title: "outputSchema",
+          description: "The schema of the output data.",
+          behavior: ["config", "ports-spec"],
+        },
+        raw: {
+          type: "boolean",
+          title: "raw",
+          description:
+            "Whether or not to return use the result of execution as raw output (true) or as a port called `result` (false). Default is false.",
+          default: false,
+          behavior: ["config"],
+        },
+        schema: {
+          type: "object",
+          properties: {},
+          required: [],
+          additionalProperties: true,
+          title: "schema",
+          description:
+            "Deprecated! Please use inputSchema/outputSchema instead. The schema of the output data.",
+          behavior: ["config", "ports-spec"],
+        },
+      },
+      required: ["code"],
+      additionalProperties: true,
+    },
+    outputSchema: {
+      type: "object",
+      properties: {},
+      required: [],
+      additionalProperties: true,
+    },
+  });
+});
+
+test("raw=false with provided schemas", async (t) => {
+  const result = await handler.describe({
+    raw: false,
+    inputSchema: {
+      type: "object",
+      properties: { foo: { type: "string" } },
+    },
+    outputSchema: {
+      type: "object",
+      properties: { result: { type: "number" } },
+    },
+  });
+  t.deepEqual(result, {
+    inputSchema: {
+      type: "object",
+      properties: {
+        code: {
+          type: "string",
+          title: "code",
+          description: "The JavaScript code to run",
+          format: "javascript",
+          behavior: ["config", "code"],
+        },
+        foo: {
+          type: "string",
+        },
+        inputSchema: {
+          type: "object",
+          properties: {},
+          required: [],
+          additionalProperties: true,
+          title: "inputSchema",
+          description: "The schema of the input data.",
+          behavior: ["config", "ports-spec"],
+        },
+        name: {
+          type: "string",
+          title: "name",
+          description:
+            'The name of the function to invoke in the supplied code. Default value is "run".',
+          default: "run",
+        },
+        outputSchema: {
+          type: "object",
+          properties: {},
+          required: [],
+          additionalProperties: true,
+          title: "outputSchema",
+          description: "The schema of the output data.",
+          behavior: ["config", "ports-spec"],
+        },
+        raw: {
+          type: "boolean",
+          title: "raw",
+          description:
+            "Whether or not to return use the result of execution as raw output (true) or as a port called `result` (false). Default is false.",
+          default: false,
+          behavior: ["config"],
+        },
+        schema: {
+          type: "object",
+          properties: {},
+          required: [],
+          additionalProperties: true,
+          title: "schema",
+          description:
+            "Deprecated! Please use inputSchema/outputSchema instead. The schema of the output data.",
+          behavior: ["config", "ports-spec"],
+        },
+      },
+      required: ["code"],
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        result: {
+          description: "The result of running the JavaScript code",
+          title: "result",
+          type: "number",
+        },
+      },
+      additionalProperties: false,
+      required: [],
+    },
+  });
+});
+
+test("raw=false without provided schemas", async (t) => {
+  const result = await handler.describe({ raw: false });
+  t.deepEqual(result, {
+    inputSchema: {
+      type: "object",
+      properties: {
+        code: {
+          type: "string",
+          title: "code",
+          description: "The JavaScript code to run",
+          format: "javascript",
+          behavior: ["config", "code"],
+        },
+        inputSchema: {
+          type: "object",
+          properties: {},
+          required: [],
+          additionalProperties: true,
+          title: "inputSchema",
+          description: "The schema of the input data.",
+          behavior: ["config", "ports-spec"],
+        },
+        name: {
+          type: "string",
+          title: "name",
+          description:
+            'The name of the function to invoke in the supplied code. Default value is "run".',
+          default: "run",
+        },
+        outputSchema: {
+          type: "object",
+          properties: {},
+          required: [],
+          additionalProperties: true,
+          title: "outputSchema",
+          description: "The schema of the output data.",
+          behavior: ["config", "ports-spec"],
+        },
+        raw: {
+          type: "boolean",
+          title: "raw",
+          description:
+            "Whether or not to return use the result of execution as raw output (true) or as a port called `result` (false). Default is false.",
+          default: false,
+          behavior: ["config"],
+        },
+        schema: {
+          type: "object",
+          properties: {},
+          required: [],
+          additionalProperties: true,
+          title: "schema",
+          description:
+            "Deprecated! Please use inputSchema/outputSchema instead. The schema of the output data.",
+          behavior: ["config", "ports-spec"],
+        },
+      },
+      required: ["code"],
+      additionalProperties: true,
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        result: {
+          description: "The result of running the JavaScript code",
+          title: "result",
+          type: ["array", "boolean", "null", "number", "object", "string"],
+        },
+      },
+      required: [],
+      additionalProperties: false,
+    },
   });
 });
 


### PR DESCRIPTION
- Adds `inputSchema` and `outputSchema` properties, to replace the now deprecated `schema` property (which is now the fallback for `outputSchema`).

- The `code` helper now automatically serializes both the input and output schemas.

- Fixes a bug relating to returning JSON Schema directly from `describe`, instead of wrapping it in `unsafeSchema`.

Fixes https://github.com/breadboard-ai/breadboard/issues/2396
Fixes https://github.com/breadboard-ai/breadboard/issues/2296