### PR TITLE
Nm paste

### DIFF
--- a/.changeset/serious-berries-speak.md
+++ b/.changeset/serious-berries-speak.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/visual-editor": patch
+---
+
+Tweak pasting of nodes when there is no metadata

--- a/packages/visual-editor/src/ui/elements/editor/editor.ts
+++ b/packages/visual-editor/src/ui/elements/editor/editor.ts
@@ -767,7 +767,8 @@ export class Editor extends LitElement {
 
           const remappedNodeIds = new Map<string, string>();
           const edits: EditSpec[] = [];
-          for (const node of graph.nodes) {
+          for (let i = 0; i < graph.nodes.length; i++) {
+            const node = graph.nodes[i];
             if (!this.#isNodeDescriptor(node)) {
               continue;
             }
@@ -789,7 +790,7 @@ export class Editor extends LitElement {
 
             // Grab the x & y coordinates, delete them, and use them to instruct
             // the graph where to place the node when it's added.
-            const x = (node.metadata.visual["x"] as number) ?? 0;
+            const x = (node.metadata.visual["x"] as number) ?? i * 40;
             const y = (node.metadata.visual["y"] as number) ?? 0;
 
             delete node.metadata.visual["x"];


### PR DESCRIPTION
When we have a node without metadata (which can happen if – say – the Build API or Breadboard Python generate the board) we currently assume {x: 0, y: 0} for it. This results with nodes being pasted directly atop one another.

While not perfect, this PR does improve the case slightly by using the pasted node's index to offset its x position a little.

Fixes #2255 