### PR TITLE
[inspector] Track whether InspectablePorts are input or output ports

### DIFF
--- a/.changeset/short-buttons-train.md
+++ b/.changeset/short-buttons-train.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard": patch
+---
+
+Add kind port to InspectablePort to tell you whether it's an input or output port

--- a/packages/breadboard/src/inspector/kits.ts
+++ b/packages/breadboard/src/inspector/kits.ts
@@ -96,11 +96,11 @@ class NodeType implements InspectableNodeType {
       return {
         inputs: {
           fixed: described.inputSchema.additionalProperties === false,
-          ports: collectPortsForType(described.inputSchema),
+          ports: collectPortsForType(described.inputSchema, "input"),
         },
         outputs: {
           fixed: described.outputSchema.additionalProperties === false,
-          ports: collectPortsForType(described.outputSchema),
+          ports: collectPortsForType(described.outputSchema, "output"),
         },
       };
     } catch (e) {

--- a/packages/breadboard/src/inspector/ports.ts
+++ b/packages/breadboard/src/inspector/ports.ts
@@ -124,6 +124,7 @@ export const collectPorts = (
         ),
         schema: portSchema,
         type: new PortType(portSchema),
+        kind: type === EdgeType.In ? "input" : "output",
       } satisfies InspectablePort;
     })
     .filter(Boolean) as InspectablePort[];
@@ -160,7 +161,10 @@ export class PortType implements InspectablePortType {
   }
 }
 
-export const collectPortsForType = (schema: Schema): InspectablePort[] => {
+export const collectPortsForType = (
+  schema: Schema,
+  kind: "input" | "output"
+): InspectablePort[] => {
   const portNames = Object.keys(schema.properties || {});
   const requiredPortNames = schema.required || [];
   portNames.sort();
@@ -181,6 +185,7 @@ export const collectPortsForType = (schema: Schema): InspectablePort[] => {
       ),
       schema: portSchema,
       type: new PortType(portSchema),
+      kind,
     } satisfies InspectablePort;
   });
 };

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -384,6 +384,11 @@ export type InspectablePort = {
    * Returns a representation of the port's type.
    */
   type: InspectablePortType;
+
+  /**
+   * Is this an input or output port?
+   */
+  kind: "input" | "output";
 };
 
 export type InspectablePortType = {


### PR DESCRIPTION
Add `kind` property to InspectablePort to tell you whether it's an input or output port.

Part of https://github.com/breadboard-ai/breadboard/issues/2298
