### PR TITLE
[connections] [visual-editor] Store the OAuth client ID locally

### DIFF
--- a/.changeset/tricky-falcons-shout.md
+++ b/.changeset/tricky-falcons-shout.md
@@ -1,0 +1,6 @@
+---
+"@breadboard-ai/connection-server": patch
+"@breadboard-ai/visual-editor": patch
+---
+
+Store the OAuth client ID locally, in addition to the token details. Useful for APIs that require the client ID to be provided.

--- a/packages/connection-server/src/api/list.ts
+++ b/packages/connection-server/src/api/list.ts
@@ -16,6 +16,7 @@ interface ListConnectionsResponse {
 
 interface Connection {
   id: string;
+  clientId: string;
   authUrl: string;
   title: string;
   description?: string;
@@ -37,6 +38,7 @@ export async function list(
       .map((config) => {
         const connection: Connection = {
           id: config.id,
+          clientId: config.oauth.client_id,
           authUrl: makeAuthorizationEndpointUrl(config),
           title: config.title ?? config.id,
         };

--- a/packages/visual-editor/src/ui/elements/connection/connection-common.ts
+++ b/packages/visual-editor/src/ui/elements/connection/connection-common.ts
@@ -25,6 +25,7 @@ export type GrantResponse =
     };
 
 export interface TokenGrant {
+  client_id: string;
   access_token: string;
   expires_in: number;
   refresh_token: string;

--- a/packages/visual-editor/src/ui/elements/connection/connection-server.ts
+++ b/packages/visual-editor/src/ui/elements/connection/connection-server.ts
@@ -35,12 +35,13 @@ export function fetchAvailableConnections(
 
 // IMPORTANT: Keep in sync with
 // breadboard/packages/connection-server/src/api/list.ts
-interface ListConnectionsResponse {
+export interface ListConnectionsResponse {
   connections: Connection[];
 }
 
 export interface Connection {
   id: string;
+  clientId: string;
   authUrl: string;
   title: string;
   description?: string;

--- a/packages/visual-editor/src/ui/elements/connection/connection-signin.ts
+++ b/packages/visual-editor/src/ui/elements/connection/connection-signin.ts
@@ -240,6 +240,7 @@ export class ConnectionSignin extends LitElement {
       return;
     }
     const settingsValue: TokenGrant = {
+      client_id: this.connection.clientId,
       access_token: grantResponse.access_token,
       expires_in: grantResponse.expires_in,
       refresh_token: grantResponse.refresh_token,


### PR DESCRIPTION
Store the OAuth client ID locally, in addition to the token details. Useful for APIs that require the client ID to be provided.

Includes an automatic migration for existing stored oauth tokens to add in this field.

Part of https://github.com/breadboard-ai/breadboard/issues/2626