### PR TITLE
[google-drive-kit] [visual-editor] Switch connection from `google-drive` to `google-drive-limited`

### DIFF
--- a/.changeset/stupid-books-bathe.md
+++ b/.changeset/stupid-books-bathe.md
@@ -1,0 +1,6 @@
+---
+"@breadboard-ai/google-drive-kit": patch
+"@breadboard-ai/visual-editor": patch
+---
+
+Switch from google-drive connection id to google-drive-limited, which requests access only to shared files, not all files.

--- a/packages/google-drive-kit/src/internal/headers.ts
+++ b/packages/google-drive-kit/src/internal/headers.ts
@@ -8,7 +8,7 @@ import { object } from "@breadboard-ai/build";
 import { code, secret } from "@google-labs/core-kit";
 
 export const { headers } = code(
-  { token: secret("connection:google-drive") },
+  { token: secret("connection:google-drive-limited") },
   { headers: object({}, "string") },
   ({ token }) => ({
     headers: {

--- a/packages/visual-editor/src/ui/elements/google-drive/google-drive-file-id.ts
+++ b/packages/visual-editor/src/ui/elements/google-drive/google-drive-file-id.ts
@@ -60,7 +60,7 @@ export class GoogleDriveFileId extends LitElement {
     if (this._authorization === undefined) {
       return html`<bb-connection-input
         @bbinputenter=${this.#onToken}
-        connectionId="google-drive"
+        connectionId="google-drive-limited"
       ></bb-connection-input>`;
     }
     if (this._pickerLib === undefined) {

--- a/packages/visual-editor/src/ui/elements/google-drive/google-drive-query.ts
+++ b/packages/visual-editor/src/ui/elements/google-drive/google-drive-query.ts
@@ -83,7 +83,7 @@ export class GoogleDriveQuery extends LitElement {
     if (this._authorization === undefined) {
       return html`<bb-connection-input
         @bbinputenter=${this.#onToken}
-        connectionId="google-drive"
+        connectionId="google-drive-limited"
       ></bb-connection-input>`;
     }
     if (this._pickerLib === undefined) {


### PR DESCRIPTION
Switches from the Google Drive OAuth scope that requests full access, to the one that only requests access to files specifically shared with the app.

Part of https://github.com/breadboard-ai/breadboard/issues/2626