### PR TITLE
[breadboard/data-store] Fix parallelism issues in Run Store

### DIFF
--- a/packages/breadboard/src/data/default-run-store.ts
+++ b/packages/breadboard/src/data/default-run-store.ts
@@ -6,41 +6,29 @@
 
 import { HarnessRunResult } from "../harness/types.js";
 import { isLLMContent, isStoredData, toInlineDataPart } from "./common.js";
-import { RunStore } from "./types.js";
+import { RunStore, RunTimestamp, RunURL } from "./types.js";
 
 export class DefaultRunStore implements RunStore {
-  #runs = new Map<string, HarnessRunResult[]>();
-  #storeId: string | null = null;
+  #runs = new Map<RunURL, Map<RunTimestamp, HarnessRunResult[]>>();
 
-  async start(storeId: string, limit = 2) {
-    if (this.#runs.has(storeId)) {
+  async start(url: RunURL): Promise<RunTimestamp> {
+    const timestamp = Date.now();
+    let store = this.#runs.get(url);
+    if (!store) {
+      store = new Map<RunTimestamp, HarnessRunResult[]>();
+    }
+
+    if (store.has(timestamp)) {
       throw new Error("Run by name has already started");
     }
 
-    this.#storeId = storeId;
-    this.#runs.set(storeId, []);
-
-    const oldStoreNames = [...this.#runs.keys()]
-      .sort((a, b) => {
-        if (a > b) return -1;
-        if (a < b) return 1;
-        return 0;
-      })
-      .slice(limit);
-
-    for (const storeName of oldStoreNames) {
-      this.#runs.delete(storeName);
-    }
-
-    return storeId;
+    store.set(timestamp, []);
+    this.#runs.set(url, store);
+    return timestamp;
   }
 
-  async write(result: HarnessRunResult) {
-    if (!this.#storeId) {
-      throw new Error("Run has not been started");
-    }
-
-    const store = this.#runs.get(this.#storeId);
+  async write(url: RunURL, timestamp: RunTimestamp, result: HarnessRunResult) {
+    const store = this.#runs.get(url);
     if (!store) {
       throw new Error("Unable to find the store");
     }
@@ -64,36 +52,54 @@ export class DefaultRunStore implements RunStore {
       }
     }
 
-    store.push(result);
+    const run = store.get(timestamp);
+    if (!run) {
+      console.warn(`No run created for timestamp ${timestamp}`);
+      return;
+    }
+
+    run.push(result);
   }
 
-  async stop() {
-    this.#storeId = null;
+  async stop(_storeId: RunURL, _timestamp: RunTimestamp) {
+    // Noop.
   }
 
-  async abort() {
-    this.#storeId = null;
+  async abort(_storeId: RunURL, _timestamp: RunTimestamp) {
+    // Noop
   }
 
-  async drop() {
-    this.#runs.clear();
+  async drop(url?: RunURL, _limit?: number) {
+    if (url) {
+      this.#runs.delete(url);
+    } else {
+      this.#runs.clear();
+    }
   }
 
-  async getNewestRuns(
-    limit = Number.POSITIVE_INFINITY
-  ): Promise<HarnessRunResult[][]> {
-    const storeNames = [...this.#runs.keys()]
-      .sort((a, b) => {
-        if (a > b) return -1;
-        if (a < b) return 1;
-        return 0;
-      })
-      .slice(0, limit);
+  async truncate(url: RunURL, limit: number) {
+    const store = this.#runs.get(url);
+    if (!store) {
+      return;
+    }
 
-    const runs = storeNames.map(
-      (storeName) => JSON.parse(JSON.stringify(this.#runs.get(storeName))) ?? []
-    );
+    if (store.size <= limit) {
+      return;
+    }
 
-    return runs;
+    const toRemove = [...store.keys()].sort((a, b) => b - a).slice(limit);
+    for (const item of toRemove) {
+      store.delete(item);
+    }
+  }
+
+  async getStoredRuns(
+    url: RunURL
+  ): Promise<Map<RunTimestamp, HarnessRunResult[]>> {
+    if (!this.#runs.has(url)) {
+      return new Map();
+    }
+
+    return this.#runs.get(url)!;
   }
 }

--- a/packages/breadboard/src/data/types.ts
+++ b/packages/breadboard/src/data/types.ts
@@ -71,6 +71,10 @@ export type SerializedDataStoreGroup = SerializedStoredData[];
 /**
  * A provider that handles storing and retrieving data.
  */
+
+export type RunURL = string;
+export type RunTimestamp = number;
+
 export type DataStoreProvider = {
   store(data: InlineDataCapabilityPart): Promise<StoredData>;
   retrieve(handle: DataStoreHandle): Promise<StoredData>;
@@ -79,12 +83,17 @@ export type DataStoreProvider = {
 };
 
 export type RunStore = {
-  start(storeId: string, limit?: number): Promise<string>;
-  write(result: HarnessRunResult): Promise<void>;
-  stop(): Promise<void>;
-  abort(): Promise<void>;
-  drop(): Promise<void>;
-  getNewestRuns(limit: number): Promise<HarnessRunResult[][]>;
+  start(url: RunURL): Promise<RunTimestamp>;
+  write(
+    url: RunURL,
+    timestamp: RunTimestamp,
+    result: HarnessRunResult
+  ): Promise<void>;
+  stop(url: RunURL, timestamp: RunTimestamp): Promise<void>;
+  abort(url: RunURL, timestamp: RunTimestamp): Promise<void>;
+  drop(url?: RunURL): Promise<void>;
+  truncate(url: RunURL, limit: number): Promise<void>;
+  getStoredRuns(url: RunURL): Promise<Map<RunTimestamp, HarnessRunResult[]>>;
 };
 
 export type DataStore = {

--- a/packages/breadboard/src/inspector/run/run.ts
+++ b/packages/breadboard/src/inspector/run/run.ts
@@ -23,7 +23,7 @@ import {
   InspectableRunNodeEvent,
   InspectableRunInputs,
 } from "../types.js";
-import { DataStore } from "../../data/types.js";
+import { DataStore, RunTimestamp, RunURL } from "../../data/types.js";
 
 const isInput = (
   event: InspectableRunEvent
@@ -40,101 +40,108 @@ export class RunObserver implements InspectableRunObserver {
   #options: RunObserverOptions;
   #runs: Run[] = [];
   #runLimit = 2;
-  #restoreRuns: Promise<void> = Promise.resolve();
+  #url: RunURL | null = null;
+  #timestamp: RunTimestamp | null = null;
 
   constructor(store: GraphDescriptorStore, options: RunObserverOptions) {
     this.#store = store;
     this.#options = options;
-
-    if (this.#options.runStore) {
-      this.#restoreRuns = this.#options.runStore
-        .getNewestRuns(this.#runLimit)
-        .then((runs) => {
-          for (let i = 0; i < runs.length; i++) {
-            const results = runs[i];
-
-            let run!: Run;
-            for (const result of results) {
-              if (result.type === "graphstart") {
-                const { path, timestamp } = result.data;
-                if (path.length === 0) {
-                  run = new Run(
-                    timestamp,
-                    this.#store,
-                    result.data.graph,
-                    this.#options
-                  );
-
-                  if (!this.#options.skipDataStore) {
-                    this.#options.dataStore?.createGroup(run.dataStoreKey);
-                  }
-                }
-              } else if (result.type === "graphend") {
-                const { path, timestamp } = result.data;
-                if (path.length === 0) {
-                  run.end = timestamp;
-                }
-              }
-
-              if (!run) {
-                console.warn("Unable to restore run");
-              }
-
-              if (!this.#options.skipDataStore) {
-                this.#options.dataStore?.replaceDataParts(
-                  run.dataStoreKey,
-                  result
-                );
-              }
-              run.addResult(result);
-            }
-
-            this.#runs.push(run);
-          }
-        });
-    }
   }
 
   async runs(): Promise<InspectableRun[]> {
     return this.#runs;
   }
 
-  async #storeInRunStore(dataKey: string, result: HarnessRunResult) {
+  async #convertRunInfoToRuns(
+    url: RunURL,
+    runInfo: Map<RunTimestamp, HarnessRunResult[]>
+  ): Promise<Run[]> {
+    const runs = await Promise.all(
+      [...runInfo]
+        .filter(([, events]) => events.length > 0)
+        .sort(([timeA], [timeB]) => {
+          return timeB - timeA;
+        })
+        .map(async ([timestamp, results]) => {
+          let run!: Run;
+
+          for (const result of results) {
+            if (result.type === "graphstart") {
+              const { path } = result.data;
+              if (path.length === 0) {
+                run = new Run(
+                  timestamp,
+                  this.#store,
+                  result.data.graph,
+                  this.#options
+                );
+
+                run.dataStoreKey = `${url}-${timestamp}`;
+                if (!this.#options.skipDataStore) {
+                  // Ensure that we release old blobs if we've encountered this
+                  // run before.
+                  this.#options.dataStore?.releaseGroup(run.dataStoreKey);
+                  this.#options.dataStore?.createGroup(run.dataStoreKey);
+                }
+              }
+            } else if (result.type === "graphend") {
+              const { path, timestamp } = result.data;
+              if (path.length === 0) {
+                run.end = timestamp;
+              }
+            }
+
+            if (!run) {
+              console.warn("Unable to restore run");
+            }
+
+            if (!this.#options.skipDataStore) {
+              await this.#options.dataStore?.replaceDataParts(
+                run.dataStoreKey,
+                result
+              );
+            }
+
+            run.addResult(result);
+          }
+
+          return run;
+        })
+    );
+
+    return runs;
+  }
+
+  async #storeInRunStore(
+    url: RunURL,
+    timestamp: RunTimestamp,
+    result: HarnessRunResult
+  ) {
     const { runStore } = this.#options;
-    if (!runStore) {
+    if (!runStore || !this.#url || !this.#timestamp) {
       return Promise.resolve();
     }
 
-    if (result.type === "graphstart") {
-      const { path } = result.data;
-      if (path.length === 0) {
-        const dataKey = Date.now().toFixed(0);
-        await runStore?.start(dataKey, this.#runLimit);
-      }
-
-      await runStore?.write(result);
-    } else if (result.type === "graphend") {
-      await runStore?.write(result);
-
-      const { path, timestamp } = result.data;
-      const run = this.#runs[0];
-      if (path.length === 0) {
-        await runStore?.stop();
-        run.end = timestamp;
-      }
-    } else if (result.type === "error") {
-      await runStore?.abort();
-    } else if (result.type !== "end") {
-      await runStore?.write(result);
+    if (result.type === "error") {
+      await runStore?.abort(url, timestamp);
+    } else {
+      await runStore?.write(url, timestamp, result);
     }
   }
 
   async observe(result: HarnessRunResult): Promise<void> {
-    await this.#restoreRuns;
-
     if (result.type === "graphstart") {
       const { path, timestamp } = result.data;
       if (path.length === 0) {
+        this.#url = result.data.graph.url ?? "no-url-graph";
+        if (this.#options.runStore) {
+          this.#timestamp = await this.#options.runStore.start(this.#url);
+          const runInfo = await this.#options.runStore.getStoredRuns(this.#url);
+          this.#runs = await this.#convertRunInfoToRuns(this.#url, runInfo);
+        } else {
+          this.#timestamp = timestamp;
+        }
+
         const run = new Run(
           timestamp,
           this.#store,
@@ -148,34 +155,36 @@ export class RunObserver implements InspectableRunObserver {
 
         this.#runs.unshift(run);
 
-        if (this.#runs.length > this.#runLimit) {
-          const groupIds = this.#runs
-            .slice(this.#runLimit)
-            .map((run) => run.dataStoreKey);
-          for (const groupId of groupIds) {
-            if (this.#options.skipDataStore) {
-              continue;
-            }
-
-            this.#options.dataStore?.releaseGroup(groupId);
-          }
-          this.#runs.length = this.#runLimit;
+        if (this.#options.runStore) {
+          await this.#options.runStore.truncate(this.#url, this.#runLimit);
         }
       }
     }
 
     const run = this.#runs[0];
     if (!run) {
-      console.warn("No run available");
+      console.warn(`No run available to store ${result.type} - stopping`);
       return;
     }
 
+    if (!this.#url || !this.#timestamp) {
+      console.warn("No URL or timestamp set for the current run - stopping");
+      return;
+    }
+
+    if (result.type === "graphend") {
+      const { path, timestamp } = result.data;
+      if (path.length === 0) {
+        run.end = timestamp;
+      }
+    }
+
     if (!this.#options.skipDataStore) {
-      this.#options.dataStore?.replaceDataParts(run.dataStoreKey, result);
+      await this.#options.dataStore?.replaceDataParts(run.dataStoreKey, result);
     }
 
     run.addResult(result);
-    await this.#storeInRunStore(run.dataStoreKey, result);
+    await this.#storeInRunStore(this.#url, this.#timestamp, result);
   }
 
   async load(
@@ -193,7 +202,7 @@ export class RunObserver implements InspectableRunObserver {
 }
 
 export class Run implements InspectableRun {
-  public readonly dataStoreKey = crypto.randomUUID();
+  public dataStoreKey: string = crypto.randomUUID();
 
   #events: EventManager;
 

--- a/packages/breadboard/tests/inspector/observer-load.ts
+++ b/packages/breadboard/tests/inspector/observer-load.ts
@@ -31,9 +31,11 @@ const loadRawRun = async (
 ): Promise<InspectableRun> => {
   const s = await readFile(join(BASE_PATH, name), "utf-8");
   const raw = JSON.parse(s) as HarnessRunResult[];
-  await Promise.all(raw.map((result) => observer.observe(result)));
-  const runs = await observer.runs();
+  for (const result of raw) {
+    await observer.observe(result);
+  }
 
+  const runs = await observer.runs();
   return runs[0];
 };
 
@@ -162,7 +164,7 @@ test("run save/load: replaceSecrets correctly replaces secrets", async (t) => {
   }
 });
 
-test("run load/save: serialization produces consistent size", async (t) => {
+test.only("run load/save: serialization produces consistent size", async (t) => {
   const observer = createRunObserver({
     logLevel: "debug",
     dataStore: createDefaultDataStore(),

--- a/packages/breadboard/tests/inspector/observer-load.ts
+++ b/packages/breadboard/tests/inspector/observer-load.ts
@@ -164,7 +164,7 @@ test("run save/load: replaceSecrets correctly replaces secrets", async (t) => {
   }
 });
 
-test.only("run load/save: serialization produces consistent size", async (t) => {
+test("run load/save: serialization produces consistent size", async (t) => {
   const observer = createRunObserver({
     logLevel: "debug",
     dataStore: createDefaultDataStore(),

--- a/packages/data-store/tests/run/idb-run-store.browser.test.ts
+++ b/packages/data-store/tests/run/idb-run-store.browser.test.ts
@@ -14,6 +14,44 @@ import {
   isLLMContent,
   toStoredDataPart,
 } from "@google-labs/breadboard";
+import { HarnessRunResult } from "@google-labs/breadboard/harness";
+
+const url = "http://www.example.com";
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const inputResult: HarnessRunResult = {
+  type: "nodeend",
+  data: {
+    node: {
+      id: "input-45dd0a3d",
+      type: "input",
+    },
+    inputs: {},
+    path: [],
+    timestamp: 10,
+    outputs: {
+      content: {
+        role: "user",
+        parts: [
+          {
+            inlineData: {
+              data: "aabbcc",
+              mimeType: "text/plain",
+            },
+          },
+        ],
+      },
+    },
+  },
+  async reply() {},
+};
+
+function copyResult(result: HarnessRunResult): HarnessRunResult {
+  // We can't use structuredClone because of the async function, so we fall back
+  // to using parse/stringify to make a copy.
+  return JSON.parse(JSON.stringify(result));
+}
 
 before(async () => {
   const store = new IDBRunStore();
@@ -21,27 +59,92 @@ before(async () => {
 });
 
 it("IDBRunStore stores run events", async () => {
-  const store = new IDBRunStore();
-  await store.start("store");
+  const runStore = new IDBRunStore();
+  const url = "http://www.example.com";
+  const timestamp = await runStore.start(url);
 
   for (const result of simpleRunResults) {
-    await store.write(result);
+    await runStore.write(url, timestamp, result);
   }
 
-  await store.stop();
-  const runs = await store.getNewestRuns();
+  await runStore.stop(url, timestamp);
+  const runs = await runStore.getStoredRuns(url);
 
-  expect(runs.length).to.equal(1);
-  expect(runs[0].length).to.equal(8);
+  expect(runs.size).to.equal(1);
+  expect([...runs.values()][0].length).to.equal(8);
 
-  await store.drop();
+  await runStore.drop();
+});
+
+it("IDBRunStore creates multiple stores per URL", async () => {
+  const runStore = new IDBRunStore();
+
+  const runTimestamp = await runStore.start(url);
+  await runStore.stop(url, runTimestamp);
+
+  // Wait 10ms so that the timestamps of the two runs don't clash.
+  await delay(10);
+
+  const runTimestamp2 = await runStore.start(url);
+  await runStore.stop(url, runTimestamp2);
+
+  const runs = await runStore.getStoredRuns(url);
+  expect(runs.size).to.equal(2);
+
+  await runStore.drop();
+});
+
+it("IDBRunStore writes data", async () => {
+  const runStore = new IDBRunStore();
+  const result = copyResult(inputResult);
+  const runTimestamp = await runStore.start(url);
+  await runStore.write(url, runTimestamp, result);
+  await runStore.stop(url, runTimestamp);
+  const runs = await runStore.getStoredRuns(url);
+
+  expect(runs.size).to.equal(1);
+  expect(runs.get(runTimestamp)![0].type).to.deep.equal(result.type);
+  expect(runs.get(runTimestamp)![0].data).to.deep.equal(result.data);
+  await runStore.drop();
+});
+
+it("IDBRunStore drops data", async () => {
+  const runStore = new IDBRunStore();
+  const result = copyResult(inputResult);
+  const runTimestamp = await runStore.start(url);
+  await runStore.write(url, runTimestamp, result);
+  await runStore.stop(url, runTimestamp);
+  await runStore.drop();
+  const runs = await runStore.getStoredRuns(url);
+  expect(runs.size).to.equal(0);
+});
+
+it.only("IDBRunStore truncates data", async () => {
+  const runStore = new IDBRunStore();
+  const result = copyResult(inputResult);
+
+  const runTimestamp = await runStore.start(url);
+  await runStore.write(url, runTimestamp, result);
+  await runStore.stop(url, runTimestamp);
+
+  // Wait 10ms so that the timestamps of the two runs don't clash.
+  await delay(10);
+
+  const runTimestamp2 = await runStore.start(url);
+  await runStore.write(url, runTimestamp2, result);
+  await runStore.stop(url, runTimestamp2);
+
+  await runStore.truncate(url, 1);
+  const runs = await runStore.getStoredRuns(url);
+  expect(runs.size).to.equal(1);
+  expect(runs.get(runTimestamp2)).to.be.ok;
 });
 
 it("IDBRunStore replaces storedData with inlineData when writing", async () => {
   // Step 1. Write the data in, converting inlineData parts to storedDataParts
   // before they get written in.
-  const store = new IDBRunStore();
-  await store.start("store");
+  const runStore = new IDBRunStore();
+  const timestamp = await runStore.start(url);
 
   for (const result of inlineDataRunResults) {
     if (result.type === "nodeend" && result.data.node.type === "input") {
@@ -61,20 +164,21 @@ it("IDBRunStore replaces storedData with inlineData when writing", async () => {
       }
     }
 
-    await store.write(result);
+    await runStore.write(url, timestamp, result);
   }
 
-  await store.stop();
+  await runStore.stop(url, timestamp);
 
   // Step 2. Get the run.
-  const run = await store.getNewestRuns();
+  const run = await runStore.getStoredRuns(url);
+  const runValues = [...run.values()];
 
-  expect(run.length).to.equal(1);
-  expect(run[0].length).to.equal(8);
-  expect(run[0][3].type).to.equal("nodeend");
+  expect(run.size).to.equal(1);
+  expect(runValues[0].length).to.equal(8);
+  expect(runValues[0][3].type).to.equal("nodeend");
 
   // Step 3. Assert we have an inlineData object.
-  const nodeToInspect = run[0][3];
+  const nodeToInspect = runValues[0][3];
   if (
     nodeToInspect.type === "nodeend" &&
     nodeToInspect.data.node.type === "input"
@@ -94,5 +198,5 @@ it("IDBRunStore replaces storedData with inlineData when writing", async () => {
     expect.fail("Unexpected node type");
   }
 
-  await store.drop();
+  await runStore.drop();
 });

--- a/packages/data-store/tests/run/idb-run-store.browser.test.ts
+++ b/packages/data-store/tests/run/idb-run-store.browser.test.ts
@@ -119,7 +119,7 @@ it("IDBRunStore drops data", async () => {
   expect(runs.size).to.equal(0);
 });
 
-it.only("IDBRunStore truncates data", async () => {
+it("IDBRunStore truncates data", async () => {
   const runStore = new IDBRunStore();
   const result = copyResult(inputResult);
 
@@ -138,6 +138,8 @@ it.only("IDBRunStore truncates data", async () => {
   const runs = await runStore.getStoredRuns(url);
   expect(runs.size).to.equal(1);
   expect(runs.get(runTimestamp2)).to.be.ok;
+
+  await runStore.drop();
 });
 
 it("IDBRunStore replaces storedData with inlineData when writing", async () => {
@@ -173,6 +175,7 @@ it("IDBRunStore replaces storedData with inlineData when writing", async () => {
   const run = await runStore.getStoredRuns(url);
   const runValues = [...run.values()];
 
+  console.log(run.size);
   expect(run.size).to.equal(1);
   expect(runValues[0].length).to.equal(8);
   expect(runValues[0][3].type).to.equal("nodeend");

--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -31,6 +31,26 @@
     "./providers": {
       "types": "./build/providers/types.d.ts",
       "default": "./build/providers/types.js"
+    },
+    "./user-input": {
+      "types": "./build/ui/elements/input/user-input.d.ts",
+      "default": "./build/ui/elements/input/user-input.js"
+    },
+    "./llm-input": {
+      "types": "./build/ui/elements/input/llm-input/llm-input.d.ts",
+      "default": "./build/ui/elements/input/llm-input/llm-input.js"
+    },
+    "./llm-input-array": {
+      "types": "./build/ui/elements/input/llm-input/llm-input-array.d.ts",
+      "default": "./build/ui/elements/input/llm-input/llm-input-array.js"
+    },
+    "./llm-output-array": {
+      "types": "./build/ui/elements/llm-output/llm-output-array.d.ts",
+      "default": "./build/ui/elements/llm-output/llm-output-array.js"
+    },
+    "./llm-output": {
+      "types": "./build/ui/elements/llm-output/llm-output.d.ts",
+      "default": "./build/ui/elements/llm-output/llm-output.js"
     }
   },
   "types": "build/index.d.ts",


### PR DESCRIPTION
Fixes #2734

This ended up being a whopper of a fix! We now store runs per URL by timestamp, which means a couple of things:

1. We no longer "leak" inputs across runs when the board changes. (Previously if two boards had identically-named inputs we would pre-fill the input based on another unrelated run.)
2. The Run Observer restores the runs from the store before creating a new one, which means if a board is open in multiple browser tabs the Run Observer will pick up the runs created in other tabs automatically.

All tests are updated.