### PR TITLE
Make the examples property of an input selectable

### DIFF
--- a/packages/visual-editor/src/ui/elements/input/input.ts
+++ b/packages/visual-editor/src/ui/elements/input/input.ts
@@ -14,6 +14,7 @@ import {
   isWebcamImage,
   isLLMContent,
   isLLMContentArray,
+  isEnum,
 } from "../../utils/index.js";
 import { LitElement, html, css } from "lit";
 import { customElement, property } from "lit/decorators.js";
@@ -377,7 +378,9 @@ export class Input extends LitElement {
             input = html`<bb-drawable-input id="${key}"></bb-drawable-input>`;
           } else if (isSelect(property)) {
             // Select input.
-            const options = property.enum || [];
+            const options = isEnum(property)
+              ? property.enum || []
+              : property.examples || [];
             input = html`<div>
               <select name="${key}" id="${key}">
                 ${options.map((option) => {

--- a/packages/visual-editor/src/ui/utils/index.ts
+++ b/packages/visual-editor/src/ui/utils/index.ts
@@ -15,6 +15,13 @@ export function isMultiline(schema: Schema) {
 }
 
 export function isSelect(schema: Schema) {
+  return (
+    (schema.enum && schema.enum.length > 0) ||
+    (schema.examples && schema.examples.length > 0)
+  );
+}
+
+export function isEnum(schema: Schema) {
   return schema.enum && schema.enum.length > 0;
 }
 


### PR DESCRIPTION
Fixes #2490 

When setting the `examples` property for an input, the options are displayed under a dropdown allowing users to select one of the options provided in the schema. For example, the following:
<img width="725" alt="Screenshot 2024-07-15 at 09 02 49" src="https://github.com/user-attachments/assets/1285c6d4-e481-43de-8444-914048550ea4">
produces the following:
<img width="153" alt="Screenshot 2024-07-15 at 09 03 19" src="https://github.com/user-attachments/assets/1b3989b0-c468-4200-8735-1d827e2fb57d">

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
