### PR TITLE
[build] Support board composition

### DIFF
--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -4,24 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { isConvergence, type Convergence } from "./internal/board/converge.js";
-import {
-  isSpecialInput,
-  type Input,
-  type InputWithDefault,
-} from "./internal/board/input.js";
-import { isLoopback, type Loopback } from "./internal/board/loopback.js";
-import {
-  isOutputPortReference,
-  OutputPortGetter,
-  type OutputPortReference,
-} from "./internal/common/port.js";
-import { anyOf } from "./internal/type-system/any-of.js";
-import type {
-  BreadboardType,
-  JsonSerializable,
-} from "./internal/type-system/type.js";
-
 export { board } from "./internal/board/board.js";
 export { constant } from "./internal/board/constant.js";
 export { converge } from "./internal/board/converge.js";
@@ -31,14 +13,15 @@ export { optionalEdge } from "./internal/board/optional.js";
 export { output } from "./internal/board/output.js";
 export { serialize } from "./internal/board/serialize.js";
 export { unsafeCast } from "./internal/board/unsafe-cast.js";
-export type {
-  // TODO(aomarks) Not quite sure about exporting and/or the name of
+export {
+  // TODO() Not quite sure about exporting and/or the name of
   // SerializableBoard.
-  SerializableBoard,
+  type SerializableBoard,
 } from "./internal/common/serializable.js";
+export { extractTypeFromValue, type Value } from "./internal/common/value.js";
 export { defineNodeType } from "./internal/define/define.js";
 export { jsonSchemaToPortConfigMap as fromJSONSchema } from "./internal/define/json-schema.js";
-export type { NodeFactoryFromDefinition } from "./internal/define/node-factory.js";
+export { type NodeFactoryFromDefinition } from "./internal/define/node-factory.js";
 export { unsafeSchema } from "./internal/define/unsafe-schema.js";
 export { kit } from "./internal/kit.js";
 export { annotate } from "./internal/type-system/annotate.js";
@@ -48,61 +31,3 @@ export { enumeration } from "./internal/type-system/enumeration.js";
 export { object, optional } from "./internal/type-system/object.js";
 export { toJSONSchema } from "./internal/type-system/type.js";
 export { unsafeType } from "./internal/type-system/unsafe.js";
-
-/**
- * A value, or something that can stand-in for a value when wiring together
- * boards.
- *
- * For example, for a string, this could be any of:
- *
- * - An actual string.
- * - A string-typed output port.
- * - A node with a primary string-typed output port.
- * - A string-typed `input`.
- */
-export type Value<T extends JsonSerializable> =
-  | T
-  | OutputPortReference<T>
-  | Input<T>
-  | InputWithDefault<T>
-  | Loopback<T>
-  | Convergence<T>;
-
-/**
- * Given a Breadboard {@link Value}, determine its JSON Schema type.
- */
-export function extractTypeFromValue(
-  value: Value<JsonSerializable>
-): BreadboardType {
-  if (typeof value === "string") {
-    return "string";
-  }
-  if (typeof value === "number") {
-    return "number";
-  }
-  if (typeof value === "boolean") {
-    return "boolean";
-  }
-  if (value === null) {
-    return "null";
-  }
-  if (isOutputPortReference(value)) {
-    return value[OutputPortGetter].type;
-  }
-  if (isSpecialInput(value)) {
-    return value.type;
-  }
-  if (isLoopback(value)) {
-    return value.type;
-  }
-  if (isConvergence(value)) {
-    return anyOf(
-      ...(value.ports.map((port) => extractTypeFromValue(port)) as [
-        BreadboardType,
-        BreadboardType,
-        ...BreadboardType[],
-      ])
-    );
-  }
-  return "unknown";
-}

--- a/packages/build/src/internal/board/output.ts
+++ b/packages/build/src/internal/board/output.ts
@@ -9,7 +9,7 @@ import type { JsonSerializable } from "../type-system/type.js";
 import type { Input, InputWithDefault } from "./input.js";
 
 export function output<T extends JsonSerializable>(
-  port: OutputPortReference<T> | Input<T> | InputWithDefault<T>,
+  port: Output<T> | OutputPortReference<T> | Input<T> | InputWithDefault<T>,
   {
     id,
     title,
@@ -30,7 +30,11 @@ export interface Output<T extends JsonSerializable | undefined> {
   readonly id?: string;
   readonly title?: string;
   readonly description?: string;
-  readonly port: OutputPortReference<T> | Input<T> | InputWithDefault<T>;
+  readonly port:
+    | Output<T>
+    | OutputPortReference<T>
+    | Input<T>
+    | InputWithDefault<T>;
 }
 
 export function isSpecialOutput(

--- a/packages/build/src/internal/board/serialize.ts
+++ b/packages/build/src/internal/board/serialize.ts
@@ -404,6 +404,18 @@ export function serialize(board: SerializableBoard): GraphDescriptor {
           wasOptional = true;
         }
 
+        if (isBoardOutput(value)) {
+          addEdge(
+            visitNodeAndReturnItsId(value.innerBoard),
+            value.innerPortName,
+            thisNodeId,
+            portName,
+            wasConstant,
+            wasOptional
+          );
+          continue;
+        }
+
         if (isLoopback(value)) {
           value = value.value;
           if (value === undefined) {

--- a/packages/build/src/internal/board/serialize.ts
+++ b/packages/build/src/internal/board/serialize.ts
@@ -19,10 +19,15 @@ import type {
 } from "../common/serializable.js";
 import { type JsonSerializable } from "../type-system/type.js";
 import {
+  BoardInstance,
   describeInput,
   describeOutput,
   isBoard,
+  isBoardInstance,
+  isBoardOutput,
   isSerializableOutputPortReference,
+  type BoardInputPorts,
+  type BoardOutputPorts,
   type GenericBoardDefinition,
 } from "./board.js";
 import { ConstantVersionOf, isConstant } from "./constant.js";
@@ -190,21 +195,28 @@ export function serialize(board: SerializableBoard): GraphDescriptor {
       if (name === "$id" || name === "$metadata") {
         continue;
       }
+
+      let nested = isBoardOutput(output) ? output : undefined;
       let port;
       let outputNodeId;
       const portMetadata: { title?: string; description?: string } = {};
       if (isSpecialOutput(output)) {
         port = output.port;
-        outputNodeId = output.id;
-        if (output.title) {
-          portMetadata.title = output.title;
-        }
-        if (output.description) {
-          portMetadata.description = output.description;
+        if (nested === undefined) {
+          outputNodeId = output.id;
+          if (output.title) {
+            portMetadata.title = output.title;
+          }
+          if (output.description) {
+            portMetadata.description = output.description;
+          }
         }
       } else {
         port = output;
       }
+
+      nested = nested ?? (isBoardOutput(port) ? port : undefined);
+
       if (isSerializableOutputPortReference(port)) {
         port = port[OutputPortGetter];
       }
@@ -240,7 +252,17 @@ export function serialize(board: SerializableBoard): GraphDescriptor {
       if (required) {
         outputNode.configuration.schema.required.push(name);
       }
-      if (isSpecialInput(port)) {
+      if (nested !== undefined) {
+        const { innerBoard, innerPortName } = nested;
+        addEdge(
+          visitNodeAndReturnItsId(innerBoard),
+          innerPortName,
+          outputNodeId,
+          name,
+          isConstant(output),
+          !required
+        );
+      } else if (isSpecialInput(port)) {
         unconnectedInputs.delete(port);
         const resolution = magicInputResolutions.get(port);
         if (resolution !== undefined) {
@@ -253,7 +275,7 @@ export function serialize(board: SerializableBoard): GraphDescriptor {
             !required
           );
         }
-      } else {
+      } else if ("node" in port) {
         addEdge(
           visitNodeAndReturnItsId(port.node),
           port.name,
@@ -315,14 +337,25 @@ export function serialize(board: SerializableBoard): GraphDescriptor {
   }
   return bgl;
 
-  function visitNodeAndReturnItsId(node: SerializableNode): string {
+  function visitNodeAndReturnItsId(
+    node: SerializableNode | BoardInstance<BoardInputPorts, BoardOutputPorts>
+  ): string {
     let descriptor = nodes.get(node);
     if (descriptor !== undefined) {
       return descriptor.id;
     }
+    let type, metadata, thisNodeId;
+    if (isBoardInstance(node)) {
+      type = "invoke";
+      metadata = undefined;
+      thisNodeId = nextIdForType("invoke");
+    } else {
+      const cast = node as SerializableNode;
+      type = cast.type;
+      metadata = cast.metadata;
+      thisNodeId = cast.id ?? nextIdForType(type);
+    }
 
-    const { type, metadata } = node;
-    const thisNodeId = node.id ?? nextIdForType(type);
     const configuration: Record<string, NodeValue> = {};
     descriptor = { id: thisNodeId, type, configuration };
 
@@ -341,11 +374,21 @@ export function serialize(board: SerializableBoard): GraphDescriptor {
     nodes.set(node, descriptor);
 
     const configurationEntries: Array<[string, NodeValue]> = [];
-    for (const [portName, inputPort] of Object.entries(node.inputs)) {
+    if (isBoardInstance(node)) {
+      configurationEntries.push([
+        "$board",
+        `#${embedBoardAndReturnItsId(node.definition)}`,
+      ]);
+    }
+    for (const [portName, inputPort] of Object.entries(
+      isBoardInstance(node) ? node.values : node.inputs
+    )) {
       unconnectedInputs.delete(inputPort);
       const values = isConvergence(inputPort.value)
         ? inputPort.value.ports
-        : [inputPort.value];
+        : inputPort.value
+          ? [inputPort.value]
+          : [inputPort];
       for (let value of values) {
         let wasConstant = false;
         if (isConstant(value)) {
@@ -413,7 +456,7 @@ export function serialize(board: SerializableBoard): GraphDescriptor {
           // TODO(aomarks) Why is this possible in the type system? An inport port
           // value can never actually be undefined, right?
           throw new Error(
-            `Internal error: value was undefined for a ${inputPort.node.type}:${inputPort.name} port.`
+            `Internal error: value was undefined for a ${inputPort.node?.type}:${inputPort.name} port.`
           );
         } else if (typeof value === "symbol") {
           // TODO(aomarks) Why is this possible in the type system? This should
@@ -429,6 +472,12 @@ export function serialize(board: SerializableBoard): GraphDescriptor {
               path: `#${embedBoardAndReturnItsId(value)}`,
             },
           ]);
+        } else if (
+          typeof value === "object" &&
+          value.constructor !== Object &&
+          "value" in value
+        ) {
+          configurationEntries.push([portName, value.value]);
         } else {
           configurationEntries.push([
             portName,

--- a/packages/build/src/internal/common/value.ts
+++ b/packages/build/src/internal/common/value.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { isConvergence, type Convergence } from "../board/converge.js";
+import {
+  isSpecialInput,
+  type Input,
+  type InputWithDefault,
+} from "../board/input.js";
+import { isLoopback, type Loopback } from "../board/loopback.js";
+import { anyOf } from "../type-system/any-of.js";
+import {
+  type BreadboardType,
+  type JsonSerializable,
+} from "../type-system/type.js";
+import {
+  isOutputPortReference,
+  OutputPortGetter,
+  type OutputPortReference,
+} from "./port.js";
+
+/**
+ * A value, or something that can stand-in for a value when wiring together
+ * boards.
+ *
+ * For example, for a string, this could be any of:
+ *
+ * - An actual string.
+ * - A string-typed output port.
+ * - A node with a primary string-typed output port.
+ * - A string-typed `input`.
+ */
+export type Value<T extends JsonSerializable> =
+  | T
+  | OutputPortReference<T>
+  | Input<T>
+  | InputWithDefault<T>
+  | Loopback<T>
+  | Convergence<T>;
+
+/**
+ * Given a Breadboard {@link Value}, determine its JSON Schema type.
+ */
+export function extractTypeFromValue(
+  value: Value<JsonSerializable>
+): BreadboardType {
+  if (typeof value === "string") {
+    return "string";
+  }
+  if (typeof value === "number") {
+    return "number";
+  }
+  if (typeof value === "boolean") {
+    return "boolean";
+  }
+  if (value === null) {
+    return "null";
+  }
+  if (isOutputPortReference(value)) {
+    return value[OutputPortGetter].type;
+  }
+  if (isSpecialInput(value)) {
+    return value.type;
+  }
+  if (isLoopback(value)) {
+    return value.type;
+  }
+  if (isConvergence(value)) {
+    return anyOf(
+      ...(value.ports.map((port) => extractTypeFromValue(port)) as [
+        BreadboardType,
+        BreadboardType,
+        ...BreadboardType[],
+      ])
+    );
+  }
+  return "unknown";
+}

--- a/packages/build/src/test/composition_test.ts
+++ b/packages/build/src/test/composition_test.ts
@@ -1,0 +1,316 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { board } from "../internal/board/board.js";
+import { input } from "../internal/board/input.js";
+import { serialize } from "../internal/board/serialize.js";
+import { defineNodeType } from "../internal/define/define.js";
+import { output } from "../internal/board/output.js";
+
+const trivialNode = defineNodeType({
+  name: "trivial",
+  inputs: {
+    trivialStrIn: { type: "string" },
+    trivialNumIn: { type: "number" },
+  },
+  outputs: { trivialOut: { type: "string" } },
+  invoke: ({ trivialStrIn, trivialNumIn }) => ({
+    trivialOut: `${trivialStrIn}:${trivialNumIn}`,
+  }),
+});
+
+test("can invoke one board in another", () => {
+  const innerStrInput = input({ description: "innerStrInput" });
+  const innerNumInput = input({ type: "number", description: "innerNumInput" });
+  const innerNode = trivialNode({
+    trivialStrIn: innerStrInput,
+    trivialNumIn: innerNumInput,
+  });
+  const innerOutput = innerNode.outputs.trivialOut;
+  const innerBoard = board({
+    inputs: { innerStrInput, innerNumInput },
+    outputs: { innerOutput },
+  });
+
+  const outerInput = input({ description: "outerInput" });
+  const nestedBoard = innerBoard({
+    innerStrInput: outerInput,
+    innerNumInput: 42,
+  });
+  const outerOutput = nestedBoard.outputs.innerOutput;
+  const outerBoard = board({
+    inputs: { outerInput },
+    outputs: { outerOutput },
+  });
+
+  const serialized = serialize(outerBoard);
+  assert.deepEqual(serialized, {
+    nodes: [
+      {
+        id: "input-0",
+        type: "input",
+        configuration: {
+          schema: {
+            type: "object",
+            properties: {
+              outerInput: { type: "string", description: "outerInput" },
+            },
+            required: ["outerInput"],
+          },
+        },
+      },
+      {
+        id: "output-0",
+        type: "output",
+        configuration: {
+          schema: {
+            type: "object",
+            required: ["outerOutput"],
+            properties: {
+              outerOutput: {
+                type: "string",
+              },
+            },
+          },
+        },
+      },
+      {
+        id: "invoke-0",
+        type: "invoke",
+        configuration: {
+          $board: "#subgraph-0",
+          innerNumInput: 42,
+        },
+      },
+    ],
+    edges: [
+      {
+        from: "input-0",
+        out: "outerInput",
+        to: "invoke-0",
+        in: "innerStrInput",
+      },
+      {
+        from: "invoke-0",
+        out: "innerOutput",
+        to: "output-0",
+        in: "outerOutput",
+      },
+    ],
+    graphs: {
+      "subgraph-0": {
+        edges: [
+          {
+            from: "input-0",
+            in: "trivialNumIn",
+            out: "innerNumInput",
+            to: "trivial-0",
+          },
+          {
+            from: "input-0",
+            out: "innerStrInput",
+            to: "trivial-0",
+            in: "trivialStrIn",
+          },
+          {
+            from: "trivial-0",
+            out: "trivialOut",
+            to: "output-0",
+            in: "innerOutput",
+          },
+        ],
+        nodes: [
+          {
+            id: "input-0",
+            type: "input",
+            configuration: {
+              schema: {
+                type: "object",
+                properties: {
+                  innerStrInput: {
+                    type: "string",
+                    description: "innerStrInput",
+                  },
+                  innerNumInput: {
+                    type: "number",
+                    description: "innerNumInput",
+                  },
+                },
+                required: ["innerNumInput", "innerStrInput"],
+              },
+            },
+          },
+          {
+            id: "output-0",
+            type: "output",
+            configuration: {
+              schema: {
+                type: "object",
+                properties: { innerOutput: { type: "string" } },
+                required: ["innerOutput"],
+              },
+            },
+          },
+          { id: "trivial-0", type: "trivial", configuration: {} },
+        ],
+      },
+    },
+  });
+});
+
+test("can invoke one board in another (output wrappers)", () => {
+  const innerStrInput = input({ description: "innerStrInput" });
+  const innerNumInput = input({ type: "number", description: "innerNumInput" });
+  const innerNode = trivialNode({
+    trivialStrIn: innerStrInput,
+    trivialNumIn: innerNumInput,
+  });
+  const innerOutput = innerNode.outputs.trivialOut;
+  const innerBoard = board({
+    inputs: { innerStrInput, innerNumInput },
+    outputs: {
+      innerOutput: output(innerOutput, { description: "innerOutput" }),
+    },
+  });
+
+  const outerInput = input({ description: "outerInput" });
+  const nestedBoard = innerBoard({
+    innerStrInput: outerInput,
+    innerNumInput: 42,
+  });
+  const outerOutput = nestedBoard.outputs.innerOutput;
+  const outerBoard = board({
+    inputs: { outerInput },
+    outputs: {
+      outerOutput: output(outerOutput, { description: "outerOutput" }),
+    },
+  });
+
+  const serialized = serialize(outerBoard);
+  assert.deepEqual(serialized, {
+    nodes: [
+      {
+        id: "input-0",
+        type: "input",
+        configuration: {
+          schema: {
+            type: "object",
+            properties: {
+              outerInput: {
+                type: "string",
+                description: "outerInput",
+              },
+            },
+            required: ["outerInput"],
+          },
+        },
+      },
+      {
+        id: "output-0",
+        type: "output",
+        configuration: {
+          schema: {
+            type: "object",
+            required: ["outerOutput"],
+            properties: {
+              outerOutput: {
+                type: "string",
+                description: "outerOutput",
+              },
+            },
+          },
+        },
+      },
+      {
+        id: "invoke-0",
+        type: "invoke",
+        configuration: {
+          $board: "#subgraph-0",
+          innerNumInput: 42,
+        },
+      },
+    ],
+    edges: [
+      {
+        from: "input-0",
+        out: "outerInput",
+        to: "invoke-0",
+        in: "innerStrInput",
+      },
+      {
+        from: "invoke-0",
+        out: "innerOutput",
+        to: "output-0",
+        in: "outerOutput",
+      },
+    ],
+    graphs: {
+      "subgraph-0": {
+        edges: [
+          {
+            from: "input-0",
+            in: "trivialNumIn",
+            out: "innerNumInput",
+            to: "trivial-0",
+          },
+          {
+            from: "input-0",
+            out: "innerStrInput",
+            to: "trivial-0",
+            in: "trivialStrIn",
+          },
+          {
+            from: "trivial-0",
+            out: "trivialOut",
+            to: "output-0",
+            in: "innerOutput",
+          },
+        ],
+        nodes: [
+          {
+            id: "input-0",
+            type: "input",
+            configuration: {
+              schema: {
+                type: "object",
+                properties: {
+                  innerStrInput: {
+                    type: "string",
+                    description: "innerStrInput",
+                  },
+                  innerNumInput: {
+                    type: "number",
+                    description: "innerNumInput",
+                  },
+                },
+                required: ["innerNumInput", "innerStrInput"],
+              },
+            },
+          },
+          {
+            id: "output-0",
+            type: "output",
+            configuration: {
+              schema: {
+                type: "object",
+                properties: {
+                  innerOutput: {
+                    type: "string",
+                    description: "innerOutput",
+                  },
+                },
+                required: ["innerOutput"],
+              },
+            },
+          },
+          { id: "trivial-0", type: "trivial", configuration: {} },
+        ],
+      },
+    },
+  });
+});


### PR DESCRIPTION
You can now instantiate a board as a component in the same way as a discrete component. Upon serialization, the inner board is added as a subgraph, and an `invoke` node is inserted to call it.

Fixes https://github.com/breadboard-ai/breadboard/issues/2571