### PR TITLE
[visual-editor] [breadboard] Behavior and picker component for Google Drive File ID

### DIFF
--- a/.changeset/many-eagles-brake.md
+++ b/.changeset/many-eagles-brake.md
@@ -1,0 +1,6 @@
+---
+"@breadboard-ai/visual-editor": patch
+"@google-labs/breadboard": patch
+---
+
+Add google-drive-file-id

--- a/packages/breadboard/src/inspector/ports.ts
+++ b/packages/breadboard/src/inspector/ports.ts
@@ -45,6 +45,7 @@ const BEHAVIOR_AFFECTS_TYPE_CHECKING: { [K in BehaviorSchema]: boolean } = {
   transient: false,
   config: false,
   "google-drive-query": false,
+  "google-drive-file-id": false,
 
   // TODO(aomarks) Not sure about many of these. Some affect the data type, some
   // only affect formatting?

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -114,7 +114,12 @@ export type BehaviorSchema =
    * Indicates that the string is a Google Drive Query. See
    * https://developers.google.com/drive/api/guides/search-files.
    */
-  | "google-drive-query";
+  | "google-drive-query"
+  /**
+   * Indicates that the string is a Google Drive File ID.
+   * https://developers.google.com/drive/api/guides/about-files#characteristics
+   */
+  | "google-drive-file-id";
 
 export type Schema = {
   title?: string;

--- a/packages/visual-editor/src/ui/elements/elements.ts
+++ b/packages/visual-editor/src/ui/elements/elements.ts
@@ -19,6 +19,7 @@ export { Editor } from "./editor/editor.js";
 export { EventDetails } from "./event-details/event-details.js";
 export { FancyJson } from "./editor/fancy-json.js";
 export { FirstRunOverlay } from "./overlay/first-run.js";
+export { GoogleDriveFileId } from "./google-drive/google-drive-file-id.js";
 export { GoogleDriveQuery } from "./google-drive/google-drive-query.js";
 export { GraphHistory } from "./graph-history/graph-history.js";
 export { GraphRenderer } from "./editor/graph-renderer.js";

--- a/packages/visual-editor/src/ui/elements/google-drive/google-drive-file-id.ts
+++ b/packages/visual-editor/src/ui/elements/google-drive/google-drive-file-id.ts
@@ -1,0 +1,141 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { LitElement, css, html } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import { type InputEnterEvent } from "../../events/events.js";
+import "../connection/connection-input.js";
+import { loadDrivePicker } from "./google-apis.js";
+
+@customElement("bb-google-drive-file-id")
+export class GoogleDriveFileId extends LitElement {
+  static styles = css`
+    :host {
+      display: flex;
+      max-width: 400px;
+    }
+
+    button {
+      background: var(--bb-inputs-500);
+      border-radius: 20px;
+      border: none;
+      color: white;
+      cursor: pointer;
+      font-size: var(--bb-label-large);
+      padding: 4px 18px;
+      white-space: nowrap;
+    }
+    button:hover {
+      background-color: var(--bb-inputs-400);
+    }
+
+    input {
+      flex-grow: 1;
+      font-size: 11px;
+      margin-left: 14px;
+      padding: 6px 8px;
+    }
+  `;
+
+  @state()
+  private _authorization?: { clientId: string; secret: string };
+
+  @state()
+  private _pickerLib?: typeof google.picker;
+
+  @property()
+  value = "";
+
+  #picker?: google.picker.Picker;
+
+  override async connectedCallback(): Promise<void> {
+    super.connectedCallback();
+    this._pickerLib ??= await loadDrivePicker();
+  }
+
+  override render() {
+    if (this._authorization === undefined) {
+      return html`<bb-connection-input
+        @bbinputenter=${this.#onToken}
+        connectionId="google-drive"
+      ></bb-connection-input>`;
+    }
+    if (this._pickerLib === undefined) {
+      return html`<p>Loading Google Drive Picker ...</p>`;
+    }
+    return html`
+      <button @click=${this.#onClickPickFiles}>Pick File</button>
+      <input
+        type="text"
+        placeholder='Click "Pick File" or paste a Google Drive File ID'
+        .value=${this.value}
+        @input=${this.#onQueryInput}
+      />
+    `;
+  }
+
+  #onToken(event: InputEnterEvent) {
+    // Prevent ui-controller from receiving an unexpected bbinputenter event.
+    //
+    // TODO(aomarks) Let's not re-use bbinputenter here, we should instead use
+    // bbtokengranted, but there is a small bit of refactoring necessary for
+    // that to work.
+    event.stopImmediatePropagation();
+    const { clientId, secret } = event.data as {
+      clientId?: string;
+      secret?: string;
+    };
+    if (clientId && secret) {
+      this._authorization = { clientId, secret };
+    }
+  }
+
+  #onClickPickFiles() {
+    if (this._authorization === undefined || this._pickerLib === undefined) {
+      return;
+    }
+    this.#destroyPicker();
+    // See https://developers.google.com/drive/picker/reference
+    this.#picker = new this._pickerLib.PickerBuilder()
+      .setAppId(this._authorization.clientId)
+      .setOAuthToken(this._authorization.secret)
+      .setCallback(this.#pickerCallback.bind(this))
+      .addView(google.picker.ViewId.DOCS)
+      .enableFeature(google.picker.Feature.NAV_HIDDEN)
+      .build();
+    this.#picker.setVisible(true);
+  }
+
+  #pickerCallback(result: google.picker.ResponseObject): void {
+    switch (result.action) {
+      case "cancel": {
+        this.#destroyPicker();
+        return;
+      }
+      case "picked": {
+        this.#destroyPicker();
+        // TODO(aomarks) Show this as a snackbar
+        console.log(`Shared 1 Google Drive file with Breadboard`);
+        if (result.docs.length > 0) {
+          this.value = result.docs[0].id;
+        }
+      }
+    }
+  }
+
+  #destroyPicker() {
+    if (this.#picker === undefined) {
+      return;
+    }
+    this.#picker.setVisible(false);
+    this.#picker.dispose();
+    this.#picker = undefined;
+  }
+
+  #onQueryInput(event: { target: HTMLTextAreaElement }) {
+    this.value = event.target.value;
+  }
+}

