### PR TITLE
retry with credentials

### DIFF
--- a/.changeset/cool-beers-mix.md
+++ b/.changeset/cool-beers-mix.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard": minor
+---
+
+Retry with credentials when board fetch fails.

--- a/packages/breadboard/src/loader/default.ts
+++ b/packages/breadboard/src/loader/default.ts
@@ -33,8 +33,18 @@ export const loadFromFile = async (path: string) => {
 };
 
 export const loadWithFetch = async (url: string | URL) => {
-  const response = await fetch(url);
-  return await response.json();
+  let response;
+  try {
+    response = await fetch(url);
+  } catch (e) {
+    // Try again with credentials.
+    // This is useful for sites that require authentication.
+    // We also don't want this to be the default behavior, because some sites
+    // like Github have * CORS headers, which will make this request fail.
+    // See https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSNotSupportingCredentials
+    response = await fetch(url, { credentials: "include" });
+  }
+  return await response?.json();
 };
 
 export class DefaultGraphProvider implements GraphProvider {


### PR DESCRIPTION
- **Retry with credentials in default fetch for boards.**
- **docs(changeset): Retry with credentials when board fetch fails.**
