### PR TITLE
Added "number" type to wildcard input

### DIFF
--- a/.changeset/fair-eyes-try.md
+++ b/.changeset/fair-eyes-try.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/template-kit": patch
+---
+
+The wildcard input for urlTemplate now accepts "number" as well as "string"

--- a/packages/template-kit/src/nodes/url-template.ts
+++ b/packages/template-kit/src/nodes/url-template.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { defineNodeType } from "@breadboard-ai/build";
+import { anyOf, defineNodeType } from "@breadboard-ai/build";
 import { parseTemplate } from "url-template";
 
 const operators = [
@@ -64,7 +64,7 @@ export default defineNodeType({
       description: "The URL template to use",
     },
     "*": {
-      type: "string",
+      type: anyOf("string", "number"),
     },
   },
   outputs: {

--- a/packages/template-kit/tests/nodes/url-template.ts
+++ b/packages/template-kit/tests/nodes/url-template.ts
@@ -66,7 +66,10 @@ test("`urlTemplateDescriber` produces valid results", async (t) => {
           path: {
             title: "path",
             description: 'Value for placeholder "path"',
-            type: "string",
+            type: [
+              "string",
+              "number"
+            ],
           },
           template: {
             title: "Template",
@@ -88,7 +91,10 @@ test("`urlTemplateDescriber` produces valid results", async (t) => {
           path: {
             title: "path",
             description: 'Value for path segment expansion placeholder "path"',
-            type: "string",
+            type: [
+              "string",
+              "number"
+            ],
           },
           template: {
             title: "Template",


### PR DESCRIPTION
Fixes #2486

Adding "number" type to wildcard input in Template Kit's `urlTemplate` node. 