### PR TITLE
[build] Add support for JSON Schema string formatting options

### DIFF
--- a/.changeset/pretty-monkeys-roll.md
+++ b/.changeset/pretty-monkeys-roll.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Add support for JSON Schema string formatting options with a new `string` function that takes an options object with format, pattern, minLength, and maxLength.

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -30,5 +30,6 @@ export { array } from "./internal/type-system/array.js";
 export { enumeration } from "./internal/type-system/enumeration.js";
 export { intersect } from "./internal/type-system/intersect.js";
 export { object, optional } from "./internal/type-system/object.js";
+export { string } from "./internal/type-system/string.js";
 export { toJSONSchema } from "./internal/type-system/type.js";
 export { unsafeType } from "./internal/type-system/unsafe.js";

--- a/packages/build/src/internal/type-system/string.ts
+++ b/packages/build/src/internal/type-system/string.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { JSONSchema4 } from "json-schema";
 import type { AdvancedBreadboardType } from "./type.js";
 
 /**
@@ -25,6 +24,5 @@ export interface StringOptions {
  * Create a string type with additional options.
  */
 export function string(options: StringOptions): AdvancedBreadboardType<string> {
-  const jsonSchema: JSONSchema4 = { type: "string", ...options };
-  return { jsonSchema };
+  return { jsonSchema: { type: "string", ...options } };
 }

--- a/packages/build/src/internal/type-system/string.ts
+++ b/packages/build/src/internal/type-system/string.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { JSONSchema4 } from "json-schema";
+import type { AdvancedBreadboardType } from "./type.js";
+
+/**
+ * JSON Schema options for strings.
+ */
+export interface StringOptions {
+  /** https://json-schema.org/understanding-json-schema/reference/string#format */
+  format?: string;
+  /** https://json-schema.org/understanding-json-schema/reference/string#regexp */
+  pattern?: string;
+  /** https://json-schema.org/understanding-json-schema/reference/string#length */
+  minLength?: number;
+  /** https://json-schema.org/understanding-json-schema/reference/string#length */
+  maxLength?: number;
+}
+
+/**
+ * Create a string type with additional options.
+ */
+export function string(options: StringOptions): AdvancedBreadboardType<string> {
+  const jsonSchema: JSONSchema4 = { type: "string", ...options };
+  return { jsonSchema };
+}

--- a/packages/build/src/test/type-expressions/string_test.ts
+++ b/packages/build/src/test/type-expressions/string_test.ts
@@ -13,6 +13,7 @@ import {
 } from "../../internal/type-system/type.js";
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/ban-ts-comment */
 
 test("no options", () => {
   const t = string({});
@@ -48,5 +49,13 @@ test("all options", () => {
     pattern: "^.*$",
     minLength: 2,
     maxLength: 42,
+  });
+});
+
+test("error: unknown option", () => {
+  string({
+    format: "uri",
+    // @ts-expect-error
+    potato: true,
   });
 });

--- a/packages/build/src/test/type-expressions/string_test.ts
+++ b/packages/build/src/test/type-expressions/string_test.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { string } from "../../internal/type-system/string.js";
+import {
+  toJSONSchema,
+  type ConvertBreadboardType,
+} from "../../internal/type-system/type.js";
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+test("no options", () => {
+  const t = string({});
+  // $ExpectType string
+  type T = ConvertBreadboardType<typeof t>;
+  assert.deepEqual(toJSONSchema(t), {
+    type: "string",
+  });
+});
+
+test("1 option", () => {
+  const t = string({ format: "email" });
+  // $ExpectType string
+  type T = ConvertBreadboardType<typeof t>;
+  assert.deepEqual(toJSONSchema(t), {
+    type: "string",
+    format: "email",
+  });
+});
+
+test("all options", () => {
+  const t = string({
+    format: "uri",
+    pattern: "^.*$",
+    minLength: 2,
+    maxLength: 42,
+  });
+  // $ExpectType string
+  type T = ConvertBreadboardType<typeof t>;
+  assert.deepEqual(toJSONSchema(t), {
+    type: "string",
+    format: "uri",
+    pattern: "^.*$",
+    minLength: 2,
+    maxLength: 42,
+  });
+});

--- a/packages/website/src/docs/build/type-expressions.md
+++ b/packages/website/src/docs/build/type-expressions.md
@@ -42,6 +42,34 @@ const numImages = input({
 });
 ```
 
+## String Formatting
+
+To add a formatting constraint to a string, use the `string` function instead of
+the `"string"` literal.
+
+### Arguments
+
+Pass an options object which any or all of the following properties:
+
+<div class="tight-list">
+
+- [`format`](https://json-schema.org/understanding-json-schema/reference/string#format)
+- [`pattern`](https://json-schema.org/understanding-json-schema/reference/string#regexp)
+- [`minLength`](https://json-schema.org/understanding-json-schema/reference/string#length)
+- [`maxLength`](https://json-schema.org/understanding-json-schema/reference/string#length)
+
+</div>
+
+### Example
+
+```ts
+import { string } from "@breadboard-ai/build";
+
+const apiAddress = input({
+  type: string({ format: "uri", maxLength: 256 }),
+});
+```
+
 ## Unknown
 
 The `"unknown"` Breadboard Type Expression matches _any JSON value_. In other

--- a/packages/website/src/docs/build/type-expressions.md
+++ b/packages/website/src/docs/build/type-expressions.md
@@ -44,12 +44,12 @@ const numImages = input({
 
 ## String Formatting
 
-To add a formatting constraint to a string, use the `string` function instead of
+To add formatting constraints to a string, use the `string` function instead of
 the `"string"` literal.
 
 ### Arguments
 
-Pass an options object which any or all of the following properties:
+Pass an options object any of the following properties:
 
 <div class="tight-list">
 


### PR DESCRIPTION
```ts
import { string } from "@breadboard-ai/build";

const apiAddress = input({
  type: string({ format: "uri", maxLength: 256 }),
});
```