--- a/packages/visual-editor/src/ui/elements/google-drive/google-drive-query.ts
+++ b/packages/visual-editor/src/ui/elements/google-drive/google-drive-query.ts
@@ -89,7 +89,6 @@ export class GoogleDriveQuery extends LitElement {
     if (this._pickerLib === undefined) {
       return html`<p>Loading Google Drive Picker ...</p>`;
     }
-    // TODO(aomarks) Hook up the textarea so it works as a real input.
     return html`
       <section id="query">
         <textarea

--- a/packages/visual-editor/src/ui/elements/input/user-input.ts
+++ b/packages/visual-editor/src/ui/elements/input/user-input.ts
@@ -11,6 +11,7 @@ import {
   isArrayOfLLMContentBehavior,
   isBoardBehavior,
   isCodeBehavior,
+  isGoogleDriveFileId,
   isGoogleDriveQuery,
   isLLMContentBehavior,
   isPortSpecBehavior,
@@ -512,6 +513,13 @@ export class UserInput extends LitElement {
                   name=${id}
                   .value=${input.value ?? defaultValue ?? ""}
                 ></bb-code-editor>`;
+                break;
+              }
+              if (isGoogleDriveFileId(input.schema)) {
+                inputField = html`<bb-google-drive-file-id
+                  id=${id}
+                  .value=${input.value ?? defaultValue ?? ""}
+                ></bb-google-drive-file-id>`;
                 break;
               }
               if (isGoogleDriveQuery(input.schema)) {

--- a/packages/visual-editor/src/ui/utils/index.ts
+++ b/packages/visual-editor/src/ui/utils/index.ts
@@ -121,6 +121,10 @@ export function isDrawableImage(schema: Schema) {
   );
 }
 
+export function isGoogleDriveFileId(schema: Schema) {
+  return schema.behavior?.includes("google-drive-file-id");
+}
+
 export function isGoogleDriveQuery(schema: Schema) {
   return schema.behavior?.includes("google-drive-query");
 }


### PR DESCRIPTION
Similar to the one for Google Drive Query, but for selecting exactly one file. Automatically populates the ID field from the picker result.

<img width="1350" alt="image" src="https://github.com/user-attachments/assets/f195bb02-c103-4900-a4e5-d37cf2a6c829">

Part of https://github.com/breadboard-ai/breadboard/issues/2626
