### PR TITLE
[google-drive-kit] Annotate file ID/query inputs with new behaviors

### DIFF
--- a/.changeset/plenty-apricots-tie.md
+++ b/.changeset/plenty-apricots-tie.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/google-drive-kit": patch
+---
+
+Annotate file ID/query inputs with new behaviors so that the dedicated input components will be used for them.

--- a/packages/google-drive-kit/src/components/export-file.ts
+++ b/packages/google-drive-kit/src/components/export-file.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { board, input, output } from "@breadboard-ai/build";
+import { annotate, board, input, output } from "@breadboard-ai/build";
 import { fetch } from "@google-labs/core-kit";
 import { urlTemplate } from "@google-labs/template-kit";
 import { headers } from "../internal/headers.js";
@@ -13,6 +13,7 @@ const fileId = input({
   title: "File ID",
   description: `The ID of the Google Drive file.
 See https://developers.google.com/drive/api/reference/rest/v3/files/export#body.PATH_PARAMETERS.file_id`,
+  type: annotate("string", { behavior: ["google-drive-file-id"] }),
 });
 
 const mimeType = input({

--- a/packages/google-drive-kit/src/components/get-file-content.ts
+++ b/packages/google-drive-kit/src/components/get-file-content.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { board, input, output } from "@breadboard-ai/build";
+import { annotate, board, input, output } from "@breadboard-ai/build";
 import { fetch } from "@google-labs/core-kit";
 import { urlTemplate } from "@google-labs/template-kit";
 import { headers } from "../internal/headers.js";
@@ -13,6 +13,7 @@ const fileId = input({
   title: "File ID",
   description: `The ID of the file.
 See https://developers.google.com/drive/api/reference/rest/v3/files/get#body.PATH_PARAMETERS.file_id`,
+  type: annotate("string", { behavior: ["google-drive-file-id"] }),
 });
 
 const url = urlTemplate({

--- a/packages/google-drive-kit/src/components/list-files.ts
+++ b/packages/google-drive-kit/src/components/list-files.ts
@@ -5,14 +5,15 @@
  */
 
 import {
+  annotate,
   array,
   board,
   enumeration,
   input,
   object,
   optional,
-  output,
   optionalEdge,
+  output,
 } from "@breadboard-ai/build";
 import { cast, fetch, unnest } from "@google-labs/core-kit";
 import { urlTemplate } from "@google-labs/template-kit";
@@ -30,6 +31,7 @@ const query = input({
   title: "Query",
   description: `A Google Drive search query.
 See https://developers.google.com/drive/api/guides/search-files for details.`,
+  type: annotate("string", { behavior: ["google-drive-query"] }),
   examples: [
     "'<folder id>' in parents",
     "name = 'hello'",


### PR DESCRIPTION
Annotate file ID/query inputs with new behaviors so that the dedicated input components will be used for them.

Part of https://github.com/breadboard-ai/breadboard/issues/2626