### PR TITLE
[build] Add describe function to Board component class

### DIFF
--- a/.changeset/thick-cameras-crash.md
+++ b/.changeset/thick-cameras-crash.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Add describe function to Board component class

--- a/packages/build/src/internal/board/board.ts
+++ b/packages/build/src/internal/board/board.ts
@@ -4,16 +4,30 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { NodeDescriberResult, Schema } from "@google-labs/breadboard";
 import type { GraphMetadata } from "@google-labs/breadboard-schema/graph.js";
+import type { JSONSchema4 } from "json-schema";
 import {
   InputPort,
+  isOutputPortReference,
   OutputPort,
+  OutputPortGetter,
   type OutputPortReference,
   type ValuesOrOutputPorts,
 } from "../common/port.js";
-import type { JsonSerializable } from "../type-system/type.js";
-import type { GenericSpecialInput, Input, InputWithDefault } from "./input.js";
-import type { Output } from "./output.js";
+import type {
+  SerializableInputPort,
+  SerializableOutputPortReference,
+} from "../common/serializable.js";
+import { toJSONSchema, type JsonSerializable } from "../type-system/type.js";
+import {
+  isSpecialInput,
+  type GenericSpecialInput,
+  type Input,
+  type InputWithDefault,
+} from "./input.js";
+import { isOptional } from "./optional.js";
+import { isSpecialOutput, type Output } from "./output.js";
 
 // TODO(aomarks) Support primary ports in boards.
 // TODO(aomarks) Support adding descriptions to board ports.
@@ -72,6 +86,7 @@ export function board<
     version,
     metadata,
     isBoard: true,
+    describe: def.describe.bind(def),
   });
 }
 
@@ -209,6 +224,7 @@ export type BoardDefinition<
   readonly description?: string;
   readonly version?: string;
   readonly metadata?: GraphMetadata;
+  describe(): Promise<NodeDescriberResult>;
 };
 
 // TODO(aomarks) Fix this definition so that it doesn't need <any, any>.
@@ -239,6 +255,59 @@ class BoardDefinitionImpl<
   ): BoardInstance<IPORTS, OPORTS> {
     return new BoardInstance(this.#inputs, this.#outputs, values);
   }
+
+  async describe(): Promise<NodeDescriberResult> {
+    const requiredInputs: string[] = [];
+    const requiredOutputs: string[] = [];
+    return {
+      inputSchema: {
+        type: "object",
+        required: requiredInputs,
+        additionalProperties: false,
+        properties: Object.fromEntries(
+          Object.entries(this.#inputs).map(([name, input]) => {
+            const { schema, required } = describeInput(input);
+            if (required) {
+              requiredInputs.push(name);
+            }
+            return [name, schema as Schema];
+          })
+        ),
+      },
+      outputSchema: {
+        type: "object",
+        required: requiredOutputs,
+        additionalProperties: false,
+        properties: Object.fromEntries(
+          Object.entries(this.#outputs).map(([name, output]) => {
+            const { schema, required } = describeOutput(output);
+            if (required) {
+              requiredOutputs.push(name);
+            }
+            return [name, schema as Schema];
+          })
+        ),
+      },
+    };
+  }
+}
+
+function getSchema(
+  value:
+    | GenericSpecialInput
+    | InputPort<JsonSerializable>
+    | Output<JsonSerializable>
+    | OutputPortReference<JsonSerializable>
+    | Input<JsonSerializable>
+    | InputWithDefault<JsonSerializable>
+): Schema {
+  if ("type" in value) {
+    return toJSONSchema(value.type) as Schema;
+  }
+  if (OutputPortGetter in value) {
+    return getSchema(value[OutputPortGetter]);
+  }
+  return getSchema(value.port);
 }
 
 class BoardInstance<
