### PR TITLE
[google-drive-kit] Use new cast node

### DIFF
--- a/.changeset/selfish-mails-hear.md
+++ b/.changeset/selfish-mails-hear.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/google-drive-kit": patch
+---
+
+Internal type-safety improvement to list-files

--- a/packages/google-drive-kit/src/list-files.ts
+++ b/packages/google-drive-kit/src/list-files.ts
@@ -13,9 +13,8 @@ import {
   optional,
   output,
   optionalEdge,
-  unsafeCast,
 } from "@breadboard-ai/build";
-import { fetch, unnest } from "@google-labs/core-kit";
+import { cast, fetch, unnest } from "@google-labs/core-kit";
 import { urlTemplate } from "@google-labs/template-kit";
 import { headers } from "./internal/headers.js";
 import { fileType } from "./types.js";
@@ -47,7 +46,7 @@ const url = urlTemplate({
 });
 
 const rawResponse = fetch({ url, headers });
-const response = unsafeCast(rawResponse, fileListType);
+const response = cast(rawResponse, fileListType);
 const { files, incompleteSearch, nextPageToken } = unnest(response);
 
 export const listFiles = board({


### PR DESCRIPTION
This improves type-safety in the visual editor when looking at the implementation of this board, because we now have a `cast` node which explicitly asserts the type for the `fetch` result, instead of wiring it up to outputs with no type checking.