### PR TITLE
[visual-editor] Show red squigglies in port tooltips under mismatched schema constraints 

### DIFF
--- a/.changeset/tender-jars-roll.md
+++ b/.changeset/tender-jars-roll.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/visual-editor": patch
+---
+
+Show red squigglies in port tooltips under mismatched schema constraints


### PR DESCRIPTION
If a wire is invalid, and the "Show Port Tooltips" setting is enabled, then the port tooltip will now show which specific part of the schema is mismatched with the other port by rendering a red squiggly line under it.

<img width="670" alt="image" src="https://github.com/breadboard-ai/breadboard/assets/48894/92c9440f-c729-4759-aec4-8f000097c137">

Part of https://github.com/breadboard-ai/breadboard/issues/2298