### PR TITLE
[visual-editor] Redirect older /graphs/ URLs to /example-boards/

### DIFF
--- a/.changeset/lemon-radios-change.md
+++ b/.changeset/lemon-radios-change.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/visual-editor": patch
+---
+
+Redirect older /graphs/ URLs to /example-boards/

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -899,7 +899,13 @@ export class Main extends LitElement {
   }
 
   async #onStartBoard(startEvent: BreadboardUI.Events.StartEvent) {
-    const url = this.#makeRelativeToCurrentBoard(startEvent.url);
+    let url = this.#makeRelativeToCurrentBoard(startEvent.url);
+
+    // Redirect older /graphs examples to /example-boards
+    if (url?.startsWith("/graphs")) {
+      url = url.replace(/^\/graphs/, "/example-boards");
+    }
+
     this.#boardId++;
     this.#setUrlParam("board", url);
 


### PR DESCRIPTION
As part of moving out the example boards to their own package I renamed the directory from which examples are served. So as not to break any old links this PR redirects any older /graphs/ URLs to the new /example-boards/ path.