### PR TITLE
[visual-editor] Fix nav filter and delete behaviors

### DIFF
--- a/.changeset/proud-jobs-eat.md
+++ b/.changeset/proud-jobs-eat.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/visual-editor": patch
+---
+
+Increase the set of reasons to refresh the side nav

--- a/packages/visual-editor/src/ui/elements/nav/nav.ts
+++ b/packages/visual-editor/src/ui/elements/nav/nav.ts
@@ -453,15 +453,21 @@ export class Navigation extends LitElement {
   protected willUpdate(
     changedProperties:
       | PropertyValueMap<{
+          providerOps: number;
+          providers: GraphProvider[];
           selectedProvider: string;
           selectedLocation: string;
           url: string | null;
+          filter: string | null;
         }>
       | Map<PropertyKey, unknown>
   ): void {
     if (
+      changedProperties.has("providerOps") ||
+      changedProperties.has("providers") ||
       changedProperties.has("selectedLocation") ||
-      changedProperties.has("selectedProvider")
+      changedProperties.has("selectedProvider") ||
+      changedProperties.has("filter")
     ) {
       this.#providerContents = this.#loadProviderContents();
     }

--- a/packages/visual-editor/src/ui/elements/overlay/provider.ts
+++ b/packages/visual-editor/src/ui/elements/overlay/provider.ts
@@ -248,7 +248,7 @@ export class ProviderOverlay extends LitElement {
 
           switch (type) {
             case "BoardServer": {
-              const url = data.get("url") as string;
+              let url = data.get("url") as string;
               if (!url) {
                 return;
               }
@@ -256,6 +256,9 @@ export class ProviderOverlay extends LitElement {
               if (!apiKey) {
                 return;
               }
+
+              // Ensure there is no trailing slash on the end of the URL.
+              url = url.replace(/\/$/, "");
 
               this.dispatchEvent(
                 new GraphProviderConnectRequestEvent(


### PR DESCRIPTION
I noticed that in fixing the nav scroll issue (which was essentially being overly keen to re-render the nav) we are now too keen in the other direction. This means that when a board is created or deleted, or when a provider is updated, we don't re-render the nav (even though we do perform the action).

This PR increases the set of things that will trigger a re-render of the nav.