### PR TITLE
[agent-kit] Start converting agent kit types to Breadboard Type Expressions

### DIFF
--- a/.changeset/neat-clouds-jog.md
+++ b/.changeset/neat-clouds-jog.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/agent-kit": patch
+---
+
+Internal refactoring

--- a/package-lock.json
+++ b/package-lock.json
@@ -22331,6 +22331,9 @@
       "name": "@google-labs/agent-kit",
       "version": "0.8.1",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@breadboard-ai/build": "^0.7.1"
+      },
       "devDependencies": {
         "@ava/typescript": "^4.0.0",
         "@google-labs/breadboard": "^0.22.0",

--- a/packages/agent-kit/package.json
+++ b/packages/agent-kit/package.json
@@ -153,5 +153,8 @@
     "ava": "^5.2.0",
     "tsx": "^4.16.2",
     "typescript": "^5.5.3"
+  },
+  "dependencies": {
+    "@breadboard-ai/build": "0.7.1"
   }
 }


### PR DESCRIPTION
Converts most of the types to Breadboard Type Expressions so that they can be used with the Build API. Skipped a couple because we need a new `intersection` utility for `&` (which is like `allOf`, except for some tricky details around required properties).

Part of https://github.com/breadboard-ai/breadboard/issues/2341