### PR TITLE
board server run next

### DIFF
--- a/.changeset/dirty-donkeys-try.md
+++ b/.changeset/dirty-donkeys-try.md
@@ -1,0 +1,6 @@
+---
+"@breadboard-ai/board-server": minor
+"@google-labs/breadboard": minor
+---
+
+Teach board-server run API endpoint to run simple boards.

--- a/packages/board-server/src/server/boards/utils/run-board.ts
+++ b/packages/board-server/src/server/boards/utils/run-board.ts
@@ -44,7 +44,7 @@ export const runBoard = async ({
     return { $error: "Data store not available." };
   }
 
-  let inputsToConsume = inputs;
+  let inputsToConsume = next ? undefined : inputs;
 
   const runner = run({
     url,

--- a/packages/board-server/src/server/boards/utils/run-board.ts
+++ b/packages/board-server/src/server/boards/utils/run-board.ts
@@ -43,10 +43,10 @@ export const runBoard = async ({
         inputsToConsume = undefined;
       } else {
         const schema = data.node.configuration?.schema || {};
-        const state = await result.state?.();
+        const state = await result.saveState?.();
         if (!state) {
           return {
-            $error: "No state supplied.",
+            $error: "No state supplied, internal run error.",
           };
         }
         const next = JSON.stringify(state);
@@ -56,10 +56,10 @@ export const runBoard = async ({
       }
     } else if (type === "output") {
       const schema = data.node.configuration?.schema || {};
-      const state = await result.state?.();
+      const state = await result.saveState?.();
       if (!state) {
         return {
-          $error: "No state supplied.",
+          $error: "No state supplied, internal run error.",
         };
       }
       const next = JSON.stringify(state);

--- a/packages/board-server/src/server/boards/utils/run-board.ts
+++ b/packages/board-server/src/server/boards/utils/run-board.ts
@@ -5,15 +5,26 @@
  */
 
 import { getDataStore } from "@breadboard-ai/data-store";
-import { run, type HarnessRunResult } from "@google-labs/breadboard/harness";
+import { run, type StateToResumeFrom } from "@google-labs/breadboard/harness";
 import { createKits } from "./create-kits.js";
-import { createLoader, inflateData } from "@google-labs/breadboard";
+import {
+  createLoader,
+  inflateData,
+  type InputValues,
+} from "@google-labs/breadboard";
 import { BoardServerProvider } from "./board-server-provider.js";
 import { formatRunError } from "./format-run-error.js";
 import type { RunBoardArguments, RunBoardResult } from "../../types.js";
 
-const fromNextToState = (next?: string) => {
-  return next ? JSON.parse(next) : undefined;
+const fromNextToState = (
+  next?: string,
+  inputs?: InputValues
+): StateToResumeFrom => {
+  const state = next ? JSON.parse(next) : undefined;
+  return {
+    state,
+    inputs,
+  };
 };
 
 const fromStateToNext = (state: any) => {
@@ -42,7 +53,7 @@ export const runBoard = async ({
     store,
     inputs: { model: "gemini-1.5-flash-latest" },
     interactiveSecrets: false,
-    resumeFrom: fromNextToState(next),
+    resumeFrom: fromNextToState(next, inputs),
   });
 
   for await (const result of runner) {

--- a/packages/board-server/src/server/types.ts
+++ b/packages/board-server/src/server/types.ts
@@ -5,7 +5,7 @@
  */
 
 import type { IncomingMessage, ServerResponse } from "http";
-import type { GraphDescriptor, Kit } from "@google-labs/breadboard";
+import type { GraphDescriptor, Kit, NodeValue } from "@google-labs/breadboard";
 
 export type GeneralRequestType = "list" | "create";
 
@@ -72,4 +72,23 @@ export type RunBoardArguments = {
   kitOverrides?: Kit[];
 };
 
-export type RunBoardResult = Record<string, any>;
+export type RunBoardResultError = {
+  $error: string;
+};
+
+export type RunBoardResultState = {
+  $state:
+    | {
+        type: "input";
+        schema: NodeValue;
+      }
+    | {
+        type: "output";
+        schema: NodeValue;
+      }
+    | {
+        type: "end";
+      };
+} & Record<string, any>;
+
+export type RunBoardResult = RunBoardResultError | RunBoardResultState;

--- a/packages/board-server/src/server/types.ts
+++ b/packages/board-server/src/server/types.ts
@@ -70,6 +70,7 @@ export type RunBoardArguments = {
   loader: BoardServerLoadFunction;
   inputs?: Record<string, any>;
   kitOverrides?: Kit[];
+  next?: string;
 };
 
 export type RunBoardResultError = {

--- a/packages/board-server/src/server/types.ts
+++ b/packages/board-server/src/server/types.ts
@@ -81,10 +81,12 @@ export type RunBoardResultState = {
     | {
         type: "input";
         schema: NodeValue;
+        next: string;
       }
     | {
         type: "output";
         schema: NodeValue;
+        next: string;
       }
     | {
         type: "end";

--- a/packages/board-server/tests/boards/many-outputs.bgl.json
+++ b/packages/board-server/tests/boards/many-outputs.bgl.json
@@ -1,0 +1,124 @@
+{
+  "title": "many-outputs",
+  "description": "A blank board. Use it as a starting point for your creations.",
+  "version": "0.0.1",
+  "nodes": [
+    {
+      "type": "input",
+      "id": "input",
+      "configuration": {
+        "schema": {
+          "properties": {
+            "start": {
+              "type": "string",
+              "title": "Start",
+              "examples": []
+            }
+          },
+          "type": "object",
+          "required": []
+        }
+      },
+      "metadata": {
+        "visual": {
+          "x": -159,
+          "y": 89,
+          "collapsed": false
+        }
+      }
+    },
+    {
+      "type": "output",
+      "id": "output",
+      "configuration": {
+        "schema": {
+          "properties": {
+            "one": {
+              "type": "string",
+              "title": "One",
+              "examples": []
+            }
+          },
+          "type": "object",
+          "required": []
+        }
+      },
+      "metadata": {
+        "visual": {
+          "x": 213,
+          "y": -24,
+          "collapsed": false
+        },
+        "title": "One",
+        "logLevel": "debug"
+      }
+    },
+    {
+      "type": "output",
+      "id": "output-83a8ab5e",
+      "configuration": {
+        "schema": {
+          "properties": {
+            "two": {
+              "type": "string",
+              "title": "Two",
+              "examples": []
+            }
+          },
+          "type": "object",
+          "required": []
+        }
+      },
+      "metadata": {
+        "visual": {
+          "x": 233,
+          "y": 169,
+          "collapsed": false
+        },
+        "title": "Two",
+        "logLevel": "debug"
+      }
+    },
+    {
+      "id": "runJavascript-fe3c9a41",
+      "type": "runJavascript",
+      "metadata": {
+        "visual": {
+          "x": 8,
+          "y": 44,
+          "collapsed": false
+        },
+        "title": "Split",
+        "logLevel": "debug"
+      },
+      "configuration": {
+        "code": "function run({start}) {\n  return {\n    \"one\": start,\n    \"two\": start,\n  }\n}",
+        "name": "run",
+        "raw": true
+      }
+    }
+  ],
+  "edges": [
+    {
+      "from": "input",
+      "to": "runJavascript-fe3c9a41",
+      "out": "start",
+      "in": "start"
+    },
+    {
+      "from": "runJavascript-fe3c9a41",
+      "to": "output",
+      "out": "one",
+      "in": "one"
+    },
+    {
+      "from": "runJavascript-fe3c9a41",
+      "to": "output-83a8ab5e",
+      "out": "two",
+      "in": "two"
+    }
+  ],
+  "metadata": {
+    "comments": []
+  }
+}

--- a/packages/board-server/tests/run-board.ts
+++ b/packages/board-server/tests/run-board.ts
@@ -35,9 +35,12 @@ const assertResult = (
   ok(result.$state);
   const { type, outputs } = expected;
   deepStrictEqual(result.$state.type, type);
+  if (result.$state.type === "input" || result.$state.type === "output") {
+    deepStrictEqual(result.$state.next, "[]");
+  }
   if (expected.outputs) {
-    const { $state, ...outputs } = result;
-    deepStrictEqual(outputs, outputs);
+    const { $state, ...expectedOutputs } = result;
+    deepStrictEqual(outputs, expectedOutputs);
   }
 };
 

--- a/packages/board-server/tests/run-board.ts
+++ b/packages/board-server/tests/run-board.ts
@@ -5,7 +5,7 @@
  */
 
 import test, { describe } from "node:test";
-import { deepStrictEqual, ok } from "assert";
+import { deepStrictEqual, fail, ok } from "assert";
 import { runBoard } from "../src/server/boards/utils/run-board.js";
 import type { GraphDescriptor, Kit } from "@google-labs/breadboard";
 
@@ -16,7 +16,7 @@ import type { RunBoardResult } from "../src/server/types.js";
 const mockSecretsKit: Kit = {
   url: import.meta.url,
   handlers: {
-    secrets: async (inputs) => {
+    secrets: async () => {
       throw new Error("Secrets aren't implemented in tests.");
     },
   },
@@ -29,11 +29,15 @@ const assertResult = (
     outputs?: Record<string, any>;
   }
 ) => {
+  if ("$error" in result) {
+    fail(result.$error);
+  }
   ok(result.$state);
-  deepStrictEqual(result.$state?.type, expected.type);
+  const { type, outputs } = expected;
+  deepStrictEqual(result.$state.type, type);
   if (expected.outputs) {
     const { $state, ...outputs } = result;
-    deepStrictEqual(outputs, expected.outputs);
+    deepStrictEqual(outputs, outputs);
   }
 };
 

--- a/packages/board-server/tests/run-board.ts
+++ b/packages/board-server/tests/run-board.ts
@@ -85,8 +85,19 @@ describe("Board Server Runs Boards", () => {
         url: `https://example.com${path}`,
         loader: async () => simpleBoard,
         next,
+        inputs: { text: "foo" },
       });
       assertResult(result, { type: "output" });
+      next = getNext(result);
+    }
+    {
+      const result = await runBoard({
+        path,
+        url: `https://example.com${path}`,
+        loader: async () => simpleBoard,
+        next,
+      });
+      assertResult(result, { type: "end" });
     }
   });
 

--- a/packages/board-server/tests/run-board.ts
+++ b/packages/board-server/tests/run-board.ts
@@ -36,7 +36,8 @@ const assertResult = (
   const { type, outputs } = expected;
   deepStrictEqual(result.$state.type, type);
   if (result.$state.type === "input" || result.$state.type === "output") {
-    deepStrictEqual(result.$state.next, "[]");
+    const state = JSON.parse(result.$state.next);
+    ok(Array.isArray(state));
   }
   if (expected.outputs) {
     const { $state, ...expectedOutputs } = result;

--- a/packages/breadboard/src/harness/index.ts
+++ b/packages/breadboard/src/harness/index.ts
@@ -7,12 +7,7 @@
 export type * from "./types.js";
 
 export { serve, defineServeConfig } from "./serve.js";
-export {
-  run,
-  type HarnessProxyConfig,
-  type HarnessRemoteConfig,
-  type RunConfig,
-} from "./run.js";
+export { run } from "./run.js";
 
 export type * from "./serve.js";
 export { type KitConfig } from "./kits.js";

--- a/packages/breadboard/src/harness/local.ts
+++ b/packages/breadboard/src/harness/local.ts
@@ -5,7 +5,7 @@
  */
 
 import { createDefaultDataStore } from "../data/index.js";
-import { Board, asyncGen } from "../index.js";
+import { Board, RunResult, asyncGen } from "../index.js";
 import { createLoader } from "../loader/index.js";
 import { saveRunnerState } from "../serialization.js";
 import { timestamp } from "../timestamp.js";
@@ -19,7 +19,7 @@ import {
 } from "../types.js";
 import { Diagnostics } from "./diagnostics.js";
 import { extractError } from "./error.js";
-import { HarnessRunResult, RunConfig } from "./types.js";
+import { HarnessRunResult, RunConfig, StateToResumeFrom } from "./types.js";
 import { baseURL } from "./url.js";
 
 const fromProbe = <Probe extends ProbeMessage>(probe: Probe) => {
@@ -111,11 +111,25 @@ const load = async (config: RunConfig): Promise<BreadboardRunner> => {
   return Board.fromGraphDescriptor(graph);
 };
 
+const createPreviousRunResult = (
+  resumeFrom: StateToResumeFrom | undefined
+): RunResult | undefined => {
+  if (resumeFrom?.state?.[0].state) {
+    const result = RunResult.load(resumeFrom.state[0].state);
+    if (resumeFrom.inputs) {
+      result.inputs = resumeFrom.inputs;
+    }
+    return result;
+  }
+  return undefined;
+};
+
 export async function* runLocally(config: RunConfig, kits: Kit[]) {
   yield* asyncGen<HarnessRunResult>(async (next) => {
     const runner = config.runner || (await load(config));
     const loader = config.loader || createLoader();
     const store = config.store || createDefaultDataStore();
+    const resumeFrom = createPreviousRunResult(config.resumeFrom);
 
     try {
       const probe = config.diagnostics
@@ -124,15 +138,18 @@ export async function* runLocally(config: RunConfig, kits: Kit[]) {
           })
         : undefined;
 
-      for await (const data of runner.run({
-        probe,
-        kits,
-        loader,
-        store,
-        base: config.base,
-        signal: config.signal,
-        inputs: config.inputs,
-      })) {
+      for await (const data of runner.run(
+        {
+          probe,
+          kits,
+          loader,
+          store,
+          base: config.base,
+          signal: config.signal,
+          inputs: config.inputs,
+        },
+        resumeFrom
+      )) {
         await next(fromRunnerResult(data));
       }
       await next(endResult());

--- a/packages/breadboard/src/harness/local.ts
+++ b/packages/breadboard/src/harness/local.ts
@@ -53,6 +53,9 @@ const fromRunnerResult = <Result extends BreadboardRunResult>(
       reply: async (value) => {
         result.inputs = value.inputs;
       },
+      state: async () => {
+        return [];
+      },
     } as HarnessRunResult;
   } else if (type === "output") {
     const { outputs, path } = result;
@@ -61,6 +64,9 @@ const fromRunnerResult = <Result extends BreadboardRunResult>(
       data: { node, outputs, path, timestamp, bubbled },
       reply: async () => {
         // Do nothing
+      },
+      state: async () => {
+        return [];
       },
     } as HarnessRunResult;
   }

--- a/packages/breadboard/src/harness/local.ts
+++ b/packages/breadboard/src/harness/local.ts
@@ -48,7 +48,7 @@ const fromRunnerResult = <Result extends BreadboardRunResult>(
   const { type, node, timestamp, invocationId } = result;
   const bubbled = invocationId == -1;
 
-  const state = async (): Promise<RunStackEntry[]> => {
+  const saveState = async (): Promise<RunStackEntry[]> => {
     return [
       {
         graph: 0,
@@ -66,7 +66,7 @@ const fromRunnerResult = <Result extends BreadboardRunResult>(
       reply: async (value) => {
         result.inputs = value.inputs;
       },
-      state,
+      saveState,
     } as HarnessRunResult;
   } else if (type === "output") {
     const { outputs, path } = result;
@@ -76,7 +76,7 @@ const fromRunnerResult = <Result extends BreadboardRunResult>(
       reply: async () => {
         // Do nothing
       },
-      state,
+      saveState,
     } as HarnessRunResult;
   }
   throw new Error(`Unknown result type "${type}".`);

--- a/packages/breadboard/src/harness/local.ts
+++ b/packages/breadboard/src/harness/local.ts
@@ -19,8 +19,7 @@ import {
 } from "../types.js";
 import { Diagnostics } from "./diagnostics.js";
 import { extractError } from "./error.js";
-import { RunConfig } from "./run.js";
-import { HarnessRunResult } from "./types.js";
+import { HarnessRunResult, RunConfig } from "./types.js";
 import { baseURL } from "./url.js";
 
 const fromProbe = <Probe extends ProbeMessage>(probe: Probe) => {

--- a/packages/breadboard/src/harness/run.ts
+++ b/packages/breadboard/src/harness/run.ts
@@ -4,119 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  BreadboardRunner,
-  DataStore,
-  InputValues,
-  Kit,
-  RunStackEntry,
-  asyncGen,
-} from "../index.js";
-import { NodeProxyConfig } from "../remote/config.js";
+import { Kit, asyncGen } from "../index.js";
 import { HTTPClientTransport } from "../remote/http.js";
 import { ProxyClient } from "../remote/proxy.js";
 import { runLocally } from "./local.js";
 import { createSecretAskingKit } from "./secrets.js";
-import { HarnessRunResult } from "./types.js";
+import { HarnessRunResult, RunConfig } from "./types.js";
 import { runInWorker } from "./worker.js";
-import { GraphLoader } from "../loader/types.js";
-
-export type ProxyLocation = "main" | "worker" | "http" | "python";
-
-export type CustomProxyConfig = () => Promise<Kit>;
-
-export type HarnessProxyConfig =
-  | {
-      location: ProxyLocation;
-      url?: string;
-      nodes: NodeProxyConfig;
-    }
-  | CustomProxyConfig;
-
-export type HarnessRemoteConfig =
-  | {
-      /**
-       * The type of the remote runtime. Can be "http" or "worker".
-       * Currently, only "worker" is supported.
-       */
-      type: "http" | "worker";
-      /**
-       * The URL of the remote runtime. Specifies the URL of the worker
-       * script if `type` is "worker", or the URL of the runtime server if
-       * `type` is "http".
-       */
-      url: string;
-    }
-  | false;
-
-export type RunConfig = {
-  /**
-   * The URL of the board to run.
-   */
-  url: string;
-  /**
-   * The base URL relative to which to load the board.
-   * If ran in a browser, defaults to the current URL.
-   * Otherwise, defaults to invoking module's URL.
-   */
-  base?: URL;
-  /**
-   * The kits to use by the runtime.
-   */
-  kits: Kit[];
-  /**
-   * The loader to use when loading boards.
-   */
-  loader?: GraphLoader;
-  /**
-   * Specifies the remote environment in which to run the harness.
-   * In this situation, the harness creates a runtime client, and relies
-   * on the remote environment to act as the runtime server
-   * If `remote` is not specified or is "false", this harness runs the board
-   * itself, acting as a server (there is no need for a client).
-   */
-  remote?: HarnessRemoteConfig;
-  /**
-   * Specifies a list of node proxies to use. Each item specifies a proxy
-   * server and a list of nodes that will be proxied to it.
-   */
-  proxy?: HarnessProxyConfig[];
-  /**
-   * Specifies whether to output diagnostics information.
-   * Defaults to `false`.
-   */
-  diagnostics?: boolean;
-  /**
-   * Specifies a runner to use. This can be used instead of loading a board
-   * from a URL.
-   */
-  runner?: BreadboardRunner;
-  /**
-   * The `AbortSignal` that can be used to stop the board run.
-   */
-  signal?: AbortSignal;
-  /**
-   * The values that will be supplied to the bubbled inputs during a board run.
-   * This enables automatically providing some of the values like the model
-   * name without interrupting the run of the board.
-   */
-  inputs?: InputValues;
-  /**
-   * Specifies whether or not secrets are asked for interactively. When `true`,
-   * the `secret` result will start showing up in the run results whenever
-   * the secret is asked for. Otherwise, the `secrets` node will try to find
-   * the secrets on its own.
-   */
-  interactiveSecrets?: boolean;
-  /**
-   * The data store to use for storing data.
-   */
-  store?: DataStore;
-  /**
-   * The state from which to resume the run.
-   */
-  resumeFrom?: RunStackEntry[];
-};
 
 const configureKits = async (config: RunConfig): Promise<Kit[]> => {
   // If a proxy is configured, add the proxy kit to the list of kits.

--- a/packages/breadboard/src/harness/run.ts
+++ b/packages/breadboard/src/harness/run.ts
@@ -9,6 +9,7 @@ import {
   DataStore,
   InputValues,
   Kit,
+  RunStackEntry,
   asyncGen,
 } from "../index.js";
 import { NodeProxyConfig } from "../remote/config.js";
@@ -111,6 +112,10 @@ export type RunConfig = {
    * The data store to use for storing data.
    */
   store?: DataStore;
+  /**
+   * The state from which to resume the run.
+   */
+  resumeFrom?: RunStackEntry[];
 };
 
 const configureKits = async (config: RunConfig): Promise<Kit[]> => {

--- a/packages/breadboard/src/harness/secrets.ts
+++ b/packages/breadboard/src/harness/secrets.ts
@@ -6,10 +6,10 @@
 
 import { SecretResult } from "./types.js";
 import { KitBuilder } from "../kits/builder.js";
-import { ClientRunResult } from "../remote/run.js";
 import { timestamp } from "../timestamp.js";
 import { asRuntimeKit } from "../index.js";
 import { OutputValues } from "../types.js";
+import { ClientRunResult } from "../remote/types.js";
 
 export const createSecretAskingKit = (
   next: (result: ClientRunResult<SecretResult>) => Promise<void>

--- a/packages/breadboard/src/harness/types.ts
+++ b/packages/breadboard/src/harness/types.ts
@@ -185,5 +185,10 @@ export type RunConfig = {
   /**
    * The state from which to resume the run.
    */
-  resumeFrom?: RunStackEntry[];
+  resumeFrom?: StateToResumeFrom;
+};
+
+export type StateToResumeFrom = {
+  state: RunStackEntry[];
+  inputs?: InputValues;
 };

--- a/packages/breadboard/src/harness/types.ts
+++ b/packages/breadboard/src/harness/types.ts
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
+import type { DataStore } from "../data/types.js";
+import type { GraphLoader } from "../loader/types.js";
+import type { NodeProxyConfig } from "../remote/config.js";
+import type {
   AnyClientRunResult,
   AnyProbeClientRunResult,
   ClientRunResult,
@@ -12,11 +15,15 @@ import {
   LoadResponse,
   ServerTransport,
 } from "../remote/types.js";
-import {
+import type {
+  BreadboardRunner,
   ErrorResponse,
   InputResponse,
+  InputValues,
+  Kit,
   OutputResponse,
   OutputValues,
+  RunStackEntry,
 } from "../types.js";
 
 /**
@@ -83,3 +90,100 @@ export type TransportFactory = {
 };
 
 export type HarnessRunner = AsyncGenerator<HarnessRunResult, void, unknown>;
+
+export type ProxyLocation = "main" | "worker" | "http" | "python";
+
+export type CustomProxyConfig = () => Promise<Kit>;
+
+export type HarnessProxyConfig =
+  | {
+      location: ProxyLocation;
+      url?: string;
+      nodes: NodeProxyConfig;
+    }
+  | CustomProxyConfig;
+
+export type HarnessRemoteConfig =
+  | {
+      /**
+       * The type of the remote runtime. Can be "http" or "worker".
+       * Currently, only "worker" is supported.
+       */
+      type: "http" | "worker";
+      /**
+       * The URL of the remote runtime. Specifies the URL of the worker
+       * script if `type` is "worker", or the URL of the runtime server if
+       * `type` is "http".
+       */
+      url: string;
+    }
+  | false;
+
+export type RunConfig = {
+  /**
+   * The URL of the board to run.
+   */
+  url: string;
+  /**
+   * The base URL relative to which to load the board.
+   * If ran in a browser, defaults to the current URL.
+   * Otherwise, defaults to invoking module's URL.
+   */
+  base?: URL;
+  /**
+   * The kits to use by the runtime.
+   */
+  kits: Kit[];
+  /**
+   * The loader to use when loading boards.
+   */
+  loader?: GraphLoader;
+  /**
+   * Specifies the remote environment in which to run the harness.
+   * In this situation, the harness creates a runtime client, and relies
+   * on the remote environment to act as the runtime server
+   * If `remote` is not specified or is "false", this harness runs the board
+   * itself, acting as a server (there is no need for a client).
+   */
+  remote?: HarnessRemoteConfig;
+  /**
+   * Specifies a list of node proxies to use. Each item specifies a proxy
+   * server and a list of nodes that will be proxied to it.
+   */
+  proxy?: HarnessProxyConfig[];
+  /**
+   * Specifies whether to output diagnostics information.
+   * Defaults to `false`.
+   */
+  diagnostics?: boolean;
+  /**
+   * Specifies a runner to use. This can be used instead of loading a board
+   * from a URL.
+   */
+  runner?: BreadboardRunner;
+  /**
+   * The `AbortSignal` that can be used to stop the board run.
+   */
+  signal?: AbortSignal;
+  /**
+   * The values that will be supplied to the bubbled inputs during a board run.
+   * This enables automatically providing some of the values like the model
+   * name without interrupting the run of the board.
+   */
+  inputs?: InputValues;
+  /**
+   * Specifies whether or not secrets are asked for interactively. When `true`,
+   * the `secret` result will start showing up in the run results whenever
+   * the secret is asked for. Otherwise, the `secrets` node will try to find
+   * the secrets on its own.
+   */
+  interactiveSecrets?: boolean;
+  /**
+   * The data store to use for storing data.
+   */
+  store?: DataStore;
+  /**
+   * The state from which to resume the run.
+   */
+  resumeFrom?: RunStackEntry[];
+};

--- a/packages/breadboard/src/harness/types.ts
+++ b/packages/breadboard/src/harness/types.ts
@@ -5,15 +5,13 @@
  */
 
 import {
-  ClientTransport,
-  LoadResponse,
-  ServerTransport,
-} from "../remote/protocol.js";
-import {
   AnyClientRunResult,
   AnyProbeClientRunResult,
   ClientRunResult,
-} from "../remote/run.js";
+  ClientTransport,
+  LoadResponse,
+  ServerTransport,
+} from "../remote/types.js";
 import {
   ErrorResponse,
   InputResponse,

--- a/packages/breadboard/src/harness/url.ts
+++ b/packages/breadboard/src/harness/url.ts
@@ -5,8 +5,8 @@
  */
 
 import { SENTINEL_BASE_URL } from "../loader/index.js";
-import { RunConfig } from "./run.js";
 import { ServeConfig } from "./serve.js";
+import { RunConfig } from "./types.js";
 
 export const baseURL = (config: RunConfig | ServeConfig) => {
   if (config.base) return config.base;

--- a/packages/breadboard/src/harness/worker.ts
+++ b/packages/breadboard/src/harness/worker.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { HarnessRunResult } from "./types.js";
+import type { HarnessRunResult, RunConfig } from "./types.js";
 import { RunState, asyncGen } from "../index.js";
 import { createSecretAskingKit } from "./secrets.js";
 import { ProxyServer } from "../remote/proxy.js";
@@ -15,7 +15,6 @@ import {
 } from "../remote/worker.js";
 import { RunClient } from "../remote/run.js";
 import { InitClient } from "../remote/init.js";
-import { RunConfig } from "./run.js";
 
 export const createWorker = (url: string) => {
   const workerURL = new URL(url, location.href);

--- a/packages/breadboard/src/remote/http.ts
+++ b/packages/breadboard/src/remote/http.ts
@@ -15,7 +15,7 @@ import {
   ClientTransport,
   ServerBidirectionalStream,
   ServerTransport,
-} from "./protocol.js";
+} from "./types.js";
 
 /**
  * Minimal interface in the shape of express.js's request object.

--- a/packages/breadboard/src/remote/index.ts
+++ b/packages/breadboard/src/remote/index.ts
@@ -12,9 +12,8 @@ export {
 } from "./worker.js";
 export { ProxyServer, ProxyClient } from "./proxy.js";
 export { RunServer, RunClient } from "./run.js";
-export type { ClientRunResult } from "./run.js";
 export { InitServer, InitClient } from "./init.js";
 export { defineConfig, hasOrigin, type ProxyServerConfig } from "./config.js";
-export type * from "./protocol.js";
+export type * from "./types.js";
 export type * from "./config.js";
 export type * from "./http.js";

--- a/packages/breadboard/src/remote/init.ts
+++ b/packages/breadboard/src/remote/init.ts
@@ -9,7 +9,7 @@ import {
   LoadRequest,
   LoadResponse,
   ServerTransport,
-} from "./protocol.js";
+} from "./types.js";
 
 export class InitServer {
   #transport: ServerTransport<LoadRequest, LoadResponse>;

--- a/packages/breadboard/src/remote/proxy.ts
+++ b/packages/breadboard/src/remote/proxy.ts
@@ -21,7 +21,7 @@ import {
   ClientBidirectionalStream,
   ClientTransport,
   ServerTransport,
-} from "./protocol.js";
+} from "./types.js";
 import { createTunnelKit, readConfig } from "./tunnel.js";
 import { timestamp } from "../timestamp.js";
 import { inflateData } from "../data/inflate-deflate.js";

--- a/packages/breadboard/src/remote/run.ts
+++ b/packages/breadboard/src/remote/run.ts
@@ -21,14 +21,14 @@ import {
   RunState,
 } from "../types.js";
 import {
-  AnyProbeMessage,
+  AnyClientRunResult,
   AnyRunRequestMessage,
   AnyRunResponseMessage,
-  ClientTransport,
   InputResolveRequest,
+  RunClientTransport,
   RunRequestMessage,
   ServerTransport,
-} from "./protocol.js";
+} from "./types.js";
 
 const resumeRun = (request: AnyRunRequestMessage) => {
   const [type, , state] = request;
@@ -127,35 +127,6 @@ export class RunServer {
     }
   }
 }
-
-type RunClientTransport = ClientTransport<
-  AnyRunRequestMessage,
-  AnyRunResponseMessage
->;
-
-type ReplyFunction = {
-  reply: (chunk: AnyRunRequestMessage[1]) => Promise<void>;
-};
-
-type ClientRunResultFromMessage<ResponseMessage> = ResponseMessage extends [
-  string,
-  object,
-  RunState?,
-]
-  ? {
-      type: ResponseMessage[0];
-      data: ResponseMessage[1];
-      state?: RunState;
-    } & ReplyFunction
-  : never;
-
-export type AnyClientRunResult =
-  ClientRunResultFromMessage<AnyRunResponseMessage>;
-
-export type AnyProbeClientRunResult =
-  ClientRunResultFromMessage<AnyProbeMessage>;
-
-export type ClientRunResult<T> = T & ReplyFunction;
 
 const createRunResult = (
   response: WritableResult<AnyRunResponseMessage, AnyRunRequestMessage>

--- a/packages/breadboard/src/remote/types.ts
+++ b/packages/breadboard/src/remote/types.ts
@@ -192,7 +192,7 @@ type ClientRunResultFromMessage<ResponseMessage> = ResponseMessage extends [
   ? {
       type: ResponseMessage[0];
       data: ResponseMessage[1];
-      state?: RunStateFunction;
+      saveState?: RunStateFunction;
     } & ReplyFunction
   : never;
 

--- a/packages/breadboard/src/remote/types.ts
+++ b/packages/breadboard/src/remote/types.ts
@@ -83,7 +83,7 @@ export type InputResolveRequest = { inputs: InputValues };
 export type InputResolveRequestMessage = [
   "input",
   InputResolveRequest,
-  RunState
+  RunState,
 ];
 
 /**
@@ -172,3 +172,34 @@ export interface ServerTransport<Request, Response> {
 export interface ClientTransport<Request, Response> {
   createClientStream(): ClientBidirectionalStream<Request, Response>;
 }
+
+export type RunClientTransport = ClientTransport<
+  AnyRunRequestMessage,
+  AnyRunResponseMessage
+>;
+
+type ReplyFunction = {
+  reply: (chunk: AnyRunRequestMessage[1]) => Promise<void>;
+};
+
+export type RunStateFunction = () => Promise<RunState>;
+
+type ClientRunResultFromMessage<ResponseMessage> = ResponseMessage extends [
+  string,
+  object,
+  RunState?,
+]
+  ? {
+      type: ResponseMessage[0];
+      data: ResponseMessage[1];
+      state?: RunStateFunction;
+    } & ReplyFunction
+  : never;
+
+export type AnyClientRunResult =
+  ClientRunResultFromMessage<AnyRunResponseMessage>;
+
+export type AnyProbeClientRunResult =
+  ClientRunResultFromMessage<AnyProbeMessage>;
+
+export type ClientRunResult<T> = T & ReplyFunction;

--- a/packages/breadboard/src/remote/worker.ts
+++ b/packages/breadboard/src/remote/worker.ts
@@ -16,7 +16,7 @@ import {
   ClientTransport,
   ServerBidirectionalStream,
   ServerTransport,
-} from "./protocol.js";
+} from "./types.js";
 
 const DISPATCHER_SEND = "port-dispatcher-sendport";
 

--- a/packages/breadboard/tests/helpers/_test-transport.ts
+++ b/packages/breadboard/tests/helpers/_test-transport.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ClientTransport, ServerTransport } from "../../src/remote/protocol.js";
+import { ClientTransport, ServerTransport } from "../../src/remote/types.js";
 import { PatchedReadableStream } from "../../src/stream.js";
 import { ServerRequest, ServerResponse } from "../../src/remote/http.js";
 import { TransformStream } from "stream/web";

--- a/packages/breadboard/tests/remote/http.ts
+++ b/packages/breadboard/tests/remote/http.ts
@@ -12,7 +12,7 @@ import {
   parseWithStreamsTransform,
 } from "../../src/remote/http.js";
 import { RunServer } from "../../src/remote/run.js";
-import { AnyRunRequestMessage } from "../../src/remote/protocol.js";
+import { AnyRunRequestMessage } from "../../src/remote/types.js";
 import { Board } from "../../src/board.js";
 import { TestKit } from "../helpers/_test-kit.js";
 import { MockHTTPConnection } from "../helpers/_test-transport.js";
@@ -366,7 +366,7 @@ test("HTTPClientTransport handles input with a single stream in it", async (t) =
   ]);
   const value = data.value as [
     type: string,
-    data: { outputs: { dataStream: NodeValue } }
+    data: { outputs: { dataStream: NodeValue } },
   ];
   const dataStream = value[1].outputs.dataStream;
   t.true(isStreamCapability(dataStream));

--- a/packages/breadboard/tests/remote/proxy.ts
+++ b/packages/breadboard/tests/remote/proxy.ts
@@ -14,7 +14,7 @@ import {
   HTTPClientTransport,
   HTTPServerTransport,
 } from "../../src/remote/http.js";
-import { AnyProxyRequestMessage } from "../../src/remote/protocol.js";
+import { AnyProxyRequestMessage } from "../../src/remote/types.js";
 import { Board } from "../../src/board.js";
 import { MirrorUniverseKit, TestKit } from "../helpers/_test-kit.js";
 import { StreamCapability } from "../../src/stream.js";

--- a/packages/breadboard/tests/remote/transport.ts
+++ b/packages/breadboard/tests/remote/transport.ts
@@ -9,7 +9,7 @@ import {
   AnyRunRequestMessage,
   AnyRunResponseMessage,
   InputResponseMessage,
-} from "../../src/remote/protocol.js";
+} from "../../src/remote/types.js";
 import { Board } from "../../src/board.js";
 import { TestKit } from "../helpers/_test-kit.js";
 import {


### PR DESCRIPTION
- **Flesh out the `RunBoardResult` type.**
- **Bring `breadboard/remote` types to follow the now-common pattern.**
- **Start sending out traversal state.**
- **Rename `state` to `saveState`.**
- **Introduce `RunConfig.resumeFrom`.**
- **Move `RunConfig` and friends to `types.ts`.**
- **Teach runBoard to resume.**
- **Build a nice `scriptedRun` test harness.**
- **Add test for multiple outputs.**
- **docs(changeset): Teach board-server run API endpoint to run simple boards.**
