### PR TITLE
fewer leaks

### DIFF
--- a/.changeset/fast-pillows-serve.md
+++ b/.changeset/fast-pillows-serve.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/core-kit": patch
+---
+
+Stop leaking blob URLs in runJavascript.

--- a/packages/core-kit/src/nodes/run-javascript.ts
+++ b/packages/core-kit/src/nodes/run-javascript.ts
@@ -103,12 +103,14 @@ const runInBrowser = async ({
     [x in WebWorkerResultType]: string;
   };
 
-  const worker = new Worker(URL.createObjectURL(blob));
+  const workerURL = URL.createObjectURL(blob);
+  const worker = new Worker(workerURL);
   const result = new Promise<string>((resolve, reject) => {
     worker.onmessage = (e) => {
       const data = e.data as WebWorkerResult;
       if (data.result) {
         resolve(data.result);
+        URL.revokeObjectURL(workerURL);
         return;
       } else if (data.error) {
         console.log("Error in worker", data.error);


### PR DESCRIPTION
- **Revoke worker URL after it's run in `runJavascript` component.**
- **docs(changeset): Stop leaking blob URLs in runJavascript.**
