### PR TITLE
remote run

### DIFF
--- a/.changeset/rude-apricots-fly.md
+++ b/.changeset/rude-apricots-fly.md
@@ -1,0 +1,6 @@
+---
+"@breadboard-ai/board-server": minor
+"@google-labs/breadboard": minor
+---
+
+Introduce RemoteRunner (over HTTPS)

--- a/packages/board-server/src/server/boards/run.ts
+++ b/packages/board-server/src/server/boards/run.ts
@@ -4,12 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { RunBoardResult, ApiHandler, BoardParseResult } from "../types.js";
+import type { ApiHandler, BoardParseResult } from "../types.js";
 import { loadFromStore } from "./utils/board-server-provider.js";
 import { verifyKey } from "./utils/verify-key.js";
 import { secretsKit } from "../proxy/secrets.js";
 import { runBoard } from "./utils/run-board.js";
 import { getStore } from "../store.js";
+import type { AnyRunResponseMessage } from "@google-labs/breadboard/remote";
 
 const runHandler: ApiHandler = async (parsed, req, res, body) => {
   const { board, url } = parsed as BoardParseResult;
@@ -20,7 +21,7 @@ const runHandler: ApiHandler = async (parsed, req, res, body) => {
     res.end(JSON.stringify({ $error: keyVerificationResult.error }));
     return true;
   }
-  const writer = new WritableStream<RunBoardResult>({
+  const writer = new WritableStream<AnyRunResponseMessage>({
     write(chunk) {
       res.write(`data: ${JSON.stringify(chunk)}\n\n`);
     },

--- a/packages/board-server/src/server/boards/run.ts
+++ b/packages/board-server/src/server/boards/run.ts
@@ -10,7 +10,7 @@ import { verifyKey } from "./utils/verify-key.js";
 import { secretsKit } from "../proxy/secrets.js";
 import { runBoard } from "./utils/run-board.js";
 import { getStore } from "../store.js";
-import type { AnyRunResponseMessage } from "@google-labs/breadboard/remote";
+import type { RemoteMessage } from "@google-labs/breadboard/remote";
 
 const runHandler: ApiHandler = async (parsed, req, res, body) => {
   const { board, url } = parsed as BoardParseResult;
@@ -21,7 +21,7 @@ const runHandler: ApiHandler = async (parsed, req, res, body) => {
     res.end(JSON.stringify({ $error: keyVerificationResult.error }));
     return true;
   }
-  const writer = new WritableStream<AnyRunResponseMessage>({
+  const writer = new WritableStream<RemoteMessage>({
     write(chunk) {
       res.write(`data: ${JSON.stringify(chunk)}\n\n`);
     },

--- a/packages/board-server/src/server/boards/utils/run-board.ts
+++ b/packages/board-server/src/server/boards/utils/run-board.ts
@@ -83,7 +83,7 @@ export const runBoard = async ({
     const { type, data, reply } = result;
     switch (type) {
       case "graphstart": {
-        await writer.write(["graphstart", data.path, data.timestamp]);
+        await writer.write(["graphstart", data]);
         break;
       }
       case "graphend": {

--- a/packages/board-server/src/server/boards/utils/run-board.ts
+++ b/packages/board-server/src/server/boards/utils/run-board.ts
@@ -87,15 +87,15 @@ export const runBoard = async ({
         break;
       }
       case "graphend": {
-        await writer.write(["graphend", data.path, data.timestamp]);
+        await writer.write(["graphend", data]);
         break;
       }
       case "nodestart": {
-        await writer.write(["nodestart", data.path, data.timestamp, data.node]);
+        await writer.write(["nodestart", data]);
         break;
       }
       case "nodeend": {
-        await writer.write(["nodeend", data.path, data.timestamp, data.node]);
+        await writer.write(["nodeend", data]);
         break;
       }
       case "skip": {
@@ -125,7 +125,7 @@ export const runBoard = async ({
           store,
           data.outputs
         )) as OutputValues;
-        await writer.write(["output", outputs]);
+        await writer.write(["output", { ...data, outputs }]);
         break;
       }
       case "error": {

--- a/packages/board-server/src/server/boards/utils/run-board.ts
+++ b/packages/board-server/src/server/boards/utils/run-board.ts
@@ -99,13 +99,7 @@ export const runBoard = async ({
         break;
       }
       case "skip": {
-        await writer.write([
-          "skip",
-          data.path,
-          data.timestamp,
-          data.node,
-          data.missingInputs,
-        ]);
+        await writer.write(["skip", data]);
         break;
       }
       case "input": {

--- a/packages/board-server/src/server/boards/utils/run-board.ts
+++ b/packages/board-server/src/server/boards/utils/run-board.ts
@@ -135,7 +135,7 @@ export const runBoard = async ({
       }
       case "end": {
         if (diagnostics) {
-          await writer.write(["end", data.timestamp, data.last]);
+          await writer.write(["end", data]);
         }
         return;
       }

--- a/packages/board-server/src/server/boards/utils/run-board.ts
+++ b/packages/board-server/src/server/boards/utils/run-board.ts
@@ -7,30 +7,11 @@
 import { getDataStore } from "@breadboard-ai/data-store";
 import { createLoader, type ReanimationState } from "@google-labs/breadboard";
 import { handleRunGraphRequest } from "@google-labs/breadboard/remote";
-import type { RunBoardArguments, RunBoardStateStore } from "../../types.js";
+import type { RunBoardArguments } from "../../types.js";
 import { BoardServerProvider } from "./board-server-provider.js";
 import { createKits } from "./create-kits.js";
 
 export const timestamp = () => globalThis.performance.now();
-
-const fromNextToState = async (
-  store: RunBoardStateStore,
-  user: string,
-  next?: string
-): Promise<ReanimationState | undefined> => {
-  if (!next) {
-    return undefined;
-  }
-  return store.loadReanimationState(user, next);
-};
-
-const fromStateToNext = async (
-  store: RunBoardStateStore,
-  user: string,
-  state: ReanimationState
-): Promise<string> => {
-  return store.saveReanimationState(user, state);
-};
 
 export const runBoard = async ({
   url,
@@ -67,11 +48,14 @@ export const runBoard = async ({
       loader: createLoader([new BoardServerProvider(path, loader)]),
       dataStore: store,
       stateStore: {
-        load(next?: string) {
-          return fromNextToState(runStateStore, user, next);
+        async load(next?: string) {
+          if (!next) {
+            return undefined;
+          }
+          return runStateStore.loadReanimationState(user, next);
         },
-        save(state: ReanimationState) {
-          return fromStateToNext(runStateStore, user, state);
+        async save(state: ReanimationState) {
+          return runStateStore.saveReanimationState(user, state);
         },
       },
       inputs: { model: "gemini-1.5-flash-latest" },

--- a/packages/board-server/src/server/boards/utils/run-board.ts
+++ b/packages/board-server/src/server/boards/utils/run-board.ts
@@ -18,6 +18,8 @@ import { BoardServerProvider } from "./board-server-provider.js";
 import { createKits } from "./create-kits.js";
 import { formatRunError } from "./format-run-error.js";
 
+export const timestamp = () => globalThis.performance.now();
+
 const fromNextToState = async (
   store: RunBoardStateStore,
   user: string,
@@ -51,7 +53,10 @@ export const runBoard = async ({
 }: RunBoardArguments): Promise<void> => {
   const store = getDataStore();
   if (!store) {
-    await writer.write(["error", "Data store not available."]);
+    await writer.write([
+      "error",
+      { error: "Data store not available.", timestamp: timestamp() },
+    ]);
     return;
   }
   // TODO: Figure out if this is the right thing to do here.
@@ -130,7 +135,10 @@ export const runBoard = async ({
         break;
       }
       case "error": {
-        await writer.write(["error", formatRunError(data.error)]);
+        await writer.write([
+          "error",
+          { error: formatRunError(data.error), timestamp: timestamp() },
+        ]);
         return;
       }
       case "end": {
@@ -144,5 +152,11 @@ export const runBoard = async ({
       }
     }
   }
-  writer.write(["error", "Run completed without signaling end or error."]);
+  writer.write([
+    "error",
+    {
+      error: "Run completed without signaling end or error.",
+      timestamp: timestamp(),
+    },
+  ]);
 };

--- a/packages/board-server/src/server/boards/utils/run-board.ts
+++ b/packages/board-server/src/server/boards/utils/run-board.ts
@@ -116,7 +116,7 @@ export const runBoard = async ({
             user,
             reanimationState
           );
-          await writer.write(["input", { schema, next }]);
+          await writer.write(["input", data, next]);
           return;
         }
       }

--- a/packages/board-server/src/server/boards/utils/run-board.ts
+++ b/packages/board-server/src/server/boards/utils/run-board.ts
@@ -40,6 +40,7 @@ export const runBoard = async ({
     {
       inputs,
       next,
+      diagnostics,
     },
     {
       url,

--- a/packages/board-server/src/server/types.ts
+++ b/packages/board-server/src/server/types.ts
@@ -8,24 +8,9 @@ import type {
   GraphDescriptor,
   InputValues,
   Kit,
-  NodeDescriptor,
-  NodeValue,
-  OutputValues,
   ReanimationState,
 } from "@google-labs/breadboard";
-import type {
-  RemoteMessage,
-  EndRemoteMessage,
-  ErrorRemoteMessage,
-  GraphEndRemoteMessage,
-  GraphStartRemoteMessage,
-  InputRemoteMessage,
-  NodeEndRemoteMessage,
-  NodeStartRemoteMessage,
-  OutputRemoteMessage,
-  SkipRemoteMessage,
-  RemoteMessageWriter,
-} from "@google-labs/breadboard/remote";
+import type { RemoteMessageWriter } from "@google-labs/breadboard/remote";
 import type { IncomingMessage, ServerResponse } from "http";
 
 export type GeneralRequestType = "list" | "create";

--- a/packages/board-server/src/server/types.ts
+++ b/packages/board-server/src/server/types.ts
@@ -18,6 +18,7 @@ import type path from "path";
 import type {
   EndResponseMessage,
   ErrorResponseMessage,
+  SkipMessage,
   LastNode,
 } from "@google-labs/breadboard/remote";
 
@@ -146,13 +147,7 @@ export type RunBoardResultNodeEnd = [
   node: NodeDescriptor,
 ];
 
-export type RunBoardResultSkip = [
-  "skip",
-  path: number[],
-  timestamp: number,
-  node: NodeDescriptor,
-  missingInputs: string[],
-];
+export type RunBoardResultSkip = SkipMessage;
 
 export type RunBoardResultError = ErrorResponseMessage;
 

--- a/packages/board-server/src/server/types.ts
+++ b/packages/board-server/src/server/types.ts
@@ -9,10 +9,13 @@ import type {
   GraphDescriptor,
   InputValues,
   Kit,
+  NodeDescriptor,
   NodeValue,
   OutputValues,
   ReanimationState,
 } from "@google-labs/breadboard";
+import type path from "path";
+import type { LastNode } from "@google-labs/breadboard/remote";
 
 export type GeneralRequestType = "list" | "create";
 
@@ -72,15 +75,35 @@ export type InvokeBoardArguments = {
 };
 
 export type RunBoardArguments = {
+  /**
+   * The full URL or the requested board, like
+   * `https://board.server/boards/@user/board.bgl.json`.
+   */
   url: string;
+  /**
+   * The path to the board, like `@user/board.bgl.json`.
+   */
   path: string;
+  /**
+   * The user who is running the board.
+   */
   user: string;
+  /**
+   * The function that supplies the actual board given the path.
+   */
   loader: BoardServerLoadFunction;
+  /**
+   * The state store for graph reanimation.
+   */
   runStateStore: RunBoardStateStore;
+  /**
+   * The writer for the results of the board run.
+   */
   writer: RunBoardResultWriter;
   inputs?: InputValues;
   kitOverrides?: Kit[];
   next?: string;
+  diagnostics?: boolean;
 };
 
 export type RunBoardStateStore = {
@@ -92,6 +115,40 @@ export type RunBoardStateStore = {
 };
 
 export type RunBoardResultWriter = WritableStreamDefaultWriter<RunBoardResult>;
+
+export type RunBoardResultGraphStart = [
+  "graphstart",
+  path: number[],
+  timestamp: number,
+];
+
+export type RunBoardResultGraphEnd = [
+  "graphend",
+  path: number[],
+  timestamp: number,
+];
+
+export type RunBoardResultNodeStart = [
+  "nodestart",
+  path: number[],
+  timestamp: number,
+  node: NodeDescriptor,
+];
+
+export type RunBoardResultNodeEnd = [
+  "nodeend",
+  path: number[],
+  timestamp: number,
+  node: NodeDescriptor,
+];
+
+export type RunBoardResultSkip = [
+  "skip",
+  path: number[],
+  timestamp: number,
+  node: NodeDescriptor,
+  missingInputs: string[],
+];
 
 export type RunBoardResultError = ["error", error: string];
 
@@ -105,7 +162,15 @@ export type RunBoardResultInput = [
   },
 ];
 
+export type RunBoardResultEnd = ["end", timestamp: number, last?: LastNode];
+
 export type RunBoardResult =
   | RunBoardResultError
   | RunBoardResultOutput
-  | RunBoardResultInput;
+  | RunBoardResultInput
+  | RunBoardResultGraphStart
+  | RunBoardResultGraphEnd
+  | RunBoardResultNodeStart
+  | RunBoardResultNodeEnd
+  | RunBoardResultSkip
+  | RunBoardResultEnd;

--- a/packages/board-server/src/server/types.ts
+++ b/packages/board-server/src/server/types.ts
@@ -16,6 +16,7 @@ import type {
 import type {
   EndResponseMessage,
   ErrorResponseMessage,
+  GraphStartRemoteMessage,
   SkipRemoteMessage,
 } from "@google-labs/breadboard/remote";
 import type { IncomingMessage, ServerResponse } from "http";
@@ -119,11 +120,7 @@ export type RunBoardStateStore = {
 
 export type RunBoardResultWriter = WritableStreamDefaultWriter<RunBoardResult>;
 
-export type RunBoardResultGraphStart = [
-  "graphstart",
-  path: number[],
-  timestamp: number,
-];
+export type RunBoardResultGraphStart = GraphStartRemoteMessage;
 
 export type RunBoardResultGraphEnd = [
   "graphend",

--- a/packages/board-server/src/server/types.ts
+++ b/packages/board-server/src/server/types.ts
@@ -14,6 +14,7 @@ import type {
   ReanimationState,
 } from "@google-labs/breadboard";
 import type {
+  AnyRunResponseMessage,
   EndRemoteMessage,
   ErrorRemoteMessage,
   GraphEndRemoteMessage,
@@ -123,15 +124,5 @@ export type RunBoardStateStore = {
   saveReanimationState(user: string, state: ReanimationState): Promise<string>;
 };
 
-export type RunBoardResultWriter = WritableStreamDefaultWriter<RunBoardResult>;
-
-export type RunBoardResult =
-  | ErrorRemoteMessage
-  | OutputRemoteMessage
-  | InputRemoteMessage
-  | GraphStartRemoteMessage
-  | GraphEndRemoteMessage
-  | NodeStartRemoteMessage
-  | NodeEndRemoteMessage
-  | SkipRemoteMessage
-  | EndRemoteMessage;
+export type RunBoardResultWriter =
+  WritableStreamDefaultWriter<AnyRunResponseMessage>;

--- a/packages/board-server/src/server/types.ts
+++ b/packages/board-server/src/server/types.ts
@@ -17,6 +17,7 @@ import type {
 import type path from "path";
 import type {
   EndResponseMessage,
+  ErrorResponseMessage,
   LastNode,
 } from "@google-labs/breadboard/remote";
 
@@ -153,7 +154,7 @@ export type RunBoardResultSkip = [
   missingInputs: string[],
 ];
 
-export type RunBoardResultError = ["error", error: string];
+export type RunBoardResultError = ErrorResponseMessage;
 
 export type RunBoardResultOutput = ["output", outputs: OutputValues];
 

--- a/packages/board-server/src/server/types.ts
+++ b/packages/board-server/src/server/types.ts
@@ -14,13 +14,13 @@ import type {
   ReanimationState,
 } from "@google-labs/breadboard";
 import type {
-  EndResponseMessage,
-  ErrorResponseMessage,
+  EndRemoteMessage,
+  ErrorRemoteMessage,
   GraphEndRemoteMessage,
   GraphStartRemoteMessage,
   NodeEndRemoteMessage,
   NodeStartRemoteMessage,
-  OutputResponseMessage,
+  OutputRemoteMessage,
   SkipRemoteMessage,
 } from "@google-labs/breadboard/remote";
 import type { IncomingMessage, ServerResponse } from "http";
@@ -133,12 +133,12 @@ export type RunBoardResultInput = [
 ];
 
 export type RunBoardResult =
-  | ErrorResponseMessage
-  | OutputResponseMessage
+  | ErrorRemoteMessage
+  | OutputRemoteMessage
   | RunBoardResultInput
   | GraphStartRemoteMessage
   | GraphEndRemoteMessage
   | NodeStartRemoteMessage
   | NodeEndRemoteMessage
   | SkipRemoteMessage
-  | EndResponseMessage;
+  | EndRemoteMessage;

--- a/packages/board-server/src/server/types.ts
+++ b/packages/board-server/src/server/types.ts
@@ -18,6 +18,7 @@ import type {
   ErrorRemoteMessage,
   GraphEndRemoteMessage,
   GraphStartRemoteMessage,
+  InputRemoteMessage,
   NodeEndRemoteMessage,
   NodeStartRemoteMessage,
   OutputRemoteMessage,
@@ -124,18 +125,10 @@ export type RunBoardStateStore = {
 
 export type RunBoardResultWriter = WritableStreamDefaultWriter<RunBoardResult>;
 
-export type RunBoardResultInput = [
-  "input",
-  data: {
-    schema: NodeValue;
-    next: string;
-  },
-];
-
 export type RunBoardResult =
   | ErrorRemoteMessage
   | OutputRemoteMessage
-  | RunBoardResultInput
+  | InputRemoteMessage
   | GraphStartRemoteMessage
   | GraphEndRemoteMessage
   | NodeStartRemoteMessage

--- a/packages/board-server/src/server/types.ts
+++ b/packages/board-server/src/server/types.ts
@@ -14,7 +14,7 @@ import type {
   ReanimationState,
 } from "@google-labs/breadboard";
 import type {
-  AnyRunResponseMessage,
+  RemoteMessage,
   EndRemoteMessage,
   ErrorRemoteMessage,
   GraphEndRemoteMessage,
@@ -124,5 +124,4 @@ export type RunBoardStateStore = {
   saveReanimationState(user: string, state: ReanimationState): Promise<string>;
 };
 
-export type RunBoardResultWriter =
-  WritableStreamDefaultWriter<AnyRunResponseMessage>;
+export type RunBoardResultWriter = WritableStreamDefaultWriter<RemoteMessage>;

--- a/packages/board-server/src/server/types.ts
+++ b/packages/board-server/src/server/types.ts
@@ -16,7 +16,11 @@ import type {
 import type {
   EndResponseMessage,
   ErrorResponseMessage,
+  GraphEndRemoteMessage,
   GraphStartRemoteMessage,
+  NodeEndRemoteMessage,
+  NodeStartRemoteMessage,
+  OutputResponseMessage,
   SkipRemoteMessage,
 } from "@google-labs/breadboard/remote";
 import type { IncomingMessage, ServerResponse } from "http";
@@ -122,31 +126,17 @@ export type RunBoardResultWriter = WritableStreamDefaultWriter<RunBoardResult>;
 
 export type RunBoardResultGraphStart = GraphStartRemoteMessage;
 
-export type RunBoardResultGraphEnd = [
-  "graphend",
-  path: number[],
-  timestamp: number,
-];
+export type RunBoardResultGraphEnd = GraphEndRemoteMessage;
 
-export type RunBoardResultNodeStart = [
-  "nodestart",
-  path: number[],
-  timestamp: number,
-  node: NodeDescriptor,
-];
+export type RunBoardResultNodeStart = NodeStartRemoteMessage;
 
-export type RunBoardResultNodeEnd = [
-  "nodeend",
-  path: number[],
-  timestamp: number,
-  node: NodeDescriptor,
-];
+export type RunBoardResultNodeEnd = NodeEndRemoteMessage;
 
 export type RunBoardResultSkip = SkipRemoteMessage;
 
 export type RunBoardResultError = ErrorResponseMessage;
 
-export type RunBoardResultOutput = ["output", outputs: OutputValues];
+export type RunBoardResultOutput = OutputResponseMessage;
 
 export type RunBoardResultInput = [
   "input",

--- a/packages/board-server/src/server/types.ts
+++ b/packages/board-server/src/server/types.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { IncomingMessage, ServerResponse } from "http";
 import type {
   GraphDescriptor,
   InputValues,
@@ -14,13 +13,12 @@ import type {
   OutputValues,
   ReanimationState,
 } from "@google-labs/breadboard";
-import type path from "path";
 import type {
   EndResponseMessage,
   ErrorResponseMessage,
-  SkipMessage,
-  LastNode,
+  SkipRemoteMessage,
 } from "@google-labs/breadboard/remote";
+import type { IncomingMessage, ServerResponse } from "http";
 
 export type GeneralRequestType = "list" | "create";
 
@@ -147,7 +145,7 @@ export type RunBoardResultNodeEnd = [
   node: NodeDescriptor,
 ];
 
-export type RunBoardResultSkip = SkipMessage;
+export type RunBoardResultSkip = SkipRemoteMessage;
 
 export type RunBoardResultError = ErrorResponseMessage;
 

--- a/packages/board-server/src/server/types.ts
+++ b/packages/board-server/src/server/types.ts
@@ -15,7 +15,10 @@ import type {
   ReanimationState,
 } from "@google-labs/breadboard";
 import type path from "path";
-import type { LastNode } from "@google-labs/breadboard/remote";
+import type {
+  EndResponseMessage,
+  LastNode,
+} from "@google-labs/breadboard/remote";
 
 export type GeneralRequestType = "list" | "create";
 
@@ -162,7 +165,7 @@ export type RunBoardResultInput = [
   },
 ];
 
-export type RunBoardResultEnd = ["end", timestamp: number, last?: LastNode];
+export type RunBoardResultEnd = EndResponseMessage;
 
 export type RunBoardResult =
   | RunBoardResultError

--- a/packages/board-server/src/server/types.ts
+++ b/packages/board-server/src/server/types.ts
@@ -124,20 +124,6 @@ export type RunBoardStateStore = {
 
 export type RunBoardResultWriter = WritableStreamDefaultWriter<RunBoardResult>;
 
-export type RunBoardResultGraphStart = GraphStartRemoteMessage;
-
-export type RunBoardResultGraphEnd = GraphEndRemoteMessage;
-
-export type RunBoardResultNodeStart = NodeStartRemoteMessage;
-
-export type RunBoardResultNodeEnd = NodeEndRemoteMessage;
-
-export type RunBoardResultSkip = SkipRemoteMessage;
-
-export type RunBoardResultError = ErrorResponseMessage;
-
-export type RunBoardResultOutput = OutputResponseMessage;
-
 export type RunBoardResultInput = [
   "input",
   data: {
@@ -146,15 +132,13 @@ export type RunBoardResultInput = [
   },
 ];
 
-export type RunBoardResultEnd = EndResponseMessage;
-
 export type RunBoardResult =
-  | RunBoardResultError
-  | RunBoardResultOutput
+  | ErrorResponseMessage
+  | OutputResponseMessage
   | RunBoardResultInput
-  | RunBoardResultGraphStart
-  | RunBoardResultGraphEnd
-  | RunBoardResultNodeStart
-  | RunBoardResultNodeEnd
-  | RunBoardResultSkip
-  | RunBoardResultEnd;
+  | GraphStartRemoteMessage
+  | GraphEndRemoteMessage
+  | NodeStartRemoteMessage
+  | NodeEndRemoteMessage
+  | SkipRemoteMessage
+  | EndResponseMessage;

--- a/packages/board-server/src/server/types.ts
+++ b/packages/board-server/src/server/types.ts
@@ -24,6 +24,7 @@ import type {
   NodeStartRemoteMessage,
   OutputRemoteMessage,
   SkipRemoteMessage,
+  RemoteMessageWriter,
 } from "@google-labs/breadboard/remote";
 import type { IncomingMessage, ServerResponse } from "http";
 
@@ -109,7 +110,7 @@ export type RunBoardArguments = {
   /**
    * The writer for the results of the board run.
    */
-  writer: RunBoardResultWriter;
+  writer: RemoteMessageWriter;
   inputs?: InputValues;
   kitOverrides?: Kit[];
   next?: string;
@@ -123,5 +124,3 @@ export type RunBoardStateStore = {
   ): Promise<ReanimationState | undefined>;
   saveReanimationState(user: string, state: ReanimationState): Promise<string>;
 };
-
-export type RunBoardResultWriter = WritableStreamDefaultWriter<RemoteMessage>;

--- a/packages/board-server/tests/run-board.ts
+++ b/packages/board-server/tests/run-board.ts
@@ -60,8 +60,16 @@ const assertResults = (
         );
         break;
       }
+      case "graphstart": {
+        const [, data] = result;
+        deepStrictEqual(
+          data.path,
+          expected.path,
+          `Expected path "${JSON.stringify(data.path)}" to match "${JSON.stringify(expected.path)}" at index ${index}`
+        );
+        break;
+      }
       case "graphend":
-      case "graphstart":
       case "nodestart":
       case "nodeend": {
         const [, path] = result;

--- a/packages/board-server/tests/run-board.ts
+++ b/packages/board-server/tests/run-board.ts
@@ -35,7 +35,6 @@ const assertResults = (
   index = 0
 ) => {
   if (results.length !== expectedResults.length) {
-    console.log("Results:", results);
     fail(
       `Expected ${expectedResults.length} results, but got ${results.length} at index ${index}`
     );

--- a/packages/board-server/tests/run-board.ts
+++ b/packages/board-server/tests/run-board.ts
@@ -18,7 +18,7 @@ import simpleBoard from "./boards/simple.bgl.json" with { type: "json" };
 import multipleInputsBoard from "./boards/many-inputs.bgl.json" with { type: "json" };
 import manyOutputsBoard from "./boards/many-outputs.bgl.json" with { type: "json" };
 import invokeWithBubblingInput from "./boards/invoke-board-with-bubbling-input.bgl.json" with { type: "json" };
-import type { AnyRunResponseMessage } from "@google-labs/breadboard/remote";
+import type { RemoteMessage } from "@google-labs/breadboard/remote";
 
 const mockSecretsKit: Kit = {
   url: import.meta.url,
@@ -30,7 +30,7 @@ const mockSecretsKit: Kit = {
 };
 
 const assertResults = (
-  results: AnyRunResponseMessage[],
+  results: RemoteMessage[],
   expectedResults: ExpectedResult[],
   index = 0
 ) => {
@@ -76,7 +76,7 @@ const assertResults = (
   }
 };
 
-const getNext = (result?: AnyRunResponseMessage) => {
+const getNext = (result?: RemoteMessage) => {
   if (!result) {
     fail("No result provided.");
   }
@@ -124,8 +124,8 @@ const scriptedRun = async (
   let next;
   const path = "/path/to/board";
   for (const [index, { inputs, expected }] of script.entries()) {
-    const results: AnyRunResponseMessage[] = [];
-    const writer = new WritableStream<AnyRunResponseMessage>({
+    const results: RemoteMessage[] = [];
+    const writer = new WritableStream<RemoteMessage>({
       async write(chunk) {
         results.push(chunk);
       },
@@ -150,8 +150,8 @@ const scriptedRun = async (
 describe("Board Server Runs Boards", () => {
   test("can start a simple board", async () => {
     const path = "/path/to/board";
-    const results: AnyRunResponseMessage[] = [];
-    const writer = new WritableStream<AnyRunResponseMessage>({
+    const results: RemoteMessage[] = [];
+    const writer = new WritableStream<RemoteMessage>({
       async write(chunk) {
         results.push(chunk);
       },
@@ -180,8 +180,8 @@ describe("Board Server Runs Boards", () => {
   test("can start a simple board with inputs", async () => {
     const path = "/path/to/board";
     const inputs = { text: "bar" };
-    const results: AnyRunResponseMessage[] = [];
-    const writer = new WritableStream<AnyRunResponseMessage>({
+    const results: RemoteMessage[] = [];
+    const writer = new WritableStream<RemoteMessage>({
       async write(chunk) {
         results.push(chunk);
       },
@@ -208,8 +208,8 @@ describe("Board Server Runs Boards", () => {
   test("can start a board with multiple inputs", async () => {
     const path = "/path/to/board";
     const inputs = { text: "bar", number: 42 };
-    const results: AnyRunResponseMessage[] = [];
-    const writer = new WritableStream<AnyRunResponseMessage>({
+    const results: RemoteMessage[] = [];
+    const writer = new WritableStream<RemoteMessage>({
       async write(chunk) {
         results.push(chunk);
       },

--- a/packages/board-server/tests/run-board.ts
+++ b/packages/board-server/tests/run-board.ts
@@ -18,7 +18,7 @@ import simpleBoard from "./boards/simple.bgl.json" with { type: "json" };
 import multipleInputsBoard from "./boards/many-inputs.bgl.json" with { type: "json" };
 import manyOutputsBoard from "./boards/many-outputs.bgl.json" with { type: "json" };
 import invokeWithBubblingInput from "./boards/invoke-board-with-bubbling-input.bgl.json" with { type: "json" };
-import type { RunBoardResult } from "../src/server/types.js";
+import type { AnyRunResponseMessage } from "@google-labs/breadboard/remote";
 
 const mockSecretsKit: Kit = {
   url: import.meta.url,
@@ -30,7 +30,7 @@ const mockSecretsKit: Kit = {
 };
 
 const assertResults = (
-  results: RunBoardResult[],
+  results: AnyRunResponseMessage[],
   expectedResults: ExpectedResult[],
   index = 0
 ) => {
@@ -76,7 +76,7 @@ const assertResults = (
   }
 };
 
-const getNext = (result?: RunBoardResult) => {
+const getNext = (result?: AnyRunResponseMessage) => {
   if (!result) {
     fail("No result provided.");
   }
@@ -124,8 +124,8 @@ const scriptedRun = async (
   let next;
   const path = "/path/to/board";
   for (const [index, { inputs, expected }] of script.entries()) {
-    const results: RunBoardResult[] = [];
-    const writer = new WritableStream<RunBoardResult>({
+    const results: AnyRunResponseMessage[] = [];
+    const writer = new WritableStream<AnyRunResponseMessage>({
       async write(chunk) {
         results.push(chunk);
       },
@@ -150,8 +150,8 @@ const scriptedRun = async (
 describe("Board Server Runs Boards", () => {
   test("can start a simple board", async () => {
     const path = "/path/to/board";
-    const results: RunBoardResult[] = [];
-    const writer = new WritableStream<RunBoardResult>({
+    const results: AnyRunResponseMessage[] = [];
+    const writer = new WritableStream<AnyRunResponseMessage>({
       async write(chunk) {
         results.push(chunk);
       },
@@ -180,8 +180,8 @@ describe("Board Server Runs Boards", () => {
   test("can start a simple board with inputs", async () => {
     const path = "/path/to/board";
     const inputs = { text: "bar" };
-    const results: RunBoardResult[] = [];
-    const writer = new WritableStream<RunBoardResult>({
+    const results: AnyRunResponseMessage[] = [];
+    const writer = new WritableStream<AnyRunResponseMessage>({
       async write(chunk) {
         results.push(chunk);
       },
@@ -208,8 +208,8 @@ describe("Board Server Runs Boards", () => {
   test("can start a board with multiple inputs", async () => {
     const path = "/path/to/board";
     const inputs = { text: "bar", number: 42 };
-    const results: RunBoardResult[] = [];
-    const writer = new WritableStream<RunBoardResult>({
+    const results: AnyRunResponseMessage[] = [];
+    const writer = new WritableStream<AnyRunResponseMessage>({
       async write(chunk) {
         results.push(chunk);
       },

--- a/packages/board-server/tests/run-board.ts
+++ b/packages/board-server/tests/run-board.ts
@@ -80,12 +80,12 @@ const getNext = (result?: RunBoardResult) => {
   if (!result) {
     fail("No result provided.");
   }
-  const [type, data] = result;
+  const [type, data, next] = result;
   if (type === "error") {
     fail(data.error as string);
   }
   if (type === "input") {
-    return data.next;
+    return next;
   }
   if (type === "output") {
     return undefined;

--- a/packages/board-server/tests/run-board.ts
+++ b/packages/board-server/tests/run-board.ts
@@ -82,7 +82,7 @@ const getNext = (result?: RunBoardResult) => {
   }
   const [type, data] = result;
   if (type === "error") {
-    fail(data);
+    fail(data.error as string);
   }
   if (type === "input") {
     return data.next;

--- a/packages/board-server/tests/run-board.ts
+++ b/packages/board-server/tests/run-board.ts
@@ -54,29 +54,21 @@ const assertResults = (
     switch (type) {
       case "output": {
         deepStrictEqual(
-          data,
+          data.outputs,
           expected.outputs,
           `Expected outputs to match at index ${index}`
         );
         break;
       }
-      case "graphstart": {
+      case "graphstart":
+      case "graphend":
+      case "nodestart":
+      case "nodeend": {
         const [, data] = result;
         deepStrictEqual(
           data.path,
           expected.path,
           `Expected path "${JSON.stringify(data.path)}" to match "${JSON.stringify(expected.path)}" at index ${index}`
-        );
-        break;
-      }
-      case "graphend":
-      case "nodestart":
-      case "nodeend": {
-        const [, path] = result;
-        deepStrictEqual(
-          path,
-          expected.path,
-          `Expected path "${JSON.stringify(path)}" to match "${JSON.stringify(expected.path)}" at index ${index}`
         );
         break;
       }

--- a/packages/breadboard-cli/tests/index.ts
+++ b/packages/breadboard-cli/tests/index.ts
@@ -16,7 +16,6 @@ console.debug("packageDir", packageDir);
 const dist = path.resolve(path.join(packageDir, "dist"));
 
 const cliPathJs = path.resolve(path.join(dist, "src", "index.js"));
-console.log("cliPath", path.resolve(cliPathJs));
 console.assert(fs.existsSync(cliPathJs));
 
 type ChildProcessCallback = {

--- a/packages/breadboard/src/data/types.ts
+++ b/packages/breadboard/src/data/types.ts
@@ -5,6 +5,7 @@
  */
 
 import { HarnessRunResult } from "../harness/types.js";
+import { ReanimationState } from "../run/types.js";
 
 export type FunctionCallCapabilityPart = {
   functionCall: {
@@ -109,4 +110,9 @@ export type DataStore = {
     storeId?: string
   ): Promise<SerializedDataStoreGroup | null>;
   store(blob: Blob, storeId?: string): Promise<StoredDataCapabilityPart>;
+};
+
+export type StateStore = {
+  load(key: string): Promise<ReanimationState | undefined>;
+  save(state: ReanimationState): Promise<string>;
 };

--- a/packages/breadboard/src/data/types.ts
+++ b/packages/breadboard/src/data/types.ts
@@ -114,5 +114,5 @@ export type DataStore = {
 
 export type StateStore = {
   load(key?: string): Promise<ReanimationState | undefined>;
-  save(state: ReanimationState): Promise<string | undefined>;
+  save(state: ReanimationState): Promise<string>;
 };

--- a/packages/breadboard/src/data/types.ts
+++ b/packages/breadboard/src/data/types.ts
@@ -113,6 +113,6 @@ export type DataStore = {
 };
 
 export type StateStore = {
-  load(key: string): Promise<ReanimationState | undefined>;
-  save(state: ReanimationState): Promise<string>;
+  load(key?: string): Promise<ReanimationState | undefined>;
+  save(state: ReanimationState): Promise<string | undefined>;
 };

--- a/packages/breadboard/src/harness/error.ts
+++ b/packages/breadboard/src/harness/error.ts
@@ -17,3 +17,24 @@ export const extractError = (e: unknown) => {
   }
   return message;
 };
+
+export const formatRunError = (e: unknown) => {
+  if (typeof e === "string") {
+    return e;
+  }
+  if (e instanceof Error) {
+    return e.message;
+  }
+  if ("message" in (e as { message: string })) {
+    return (e as { message: string }).message;
+  }
+  // Presume it's an ErrorObject.
+  const error = (e as { error: unknown }).error;
+  if (typeof error === "string") {
+    return error;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return JSON.stringify(error);
+};

--- a/packages/breadboard/src/harness/index.ts
+++ b/packages/breadboard/src/harness/index.ts
@@ -5,6 +5,7 @@
  */
 
 import { LocalRunner } from "./local-runner.js";
+import { RemoteRunner } from "./remote-runner.js";
 import { HarnessRunner, RunConfig } from "./types.js";
 
 export type * from "./types.js";
@@ -19,5 +20,8 @@ export { createWorker } from "./worker.js";
 export { createSecretAskingKit } from "./secrets.js";
 
 export const createRunner = (config: RunConfig): HarnessRunner => {
+  if (config.remote) {
+    return new RemoteRunner(config);
+  }
   return new LocalRunner(config);
 };

--- a/packages/breadboard/src/harness/local-runner.ts
+++ b/packages/breadboard/src/harness/local-runner.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
+import type {
   HarnessRunner,
   HarnessRunResult,
   RunConfig,

--- a/packages/breadboard/src/harness/remote-runner.ts
+++ b/packages/breadboard/src/harness/remote-runner.ts
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { InspectableRunObserver } from "../inspector/types.js";
+import { Schema, InputValues } from "../types.js";
+import type {
+  HarnessRunner,
+  HarnessRunResult,
+  RunConfig,
+  RunEventTarget,
+} from "./types.js";
+import {
+  chunkRepairTransform,
+  serverStreamEventDecoder,
+} from "../remote/http.js";
+
+export class HttpClient {
+  #url: string;
+  /**
+   * The API key for the remote service.
+   */
+  #key: string;
+  #fetch: typeof globalThis.fetch;
+  /**
+   * The ticket for the next request.
+   */
+  #next: string | null = null;
+
+  constructor(
+    url: string,
+    key: string,
+    fetch: typeof globalThis.fetch = globalThis.fetch
+  ) {
+    this.#url = url;
+    this.#key = key;
+    this.#fetch = fetch;
+  }
+
+  #createBody(inputs: InputValues): string {
+    const body: InputValues = {
+      ...inputs,
+      $key: this.#key,
+    };
+    if (this.#next) {
+      body.$next = this.#next;
+    }
+    return JSON.stringify(body);
+  }
+
+  async send(inputs: InputValues) {
+    const response = await this.#fetch(this.#url, {
+      method: "POST",
+      body: this.#createBody(inputs),
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error: ${response.status}`);
+    }
+
+    response.body
+      ?.pipeThrough(new TextDecoderStream())
+      .pipeThrough(chunkRepairTransform())
+      .pipeThrough(serverStreamEventDecoder())
+      .pipeTo(
+        new WritableStream({
+          write(chunk) {
+            const data = JSON.parse(chunk);
+          },
+        })
+      );
+
+    return response.text();
+  }
+}
+
+export class RemoteRunner
+  extends (EventTarget as RunEventTarget)
+  implements HarnessRunner
+{
+  #config: RunConfig;
+  #observers: InspectableRunObserver[] = [];
+
+  constructor(config: RunConfig) {
+    super();
+    this.#config = config;
+  }
+
+  addObserver(observer: InspectableRunObserver): void {
+    this.#observers.push(observer);
+  }
+
+  async #notifyObservers(result: HarnessRunResult) {
+    for (const observer of this.#observers) {
+      try {
+        await observer.observe(result);
+      } catch (e) {
+        console.error("Observer failed to observe result", result, e);
+      }
+    }
+  }
+
+  running(): boolean {
+    throw new Error("Method not implemented.");
+  }
+  secretKeys(): string[] | null {
+    throw new Error("Method not implemented.");
+  }
+  inputSchema(): Schema | null {
+    throw new Error("Method not implemented.");
+  }
+  run(inputs?: InputValues): Promise<boolean> {
+    throw new Error("Method not implemented.");
+  }
+}

--- a/packages/breadboard/src/harness/remote-runner.ts
+++ b/packages/breadboard/src/harness/remote-runner.ts
@@ -10,11 +10,59 @@ import type {
   HarnessRunResult,
   RunConfig,
   RunEventTarget,
+  SecretResult,
 } from "./types.js";
 import {
   chunkRepairTransform,
   serverStreamEventDecoder,
 } from "../remote/http.js";
+import type { AsRemoteMessage, RemoteMessage } from "../remote/types.js";
+import {
+  EndEvent,
+  InputEvent,
+  GraphEndEvent,
+  GraphStartEvent,
+  NodeEndEvent,
+  NodeStartEvent,
+  OutputEvent,
+  RunnerErrorEvent,
+  SecretEvent,
+  SkipEvent,
+  PauseEvent,
+  ResumeEvent,
+  StartEvent,
+} from "./events.js";
+
+export type SecretRemoteMessage = AsRemoteMessage<SecretResult>;
+
+export type HarnessRemoteMessage = RemoteMessage | SecretRemoteMessage;
+
+export type MessageConsumer = (message: HarnessRemoteMessage) => Promise<void>;
+
+export type FetchType = typeof globalThis.fetch;
+
+export const remoteMessageTransform = () => {
+  return new TransformStream<string, HarnessRemoteMessage>({
+    transform(chunk, controller) {
+      try {
+        const message = JSON.parse(chunk) as HarnessRemoteMessage;
+        controller.enqueue(message);
+      } catch (e) {
+        throw new Error("Chunk parsing error.");
+      }
+    },
+  });
+};
+
+function createResolvablePromise<T>(): [Promise<T>, (value: T) => void] {
+  let resolve: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return [promise, resolve!];
+}
+
+export const now = () => ({ timestamp: globalThis.performance.now() });
 
 export class HttpClient {
   #url: string;
@@ -22,19 +70,20 @@ export class HttpClient {
    * The API key for the remote service.
    */
   #key: string;
-  #fetch: typeof globalThis.fetch;
-  /**
-   * The ticket for the next request.
-   */
-  #next: string | null = null;
+  #fetch: FetchType;
+  #writer: MessageConsumer;
+  #fetching = false;
+  #lastMessage: HarnessRemoteMessage | null = null;
 
   constructor(
     url: string,
     key: string,
-    fetch: typeof globalThis.fetch = globalThis.fetch
+    writer: MessageConsumer,
+    fetch: FetchType = globalThis.fetch
   ) {
     this.#url = url;
     this.#key = key;
+    this.#writer = writer;
     this.#fetch = fetch;
   }
 
@@ -43,13 +92,29 @@ export class HttpClient {
       ...inputs,
       $key: this.#key,
     };
-    if (this.#next) {
-      body.$next = this.#next;
+    if (this.#lastMessage) {
+      const [, , next] = this.#lastMessage;
+      if (next) {
+        body.$next = next;
+      }
     }
     return JSON.stringify(body);
   }
 
-  async send(inputs: InputValues) {
+  fetching(): boolean {
+    return this.#fetching;
+  }
+
+  lastMessage(): HarnessRemoteMessage | null {
+    return this.#lastMessage;
+  }
+
+  async send(inputs: InputValues): Promise<boolean> {
+    if (this.#fetching) {
+      throw new Error("Fetch is already in progress.");
+    }
+    this.#lastMessage = null;
+    this.#fetching = true;
     const response = await this.#fetch(this.#url, {
       method: "POST",
       body: this.#createBody(inputs),
@@ -59,19 +124,31 @@ export class HttpClient {
       throw new Error(`HTTP error: ${response.status}`);
     }
 
+    const [promise, resolver] = createResolvablePromise<void>();
+
     response.body
       ?.pipeThrough(new TextDecoderStream())
       .pipeThrough(chunkRepairTransform())
       .pipeThrough(serverStreamEventDecoder())
+      .pipeThrough(remoteMessageTransform())
       .pipeTo(
         new WritableStream({
-          write(chunk) {
-            const data = JSON.parse(chunk);
+          write: async (message) => {
+            const [type] = message;
+            if (type === "secret" || type === "input") {
+              this.#lastMessage = message;
+            }
+            await this.#writer(message);
+          },
+          close: () => {
+            this.#fetching = false;
+            resolver();
           },
         })
       );
 
-    return response.text();
+    await promise;
+    return this.#lastMessage === null;
   }
 }
 
@@ -80,6 +157,7 @@ export class RemoteRunner
   implements HarnessRunner
 {
   #config: RunConfig;
+  #client: HttpClient | null = null;
   #observers: InspectableRunObserver[] = [];
 
   constructor(config: RunConfig) {
@@ -102,15 +180,129 @@ export class RemoteRunner
   }
 
   running(): boolean {
-    throw new Error("Method not implemented.");
+    return this.#client?.fetching() || false;
   }
+
   secretKeys(): string[] | null {
-    throw new Error("Method not implemented.");
+    if (this.#client?.fetching()) {
+      return null;
+    }
+    const message = this.#client?.lastMessage();
+    if (!message || message[0] !== "secret") {
+      return null;
+    }
+    return message[1].keys;
   }
+
   inputSchema(): Schema | null {
-    throw new Error("Method not implemented.");
+    if (this.#client?.fetching()) {
+      return null;
+    }
+    const message = this.#client?.lastMessage();
+    if (!message || message[0] !== "input") {
+      return null;
+    }
+    return message[1].inputArguments.schema || null;
   }
-  run(inputs?: InputValues): Promise<boolean> {
-    throw new Error("Method not implemented.");
+
+  #initializeClient() {
+    const remote = this.#config.remote;
+    if (!remote) {
+      throw new Error("Remote configuration isn't specified.");
+    }
+    if (remote.type !== "http") {
+      throw new Error(`This runner only supports "http" remote configuration`);
+    }
+    const url = remote.url;
+    if (!url) {
+      throw new Error("Remote URL isn't specified.");
+    }
+    const key = remote.key;
+    if (!key) {
+      throw new Error("Remote API Key isn't specified.");
+    }
+    this.#client = new HttpClient(url, key, async (message) => {
+      await this.#processMessage(message);
+    });
+  }
+
+  async #processMessage(message: HarnessRemoteMessage) {
+    const [type, data, next] = message;
+    await this.#notifyObservers({
+      type,
+      data,
+      async reply() {},
+    } as HarnessRunResult);
+    switch (type) {
+      case "input": {
+        const haveInputs = !next;
+        this.dispatchEvent(new InputEvent(haveInputs, data));
+        if (!haveInputs) {
+          // When there are no inputs to consume, pause the run
+          // and wait for the next input.
+          this.dispatchEvent(new InputEvent(false, data));
+          this.dispatchEvent(new PauseEvent(false, now()));
+        }
+        break;
+      }
+      case "error": {
+        this.dispatchEvent(new RunnerErrorEvent(data));
+        break;
+      }
+      case "end": {
+        this.dispatchEvent(new EndEvent(data));
+        break;
+      }
+      case "skip": {
+        this.dispatchEvent(new SkipEvent(data));
+        break;
+      }
+      case "graphstart": {
+        this.dispatchEvent(new GraphStartEvent(data));
+        break;
+      }
+      case "graphend": {
+        this.dispatchEvent(new GraphEndEvent(data));
+        break;
+      }
+      case "nodestart": {
+        this.dispatchEvent(new NodeStartEvent(data));
+        break;
+      }
+      case "nodeend": {
+        this.dispatchEvent(new NodeEndEvent(data));
+        break;
+      }
+      case "output": {
+        this.dispatchEvent(new OutputEvent(data));
+        break;
+      }
+      case "secret": {
+        const haveInputs = !next;
+        this.dispatchEvent(new SecretEvent(haveInputs, data));
+        if (!haveInputs) {
+          // When there are no inputs to consume, pause the run
+          // and wait for the next input.
+          this.dispatchEvent(new SecretEvent(false, data));
+          this.dispatchEvent(new PauseEvent(false, now()));
+          return false;
+        }
+        break;
+      }
+    }
+    return false;
+  }
+
+  async run(inputs?: InputValues): Promise<boolean> {
+    const starting = !this.#client;
+    if (!this.#client) {
+      this.#initializeClient();
+    }
+
+    this.dispatchEvent(
+      starting ? new StartEvent(now()) : new ResumeEvent(now())
+    );
+
+    return this.#client!.send(inputs || {});
   }
 }

--- a/packages/breadboard/src/harness/remote-runner.ts
+++ b/packages/breadboard/src/harness/remote-runner.ts
@@ -251,6 +251,7 @@ export class RemoteRunner
       }
       case "end": {
         this.dispatchEvent(new EndEvent(data));
+        this.#client = null;
         break;
       }
       case "skip": {

--- a/packages/breadboard/src/harness/types.ts
+++ b/packages/breadboard/src/harness/types.ts
@@ -123,7 +123,6 @@ export type HarnessRemoteConfig =
   | {
       /**
        * The type of the remote runtime. Can be "http" or "worker".
-       * Currently, only "worker" is supported.
        */
       type: "http" | "worker";
       /**
@@ -132,6 +131,10 @@ export type HarnessRemoteConfig =
        * `type` is "http".
        */
       url: string;
+      /**
+       * API Key
+       */
+      key?: string;
     }
   | false;
 

--- a/packages/breadboard/src/remote/http.ts
+++ b/packages/breadboard/src/remote/http.ts
@@ -37,7 +37,7 @@ const isIterable = (o: unknown): boolean => {
   return typeof o === "object" && o !== null && Symbol.iterator in o;
 };
 
-const serverStreamEventDecoder = () => {
+export const serverStreamEventDecoder = () => {
   return new TransformStream<string, string>({
     transform(chunk, controller) {
       if (chunk.startsWith("data: ")) {
@@ -154,7 +154,7 @@ export type HTTPClientTransportOptions = RequestInit & {
  *
  * @returns The transform stream that repaired chunks.
  */
-const chunkRepairTransform = () => {
+export const chunkRepairTransform = () => {
   let queue: string[] = [];
   return new TransformStream<string, string>({
     transform(chunk, controller) {

--- a/packages/breadboard/src/remote/index.ts
+++ b/packages/breadboard/src/remote/index.ts
@@ -17,3 +17,4 @@ export { defineConfig, hasOrigin, type ProxyServerConfig } from "./config.js";
 export type * from "./types.js";
 export type * from "./config.js";
 export type * from "./http.js";
+export { handleRunGraphRequest } from "./run-graph-server.js";

--- a/packages/breadboard/src/remote/run-graph-server.ts
+++ b/packages/breadboard/src/remote/run-graph-server.ts
@@ -25,6 +25,7 @@ export const handleRunGraphRequest = async (
     stateStore,
     inputs: defaultInputs,
     diagnostics,
+    graph,
   } = config;
   const { next, inputs } = request;
 
@@ -35,6 +36,7 @@ export const handleRunGraphRequest = async (
   const state = createRunStateManager(resumeFrom, inputs);
 
   const runner = run({
+    runner: graph,
     url,
     kits,
     loader,
@@ -77,6 +79,7 @@ export const handleRunGraphRequest = async (
           const reanimationState = state.lifecycle().reanimationState();
           const next = await stateStore.save(reanimationState);
           await writer.write(["input", data, next]);
+          await writer.close();
           return;
         }
       }
@@ -93,12 +96,14 @@ export const handleRunGraphRequest = async (
           "error",
           { error: formatRunError(data.error), timestamp: timestamp() },
         ]);
+        await writer.close();
         return;
       }
       case "end": {
         if (diagnostics) {
           await writer.write(["end", data]);
         }
+        await writer.close();
         return;
       }
       default: {

--- a/packages/breadboard/src/remote/run-graph-server.ts
+++ b/packages/breadboard/src/remote/run-graph-server.ts
@@ -24,14 +24,15 @@ export const handleRunGraphRequest = async (
     dataStore,
     stateStore,
     inputs: defaultInputs,
-    diagnostics,
     graph,
   } = config;
-  const { next, inputs } = request;
+  const { next, inputs, diagnostics = false } = request;
 
   let inputsToConsume = next ? undefined : inputs;
 
   const resumeFrom = await stateStore?.load(next);
+
+  console.log("🌻 next in resumeFrom", next, resumeFrom);
 
   const state = createRunStateManager(resumeFrom, inputs);
 

--- a/packages/breadboard/src/remote/run-graph-server.ts
+++ b/packages/breadboard/src/remote/run-graph-server.ts
@@ -32,8 +32,6 @@ export const handleRunGraphRequest = async (
 
   const resumeFrom = await stateStore?.load(next);
 
-  console.log("🌻 next in resumeFrom", next, resumeFrom);
-
   const state = createRunStateManager(resumeFrom, inputs);
 
   const runner = run({

--- a/packages/breadboard/src/remote/run-graph-server.ts
+++ b/packages/breadboard/src/remote/run-graph-server.ts
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ServerRunConfig, ServerRunRequest } from "./types.js";
+import { run } from "../harness/run.js";
+import { OutputValues } from "../types.js";
+import { timestamp } from "../timestamp.js";
+import { createRunStateManager } from "../run/index.js";
+import { inflateData } from "../data/inflate-deflate.js";
+import { formatRunError } from "../harness/error.js";
+
+export const handleRunGraphRequest = async (
+  request: ServerRunRequest,
+  config: ServerRunConfig
+): Promise<void> => {
+  const {
+    url,
+    kits,
+    writer,
+    loader,
+    dataStore,
+    stateStore,
+    inputs: defaultInputs,
+    diagnostics,
+  } = config;
+  const { next, inputs } = request;
+
+  let inputsToConsume = next ? undefined : inputs;
+
+  const resumeFrom = await stateStore?.load(next);
+
+  const state = createRunStateManager(resumeFrom, inputs);
+
+  const runner = run({
+    url,
+    kits,
+    loader,
+    store: dataStore,
+    inputs: defaultInputs,
+    interactiveSecrets: false,
+    diagnostics,
+    state,
+  });
+
+  for await (const result of runner) {
+    const { type, data, reply } = result;
+    switch (type) {
+      case "graphstart": {
+        await writer.write(["graphstart", data]);
+        break;
+      }
+      case "graphend": {
+        await writer.write(["graphend", data]);
+        break;
+      }
+      case "nodestart": {
+        await writer.write(["nodestart", data]);
+        break;
+      }
+      case "nodeend": {
+        await writer.write(["nodeend", data]);
+        break;
+      }
+      case "skip": {
+        await writer.write(["skip", data]);
+        break;
+      }
+      case "input": {
+        if (inputsToConsume && Object.keys(inputsToConsume).length > 0) {
+          await reply({ inputs: inputsToConsume });
+          inputsToConsume = undefined;
+          break;
+        } else {
+          const reanimationState = state.lifecycle().reanimationState();
+          const next = await stateStore.save(reanimationState);
+          await writer.write(["input", data, next]);
+          return;
+        }
+      }
+      case "output": {
+        const outputs = (await inflateData(
+          dataStore,
+          data.outputs
+        )) as OutputValues;
+        await writer.write(["output", { ...data, outputs }]);
+        break;
+      }
+      case "error": {
+        await writer.write([
+          "error",
+          { error: formatRunError(data.error), timestamp: timestamp() },
+        ]);
+        return;
+      }
+      case "end": {
+        if (diagnostics) {
+          await writer.write(["end", data]);
+        }
+        return;
+      }
+      default: {
+        console.log("Unknown type", type, data);
+      }
+    }
+  }
+  writer.write([
+    "error",
+    {
+      error: "Run completed without signaling end or error.",
+      timestamp: timestamp(),
+    },
+  ]);
+};

--- a/packages/breadboard/src/remote/run.ts
+++ b/packages/breadboard/src/remote/run.ts
@@ -24,17 +24,14 @@ import {
 import {
   AnyClientRunResult,
   AnyRunRequestMessage,
-  AnyRunResponseMessage,
+  RemoteMessage,
   InputResolveRequest,
   RunClientTransport,
   RunRequestMessage,
   ServerTransport,
 } from "./types.js";
 
-type RunServerTransport = ServerTransport<
-  AnyRunRequestMessage,
-  AnyRunResponseMessage
->;
+type RunServerTransport = ServerTransport<AnyRunRequestMessage, RemoteMessage>;
 
 export class RunServer {
   #transport: RunServerTransport;
@@ -65,7 +62,7 @@ export class RunServer {
             if (type == "nodestart") {
               response.push(message.state);
             }
-            await responses.write(response as AnyRunResponseMessage);
+            await responses.write(response as RemoteMessage);
           })
         : undefined,
     };
@@ -110,7 +107,7 @@ export class RunServer {
 }
 
 const createRunResult = (
-  response: WritableResult<AnyRunResponseMessage, AnyRunRequestMessage>
+  response: WritableResult<RemoteMessage, AnyRunRequestMessage>
 ): AnyClientRunResult => {
   const [type, data, state] = response.data;
   const reply = async (chunk: AnyRunRequestMessage[1]) => {

--- a/packages/breadboard/src/remote/run.ts
+++ b/packages/breadboard/src/remote/run.ts
@@ -73,13 +73,11 @@ export class RunServer {
     try {
       for await (const stop of runGraph(runner, servingContext)) {
         if (stop.type === "input") {
-          const state = stop.runState as RunState;
           const { node, inputArguments, timestamp, path, invocationId } = stop;
           const bubbled = invocationId == -1;
           await responses.write([
             "input",
             { node, inputArguments, timestamp, path, bubbled },
-            state,
           ]);
           request = await requestReader.read();
           if (request.done) {

--- a/packages/breadboard/src/remote/run.ts
+++ b/packages/breadboard/src/remote/run.ts
@@ -6,7 +6,6 @@
 
 import { Diagnostics } from "../harness/diagnostics.js";
 import { extractError } from "../harness/error.js";
-import { RunResult } from "../run.js";
 import { createRunStateManager } from "../run/index.js";
 import { runGraph } from "../run/run-graph.js";
 import { RunState } from "../run/types.js";
@@ -32,24 +31,6 @@ import {
   ServerTransport,
 } from "./types.js";
 
-const resumeRun = (request: AnyRunRequestMessage) => {
-  const [type, , state] = request;
-
-  // There may not be any state to resume from.
-  if (!state) return undefined;
-
-  if (state.length > 1) {
-    throw new Error("I don't yet know how to resume from nested subgraphs.");
-  }
-
-  const result = RunResult.load(state[0].state as string);
-  if (type === "input") {
-    const [, inputs] = request;
-    result.inputs = inputs.inputs;
-  }
-  return result;
-};
-
 type RunServerTransport = ServerTransport<
   AnyRunRequestMessage,
   AnyRunResponseMessage
@@ -72,7 +53,6 @@ export class RunServer {
     let request = await requestReader.read();
     if (request.done) return;
 
-    const result = resumeRun(request.value);
     const responses = stream.writableResponses.getWriter();
 
     const servingContext: NodeHandlerContext = {
@@ -91,11 +71,7 @@ export class RunServer {
     };
 
     try {
-      for await (const stop of runGraph(
-        runner,
-        servingContext,
-        result?.state
-      )) {
+      for await (const stop of runGraph(runner, servingContext)) {
         if (stop.type === "input") {
           const state = stop.runState as RunState;
           const { node, inputArguments, timestamp, path, invocationId } = stop;
@@ -145,7 +121,7 @@ const createRunResult = (
         "For now, we cannot reply to messages other than 'input'."
       );
     }
-    await response.reply([type, chunk as InputResolveRequest, state]);
+    await response.reply([type, chunk as InputResolveRequest]);
   };
   return {
     type,

--- a/packages/breadboard/src/remote/types.ts
+++ b/packages/breadboard/src/remote/types.ts
@@ -149,18 +149,18 @@ export type AnyRunRequestMessage =
   | RunRequestMessage
   | InputResolveRequestMessage;
 
-export type NodeStartMessage = RemoteMessage<NodeStartProbeMessage>;
-export type NodeEndMessage = RemoteMessage<NodeEndProbeMessage>;
-export type GraphStartMessage = RemoteMessage<GraphStartProbeMessage>;
-export type GraphEndMessage = RemoteMessage<GraphEndProbeMessage>;
-export type SkipMessage = RemoteMessage<SkipProbeMessage>;
+export type NodeStartRemoteMessage = RemoteMessage<NodeStartProbeMessage>;
+export type NodeEndRemoteMessage = RemoteMessage<NodeEndProbeMessage>;
+export type GraphStartRemoteMessage = RemoteMessage<GraphStartProbeMessage>;
+export type GraphEndRemoteMessage = RemoteMessage<GraphEndProbeMessage>;
+export type SkipRemoteMessage = RemoteMessage<SkipProbeMessage>;
 
 export type AnyProbeMessage =
-  | NodeStartMessage
-  | NodeEndMessage
-  | GraphStartMessage
-  | GraphEndMessage
-  | SkipMessage;
+  | NodeStartRemoteMessage
+  | NodeEndRemoteMessage
+  | GraphStartRemoteMessage
+  | GraphEndRemoteMessage
+  | SkipRemoteMessage;
 
 export type AnyRunResponseMessage =
   | OutputResponseMessage

--- a/packages/breadboard/src/remote/types.ts
+++ b/packages/breadboard/src/remote/types.ts
@@ -10,6 +10,7 @@ import type { RunState } from "../run/types.js";
 import { PatchedReadableStream } from "../stream.js";
 import {
   ErrorResponse,
+  GraphDescriptor,
   GraphEndProbeMessage,
   GraphStartProbeMessage,
   InputResponse,
@@ -233,6 +234,7 @@ export type ServerRunRequest = {
 };
 
 export type ServerRunConfig = {
+  graph?: GraphDescriptor;
   url: string;
   kits: Kit[];
   writer: RemoteMessageWriter;
@@ -240,5 +242,10 @@ export type ServerRunConfig = {
   dataStore: DataStore;
   stateStore: StateStore;
   inputs?: InputValues;
-  diagnostics: boolean;
+  diagnostics?: boolean;
 };
+
+export type RemoteRunRequestBody = {
+  $key: string;
+  $next?: string;
+} & InputValues;

--- a/packages/breadboard/src/remote/types.ts
+++ b/packages/breadboard/src/remote/types.ts
@@ -65,7 +65,11 @@ export type LoadResponse = {
 
 type GenericResult = { type: string; data: unknown };
 
-type RemoteMessage<T extends GenericResult> = [T["type"], T["data"], RunState?];
+type RemoteMessage<T extends GenericResult> = [
+  T["type"],
+  T["data"],
+  next?: string,
+];
 
 /**
  * A run request is an empty object.
@@ -74,13 +78,17 @@ type RemoteMessage<T extends GenericResult> = [T["type"], T["data"], RunState?];
 export type RunRequest = Record<string, never>;
 export type RunRequestMessage = ["run", RunRequest, RunState?];
 export type OutputRemoteMessage = ["output", OutputResponse];
-export type InputResponseMessage = ["input", InputResponse, RunState];
+export type InputRemoveMessage = ["input", InputResponse, next?: string];
 
 /**
  * Sent by the client to provide inputs, requested by the server.
  */
 export type InputResolveRequest = { inputs: InputValues };
-export type InputRemoteMessage = ["input", InputResolveRequest, next?: string];
+export type InputResolveRequestMessage = [
+  "input",
+  InputResolveRequest,
+  next?: string,
+];
 
 export type LastNode = {
   node: NodeDescriptor;
@@ -141,7 +149,9 @@ export type AnyProxyResponseMessage =
   | ProxyChunkResponseMessage
   | EndRemoteMessage;
 
-export type AnyRunRequestMessage = RunRequestMessage | InputRemoteMessage;
+export type AnyRunRequestMessage =
+  | RunRequestMessage
+  | InputResolveRequestMessage;
 
 export type NodeStartRemoteMessage = RemoteMessage<NodeStartProbeMessage>;
 export type NodeEndRemoteMessage = RemoteMessage<NodeEndProbeMessage>;
@@ -158,7 +168,7 @@ export type AnyProbeMessage =
 
 export type AnyRunResponseMessage =
   | OutputRemoteMessage
-  | InputResponseMessage
+  | InputRemoveMessage
   | EndRemoteMessage
   | ErrorRemoteMessage
   | AnyProbeMessage;
@@ -195,7 +205,7 @@ export type RunStateFunction = () => Promise<RunState>;
 type ClientRunResultFromMessage<ResponseMessage> = ResponseMessage extends [
   string,
   object,
-  RunState?,
+  string?,
 ]
   ? {
       type: ResponseMessage[0];

--- a/packages/breadboard/src/remote/types.ts
+++ b/packages/breadboard/src/remote/types.ts
@@ -73,18 +73,14 @@ type RemoteMessage<T extends GenericResult> = [T["type"], T["data"], RunState?];
  */
 export type RunRequest = Record<string, never>;
 export type RunRequestMessage = ["run", RunRequest, RunState?];
-export type OutputResponseMessage = ["output", OutputResponse];
+export type OutputRemoteMessage = ["output", OutputResponse];
 export type InputResponseMessage = ["input", InputResponse, RunState];
 
 /**
  * Sent by the client to provide inputs, requested by the server.
  */
 export type InputResolveRequest = { inputs: InputValues };
-export type InputResolveRequestMessage = [
-  "input",
-  InputResolveRequest,
-  RunState,
-];
+export type InputRemoteMessage = ["input", InputResolveRequest, RunState];
 
 export type LastNode = {
   node: NodeDescriptor;
@@ -99,10 +95,10 @@ export type End = {
   timestamp: number;
   last?: LastNode;
 };
-export type EndResponseMessage = ["end", End];
+export type EndRemoteMessage = ["end", End];
 export type EndRequestMessage = ["end", End];
 
-export type ErrorResponseMessage = ["error", ErrorResponse];
+export type ErrorRemoteMessage = ["error", ErrorResponse];
 
 /**
  * Sent by the client to request to proxy a node.
@@ -141,13 +137,11 @@ export type ProxyChunkResponseMessage = ["chunk", ProxyChunkResponse];
 export type AnyProxyRequestMessage = ProxyRequestMessage | EndRequestMessage;
 export type AnyProxyResponseMessage =
   | ProxyResponseMessage
-  | ErrorResponseMessage
+  | ErrorRemoteMessage
   | ProxyChunkResponseMessage
-  | EndResponseMessage;
+  | EndRemoteMessage;
 
-export type AnyRunRequestMessage =
-  | RunRequestMessage
-  | InputResolveRequestMessage;
+export type AnyRunRequestMessage = RunRequestMessage | InputRemoteMessage;
 
 export type NodeStartRemoteMessage = RemoteMessage<NodeStartProbeMessage>;
 export type NodeEndRemoteMessage = RemoteMessage<NodeEndProbeMessage>;
@@ -163,10 +157,10 @@ export type AnyProbeMessage =
   | SkipRemoteMessage;
 
 export type AnyRunResponseMessage =
-  | OutputResponseMessage
+  | OutputRemoteMessage
   | InputResponseMessage
-  | EndResponseMessage
-  | ErrorResponseMessage
+  | EndRemoteMessage
+  | ErrorRemoteMessage
   | AnyProbeMessage;
 
 export interface ClientBidirectionalStream<Request, Response> {

--- a/packages/breadboard/src/remote/types.ts
+++ b/packages/breadboard/src/remote/types.ts
@@ -5,7 +5,6 @@
  */
 
 import { DataStore, StateStore } from "../data/types.js";
-import { RunConfig } from "../harness/types.js";
 import { GraphLoader } from "../loader/types.js";
 import type { RunState } from "../run/types.js";
 import { PatchedReadableStream } from "../stream.js";

--- a/packages/breadboard/src/remote/types.ts
+++ b/packages/breadboard/src/remote/types.ts
@@ -65,7 +65,7 @@ export type LoadResponse = {
 
 type GenericResult = { type: string; data: unknown };
 
-type RemoteMessage<T extends GenericResult> = [
+type AsRemoteMessage<T extends GenericResult> = [
   T["type"],
   T["data"],
   next?: string,
@@ -153,25 +153,25 @@ export type AnyRunRequestMessage =
   | RunRequestMessage
   | InputResolveRequestMessage;
 
-export type NodeStartRemoteMessage = RemoteMessage<NodeStartProbeMessage>;
-export type NodeEndRemoteMessage = RemoteMessage<NodeEndProbeMessage>;
-export type GraphStartRemoteMessage = RemoteMessage<GraphStartProbeMessage>;
-export type GraphEndRemoteMessage = RemoteMessage<GraphEndProbeMessage>;
-export type SkipRemoteMessage = RemoteMessage<SkipProbeMessage>;
+export type NodeStartRemoteMessage = AsRemoteMessage<NodeStartProbeMessage>;
+export type NodeEndRemoteMessage = AsRemoteMessage<NodeEndProbeMessage>;
+export type GraphStartRemoteMessage = AsRemoteMessage<GraphStartProbeMessage>;
+export type GraphEndRemoteMessage = AsRemoteMessage<GraphEndProbeMessage>;
+export type SkipRemoteMessage = AsRemoteMessage<SkipProbeMessage>;
 
-export type AnyProbeMessage =
+export type DiagnosticsRemoteMessage =
   | NodeStartRemoteMessage
   | NodeEndRemoteMessage
   | GraphStartRemoteMessage
   | GraphEndRemoteMessage
   | SkipRemoteMessage;
 
-export type AnyRunResponseMessage =
+export type RemoteMessage =
   | OutputRemoteMessage
   | InputRemoteMessage
   | EndRemoteMessage
   | ErrorRemoteMessage
-  | AnyProbeMessage;
+  | DiagnosticsRemoteMessage;
 
 export interface ClientBidirectionalStream<Request, Response> {
   writableRequests: WritableStream<Request>;
@@ -193,7 +193,7 @@ export interface ClientTransport<Request, Response> {
 
 export type RunClientTransport = ClientTransport<
   AnyRunRequestMessage,
-  AnyRunResponseMessage
+  RemoteMessage
 >;
 
 type ReplyFunction = {
@@ -214,10 +214,9 @@ type ClientRunResultFromMessage<ResponseMessage> = ResponseMessage extends [
     } & ReplyFunction
   : never;
 
-export type AnyClientRunResult =
-  ClientRunResultFromMessage<AnyRunResponseMessage>;
+export type AnyClientRunResult = ClientRunResultFromMessage<RemoteMessage>;
 
 export type AnyProbeClientRunResult =
-  ClientRunResultFromMessage<AnyProbeMessage>;
+  ClientRunResultFromMessage<DiagnosticsRemoteMessage>;
 
 export type ClientRunResult<T> = T & ReplyFunction;

--- a/packages/breadboard/src/remote/types.ts
+++ b/packages/breadboard/src/remote/types.ts
@@ -65,7 +65,7 @@ export type LoadResponse = {
 
 type GenericResult = { type: string; data: unknown };
 
-type AsRemoteMessage<T extends GenericResult> = [
+export type AsRemoteMessage<T extends GenericResult> = [
   T["type"],
   T["data"],
   next?: string,
@@ -172,6 +172,9 @@ export type RemoteMessage =
   | EndRemoteMessage
   | ErrorRemoteMessage
   | DiagnosticsRemoteMessage;
+
+export type RemoteMessageWriter = WritableStreamDefaultWriter<RemoteMessage>;
+export type RemoteMessageWritableStream = WritableStream<RemoteMessage>;
 
 export interface ClientBidirectionalStream<Request, Response> {
   writableRequests: WritableStream<Request>;

--- a/packages/breadboard/src/remote/types.ts
+++ b/packages/breadboard/src/remote/types.ts
@@ -80,7 +80,7 @@ export type InputResponseMessage = ["input", InputResponse, RunState];
  * Sent by the client to provide inputs, requested by the server.
  */
 export type InputResolveRequest = { inputs: InputValues };
-export type InputRemoteMessage = ["input", InputResolveRequest, RunState];
+export type InputRemoteMessage = ["input", InputResolveRequest, next?: string];
 
 export type LastNode = {
   node: NodeDescriptor;

--- a/packages/breadboard/src/remote/types.ts
+++ b/packages/breadboard/src/remote/types.ts
@@ -78,7 +78,7 @@ type RemoteMessage<T extends GenericResult> = [
 export type RunRequest = Record<string, never>;
 export type RunRequestMessage = ["run", RunRequest, RunState?];
 export type OutputRemoteMessage = ["output", OutputResponse];
-export type InputRemoveMessage = ["input", InputResponse, next?: string];
+export type InputRemoteMessage = ["input", InputResponse, next?: string];
 
 /**
  * Sent by the client to provide inputs, requested by the server.
@@ -168,7 +168,7 @@ export type AnyProbeMessage =
 
 export type AnyRunResponseMessage =
   | OutputRemoteMessage
-  | InputRemoveMessage
+  | InputRemoteMessage
   | EndRemoteMessage
   | ErrorRemoteMessage
   | AnyProbeMessage;

--- a/packages/breadboard/src/remote/types.ts
+++ b/packages/breadboard/src/remote/types.ts
@@ -5,6 +5,7 @@
  */
 
 import { DataStore, StateStore } from "../data/types.js";
+import { RunConfig } from "../harness/types.js";
 import { GraphLoader } from "../loader/types.js";
 import type { RunState } from "../run/types.js";
 import { PatchedReadableStream } from "../stream.js";
@@ -231,6 +232,7 @@ export type ClientRunResult<T> = T & ReplyFunction;
 export type ServerRunRequest = {
   inputs?: InputValues;
   next?: string;
+  diagnostics?: boolean;
 };
 
 export type ServerRunConfig = {
@@ -245,7 +247,10 @@ export type ServerRunConfig = {
   diagnostics?: boolean;
 };
 
+export type RemoteRunConfig = Omit<RunConfig, "kits">;
+
 export type RemoteRunRequestBody = {
   $key: string;
   $next?: string;
+  $diagnostics?: boolean;
 } & InputValues;

--- a/packages/breadboard/src/remote/types.ts
+++ b/packages/breadboard/src/remote/types.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { DataStore, StateStore } from "../data/types.js";
+import { RunConfig } from "../harness/types.js";
+import { GraphLoader } from "../loader/types.js";
 import type { RunState } from "../run/types.js";
 import { PatchedReadableStream } from "../stream.js";
 import {
@@ -12,6 +15,7 @@ import {
   GraphStartProbeMessage,
   InputResponse,
   InputValues,
+  Kit,
   NodeDescriptor,
   NodeEndProbeMessage,
   NodeStartProbeMessage,
@@ -223,3 +227,19 @@ export type AnyProbeClientRunResult =
   ClientRunResultFromMessage<DiagnosticsRemoteMessage>;
 
 export type ClientRunResult<T> = T & ReplyFunction;
+
+export type ServerRunRequest = {
+  inputs: InputValues;
+  next: string;
+};
+
+export type ServerRunConfig = {
+  url: string;
+  kits: Kit[];
+  writer: RemoteMessageWriter;
+  loader: GraphLoader;
+  dataStore: DataStore;
+  stateStore: StateStore;
+  inputs?: InputValues;
+  diagnostics: boolean;
+};

--- a/packages/breadboard/src/remote/types.ts
+++ b/packages/breadboard/src/remote/types.ts
@@ -229,8 +229,8 @@ export type AnyProbeClientRunResult =
 export type ClientRunResult<T> = T & ReplyFunction;
 
 export type ServerRunRequest = {
-  inputs: InputValues;
-  next: string;
+  inputs?: InputValues;
+  next?: string;
 };
 
 export type ServerRunConfig = {

--- a/packages/breadboard/src/remote/types.ts
+++ b/packages/breadboard/src/remote/types.ts
@@ -149,12 +149,18 @@ export type AnyRunRequestMessage =
   | RunRequestMessage
   | InputResolveRequestMessage;
 
+export type NodeStartMessage = RemoteMessage<NodeStartProbeMessage>;
+export type NodeEndMessage = RemoteMessage<NodeEndProbeMessage>;
+export type GraphStartMessage = RemoteMessage<GraphStartProbeMessage>;
+export type GraphEndMessage = RemoteMessage<GraphEndProbeMessage>;
+export type SkipMessage = RemoteMessage<SkipProbeMessage>;
+
 export type AnyProbeMessage =
-  | RemoteMessage<NodeStartProbeMessage>
-  | RemoteMessage<NodeEndProbeMessage>
-  | RemoteMessage<GraphStartProbeMessage>
-  | RemoteMessage<GraphEndProbeMessage>
-  | RemoteMessage<SkipProbeMessage>;
+  | NodeStartMessage
+  | NodeEndMessage
+  | GraphStartMessage
+  | GraphEndMessage
+  | SkipMessage;
 
 export type AnyRunResponseMessage =
   | OutputResponseMessage

--- a/packages/breadboard/tests/editor/metadata.ts
+++ b/packages/breadboard/tests/editor/metadata.ts
@@ -38,7 +38,6 @@ test("editGraph correctly edits node metadata", async (t) => {
     "test",
     true
   );
-  console.log(result);
   t.is(result.success, true);
 
   const newMetadata = { title: "bar" };

--- a/packages/breadboard/tests/node/run/local-runner.ts
+++ b/packages/breadboard/tests/node/run/local-runner.ts
@@ -8,47 +8,22 @@ import { GraphDescriptor } from "@google-labs/breadboard-schema/graph.js";
 import { deepStrictEqual, ok } from "node:assert";
 import test, { describe } from "node:test";
 import { LocalRunner } from "../../../src/harness/local-runner.js";
-import { HarnessRunner } from "../../../src/harness/types.js";
 import { createLoader } from "../../../src/loader/index.js";
 import { OutputResponse } from "../../../src/types.js";
 import { testKit } from "../test-kit.js";
+import {
+  EventLogEntry,
+  eventNamesFromLog,
+  logEvents,
+  queryLog,
+} from "./test-utils.js";
 
+import askForSecret from "../../bgl/ask-for-secret.bgl.json" with { type: "json" };
 import multiLevelInvoke from "../../bgl/multi-level-invoke.bgl.json" with { type: "json" };
 import simple from "../../bgl/simple.bgl.json" with { type: "json" };
-import askForSecret from "../../bgl/ask-for-secret.bgl.json" with { type: "json" };
 
 const BGL_DIR = new URL("../../../tests/bgl/test.bgl.json", import.meta.url)
   .href;
-
-type EventLogEntry = [name: string, data: unknown];
-
-const eventNamesFromLog = (log: EventLogEntry[]) => log.map(([name]) => name);
-const queryLog = (log: EventLogEntry[], name: string) =>
-  log.find(([n]) => n == name)?.[1];
-
-const logEvents = (runner: HarnessRunner, events: EventLogEntry[]) => {
-  const eventNames = [
-    "start",
-    "pause",
-    "resume",
-    "input",
-    "output",
-    "secret",
-    "error",
-    "skip",
-    "graphstart",
-    "graphend",
-    "nodestart",
-    "nodeend",
-    "end",
-  ];
-  eventNames.forEach((name) => {
-    runner.addEventListener(name, (event) => {
-      const e = event as unknown as { data: unknown };
-      events.push([name, e.data]);
-    });
-  });
-};
 
 describe("LocalRunner", async () => {
   test("simple graph with no diagnostics", async () => {

--- a/packages/breadboard/tests/node/run/remote-runner.ts
+++ b/packages/breadboard/tests/node/run/remote-runner.ts
@@ -6,11 +6,31 @@
 
 import test, { describe } from "node:test";
 
-import simple from "../../bgl/simple.bgl.json" with { type: "json" };
-import { fail } from "node:assert";
-import { LocalRunner } from "../../../src/harness/local-runner.js";
+import { GraphDescriptor } from "@google-labs/breadboard-schema/graph.js";
+import { deepStrictEqual, fail, ok } from "node:assert";
+import { RemoteRunner } from "../../../src/harness/remote-runner.js";
+import {
+  createDefaultDataStore,
+  createLoader,
+  OutputResponse,
+} from "../../../src/index.js";
+import { handleRunGraphRequest } from "../../../src/remote/run-graph-server.js";
+import {
+  RemoteMessage,
+  RemoteRunRequestBody,
+  ServerRunConfig,
+} from "../../../src/remote/types.js";
+import { testKit } from "../test-kit.js";
+import {
+  EventLogEntry,
+  eventNamesFromLog,
+  logEvents,
+  queryLog,
+} from "./test-utils.js";
 
-const mockFetch = (runner: LocalRunner) => {
+import simple from "../../bgl/simple.bgl.json" with { type: "json" };
+
+const mockFetch = (graph: GraphDescriptor) => {
   const result: typeof globalThis.fetch = async (request, init) => {
     const url = request as string;
     const { method, body } = init || {};
@@ -20,13 +40,86 @@ const mockFetch = (runner: LocalRunner) => {
     if (url !== "https://example.com/run") {
       fail(`Only "https://example.com/run" is supported by mockFetch.`);
     }
-    return new Response();
+    if (!body) {
+      fail("No body provided in request.");
+    }
+    const {
+      $key,
+      $next: next,
+      ...inputs
+    } = JSON.parse(body as string) as RemoteRunRequestBody;
+
+    if ($key !== "my-key") {
+      fail(`Invalid key provided. Use "my-key".`);
+    }
+
+    const pipe = new TransformStream<RemoteMessage, string>({
+      transform(message, controller) {
+        controller.enqueue(`data: ${JSON.stringify(message)}\n\n`);
+      },
+    });
+
+    const config: ServerRunConfig = {
+      graph,
+      url: import.meta.url,
+      kits: [testKit],
+      writer: pipe.writable.getWriter(),
+      loader: createLoader(),
+      dataStore: createDefaultDataStore(),
+      stateStore: {
+        async load(next?: string) {
+          return next ? JSON.parse(next as string) : undefined;
+        },
+        async save(state) {
+          return JSON.stringify(state);
+        },
+      },
+    };
+
+    handleRunGraphRequest({ inputs: inputs, next }, config);
+
+    return new Response(pipe.readable.pipeThrough(new TextEncoderStream()));
   };
   return result;
 };
 
 describe("RemoteRunner", async () => {
   test("can run simple graph", async () => {
-    // Test code here
+    const events: EventLogEntry[] = [];
+
+    const runner = new RemoteRunner(
+      {
+        remote: {
+          type: "http",
+          key: "my-key",
+          url: "https://example.com/run",
+        },
+        url: import.meta.url,
+        kits: [],
+      },
+      mockFetch(simple)
+    );
+    logEvents(runner, events);
+    {
+      const result = await runner.run();
+      ok(result == false);
+      ok(!runner.running());
+      deepStrictEqual(eventNamesFromLog(events), ["start", "input", "pause"]);
+    }
+    {
+      const result = await runner.run({ text: "foo" });
+      ok(result == true);
+      ok(!runner.running());
+      deepStrictEqual(eventNamesFromLog(events), [
+        "start",
+        "input",
+        "pause",
+        "resume",
+        "output",
+        "end",
+      ]);
+      const output = queryLog(events, "output") as OutputResponse;
+      deepStrictEqual(output.outputs, { text: "foo" });
+    }
   });
 });

--- a/packages/breadboard/tests/node/run/remote-runner.ts
+++ b/packages/breadboard/tests/node/run/remote-runner.ts
@@ -6,85 +6,23 @@
 
 import test, { describe } from "node:test";
 
-import { GraphDescriptor } from "@google-labs/breadboard-schema/graph.js";
-import { deepStrictEqual, fail, ok } from "node:assert";
+import { deepStrictEqual, ok } from "node:assert";
 import { RemoteRunner } from "../../../src/harness/remote-runner.js";
-import {
-  createDefaultDataStore,
-  createLoader,
-  OutputResponse,
-} from "../../../src/index.js";
-import { handleRunGraphRequest } from "../../../src/remote/run-graph-server.js";
-import {
-  RemoteMessage,
-  RemoteRunRequestBody,
-  ServerRunConfig,
-} from "../../../src/remote/types.js";
-import { testKit } from "../test-kit.js";
+import { GraphDescriptor, OutputResponse } from "../../../src/index.js";
 import {
   EventLogEntry,
   eventNamesFromLog,
   logEvents,
+  mockFetch,
   queryLog,
 } from "./test-utils.js";
 
+import askForSecret from "../../bgl/ask-for-secret.bgl.json" with { type: "json" };
 import simple from "../../bgl/simple.bgl.json" with { type: "json" };
+import multiLevelInvoke from "../../bgl/multi-level-invoke.bgl.json" with { type: "json" };
 
-const mockFetch = (graph: GraphDescriptor) => {
-  const result: typeof globalThis.fetch = async (request, init) => {
-    const url = request as string;
-    const { method, body } = init || {};
-    if (method !== "POST") {
-      fail("Only POST requests are supported by mockFetch.");
-    }
-    if (url !== "https://example.com/run") {
-      fail(`Only "https://example.com/run" is supported by mockFetch.`);
-    }
-    if (!body) {
-      fail("No body provided in request.");
-    }
-    const {
-      $key,
-      $next: next,
-      $diagnostics: diagnostics,
-      ...inputs
-    } = JSON.parse(body as string) as RemoteRunRequestBody;
-
-    console.log("🌻 body in mockFetch", body);
-
-    if ($key !== "my-key") {
-      fail(`Invalid key provided. Use "my-key".`);
-    }
-
-    const pipe = new TransformStream<RemoteMessage, string>({
-      transform(message, controller) {
-        controller.enqueue(`data: ${JSON.stringify(message)}\n\n`);
-      },
-    });
-
-    const config: ServerRunConfig = {
-      graph,
-      url: import.meta.url,
-      kits: [testKit],
-      writer: pipe.writable.getWriter(),
-      loader: createLoader(),
-      dataStore: createDefaultDataStore(),
-      stateStore: {
-        async load(next?: string) {
-          return next ? JSON.parse(next as string) : undefined;
-        },
-        async save(state) {
-          return JSON.stringify(state);
-        },
-      },
-    };
-
-    handleRunGraphRequest({ inputs: inputs, next, diagnostics }, config);
-
-    return new Response(pipe.readable.pipeThrough(new TextEncoderStream()));
-  };
-  return result;
-};
+const BGL_DIR = new URL("../../../tests/bgl/test.bgl.json", import.meta.url)
+  .href;
 
 describe("RemoteRunner", async () => {
   test("simple graph with no diagnostics", async () => {
@@ -172,6 +110,116 @@ describe("RemoteRunner", async () => {
       ]);
       const output = queryLog(events, "output") as OutputResponse;
       deepStrictEqual(output.outputs, { text: "foo" });
+    }
+  });
+
+  test("multi-level invoke graph with diagnostics", async () => {
+    const events: EventLogEntry[] = [];
+    const graph = multiLevelInvoke as GraphDescriptor;
+    graph.url = BGL_DIR;
+    const runner = new RemoteRunner(
+      {
+        remote: {
+          type: "http",
+          key: "my-key",
+          url: "https://example.com/run",
+        },
+        url: import.meta.url,
+        diagnostics: true,
+      },
+      mockFetch(graph)
+    );
+    logEvents(runner, events);
+    {
+      const result = await runner.run();
+      ok(!result);
+      ok(!runner.running());
+      deepStrictEqual(eventNamesFromLog(events), [
+        "start",
+        "graphstart",
+        "nodestart",
+        "graphstart",
+        "nodestart",
+        "input",
+        "pause",
+      ]);
+    }
+    {
+      events.length = 0;
+      const result = await runner.run({ name: "Bob" });
+      ok(!result);
+      ok(!runner.running());
+      deepStrictEqual(eventNamesFromLog(events), [
+        "resume",
+        "nodeend",
+        "nodestart",
+        "graphstart",
+        "nodestart",
+        "input",
+        "pause",
+      ]);
+    }
+    {
+      events.length = 0;
+      const result = await runner.run({ location: "Neptune" });
+      ok(result);
+      ok(!runner.running());
+      deepStrictEqual(eventNamesFromLog(events), [
+        "resume",
+        "nodeend",
+        "nodestart",
+        "nodeend",
+        "skip",
+        "nodestart",
+        "nodeend",
+        "graphend",
+        "nodeend",
+        "nodestart",
+        "nodeend",
+        "nodestart",
+        "nodeend",
+        "graphend",
+        "nodeend",
+        "nodestart",
+        "output",
+        "nodeend",
+        "graphend",
+        "end",
+      ]);
+      const output = queryLog(events, "output") as OutputResponse;
+      deepStrictEqual(output.outputs, {
+        greeting: 'Greeting is: "Hello, Bob from Neptune!"',
+      });
+    }
+  });
+
+  test("correctly handles secret inputs", async () => {
+    const events: EventLogEntry[] = [];
+    const runner = new RemoteRunner(
+      {
+        remote: {
+          type: "http",
+          key: "my-key",
+          url: "https://example.com/run",
+        },
+        url: import.meta.url,
+        diagnostics: true,
+      },
+      mockFetch(askForSecret as GraphDescriptor)
+    );
+    logEvents(runner, events);
+    {
+      const result = await runner.run();
+      ok(result);
+      ok(!runner.running());
+      deepStrictEqual(eventNamesFromLog(events), [
+        "start",
+        "graphstart",
+        "nodestart",
+        "nodeend",
+        "graphend",
+        "end",
+      ]);
     }
   });
 });

--- a/packages/breadboard/tests/node/run/remote-runner.ts
+++ b/packages/breadboard/tests/node/run/remote-runner.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import test, { describe } from "node:test";
+
+import simple from "../../bgl/simple.bgl.json" with { type: "json" };
+import { fail } from "node:assert";
+import { LocalRunner } from "../../../src/harness/local-runner.js";
+
+const mockFetch = (runner: LocalRunner) => {
+  const result: typeof globalThis.fetch = async (request, init) => {
+    const url = request as string;
+    const { method, body } = init || {};
+    if (method !== "POST") {
+      fail("Only POST requests are supported by mockFetch.");
+    }
+    if (url !== "https://example.com/run") {
+      fail(`Only "https://example.com/run" is supported by mockFetch.`);
+    }
+    return new Response();
+  };
+  return result;
+};
+
+describe("RemoteRunner", async () => {
+  test("can run simple graph", async () => {
+    // Test code here
+  });
+});

--- a/packages/breadboard/tests/node/run/test-utils.ts
+++ b/packages/breadboard/tests/node/run/test-utils.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { HarnessRunner } from "../../../src/harness/types.js";
+
+export type EventLogEntry = [name: string, data: unknown];
+
+export const eventNamesFromLog = (log: EventLogEntry[]) =>
+  log.map(([name]) => name);
+
+export const queryLog = (log: EventLogEntry[], name: string) =>
+  log.find(([n]) => n == name)?.[1];
+
+export const logEvents = (runner: HarnessRunner, events: EventLogEntry[]) => {
+  const eventNames = [
+    "start",
+    "pause",
+    "resume",
+    "input",
+    "output",
+    "secret",
+    "error",
+    "skip",
+    "graphstart",
+    "graphend",
+    "nodestart",
+    "nodeend",
+    "end",
+  ];
+  eventNames.forEach((name) => {
+    runner.addEventListener(name, (event) => {
+      const e = event as unknown as { data: unknown };
+      events.push([name, e.data]);
+    });
+  });
+};

--- a/packages/breadboard/tests/node/run/test-utils.ts
+++ b/packages/breadboard/tests/node/run/test-utils.ts
@@ -4,7 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { GraphDescriptor } from "@google-labs/breadboard-schema/graph.js";
 import { HarnessRunner } from "../../../src/harness/types.js";
+import { fail } from "assert";
+import {
+  RemoteMessage,
+  RemoteRunRequestBody,
+  ServerRunConfig,
+} from "../../../src/remote/types.js";
+import { testKit } from "../test-kit.js";
+import { createDefaultDataStore, createLoader } from "../../../src/index.js";
+import { handleRunGraphRequest } from "../../../src/remote/run-graph-server.js";
 
 export type EventLogEntry = [name: string, data: unknown];
 
@@ -36,4 +46,58 @@ export const logEvents = (runner: HarnessRunner, events: EventLogEntry[]) => {
       events.push([name, e.data]);
     });
   });
+};
+
+export const mockFetch = (graph: GraphDescriptor) => {
+  const result: typeof globalThis.fetch = async (request, init) => {
+    const url = request as string;
+    const { method, body } = init || {};
+    if (method !== "POST") {
+      fail("Only POST requests are supported by mockFetch.");
+    }
+    if (url !== "https://example.com/run") {
+      fail(`Only "https://example.com/run" is supported by mockFetch.`);
+    }
+    if (!body) {
+      fail("No body provided in request.");
+    }
+    const {
+      $key,
+      $next: next,
+      $diagnostics: diagnostics,
+      ...inputs
+    } = JSON.parse(body as string) as RemoteRunRequestBody;
+
+    if ($key !== "my-key") {
+      fail(`Invalid key provided. Use "my-key".`);
+    }
+
+    const pipe = new TransformStream<RemoteMessage, string>({
+      transform(message, controller) {
+        controller.enqueue(`data: ${JSON.stringify(message)}\n\n`);
+      },
+    });
+
+    const config: ServerRunConfig = {
+      graph,
+      url: import.meta.url,
+      kits: [testKit],
+      writer: pipe.writable.getWriter(),
+      loader: createLoader(),
+      dataStore: createDefaultDataStore(),
+      stateStore: {
+        async load(next?: string) {
+          return next ? JSON.parse(next as string) : undefined;
+        },
+        async save(state) {
+          return JSON.stringify(state);
+        },
+      },
+    };
+
+    handleRunGraphRequest({ inputs: inputs, next, diagnostics }, config);
+
+    return new Response(pipe.readable.pipeThrough(new TextEncoderStream()));
+  };
+  return result;
 };

--- a/packages/breadboard/tests/node/test-kit.ts
+++ b/packages/breadboard/tests/node/test-kit.ts
@@ -119,6 +119,14 @@ export const testKit: Kit = {
             };
       },
     },
+    secrets: {
+      invoke: async (inputs) => {
+        const { keys } = inputs as { keys: string[] };
+        return Object.fromEntries(
+          keys.map((key: string) => [key, "secret-value"])
+        );
+      },
+    },
   },
 };
 

--- a/packages/breadboard/tests/remote/transport.ts
+++ b/packages/breadboard/tests/remote/transport.ts
@@ -5,10 +5,7 @@
  */
 
 import test from "ava";
-import {
-  AnyRunRequestMessage,
-  AnyRunResponseMessage,
-} from "../../src/remote/types.js";
+import { AnyRunRequestMessage, RemoteMessage } from "../../src/remote/types.js";
 import { Board } from "../../src/board.js";
 import { TestKit } from "../helpers/_test-kit.js";
 import { createMockWorkers } from "../helpers/_test-transport.js";
@@ -32,7 +29,7 @@ test("Continuous streaming", async (t) => {
 
   const clientTransport = new WorkerClientTransport<
     AnyRunRequestMessage,
-    AnyRunResponseMessage
+    RemoteMessage
   >(hostDispatcher.send("test"));
   const server = new RunServer(
     new WorkerServerTransport(workerDispatcher.receive("test"))


### PR DESCRIPTION
- **Plumb diagnostic events through run-board.**
- **Sketch out RemoteRunner.**
- **Switch `end` to use EndResponseMessage.**
- **Switch `error` to use ErrorResponseMessage.**
- **Switch `skip` to use SkipMessage.**
- **Naming tweaks.**
- **Switch `graphstart` to use GraphStartRemoteMessage.**
- **Switch all but `input` to use *ResponseMessage.**
- **Massage types a bit.**
- **Remote type renames.**
- **Clip out RunState bits.**
- **Remove RunState from InputRemoteMessage.**
- **Switch `input` to use InputRemoteMessage.**
- **Remove RunBoardResult.**
- **Tweak type names.**
- **Another sketch of RemoteRunner.**
- **Start sketching out tests.**
- **Sketch out `handleRunGraphRequest`.**
- **Replace board server logic with the `handleRunGraphRequest` call.**
- **Polish.**
- **Add first test.**
- **Actually pass `$next` to the next request.**
- **Teach RemoteRunner to handle secrets.**
- **Teach `runBoard` to pass diagnostics flag.**
- **Remove spurious logging in tests.**
- **Expose RemoteRunner in the API.**
- **docs(changeset): Introduce RemoteRunner (over HTTPS)**
