### PR TITLE
[breadboard] Add "wires" property to NodeDescriberContext

### DIFF
--- a/.changeset/large-cycles-refuse.md
+++ b/.changeset/large-cycles-refuse.md
@@ -1,0 +1,6 @@
+---
+"@google-labs/breadboard": patch
+"@breadboard-ai/build": patch
+---
+
+Add "wires" property to NodeDescriberContext which exposes a describe() function for getting the actual schema of a connected port if needed.

--- a/packages/breadboard/src/inspector/graph.ts
+++ b/packages/breadboard/src/inspector/graph.ts
@@ -112,6 +112,28 @@ class Graph implements InspectableGraphWithStore {
     const context: NodeDescriberContext = {
       outerGraph: this.#graph,
       loader,
+      wires: {
+        incoming: Object.fromEntries(
+          (options?.incoming ?? []).map((edge) => [
+            edge.in,
+            {
+              outputPort: {
+                describe: async () => (await edge.outPort()).type.schema,
+              },
+            },
+          ])
+        ),
+        outgoing: Object.fromEntries(
+          (options?.outgoing ?? []).map((edge) => [
+            edge.out,
+            {
+              inputPort: {
+                describe: async () => (await edge.inPort()).type.schema,
+              },
+            },
+          ])
+        ),
+      },
     };
     if (this.#url) {
       context.base = this.#url;

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -236,6 +236,23 @@ export type NodeDescriberContext = {
    * The loader that can be used to load graphs.
    */
   loader?: GraphLoader;
+  /**
+   * Information about the wires currently connected to this node.
+   */
+  wires: NodeDescriberWires;
+};
+
+export type NodeDescriberWires = {
+  // Note we only include the output port of incoming wires, and the input port
+  // of outgoing wires, because this object is consumed by describe functions,
+  // and it wouldn't make sense to ask about ports on the node we're
+  // implementing the describe function for, because that would be recursive.
+  incoming: Record<string, { outputPort: NodeDescriberPort }>;
+  outgoing: Record<string, { inputPort: NodeDescriberPort }>;
+};
+
+export type NodeDescriberPort = {
+  describe(): Promise<Schema>;
 };
 
 /**

--- a/packages/build/src/internal/define/definition.ts
+++ b/packages/build/src/internal/define/definition.ts
@@ -235,7 +235,10 @@ export class DefinitionImpl<
       const { staticValues, dynamicValues } =
         this.#applyDefaultsAndPartitionRuntimeInputValues(values ?? {});
       user = await this.#describe(staticValues, dynamicValues, {
-        ...(context ?? { outerGraph: { nodes: [], edges: [] } }),
+        ...(context ?? {
+          outerGraph: { nodes: [], edges: [] },
+          wires: { incoming: {}, outgoing: {} },
+        }),
         inputSchema: jsonSchemaToPortConfigMap(
           (inboundEdges as JSONSchema4) ?? {}
         ),

--- a/packages/build/src/test/describe_test.ts
+++ b/packages/build/src/test/describe_test.ts
@@ -405,12 +405,14 @@ test("describe receives context", async () => {
   const input: NodeDescriberContext = {
     base: new URL("http://example.com/"),
     outerGraph: { nodes: [], edges: [] },
+    wires: { incoming: {}, outgoing: {} },
   };
   const expected: NodeDescriberContextWithSchemas = {
     base: new URL("http://example.com/"),
     outerGraph: { nodes: [], edges: [] },
     inputSchema: {},
     outputSchema: {},
+    wires: { incoming: {}, outgoing: {} },
   };
   let actual: NodeDescriberContext | undefined;
   defineNodeType({
@@ -469,6 +471,7 @@ test("describe receives converted inputSchema and outputSchema and can return it
   const testContext: NodeDescriberContext = {
     base: new URL("http://example.com/"),
     outerGraph: { nodes: [], edges: [] },
+    wires: { incoming: {}, outgoing: {} },
   };
 
   const testInputSchema: Schema = {
@@ -522,6 +525,7 @@ test("describe receives converted inputSchema and outputSchema and can return it
         },
       },
     },
+    wires: { incoming: {}, outgoing: {} },
   };
 
   const expectedDescription = {

--- a/packages/core-kit/tests/invoke.ts
+++ b/packages/core-kit/tests/invoke.ts
@@ -46,6 +46,7 @@ test("describe with context.base and no values", async (t) => {
     await handler.describe(undefined, undefined, undefined, {
       base: new URL("http://example.com/"),
       outerGraph: { nodes: [], edges: [] },
+      wires: { incoming: {}, outgoing: {} },
     }),
     {
       inputSchema: {
@@ -86,6 +87,7 @@ test("describe with context.base and invalid $board", async (t) => {
     await handler.describe({ $board: "invalid.json" }, undefined, undefined, {
       base: new URL("file://invalid/base"),
       outerGraph: { nodes: [], edges: [] },
+      wires: { incoming: {}, outgoing: {} },
     }),
     {
       inputSchema: {
@@ -161,6 +163,7 @@ test("describe with context.base and valid $board", async (t) => {
       {
         base: new URL("http://example.com/"),
         outerGraph: { nodes: [], edges: [] },
+        wires: { incoming: {}, outgoing: {} },
       }
     ),
     {


### PR DESCRIPTION
Add `wires` property to NodeDescriberContext which exposes a `describe()` function for getting the actual schema of a connected port if needed.