### PR TITLE
[connections] Make connection server dev script use secrets/local.json if available

### DIFF
--- a/packages/connection-server/package.json
+++ b/packages/connection-server/package.json
@@ -33,7 +33,7 @@
   },
   "wireit": {
     "dev:nowatch": {
-      "command": "node --enable-source-maps dist/index.js",
+      "command": "[ -f ./secrets/local.json ] && export CONNECTIONS_FILE=./secrets/local.json; node --enable-source-maps dist/index.js",
       "service": true,
       "env": {
         "ALLOWED_ORIGINS": "http://localhost:5173"


### PR DESCRIPTION
Now if you make a file `secrets/local.json`, the `dev` script will pick it up automatically.