### PR TITLE
Fix overly constrained version constraints

### DIFF
--- a/.changeset/small-comics-cry.md
+++ b/.changeset/small-comics-cry.md
@@ -1,0 +1,14 @@
+---
+"@breadboard-ai/google-drive-kit": patch
+"@google-labs/breadboard-cli": patch
+"@breadboard-ai/example-boards": patch
+"@breadboard-ai/visual-editor": patch
+"@google-labs/template-kit": patch
+"@breadboard-ai/python-wasm": patch
+"@google-labs/gemini-kit": patch
+"@google-labs/agent-kit": patch
+"@google-labs/core-kit": patch
+"@google-labs/json-kit": patch
+---
+
+Unpin @breadboard-ai/build dependency from being overly constrained

--- a/packages/agent-kit/package.json
+++ b/packages/agent-kit/package.json
@@ -155,6 +155,6 @@
     "typescript": "^5.5.3"
   },
   "dependencies": {
-    "@breadboard-ai/build": "0.7.1"
+    "@breadboard-ai/build": "^0.7.1"
   }
 }

--- a/packages/breadboard-cli/package.json
+++ b/packages/breadboard-cli/package.json
@@ -156,7 +156,7 @@
     "typescript": "^5.5.3"
   },
   "dependencies": {
-    "@breadboard-ai/build": "0.7.1",
+    "@breadboard-ai/build": "^0.7.1",
     "@breadboard-ai/import": "0.1.5",
     "@breadboard-ai/visual-editor": "^1.12.0",
     "@google-labs/breadboard": "^0.22.0",

--- a/packages/core-kit/package.json
+++ b/packages/core-kit/package.json
@@ -130,7 +130,7 @@
     "typescript": "^5.5.3"
   },
   "dependencies": {
-    "@breadboard-ai/build": "0.7.1",
+    "@breadboard-ai/build": "^0.7.1",
     "@google-labs/breadboard": "^0.22.0"
   }
 }

--- a/packages/example-boards/package.json
+++ b/packages/example-boards/package.json
@@ -133,7 +133,7 @@
     "typescript": "^5.5.3"
   },
   "dependencies": {
-    "@breadboard-ai/build": "0.7.1",
+    "@breadboard-ai/build": "^0.7.1",
     "@breadboard-ai/google-drive-kit": "0.2.0",
     "@breadboard-ai/manifest": "^0.3.0",
     "@breadboard-ai/python-wasm": "0.1.3",

--- a/packages/gemini-kit/package.json
+++ b/packages/gemini-kit/package.json
@@ -134,7 +134,7 @@
     "typescript": "^5.5.3"
   },
   "dependencies": {
-    "@breadboard-ai/build": "0.7.1",
+    "@breadboard-ai/build": "^0.7.1",
     "@google-labs/breadboard": "^0.22.0",
     "@google-labs/core-kit": "^0.11.0",
     "@google-labs/json-kit": "^0.3.3",

--- a/packages/google-drive-kit/package.json
+++ b/packages/google-drive-kit/package.json
@@ -131,7 +131,7 @@
     }
   },
   "dependencies": {
-    "@breadboard-ai/build": "0.7.1",
+    "@breadboard-ai/build": "^0.7.1",
     "@google-labs/core-kit": "^0.11.0",
     "@google-labs/template-kit": "^0.3.5"
   },

--- a/packages/json-kit/package.json
+++ b/packages/json-kit/package.json
@@ -99,7 +99,7 @@
     "typescript": "^5.5.3"
   },
   "dependencies": {
-    "@breadboard-ai/build": "0.7.1",
+    "@breadboard-ai/build": "^0.7.1",
     "@google-labs/breadboard": "^0.22.0",
     "@rgrove/parse-xml": "^4.1.0",
     "@types/json-schema": "^7.0.15",

--- a/packages/python-wasm/package.json
+++ b/packages/python-wasm/package.json
@@ -115,7 +115,7 @@
     }
   },
   "dependencies": {
-    "@breadboard-ai/build": "0.7.1",
+    "@breadboard-ai/build": "^0.7.1",
     "pyodide": "^0.26.1"
   },
   "devDependencies": {

--- a/packages/template-kit/package.json
+++ b/packages/template-kit/package.json
@@ -116,7 +116,7 @@
     "typescript": "^5.5.3"
   },
   "dependencies": {
-    "@breadboard-ai/build": "0.7.1",
+    "@breadboard-ai/build": "^0.7.1",
     "@google-labs/breadboard": "^0.22.0",
     "url-template": "^3.1.0"
   }

--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -267,7 +267,7 @@
     "vitest": "^2.0.4"
   },
   "dependencies": {
-    "@breadboard-ai/build": "0.7.1",
+    "@breadboard-ai/build": "^0.7.1",
     "@breadboard-ai/data-store": "^0.0.1",
     "@breadboard-ai/example-boards": "0.1.1",
     "@breadboard-ai/google-drive-kit": "0.2.0",


### PR DESCRIPTION
All of our `@breadboard-ai/build` version constraints were `0.7.1` instead of `^0.7.1`. Not sure why, but now they are fixed.