### PR TITLE
Revert "map bubbling"

### DIFF
--- a/packages/core-kit/src/nodes/map.ts
+++ b/packages/core-kit/src/nodes/map.ts
@@ -104,10 +104,6 @@ const mapNode = defineNodeType({
           base: base || context?.base,
           invocationPath: [...(context?.invocationPath || []), index],
         };
-        // Remove the ability to bubble up inputs from the mapped boards.
-        delete newContext.requestInput;
-        // Remove the ability to bubble up outputs from the mapped boards.
-        delete newContext.provideOutput;
         const outputs = await runnableBoard.runOnce(
           { item, index, list },
           newContext

--- a/packages/core-kit/tests/data/boards/map-throw-error.bgl.json
+++ b/packages/core-kit/tests/data/boards/map-throw-error.bgl.json
@@ -57,10 +57,15 @@
           "configuration": {
             "schema": {
               "properties": {
-                "item": {
-                  "type": "string",
-                  "title": "Item",
-                  "examples": []
+                "context": {
+                  "type": "array",
+                  "title": "Context",
+                  "examples": [],
+                  "items": {
+                    "type": "object",
+                    "behavior": ["llm-content"]
+                  },
+                  "default": "[{\"role\":\"user\",\"parts\":[{\"text\":\"\"}]}]"
                 }
               },
               "type": "object",
@@ -69,7 +74,7 @@
           },
           "metadata": {
             "visual": {
-              "x": -82,
+              "x": -82.00000000000003,
               "y": -1,
               "collapsed": false
             }
@@ -82,9 +87,14 @@
             "schema": {
               "properties": {
                 "context": {
-                  "type": "string",
-                  "title": "Nothing",
-                  "examples": []
+                  "type": "array",
+                  "title": "Context",
+                  "examples": [],
+                  "items": {
+                    "type": "object",
+                    "behavior": ["llm-content"]
+                  },
+                  "default": "null"
                 }
               },
               "type": "object",
@@ -104,7 +114,7 @@
           "type": "runJavascript",
           "metadata": {
             "visual": {
-              "x": 57,
+              "x": 56.99999999999997,
               "y": -4,
               "collapsed": false
             },
@@ -127,11 +137,10 @@
         {
           "from": "input",
           "to": "runJavascript-41b20d06",
-          "out": "item",
-          "in": "item"
+          "out": "context",
+          "in": "context"
         }
-      ],
-      "url": "file://fsapi~boards/map-throw-error.bgl.json#3ed1e058-5fcf-4c30-b91e-abae6cb4794e"
+      ]
     }
   }
 }


### PR DESCRIPTION
Reverts breadboard-ai/breadboard#2629

I realized this weekend that this directly affects Specialist, since it uses `map` to invoke tools -- which mean that this removes the ability for tools to use the `Human` component. Whoops.