### PR TITLE
[visual-editor] Refactor token handling logic to be more re-usable

### DIFF
--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -78,6 +78,12 @@ const ORIGIN_TO_CONNECTION_SERVER: Record<string, string> = {
     "https://connections-dot-breadboard-community.wl.r.appspot.com",
 };
 
+const ENVIRONMENT: Environment = {
+  connectionServerUrl:
+    ORIGIN_TO_CONNECTION_SERVER[new URL(window.location.href).origin],
+  connectionRedirectUrl: "/oauth/",
+};
+
 @customElement("bb-main")
 export class Main extends LitElement {
   @property({ reflect: true })
@@ -147,11 +153,7 @@ export class Main extends LitElement {
   providerOps = 0;
 
   @provide({ context: environmentContext })
-  environment: Environment = {
-    connectionServerUrl:
-      ORIGIN_TO_CONNECTION_SERVER[new URL(window.location.href).origin],
-    connectionRedirectUrl: "/oauth/",
-  };
+  environment = ENVIRONMENT;
 
   @provide({ context: dataStoreContext })
   dataStore: { instance: DataStore | null } = { instance: createDataStore() };

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -49,6 +49,10 @@ import type {
 import PythonWasmKit from "@breadboard-ai/python-wasm";
 import GoogleDriveKit from "@breadboard-ai/google-drive-kit";
 import { RecentBoardStore } from "./data/recent-boards";
+import {
+  TokenVendor,
+  tokenVendorContext,
+} from "./ui/elements/connection/token-vendor.js";
 
 const REPLAY_DELAY_MS = 10;
 const STORAGE_PREFIX = "bb-main";
@@ -154,6 +158,9 @@ export class Main extends LitElement {
 
   @provide({ context: environmentContext })
   environment = ENVIRONMENT;
+
+  @provide({ context: tokenVendorContext })
+  tokenVendor!: TokenVendor;
 
   @provide({ context: dataStoreContext })
   dataStore: { instance: DataStore | null } = { instance: createDataStore() };
@@ -499,6 +506,7 @@ export class Main extends LitElement {
     this.#proxy = config.proxy || [];
     if (this.#settings) {
       this.settingsHelper = new SettingsHelperImpl(this.#settings);
+      this.tokenVendor = new TokenVendor(this.settingsHelper, ENVIRONMENT);
     }
     // Single loader instance for all boards.
     this.#loader = createLoader(this.#providers);

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -2368,19 +2368,19 @@ class SettingsHelperImpl implements SettingsHelper {
     return this.#store.values[section].items.get(name);
   }
 
-  set(
+  async set(
     section: SETTINGS_TYPE,
     name: string,
     value: SettingEntry["value"]
-  ): void {
+  ): Promise<void> {
     const values = this.#store.values;
     values[section].items.set(name, value);
-    this.#store.save(values);
+    await this.#store.save(values);
   }
 
-  delete(section: SETTINGS_TYPE, name: string): void {
+  async delete(section: SETTINGS_TYPE, name: string): Promise<void> {
     const values = this.#store.values;
     values[section].items.delete(name);
-    this.#store.save(values);
+    await this.#store.save(values);
   }
 }

--- a/packages/visual-editor/src/ui/elements/connection/connection-common.ts
+++ b/packages/visual-editor/src/ui/elements/connection/connection-common.ts
@@ -24,7 +24,7 @@ export type GrantResponse =
       refresh_token: string;
     };
 
-export interface GrantSettingsValue {
+export interface TokenGrant {
   access_token: string;
   expires_in: number;
   refresh_token: string;

--- a/packages/visual-editor/src/ui/elements/connection/connection-common.ts
+++ b/packages/visual-editor/src/ui/elements/connection/connection-common.ts
@@ -30,3 +30,18 @@ export interface GrantSettingsValue {
   refresh_token: string;
   issue_time: number;
 }
+
+export type RefreshResponse =
+  | { error: string }
+  | {
+      error?: undefined;
+      access_token: string;
+      expires_in: number;
+    };
+
+// IMPORTANT: Keep in sync with
+// breadboard/packages/connection-server/src/api/refresh.ts
+export interface RefreshRequest {
+  connection_id: string;
+  refresh_token: string;
+}

--- a/packages/visual-editor/src/ui/elements/connection/connection-input.ts
+++ b/packages/visual-editor/src/ui/elements/connection/connection-input.ts
@@ -6,32 +6,23 @@
 
 import { consume } from "@lit/context";
 import { Task, TaskStatus } from "@lit/task";
-import { LitElement, css, html } from "lit";
+import { LitElement, css, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import {
   environmentContext,
   type Environment,
 } from "../../contexts/environment.js";
-import { settingsHelperContext } from "../../contexts/settings-helper.js";
 import { InputEnterEvent } from "../../events/events.js";
-import { SETTINGS_TYPE, type SettingsHelper } from "../../types/types.js";
-import type {
-  TokenGrant,
-  RefreshRequest,
-  RefreshResponse,
-} from "./connection-common.js";
 import {
   fetchAvailableConnections,
   type Connection,
 } from "./connection-server.js";
 import "./connection-signin.js";
-
-/**
- * If a token is going to expire in less than this many milliseconds, we treat
- * it as though it is already expired, since there might be a delay between
- * returning it from here and it actually getting used.
- */
-const EXPIRY_THRESHOLD_MS = /* 1 minute */ 60_000;
+import {
+  ExpiredTokenResult,
+  TokenVendor,
+  tokenVendorContext,
+} from "./token-vendor.js";
 
 /**
  * Input element for handling secrets provided by OAuth connections.
@@ -44,8 +35,8 @@ export class ConnectionInput extends LitElement {
   @consume({ context: environmentContext })
   environment?: Environment;
 
-  @consume({ context: settingsHelperContext })
-  settingsHelper?: SettingsHelper;
+  @consume({ context: tokenVendorContext })
+  tokenVendor?: TokenVendor;
 
   #availableConnections = fetchAvailableConnections(
     this,
@@ -57,22 +48,18 @@ export class ConnectionInput extends LitElement {
 
   #refreshTask = new Task(this, {
     autoRun: false,
-    task: (
+    task: async (
       // TOOD(aomarks) The way we receive parameters here is a bit odd. It would
       // be cool if I could have some parameters defined in `args`, and others
       // passed to `run`, but right now Task only allows one or the other.
-      [grant, connectionId, environment, settingsHelper]: [
-        TokenGrant,
-        typeof this.connectionId,
-        typeof this.environment,
-        typeof this.settingsHelper,
-      ],
+      [expired]: [ExpiredTokenResult],
       { signal }
     ) => {
-      if (!grant || !connectionId || !environment || !settingsHelper) {
+      if (!expired) {
         throw new Error("Uninitialized");
       }
-      this.#refresh(grant, connectionId, environment, settingsHelper, signal);
+      const refreshed = await expired.refresh({ signal });
+      this.#broadcastSecret(refreshed.grant.access_token);
     },
   });
 
@@ -83,38 +70,17 @@ export class ConnectionInput extends LitElement {
   `;
 
   render() {
-    const grant = this.#getGrantFromSettings();
-    if (grant === undefined) {
-      return this.#renderSigninButton();
+    if (!this.tokenVendor || !this.connectionId) {
+      return nothing;
     }
-    const expired = this.#accessTokenIsExpired(grant);
-    if (expired) {
+    const grant = this.tokenVendor.getToken(this.connectionId);
+    if (grant.state === "signedout") {
+      return this.#renderSigninButton();
+    } else if (grant.state === "expired") {
       return this.#refreshAndRenderStatus(grant);
     }
-    this.#broadcastSecret(grant.access_token);
+    this.#broadcastSecret(grant.grant.access_token);
     return html`Token was fresh`;
-  }
-
-  #getGrantFromSettings(): TokenGrant | undefined {
-    if (!this.connectionId || !this.settingsHelper) {
-      return undefined;
-    }
-    const setting = this.settingsHelper.get(
-      SETTINGS_TYPE.CONNECTIONS,
-      this.connectionId
-    );
-    if (setting === undefined) {
-      return undefined;
-    }
-    return JSON.parse(String(setting.value)) as TokenGrant;
-  }
-
-  #accessTokenIsExpired(grant: TokenGrant): boolean {
-    const expiresAt =
-      /* absolute milliseconds */ grant.issue_time +
-      /* relative seconds */ grant.expires_in * 1000;
-    const expiresIn = expiresAt - /* unix milliseconds */ Date.now();
-    return expiresIn <= EXPIRY_THRESHOLD_MS;
   }
 
   #renderSigninButton() {
@@ -148,56 +114,15 @@ export class ConnectionInput extends LitElement {
     });
   }
 
-  #refreshAndRenderStatus(grant: TokenGrant) {
+  #refreshAndRenderStatus(grant: ExpiredTokenResult) {
     if (this.#refreshTask.status === TaskStatus.INITIAL) {
-      this.#refreshTask.run([
-        grant,
-        this.connectionId,
-        this.environment,
-        this.settingsHelper,
-      ]);
+      this.#refreshTask.run([grant]);
     }
     return this.#refreshTask.render({
       pending: () => html`<p>Refreshing token ...</p>`,
       error: (e) => html`<p>Error refreshing token: ${e}</p>`,
       complete: () => html`<p>Token refreshed!</p>`,
     });
-  }
-
-  async #refresh(
-    grant: TokenGrant,
-    connectionId: string,
-    environment: Environment,
-    settingsHelper: SettingsHelper,
-    signal: AbortSignal
-  ) {
-    const refreshUrl = new URL("refresh", environment.connectionServerUrl);
-    refreshUrl.search = new URLSearchParams({
-      connection_id: connectionId,
-      refresh_token: grant.refresh_token,
-    } satisfies RefreshRequest).toString();
-
-    const now = Date.now();
-    const httpRes = await fetch(refreshUrl, { signal, credentials: "include" });
-    if (!httpRes.ok) {
-      throw new Error(String(httpRes.status));
-    }
-    const jsonRes = (await httpRes.json()) as RefreshResponse;
-    if (jsonRes.error !== undefined) {
-      throw new Error(jsonRes.error);
-    }
-
-    const updatedGrant: TokenGrant = {
-      access_token: jsonRes.access_token,
-      expires_in: jsonRes.expires_in,
-      issue_time: now,
-      refresh_token: grant.refresh_token,
-    };
-    settingsHelper.set(SETTINGS_TYPE.CONNECTIONS, connectionId, {
-      name: connectionId,
-      value: JSON.stringify(updatedGrant),
-    });
-    this.#broadcastSecret(updatedGrant.access_token);
   }
 
   #broadcastSecret(secret: string) {

