### PR TITLE
[inspector] Add analyzeCanConnect method

### DIFF
--- a/.changeset/rich-lies-accept.md
+++ b/.changeset/rich-lies-accept.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard": patch
+---
+
+Add analyzeCanConnect method to InspectablePort which is like canConnect but with detailed error messages.

--- a/packages/breadboard/src/inspector/edge.ts
+++ b/packages/breadboard/src/inspector/edge.ts
@@ -97,14 +97,11 @@ class Edge implements InspectableEdge {
     if (outPort === undefined || inPort === undefined) {
       return { status: "unknown" };
     }
-    if (!outPort.type.canConnect(inPort.type)) {
+    const canConnectAnalysis = outPort.type.analyzeCanConnect(inPort.type);
+    if (!canConnectAnalysis.canConnect) {
       return {
         status: "invalid",
-        errors: [
-          {
-            message: `The schema of "${this.in}" is not compatible with "${this.out}"`,
-          },
-        ],
+        errors: canConnectAnalysis.details,
       };
     }
     return { status: "valid" };

--- a/packages/breadboard/src/inspector/ports.ts
+++ b/packages/breadboard/src/inspector/ports.ts
@@ -9,6 +9,7 @@ import { JSONSchema4 } from "json-schema";
 import { BehaviorSchema, NodeConfiguration, Schema } from "../types.js";
 import { DEFAULT_SCHEMA, EdgeType } from "./schemas.js";
 import {
+  CanConnectAnalysis,
   InspectableEdge,
   InspectablePort,
   InspectablePortType,
@@ -137,14 +138,26 @@ export class PortType implements InspectablePortType {
   }
 
   canConnect(to: InspectablePortType): boolean {
+    return this.analyzeCanConnect(to).canConnect;
+  }
+
+  analyzeCanConnect(to: InspectablePortType): CanConnectAnalysis {
     // Check standard JSON Schema subset rules.
-    if (
-      !analyzeIsJsonSubSchema(
-        this.schema as JSONSchema4,
-        to.schema as JSONSchema4
-      ).isSubSchema
-    ) {
-      return false;
+    const subSchemaAnalysis = analyzeIsJsonSubSchema(
+      this.schema as JSONSchema4,
+      to.schema as JSONSchema4
+    );
+    if (!subSchemaAnalysis.isSubSchema) {
+      return {
+        canConnect: false,
+        details: subSchemaAnalysis.details.map((detail) => ({
+          message: "Incompatible schema",
+          detail: {
+            outputPath: detail.pathA,
+            inputPath: detail.pathB,
+          },
+        })),
+      };
     }
     // Check Breadboard-specific behaviors.
     const fromBehaviors = new Set(this.schema.behavior);
@@ -153,10 +166,18 @@ export class PortType implements InspectablePortType {
         BEHAVIOR_AFFECTS_TYPE_CHECKING[toBehavior] &&
         !fromBehaviors.has(toBehavior)
       ) {
-        return false;
+        return {
+          canConnect: false,
+          details: [
+            {
+              message: "Incompatible behaviors",
+              detail: { outputPath: ["behavior"], inputPath: ["behavior"] },
+            },
+          ],
+        };
       }
     }
-    return true;
+    return { canConnect: true };
   }
 }
 

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -30,6 +30,7 @@ import {
   Schema,
 } from "../types.js";
 import { DataStore, SerializedDataStoreGroup } from "../data/types.js";
+import { type JsonSubSchemaAnalysisDetail } from "@google-labs/breadboard-schema/subschema.js";
 
 export type GraphVersion = number;
 
@@ -183,8 +184,10 @@ export type ValidateResult =
 
 export interface ValidateError {
   message: string;
-  // TODO(aomarks) Could add more data here in future, e.g. a path to the part
-  // of the schema which is invalid for fancy highlighting, etc.
+  detail?: {
+    outputPath: Array<string | number>;
+    inputPath: Array<string | number>;
+  };
 }
 
 export type InspectableSubgraphs = Record<GraphIdentifier, InspectableGraph>;
@@ -402,7 +405,21 @@ export type InspectablePortType = {
    * @param to the incoming port type to which to connect.
    */
   canConnect(to: InspectablePortType): boolean;
+
+  analyzeCanConnect(to: InspectablePortType): CanConnectAnalysis;
 };
+
+export type CanConnectAnalysis =
+  | { canConnect: true; details?: never }
+  | { canConnect: false; details: CanConnectAnalysisDetail[] };
+
+export interface CanConnectAnalysisDetail {
+  message: string;
+  detail?: {
+    outputPath: Array<string | number>;
+    inputPath: Array<string | number>;
+  };
+}
 
 /**
  * Represents one side (input or output) of ports of a node.


### PR DESCRIPTION
Add analyzeCanConnect method to InspectablePort which is like canConnect but with detailed error messages.

Part of https://github.com/breadboard-ai/breadboard/issues/2298