### PR TITLE
[build] New improved board function

### DIFF
--- a/.changeset/blue-sheep-smile.md
+++ b/.changeset/blue-sheep-smile.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": minor
+---
+
+Changes to the signature of the board function. Introduces new inputNode and outputNode functions which are used for polymorphic boards.

--- a/.changeset/small-geese-dance.md
+++ b/.changeset/small-geese-dance.md
@@ -1,0 +1,6 @@
+---
+"@google-labs/gemini-kit": patch
+"@google-labs/core-kit": patch
+---
+
+Updates for new board function API in build package

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { board } from "./internal/board/board.js";
+export { board, inputNode, outputNode } from "./internal/board/board.js";
 export { constant } from "./internal/board/constant.js";
 export { converge } from "./internal/board/converge.js";
 export { input } from "./internal/board/input.js";

--- a/packages/build/src/internal/board/output.ts
+++ b/packages/build/src/internal/board/output.ts
@@ -4,12 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { OutputPortReference } from "../common/port.js";
+import type { Value } from "../common/value.js";
 import type { JsonSerializable } from "../type-system/type.js";
-import type { Input, InputWithDefault } from "./input.js";
 
-export function output<T extends JsonSerializable>(
-  port: Output<T> | OutputPortReference<T> | Input<T> | InputWithDefault<T>,
+export function output<T extends JsonSerializable | undefined>(
+  port: Value<T>,
   {
     id,
     title,
@@ -25,16 +24,14 @@ export function output<T extends JsonSerializable>(
   };
 }
 
-export interface Output<T extends JsonSerializable | undefined> {
+export interface Output<
+  T extends JsonSerializable | undefined = JsonSerializable | undefined,
+> {
   readonly __SpecialOutputBrand: true;
   readonly id?: string;
   readonly title?: string;
   readonly description?: string;
-  readonly port:
-    | Output<T>
-    | OutputPortReference<T>
-    | Input<T>
-    | InputWithDefault<T>;
+  readonly port: Value<T>;
 }
 
 export function isSpecialOutput(

--- a/packages/build/src/internal/board/serialize.ts
+++ b/packages/build/src/internal/board/serialize.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 // TODO(aomarks) Switch import to schema package
 import type {
   GraphDescriptor,
@@ -19,7 +21,7 @@ import type {
 } from "../common/serializable.js";
 import { type JsonSerializable } from "../type-system/type.js";
 import {
-  BoardInstance,
+  OldBoardInstance,
   describeInput,
   describeOutput,
   isBoard,
@@ -280,10 +282,10 @@ export function serialize(board: SerializableBoard): GraphDescriptor {
             !required
           );
         }
-      } else if ("node" in port) {
+      } else if ("node" in (port as any)) {
         addEdge(
-          visitNodeAndReturnItsId(port.node),
-          port.name,
+          visitNodeAndReturnItsId((port as any).node),
+          (port as any).name,
           outputNodeId,
           name,
           isConstant(output),
@@ -343,7 +345,7 @@ export function serialize(board: SerializableBoard): GraphDescriptor {
   return bgl;
 
   function visitNodeAndReturnItsId(
-    node: SerializableNode | BoardInstance<BoardInputPorts, BoardOutputPorts>
+    node: SerializableNode | OldBoardInstance<BoardInputPorts, BoardOutputPorts>
   ): string {
     let descriptor = nodes.get(node);
     if (descriptor !== undefined) {

--- a/packages/build/src/internal/common/serializable.ts
+++ b/packages/build/src/internal/common/serializable.ts
@@ -61,6 +61,7 @@ export interface SerializableBoard {
           | InputWithDefault<JsonSerializable>
         >
       >;
+  id?: string;
   title?: string;
   description?: string;
   version?: string;

--- a/packages/build/src/internal/common/type-util.ts
+++ b/packages/build/src/internal/common/type-util.ts
@@ -64,3 +64,31 @@ export type BroadenBasicType<T extends string | number | boolean> =
  * See https://github.com/microsoft/TypeScript/issues/31751#issuecomment-498526919
  */
 export type IsNever<T> = [T] extends [never] ? true : false;
+
+/**
+ * Remove all readonly modifiers on an object.
+ */
+export type RemoveReadonly<T> = { -readonly [K in keyof T]: T[K] };
+
+/**
+ * For each property in an object, if its value can be `undefined`, mark that
+ * property as optional.
+ */
+export type AutoOptional<T> =
+  T /* See Distributive Conditional Types */ extends unknown
+    ? {
+        [K in keyof T as undefined extends T[K] ? K : never]?: T[K];
+      } & { [K in keyof T as undefined extends T[K] ? never : K]: T[K] }
+    : never;
+
+export type FlattenUnion<T> = {
+  [K in keyof UnionToIntersection<T>]: K extends keyof T
+    ? T[K]
+    : UnionToIntersection<T>[K] | undefined;
+};
+
+export type UnionToIntersection<U> = (
+  U extends unknown ? (k: U) => void : never
+) extends (k: infer I) => void
+  ? I
+  : never;

--- a/packages/build/src/internal/common/value.ts
+++ b/packages/build/src/internal/common/value.ts
@@ -18,6 +18,7 @@ import {
 } from "../type-system/type.js";
 import {
   isOutputPortReference,
+  OutputPort,
   OutputPortGetter,
   type OutputPortReference,
 } from "./port.js";
@@ -33,13 +34,16 @@ import {
  * - A node with a primary string-typed output port.
  * - A string-typed `input`.
  */
-export type Value<T extends JsonSerializable> =
+export type Value<
+  T extends JsonSerializable | undefined = JsonSerializable | undefined,
+> =
   | T
+  | OutputPort<T>
   | OutputPortReference<T>
   | Input<T>
   | InputWithDefault<T>
-  | Loopback<T>
-  | Convergence<T>;
+  | Loopback<Exclude<T, /* TODO(aomarks) Questionable */ undefined>>
+  | Convergence<Exclude<T, /* TODO(aomarks) Questionable */ undefined>>;
 
 /**
  * Given a Breadboard {@link Value}, determine its JSON Schema type.

--- a/packages/build/src/internal/define/definition.ts
+++ b/packages/build/src/internal/define/definition.ts
@@ -52,7 +52,7 @@ import { array } from "../type-system/array.js";
 import { object } from "../type-system/object.js";
 import { normalizeBreadboardError } from "../common/error.js";
 import type { Convergence } from "../board/converge.js";
-import type { BoardDefinition } from "../board/board.js";
+import type { SerializableBoard } from "../common/serializable.js";
 
 export interface Definition<
   /* Static Inputs   */ SI extends { [K: string]: JsonSerializable },
@@ -475,8 +475,7 @@ type StrictInstantiateArgs<
   [K in keyof Omit<SI, OI | "$id" | "$metadata">]: IM[K extends keyof IM
     ? K
     : never]["board"] extends true
-    ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      InstantiateArg<SI[K]> | BoardDefinition<any, any>
+    ? InstantiateArg<SI[K]> | SerializableBoard
     : InstantiateArg<SI[K]>;
 } & {
   [K in OI]?:

--- a/packages/build/src/internal/kit.ts
+++ b/packages/build/src/internal/kit.ts
@@ -12,7 +12,7 @@ import type {
   NodeHandlerContext,
   NodeHandlerFunction,
 } from "@google-labs/breadboard";
-import type { GenericBoardDefinition } from "./board/board.js";
+import type { BoardDefinition } from "./board/board.js";
 import { serialize } from "./board/serialize.js";
 import {
   isDiscreteComponent,
@@ -26,7 +26,7 @@ export interface KitOptions {
   version: string;
   url: string;
   tags?: KitTag[];
-  components: Array<GenericDiscreteComponent | GenericBoardDefinition>;
+  components: Array<GenericDiscreteComponent | BoardDefinition>;
 }
 
 export function kit(options: KitOptions): KitConstructor<Kit> {
@@ -62,7 +62,7 @@ export function kit(options: KitOptions): KitConstructor<Kit> {
   };
 }
 
-function makeBoardComponentHandler(board: GenericBoardDefinition): NodeHandler {
+function makeBoardComponentHandler(board: BoardDefinition): NodeHandler {
   const serialized = serialize(board);
   return {
     metadata: board.metadata,

--- a/packages/build/src/test/better-board_test.ts
+++ b/packages/build/src/test/better-board_test.ts
@@ -1,0 +1,428 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import test, { describe } from "node:test";
+import { board, inputNode, outputNode } from "../internal/board/board.js";
+import { converge, type Convergence } from "../internal/board/converge.js";
+import {
+  input,
+  type Input,
+  type InputWithDefault,
+} from "../internal/board/input.js";
+import { loopback, type Loopback } from "../internal/board/loopback.js";
+import { output, type Output } from "../internal/board/output.js";
+import type {
+  OutputPort,
+  OutputPortReference,
+} from "../internal/common/port.js";
+import type { Value } from "../internal/common/value.js";
+
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+// TODO(aomarks) board definitions that take boards (we have this working for
+// discrete component, but not boards).
+
+describe("input types", () => {
+  test("required", () => {
+    const foo = input();
+    // $ExpectType BoardDefinition<{ foo: string; }, {}>
+    board({ inputs: { foo }, outputs: {} });
+  });
+
+  test("optional", () => {
+    const foo = input({ optional: true });
+    // $ExpectType BoardDefinition<{ foo?: string | undefined; }, {}>
+    board({ inputs: { foo }, outputs: {} });
+  });
+
+  test("with default", () => {
+    const foo = input({ default: "foo" });
+    // $ExpectType BoardDefinition<{ foo?: string | undefined; }, {}>
+    board({ inputs: { foo }, outputs: {} });
+  });
+
+  test("multiple", () => {
+    const foo = input();
+    const bar = input({ type: "number" });
+    const baz = input({ type: "boolean", default: true });
+    const qux = input({ optional: true });
+
+    // $ExpectType BoardDefinition<{ foo: string; }, {}>
+    board({ inputs: [inputNode({ foo })], outputs: {} });
+
+    // $ExpectType BoardDefinition<{ foo: string; } | { bar: number; }, {}>
+    board({ inputs: [inputNode({ foo }), inputNode({ bar })], outputs: {} });
+
+    // $ExpectType BoardDefinition<{ foo: string; bar: number; } | { bar: number; }, {}>
+    board({
+      inputs: [inputNode({ foo, bar }), inputNode({ bar })],
+      outputs: {},
+    });
+
+    // $ExpectType BoardDefinition<{ baz?: boolean | undefined; }, {}>
+    board({ inputs: [inputNode({ baz })], outputs: {} });
+
+    // $ExpectType BoardDefinition<{ qux?: string | undefined; }, {}>
+    board({ inputs: [inputNode({ qux })], outputs: {} });
+  });
+});
+
+describe("output types", () => {
+  test("output port", () => {
+    const foo = {} as OutputPort<string>;
+    // $ExpectType BoardDefinition<{}, { foo: string; }>
+    board({ inputs: {}, outputs: { foo } });
+  });
+
+  test("output port reference", () => {
+    const foo = {} as OutputPortReference<string>;
+    // $ExpectType BoardDefinition<{}, { foo: string; }>
+    board({ inputs: {}, outputs: { foo } });
+  });
+
+  test("input", () => {
+    const foo = input();
+    // $ExpectType BoardDefinition<{}, { foo: string; }>
+    board({ inputs: {}, outputs: { foo } });
+  });
+
+  test("optional input", () => {
+    const foo = input({ optional: true });
+    // $ExpectType BoardDefinition<{}, { foo?: string | undefined; }>
+    board({ inputs: {}, outputs: { foo } });
+  });
+
+  test("input with default", () => {
+    const foo = input({ optional: true });
+    // $ExpectType BoardDefinition<{}, { foo?: string | undefined; }>
+    board({ inputs: {}, outputs: { foo } });
+  });
+
+  test("loopback", () => {
+    const foo = loopback();
+    // $ExpectType BoardDefinition<{}, { foo: string; }>
+    board({ inputs: {}, outputs: { foo } });
+  });
+
+  test("convergence", () => {
+    const foo = converge(input(), input());
+    // $ExpectType BoardDefinition<{}, { foo: string; }>
+    board({ inputs: {}, outputs: { foo } });
+  });
+
+  test("multiple", () => {
+    const foo = input();
+    const bar = input({ type: "number" });
+    const baz = input({ type: "boolean", default: true });
+    const qux = input({ optional: true });
+
+    // $ExpectType BoardDefinition<{}, { foo: string; }>
+    board({ inputs: {}, outputs: [outputNode({ foo })] });
+
+    // $ExpectType BoardDefinition<{}, { baz?: boolean | undefined; }>
+    board({ inputs: {}, outputs: [outputNode({ baz })] });
+
+    // $ExpectType BoardDefinition<{}, { qux?: string | undefined; }>
+    board({ inputs: {}, outputs: [outputNode({ qux })] });
+
+    // $ExpectType BoardDefinition<{}, { foo: string; bar: number; } | { foo: string; }>
+    const b = board({
+      inputs: {},
+      outputs: [outputNode({ foo, bar }), outputNode({ foo })],
+    });
+
+    // $ExpectType { foo: Value<string>; bar: Value<number | undefined>; }
+    b({}).outputs;
+
+    // $ExpectType BoardDefinition<{}, { baz?: boolean | undefined; }>
+    board({ inputs: {}, outputs: [outputNode({ baz })] });
+
+    // $ExpectType BoardDefinition<{}, { qux?: string | undefined; }>
+    board({ inputs: {}, outputs: [outputNode({ qux })] });
+  });
+});
+
+describe("instantiate function", () => {
+  describe("monomorphic", () => {
+    const foo = input();
+    const bar = input({ type: "number", optional: true });
+    // $ExpectType BoardDefinition<{ bar?: number | undefined; foo: string; }, { bar?: number | undefined; foo: string; }>
+    const b = board({ inputs: { foo, bar }, outputs: { foo, bar } });
+    // $ExpectType { bar?: Value<number | undefined>; foo: Value<string>; }
+    const x = {} as Parameters<typeof b>[0];
+
+    test("instance types", () => {
+      // $ExpectType BoardInstance<{ bar?: number | undefined; foo: string; }, { bar?: number | undefined; foo: string; }>
+      const inst = b({ foo: "foo", bar: 123 });
+
+      // $ExpectType { bar?: Value<number | undefined>; foo: Value<string>; }
+      inst.outputs;
+    });
+
+    test("required values", () => {
+      b({ foo: "foo" });
+      b(
+        // @ts-expect-error
+        { bar: 123 }
+      );
+      // @ts-expect-error
+      b();
+      b(
+        // @ts-expect-error
+        {}
+      );
+    });
+
+    test("raw value", () => {
+      b({
+        foo: "foo",
+        bar: 123,
+      });
+
+      b({
+        // @ts-expect-error
+        foo: 123,
+        // @ts-expect-error
+        bar: "bar",
+      });
+    });
+
+    test("output port", () => {
+      b({
+        foo: {} as OutputPort<string>,
+        bar: {} as OutputPort<number>,
+      });
+
+      b({
+        // @ts-expect-error
+        foo: {} as OutputPort<number>,
+        // @ts-expect-error
+        bar: {} as OutputPort<string>,
+      });
+    });
+
+    test("output port reference", () => {
+      b({
+        foo: {} as OutputPortReference<string>,
+        bar: {} as OutputPortReference<number>,
+      });
+
+      b({
+        // @ts-expect-error
+        foo: {} as OutputPortReference<number>,
+        // @ts-expect-error
+        bar: {} as OutputPortReference<string>,
+      });
+    });
+
+    test("input", () => {
+      b({
+        foo: input(),
+        bar: input({ type: "number" }),
+      });
+
+      b({
+        // @ts-expect-error
+        foo: input({ type: "number" }),
+        // @ts-expect-error
+        bar: input(),
+      });
+    });
+
+    test("optional input", () => {
+      b({
+        // @ts-expect-error
+        foo: input({ optional: true }),
+        bar: input({ type: "number", optional: true }),
+      });
+    });
+
+    test("input with default", () => {
+      b({
+        foo: input({ default: "foo" }),
+        bar: input({ type: "number", default: 123 }),
+      });
+    });
+
+    test("loopback", () => {
+      b({
+        foo: loopback(),
+        bar: loopback({ type: "number" }),
+      });
+
+      b({
+        // @ts-expect-error
+        foo: loopback({ type: "number" }),
+        // @ts-expect-error
+        bar: loopback(),
+      });
+    });
+
+    test("convergence", () => {
+      b({
+        foo: converge(input(), input()),
+        bar: converge(input({ type: "number" }), input({ type: "number" })),
+      });
+      b({
+        // @ts-expect-error
+        foo: converge(input({ type: "number" }), input({ type: "number" })),
+        // @ts-expect-error
+        bar: converge(input(), input()),
+      });
+    });
+  });
+
+  test("polymorphic", () => {
+    const foo = input();
+    const bar = input({ type: "number" });
+    // $ExpectType BoardDefinition<{ foo: string; } | { bar: number; }, {}>
+    const b = board({
+      inputs: [inputNode({ foo }), inputNode({ bar })],
+      outputs: {},
+    });
+    // $ExpectType { foo: Value<string>; } | { bar: Value<number>; }
+    const x = {} as Parameters<typeof b>[0];
+
+    test("instantiate function types", () => {
+      // @ts-expect-error
+      b();
+      b(
+        // @ts-expect-error
+        {}
+      );
+      b({ foo: "foo" });
+      b({ bar: 123 });
+      b({
+        foo: "foo",
+        // @ts-expect-error
+        xxx: 123,
+      });
+      b({
+        // @ts-expect-error
+        foo: 123,
+      });
+      b({
+        // @ts-expect-error
+        bar: "bar",
+      });
+    });
+  });
+});
+
+test("board metadata", () => {
+  const foo = input();
+  // $ExpectType BoardDefinition<{ foo: string; }, {}>
+  board({
+    id: "my-id",
+    title: "My Title",
+    description: "My Description",
+    version: "1.0.0",
+    metadata: {},
+
+    inputs: { foo },
+    outputs: {},
+  });
+});
+
+test("one input node metadata", () => {
+  const foo = input();
+  // $ExpectType BoardDefinition<{ foo: string; }, {}>
+  board({
+    inputs: inputNode(
+      { foo },
+      {
+        id: "input-node-id",
+        description: "Input Node Description",
+      }
+    ),
+    outputs: {},
+  });
+});
+
+test("one output node metadata", () => {
+  const foo = input({ type: "boolean" });
+  // $ExpectType BoardDefinition<{}, { foo: boolean; }>
+  board({
+    inputs: {},
+    outputs: outputNode(
+      { foo },
+      {
+        id: "output-node-id",
+        description: "Output Node Description",
+      }
+    ),
+  });
+});
+
+test("output port metadata", () => {
+  const foo = input();
+  const bar = input({ type: "number" });
+  // $ExpectType BoardDefinition<{}, { foo: string; bar: number; }>
+  board({
+    inputs: {},
+    outputs: {
+      foo: output(foo, {
+        id: "foo-port-id",
+        description: "Foo Port Description",
+      }),
+      bar: output(bar, {
+        id: "bar-port-id",
+        description: "Bar Port Description",
+      }),
+    },
+  });
+});
+
+describe("exotic output types", () => {
+  // $ExpectType BoardDefinition<{}, { foo: number | boolean; }>
+  board({
+    inputs: {},
+    outputs: { foo: {} as Loopback<number | boolean> },
+  });
+
+  // $ExpectType BoardDefinition<{}, { foo: number | boolean; }>
+  board({
+    inputs: {},
+    outputs: { foo: {} as Convergence<number | boolean> },
+  });
+
+  // $ExpectType BoardDefinition<{}, { foo: number | boolean; }>
+  board({
+    inputs: {},
+    outputs: { foo: {} as Output<number | boolean> },
+  });
+
+  // $ExpectType BoardDefinition<{}, { foo: number | boolean; }>
+  board({
+    inputs: {},
+    outputs: { foo: {} as OutputPort<number | boolean> },
+  });
+
+  // $ExpectType BoardDefinition<{}, { foo: number | boolean; }>
+  board({
+    inputs: {},
+    outputs: { foo: {} as OutputPortReference<number | boolean> },
+  });
+
+  // $ExpectType BoardDefinition<{}, { foo: number | boolean; }>
+  board({
+    inputs: {},
+    outputs: { foo: {} as Input<number | boolean> },
+  });
+
+  // $ExpectType BoardDefinition<{}, { foo?: number | boolean | undefined; }>
+  board({
+    inputs: {},
+    outputs: { foo: {} as InputWithDefault<number | boolean> },
+  });
+
+  // $ExpectType BoardDefinition<{}, { foo: number | boolean; }>
+  board({
+    inputs: {},
+    outputs: { foo: {} as Value<number | boolean> },
+  });
+});

--- a/packages/build/src/test/input_test.ts
+++ b/packages/build/src/test/input_test.ts
@@ -20,6 +20,7 @@ import type {
   BreadboardType,
   JsonSerializable,
 } from "../internal/type-system/type.js";
+import { inputNode } from "../internal/board/board.js";
 
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
@@ -258,17 +259,22 @@ test("multiple input nodes with ids and metadata", () => {
     invoke: () => ({ d: "foo" }),
   })({ a, b, c }).outputs;
 
-  // $ExpectType BoardDefinition<{ a: Input<string | undefined>; b: Input<number | undefined>; c: Input<boolean>; }, { d: OutputPort<string>; }>
+  // $ExpectType BoardDefinition<{ a: string; b: number; c: boolean; } | { b: number; c: boolean; } | { c: boolean; a: string; }, { d: string; }>
   const brd = board({
     inputs: [
-      { a, b, c },
-      {
-        $id: "foo",
-        $metadata: { title: "Foo Title", description: "Foo Desc" },
-        b,
-        c,
-      },
-      { c, a },
+      inputNode({ a, b, c }),
+      inputNode(
+        {
+          b,
+          c,
+        },
+        {
+          id: "foo",
+          title: "Foo Title",
+          description: "Foo Desc",
+        }
+      ),
+      inputNode({ c, a }),
     ],
     outputs: {
       d,
@@ -363,7 +369,7 @@ test("optional inputs aren't required in JSON schema", () => {
 
   const { baz } = def({ foo: req, bar: opt }).outputs;
 
-  // $ExpectType BoardDefinition<{ req: Input<number>; opt: Input<number | undefined>; }, { baz: OutputPort<number>; }>
+  // $ExpectType BoardDefinition<{ opt?: number | undefined; req: number; }, { baz: number; }>
   const brd = board({
     inputs: {
       req,

--- a/packages/build/src/test/serialize_test.ts
+++ b/packages/build/src/test/serialize_test.ts
@@ -17,15 +17,16 @@ import {
   optionalEdge,
   output,
   unsafeCast,
+  type SerializableBoard,
 } from "../index.js";
-import { board, type GenericBoardDefinition } from "../internal/board/board.js";
+import { board } from "../internal/board/board.js";
 import { constant } from "../internal/board/constant.js";
 import { input } from "../internal/board/input.js";
 import { loopback } from "../internal/board/loopback.js";
 import { serialize } from "../internal/board/serialize.js";
 
 function checkSerialization(
-  board: GenericBoardDefinition,
+  board: SerializableBoard,
   expected: GraphDescriptor
 ) {
   const actual = serialize(board);

--- a/packages/core-kit/src/nodes/code.ts
+++ b/packages/core-kit/src/nodes/code.ts
@@ -18,6 +18,8 @@ import type {
   JsonSerializable,
 } from "@breadboard-ai/build/internal/type-system/type.js";
 import runJavascript from "./run-javascript.js";
+import type { Convergence } from "@breadboard-ai/build/internal/board/converge.js";
+import type { Loopback } from "@breadboard-ai/build/internal/board/loopback.js";
 
 /**
  * The `code` function creates a {@link runJavascript} Breadboard node in a
@@ -145,7 +147,9 @@ export interface CodeOutputConfig {
 }
 
 type CodeNodeInputs<I extends Record<string, Value<JsonSerializable>>> = {
-  [K in keyof I]: I[K] extends Value<infer T> ? T : never;
+  [K in keyof I]: I[K] extends Value<infer T extends JsonSerializable>
+    ? T
+    : never;
 };
 
 type ConvertOutput<T extends BreadboardType | CodeOutputConfig> =
@@ -163,7 +167,12 @@ type ConvertOutput<T extends BreadboardType | CodeOutputConfig> =
 type StrictCodeFunctionParams<
   I extends Record<string, Value<JsonSerializable>>,
 > = {
-  [K in keyof I]: I[K] extends Value<infer T> ? T : never;
+  [K in keyof I]: I[K] extends
+    | Convergence<infer T>
+    | Loopback<infer T>
+    | Value<infer T>
+    ? T
+    : never;
 };
 
 type ConvertBreadboardTypes<

--- a/packages/core-kit/tests/code_test.ts
+++ b/packages/core-kit/tests/code_test.ts
@@ -6,7 +6,14 @@
 
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
-import { board, defineNodeType, input, serialize } from "@breadboard-ai/build";
+import {
+  board,
+  converge,
+  defineNodeType,
+  input,
+  loopback,
+  serialize,
+} from "@breadboard-ai/build";
 import test from "ava";
 import { code } from "@google-labs/core-kit";
 
@@ -265,5 +272,27 @@ test("can return error", (t) => {
     },
   }));
 
+  t.pass();
+});
+
+test("exotic inputs", (t) => {
+  code(
+    {
+      in1:
+        // $ExpectType Convergence<string | number>
+        converge(input(), input({ type: "number" })),
+      in2:
+        // $ExpectType Loopback<boolean>
+        loopback({ type: "boolean" }),
+    },
+    { out: "string" },
+    ({ in1, in2 }) => {
+      // $ExpectType string | number
+      in1;
+      // $ExpectType boolean
+      in2;
+      return { out: "foo" };
+    }
+  );
   t.pass();
 });

--- a/packages/gemini-kit/src/boards/gemini-generator.ts
+++ b/packages/gemini-kit/src/boards/gemini-generator.ts
@@ -19,6 +19,8 @@ import {
   output,
   unsafeCast,
   unsafeType,
+  inputNode,
+  outputNode,
 } from "@breadboard-ai/build";
 import { ConvertBreadboardType } from "@breadboard-ai/build/internal/type-system/type.js";
 import { Schema } from "@google-labs/breadboard";
@@ -537,13 +539,8 @@ export default board({
     },
   },
   version: "0.1.0",
-  inputs: [
+  inputs: inputNode(
     {
-      $id: "inputs",
-      $metadata: {
-        title: "Input Parameters",
-        description: "Collecting input parameters",
-      },
       systemInstruction,
       text,
       model,
@@ -555,33 +552,42 @@ export default board({
       safetySettings,
       stopSequences,
     },
-  ],
-  outputs: [
     {
-      $id: "content-output",
-      $metadata: {
+      id: "inputs",
+      title: "Input Parameters",
+      description: "Collecting input parameters",
+    }
+  ),
+  outputs: [
+    outputNode(
+      {
+        context: output(formattedResponse.outputs.context, {
+          title: "Context",
+          description: "The conversation context",
+        }),
+        text: output(formattedResponse.outputs.text, {
+          title: "Text",
+          description: "The generated text",
+        }),
+      },
+      {
+        id: "content-output",
         title: "Content Output",
         description: "Outputting content",
+      }
+    ),
+    outputNode(
+      {
+        context: output(formattedResponse.outputs.context, {
+          title: "Context",
+          description: "The conversation context",
+        }),
       },
-      context: output(formattedResponse.outputs.context, {
-        title: "Context",
-        description: "The conversation context",
-      }),
-      text: output(formattedResponse.outputs.text, {
-        title: "Text",
-        description: "The generated text",
-      }),
-    },
-    {
-      $id: "tool-call-output",
-      $metadata: {
+      {
+        id: "tool-call-output",
         title: "Tool Call Output",
         description: "Outputting a tool call",
-      },
-      context: output(formattedResponse.outputs.context, {
-        title: "Context",
-        description: "The conversation context",
-      }),
-    },
+      }
+    ),
   ],
 });


### PR DESCRIPTION
Introduces a change to the signature of `board` in the build API which brings better typing and clarity, especially for polymorphic boards.

You can now declare board inputs in one of 3 ways:

1. As a plain bag of inputs, which automatically creates a single input node:
   ```ts
   board({inputs: {foo, bar}});
   ```

2. As an input node object, which lets you add metadata to it:
   ```ts
   board({
     inputs: inputNode(
       { foo, bar },
       {
         id: "my-inputs",
         description: "My Inputs",
       }
     ),
   });
   ```

3. As an array of input nodes, which lets you have many input nodes (the `inputNode` wrapper is required in this case, because I think if you're doing more than one input node, we should encourage the use of descriptions to explain the polymorphism):
   ```ts
   board({
     inputs: [
       inputNode({ foo }, { id: "inputs-a", description: "Inputs A" }),
       inputNode({ bar }, { id: "inputs-b", description: "Inputs B" }),
     ],
   });
   ```

There is a similar treatment for outputs.

Also, fixes polymorphic board instance signatures, which didn't quite handle optional properties properly previously.