### PR TITLE
start tags

### DIFF
--- a/.changeset/six-numbers-train.md
+++ b/.changeset/six-numbers-train.md
@@ -1,0 +1,6 @@
+---
+"@google-labs/breadboard": minor
+"@google-labs/breadboard-schema": minor
+---
+
+Add support for multiple graph entry points and start tags.

--- a/packages/breadboard/src/harness/local.ts
+++ b/packages/breadboard/src/harness/local.ts
@@ -146,7 +146,7 @@ export async function* runLocally(config: RunConfig, kits: Kit[]) {
     const runner = config.runner || (await load(config));
     const loader = config.loader || createLoader();
     const store = config.store || createDefaultDataStore();
-    const { base, signal, inputs, state } = config;
+    const { base, signal, inputs, state, start } = config;
 
     try {
       let last: LastNode | undefined;
@@ -167,6 +167,7 @@ export async function* runLocally(config: RunConfig, kits: Kit[]) {
         signal,
         inputs,
         state,
+        start,
       })) {
         last = maybeSaveResult(data, last);
         await next(fromRunnerResult(data));

--- a/packages/breadboard/src/harness/types.ts
+++ b/packages/breadboard/src/harness/types.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { StartLabel } from "@google-labs/breadboard-schema/graph.js";
 import type { DataStore } from "../data/types.js";
 import { InspectableRunObserver } from "../inspector/types.js";
 import type { GraphLoader } from "../loader/types.js";
@@ -201,6 +202,12 @@ export type RunConfig = {
    * The state from which to resume the run.
    */
   state?: ManagedRunState;
+  /**
+   * Start label to use for the run. This is useful for specifying a particular
+   * node as the start of the run. If not provided, nodes without any incoming
+   * edges will be used.
+   */
+  start?: StartLabel;
 };
 
 export type RunEventMap = {

--- a/packages/breadboard/src/run/run-graph.ts
+++ b/packages/breadboard/src/run/run-graph.ts
@@ -32,7 +32,7 @@ export async function* runGraph(
   resumeFrom?: TraversalResult
 ): AsyncGenerator<BreadboardRunResult> {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { inputs, ...context } = args;
+  const { inputs, start, ...context } = args;
   const { probe, state, invocationPath = [] } = context;
 
   const lifecycle = state?.lifecycle();
@@ -82,7 +82,7 @@ export async function* runGraph(
 
     const path = () => [...invocationPath, invocationId];
 
-    const machine = new TraversalMachine(graph, resumeFrom);
+    const machine = new TraversalMachine(graph, resumeFrom, start);
     await probe?.report?.({
       type: "graphstart",
       data: { graph, path: invocationPath, timestamp: timestamp() },

--- a/packages/breadboard/src/traversal/index.ts
+++ b/packages/breadboard/src/traversal/index.ts
@@ -24,7 +24,8 @@ const isStartNode = (
   if (!node.metadata?.tags) return false;
   return node.metadata.tags.some((tag) => {
     const startTag = tag as StartTag;
-    if (!("type" in startTag) || startTag.type !== "start") return false;
+    if (typeof startTag === "string") return startTag === "start";
+    if (startTag.type !== "start") return false;
     const label = startTag.label ?? "default";
     return start === label;
   });

--- a/packages/breadboard/src/traversal/iterator.ts
+++ b/packages/breadboard/src/traversal/iterator.ts
@@ -14,16 +14,10 @@ export class TraversalMachineIterator
 {
   graph: GraphRepresentation;
   #current: TraversalResult;
-  #noParallelExecution: boolean;
 
-  constructor(
-    graph: GraphRepresentation,
-    result: TraversalResult,
-    noParallelExecution = true
-  ) {
+  constructor(graph: GraphRepresentation, result: TraversalResult) {
     this.graph = graph;
     this.#current = result;
-    this.#noParallelExecution = noParallelExecution;
   }
 
   async next(): Promise<IteratorResult<TraversalResult>> {

--- a/packages/breadboard/src/traversal/machine.ts
+++ b/packages/breadboard/src/traversal/machine.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { StartLabel } from "@google-labs/breadboard-schema/graph.js";
 import type { GraphDescriptor, TraversalResult } from "../types.js";
 import { TraversalMachineIterator } from "./iterator.js";
 import { GraphRepresentation } from "./representation.js";
@@ -14,8 +15,12 @@ export class TraversalMachine implements AsyncIterable<TraversalResult> {
   graph: GraphRepresentation;
   previousResult?: TraversalResult;
 
-  constructor(descriptor: GraphDescriptor, result?: TraversalResult) {
-    this.graph = new GraphRepresentation(descriptor);
+  constructor(
+    descriptor: GraphDescriptor,
+    result?: TraversalResult,
+    start?: StartLabel
+  ) {
+    this.graph = new GraphRepresentation(descriptor, start);
     this.previousResult = result;
   }
 

--- a/packages/breadboard/src/traversal/representation.ts
+++ b/packages/breadboard/src/traversal/representation.ts
@@ -41,6 +41,7 @@ export class GraphRepresentation {
   #findEntries() {
     const entries = new Set<NodeIdentifier>();
     const start = this.start ?? "default";
+    let hasStartLabels = false;
     this.nodes.forEach((node) => {
       node.metadata?.tags?.forEach((tag) => {
         const startTag = tag as StartTag;
@@ -48,6 +49,7 @@ export class GraphRepresentation {
           entries.add(node.id);
         } else if (startTag.type === "start") {
           const label = startTag.label ?? "default";
+          hasStartLabels = true;
           if (label === start) {
             entries.add(node.id);
           }
@@ -60,6 +62,12 @@ export class GraphRepresentation {
       return Array.from(entries);
     }
 
+    // If there were start labels present, return an empty array, since we
+    // are asked to traverse a graph from a non-existent entry point.
+    if (hasStartLabels) {
+      return [];
+    }
+
     // Otherwise, fall back to computing entries based on edges.
     return Array.from(this.nodes.keys()).filter((node) =>
       this.#notInHeads(node)
@@ -67,7 +75,7 @@ export class GraphRepresentation {
   }
 
   constructor(descriptor: GraphDescriptor, start?: StartLabel) {
-    if (this.start) {
+    if (start) {
       this.start = start;
     }
     this.tails = descriptor.edges.reduce((acc, edge) => {

--- a/packages/breadboard/src/traversal/representation.ts
+++ b/packages/breadboard/src/traversal/representation.ts
@@ -44,7 +44,9 @@ export class GraphRepresentation {
     this.nodes.forEach((node) => {
       node.metadata?.tags?.forEach((tag) => {
         const startTag = tag as StartTag;
-        if ("type" in startTag && startTag.type === "start") {
+        if (typeof startTag === "string" && startTag === "start") {
+          entries.add(node.id);
+        } else if (startTag.type === "start") {
           const label = startTag.label ?? "default";
           if (label === start) {
             entries.add(node.id);

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -15,6 +15,7 @@ import type {
   NodeTypeIdentifier,
   NodeValue,
   OutputValues,
+  StartLabel,
 } from "@google-labs/breadboard-schema/graph.js";
 import { GraphLoader } from "./loader/types.js";
 import {
@@ -714,6 +715,12 @@ export type RunArguments = NodeHandlerContext & {
    * action will be taken. For example, the web-based harness will ask the user.
    */
   inputs?: InputValues;
+  /**
+   * Start label to use for the run. This is useful for specifying a particular
+   * node as the start of the run. If not provided, nodes without any incoming
+   * edges will be used.
+   */
+  start?: StartLabel;
 };
 
 export interface BreadboardNode<Inputs, Outputs> {

--- a/packages/breadboard/tests/data/describe-start-tag-no-run.json
+++ b/packages/breadboard/tests/data/describe-start-tag-no-run.json
@@ -1,0 +1,37 @@
+{
+  "edges": [
+    {
+      "from": "node-b",
+      "out": "text",
+      "to": "node-c",
+      "in": "data"
+    },
+    {
+      "from": "node-a",
+      "out": "text",
+      "to": "node-d",
+      "in": "data"
+    }
+  ],
+  "nodes": [
+    { "id": "node-a", "type": "input" },
+    {
+      "id": "node-b",
+      "type": "input",
+      "metadata": {
+        "tags": [
+          {
+            "type": "start",
+            "label": "describe"
+          }
+        ]
+      }
+    },
+    { "id": "node-c", "type": "output" },
+    { "id": "node-d", "type": "output" }
+  ],
+  "inputs": { "text": "foo" },
+  "outputs": [],
+  "sequence": [],
+  "throws": true
+}

--- a/packages/breadboard/tests/data/describe-start-tag-run.json
+++ b/packages/breadboard/tests/data/describe-start-tag-run.json
@@ -1,0 +1,37 @@
+{
+  "edges": [
+    {
+      "from": "node-b",
+      "out": "text",
+      "to": "node-c",
+      "in": "data"
+    },
+    {
+      "from": "node-a",
+      "out": "text",
+      "to": "node-d",
+      "in": "data"
+    }
+  ],
+  "nodes": [
+    { "id": "node-a", "type": "input" },
+    {
+      "id": "node-b",
+      "type": "input",
+      "metadata": {
+        "tags": [
+          {
+            "type": "start",
+            "label": "describe"
+          }
+        ]
+      }
+    },
+    { "id": "node-c", "type": "output" },
+    { "id": "node-d", "type": "output" }
+  ],
+  "inputs": { "text": "foo" },
+  "outputs": [{ "data": "foo" }],
+  "sequence": ["node-b", "node-c"],
+  "start": "describe"
+}

--- a/packages/breadboard/tests/data/simple-start-tag.json
+++ b/packages/breadboard/tests/data/simple-start-tag.json
@@ -1,0 +1,31 @@
+{
+  "edges": [
+    {
+      "from": "node-b",
+      "out": "text",
+      "to": "node-c",
+      "in": "data"
+    },
+    {
+      "from": "node-a",
+      "out": "text",
+      "to": "node-d",
+      "in": "data"
+    }
+  ],
+  "nodes": [
+    { "id": "node-a", "type": "input" },
+    {
+      "id": "node-b",
+      "type": "input",
+      "metadata": {
+        "tags": ["start"]
+      }
+    },
+    { "id": "node-c", "type": "output" },
+    { "id": "node-d", "type": "output" }
+  ],
+  "inputs": { "text": "foo" },
+  "outputs": [{ "data": "foo" }],
+  "sequence": ["node-b", "node-c"]
+}

--- a/packages/breadboard/tests/data/specified-start-tag.json
+++ b/packages/breadboard/tests/data/specified-start-tag.json
@@ -1,0 +1,35 @@
+{
+  "edges": [
+    {
+      "from": "node-b",
+      "out": "text",
+      "to": "node-c",
+      "in": "data"
+    },
+    {
+      "from": "node-a",
+      "out": "text",
+      "to": "node-d",
+      "in": "data"
+    }
+  ],
+  "nodes": [
+    { "id": "node-a", "type": "input" },
+    {
+      "id": "node-b",
+      "type": "input",
+      "metadata": {
+        "tags": [
+          {
+            "type": "start"
+          }
+        ]
+      }
+    },
+    { "id": "node-c", "type": "output" },
+    { "id": "node-d", "type": "output" }
+  ],
+  "inputs": { "text": "foo" },
+  "outputs": [{ "data": "foo" }],
+  "sequence": ["node-b", "node-c"]
+}

--- a/packages/breadboard/tests/data/start-tag-in-the-middle.json
+++ b/packages/breadboard/tests/data/start-tag-in-the-middle.json
@@ -1,0 +1,33 @@
+{
+  "edges": [
+    {
+      "from": "node-a",
+      "out": "text",
+      "to": "node-b",
+      "in": "text"
+    },
+    {
+      "from": "node-b",
+      "out": "text",
+      "to": "node-c",
+      "in": "text"
+    }
+  ],
+  "nodes": [
+    { "id": "node-a", "type": "input" },
+    {
+      "id": "node-b",
+      "type": "make",
+      "metadata": {
+        "tags": [
+          {
+            "type": "start"
+          }
+        ]
+      }
+    },
+    { "id": "node-c", "type": "output" }
+  ],
+  "outputs": [{ "text": "Hello, world!" }],
+  "sequence": ["node-b", "node-c"]
+}

--- a/packages/breadboard/tests/machine.ts
+++ b/packages/breadboard/tests/machine.ts
@@ -17,6 +17,7 @@ import {
   OutputValues,
 } from "../src/types.js";
 import { MachineResult } from "../src/traversal/result.js";
+import { StartLabel } from "@google-labs/breadboard-schema/graph.js";
 
 const IN_DIR = "./tests/data/";
 
@@ -25,6 +26,7 @@ interface TestGraphDescriptor extends GraphDescriptor {
   inputs: InputValues;
   outputs: OutputValues[];
   throws: boolean;
+  start: StartLabel;
 }
 
 const graphs = (await readdir(`${IN_DIR}/`)).filter((file) =>
@@ -41,7 +43,7 @@ await Promise.all(
         t.log("Skipped");
         return;
       }
-      const machine = new TraversalMachine(graph);
+      const machine = new TraversalMachine(graph, undefined, graph.start);
       const outputs: OutputValues[] = [];
       const sequence: string[] = [];
       const run = async () => {

--- a/packages/breadboard/tests/machine.ts
+++ b/packages/breadboard/tests/machine.ts
@@ -62,6 +62,11 @@ await Promise.all(
               result.outputs = list.length ? { list, text } : { text };
               break;
             }
+            case "make": {
+              // A node that creates its own output.
+              result.outputs = { text: "Hello, world!" };
+              break;
+            }
             case "error": {
               result.outputs = {
                 $error: {

--- a/packages/schema/breadboard.schema.json
+++ b/packages/schema/breadboard.schema.json
@@ -303,10 +303,53 @@
 						"info"
 					],
 					"description": "Logging level."
+				},
+				"tags": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/NodeTag"
+					},
+					"description": "Tags associated with the node. Can be either a string or a structured tag, like a `StartTag`."
 				}
 			},
 			"additionalProperties": false,
 			"description": "Represents metadata of a node. This is an optional part of the `NodeDescriptor` that can be used to provide additional information about the node."
+		},
+		"NodeTag": {
+			"anyOf": [
+				{
+					"type": "string"
+				},
+				{
+					"$ref": "#/definitions/StartTag"
+				}
+			],
+			"description": "Represents a tag that can be associated with a node."
+		},
+		"StartTag": {
+			"type": "object",
+			"properties": {
+				"type": {
+					"type": "string",
+					"const": "start"
+				},
+				"label": {
+					"$ref": "#/definitions/StartLabel"
+				}
+			},
+			"required": [
+				"type"
+			],
+			"additionalProperties": false,
+			"description": "Represents a start tag, which is a special tag that can be associated with a node. It is used to indicate that the node is a starting point for traversal. The `label` field allows the user to specify additional way to specify the kind of traversal they are looking for."
+		},
+		"StartLabel": {
+			"type": "string",
+			"enum": [
+				"default",
+				"describe"
+			],
+			"description": "Valid start labels."
 		},
 		"GraphTag": {
 			"type": "string",

--- a/packages/schema/breadboard.schema.json
+++ b/packages/schema/breadboard.schema.json
@@ -318,7 +318,8 @@
 		"NodeTag": {
 			"anyOf": [
 				{
-					"type": "string"
+					"type": "string",
+					"const": "start"
 				},
 				{
 					"$ref": "#/definitions/StartTag"

--- a/packages/schema/breadboard.schema.json
+++ b/packages/schema/breadboard.schema.json
@@ -61,6 +61,11 @@
 					"description": "For internal testing only. Do not use.",
 					"deprecated": "For internal testing only. Do not use."
 				},
+				"start": {
+					"$ref": "#/definitions/StartLabel",
+					"description": "For internal testing only. Do not use.",
+					"deprecated": "For internal testing only. Do not use."
+				},
 				"metadata": {
 					"$ref": "#/definitions/GraphMetadata",
 					"description": "Metadata associated with the graph."
@@ -188,6 +193,14 @@
 		"NodeIdentifier": {
 			"type": "string",
 			"description": "Unique identifier of a node in a graph."
+		},
+		"StartLabel": {
+			"type": "string",
+			"enum": [
+				"default",
+				"describe"
+			],
+			"description": "Valid start labels."
 		},
 		"GraphMetadata": {
 			"type": "object",
@@ -343,14 +356,6 @@
 			],
 			"additionalProperties": false,
 			"description": "Represents a start tag, which is a special tag that can be associated with a node. It is used to indicate that the node is a starting point for traversal. The `label` field allows the user to specify additional way to specify the kind of traversal they are looking for."
-		},
-		"StartLabel": {
-			"type": "string",
-			"enum": [
-				"default",
-				"describe"
-			],
-			"description": "Valid start labels."
 		},
 		"GraphTag": {
 			"type": "string",

--- a/packages/schema/src/graph.ts
+++ b/packages/schema/src/graph.ts
@@ -149,7 +149,33 @@ export type NodeMetadata = {
    * Logging level.
    */
   logLevel?: "debug" | "info";
+  /**
+   * Tags associated with the node. Can be either a string or a structured tag,
+   * like a `StartTag`.
+   */
+  tags?: NodeTag[];
 };
+
+/**
+ * Represents a tag that can be associated with a node.
+ */
+export type NodeTag = string | StartTag;
+
+/**
+ * Represents a start tag, which is a special tag that can be associated with a
+ * node. It is used to indicate that the node is a starting point for traversal.
+ * The `label` field allows the user to specify additional way to specify the
+ * kind of traversal they are looking for.
+ */
+export type StartTag = {
+  type: "start";
+  label?: StartLabel;
+};
+
+/**
+ * Valid start labels.
+ */
+export type StartLabel = "default" | "describe";
 
 /**
  * Represents references to a "kit": a collection of `NodeHandlers`.

--- a/packages/schema/src/graph.ts
+++ b/packages/schema/src/graph.ts
@@ -159,7 +159,15 @@ export type NodeMetadata = {
 /**
  * Represents a tag that can be associated with a node.
  */
-export type NodeTag = string | StartTag;
+export type NodeTag =
+  /**
+   * A simple start tag, which is the same as { type: "start" }.
+   */
+  | "start"
+  /**
+   * A tag that indicates that the node is a starting point for traversal.
+   */
+  | StartTag;
 
 /**
  * Represents a start tag, which is a special tag that can be associated with a

--- a/packages/schema/src/graph.ts
+++ b/packages/schema/src/graph.ts
@@ -360,6 +360,12 @@ type TestProperties = {
    * @deprecated For internal testing only. Do not use.
    */
   explanation?: string;
+
+  /**
+   * For internal testing only. Do not use.
+   * @deprecated For internal testing only. Do not use.
+   */
+  start?: StartLabel;
 };
 
 /**


### PR DESCRIPTION
- **Remove `noParallelExecution` flag.**
- **Sketch out the basics.**
- **Allow starting from the middle of a graph.**
- **Allow simple start tags.**
- **Teach TraversalMachine to start with different labels.**
- **Plumb `StartLabel` to `RunArguments`.**
- **Plumb `StartLabel` to Run API.**
- **docs(changeset): Add support for multiple graph entry points and start tags.**
