### PR TITLE
firebase

### DIFF
--- a/.changeset/plenty-shoes-kick.md
+++ b/.changeset/plenty-shoes-kick.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/visual-editor": patch
+---
+
+Remove explicit site name from Firebase hosting config

--- a/packages/visual-editor/firebase.json
+++ b/packages/visual-editor/firebase.json
@@ -1,6 +1,5 @@
 {
   "hosting": {
-    "site": "breadboard-ai",
     "public": "dist",
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
     "rewrites": [


### PR DESCRIPTION
Remove reference to specific site in firebase config

The project "breadboard-ai" is owned by the breadboard team. This config won't
work for users without access to this project.

The "site" property is optional. Without it, the deploy command will deploy to
the default site in the current project.