### PR TITLE
Create new `spread` using new `code` from Core Kit

### DIFF
--- a/packages/example-boards/src/utils/spread.ts
+++ b/packages/example-boards/src/utils/spread.ts
@@ -4,16 +4,43 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { OutputValues, code } from "@google-labs/breadboard";
+import { OutputValues, code as breadboardCode } from "@google-labs/breadboard";
+import { code } from "@google-labs/core-kit";
+import { CodeOutputConfig } from "../../../core-kit/dist/src/nodes/code";
+import { BreadboardType, JsonSerializable } from "@breadboard-ai/build/internal/type-system/type.js";
+import { Input } from "@breadboard-ai/build/internal/board/input.js";
+import { OutputPort } from "@breadboard-ai/build/internal/common/port.js";
 
-const spread = code<{ object: object }, OutputValues>((inputs) => {
+const spread = breadboardCode<{ object: object }, OutputValues>((inputs) => {
   const object = inputs.object;
   if (typeof object !== "object") {
     throw new Error(`object is of type ${typeof object} not object`);
   }
   return { ...object };
-});
+}); // TODO(Tina): This can be removed after boards switch to using `createSpreadNode` instead
 
 type spread = typeof spread;
 
 export { spread };
+
+export function createSpreadNode<T extends Record<string, BreadboardType | CodeOutputConfig>>(obj: Input<object & JsonSerializable> | OutputPort<JsonSerializable>, returnType: T) {
+  const spread = code(
+      {
+          $metadata: {
+              title: "Spread",
+              description: "Spread the properties of an object into a new object",
+          },
+          obj
+      },
+      returnType,
+      ({ obj }) => {
+          if (typeof obj !== "object") {
+              throw new Error(`object is of type ${typeof obj} not object`);
+          }
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          return { ...obj } as any;
+
+      }
+  );
+  return spread;
+}


### PR DESCRIPTION
Fixes #2647

A couple example boards use a `spread` helper function which uses the built-in Breadboard `code`, but the Build API requires the new `code` from the Core Kit instead.

The new helper function creates a `spread` code node from a given object type input and a specified return structure.