### PR TITLE
serial map

### DIFF
--- a/.changeset/spicy-jars-cross.md
+++ b/.changeset/spicy-jars-cross.md
@@ -1,0 +1,6 @@
+---
+"@google-labs/breadboard": minor
+"@google-labs/core-kit": minor
+---
+
+Refactor `map` to run serially when `RunStateManager` is present.

--- a/packages/breadboard/src/index.ts
+++ b/packages/breadboard/src/index.ts
@@ -113,3 +113,6 @@ export {
  * Managed Run State API
  */
 export { createRunStateManager } from "./run/index.js";
+
+export { invokeGraph } from "./run/invoke-graph.js";
+export { runGraph } from "./run/run-graph.js";

--- a/packages/breadboard/src/run/index.ts
+++ b/packages/breadboard/src/run/index.ts
@@ -4,15 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { InputValues } from "../types.js";
 import { RunStateManager } from "./manager.js";
-import { emptyEntry } from "./registry.js";
 import type {
-  LifecyclePathRegistryEntry,
   ManagedRunState,
   ReanimationInputs,
   ReanimationState,
-  RunStackEntry,
 } from "./types.js";
 
 export const createRunStateManager = (

--- a/packages/breadboard/src/run/manager.ts
+++ b/packages/breadboard/src/run/manager.ts
@@ -4,16 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { InputValues } from "../types.js";
 import { LifecycleManager } from "./lifecycle.js";
 import { Reanimator } from "./reanimator.js";
 import type {
-  LifecyclePathRegistryEntry,
   ManagedRunState,
   ReanimationController,
   ReanimationInputs,
   ReanimationState,
-  RunStackEntry,
 } from "./types.js";
 
 export class RunStateManager implements ManagedRunState {

--- a/packages/core-kit/src/nodes/map.ts
+++ b/packages/core-kit/src/nodes/map.ts
@@ -13,7 +13,13 @@ import type { Input } from "@breadboard-ai/build/internal/board/input.js";
 import type { OutputPortReference } from "@breadboard-ai/build/internal/common/port.js";
 import type { Expand } from "@breadboard-ai/build/internal/common/type-util.js";
 import type { JsonSerializable } from "@breadboard-ai/build/internal/type-system/type.js";
-import { getRunner } from "../utils.js";
+import {
+  getGraphDescriptor,
+  GraphDescriptor,
+  invokeGraph,
+  NodeHandlerContext,
+  OutputValues,
+} from "@google-labs/breadboard";
 
 /**
  * Apply the given board to all elements of the given array-type Breadboard
@@ -37,6 +43,31 @@ type ExtractOutputTypes<B extends BoardOutputPorts> = {
       ? never
       : T
     : never;
+};
+
+const invokeGraphPerItem = async (
+  graph: GraphDescriptor,
+  item: JsonSerializable,
+  index: number,
+  list: JsonSerializable,
+  context: NodeHandlerContext
+) => {
+  // If the current board has a URL, pass it as new base.
+  // Otherwise, use the previous base.
+  const base = context?.board?.url && new URL(context.board?.url);
+
+  const newContext = {
+    ...context,
+    base: base || context?.base,
+    invocationPath: [...(context?.invocationPath || []), index],
+  };
+  const outputs = await invokeGraph(graph, { item, index, list }, newContext);
+  // TODO(aomarks) Map functions have an "item" input, but not an "item"
+  // output. Instead, all outputs become the map result. That's a bit
+  // weird, since it means you can't e.g. map a string to a string; only a
+  // string to an object containing a string. Let's try and migrate to a
+  // symmetrical map type, will need an opt-in flag initially.
+  return outputs;
 };
 
 const mapNode = defineNodeType({
@@ -89,33 +120,24 @@ const mapNode = defineNodeType({
       // be able to even get to invoke. We know the JSON schema up-front.
       throw new Error(`Expected list to be an array, but got ${list}`);
     }
-    const runnableBoard = await getRunner(board, context);
-    if (!runnableBoard) return { list };
-    const result = await Promise.all(
-      list.map(async (item, index) => {
-        // TODO: Express as a multi-turn `run`.
-
-        // If the current board has a URL, pass it as new base.
-        // Otherwise, use the previous base.
-        const base = context?.board?.url && new URL(context.board?.url);
-
-        const newContext = {
-          ...context,
-          base: base || context?.base,
-          invocationPath: [...(context?.invocationPath || []), index],
-        };
-        const outputs = await runnableBoard.runOnce(
-          { item, index, list },
-          newContext
+    const graph = await getGraphDescriptor(board, context);
+    if (!graph) return { list };
+    let result: OutputValues[];
+    const runSerially = !!context.state;
+    if (runSerially) {
+      result = [];
+      for (const [index, item] of list.entries()) {
+        result.push(
+          await invokeGraphPerItem(graph, item, index, list, context)
         );
-        // TODO(aomarks) Map functions have an "item" input, but not an "item"
-        // output. Instead, all outputs become the map result. That's a bit
-        // weird, since it means you can't e.g. map a string to a string; only a
-        // string to an object containing a string. Let's try and migrate to a
-        // symmetrical map type, will need an opt-in flag initially.
-        return outputs;
-      })
-    );
+      }
+    } else {
+      result = await Promise.all(
+        list.map(async (item, index) => {
+          return invokeGraphPerItem(graph, item, index, list, context);
+        })
+      );
+    }
 
     const errors = result.filter((r) => r.$error);
     if (errors.length === 0) {

--- a/packages/core-kit/tests/map.ts
+++ b/packages/core-kit/tests/map.ts
@@ -7,7 +7,7 @@
 import test from "ava";
 
 import map from "../src/nodes/map.js";
-import { Capability, InputValues, Board } from "@google-labs/breadboard";
+import { Capability, Board } from "@google-labs/breadboard";
 import { Core } from "../src/index.js";
 
 test("map with no board just outputs list", async (t) => {
@@ -16,60 +16,6 @@ test("map with no board just outputs list", async (t) => {
   };
   const outputs = await map.invoke(inputs, {});
   t.deepEqual(outputs, { list: [1, 2, 3] });
-});
-
-test("map with board", async (t) => {
-  const inputs = {
-    list: [1, 2, 3],
-    board: {
-      kind: "board",
-      board: {
-        kits: [],
-        edges: [],
-        nodes: [],
-        runOnce: async (inputs: InputValues) => {
-          return inputs;
-        },
-      },
-    },
-  };
-  const outputs = await map.invoke(inputs, {});
-  t.deepEqual(outputs, {
-    list: [
-      { index: 0, item: 1, list: [1, 2, 3] },
-      { index: 1, item: 2, list: [1, 2, 3] },
-      { index: 2, item: 3, list: [1, 2, 3] },
-    ],
-  });
-});
-
-test("using map as part of a board", async (t) => {
-  const board = new Board();
-  const core = board.addKit(Core);
-  const input = board.input();
-  const map = core.map({
-    board: {
-      kind: "board",
-      board: {
-        kits: [],
-        edges: [],
-        nodes: [],
-        runOnce: async (inputs: InputValues) => {
-          return inputs;
-        },
-      },
-    } as Capability, // TODO: Fix types.
-  });
-  input.wire("list->", map);
-  map.wire("list->", board.output());
-  const outputs = await board.runOnce({ list: [1, 2, 3] }, { kits: [core] });
-  t.deepEqual(outputs, {
-    list: [
-      { index: 0, item: 1, list: [1, 2, 3] },
-      { index: 1, item: 2, list: [1, 2, 3] },
-      { index: 2, item: 3, list: [1, 2, 3] },
-    ],
-  });
 });
 
 test("sending a real board to a map", async (t) => {


### PR DESCRIPTION
- **Remove unused inputs.**
- **Remove tests that rely on GraphDescriptor actually being a BoardRunner.**
- **Refactor `map` to switch to serial mode when `RunStateManager` is present.**
- **docs(changeset): Refactor `map` to run serially when `RunStateManager` is present.**
