### PR TITLE
[visual-editor] Fall back to URL constructor for browsers without `canParse`

### DIFF
--- a/.changeset/mean-shirts-relax.md
+++ b/.changeset/mean-shirts-relax.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/visual-editor": patch
+---
+
+Fall back to URL Constructor for browsers without canParse

--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://wombat-dressing-room.appspot.com"
   },
-  "version": "1.10.10",
+  "version": "1.10.11",
   "description": "The Web runtime for Breadboard",
   "main": "./build/index.js",
   "exports": {

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -844,11 +844,28 @@ export class Main extends LitElement {
     this.requestUpdate();
   }
 
+  #canParse(url: string) {
+    // TypeScript assumes that if `canParse` does not exist, then URL is
+    // `never`. However, in older browsers that's not true. We therefore take a
+    // temporary copy of the URL constructor here.
+    const UrlCtor = URL;
+    if ("canParse" in URL) {
+      return URL.canParse(url);
+    }
+
+    try {
+      new UrlCtor(url);
+      return true;
+    } catch (err) {
+      return false;
+    }
+  }
+
   #makeRelativeToCurrentBoard(boardUrl: string | null) {
     // An inability to parse the URL below likely means it's an example board,
     // which doesn't carry a protocol, etc. In such cases we just return the
     // URL as-is.
-    if (boardUrl && URL.canParse(boardUrl)) {
+    if (boardUrl && this.#canParse(boardUrl)) {
       if (this.url) {
         try {
           const base = new URL(this.url);


### PR DESCRIPTION
Fixes #2409