--- a/packages/visual-editor/src/ui/elements/connection/connection-input.ts
+++ b/packages/visual-editor/src/ui/elements/connection/connection-input.ts
@@ -16,7 +16,7 @@ import { settingsHelperContext } from "../../contexts/settings-helper.js";
 import { InputEnterEvent } from "../../events/events.js";
 import { SETTINGS_TYPE, type SettingsHelper } from "../../types/types.js";
 import type {
-  GrantSettingsValue,
+  TokenGrant,
   RefreshRequest,
   RefreshResponse,
 } from "./connection-common.js";
@@ -62,7 +62,7 @@ export class ConnectionInput extends LitElement {
       // be cool if I could have some parameters defined in `args`, and others
       // passed to `run`, but right now Task only allows one or the other.
       [grant, connectionId, environment, settingsHelper]: [
-        GrantSettingsValue,
+        TokenGrant,
         typeof this.connectionId,
         typeof this.environment,
         typeof this.settingsHelper,
@@ -95,7 +95,7 @@ export class ConnectionInput extends LitElement {
     return html`Token was fresh`;
   }
 
-  #getGrantFromSettings(): GrantSettingsValue | undefined {
+  #getGrantFromSettings(): TokenGrant | undefined {
     if (!this.connectionId || !this.settingsHelper) {
       return undefined;
     }
@@ -106,10 +106,10 @@ export class ConnectionInput extends LitElement {
     if (setting === undefined) {
       return undefined;
     }
-    return JSON.parse(String(setting.value)) as GrantSettingsValue;
+    return JSON.parse(String(setting.value)) as TokenGrant;
   }
 
-  #accessTokenIsExpired(grant: GrantSettingsValue): boolean {
+  #accessTokenIsExpired(grant: TokenGrant): boolean {
     const expiresAt =
       /* absolute milliseconds */ grant.issue_time +
       /* relative seconds */ grant.expires_in * 1000;
@@ -148,7 +148,7 @@ export class ConnectionInput extends LitElement {
     });
   }
 
