### PR TITLE
[visual-editor] Fix editor lock

### DIFF
--- a/.changeset/pretty-islands-prove.md
+++ b/.changeset/pretty-islands-prove.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/visual-editor": patch
+---
+
+Fix editor locking input focus (again)

--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "registry": "https://wombat-dressing-room.appspot.com"
   },
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "The Web runtime for Breadboard",
   "main": "./build/index.js",
   "exports": {

--- a/packages/visual-editor/src/ui/elements/input/code-editor/code-editor.ts
+++ b/packages/visual-editor/src/ui/elements/input/code-editor/code-editor.ts
@@ -20,7 +20,7 @@ export class CodeEditor extends LitElement {
   #content: Ref<HTMLDivElement> = createRef();
   #value: string | null = null;
 
-  #onKeyDownBound = this.#onKeyDown.bind(this);
+  #onKeyUpBound = this.#onKeyUp.bind(this);
 
   static styles = css`
     :host {
@@ -99,27 +99,27 @@ export class CodeEditor extends LitElement {
     this.#attemptEditorUpdate();
   }
 
-  #onKeyDown() {
+  #onKeyUp() {
     this.dispatchEvent(new CodeChangeEvent());
   }
 
   connectedCallback(): void {
     super.connectedCallback();
 
-    this.addEventListener("keydown", this.#onKeyDownBound);
+    this.addEventListener("keyup", this.#onKeyUpBound);
   }
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
 
-    this.removeEventListener("keydown", this.#onKeyDownBound);
+    this.removeEventListener("keyup", this.#onKeyUpBound);
   }
 
   render() {
     return html`<div ${ref(this.#content)}></div>`;
   }
 
-  unhookSafely() {
+  destroy() {
     if (!this.#editor) {
       return;
     }

--- a/packages/visual-editor/src/ui/elements/node-info/node-configuration.ts
+++ b/packages/visual-editor/src/ui/elements/node-info/node-configuration.ts
@@ -418,19 +418,23 @@ export class NodeConfigurationInfo extends LitElement {
       changedProperties.has("subGraphId") ||
       changedProperties.has("selectedNodeIds")
     ) {
-      if (!this.#nodeConfigurationFormRef.value) {
-        return;
-      }
+      this.destroyEditors();
+    }
+  }
 
-      // Here we must unhook the editor *before* it is removed from the DOM,
-      // otherwise CodeMirror will hold onto focus if it has it.
-      const editors =
-        this.#nodeConfigurationFormRef.value.querySelectorAll<CodeEditor>(
-          "bb-code-editor"
-        );
-      for (const editor of editors) {
-        editor.unhookSafely();
-      }
+  destroyEditors() {
+    if (!this.#nodeConfigurationFormRef.value) {
+      return;
+    }
+
+    // Here we must unhook the editor *before* it is removed from the DOM,
+    // otherwise CodeMirror will hold onto focus if it has it.
+    const editors =
+      this.#nodeConfigurationFormRef.value.querySelectorAll<CodeEditor>(
+        "bb-code-editor"
+      );
+    for (const editor of editors) {
+      editor.destroy();
     }
   }
 

--- a/packages/visual-editor/src/ui/elements/ui-controller/ui-controller.ts
+++ b/packages/visual-editor/src/ui/elements/ui-controller/ui-controller.ts
@@ -46,6 +46,7 @@ import { EditorMode } from "../../utils/mode.js";
 import { guard } from "lit/directives/guard.js";
 import { cache } from "lit/directives/cache.js";
 import { classMap } from "lit/directives/class-map.js";
+import { type NodeConfigurationInfo } from "../elements.js";
 
 type inputCallback = (data: Record<string, unknown>) => void;
 
@@ -121,6 +122,7 @@ export class UI extends LitElement {
   @state()
   history: EditHistory | null = null;
 
+  #nodeConfigurationRef: Ref<NodeConfigurationInfo> = createRef();
   #nodeSchemaUpdateCount = -1;
   #lastEdgeCount = -1;
   #lastBoardId = -1;
@@ -492,6 +494,7 @@ export class UI extends LitElement {
           .editable=${true}
           .providers=${this.providers}
           .providerOps=${this.providerOps}
+          ${ref(this.#nodeConfigurationRef)}
           name="Selected Node"
           @bbschemachange=${() => {
             this.#nodeSchemaUpdateCount++;
@@ -608,6 +611,18 @@ export class UI extends LitElement {
         },
         { once: true }
       );
+    }
+
+    // If we are about to re-render and remove the node configuration element
+    // we need to make sure that we are destroying all instances of the Code
+    // Editor before that happens. If not, CodeMirror will retain focus and a
+    // user won't be able to edit their inputs.
+    //
+    // If there is an "internal switch" from one node configuration view to
+    // another the element will take care of destroying the editors when it
+    // sees fit.
+    if (this.selectedNodeIds.length === 0 && this.#nodeConfigurationRef.value) {
+      this.#nodeConfigurationRef.value.destroyEditors();
     }
 
     const sidePanel = cache(


### PR DESCRIPTION
Fixes #2412

It turns out there were still cases where focus was being locked by CodeMirror. Hopefully this set of changes fixes that.