### PR TITLE
Fix invalid changesets resulting from moved/archived packages

### DIFF
--- a/.changeset/bright-eyes-unite.md
+++ b/.changeset/bright-eyes-unite.md
@@ -1,5 +1,5 @@
 ---
-"@google-labs/visual-editor": patch
+"@breadboard-ai/visual-editor": patch
 ---
 
 Improve paste handling in main area

--- a/.changeset/clean-kangaroos-wonder.md
+++ b/.changeset/clean-kangaroos-wonder.md
@@ -1,5 +1,5 @@
 ---
-"@google-labs/visual-editor": patch
+"@breadboard-ai/visual-editor": patch
 ---
 
 Add Getting Started Guide to Visual Editor

--- a/.changeset/cold-parrots-behave.md
+++ b/.changeset/cold-parrots-behave.md
@@ -1,5 +1,5 @@
 ---
-"@google-labs/visual-editor": patch
+"@breadboard-ai/visual-editor": patch
 ---
 
 Change edit board to close

--- a/.changeset/four-dolls-provide.md
+++ b/.changeset/four-dolls-provide.md
@@ -1,7 +1,5 @@
 ---
-"@google-labs/breadboard-extension": patch
 "@google-labs/breadboard-cli": patch
-"@google-labs/cloud-function": patch
 "@breadboard-ai/visual-editor": patch
 "@breadboard-ai/board-server": patch
 "@google-labs/breadboard-hello-world": patch

--- a/.changeset/good-birds-brush.md
+++ b/.changeset/good-birds-brush.md
@@ -1,5 +1,5 @@
 ---
-"@google-labs/visual-editor": patch
+"@breadboard-ai/visual-editor": patch
 ---
 
 Enable pasting when on the Welcome Pane

--- a/.changeset/mean-shirts-relax.md
+++ b/.changeset/mean-shirts-relax.md
@@ -1,5 +1,5 @@
 ---
-"@google-labs/visual-editor": patch
+"@breadboard-ai/visual-editor": patch
 ---
 
 Fall back to URL Constructor for browsers without canParse

--- a/.changeset/nasty-wombats-roll.md
+++ b/.changeset/nasty-wombats-roll.md
@@ -1,5 +1,5 @@
 ---
-"@google-labs/visual-editor": patch
+"@breadboard-ai/visual-editor": patch
 ---
 
 Fix subgraph metadata bug

--- a/.changeset/ninety-bananas-argue.md
+++ b/.changeset/ninety-bananas-argue.md
@@ -1,5 +1,5 @@
 ---
-"@google-labs/visual-editor": patch
+"@breadboard-ai/visual-editor": patch
 ---
 
 Add New Board button to Welcome Pane

--- a/.changeset/olive-trees-reply.md
+++ b/.changeset/olive-trees-reply.md
@@ -1,6 +1,6 @@
 ---
 "@google-labs/breadboard-cli": minor
-"@google-labs/visual-editor": minor
+"@breadboard-ai/visual-editor": minor
 "@breadboard-ai/board-server": minor
 ---
 

--- a/.changeset/orange-glasses-build.md
+++ b/.changeset/orange-glasses-build.md
@@ -1,5 +1,5 @@
 ---
-"@google-labs/breadboard-web": patch
+"@breadboard-ai/visual-editor": patch
 ---
 
 Remind generate-graphs that it depends on agent-kit

--- a/.changeset/polite-wolves-remember.md
+++ b/.changeset/polite-wolves-remember.md
@@ -1,5 +1,5 @@
 ---
-"@google-labs/visual-editor": patch
+"@breadboard-ai/visual-editor": patch
 ---
 
 Add fancy-json component for rendering JSON with configurable highlighting

--- a/.changeset/red-baboons-yell.md
+++ b/.changeset/red-baboons-yell.md
@@ -1,5 +1,5 @@
 ---
-"@google-labs/visual-editor": patch
+"@breadboard-ai/visual-editor": patch
 ---
 
 Default node x & y to 0 if not set

--- a/.changeset/rude-bananas-repair.md
+++ b/.changeset/rude-bananas-repair.md
@@ -1,5 +1,5 @@
 ---
-"@google-labs/visual-editor": patch
+"@breadboard-ai/visual-editor": patch
 ---
 
 Clean up recent boards on delete

--- a/.changeset/sharp-zebras-battle.md
+++ b/.changeset/sharp-zebras-battle.md
@@ -1,5 +1,5 @@
 ---
-"@google-labs/visual-editor": patch
+"@breadboard-ai/visual-editor": patch
 ---
 
 Tweak the board selector to only show tools

--- a/.changeset/small-toys-cough.md
+++ b/.changeset/small-toys-cough.md
@@ -1,5 +1,5 @@
 ---
-"@google-labs/visual-editor": patch
+"@breadboard-ai/visual-editor": patch
 ---
 
 Remove default when changing from array to anything else

--- a/.changeset/spotty-tips-knock.md
+++ b/.changeset/spotty-tips-knock.md
@@ -1,7 +1,7 @@
 ---
 "@breadboard-ai/connection-server": minor
 "@google-labs/breadboard-cli": minor
-"@google-labs/visual-editor": minor
+"@breadboard-ai/visual-editor": minor
 "@google-labs/breadboard-website": minor
 ---
 

--- a/.changeset/stupid-clocks-sleep.md
+++ b/.changeset/stupid-clocks-sleep.md
@@ -1,5 +1,5 @@
 ---
-"@google-labs/visual-editor": patch
+"@breadboard-ai/visual-editor": patch
 ---
 
 Null out the editor property sooner

--- a/.changeset/tasty-starfishes-repeat.md
+++ b/.changeset/tasty-starfishes-repeat.md
@@ -1,5 +1,5 @@
 ---
-"@google-labs/visual-editor": patch
+"@breadboard-ai/visual-editor": patch
 ---
 
 Attempt to maintain property order in the schema editor

--- a/.changeset/tender-jars-roll.md
+++ b/.changeset/tender-jars-roll.md
@@ -1,5 +1,5 @@
 ---
-"@google-labs/visual-editor": patch
+"@breadboard-ai/visual-editor": patch
 ---
 
 Show red squigglies in port tooltips under mismatched schema constraints

--- a/.changeset/thirty-walls-sort.md
+++ b/.changeset/thirty-walls-sort.md
@@ -1,5 +1,5 @@
 ---
-"@google-labs/visual-editor": patch
+"@breadboard-ai/visual-editor": patch
 ---
 
 Version Bump

--- a/.changeset/weak-files-beg.md
+++ b/.changeset/weak-files-beg.md
@@ -1,5 +1,5 @@
 ---
-"@google-labs/visual-editor": patch
+"@breadboard-ai/visual-editor": patch
 ---
 
 Release drag behavior when clicking on port

--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -1,8 +1,5 @@
 {
   "name": "@breadboard-ai/visual-editor",
-  "publishConfig": {
-    "registry": "https://wombat-dressing-room.appspot.com"
-  },
   "version": "1.11.2",
   "description": "The Web runtime for Breadboard",
   "main": "./build/index.js",


### PR DESCRIPTION
Also remove `publishConfig` from visual-editor package, (not needed for the `@breadboard-ai` npm namespace)