### PR TITLE
interruptible run endpoint

### DIFF
--- a/.changeset/khaki-rules-doubt.md
+++ b/.changeset/khaki-rules-doubt.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/board-server": minor
+---
+
+Implement the `run` API endpoint.

--- a/.changeset/pink-steaks-roll.md
+++ b/.changeset/pink-steaks-roll.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard": minor
+---
+
+Make sure that reanimator correctly adjusts invocationId when resuming.

--- a/packages/board-server/package.json
+++ b/packages/board-server/package.json
@@ -4,7 +4,7 @@
     "registry": "https://wombat-dressing-room.appspot.com"
   },
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Board Server",
   "main": "./dist/server/index.js",
   "exports": "./dist/server/index.js",

--- a/packages/board-server/src/server/boards/index.ts
+++ b/packages/board-server/src/server/boards/index.ts
@@ -97,7 +97,8 @@ export const serveBoardsAPI = async (
     }
     case "run": {
       if (!corsAll(req, res)) return true;
-      if (await run(parsed, req, res)) return true;
+      const body = await getBody(req);
+      if (await run(parsed, req, res, body)) return true;
       break;
     }
     default: {

--- a/packages/board-server/src/server/boards/index.ts
+++ b/packages/board-server/src/server/boards/index.ts
@@ -17,6 +17,7 @@ import invoke from "./invoke.js";
 import describe from "./describe.js";
 import { parse } from "./utils/board-api-parser.js";
 import { cors, corsAll } from "../cors.js";
+import run from "./run.js";
 
 const getBody = async (req: IncomingMessage): Promise<unknown> => {
   const chunks: string[] = [];
@@ -92,6 +93,11 @@ export const serveBoardsAPI = async (
     case "describe": {
       if (!corsAll(req, res)) return true;
       if (await describe(parsed, req, res)) return true;
+      break;
+    }
+    case "run": {
+      if (!corsAll(req, res)) return true;
+      if (await run(parsed, req, res)) return true;
       break;
     }
     default: {

--- a/packages/board-server/src/server/boards/run.ts
+++ b/packages/board-server/src/server/boards/run.ts
@@ -12,7 +12,7 @@ import { runBoard } from "./utils/run-board.js";
 
 const runHandler: ApiHandler = async (parsed, req, res, body) => {
   const { board, url } = parsed as BoardParseResult;
-  const inputs = body as Record<string, any>;
+  const { $next: next, ...inputs } = body as Record<string, any>;
   const keyVerificationResult = await verifyKey(inputs);
   if (!keyVerificationResult.success) {
     res.writeHead(200, { "Content-Type": "application/json" });
@@ -33,6 +33,7 @@ const runHandler: ApiHandler = async (parsed, req, res, body) => {
     loader: loadFromStore,
     kitOverrides: [secretsKit],
     writer,
+    next,
   });
   writer.close();
   res.end();

--- a/packages/board-server/src/server/boards/run.ts
+++ b/packages/board-server/src/server/boards/run.ts
@@ -9,6 +9,7 @@ import { loadFromStore } from "./utils/board-server-provider.js";
 import { verifyKey } from "./utils/verify-key.js";
 import { secretsKit } from "../proxy/secrets.js";
 import { runBoard } from "./utils/run-board.js";
+import { getStore } from "../store.js";
 
 const runHandler: ApiHandler = async (parsed, req, res, body) => {
   const { board, url } = parsed as BoardParseResult;
@@ -24,6 +25,9 @@ const runHandler: ApiHandler = async (parsed, req, res, body) => {
       res.write(`data: ${JSON.stringify(chunk)}\n\n`);
     },
   }).getWriter();
+
+  const runStateStore = getStore();
+
   res.setHeader("Content-Type", "text/event-stream");
   res.statusCode = 200;
   await runBoard({
@@ -35,6 +39,7 @@ const runHandler: ApiHandler = async (parsed, req, res, body) => {
     kitOverrides: [secretsKit],
     writer,
     next,
+    runStateStore,
   });
   writer.close();
   res.end();

--- a/packages/board-server/src/server/boards/run.ts
+++ b/packages/board-server/src/server/boards/run.ts
@@ -24,7 +24,9 @@ const runHandler: ApiHandler = async (parsed, req, res, body) => {
       res.write(`data: ${JSON.stringify(chunk)}\n\n`);
     },
   }).getWriter();
-  const result = await runBoard({
+  res.setHeader("Content-Type", "text/event-stream");
+  res.statusCode = 200;
+  await runBoard({
     url,
     path: board,
     inputs,
@@ -32,9 +34,8 @@ const runHandler: ApiHandler = async (parsed, req, res, body) => {
     kitOverrides: [secretsKit],
     writer,
   });
-  res.setHeader("Content-Type", "text/event-stream");
-  res.statusCode = 200;
-  res.end(JSON.stringify(result));
+  writer.close();
+  res.end();
   return true;
 };
 

--- a/packages/board-server/src/server/boards/run.ts
+++ b/packages/board-server/src/server/boards/run.ts
@@ -29,6 +29,7 @@ const runHandler: ApiHandler = async (parsed, req, res, body) => {
   await runBoard({
     url,
     path: board,
+    user: keyVerificationResult.user!,
     inputs,
     loader: loadFromStore,
     kitOverrides: [secretsKit],

--- a/packages/board-server/src/server/boards/run.ts
+++ b/packages/board-server/src/server/boards/run.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { RunBoardResult, ApiHandler, BoardParseResult } from "../types.js";
+import { loadFromStore } from "./utils/board-server-provider.js";
+import { verifyKey } from "./utils/verify-key.js";
+import { secretsKit } from "../proxy/secrets.js";
+import { runBoard } from "./utils/run-board.js";
+
+const runHandler: ApiHandler = async (parsed, req, res, body) => {
+  const { board, url } = parsed as BoardParseResult;
+  const inputs = body as Record<string, any>;
+  const keyVerificationResult = await verifyKey(inputs);
+  if (!keyVerificationResult.success) {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ $error: keyVerificationResult.error }));
+    return true;
+  }
+  const writer = new WritableStream<RunBoardResult>({
+    write(chunk) {
+      res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+    },
+  }).getWriter();
+  const result = await runBoard({
+    url,
+    path: board,
+    inputs,
+    loader: loadFromStore,
+    kitOverrides: [secretsKit],
+    writer,
+  });
+  res.setHeader("Content-Type", "text/event-stream");
+  res.statusCode = 200;
+  res.end(JSON.stringify(result));
+  return true;
+};
+
+export default runHandler;

--- a/packages/board-server/src/server/boards/utils/run-board.ts
+++ b/packages/board-server/src/server/boards/utils/run-board.ts
@@ -54,7 +54,7 @@ export const runBoard = async ({
     store,
     inputs: { model: "gemini-1.5-flash-latest" },
     interactiveSecrets: false,
-    diagnostics: true,
+    diagnostics: false,
     state,
   });
 

--- a/packages/board-server/src/server/boards/utils/run-board.ts
+++ b/packages/board-server/src/server/boards/utils/run-board.ts
@@ -9,11 +9,10 @@ import {
   createLoader,
   createRunStateManager,
   inflateData,
-  type InputValues,
   type OutputValues,
   type ReanimationState,
 } from "@google-labs/breadboard";
-import { run, type StateToResumeFrom } from "@google-labs/breadboard/harness";
+import { run } from "@google-labs/breadboard/harness";
 import type { RunBoardArguments, RunBoardResult } from "../../types.js";
 import { BoardServerProvider } from "./board-server-provider.js";
 import { createKits } from "./create-kits.js";
@@ -64,11 +63,9 @@ export const runBoard = async ({
         await reply({ inputs: inputsToConsume });
         inputsToConsume = undefined;
       } else {
-        const {
-          node: { configuration },
-        } = data;
+        const { inputArguments } = data;
         const reanimationState = state.lifecycle().reanimationState();
-        const schema = configuration?.schema || {};
+        const schema = inputArguments?.schema || {};
         const next = fromStateToNext(reanimationState);
         return {
           outputs,

--- a/packages/board-server/src/server/boards/utils/run-board.ts
+++ b/packages/board-server/src/server/boards/utils/run-board.ts
@@ -54,6 +54,7 @@ export const runBoard = async ({
     store,
     inputs: { model: "gemini-1.5-flash-latest" },
     interactiveSecrets: false,
+    diagnostics: true,
     state,
   });
 
@@ -87,10 +88,11 @@ export const runBoard = async ({
         return;
       }
       case "end": {
+        console.log("Run completed.", data.last);
         return;
       }
       default: {
-        console.log("UNKNOWN RESULT", type, data);
+        console.log("Diagnostics", type, data);
       }
     }
   }

--- a/packages/board-server/src/server/boards/utils/verify-key.ts
+++ b/packages/board-server/src/server/boards/utils/verify-key.ts
@@ -1,7 +1,7 @@
 import { getStore } from "../../store.js";
 
-export const verifyKey = async (inputs: Record<string, any>) => {
-  const key = inputs.$key;
+export const verifyKey = async (inputs: Record<string, any> | undefined) => {
+  const key = inputs?.$key;
   if (!key) {
     return { success: false, error: "No key supplied" };
   }

--- a/packages/board-server/src/server/boards/utils/verify-key.ts
+++ b/packages/board-server/src/server/boards/utils/verify-key.ts
@@ -11,5 +11,5 @@ export const verifyKey = async (inputs: Record<string, any> | undefined) => {
     return { success: false, error: userStore.error };
   }
   delete inputs.$key;
-  return { success: true };
+  return { success: true, user: userStore.store };
 };

--- a/packages/board-server/src/server/info/index.ts
+++ b/packages/board-server/src/server/info/index.ts
@@ -8,6 +8,7 @@ import type { IncomingMessage, ServerResponse } from "http";
 import { getStore, type ServerInfo } from "../store.js";
 import { methodNotAllowed } from "../errors.js";
 import { corsAll } from "../cors.js";
+import packageInfo from "../../../package.json" with { type: "json" };
 
 const DEFAULT_SERVER_INFO: ServerInfo = {
   title: "Board Server",
@@ -42,9 +43,10 @@ export const serveInfoAPI = async (
 
   const store = getStore();
   const info = (await store.getServerInfo()) || DEFAULT_SERVER_INFO;
+  const version = packageInfo.version;
 
   res.setHeader("Content-Type", "application/json");
-  res.end(JSON.stringify(info));
+  res.end(JSON.stringify({ ...info, version }));
 
   return true;
 };

--- a/packages/board-server/src/server/store.ts
+++ b/packages/board-server/src/server/store.ts
@@ -12,6 +12,7 @@ import {
 } from "@google-labs/breadboard";
 
 const REANIMATION_COLLECTION_ID = "resume";
+const EXPIRATION_TIME_MS = 1000 * 60 * 60 * 24 * 2; // 2 days
 
 export type GetUserStoreResult =
   | { success: true; store: string }
@@ -101,8 +102,9 @@ class Store {
     state: ReanimationState
   ): Promise<string> {
     const timestamp = new Date();
+    const expireAt = new Date(timestamp.getTime() + EXPIRATION_TIME_MS);
     const docRef = this.#getReanimationStateDoc(user);
-    await docRef.set({ state: JSON.stringify(state), timestamp });
+    await docRef.set({ state: JSON.stringify(state), timestamp, expireAt });
     return docRef.id;
   }
 

--- a/packages/board-server/src/server/store.ts
+++ b/packages/board-server/src/server/store.ts
@@ -10,6 +10,7 @@ import {
   type GraphDescriptor,
   type ReanimationState,
 } from "@google-labs/breadboard";
+import type { RunBoardStateStore } from "./types.js";
 
 const REANIMATION_COLLECTION_ID = "resume";
 const EXPIRATION_TIME_MS = 1000 * 60 * 60 * 24 * 2; // 2 days
@@ -77,7 +78,7 @@ export type BoardServerCorsConfig = {
   allow: string[];
 };
 
-class Store {
+class Store implements RunBoardStateStore {
   #database;
 
   constructor(storeName: string) {

--- a/packages/board-server/src/server/types.ts
+++ b/packages/board-server/src/server/types.ts
@@ -74,26 +74,27 @@ export type RunBoardArguments = {
   url: string;
   path: string;
   loader: BoardServerLoadFunction;
+  writer: RunBoardResultWriter;
   inputs?: InputValues;
   kitOverrides?: Kit[];
   next?: string;
 };
 
-export type RunBoardResultError = {
-  $error: string;
-};
+export type RunBoardResultWriter = WritableStreamDefaultWriter<RunBoardResult>;
 
-export type RunBoardResultState = {
-  outputs: OutputValues[];
-  $state:
-    | {
-        type: "input";
-        schema: NodeValue;
-        next: string;
-      }
-    | {
-        type: "end";
-      };
-};
+export type RunBoardResultError = ["error", error: string];
 
-export type RunBoardResult = RunBoardResultError | RunBoardResultState;
+export type RunBoardResultOutput = ["output", outputs: OutputValues];
+
+export type RunBoardResultInput = [
+  "input",
+  data: {
+    schema: NodeValue;
+    next: string;
+  },
+];
+
+export type RunBoardResult =
+  | RunBoardResultError
+  | RunBoardResultOutput
+  | RunBoardResultInput;

--- a/packages/board-server/src/server/types.ts
+++ b/packages/board-server/src/server/types.ts
@@ -73,6 +73,7 @@ export type InvokeBoardArguments = {
 export type RunBoardArguments = {
   url: string;
   path: string;
+  user: string;
   loader: BoardServerLoadFunction;
   writer: RunBoardResultWriter;
   inputs?: InputValues;

--- a/packages/board-server/src/server/types.ts
+++ b/packages/board-server/src/server/types.ts
@@ -11,6 +11,7 @@ import type {
   Kit,
   NodeValue,
   OutputValues,
+  ReanimationState,
 } from "@google-labs/breadboard";
 
 export type GeneralRequestType = "list" | "create";
@@ -75,10 +76,19 @@ export type RunBoardArguments = {
   path: string;
   user: string;
   loader: BoardServerLoadFunction;
+  runStateStore: RunBoardStateStore;
   writer: RunBoardResultWriter;
   inputs?: InputValues;
   kitOverrides?: Kit[];
   next?: string;
+};
+
+export type RunBoardStateStore = {
+  loadReanimationState(
+    user: string,
+    ticket: string
+  ): Promise<ReanimationState | undefined>;
+  saveReanimationState(user: string, state: ReanimationState): Promise<string>;
 };
 
 export type RunBoardResultWriter = WritableStreamDefaultWriter<RunBoardResult>;

--- a/packages/board-server/tests/run-board.ts
+++ b/packages/board-server/tests/run-board.ts
@@ -11,6 +11,7 @@ import type {
   GraphDescriptor,
   Kit,
   OutputValues,
+  ReanimationState,
 } from "@google-labs/breadboard";
 
 import simpleBoard from "./boards/simple.bgl.json" with { type: "json" };
@@ -86,6 +87,15 @@ type RunScriptEntry = {
   expected: ExpectedResult[];
 };
 
+const runStateStore = {
+  async loadReanimationState(user: string, ticket: string) {
+    return JSON.parse(ticket) as ReanimationState;
+  },
+  async saveReanimationState(user: string, state: any) {
+    return JSON.stringify(state);
+  },
+};
+
 const scriptedRun = async (
   board: GraphDescriptor,
   script: RunScriptEntry[]
@@ -99,13 +109,16 @@ const scriptedRun = async (
         results.push(chunk);
       },
     }).getWriter();
+
     await runBoard({
+      user: "test",
       path,
       url: `https://example.com${path}`,
       loader: async () => board,
       inputs,
       next,
       writer,
+      runStateStore,
     });
     assertResults(results, expected, index);
     next = getNext(results[results.length - 1]);
@@ -122,10 +135,12 @@ describe("Board Server Runs Boards", () => {
       },
     }).getWriter();
     await runBoard({
+      user: "test",
       path,
       url: `https://example.com${path}`,
       loader: async () => simpleBoard,
       writer,
+      runStateStore,
     });
     assertResults(results, [{ type: "input" }]);
   });
@@ -150,11 +165,13 @@ describe("Board Server Runs Boards", () => {
       },
     }).getWriter();
     await runBoard({
+      user: "test",
       path,
       url: `https://example.com${path}`,
       inputs,
       loader: async () => simpleBoard,
       writer,
+      runStateStore,
     });
     assertResults(results, [
       {
@@ -176,11 +193,13 @@ describe("Board Server Runs Boards", () => {
       },
     }).getWriter();
     await runBoard({
+      user: "test",
       path,
       url: `https://example.com${path}`,
       inputs,
       loader: async () => multipleInputsBoard as GraphDescriptor,
       writer,
+      runStateStore,
     });
     assertResults(results, [{ type: "input" }]);
   });

--- a/packages/breadboard/src/harness/types.ts
+++ b/packages/breadboard/src/harness/types.ts
@@ -15,7 +15,7 @@ import type {
   LoadResponse,
   ServerTransport,
 } from "../remote/types.js";
-import type { ManagedRunState, RunState } from "../run/types.js";
+import type { ManagedRunState } from "../run/types.js";
 import type {
   BreadboardRunner,
   ErrorResponse,
@@ -186,9 +186,4 @@ export type RunConfig = {
    * The state from which to resume the run.
    */
   state?: ManagedRunState;
-};
-
-export type StateToResumeFrom = {
-  state: RunState;
-  inputs?: InputValues;
 };

--- a/packages/breadboard/src/remote/types.ts
+++ b/packages/breadboard/src/remote/types.ts
@@ -86,11 +86,19 @@ export type InputResolveRequestMessage = [
   RunState,
 ];
 
+export type LastNode = {
+  node: NodeDescriptor;
+  missing: string[];
+};
+
 /**
  * Indicates that the board is done running.
  * Can only be the last message in the response stream.
  */
-export type End = { timestamp: number };
+export type End = {
+  timestamp: number;
+  last?: LastNode;
+};
 export type EndResponseMessage = ["end", End];
 export type EndRequestMessage = ["end", End];
 

--- a/packages/breadboard/src/run/reanimator.ts
+++ b/packages/breadboard/src/run/reanimator.ts
@@ -26,26 +26,27 @@ export class Reanimator implements ReanimationController {
   }
 
   enter(invocationPath: number[]): ReanimationFrameController {
-    const stackEntry = this.#resumeFrom[invocationPath.join("-")];
-    if (!stackEntry) {
+    const entryId = invocationPath.join("-");
+    const entry = this.#resumeFrom[entryId];
+    if (!entry) {
       return new FrameReanimator(undefined);
     }
-    if (!stackEntry || !stackEntry.state) {
+    if (!entry || !entry.state) {
       throw new Error("Cannot reanimate without a state");
     }
-    const result = loadRunnerState(stackEntry.state).state;
+    const result = loadRunnerState(entry.state).state;
     result.outputs = {
       ...this.#inputs,
       ...result.partialOutputs,
     };
     this.#inputs = undefined;
-    const replayOutputs = stackEntry.outputs ? [stackEntry.outputs] : [];
+    const replayOutputs = entry.outputs ? [entry.outputs] : [];
 
     // Always return the new instance:
     // wraps the actual ReanimationFrame, if any.
     return new FrameReanimator({
       result,
-      invocationPath: stackEntry.path,
+      invocationPath: entry.path,
       replayOutputs,
     });
   }

--- a/packages/breadboard/tests/node/run/interruptible-run-graph.ts
+++ b/packages/breadboard/tests/node/run/interruptible-run-graph.ts
@@ -68,7 +68,7 @@ describe("interruptibleRunGraph end-to-end", async () => {
           type: "input",
           state: {
             "": { node: "invoke-b5fe388d" },
-            "1": { node: "input" },
+            "2": { node: "input" },
           },
         },
         inputs: { location: "New York" },
@@ -104,7 +104,7 @@ describe("interruptibleRunGraph end-to-end", async () => {
           state: {
             "": { node: "invoke-d5aa6bf1" },
             "1": { node: "invoke-b5fe388d" },
-            "1-1": { node: "input" },
+            "1-2": { node: "input" },
           },
         },
         inputs: { location: "New York" },

--- a/packages/website/src/docs/reference/board-run-api-endpoint.md
+++ b/packages/website/src/docs/reference/board-run-api-endpoint.md
@@ -1,0 +1,195 @@
+---
+layout: docs.liquid
+title: Board Run API Endpoint Protocol
+tags:
+  - reference
+  - miscellaneous
+---
+
+Describes how to use the Board Run API Endpoint. This API endpoint is different from the [invoke BSE endpoint](../bse/#the-invoke-path) in that it follows the ["Run" mode semantics](/breadboard/docs/reference/runtime-semantics#run-mode).
+
+## Endpoint
+
+`POST {API_URL}`
+
+When using Board Server, it will be the URL of the board, with the `json` extension replaced by `api/run`. For example a board at this location:
+
+```url
+http://mycoolboardserver.example.com/boards/@pluto/chat-agent.bgl.json
+```
+
+Will have the API endpoint at:
+
+```url
+http://mycoolboardserver.example.com/boards/@pluto/chat-agent.bgl.api/run
+```
+
+## Authentication
+
+Authentication is performed using an API key.
+
+- Include the API key in the request body with the key `$key`.
+
+## Request
+
+### Headers
+
+- `Content-Type: application/json`
+
+### Body
+
+The request body should be a JSON object with the following structure:
+
+```json
+{
+  "$key": "YOUR_API_KEY",
+  "$next": "OPTIONAL_RESUMPTION_STATE",
+  ...inputs
+}
+```
+
+- `$key` (string, required): The API key. When accessing this endpoint on a Board Server, the Board Server API Key.
+- `$next` (string, optional): The state to resume from, if continuing a previous interaction.
+- `...inputs` (object, required): The inputs to the board. The structure of this object depends on the specific board being run and must match the schema supplied in the input request.
+
+Example input for initiating request:
+
+```json
+{
+  "$key": "YOUR_API_KEY",
+  "context": [
+    {
+      "role": "user",
+      "parts": [
+        {
+          "text": "Hello, my name is Pluto! When talking with me, please start by addressing me by name"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Example input for continuing request:
+
+```json
+{
+  "$key": "YOUR_API_KEY",
+  "$next": "RESUME_FROM_THIS_STATE",
+  "text": {
+    "role": "user",
+    "parts": [{ "text": "What is Breadboard?" }]
+  }
+}
+```
+
+You can also initiate request with no inputs. In this case, the response will contain the `input` type response and supply the schema:
+
+```json
+{
+  "$key": "YOUR_API_KEY"
+}
+```
+
+## Response
+
+The response is a Server-Sent Events (SSE) stream. Each event in the stream is a serialized JSON object prefixed by `data: ` and separated by `\n\n`.
+
+### Event Format
+
+Each event is an array with two elements: `[type, data]`
+
+The `type` can be one of the following:
+
+1. `"input"`
+2. `"output"`
+3. `"error"`
+
+### Event Types
+
+1. Input Event
+
+```json
+["input", {
+  "schema": { ... },
+  "next": "RESUMPTION_STATE"
+}]
+```
+
+- `schema` (object): Describes the expected input schema.
+- `next` (string): A token representing the state to use when resuming the interaction.
+
+2. Output Event
+
+```json
+["output", {
+  "output": [ ... ]
+}]
+```
+
+- `output` (array): Contains the output data from the board.
+
+3. Error Event
+
+```json
+["error", "ERROR_MESSAGE"]
+```
+
+- The second element is a string describing the error that occurred.
+
+## Error Handling
+
+- If an error occurs during processing, an error event will be sent in the SSE stream.
+- HTTP status codes are used to indicate request-level errors (e.g., 400 for bad requests, 401 for authentication errors).
+
+## Resuming Interactions
+
+To continue an interaction:
+
+1. Extract the `next` value from the most recent input event.
+2. Include this value as `$next` in your next request body.
+
+## Examples
+
+### Initiating a conversation
+
+Request:
+
+```http
+POST {API_URL} HTTP/1.1
+Content-Type: application/json
+
+{
+  "$key": "YOUR_API_KEY",
+  "context": [
+    {
+      "role": "user",
+      "parts": [{ "text": "Hello, my name is Dimitri! When talking with me, please start by addressing me by name" }]
+    }
+  ]
+}
+```
+
+### Continuing a conversation
+
+Request:
+
+```http
+POST {API_URL} HTTP/1.1
+Content-Type: application/json
+
+{
+  "$key": "YOUR_API_KEY",
+  "$next": "PREVIOUS_NEXT_VALUE",
+  "text": {
+    "role": "user",
+    "parts": [{ "text": "What is Breadboard?" }]
+  }
+}
+```
+
+## Notes
+
+- The specific structure of inputs and outputs may vary depending on the board being run.
+- Always handle the SSE stream properly, parsing each event and acting accordingly based on its type.
+- Store the `next` value from input events to enable conversation continuity.


### PR DESCRIPTION
- **Remove unused types/imports.**
- **Switch to WritableStreamDefaultWriter to stream outputs.**
- **Sketch out `run` api endpoint.**
- **It's working!**
- **Pass next.**
- **Teach `end` result to provide last node.**
- **Teach resume to also adjust the invocation path.**
- **Start storing `ReanimationState` in firestore.**
- **Teach board store about TTL.**
- **Also display version on `/info` request.**
- **Update tests.**
- **Update more tests.**
- **Add docs.**
- **docs(changeset): Make sure that reanimator correctly adjusts invocationId when resuming.**
- **docs(changeset): Implement the `run` API endpoint.**