-  #refreshAndRenderStatus(grant: GrantSettingsValue) {
+  #refreshAndRenderStatus(grant: TokenGrant) {
     if (this.#refreshTask.status === TaskStatus.INITIAL) {
       this.#refreshTask.run([
         grant,
@@ -165,7 +165,7 @@ export class ConnectionInput extends LitElement {
   }
 
   async #refresh(
-    grant: GrantSettingsValue,
+    grant: TokenGrant,
     connectionId: string,
     environment: Environment,
     settingsHelper: SettingsHelper,
@@ -187,7 +187,7 @@ export class ConnectionInput extends LitElement {
       throw new Error(jsonRes.error);
     }
 
-    const updatedGrant: GrantSettingsValue = {
+    const updatedGrant: TokenGrant = {
       access_token: jsonRes.access_token,
       expires_in: jsonRes.expires_in,
       issue_time: now,

--- a/packages/visual-editor/src/ui/elements/connection/connection-input.ts
+++ b/packages/visual-editor/src/ui/elements/connection/connection-input.ts
@@ -5,6 +5,7 @@
  */
 
 import { consume } from "@lit/context";
+import { Task, TaskStatus } from "@lit/task";
 import { LitElement, css, html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import {
@@ -12,15 +13,18 @@ import {
   type Environment,
 } from "../../contexts/environment.js";
 import { settingsHelperContext } from "../../contexts/settings-helper.js";
-import { SETTINGS_TYPE, type SettingsHelper } from "../../types/types.js";
-import type { GrantSettingsValue } from "./connection-common.js";
-import "./connection-signin.js";
-import {
-  type Connection,
-  fetchAvailableConnections,
-} from "./connection-server.js";
-import { Task, TaskStatus } from "@lit/task";
 import { InputEnterEvent } from "../../events/events.js";
+import { SETTINGS_TYPE, type SettingsHelper } from "../../types/types.js";
+import type {
+  GrantSettingsValue,
+  RefreshRequest,
+  RefreshResponse,
+} from "./connection-common.js";
+import {
+  fetchAvailableConnections,
+  type Connection,
+} from "./connection-server.js";
+import "./connection-signin.js";
 
 /**
  * If a token is going to expire in less than this many milliseconds, we treat
@@ -209,18 +213,3 @@ export class ConnectionInput extends LitElement {
     );
   }
 }
-
-// IMPORTANT: Keep in sync with
-// breadboard/packages/connection-server/src/api/refresh.ts
-interface RefreshRequest {
-  connection_id: string;
-  refresh_token: string;
-}
-
-type RefreshResponse =
-  | { error: string }
-  | {
-      error?: undefined;
-      access_token: string;
-      expires_in: number;
-    };

--- a/packages/visual-editor/src/ui/elements/connection/connection-signin.ts
+++ b/packages/visual-editor/src/ui/elements/connection/connection-signin.ts
@@ -16,7 +16,7 @@ import { SETTINGS_TYPE, type SettingsHelper } from "../../types/types.js";
 import {
   oauthTokenBroadcastChannelName,
   type GrantResponse,
-  type GrantSettingsValue,
+  type TokenGrant,
   type OAuthStateParameter,
 } from "./connection-common.js";
 import type { Connection } from "./connection-server.js";
@@ -239,7 +239,7 @@ export class ConnectionSignin extends LitElement {
       this._state = "signedout";
       return;
     }
-    const settingsValue: GrantSettingsValue = {
+    const settingsValue: TokenGrant = {
       access_token: grantResponse.access_token,
       expires_in: grantResponse.expires_in,
       refresh_token: grantResponse.refresh_token,

--- a/packages/visual-editor/src/ui/elements/connection/connection-signin.ts
+++ b/packages/visual-editor/src/ui/elements/connection/connection-signin.ts
@@ -245,10 +245,14 @@ export class ConnectionSignin extends LitElement {
       refresh_token: grantResponse.refresh_token,
       issue_time: now,
     };
-    this.settingsHelper.set(SETTINGS_TYPE.CONNECTIONS, this.connection.id, {
-      name: this.connection.id,
-      value: JSON.stringify(settingsValue),
-    });
+    await this.settingsHelper.set(
+      SETTINGS_TYPE.CONNECTIONS,
+      this.connection.id,
+      {
+        name: this.connection.id,
+        value: JSON.stringify(settingsValue),
+      }
+    );
     this.dispatchEvent(new TokenGrantedEvent(grantResponse.access_token));
     this._state = "signedin";
   }

--- a/packages/visual-editor/src/ui/elements/connection/token-vendor.ts
+++ b/packages/visual-editor/src/ui/elements/connection/token-vendor.ts
@@ -1,0 +1,146 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createContext } from "@lit/context";
+import { type Environment } from "../../contexts/environment.js";
+import { SETTINGS_TYPE, type SettingsHelper } from "../../types/types.js";
+import {
+  type RefreshRequest,
+  type RefreshResponse,
+  type TokenGrant,
+} from "./connection-common.js";
+
+export const tokenVendorContext = createContext<TokenVendor>("TokenVendor");
+
+export type TokenResult =
+  | ValidTokenResult
+  | ExpiredTokenResult
+  | SignedOutTokenResult;
+
+/**
+ * The token is valid and ready to be used.
+ */
+export interface ValidTokenResult {
+  state: "valid";
+  grant: TokenGrant;
+  expired?: never;
+  refresh?: never;
+}
+
+/**
+ * The user is signed-in to this service, but the token we have is expired. Call
+ * the `refresh` method to automatically refresh it.
+ */
+export interface ExpiredTokenResult {
+  state: "expired";
+  grant?: never;
+  expired?: never;
+  refresh: (opts?: { signal?: AbortSignal }) => Promise<ValidTokenResult>;
+}
+
+/**
+ * The user is not signed-in to this service. In this case, typically a
+ * `<bb-connection-signin>` element should be displayed to prompt the user to
+ * sign-in.
+ */
+export interface SignedOutTokenResult {
+  state: "signedout";
+  grant?: never;
+  expired?: never;
+  refresh?: never;
+}
+
+/**
+ * If a token is going to expire in less than this many milliseconds, we treat
+ * it as though it is already expired, since there might be a delay between
+ * returning it from here and it actually getting used.
+ */
+const EXPIRY_THRESHOLD_MS = /* 1 minute */ 60_000;
+
+/**
+ * Provides access to authorization tokens stored in settings, and the ability
+ * to refresh them if they are expired.
+ *
+ * There should typically be one instance of this class per Visual Editor, and
+ * elements should discover it using the {@link tokenVendorContext} Lit
+ * context, which should be provided by the top-level Visual Editor element.
+ */
+export class TokenVendor {
+  #settings: SettingsHelper;
+  #environment: Environment;
+
+  constructor(settings: SettingsHelper, environment: Environment) {
+    this.#settings = settings;
+    this.#environment = environment;
+  }
+
+  getToken(connectionId: string): TokenResult {
+    const grantJsonText = this.#settings.get(
+      SETTINGS_TYPE.CONNECTIONS,
+      connectionId
+    );
+    if (grantJsonText === undefined) {
+      return { state: "signedout" };
+    }
+    const grant = JSON.parse(String(grantJsonText.value)) as TokenGrant;
+    if (grantIsExpired(grant)) {
+      return {
+        state: "expired",
+        refresh: (opts?: { signal?: AbortSignal }) =>
+          this.#refresh(connectionId, grant.refresh_token, opts?.signal),
+      };
+    }
+    return { state: "valid", grant };
+  }
+
+  async #refresh(
+    connectionId: string,
+    refreshToken: string,
+    signal?: AbortSignal
+  ): Promise<ValidTokenResult> {
+    const refreshUrl = new URL(
+      "refresh",
+      this.#environment.connectionServerUrl
+    );
+    refreshUrl.search = new URLSearchParams({
+      connection_id: connectionId,
+      refresh_token: refreshToken,
+    } satisfies RefreshRequest).toString();
+
+    const now = Date.now();
+    const httpRes = await fetch(refreshUrl, {
+      signal,
+      credentials: "include",
+    });
+    if (!httpRes.ok) {
+      throw new Error(String(httpRes.status));
+    }
+    const jsonRes = (await httpRes.json()) as RefreshResponse;
+    if (jsonRes.error !== undefined) {
+      throw new Error(jsonRes.error);
+    }
+
+    const updatedGrant: TokenGrant = {
+      access_token: jsonRes.access_token,
+      expires_in: jsonRes.expires_in,
+      issue_time: now,
+      refresh_token: refreshToken,
+    };
+    await this.#settings.set(SETTINGS_TYPE.CONNECTIONS, connectionId, {
+      name: connectionId,
+      value: JSON.stringify(updatedGrant),
+    });
+    return { state: "valid", grant: updatedGrant };
+  }
+}
+
+function grantIsExpired(grant: TokenGrant): boolean {
+  const expiresAt =
+    /* absolute milliseconds */ grant.issue_time +
+    /* relative seconds */ grant.expires_in * 1000;
+  const expiresIn = expiresAt - /* unix milliseconds */ Date.now();
+  return expiresIn <= EXPIRY_THRESHOLD_MS;
+}

--- a/packages/visual-editor/src/ui/types/types.ts
+++ b/packages/visual-editor/src/ui/types/types.ts
@@ -189,8 +189,12 @@ export type CustomSettingsElement = HTMLElement & {
  */
 export interface SettingsHelper {
   get(section: SETTINGS_TYPE, name: string): SettingEntry["value"] | undefined;
-  set(section: SETTINGS_TYPE, name: string, value: SettingEntry["value"]): void;
-  delete(section: SETTINGS_TYPE, name: string): void;
+  set(
+    section: SETTINGS_TYPE,
+    name: string,
+    value: SettingEntry["value"]
+  ): Promise<void>;
+  delete(section: SETTINGS_TYPE, name: string): Promise<void>;
 }
 
 /**


### PR DESCRIPTION
Adds a `TokenVendor` class and Lit context, and refactors `connection-input` to use it. This piece will be useful for other elements that need to directly access OAuth tokens (like an upcoming Google Drive widget).