### PR TITLE
[core-kit] Reflect incoming schema as output schema

### DIFF
--- a/.changeset/famous-ghosts-provide.md
+++ b/.changeset/famous-ghosts-provide.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/core-kit": patch
+---
+
+The unnest node now uses the actual describe function of the connected node to discover the incoming schema, and sets the outgoing schema to match.

--- a/packages/core-kit/src/nodes/unnest.ts
+++ b/packages/core-kit/src/nodes/unnest.ts
@@ -53,9 +53,11 @@ export const unnestNode = defineNodeType({
       type: "unknown",
     },
   },
-  describe: (_, __, context) => {
+  describe: async (_, __, context) => {
+    const nestedSchema =
+      await context?.wires.incoming["nested"]?.outputPort?.describe();
     return {
-      outputs: context?.inputSchema ? unsafeSchema(context.inputSchema) : {},
+      outputs: nestedSchema ? unsafeSchema(nestedSchema) : { "*": "unknown" },
     };
   },
   invoke: ({ nested }) => {


### PR DESCRIPTION
The unnest node now uses the actual describe function of the connected node to discover the incoming schema, and sets the outgoing schema to match.