### PR TITLE
Export jsonata node from json-kit

### DIFF
--- a/.changeset/silver-pandas-applaud.md
+++ b/.changeset/silver-pandas-applaud.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/json-kit": patch
+---
+
+Exporting jsonata node from index

--- a/packages/json-kit/src/index.ts
+++ b/packages/json-kit/src/index.ts
@@ -17,6 +17,8 @@ import schemish from "./nodes/schemish.js";
 import validateJson from "./nodes/validate-json.js";
 import xmlToJson from "./nodes/xml-to-json.js";
 
+export { default as jsonata } from "./nodes/jsonata.js";
+
 const JSONKit = new KitBuilder({
   title: "JSON Kit",
   description:


### PR DESCRIPTION
Fixes #2547 

Added a line to export the `jsonata` node from the json kit. This node has already been migrated to the new Build API. Currently, the node cannot be imported directly and it has an unknown type when invoked from the kit, which causes errors when using in boards created with the Build API.
