### PR TITLE
[visual-editor] Improve paste handling

### DIFF
--- a/.changeset/bright-eyes-unite.md
+++ b/.changeset/bright-eyes-unite.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/visual-editor": patch
+---
+
+Improve paste handling in main area

--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://wombat-dressing-room.appspot.com"
   },
-  "version": "1.10.11",
+  "version": "1.10.12",
   "description": "The Web runtime for Breadboard",
   "main": "./build/index.js",
   "exports": {

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -592,11 +592,30 @@ export class Main extends LitElement {
     }
   }
 
+  #receivesInputPreference(target: EventTarget) {
+    return (
+      target instanceof HTMLInputElement ||
+      target instanceof HTMLTextAreaElement ||
+      target instanceof HTMLSelectElement ||
+      target instanceof HTMLCanvasElement
+    );
+  }
+
   #onKeyDown(evt: KeyboardEvent) {
     const isMac = navigator.platform.indexOf("Mac") === 0;
     const isCtrlCommand = isMac ? evt.metaKey : evt.ctrlKey;
 
     if (evt.key === "v" && isCtrlCommand && !this.graph) {
+      // Only allow a paste when there's nothing else in the composed path that
+      // would accept the paste first.
+      if (
+        evt
+          .composedPath()
+          .some((target) => this.#receivesInputPreference(target))
+      ) {
+        return;
+      }
+
       evt.preventDefault();
 
       navigator.clipboard.readText().then((content) => {


### PR DESCRIPTION
Fixes #2423

We were overly eager with handling keyboard pastes at the root. Now we check to see if there's anything else in the composed path that would be better handling the paste first, and, if not, _then_ we go ahead and try to paste the board contents.