### PR TITLE
more core docs

### DIFF
--- a/.changeset/pink-cougars-cover.md
+++ b/.changeset/pink-cougars-cover.md
@@ -1,0 +1,9 @@
+---
+"@breadboard-ai/visual-editor": patch
+"@google-labs/breadboard": patch
+"@google-labs/agent-kit": patch
+"@google-labs/core-kit": patch
+"@google-labs/breadboard-website": patch
+---
+
+Update titles and help links in Core Kit.

--- a/packages/agent-kit/agent.kit.json
+++ b/packages/agent-kit/agent.kit.json
@@ -7,7 +7,10 @@
     "human": {
       "title": "Human",
       "metadata": {
-        "icon": "human"
+        "icon": "human",
+        "help": {
+          "url": "https://breadboard-ai.github.io/breadboard/docs/kits/agents/#human"
+        }
       },
       "description": "A human in the loop. Use this node to insert a real person (user input) into your team of synthetic workers.",
       "version": "0.0.1",
@@ -914,7 +917,10 @@
     "specialist": {
       "title": "Specialist",
       "metadata": {
-        "icon": "smart-toy"
+        "icon": "smart-toy",
+        "help": {
+          "url": "https://breadboard-ai.github.io/breadboard/docs/kits/agents/#specialist"
+        }
       },
       "description": "Given instructions on how to act, performs a single task, optionally invoking tools.",
       "edges": [
@@ -2316,7 +2322,10 @@
     "looper": {
       "title": "Looper",
       "metadata": {
-        "icon": "laps"
+        "icon": "laps",
+        "help": {
+          "url": "https://breadboard-ai.github.io/breadboard/docs/kits/agents/#looper"
+        }
       },
       "description": "A worker whose job it is to repeat the same thing over and over, until some condition is met or the max count of repetitions is reached.",
       "version": "0.0.1",
@@ -2585,7 +2594,10 @@
     "joiner": {
       "title": "Joiner",
       "metadata": {
-        "icon": "merge-type"
+        "icon": "merge-type",
+        "help": {
+          "url": "https://breadboard-ai.github.io/breadboard/docs/kits/agents/#joiner"
+        }
       },
       "description": "Joins two or more worker contexts into one. Great for combining results of multiple workers.",
       "version": "0.0.1",

--- a/packages/agent-kit/agent.kit.json
+++ b/packages/agent-kit/agent.kit.json
@@ -916,7 +916,7 @@
       "metadata": {
         "icon": "smart-toy"
       },
-      "description": "All-in-one worker. A work in progress, incorporates all the learnings from making previous workers.",
+      "description": "Given instructions on how to act, performs a single task, optionally invoking tools.",
       "edges": [
         {
           "from": "fn-13",

--- a/packages/agent-kit/agent.kit.json
+++ b/packages/agent-kit/agent.kit.json
@@ -409,6 +409,9 @@
       "title": "Repeater",
       "description": "A worker whose job it is to repeat the same thing over and over, until some condition is met or the max count of repetitions is reached.",
       "version": "0.0.1",
+      "metadata": {
+        "deprecated": true
+      },
       "edges": [
         {
           "from": "counter",
@@ -571,6 +574,9 @@
       "title": "Structured Worker",
       "description": "A worker who outputs structure data (JSON) provided a schema.",
       "version": "0.0.1",
+      "metadata": {
+        "deprecated": true
+      },
       "edges": [
         {
           "from": "assembleContext",
@@ -2142,6 +2148,9 @@
       "title": "Worker",
       "description": "The essential Agent building block",
       "version": "0.0.1",
+      "metadata": {
+        "deprecated": true
+      },
       "edges": [
         {
           "from": "assembleContext",

--- a/packages/agent-kit/src/boards/human.ts
+++ b/packages/agent-kit/src/boards/human.ts
@@ -428,6 +428,9 @@ export default await board(({ context, title, description }) => {
   title: "Human",
   metadata: {
     icon: "human",
+    help: {
+      url: "https://breadboard-ai.github.io/breadboard/docs/kits/agents/#human",
+    },
   },
   description:
     "A human in the loop. Use this node to insert a real person (user input) into your team of synthetic workers.",

--- a/packages/agent-kit/src/boards/joiner.ts
+++ b/packages/agent-kit/src/boards/joiner.ts
@@ -52,6 +52,9 @@ export default await board(({ merge }) => {
   title: "Joiner",
   metadata: {
     icon: "merge-type",
+    help: {
+      url: "https://breadboard-ai.github.io/breadboard/docs/kits/agents/#joiner",
+    },
   },
   description:
     "Joins two or more worker contexts into one. Great for combining results of multiple workers.",

--- a/packages/agent-kit/src/boards/looper.ts
+++ b/packages/agent-kit/src/boards/looper.ts
@@ -322,6 +322,9 @@ export default await board(({ context, task }) => {
   title: "Looper",
   metadata: {
     icon: "laps",
+    help: {
+      url: "https://breadboard-ai.github.io/breadboard/docs/kits/agents/#looper",
+    },
   },
   description:
     "A worker whose job it is to repeat the same thing over and over, until some condition is met or the max count of repetitions is reached.",

--- a/packages/agent-kit/src/boards/repeater.ts
+++ b/packages/agent-kit/src/boards/repeater.ts
@@ -107,4 +107,7 @@ export default await board(({ context, worker, max }) => {
   description:
     "A worker whose job it is to repeat the same thing over and over, until some condition is met or the max count of repetitions is reached.",
   version: "0.0.1",
+  metadata: {
+    deprecated: true,
+  },
 });

--- a/packages/agent-kit/src/boards/specialist.ts
+++ b/packages/agent-kit/src/boards/specialist.ts
@@ -247,7 +247,7 @@ const specialist = await board(({ in: context, persona, task, tools }) => {
     icon: "smart-toy",
   },
   description:
-    "All-in-one worker. A work in progress, incorporates all the learnings from making previous workers.",
+    "Given instructions on how to act, performs a single task, optionally invoking tools.",
 });
 
 specialist.graphs = { boardToFunction, invokeBoardWithArgs };

--- a/packages/agent-kit/src/boards/specialist.ts
+++ b/packages/agent-kit/src/boards/specialist.ts
@@ -245,6 +245,9 @@ const specialist = await board(({ in: context, persona, task, tools }) => {
   title: "Specialist",
   metadata: {
     icon: "smart-toy",
+    help: {
+      url: "https://breadboard-ai.github.io/breadboard/docs/kits/agents/#specialist",
+    },
   },
   description:
     "Given instructions on how to act, performs a single task, optionally invoking tools.",

--- a/packages/agent-kit/src/boards/structured-worker.ts
+++ b/packages/agent-kit/src/boards/structured-worker.ts
@@ -268,4 +268,7 @@ export default await board(({ context, instruction, schema }) => {
   title: "Structured Worker",
   description: "A worker who outputs structure data (JSON) provided a schema.",
   version: "0.0.1",
+  metadata: {
+    deprecated: true,
+  },
 });

--- a/packages/agent-kit/src/boards/worker.ts
+++ b/packages/agent-kit/src/boards/worker.ts
@@ -105,4 +105,7 @@ export default await board(({ context, instruction, stopSequences }) => {
   title: "Worker",
   description: "The essential Agent building block",
   version: "0.0.1",
+  metadata: {
+    deprecated: true,
+  },
 });

--- a/packages/breadboard/src/kits/load.ts
+++ b/packages/breadboard/src/kits/load.ts
@@ -45,6 +45,7 @@ class GraphDescriptorNodeHandler implements NodeHandlerObject {
     if (metadata?.deprecated)
       this.metadata.deprecated = metadata.deprecated as boolean;
     if (metadata?.icon) this.metadata.icon = metadata.icon;
+    if (metadata?.help) this.metadata.help = metadata.help;
   }
 
   async describe() {

--- a/packages/core-kit/src/nodes/curry.ts
+++ b/packages/core-kit/src/nodes/curry.ts
@@ -90,6 +90,9 @@ const metadata = {
   title: "Curry",
   description:
     "Takes a board and bakes in (curries) supplied arguments into it. Very useful when we want to invoke a board with the same arguments many times (like with `map`).",
+  help: {
+    url: "https://breadboard-ai.github.io/breadboard/docs/kits/core/#the-curry-component",
+  },
 } satisfies NodeHandlerMetadata;
 
 export default { metadata, invoke, describe };

--- a/packages/core-kit/src/nodes/deflate.ts
+++ b/packages/core-kit/src/nodes/deflate.ts
@@ -13,6 +13,9 @@ export default defineNodeType({
     title: "Deflate",
     description:
       "Converts all inline data to stored data, saving memory. Useful when working with multimodal content. Safely passes data through if it's already stored or no inline data is present.",
+    help: {
+      url: "https://breadboard-ai.github.io/breadboard/docs/kits/core/#the-deflate-component",
+    },
   },
   inputs: {
     data: {

--- a/packages/core-kit/src/nodes/deflate.ts
+++ b/packages/core-kit/src/nodes/deflate.ts
@@ -17,12 +17,14 @@ export default defineNodeType({
   inputs: {
     data: {
       type: object({}),
+      title: "Data",
       description: "Data to deflate.",
     },
   },
   outputs: {
     data: {
       type: object({}),
+      title: "Data",
       description: "Deflated data.",
     },
   },

--- a/packages/core-kit/src/nodes/fetch.ts
+++ b/packages/core-kit/src/nodes/fetch.ts
@@ -81,6 +81,9 @@ export default defineNodeType({
     title: "Fetch",
     description:
       "A wrapper around `fetch` API. Use this node to fetch content from the Web.",
+    help: {
+      url: "https://breadboard-ai.github.io/breadboard/docs/kits/core/#the-fetch-component",
+    },
   },
   inputs: {
     url: {

--- a/packages/core-kit/src/nodes/fetch.ts
+++ b/packages/core-kit/src/nodes/fetch.ts
@@ -85,30 +85,39 @@ export default defineNodeType({
   inputs: {
     url: {
       description: "The URL to fetch",
+      title: "URL",
       type: "string",
     },
     method: {
+      title: "Method",
+      behavior: ["config"],
       description: "The HTTP method to use",
       type: enumeration("GET", "POST", "PUT", "DELETE"),
       default: "GET",
     },
     headers: {
+      title: "Headers",
       description: "Headers to send with the request",
       type: object({}, "string"),
       default: {},
     },
     body: {
+      title: "Body",
       description: "The body of the request",
       type: "unknown",
       optional: true,
     },
     raw: {
+      title: "Raw",
+      behavior: ["config"],
       description:
         "Whether or not to return raw text (as opposed to parsing JSON)",
       type: "boolean",
       default: false,
     },
     stream: {
+      title: "Stream",
+      behavior: ["config"],
       description: "Whether or not to return a stream",
       type: "boolean",
       default: false,
@@ -116,23 +125,28 @@ export default defineNodeType({
   },
   outputs: {
     response: {
+      title: "Response",
       description: "The response from the fetch request",
       type: "unknown",
       primary: true,
     },
     status: {
+      title: "Status",
       description: "The HTTP status code of the response",
       type: "number",
     },
     statusText: {
+      title: "Status Text",
       description: "The status text of the response",
       type: "string",
     },
     contentType: {
+      title: "Content Type",
       description: "The content type of the response",
       type: anyOf("string", "null"),
     },
     responseHeaders: {
+      title: "Response Headers",
       description: "The headers of the response",
       type: object({}, "string"),
     },

--- a/packages/core-kit/src/nodes/inflate.ts
+++ b/packages/core-kit/src/nodes/inflate.ts
@@ -12,6 +12,9 @@ export default defineNodeType({
   metadata: {
     title: "Inflate",
     description: "Converts stored data to base64.",
+    help: {
+      url: "https://breadboard-ai.github.io/breadboard/docs/kits/core/#the-inflate-component",
+    },
   },
   inputs: {
     data: {

--- a/packages/core-kit/src/nodes/inflate.ts
+++ b/packages/core-kit/src/nodes/inflate.ts
@@ -16,12 +16,14 @@ export default defineNodeType({
   inputs: {
     data: {
       type: object({}),
+      title: "Data",
       description: "Data to inflate.",
     },
   },
   outputs: {
     data: {
       type: object({}),
+      title: "Data",
       description: "inflated data.",
     },
   },

--- a/packages/core-kit/src/nodes/invoke.ts
+++ b/packages/core-kit/src/nodes/invoke.ts
@@ -86,6 +86,9 @@ export default defineNodeType({
     title: "Invoke",
     description:
       "Invokes (runOnce) specified board, supplying remaining incoming wires as inputs for that board. Returns the outputs of the board.",
+    help: {
+      url: "https://breadboard-ai.github.io/breadboard/docs/kits/core/#the-invoke-component",
+    },
   },
   inputs: {
     path: {

--- a/packages/core-kit/src/nodes/invoke.ts
+++ b/packages/core-kit/src/nodes/invoke.ts
@@ -96,7 +96,7 @@ export default defineNodeType({
       optional: true,
     },
     $board: {
-      title: "board",
+      title: "Board",
       behavior: ["board", "config"],
       description:
         "The board to invoke. Can be a BoardCapability, a graph or a URL",

--- a/packages/core-kit/src/nodes/map.ts
+++ b/packages/core-kit/src/nodes/map.ts
@@ -45,6 +45,9 @@ const mapNode = defineNodeType({
     title: "Map",
     description:
       "Given a list and a board, iterates over this list (just like your usual JavaScript `map` function), invoking (runOnce) the supplied board for each item.",
+    help: {
+      url: "https://breadboard-ai.github.io/breadboard/docs/kits/core/#the-map-component",
+    },
   },
   inputs: {
     list: {

--- a/packages/core-kit/src/nodes/passthrough.ts
+++ b/packages/core-kit/src/nodes/passthrough.ts
@@ -12,6 +12,9 @@ export default defineNodeType({
     title: "Passthrough",
     description:
       "Takes all inputs and passes them through as outputs. Effectively, a no-op node in Breadboard.",
+    help: {
+      url: "https://breadboard-ai.github.io/breadboard/docs/kits/core/#the-passthrough-component",
+    },
   },
   inputs: {
     "*": {

--- a/packages/core-kit/tests/invoke.ts
+++ b/packages/core-kit/tests/invoke.ts
@@ -16,7 +16,7 @@ test("describe with no values and no context.base", async (t) => {
           behavior: ["board", "config"],
           description:
             "The board to invoke. Can be a BoardCapability, a graph or a URL",
-          title: "board",
+          title: "Board",
           type: "object",
           additionalProperties: false,
           properties: {},
@@ -55,7 +55,7 @@ test("describe with context.base and no values", async (t) => {
             behavior: ["board", "config"],
             description:
               "The board to invoke. Can be a BoardCapability, a graph or a URL",
-            title: "board",
+            title: "Board",
             type: "object",
             additionalProperties: false,
             properties: {},
@@ -96,7 +96,7 @@ test("describe with context.base and invalid $board", async (t) => {
             behavior: ["board", "config"],
             description:
               "The board to invoke. Can be a BoardCapability, a graph or a URL",
-            title: "board",
+            title: "Board",
             type: "object",
             additionalProperties: false,
             properties: {},
@@ -175,7 +175,7 @@ test("describe with context.base and valid $board", async (t) => {
             behavior: ["board", "config"],
             description:
               "The board to invoke. Can be a BoardCapability, a graph or a URL",
-            title: "board",
+            title: "Board",
             type: "object",
             additionalProperties: false,
             properties: {},

--- a/packages/visual-editor/public/agent.kit.json
+++ b/packages/visual-editor/public/agent.kit.json
@@ -7,7 +7,10 @@
     "human": {
       "title": "Human",
       "metadata": {
-        "icon": "human"
+        "icon": "human",
+        "help": {
+          "url": "https://breadboard-ai.github.io/breadboard/docs/kits/agents/#human"
+        }
       },
       "description": "A human in the loop. Use this node to insert a real person (user input) into your team of synthetic workers.",
       "version": "0.0.1",
@@ -914,7 +917,10 @@
     "specialist": {
       "title": "Specialist",
       "metadata": {
-        "icon": "smart-toy"
+        "icon": "smart-toy",
+        "help": {
+          "url": "https://breadboard-ai.github.io/breadboard/docs/kits/agents/#specialist"
+        }
       },
       "description": "Given instructions on how to act, performs a single task, optionally invoking tools.",
       "edges": [
@@ -2316,7 +2322,10 @@
     "looper": {
       "title": "Looper",
       "metadata": {
-        "icon": "laps"
+        "icon": "laps",
+        "help": {
+          "url": "https://breadboard-ai.github.io/breadboard/docs/kits/agents/#looper"
+        }
       },
       "description": "A worker whose job it is to repeat the same thing over and over, until some condition is met or the max count of repetitions is reached.",
       "version": "0.0.1",
@@ -2585,7 +2594,10 @@
     "joiner": {
       "title": "Joiner",
       "metadata": {
-        "icon": "merge-type"
+        "icon": "merge-type",
+        "help": {
+          "url": "https://breadboard-ai.github.io/breadboard/docs/kits/agents/#joiner"
+        }
       },
       "description": "Joins two or more worker contexts into one. Great for combining results of multiple workers.",
       "version": "0.0.1",

--- a/packages/visual-editor/public/agent.kit.json
+++ b/packages/visual-editor/public/agent.kit.json
@@ -916,7 +916,7 @@
       "metadata": {
         "icon": "smart-toy"
       },
-      "description": "All-in-one worker. A work in progress, incorporates all the learnings from making previous workers.",
+      "description": "Given instructions on how to act, performs a single task, optionally invoking tools.",
       "edges": [
         {
           "from": "fn-13",

--- a/packages/visual-editor/public/agent.kit.json
+++ b/packages/visual-editor/public/agent.kit.json
@@ -409,6 +409,9 @@
       "title": "Repeater",
       "description": "A worker whose job it is to repeat the same thing over and over, until some condition is met or the max count of repetitions is reached.",
       "version": "0.0.1",
+      "metadata": {
+        "deprecated": true
+      },
       "edges": [
         {
           "from": "counter",
@@ -571,6 +574,9 @@
       "title": "Structured Worker",
       "description": "A worker who outputs structure data (JSON) provided a schema.",
       "version": "0.0.1",
+      "metadata": {
+        "deprecated": true
+      },
       "edges": [
         {
           "from": "assembleContext",
@@ -2142,6 +2148,9 @@
       "title": "Worker",
       "description": "The essential Agent building block",
       "version": "0.0.1",
+      "metadata": {
+        "deprecated": true
+      },
       "edges": [
         {
           "from": "assembleContext",

--- a/packages/visual-editor/public/example-boards/playground/best-of-n.json
+++ b/packages/visual-editor/public/example-boards/playground/best-of-n.json
@@ -254,7 +254,7 @@
                         "properties": {},
                         "required": [],
                         "additionalProperties": false,
-                        "title": "board",
+                        "title": "Board",
                         "description": "The board to invoke. Can be a BoardCapability, a graph or a URL",
                         "behavior": [
                           "board",

--- a/packages/visual-editor/public/example-boards/playground/nager.date/available-countries.json
+++ b/packages/visual-editor/public/example-boards/playground/nager.date/available-countries.json
@@ -27,7 +27,7 @@
                 "object",
                 "string"
               ],
-              "title": "response",
+              "title": "Response",
               "description": "The response from the fetch request"
             }
           }

--- a/packages/visual-editor/public/example-boards/playground/nager.date/country-info.json
+++ b/packages/visual-editor/public/example-boards/playground/nager.date/country-info.json
@@ -187,7 +187,7 @@
                 "object",
                 "string"
               ],
-              "title": "response",
+              "title": "Response",
               "description": "The response from the fetch request"
             }
           }

--- a/packages/visual-editor/public/example-boards/playground/nager.date/long-weekend.json
+++ b/packages/visual-editor/public/example-boards/playground/nager.date/long-weekend.json
@@ -206,7 +206,7 @@
                 "object",
                 "string"
               ],
-              "title": "response",
+              "title": "Response",
               "description": "The response from the fetch request"
             }
           }

--- a/packages/visual-editor/public/example-boards/playground/tour-guide-writer.json
+++ b/packages/visual-editor/public/example-boards/playground/tour-guide-writer.json
@@ -225,7 +225,7 @@
                         "properties": {},
                         "required": [],
                         "additionalProperties": false,
-                        "title": "board",
+                        "title": "Board",
                         "description": "The board to invoke. Can be a BoardCapability, a graph or a URL",
                         "behavior": [
                           "board",

--- a/packages/website/src/docs/kits/core.md
+++ b/packages/website/src/docs/kits/core.md
@@ -54,13 +54,23 @@ If we need to print out a set of greetings for a bunch of people visiting from t
 
 {{ "/breadboard/static/boards/kits/core-deflate.bgl.json" | board }}
 
-This component converts all inline data to stored data, saving memory. Useful when working with multimodal content. Safely passes data through if it's already stored or no inline data is present.
+This component converts all [inline data to stored data](/breadboard/docs/reference/data-store/), saving memory. Useful when working with multimodal content.
 
 ### Input ports
 
+The component has a single input port.
+
+- **Data** (id: `data`) -- the data to scan and convert all instances of inline base64-encoded strings to lightweight handles. Data can be of any shape.
+
 ### Output ports
 
+The component has a single output port.
+
+- **Data** (id: `data`) -- the result of deflating the input data. Safely passes data through if it's already stored or no inline data is present.
+
 ### Example
+
+In the board above, a chunk of JSON is fetched. This JSON contains a base64-encoded string of an image. The `deflate` component turns it into a lightweight handle and then passes it on to output.
 
 ### Implementation
 

--- a/packages/website/src/docs/kits/core.md
+++ b/packages/website/src/docs/kits/core.md
@@ -80,35 +80,47 @@ In the board above, a chunk of JSON is fetched. This JSON contains a base64-enco
 
 {{ "/breadboard/static/boards/kits/core-fetch.bgl.json" | board }}
 
-Use this component to fetch data from the Internet. Practically, this is a wrapper around [`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
+Use this component to fetch data from the Internet. Implementation-wise, this is a wrapper around [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) with a few Breadboard-specific tweaks.
+
+The tweaks are:
+
+- When "Content-Type" is specified as "multipart/form-data", the value passed into the **Body** port is treated as a key/value object representing [FormData](https://developer.mozilla.org/en-US/docs/Web/API/FormData) properties and their values.
+
+- Before sending the request, all [Data store lightweight handles](/breadboard/docs/reference/data-store/) are converted to base64 encoded strings or multipart encoded chunks, depending on the content type.
+
+- After receiving the response, any [blob]() responses are converted to [Data Store lightweight handles](/breadboard/docs/reference/data-store/).
 
 ### Input ports
 
-- `url` -- required, URL to fetch. For now, this component can only make a GET request.
-- `headers` -- object (optional), a set of headers to be passed to the request.
-- `raw` boolean (optional), specifies whether or not to return raw text (`true`) or parse the response as JSON (`false`). The default value is `false`.
+The component has the following input ports.
+
+- **URL** (id: `url`) -- required, the URL to fetch.
+
+- **Method** (id: `method`) -- string (optional), the request [method](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods). Default is `GET`.
+
+- **Headers** (id: `headers`) -- object (optional), a set of [request headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers). Default is empty.
+
+- **Body** (id: `body`) -- object (optional), the [request body](https://developer.mozilla.org/en-US/docs/Web/API/RequestInit#body). Default is empty.
+
+- **Raw** (id: `raw`) -- boolean (optional), specifies whether or not to return raw text (`true`) or parse the response as JSON (`false`). The default value is `false`.
+
+- **Stream** (id: `stream`) -- boolean (optional), specifies whether the response is expected to be a stream. The default value is `false`.
 
 ### Output ports
 
-- `response` -- the response from the server. If `raw` is `false`, the response will be parsed as JSON.
+- **Content Type** (id: 'contentType') -- contains response content type.
+
+- **Response** (id: `response`) -- the response from the server. If `raw` is `false` (which it is by default) and content type is `application/json`, the response will be parsed as JSON.
+
+- **Response Headers** (id: `responseHeaders`) -- contains [response headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers).
+
+- **Status** (id: `status`) -- contains [response status code](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status)
+
+- **Status Text** (id: `statusText`) -- contains response status text.
 
 ### Example
 
-If we would like to fetch data from `https://example.com`, we would send the following inputs to `fetch`:
-
-```json
-{
-  "url": "https://example.com"
-}
-```
-
-And receive this output:
-
-```json
-{
-  "response": "<response from https://example.com>"
-}
-```
+In the board above, the `fetch` component makes a call to Wikipedia [open search API](https://www.mediawiki.org/wiki/API:Opensearch) and then passes the response to the output.
 
 ### Implementation
 

--- a/packages/website/src/docs/kits/core.md
+++ b/packages/website/src/docs/kits/core.md
@@ -191,13 +191,42 @@ Following the semantics of the "run as component" mode, all inputs of the invoke
 
 {{ "/breadboard/static/boards/kits/core-map.bgl.json" | board }}
 
-Given a list and a board, iterates over this list (just like your usual JavaScript `map` function), invoking (runOnce) the supplied board for each item.
+Given a list items and a board, runs the board in "[run as component](/breadboard/docs/reference/runtime-semantics/#run-as-component-mode)" mode for each item in the list. Similar in to JavaScript [Array.prototype.map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) function, except boards run in parallel.
+
+When running the board, the `map` component will supply three inputs with these ids:
+
+- `item` -- the item from the list
+- `index` -- the index of the item in the list
+- `list` -- the entire list.
+
+This very is similar to the arguments of the JavaScript [Array.prototype.map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) function.
 
 ### Input ports
 
+The component has two statically defined input ports:
+
+- **Board** (id: `board`) -- required, a board to run. The board can be specified as a URL to the [BGL file](/breadboard/docs/concepts/#breadboard-graph-language-bgl), or as BGL directly.
+
+- **List** (id: `list`) -- optional, an array of items to supply to the board as inputs.
+
 ### Output ports
 
+The component has one statically defined output port:
+
+- **List** (id: `list`) -- optional, an array of results from each board's run.
+
 ### Example
+
+Given this board that creates a simple greeting given a name and location:
+
+{{ "/breadboard/static/boards/kits/example-simple-greeting.bgl.json" | board }}
+
+We can use the `map` component to print out a set of greetings for a bunch of people.
+
+{{ "/breadboard/static/boards/kits/core-map.bgl.json" | board }}
+
+> [!TIP]
+> The [`curry`](#the-curry-component) component and `map` component often go hand in hand, just like in the example above. Currying provides a convenient way to pass unchanging arguments to the board that is being invoked multiple times via `map`.
 
 ### Implementation
 

--- a/packages/website/src/docs/kits/core.md
+++ b/packages/website/src/docs/kits/core.md
@@ -174,9 +174,11 @@ The output ports of this component are the outputs of the invoked board.
 
 ### Example
 
-In the board above, the `invoke` component is used to invoke this board. Following the semantics of the "run as component" mode, all inputs of the invoked board are populated by the input ports of the `invoke` component input ports, and all outputs of the invoked board are passed as output ports.
+In the board above, the `invoke` component is used to invoke this board:
 
 {{ "/breadboard/static/boards/kits/example-simple-greeting.bgl.json" | board }}
+
+Following the semantics of the "run as component" mode, all inputs of the invoked board are populated by the input ports of the `invoke` component input ports, and all outputs of the invoked board are passed as output ports.
 
 > [!TIP]
 > Note how "Name" and "Location" input ports, as well as the "Greeting" output ports pop up in the Visual Editor when the "Board" input port is populated. This is the key property of the "[run as component](/breadboard/docs/reference/runtime-semantics/#run-as-component-mode)" mode: the board API is declarative and can be statically described.

--- a/packages/website/src/docs/kits/core.md
+++ b/packages/website/src/docs/kits/core.md
@@ -23,7 +23,7 @@ Takes a board and bakes in (or [curries](https://en.wikipedia.org/wiki/Currying)
 
 The `curry` component has a single input port plus any number of additional ports.
 
-- **Board** (id `$board`) -- the board to curry the values into. This port has the `board` behavior and will accept a URL of the board or the actual BGL of the board.
+- **Board** (id: `$board`) -- the board to curry the values into. This port has the `board` behavior and will accept a URL of the board or the actual BGL of the board.
 
 Values supplied with any additional ports will be curried into the output board.
 

--- a/packages/website/src/docs/kits/core.md
+++ b/packages/website/src/docs/kits/core.md
@@ -54,7 +54,7 @@ If we need to print out a set of greetings for a bunch of people visiting from t
 
 {{ "/breadboard/static/boards/kits/core-deflate.bgl.json" | board }}
 
-Converts all inline data to stored data, saving memory. Useful when working with multimodal content. Safely passes data through if it's already stored or no inline data is present.
+This component converts all inline data to stored data, saving memory. Useful when working with multimodal content. Safely passes data through if it's already stored or no inline data is present.
 
 ### Input ports
 

--- a/packages/website/src/docs/kits/core.md
+++ b/packages/website/src/docs/kits/core.md
@@ -236,35 +236,15 @@ We can use the `map` component to print out a set of greetings for a bunch of pe
 
 {{ "/breadboard/static/boards/kits/core-passthrough.bgl.json" | board }}
 
-This is a no-op component. It takes the input property bag and passes it along as output, unmodified. This component can be useful when the board needs an entry point, but the rest of the board forms a cycle.
+This is a no-op component. It takes the input port values and passes them along as output port values, unmodified. Just like any [no-op statement](<https://en.wikipedia.org/wiki/NOP_(code)>) in programming, this component comes in handy in various situations, like when the board needs an entry point, but the rest of the board forms a cycle.
 
 ### Input ports
 
-- any properties
+- any ports that are wired in.
 
 ### Output ports
 
-- the properties that were passed as inputs
-
-### Example
-
-```js
-board.input().wire("say->", board.passthrough().wire("say->", board.output()));
-
-board.runOnce({
-  say: "Hello, world!",
-});
-
-console.log("result", result);
-```
-
-Will produce this output:
-
-```sh
-result { say: 'Hello, world!' }
-```
-
-See [Chapter 9: Let's build a chatbot](https://github.com/breadboard-ai/breadboard/tree/main/packages/breadboard/docs/tutorial#chapter-9-lets-build-a-chat-bot) of Breadboard tutorial to see another example of usage.
+- the mirror of the ports wired in.
 
 ### Implementation
 

--- a/packages/website/src/docs/kits/core.md
+++ b/packages/website/src/docs/kits/core.md
@@ -156,28 +156,30 @@ In the board above, any multimedia content supplied as input will be turned into
 
 {{ "/breadboard/static/boards/kits/core-invoke.bgl.json" | board }}
 
-Invokes (runOnce) specified board, supplying remaining incoming wires as inputs for that board. Returns the outputs of the board.
+Invokes (using "[run as component](/breadboard/docs/reference/runtime-semantics/#run-as-component-mode)" runtime mode) specified board, supplying remaining incoming wires as input ports for that board. Returns the outputs of the board as its own output ports.
 
-Use this component to invoke another board from this board.
-
-It recognizes `path`, `graph`, and `board` properties that specify, respectively, a file path or URL to the serialized board, directly the serialized-as-JSON board, and a `BoardCapability` (returned by `lambda` or `import`).
-
-The rest of the inputs in the property bag are passed along to the invoked board as its inputs. If other inputs were bound to the board via wires into the `lambda` or `import` component, then those have precedence over inputs passed here.
-
-The outputs of the invoked board will be passed along as outputs of the `invoke` component.
+Use this component to invoke another board from your board.
 
 ### Input ports
 
-- `path`, which specifes the file path or URL to the serialized board to be included.
-- `graph`, which is a serialized board
-- `board`, a `BoardCapability` representing a board, created by `lambda` or `import`.
-- any other properties are passed as inputs for the invoked board.
+This component has a single static input port and multiple dynamic ports.
+
+- **Board** (id: `$board`) -- required, a board to run. The board can be specified as a URL to the [BGL file](/breadboard/docs/concepts/#breadboard-graph-language-bgl), or as BGL directly.
+
+- all other wired in ports are passed as the input values for the board.
 
 ### Output ports
 
-- the outputs of the invoked board
+The output ports of this component are the outputs of the invoked board.
 
 ### Example
+
+In the board above, the `invoke` component is used to invoke this board. Following the semantics of the "run as component" mode, all inputs of the invoked board are populated by the input ports of the `invoke` component input ports, and all outputs of the invoked board are passed as output ports.
+
+{{ "/breadboard/static/boards/kits/example-simple-greeting.bgl.json" | board }}
+
+> [!TIP]
+> Note how "Name" and "Location" input ports, as well as the "Greeting" output ports pop up in the Visual Editor when the "Board" input port is populated. This is the key property of the "[run as component](/breadboard/docs/reference/runtime-semantics/#run-as-component-mode)" mode: the board API is declarative and can be statically described.
 
 ### Implementation
 

--- a/packages/website/src/docs/kits/core.md
+++ b/packages/website/src/docs/kits/core.md
@@ -118,13 +118,23 @@ And receive this output:
 
 {{ "/breadboard/static/boards/kits/core-inflate.bgl.json" | board }}
 
-Converts stored data to base64.
+Does opposite of what the [`deflate`](#the-deflate-component) component does. Scans provided data and converts all [lightweight handles to inline, base64 encoded strings](/breadboard/docs/reference/data-store/).
 
 ### Input ports
 
+The component has a single input port.
+
+- **Data** (id: `data`) -- the data to scan and convert all instances of lightweight handles to inline base64-encoded strings. Data can be of any shape.
+
 ### Output ports
 
+The component has a single output port.
+
+- **Data** (id: `data`) -- the result of inflating the input data. Safely passes data through if it's already inline or no stored data is present.
+
 ### Example
+
+In the board above, any multimedia content supplied as input will be turned into base64-encoded strings.
 
 ### Implementation
 

--- a/packages/website/src/docs/reference/data-store.md
+++ b/packages/website/src/docs/reference/data-store.md
@@ -1,0 +1,23 @@
+---
+layout: docs.liquid
+title: Handling Multimodal Content Efficiently with Data Store
+tags:
+  - reference
+  - miscellaneous
+---
+
+When handling multimodal content, we can quickly end up passing around large chunks of data between components. This is particularly true when this data is encoded as inline [base64 content](https://en.wikipedia.org/wiki/Base64), resulting in very large text strings being passed over the wires.
+
+To handle such content more efficiently, Breadboard has a concept of a **Data Store**: a way to temporarily store large content across board runs.
+
+Once the data is stored in the Data Store, only the handle pointing to the stored data is being passed to across the wires, which is a lot more memory-efficient.
+
+Adding Data Store means that now, we need to be a bit more aware of whether or not the data we're passing is just a handle or a base64 string. If our component expects to consume a base64 string and gets an opaque handle instead, it will unlikely function as intended.
+
+Some components are innately aware of the difference. For example, the [`fetch`](/breadboard/docs/kits/core/#the-fetch-component) component will automatically convert handles into base64 strings before making a request, and base64 strings to handles before passing the response onto the next component. Similarly, the [`output`](/breadboard/docs/reference/kits/built-in/#the-output-component) component knows how to display both kinds of data, and the [`input`](/breadboard/docs/reference/kits/built-in/#the-input-component) will automatically convert any base64 strings into handles.
+
+For components that aren't aware of the distinction between the inline base64 data and the data stored in the Data Store, there are two helpers: the [`deflate`](/breadboard/docs/kits/core/#the-deflate-component) and [`inflate`](https://breadboard-ai.github.io/breadboard/docs/kits/core/#the-inflate-component) components.
+
+The `deflate` component scans the data supplied as input, looks for any base64 content and then stores that content, converting it into a handle in data. Think of it as "deflating" the large chunk of data that's being passed as input and outputting lightweight handles.
+
+The `inflate` component does the opposite: it looks for handles and replaces them with base64 string representing the data. It "inflates" all lightweight handles it finds into a large chunk of inlined data.

--- a/packages/website/src/docs/reference/data-store.md
+++ b/packages/website/src/docs/reference/data-store.md
@@ -12,12 +12,47 @@ To handle such content more efficiently, Breadboard has a concept of a **Data St
 
 Once the data is stored in the Data Store, only the handle pointing to the stored data is being passed to across the wires, which is a lot more memory-efficient.
 
-Adding Data Store means that now, we need to be a bit more aware of whether or not the data we're passing is just a handle or a base64 string. If our component expects to consume a base64 string and gets an opaque handle instead, it will unlikely function as intended.
+> [!NOTE]
+> Currently, Breadboard uses in-memory [blobs](https://developer.mozilla.org/en-US/docs/Web/API/Blob) to store data, but we're hoping to add more scalable and less ephemeral Data Store implementation in the future.
 
-Some components are innately aware of the difference. For example, the [`fetch`](/breadboard/docs/kits/core/#the-fetch-component) component will automatically convert handles into base64 strings before making a request, and base64 strings to handles before passing the response onto the next component. Similarly, the [`output`](/breadboard/docs/reference/kits/built-in/#the-output-component) component knows how to display both kinds of data, and the [`input`](/breadboard/docs/reference/kits/built-in/#the-input-component) will automatically convert any base64 strings into handles.
+With Data Store in the mix, we need to be aware of whether or not the data we're passing is just a handle or a base64 string. If our component expects to consume a base64 string and gets an opaque handle instead, it will unlikely function as intended.
+
+Some components are innately aware of the difference. For example, the [`fetch`](/breadboard/docs/kits/core/#the-fetch-component) component will automatically convert handles into base64 strings before making a request. Similarly, the [`output`](/breadboard/docs/reference/kits/built-in/#the-output-component) component knows how to display both kinds of data, and the [`input`](/breadboard/docs/reference/kits/built-in/#the-input-component) will automatically convert any base64 strings into handles.
 
 For components that aren't aware of the distinction between the inline base64 data and the data stored in the Data Store, there are two helpers: the [`deflate`](/breadboard/docs/kits/core/#the-deflate-component) and [`inflate`](https://breadboard-ai.github.io/breadboard/docs/kits/core/#the-inflate-component) components.
 
-The `deflate` component scans the data supplied as input, looks for any base64 content and then stores that content, converting it into a handle in data. Think of it as "deflating" the large chunk of data that's being passed as input and outputting lightweight handles.
+{{ "/breadboard/static/boards/kits/core-deflate.bgl.json" | board }}
 
-The `inflate` component does the opposite: it looks for handles and replaces them with base64 string representing the data. It "inflates" all lightweight handles it finds into a large chunk of inlined data.
+The **deflate** component scans the data supplied as input, looks for any base64 content and then stores that content, converting it into a handle in data. Think of it as "deflating" the large chunk of data that's being passed as input and outputting lightweight handles.
+
+{{ "/breadboard/static/boards/kits/core-inflate.bgl.json" | board }}
+
+The **inflate** component does the opposite: it looks for handles and replaces them with base64 string representing the data. It "inflates" all lightweight handles it finds into a large chunk of inlined data.
+
+To do their work, both components look for a certain shape of an object in the JSON input. If we want them to successfully inflate or deflate data, we must match the shape.
+
+When deflating, the component is looking for this shape:
+
+```json
+{
+  "inlineData": {
+    "mimeType": "string of the content MIME type",
+    "data": "base64-encoded data"
+  }
+}
+```
+
+> [!TIP]
+> The shape of the inline data matches that of Gemini API's [Blob](https://ai.google.dev/api/rest/v1/Content#blob) structure.
+
+When inflating, the component is looking for this shape:
+
+```json
+{
+  "storedData": {
+    "handle": "handle that Data Store knows how to recognize"
+  }
+}
+```
+
+When they encounter the shape they're looking for, they return back the same data, but with that shape replaced by its opposite: the `inlineData` becomes `storedData` when deflating and `storedData` becomes `inlineData` when inflating.

--- a/packages/website/src/docs/reference/kits/built-in.md
+++ b/packages/website/src/docs/reference/kits/built-in.md
@@ -75,7 +75,7 @@ The **Behavior** parameter contains the list of various useful shapes of JSON ob
 - **Port Spec** -- the input port expects the JSON value to be a Port Spec: the [JSON Schema] specifically formatted to inform Breadboard about the input / output port definition (literally what is described in this section).
 
 > [!NOTE]
-> The Visual Editor Schema editor produces [JSON Schema](https://json-schema.org/) for each input. This JSON schema (or more precisely, the **Port Spec** dialect of it) is what is stored in the [BGL](http://localhost:8000/breadboard/docs/concepts/#breadboard-graph-language-bgl) representation of the board.
+> The Visual Editor Schema editor produces [JSON Schema](https://json-schema.org/) for each input. This JSON schema (or more precisely, the **Port Spec** dialect of it) is what is stored in the [BGL](/breadboard/docs/concepts/#breadboard-graph-language-bgl) representation of the board.
 
 - **Code** -- the input port expects the value to be some sort of code (JavaScript, Python), etc.
 

--- a/packages/website/src/docs/reference/kits/built-in.md
+++ b/packages/website/src/docs/reference/kits/built-in.md
@@ -6,29 +6,29 @@ tags:
   - kits
 ---
 
-While most nodes in Breadboard come from various kits, there are two nodes that are built-in: **input** and **output**. A good way to think about them is as if they are part of the "Built-in kit": something that you always get, no matter what other kits you choose to employ.
+While most components in Breadboard come from various kits, there are two components that are built-in: **input** and **output**. A good way to think about them is as if they are part of the "Built-in kit": something that you always get, no matter what other kits you choose to employ.
 
-## Why do we need these nodes?
+## Why do we need these components?
 
-These two nodes serve a very important purpose: they communicate the API (or "shape") of the board. While it is definitely convenient in itself, it becomes super-important when we start composing graphs.
+These two components serve a very important purpose: they communicate the API (or "shape") of the board. While it is definitely convenient in itself, it becomes super-important when we start composing graphs.
 
 The **input** and **output** represent, respectively, the beginning and the end of work within a board. Every job begins with an intake of some source material and produces a deliverable. The "input" and "output" components signify those moments. The "input" component is the place where the job begins, and the "output" component (or components, depending on the job) is where it ends.
 
-By adding "input" and "output" nodes in our graph, we not only make it easy for ourselves to spot the starting and ending points of the job -- we also make this graph _reusable_. In Breadboard, graphs can be invoked by other graphs, kind of like delegating work. If we already know that there's a team of workers that does a particular job well, we can just call that team and ask it to do the job for us. When we do that, the "input" and "output" nodes of that team will inform us what the team needs to do their job successfully.
+By adding "input" and "output" components in our graph, we not only make it easy for ourselves to spot the starting and ending points of the job -- we also make this graph _reusable_. In Breadboard, graphs can be invoked by other graphs, kind of like delegating work. If we already know that there's a team of workers that does a particular job well, we can just call that team and ask it to do the job for us. When we do that, the "input" and "output" components of that team will inform us what the team needs to do their job successfully.
 
 > [!NOTE]
-> To make this more concrete, here's an example. The **input** and **output** nodes of a board are used to construct the [signature of function declarations](https://ai.google.dev/gemini-api/docs/function-calling#function_declarations) when we let the [Specialist](https://breadboard-ai.github.io/breadboard/docs/kits/agents/#specialist-tools) invoke boards as tools. From the perspective of the user, it looks entirely magical: they just add a board as a possible tool that the Specialist could call and it just works. Behind the scenes, the Specialist inspects the board, determines the inputs/outputs and supplies them to the LLM as function declarations.
+> To make this more concrete, here's an example. The **input** and **output** components of a board are used to construct the [signature of function declarations](https://ai.google.dev/gemini-api/docs/function-calling#function_declarations) when we let the [Specialist](https://breadboard-ai.github.io/breadboard/docs/kits/agents/#specialist-tools) invoke boards as tools. From the perspective of the user, it looks entirely magical: they just add a board as a possible tool that the Specialist could call and it just works. Behind the scenes, the Specialist inspects the board, determines the inputs/outputs and supplies them to the LLM as function declarations.
 
-## The `input` node
+## The `input` component
 
 {{ "/breadboard/static/boards/kits/built-in-input.bgl.json" | board }}
 
-Use this node to specify the inputs for the board. The `input` node has a single fixed input configuration port named **Schema** and a variable number of output ports.
+Use this component to specify the inputs for the board. The `input` component has a single fixed input configuration port named **Schema** and a variable number of output ports.
 
-The output ports of this node are supplied from outside of the board: either by the user when running the board directly or by another board when invoking this board from it.
+The output ports of this component are supplied from outside of the board: either by the user when running the board directly or by another board when invoking this board from it.
 
 > [!TIP]
-> It usually takes a bit of getting used to the idea that the _inputs_ of a board show up as _outputs_ of the `input` node. One metaphor that might help is that the `input` node brings the data from outside of the board.
+> It usually takes a bit of getting used to the idea that the _inputs_ of a board show up as _outputs_ of the `input` component. One metaphor that might help is that the `input` component brings the data from outside of the board.
 
 ### Input ports
 
@@ -98,21 +98,21 @@ Hidden behind the "Show more" in the Visual Editor, there are a few more paramet
 
 ### Output ports
 
-The output ports of the `input` node are defined by **Schema**.
+The output ports of the `input` component are defined by **Schema**.
 
-## The `output` node
+## The `output` component
 
 {{ "/breadboard/static/boards/kits/built-in-output.bgl.json" | board }}
 
-The `output` node does the inverse of what `input` does: it takes the values out of the board, back to the user (if called directly) or to another board (if invoked by that board). It has a variable number of input ports, and no output ports.
+The `output` component does the inverse of what `input` does: it takes the values out of the board, back to the user (if called directly) or to another board (if invoked by that board). It has a variable number of input ports, and no output ports.
 
 ### Input ports
 
-Similar to the `input` node, there's pre-defined input port called **Schema**, whose purpose is identical to **Schema** in the `input` node, with one important distinction: it defines the rest of the input ports (as opposed to output ports in `input`).
+Similar to the `input` component, there's pre-defined input port called **Schema**, whose purpose is identical to **Schema** in the `input` component, with one important distinction: it defines the rest of the input ports (as opposed to output ports in `input`).
 
 > [!WARNING]
-> Avoid defining a port with the id of `schema` in the Schema editor. It will result in the `output` node being confused, since that is the id used by **Schema**.
+> Avoid defining a port with the id of `schema` in the Schema editor. It will result in the `output` component being confused, since that is the id used by **Schema**.
 
 ### Output ports
 
-The `output` node does not have any output ports.
+The `output` component does not have any output ports.

--- a/packages/website/src/docs/reference/runtime-semantics.md
+++ b/packages/website/src/docs/reference/runtime-semantics.md
@@ -1,0 +1,31 @@
+---
+layout: docs.liquid
+title: Board Runtime Semantics
+tags:
+  - reference
+  - miscellaneous
+---
+
+In Breadboard, the concept of "running the board" is pretty important. "Running" is how we turn a [BGL file](/breadboard/docs/concepts/#breadboard-graph-language-bgl) into something that actually works. The process of "running" can be loosely described as component-by-component traversal of the entire board, following the wires, from input to output, until done.
+
+## Runtime modes
+
+The condition of "done" is different depending on the mode under which the board runs. There are two modes: the "run" mode and the "run as component" mode.
+
+### "Run" mode
+
+The **run** mode is what we typically see when we run the board directly. In this mode, the board runs until there are no more components to visit after following the wires. This means that if the board has wires that form cycles between components, this board will run forever. This isn't necessarily a bad thing. For instance, a chat bot board might be okay to run like that.
+
+In the **run** mode, the board may visit many [`input`](/breadboard/docs/reference/kits/built-in/#the-input-node) and [`output`](/breadboard/docs/reference/kits/built-in/#output-ports) components throughout the run, producing multiple outputs and requesting multiple outputs. The chat bot from example above will wait for user input (using the `input` component) and then provide a response (using the `output` component), over and over.
+
+The implementation of the **run** mode can be found in [runner.ts](https://github.com/breadboard-ai/breadboard/blob/main/packages/breadboard/src/runner.ts#L131-L132). See the `run` method.
+
+### "Run as component" mode
+
+The **run as component** mode is a bit more limited, and is designed to mimic the behavior of a component. This mode is being used whenever the board is used as a component inside of another board, be it part of a kit, or used by the [`invoke`](/breadboard/docs/kits/core/#the-invoke-component), [`map`](/breadboard/docs/kits/core/#the-map-component), or [`reduce`](/breadboard/docs/kits/core/#the-reduce-component) components.
+
+To mimic a component, the board must only request input once (just like the component would only have one set of input ports), and only provide output once -- since the component only provides outputs once.
+
+In **run as component** mode, the board will provide the same set of input values to any `input` component it visits, and not stop to request input from user. It will also stop running as soon as it encounters the first `output` component.
+
+The implementation of the **run as component** node can be found in [runner.ts](https://github.com/breadboard-ai/breadboard/blob/main/packages/breadboard/src/runner.ts#L300-L301). See the `runOnce` method.

--- a/packages/website/src/static/boards/kits/core-deflate.bgl.json
+++ b/packages/website/src/static/boards/kits/core-deflate.bgl.json
@@ -1,38 +1,7 @@
 {
-  "title": "deflate node example",
+  "title": "deflate component example",
   "version": "0.0.1",
   "nodes": [
-    {
-      "type": "input",
-      "id": "input",
-      "configuration": {
-        "schema": {
-          "properties": {
-            "context": {
-              "type": "array",
-              "title": "Context",
-              "examples": [],
-              "items": {
-                "type": "object",
-                "behavior": [
-                  "llm-content"
-                ]
-              },
-              "default": "[{\"role\":\"user\",\"parts\":[{\"text\":\"\"}]}]"
-            }
-          },
-          "type": "object",
-          "required": []
-        }
-      },
-      "metadata": {
-        "visual": {
-          "x": 0,
-          "y": 0,
-          "collapsed": false
-        }
-      }
-    },
     {
       "type": "output",
       "id": "output",
@@ -58,34 +27,83 @@
       },
       "metadata": {
         "visual": {
-          "x": 173,
-          "y": 0,
+          "x": 237,
+          "y": -165,
           "collapsed": false
         }
       }
     },
     {
-      "id": "deflate-c0515b15",
+      "id": "fetch-3a33a03d",
+      "type": "fetch",
+      "metadata": {
+        "visual": {
+          "x": -212,
+          "y": -187,
+          "collapsed": false
+        },
+        "title": "Get Inline Data",
+        "logLevel": "debug"
+      },
+      "configuration": {
+        "method": "GET",
+        "url": "https://dglazkov-getbreadboardemoji.web.val.run"
+      }
+    },
+    {
+      "id": "deflate-5a602188",
       "type": "deflate",
       "metadata": {
         "visual": {
-          "x": 61,
-          "y": -139,
+          "x": 50,
+          "y": -164,
           "collapsed": false
-        }
+        },
+        "title": "Deflate It",
+        "logLevel": "debug"
       }
     }
   ],
   "edges": [
     {
-      "from": "input",
-      "out": "context",
+      "from": "fetch-3a33a03d",
+      "to": "deflate-5a602188",
+      "out": "response",
+      "in": "data"
+    },
+    {
+      "from": "deflate-5a602188",
       "to": "output",
+      "out": "data",
       "in": "context"
     }
   ],
   "description": "No Description",
   "metadata": {
-    "tags": []
+    "tags": [],
+    "comments": [
+      {
+        "id": "comment-dedad955",
+        "text": "Fetches some inline data from the Internet.",
+        "metadata": {
+          "visual": {
+            "x": -270,
+            "y": -244,
+            "collapsed": false
+          }
+        }
+      },
+      {
+        "id": "comment-b5dcea8d",
+        "text": "Converts inline data to\na lightweight handle.",
+        "metadata": {
+          "visual": {
+            "x": 39,
+            "y": -228,
+            "collapsed": false
+          }
+        }
+      }
+    ]
   }
 }

--- a/packages/website/src/static/boards/kits/core-fetch.bgl.json
+++ b/packages/website/src/static/boards/kits/core-fetch.bgl.json
@@ -1,5 +1,5 @@
 {
-  "title": "fetch node example",
+  "title": "fetch component example",
   "version": "0.0.1",
   "nodes": [
     {
@@ -8,17 +8,9 @@
       "configuration": {
         "schema": {
           "properties": {
-            "context": {
-              "type": "array",
-              "title": "Context",
-              "examples": [],
-              "items": {
-                "type": "object",
-                "behavior": [
-                  "llm-content"
-                ]
-              },
-              "default": "[{\"role\":\"user\",\"parts\":[{\"text\":\"\"}]}]"
+            "query": {
+              "type": "string",
+              "title": "Query"
             }
           },
           "type": "object",
@@ -27,51 +19,64 @@
       },
       "metadata": {
         "visual": {
-          "x": 0,
-          "y": 0,
+          "x": -159,
+          "y": -68,
           "collapsed": false
         }
       }
     },
     {
-      "type": "output",
-      "id": "output",
-      "configuration": {
-        "schema": {
-          "properties": {
-            "context": {
-              "type": "array",
-              "title": "Context",
-              "examples": [],
-              "items": {
-                "type": "object",
-                "behavior": [
-                  "llm-content"
-                ]
-              },
-              "default": "null"
-            }
-          },
-          "type": "object",
-          "required": []
-        }
-      },
-      "metadata": {
-        "visual": {
-          "x": 173,
-          "y": 0,
-          "collapsed": false
-        }
-      }
-    },
-    {
-      "id": "fetch-1552c448",
+      "id": "fetch-e26cfef6",
       "type": "fetch",
       "metadata": {
         "visual": {
-          "x": 61,
-          "y": -222,
+          "x": 237,
+          "y": -168,
           "collapsed": false
+        },
+        "title": "Search Wikipedia",
+        "logLevel": "debug"
+      }
+    },
+    {
+      "id": "urlTemplate-3e700b37",
+      "type": "urlTemplate",
+      "metadata": {
+        "visual": {
+          "x": 0,
+          "y": -109,
+          "collapsed": false
+        },
+        "title": "Make URL",
+        "logLevel": "debug"
+      },
+      "configuration": {
+        "template": "https://en.wikipedia.org/w/api.php?action=opensearch&search={query}&origin=*"
+      }
+    },
+    {
+      "id": "output-cf0f1083",
+      "type": "output",
+      "metadata": {
+        "visual": {
+          "x": 496,
+          "y": -133,
+          "collapsed": false
+        },
+        "title": "output",
+        "logLevel": "debug"
+      },
+      "configuration": {
+        "schema": {
+          "properties": {
+            "content": {
+              "type": "object",
+              "title": "Content",
+              "examples": []
+            }
+          },
+          "type": "object",
+          "required": []
         }
       }
     }
@@ -79,13 +84,49 @@
   "edges": [
     {
       "from": "input",
-      "out": "context",
-      "to": "output",
-      "in": "context"
+      "to": "urlTemplate-3e700b37",
+      "in": "query",
+      "out": "query"
+    },
+    {
+      "from": "urlTemplate-3e700b37",
+      "to": "fetch-e26cfef6",
+      "in": "url",
+      "out": "url"
+    },
+    {
+      "from": "fetch-e26cfef6",
+      "to": "output-cf0f1083",
+      "out": "response",
+      "in": "content"
     }
   ],
   "description": "No Description",
   "metadata": {
-    "tags": []
+    "tags": [],
+    "comments": [
+      {
+        "id": "comment-202d74a1",
+        "text": "Use `promptTemplate` component to create a URL to search Wikipedia.",
+        "metadata": {
+          "visual": {
+            "x": -29,
+            "y": -191,
+            "collapsed": false
+          }
+        }
+      },
+      {
+        "id": "comment-c724bc33",
+        "text": "Make a `fetch` call \nto Wikipedia.",
+        "metadata": {
+          "visual": {
+            "x": 313,
+            "y": -225,
+            "collapsed": false
+          }
+        }
+      }
+    ]
   }
 }

--- a/packages/website/src/static/boards/kits/core-inflate.bgl.json
+++ b/packages/website/src/static/boards/kits/core-inflate.bgl.json
@@ -1,5 +1,5 @@
 {
-  "title": "inflate node example",
+  "title": "inflate component example",
   "version": "0.0.1",
   "nodes": [
     {
@@ -27,8 +27,8 @@
       },
       "metadata": {
         "visual": {
-          "x": 0,
-          "y": 0,
+          "x": -110,
+          "y": -92,
           "collapsed": false
         }
       }
@@ -58,8 +58,8 @@
       },
       "metadata": {
         "visual": {
-          "x": 173,
-          "y": 0,
+          "x": 238,
+          "y": -92,
           "collapsed": false
         }
       }
@@ -69,23 +69,44 @@
       "type": "inflate",
       "metadata": {
         "visual": {
-          "x": 68,
-          "y": -155,
+          "x": 63,
+          "y": -90,
           "collapsed": false
-        }
+        },
+        "title": "Inflate",
+        "logLevel": "debug"
       }
     }
   ],
   "edges": [
     {
       "from": "input",
+      "to": "inflate-a40a5fae",
       "out": "context",
+      "in": "data"
+    },
+    {
+      "from": "inflate-a40a5fae",
       "to": "output",
+      "out": "data",
       "in": "context"
     }
   ],
   "description": "No Description",
   "metadata": {
-    "tags": []
+    "tags": [],
+    "comments": [
+      {
+        "id": "comment-31810f13",
+        "text": "Converts lightweight data\nhandles to inlined\nbase64-encoded strings.",
+        "metadata": {
+          "visual": {
+            "x": 31,
+            "y": -170,
+            "collapsed": false
+          }
+        }
+      }
+    ]
   }
 }

--- a/packages/website/src/static/boards/kits/core-invoke.bgl.json
+++ b/packages/website/src/static/boards/kits/core-invoke.bgl.json
@@ -1,5 +1,5 @@
 {
-  "title": "invoke node example",
+  "title": "invoke component example",
   "version": "0.0.1",
   "nodes": [
     {
@@ -8,17 +8,10 @@
       "configuration": {
         "schema": {
           "properties": {
-            "context": {
-              "type": "array",
-              "title": "Context",
-              "examples": [],
-              "items": {
-                "type": "object",
-                "behavior": [
-                  "llm-content"
-                ]
-              },
-              "default": "[{\"role\":\"user\",\"parts\":[{\"text\":\"\"}]}]"
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "examples": []
             }
           },
           "type": "object",
@@ -27,8 +20,8 @@
       },
       "metadata": {
         "visual": {
-          "x": 0,
-          "y": 0,
+          "x": -117,
+          "y": -122,
           "collapsed": false
         }
       }
@@ -39,17 +32,10 @@
       "configuration": {
         "schema": {
           "properties": {
-            "context": {
-              "type": "array",
-              "title": "Context",
-              "examples": [],
-              "items": {
-                "type": "object",
-                "behavior": [
-                  "llm-content"
-                ]
-              },
-              "default": "null"
+            "greeting": {
+              "type": "string",
+              "title": "Greeting",
+              "examples": []
             }
           },
           "type": "object",
@@ -58,8 +44,8 @@
       },
       "metadata": {
         "visual": {
-          "x": 173,
-          "y": 0,
+          "x": 249,
+          "y": -141,
           "collapsed": false
         }
       }
@@ -69,23 +55,51 @@
       "type": "invoke",
       "metadata": {
         "visual": {
-          "x": 60,
-          "y": -145,
+          "x": 42,
+          "y": -144,
           "collapsed": false
-        }
+        },
+        "title": "Make Greeting",
+        "logLevel": "debug"
+      },
+      "configuration": {
+        "$board": {
+          "kind": "board",
+          "path": "https://breadboard-ai.github.io/breadboard/static/boards/kits/example-simple-greeting.bgl.json"
+        },
+        "location": "The Internet"
       }
     }
   ],
   "edges": [
     {
       "from": "input",
-      "out": "context",
+      "to": "invoke-f92891a8",
+      "out": "name",
+      "in": "item"
+    },
+    {
+      "from": "invoke-f92891a8",
       "to": "output",
-      "in": "context"
+      "out": "greeting",
+      "in": "greeting"
     }
   ],
   "description": "No Description",
   "metadata": {
-    "tags": []
+    "tags": [],
+    "comments": [
+      {
+        "id": "comment-f625f914",
+        "text": "Invokes the [Make a Greeting](https://breadboard-ai.web.app/?board=https%3A%2F%2Fbreadboard-ai.github.io%2Fbreadboard%2Fstatic%2Fboards%2Fkits%2Fexample-simple-greeting.bgl.json) board.",
+        "metadata": {
+          "visual": {
+            "x": 20,
+            "y": -205,
+            "collapsed": false
+          }
+        }
+      }
+    ]
   }
 }

--- a/packages/website/src/static/boards/kits/core-invoke.bgl.json
+++ b/packages/website/src/static/boards/kits/core-invoke.bgl.json
@@ -59,7 +59,7 @@
           "y": -144,
           "collapsed": false
         },
-        "title": "Make Greeting",
+        "title": "Greetings",
         "logLevel": "debug"
       },
       "configuration": {

--- a/packages/website/src/static/boards/kits/core-map.bgl.json
+++ b/packages/website/src/static/boards/kits/core-map.bgl.json
@@ -1,5 +1,5 @@
 {
-  "title": "map node example",
+  "title": "map component example",
   "version": "0.0.1",
   "nodes": [
     {
@@ -8,17 +8,17 @@
       "configuration": {
         "schema": {
           "properties": {
-            "context": {
-              "type": "array",
-              "title": "Context",
+            "location": {
+              "type": "string",
+              "title": "Location",
               "examples": [],
-              "items": {
-                "type": "object",
-                "behavior": [
-                  "llm-content"
-                ]
-              },
-              "default": "[{\"role\":\"user\",\"parts\":[{\"text\":\"\"}]}]"
+              "description": "Where is the visiting group from?"
+            },
+            "names": {
+              "type": "string",
+              "title": "Names",
+              "examples": [],
+              "description": "Specify comma-separated names."
             }
           },
           "type": "object",
@@ -27,8 +27,8 @@
       },
       "metadata": {
         "visual": {
-          "x": 0,
-          "y": 0,
+          "x": -207,
+          "y": -83,
           "collapsed": false
         }
       }
@@ -39,17 +39,11 @@
       "configuration": {
         "schema": {
           "properties": {
-            "context": {
-              "type": "array",
-              "title": "Context",
+            "greetings": {
+              "type": "string",
+              "title": "Greetings",
               "examples": [],
-              "items": {
-                "type": "object",
-                "behavior": [
-                  "llm-content"
-                ]
-              },
-              "default": "null"
+              "format": "markdown"
             }
           },
           "type": "object",
@@ -58,34 +52,163 @@
       },
       "metadata": {
         "visual": {
-          "x": 173,
-          "y": 0,
+          "x": 439,
+          "y": -98,
           "collapsed": false
         }
       }
     },
     {
-      "id": "map-ebc34876",
+      "id": "curry-af767767",
+      "type": "curry",
+      "metadata": {
+        "visual": {
+          "x": -29,
+          "y": -100,
+          "collapsed": false
+        },
+        "title": "Curry Location",
+        "logLevel": "debug"
+      },
+      "configuration": {
+        "$board": {
+          "kind": "board",
+          "path": "https://breadboard-ai.github.io/breadboard/static/boards/kits/example-simple-greeting.bgl.json"
+        }
+      }
+    },
+    {
+      "id": "map-8dc119ad",
       "type": "map",
       "metadata": {
         "visual": {
-          "x": 68,
-          "y": -167,
+          "x": 191,
+          "y": -99,
           "collapsed": false
-        }
+        },
+        "title": "Greet Each Name",
+        "logLevel": "debug"
+      }
+    },
+    {
+      "id": "runJavascript-06f2bde4",
+      "type": "runJavascript",
+      "metadata": {
+        "visual": {
+          "x": -44,
+          "y": 50,
+          "collapsed": false
+        },
+        "title": "Split Names",
+        "logLevel": "debug"
+      },
+      "configuration": {
+        "code": "function run({names}) {\n  return names.split(\",\").map((name) => name.trim());\n}"
+      }
+    },
+    {
+      "id": "runJavascript-58939abd",
+      "type": "runJavascript",
+      "metadata": {
+        "visual": {
+          "x": 234,
+          "y": 43,
+          "collapsed": false
+        },
+        "title": "Join Greetings",
+        "logLevel": "debug"
+      },
+      "configuration": {
+        "code": "function run({list}) {\n  return list.map((list) => list.greeting).join(\"\\n\\n\");\n}"
       }
     }
   ],
   "edges": [
     {
       "from": "input",
-      "out": "context",
+      "to": "curry-af767767",
+      "in": "location",
+      "out": "location"
+    },
+    {
+      "from": "curry-af767767",
+      "to": "map-8dc119ad",
+      "in": "board",
+      "out": "board"
+    },
+    {
+      "from": "runJavascript-06f2bde4",
+      "to": "map-8dc119ad",
+      "in": "list",
+      "out": "result"
+    },
+    {
+      "from": "input",
+      "to": "runJavascript-06f2bde4",
+      "in": "names",
+      "out": "names"
+    },
+    {
+      "from": "map-8dc119ad",
+      "to": "runJavascript-58939abd",
+      "in": "list",
+      "out": "list"
+    },
+    {
+      "from": "runJavascript-58939abd",
       "to": "output",
-      "in": "context"
+      "in": "greetings",
+      "out": "result"
     }
   ],
   "description": "No Description",
   "metadata": {
-    "tags": []
+    "tags": [],
+    "comments": [
+      {
+        "id": "comment-61f510a4",
+        "text": "Curry the \"Location\" input \ninto the board.",
+        "metadata": {
+          "visual": {
+            "x": -83,
+            "y": -160,
+            "collapsed": false
+          }
+        }
+      },
+      {
+        "id": "comment-4f2837ed",
+        "text": "In parallel, invoke supplied \nboard for each name\nin the list.",
+        "metadata": {
+          "visual": {
+            "x": 173,
+            "y": -185,
+            "collapsed": false
+          }
+        }
+      },
+      {
+        "id": "comment-8b71970b",
+        "text": "Some Javascript to split the names into a list...",
+        "metadata": {
+          "visual": {
+            "x": -63,
+            "y": 143,
+            "collapsed": false
+          }
+        }
+      },
+      {
+        "id": "comment-48d394c8",
+        "text": "... and some more JS to join the resulting greetings back into a string.",
+        "metadata": {
+          "visual": {
+            "x": 224,
+            "y": 134,
+            "collapsed": false
+          }
+        }
+      }
+    ]
   }
 }

--- a/packages/website/src/static/boards/kits/core-passthrough.bgl.json
+++ b/packages/website/src/static/boards/kits/core-passthrough.bgl.json
@@ -27,8 +27,8 @@
       },
       "metadata": {
         "visual": {
-          "x": -54,
-          "y": 3,
+          "x": -99,
+          "y": -51,
           "collapsed": false
         }
       }
@@ -58,8 +58,8 @@
       },
       "metadata": {
         "visual": {
-          "x": 222,
-          "y": 0,
+          "x": 299,
+          "y": -52,
           "collapsed": false
         }
       }
@@ -69,10 +69,12 @@
       "type": "passthrough",
       "metadata": {
         "visual": {
-          "x": 6.5966796875,
-          "y": -116.6416015625,
+          "x": 53,
+          "y": -51,
           "collapsed": false
-        }
+        },
+        "title": "Pass it through",
+        "logLevel": "debug"
       }
     }
   ],
@@ -92,6 +94,19 @@
   ],
   "description": "No Description",
   "metadata": {
-    "tags": []
+    "tags": [],
+    "comments": [
+      {
+        "id": "comment-229a4491",
+        "text": "Passes inputs unmodified as outputs.",
+        "metadata": {
+          "visual": {
+            "x": 47,
+            "y": -110,
+            "collapsed": false
+          }
+        }
+      }
+    ]
   }
 }


### PR DESCRIPTION
- **Added `curry` help link**
- **Change `node` -> `component` in built-in kit docs.**
- **Deprecate `worker`, `structuredWorker`, and `repeater`.**
- **Add a better description for Specialist.**
- **Add help link for Agent Kit components.**
- **Add data store reference.**
- **Document `deflate` component.**
- **Document `inflate` component.**
- **Document `fetch` component.**
- **Add help links.**
- **Add runtime semantics doc.**
- **Document `invoke` component.**
- **Tweaks.**
- **Document `map` component.**
- **Add help links for `invoke` and `map`.**
- **Document `passthrough` component.**
- **docs(changeset): Update titles and help links in Core Kit.**
