### PR TITLE
[visual-editor] Add Fancy JSON component

### DIFF
--- a/.changeset/polite-wolves-remember.md
+++ b/.changeset/polite-wolves-remember.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/visual-editor": patch
+---
+
+Add fancy-json component for rendering JSON with configurable highlighting

--- a/packages/visual-editor/src/ui/elements/editor/fancy-json.ts
+++ b/packages/visual-editor/src/ui/elements/editor/fancy-json.ts
@@ -1,0 +1,144 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { JsonSerializable } from "@breadboard-ai/build/internal/type-system/type.js";
+import { LitElement, css, html, nothing } from "lit";
+import { customElement, property } from "lit/decorators.js";
+
+export interface FancyJsonAnnotation {
+  path: Array<string | number>;
+  partName: string;
+}
+
+/**
+ * Displays some JSON with highlighting.
+ */
+@customElement("bb-fancy-json")
+export class FancyJson extends LitElement {
+  @property({ type: Object })
+  json?: JsonSerializable;
+
+  @property({ type: Number })
+  indent = 2;
+
+  #annotations?: FancyJsonAnnotation[];
+  #annotationsBySerializedPath = new Map<string, FancyJsonAnnotation[]>();
+
+  @property({ type: Array })
+  get annotations(): FancyJsonAnnotation[] | undefined {
+    return this.#annotations;
+  }
+  set annotations(annotations: FancyJsonAnnotation[] | undefined) {
+    this.#annotations = annotations;
+    this.#annotationsBySerializedPath.clear();
+    if (annotations !== undefined) {
+      for (const annotation of annotations) {
+        const key = JSON.stringify(annotation.path);
+        const val = this.#annotationsBySerializedPath.get(key);
+        if (val === undefined) {
+          this.#annotationsBySerializedPath.set(key, [annotation]);
+        } else {
+          val.push(annotation);
+        }
+      }
+    }
+  }
+
+  static styles = css`
+    pre {
+      text-wrap: wrap;
+    }
+  `;
+
+  override render() {
+    if (!this.json) {
+      return nothing;
+    }
+    return this.#renderJsonValue(this.json, 1, []);
+  }
+
+  #renderJsonValue(
+    value: JsonSerializable,
+    indent: number,
+    path: Array<string | number>
+  ): unknown {
+    const parts = [];
+
+    switch (typeof value) {
+      case "string": {
+        parts.push(JSON.stringify(value));
+        break;
+      }
+      case "number":
+      case "boolean": {
+        parts.push(value);
+        break;
+      }
+
+      case "object": {
+        if (value === null) {
+          parts.push("null");
+        } else if (Array.isArray(value)) {
+          parts.push(
+            "[",
+            ...value.map((v, i) => {
+              path.push(i);
+              const item = this.#renderJsonValue(v, indent, path);
+              path.pop();
+              return item;
+            }),
+            "]"
+          );
+        } else {
+          parts.push("{");
+          const entries = Object.entries(value);
+          if (entries.length > 0) {
+            for (let e = 0; e < entries.length; e++) {
+              parts.push("\n");
+              for (let i = 0; i < indent; i++) {
+                parts.push("  ");
+              }
+              const [key, val] = entries[e];
+              parts.push(JSON.stringify(key), ": ");
+              path.push(key);
+              parts.push(this.#renderJsonValue(val, indent + 1, path));
+              path.pop();
+              if (e < entries.length - 1) {
+                parts.push(",");
+              } else {
+                parts.push("\n");
+              }
+            }
+            for (let i = 1; i < indent; i++) {
+              parts.push("  ");
+            }
+          }
+          parts.push("}");
+        }
+        break;
+      }
+      default: {
+        value satisfies never;
+      }
+    }
+
+    if (this.annotations !== undefined) {
+      const serializedPath = JSON.stringify(path);
+      const annotations = this.#annotationsBySerializedPath.get(serializedPath);
+      if (annotations !== undefined) {
+        const partNames = [];
+        for (const annotation of annotations) {
+          if (annotation.partName) {
+            partNames.push(annotation.partName);
+          }
+        }
+        return html`<span part=${partNames.join(" ")}>${parts}</span>`;
+      }
+    }
+
+    return parts;
+  }
+}

--- a/packages/visual-editor/src/ui/elements/elements.ts
+++ b/packages/visual-editor/src/ui/elements/elements.ts
@@ -17,6 +17,7 @@ export { ConnectionSignin } from "./connection/connection-signin.js";
 export { DrawableInput } from "./input/drawable/drawable.js";
 export { Editor } from "./editor/editor.js";
 export { EventDetails } from "./event-details/event-details.js";
+export { FancyJson } from "./editor/fancy-json.js";
 export { FirstRunOverlay } from "./overlay/first-run.js";
 export { GraphHistory } from "./graph-history/graph-history.js";
 export { GraphRenderer } from "./editor/graph-renderer.js";


### PR DESCRIPTION
Add fancy-json component for rendering JSON with configurable annotations. 

You give it a JSON value, and a list of annotations. The annotations are JSON paths (e.g. `["schema", "properties", 2, "type"]`) and some CSS part name. As we render values, we wrap them in `<span part="<PART>">` so that the parent component can then choose how to style those sub-trees.

Part of https://github.com/breadboard-ai/breadboard/issues/2298