@@ -272,5 +341,89 @@ type ExtractPortTypes<PORTS extends BoardInputPorts | BoardOutputPorts> = {
 export function isBoard(value: unknown): value is GenericBoardDefinition {
   return (
     typeof value === "function" && "isBoard" in value && value.isBoard === true
+  );
+}
+
+export function describeInput(
+  input:
+    | Input<JsonSerializable | undefined>
+    | InputWithDefault<JsonSerializable | undefined>
+    | SerializableInputPort
+): {
+  schema: JSONSchema4;
+  required: boolean;
+} {
+  const schema = toJSONSchema(input.type);
+  let isSpecialOptional = false;
+  if (isSpecialInput(input)) {
+    if (input.title !== undefined) {
+      schema.title = input.title;
+    }
+    if (input.description !== undefined) {
+      schema.description = input.description;
+    }
+    if (input.default !== undefined) {
+      schema.default =
+        typeof input.default === "string"
+          ? input.default
+          : // TODO(aomarks) Why is default JSON stringified? The UI currently
+            // requires it, but seems like it should be real JSON.
+            JSON.stringify(input.default, null, 2);
+    }
+    if (input.examples !== undefined && input.examples.length > 0) {
+      schema.examples = input.examples.map((example) =>
+        typeof example === "string"
+          ? example
+          : // TODO(aomarks) Why is examples JSON stringified? The UI currently
+            // requires it, but seems like it should be real JSON.
+            JSON.stringify(example, null, 2)
+      );
+    }
+    if ("optional" in input && input.optional) {
+      isSpecialOptional = true;
+    }
+  }
+  const required = schema.default === undefined && !isSpecialOptional;
+  return { schema, required };
+}
+
+export function describeOutput(
+  output:
+    | SerializableOutputPortReference
+    | Output<JsonSerializable>
+    | Input<JsonSerializable>
+    | InputWithDefault<JsonSerializable>
+): {
+  schema: JSONSchema4;
+  required: boolean;
+} {
+  let port;
+  if (isSpecialOutput(output)) {
+    port = output.port;
+  } else {
+    port = output;
+  }
+  if (isSerializableOutputPortReference(port)) {
+    port = port[OutputPortGetter];
+  }
+  // Input<JsonSerializable> | InputWithDefault<JsonSerializable> | SerializableOutputPort | OutputPort<...>
+  const schema = toJSONSchema(port.type);
+  if (isSpecialOutput(output)) {
+    if (output.title !== undefined) {
+      schema.title = output.title;
+    }
+    if (output.description !== undefined) {
+      schema.description = output.description;
+    }
+  }
+  const required = !isOptional(port);
+  return { schema, required };
+}
+
+export function isSerializableOutputPortReference(
+  value: unknown
+): value is SerializableOutputPortReference {
+  return (
+    typeof value === "object" && value !== null && OutputPortGetter in value
   );
 }

--- a/packages/build/src/internal/board/output.ts
+++ b/packages/build/src/internal/board/output.ts
@@ -32,3 +32,13 @@ export interface Output<T extends JsonSerializable | undefined> {
   readonly description?: string;
   readonly port: OutputPortReference<T> | Input<T> | InputWithDefault<T>;
 }
+
+export function isSpecialOutput(
+  value: unknown
+): value is Output<JsonSerializable> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "__SpecialOutputBrand" in value
+  );
+}

--- a/packages/build/src/test/board_test.ts
+++ b/packages/build/src/test/board_test.ts
@@ -6,7 +6,7 @@
 
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
-import { defineNodeType } from "@breadboard-ai/build";
+import { defineNodeType, input, output } from "@breadboard-ai/build";
 import { test } from "node:test";
 import { board } from "../internal/board/board.js";
 import assert from "node:assert/strict";
@@ -219,3 +219,54 @@ test("allow setting title, description, version", () => {
     });
   });
 }
+
+test("describe board", async () => {
+  const inFoo = input({
+    title: "Foo title",
+    description: "Foo description",
+    default: "Foo default",
+    examples: ["Foo example 1", "Foo example 2"],
+  });
+  const boardA = board({
+    inputs: { inFoo },
+    outputs: {
+      outNum,
+      outStr: output(outStr, {
+        description: "outStr description",
+        title: "outStr title",
+      }),
+    },
+  });
+  const description = await boardA.describe();
+  assert.deepEqual(description, {
+    inputSchema: {
+      type: "object",
+      required: [],
+      additionalProperties: false,
+      properties: {
+        inFoo: {
+          type: "string",
+          title: "Foo title",
+          description: "Foo description",
+          default: "Foo default",
+          examples: ["Foo example 1", "Foo example 2"],
+        },
+      },
+    },
+    outputSchema: {
+      type: "object",
+      required: ["outNum", "outStr"],
+      additionalProperties: false,
+      properties: {
+        outNum: {
+          type: "number",
+        },
+        outStr: {
+          type: "string",
+          title: "outStr title",
+          description: "outStr description",
+        },
+      },
+    },
+  });
+});


### PR DESCRIPTION
Allows boards created with the `build` package to describe themselves as nodes.