### PR TITLE
[build] Make it much simpler to create kits

### DIFF
--- a/.changeset/bright-islands-roll.md
+++ b/.changeset/bright-islands-roll.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Add kit function to build for making kits

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -27,6 +27,7 @@ export { constant } from "./internal/board/constant.js";
 export { converge } from "./internal/board/converge.js";
 export { input } from "./internal/board/input.js";
 export { loopback } from "./internal/board/loopback.js";
+export { optionalEdge } from "./internal/board/optional.js";
 export { output } from "./internal/board/output.js";
 export { serialize } from "./internal/board/serialize.js";
 export { unsafeCast } from "./internal/board/unsafe-cast.js";
@@ -36,16 +37,16 @@ export type {
   SerializableBoard,
 } from "./internal/common/serializable.js";
 export { defineNodeType } from "./internal/define/define.js";
+export { jsonSchemaToPortConfigMap as fromJSONSchema } from "./internal/define/json-schema.js";
 export type { NodeFactoryFromDefinition } from "./internal/define/node-factory.js";
-export { optionalEdge } from "./internal/board/optional.js";
 export { unsafeSchema } from "./internal/define/unsafe-schema.js";
+export { kit } from "./internal/kit.js";
 export { annotate } from "./internal/type-system/annotate.js";
 export { anyOf } from "./internal/type-system/any-of.js";
 export { array } from "./internal/type-system/array.js";
 export { enumeration } from "./internal/type-system/enumeration.js";
 export { object, optional } from "./internal/type-system/object.js";
 export { toJSONSchema } from "./internal/type-system/type.js";
-export { jsonSchemaToPortConfigMap as fromJSONSchema } from "./internal/define/json-schema.js";
 export { unsafeType } from "./internal/type-system/unsafe.js";
 
 /**

--- a/packages/build/src/internal/kit.ts
+++ b/packages/build/src/internal/kit.ts
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  InputValues,
+  Kit,
+  NodeHandler,
+  NodeHandlerContext,
+  NodeHandlerFunction,
+} from "@google-labs/breadboard";
+import type { GenericBoardDefinition } from "./board/board.js";
+import { serialize } from "./board/serialize.js";
+import {
+  isDiscreteComponent,
+  type GenericDiscreteComponent,
+} from "./define/definition.js";
+
+export interface KitOptions {
+  title: string;
+  description: string;
+  version: string;
+  url: string;
+  components: Array<GenericDiscreteComponent | GenericBoardDefinition>;
+}
+
+export function kit(options: KitOptions): Kit {
+  const handlers: Record<string, NodeHandler> = Object.fromEntries(
+    options.components.map((component) => {
+      if (isDiscreteComponent(component)) {
+        return [component.id, component];
+      } else {
+        if (!component.id) {
+          // TODO(aomarks) Make id required.
+          throw new Error("To be added to a kit, boards must have an id.");
+        }
+        return [
+          component.id,
+          // TODO(aomarks) Should this just be the invoke() method on Board?
+          makeBoardComponentHandler(component),
+        ];
+      }
+    })
+  );
+
+  // TODO(aomarks) Unclear why this needs to be a class, and why it needs
+  // certain fields on both the static and instance sides.
+  return class GeneratedBreadboardKit {
+    static handlers = handlers;
+    static url = options.url;
+    handlers = handlers;
+    title = options.title;
+    description = options.description;
+    version = options.version;
+    url = options.url;
+  };
+}
+
+function makeBoardComponentHandler(board: GenericBoardDefinition): NodeHandler {
+  const serialized = serialize(board);
+  return {
+    metadata: board.metadata,
+    describe: board.describe.bind(board),
+    async invoke(inputs: InputValues, context: NodeHandlerContext) {
+      // Assume that invoke is available, since that's part of core kit, and use
+      // that to execute our serialized board.
+      const invoke = findInvokeFunctionFromContext(context);
+      if (invoke === undefined) {
+        return {
+          $error:
+            `Could not find an "invoke" node in the given context while ` +
+            `trying to execute the board with id "${board.id}" as component.`,
+        };
+      }
+      return invoke({ ...inputs, $board: serialized }, context);
+    },
+  };
+}
+
+function findInvokeFunctionFromContext(
+  context: NodeHandlerContext
+): NodeHandlerFunction | undefined {
+  for (const kit of context.kits ?? []) {
+    const invoke = kit.handlers["invoke"];
+    if (invoke !== undefined) {
+      return "invoke" in invoke ? invoke.invoke : invoke;
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
Much simpler to make kits now. Just pass in the components to the `kit` function, be they discrete or boards, and get back a usable kit.