### PR TITLE
[board-server] Simplify dev script configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7315,94 +7315,6 @@
         "node": ">=10.18.0 <11 || >=12.14.0 <13 || >=14"
       }
     },
-    "node_modules/concurrently": {
-      "version": "8.2.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "date-fns": "^2.30.0",
-        "lodash": "^4.17.21",
-        "rxjs": "^7.8.1",
-        "shell-quote": "^1.8.1",
-        "spawn-command": "0.0.2",
-        "supports-color": "^8.1.1",
-        "tree-kill": "^1.2.2",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "conc": "dist/bin/concurrently.js",
-        "concurrently": "dist/bin/concurrently.js"
-      },
-      "engines": {
-        "node": "^14.13.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
-      }
-    },
-    "node_modules/concurrently/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/concurrently/node_modules/chalk": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/concurrently/node_modules/chalk/node_modules/supports-color": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/concurrently/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/concurrently/node_modules/supports-color": {
-      "version": "8.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -7743,21 +7655,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/date-fns": {
-      "version": "2.30.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0"
-      },
-      "engines": {
-        "node": ">=0.11"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/date-time": {
@@ -19441,14 +19338,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/rxjs": {
-      "version": "7.8.1",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/safe-array-concat": {
       "version": "1.1.2",
       "dev": true,
@@ -19812,14 +19701,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/shell-quote": {
-      "version": "1.8.1",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/side-channel": {
       "version": "1.0.6",
       "license": "MIT",
@@ -19929,10 +19810,6 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
-    },
-    "node_modules/spawn-command": {
-      "version": "0.0.2",
-      "dev": true
     },
     "node_modules/spawndamnit": {
       "version": "2.0.0",
@@ -21020,14 +20897,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/tree-kill": {
-      "version": "1.2.2",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "tree-kill": "cli.js"
       }
     },
     "node_modules/ts-api-utils": {
@@ -22534,7 +22403,6 @@
       },
       "devDependencies": {
         "@types/node": "^20.14.10",
-        "concurrently": "^8.2.2",
         "esbuild": "^0.21.5",
         "eslint": "^8.57.0",
         "typescript": "^5.5.3",
@@ -23347,7 +23215,7 @@
     },
     "packages/visual-editor": {
       "name": "@breadboard-ai/visual-editor",
-      "version": "1.12.2",
+      "version": "1.12.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@breadboard-ai/build": "0.7.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "wireit",
     "lint": "wireit",
     "ci": "npm ci",
-    "s": "(cd packages/board-server && npm run dev) # Starts the board server",
+    "s": "npm run dev -w packages/board-server --watch",
     "d": "(cd packages/website && npm run dev) # Starts the docs website",
     "w": "(cd packages/visual-editor && npm run dev) # Starts the breadboard web UI",
     "check:format": "prettier --check --config .prettierrc packages/**/*.ts",

--- a/packages/board-server/package.json
+++ b/packages/board-server/package.json
@@ -16,7 +16,8 @@
     "deploy": "npm run build && gcloud app deploy",
     "add": "tsx scripts/create-account.ts",
     "serve": "wireit",
-    "dev": "export GOOGLE_CLOUD_PROJECT=$(gcloud config get-value project) &&concurrently \"npm run serve --watch\" \"(cd ../visual-editor && npm run dev)\""
+    "dev": "npm run dev:nowatch --watch",
+    "dev:nowatch": "wireit"
   },
   "wireit": {
     "build": {
@@ -67,6 +68,17 @@
       "command": "node .",
       "dependencies": [
         "build"
+      ]
+    },
+    "dev:nowatch": {
+      "command": "export GOOGLE_CLOUD_PROJECT=$(gcloud config get-value project) && node .",
+      "service": true,
+      "dependencies": [
+        "build",
+        {
+          "script": "../visual-editor:serve",
+          "cascade": false
+        }
       ]
     }
   },

--- a/packages/board-server/package.json
+++ b/packages/board-server/package.json
@@ -87,7 +87,6 @@
   "homepage": "https://github.com/breadboard-ai/breadboard#readme",
   "devDependencies": {
     "@types/node": "^20.14.10",
-    "concurrently": "^8.2.2",
     "esbuild": "^0.21.5",
     "eslint": "^8.57.0",
     "typescript": "^5.5.3",


### PR DESCRIPTION
Before, the process tree for `npm run s` (top-level script) looked like this:

```
- npm
- npm
- concurrently
  - npm
    - wireit
      - server1
  - npm
    - wireit
      - server2
```

Now it looks like this:

```
- npm
- wireit
  - server1
  - server2
```

The specific motivation for this was that `mprocs` wasn't working with `npm run s`. The reason for that was:

1. When you stop a script with `mprocs`, it sends `SIGTERM`
2. `concurrently` does not propagate `SIGTERM` to its children

npm and wireit do the right thing here, so now it should work fine.

Uninstalled concurrently as well, no need for it because wireit can already run things in parallel.

cc @timswanson-google 