### PR TITLE
[build] Make the annotate function additive

### DIFF
--- a/.changeset/smooth-lies-sniff.md
+++ b/.changeset/smooth-lies-sniff.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Behaviors added with the annotate function are now additive instead of clobbery.

--- a/packages/build/src/internal/type-system/annotate.ts
+++ b/packages/build/src/internal/type-system/annotate.ts
@@ -16,10 +16,14 @@ export function annotate<T extends BreadboardType>(
     behavior: BehaviorSchema[];
   }
 ): T {
+  const original = toJSONSchema(value);
+  const behavior = [
+    ...new Set([...(original.behavior ?? []), ...annotations.behavior]),
+  ];
   return {
     jsonSchema: {
-      ...annotations,
-      ...toJSONSchema(value),
+      ...original,
+      behavior,
     },
   } as BreadboardType as T;
 }

--- a/packages/build/src/test/type-expressions/annotate_test.ts
+++ b/packages/build/src/test/type-expressions/annotate_test.ts
@@ -55,14 +55,14 @@ test("behaviors are additive", () => {
       // $ExpectType "string"
       annotate(
         annotate("string", {
-          behavior: ["llm-content"],
+          behavior: ["llm-content", "deprecated"],
         }),
         { behavior: ["llm-content", "config"] }
       )
     ),
     {
       type: "string",
-      behavior: ["llm-content", "config"],
+      behavior: ["llm-content", "deprecated", "config"],
     }
   );
 });

--- a/packages/build/src/test/type-expressions/annotate_test.ts
+++ b/packages/build/src/test/type-expressions/annotate_test.ts
@@ -48,3 +48,21 @@ test("can annotate basic type with behavior", () => {
     }
   );
 });
+
+test("behaviors are additive", () => {
+  assert.deepEqual(
+    toJSONSchema(
+      // $ExpectType "string"
+      annotate(
+        annotate("string", {
+          behavior: ["llm-content"],
+        }),
+        { behavior: ["llm-content", "config"] }
+      )
+    ),
+    {
+      type: "string",
+      behavior: ["llm-content", "config"],
+    }
+  );
+});


### PR DESCRIPTION
So that you can annotate a type with an existing behavior and they will get merged together, instead of clobbered.