### PR TITLE
[build] [website] More build API docs

### DIFF
--- a/packages/website/src/docs/build/build.md
+++ b/packages/website/src/docs/build/build.md
@@ -7,14 +7,14 @@ tags:
 ---
 
 The Breadboard Build API is an npm package that allows you to design and compose
-boards with TypeScript.
+boards with [TypeScript](https://www.typescriptlang.org/).
 
 It is an alternative to the [Visual Editor](../visual-editor/), designed for
 users who prefer a code-first approach to working with Breadboard.
 
-Boards that you create with the Build API can easily be serialized to
-[BGL](../too-long/#the-common-format) (_Breadboard Graph Language_). BGL files
-can be executed directly, or imported into the Visual Editor.
+Boards that you create with the Build API can be serialized to
+[BGL](../too-long/#the-common-format) (_Breadboard Graph Language_), which can
+then be executed directly, or imported into the Visual Editor.
 
 ## Install
 
@@ -22,18 +22,18 @@ can be executed directly, or imported into the Visual Editor.
 npm i @breadboard-ai/build
 ```
 
-## Inputs
+## Declaring Inputs
 
-All boards begin with the declaration of one or more inputs. The `input`
+All boards begin with the declaration of one or more _inputs_. The `input`
 function declares one input port. Inputs are configured by passing an object
 with the following fields:
 
 - `type`: A [Breadboard Type Expression](../type-expressions/) that constrains
   the schema of this port. By default, inputs have type `string`.
-- `description`: A text description for documentation purposes.
 - `default`: The value this input will have if none is provided.
-- `optional`: Allows the input to have no value. (Note that an input cannot be
-  `optional` if it has a `default`.)
+- `optional`: If `true`, the input is allowed to have no value. (Note that an
+  input cannot be `optional` if it has a `default`.)
+- `description`: A text description for documentation purposes.
 - `examples`: An array of example values for documentation purposes.
 
 > [!NOTE]
@@ -47,82 +47,180 @@ with the following fields:
 ```ts
 import { input } from "@breadboard-ai/build";
 
-const prompt = input({
-  description: "Instructions for the language model.",
-  examples: ["Write a poem"],
+const topic = input({
+  description: "What should the poem be about?",
+  examples: ["Coffee in the morning", "The mind of a cat"],
 });
 
-const temperature = input({
+const stanzas = input({
   type: "number",
-  description: "The degree of randomness in token selection.",
-  default: 0.7,
+  description: "How many stanzas should the poem have?",
+  default: 4,
 });
 ```
 
-## Components
+## Using Components
 
-Boards do all of their useful things by calling _components_.
+Boards perform work by instantiating _components_.
 
-When using the Build API, components are imported from npm packages or local
-JavaScript modules, and are instantiated by calling them as a function. The
-inputs to a component are passed as the first argument of the function, and the
-values can come from inputs, or from the outputs of other components.
+Components are imported from npm packages or local JavaScript modules, and are
+instantiated by calling them as a function.
 
-In addition, some packages include _helper functions_ which provide a more
-convenient or more strongly-typed way to instantiate a component.
+> [!TIP]
+>
+> See the _Kit Documentation_ section on the left-hand side of this guide for a
+> full catalog of the components you can import and use in your boards.
 
-See the _Kit Documentation_ section on the left-hand side of this guide for a
-full catalog of the components you can import and use in your boards.
+The inputs to a component are passed as the first argument of the function.
+Input values can come from `input` ports, from the outputs of other components,
+or from literal values.
 
-## Common Components
-
-Examples of some of the most commonly used components are shown here, so that
-you can see how they work with the Build API.
-
-### Code
-
-Use the `code` helper to instantiate a `runJavascript` component:
+For example, the `geminiText` component uses the Gemini Large Language Model API
+to generate text:
 
 ```ts
-import { input } from "@breadboard-ai/build";
-import { code } from "@google-labs/core-kit";
+import { geminiText } from "@google-labs/gemini-kit";
 
-const str = input();
-
-const capitalizer = code(
-  // Inputs
-  { str },
-  // Outputs
-  { uppercase: "string" },
-  // Implementation
-  ({ str }) => {
-    return { uppercase: str.toUpperCase() };
-  }
-);
-
-const capitalized = capitalizer.outputs.uppercase;
+const poemWriter = geminiText({
+  text: poemPrompt,
+  model: "gemini-1.5-flash-latest",
+});
 ```
 
-### Template
+The output ports of a component instance in your board are accessed through the
+`outputs` property. Output ports can be passed as inputs to other components, or
+they can be configured as the final outputs of your board (see
+[Declaring outputs](#declaring-outputs)).
 
-Use the `prompt` helper to to instantiate a `promptTemplate` component using a
+```ts
+const poemText = poemWriter.outputs.text;
+```
+
+### Helper Functions
+
+Some packages additionally vend _helper functions_ alongside their components,
+which provide a more convenient or more strongly-typed way to instantiate a
+component.
+
+For example, the `prompt` helper instantiates a `promptTemplate` component using
 convenient [JavaScript tagged template
 literal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals)
 syntax:
 
 ```ts
-import { input } from "@breadboard-ai/build";
 import { prompt } from "@google-labs/template-kit";
 
-const poemTopic = input();
-const poemPrompt = prompt`Write a poem about ${poemTopic}.`;
+const poemPrompt = prompt`
+  Write a poem about ${topic} with ${stanzas} stanzas.`;
 ```
 
-## Boards & Outputs
+## Declaring Outputs
 
-<!-- TODO(aomarks) -->
+Use the `output` function to declare an output port for your board.
 
-## Serialization
+The first argument to `output` is the output port that produces the value you
+want to emit on the port. The second argument is optional (but recommmended)
+metadata to help users understand the output port, and can have the following
+properties:
+
+- `title`: Display name of the output port.
+- `description`: Description of the output port.
+
+```ts
+import { output } from "@breadboard-ai/build";
+
+const poem = output(poemWriter.outputs.text, {
+  title: "Poem",
+  description: "The poem that Gemini generated.",
+});
+```
+
+## Declaring Boards
+
+The final step in creating a board with the Build API is to call the `board`
+function. This encapsulates the inputs, outputs, and board metadata into a board
+object. This object can then be imported for use by other boards, or it can be
+serialized for execution and visualization (see [Serializing
+Boards](#serializing-boards)).
+
+The only argument to `board` is an object with the following properties:
+
+- `inputs` (required): The inputs of the board. An object whose keys are input
+  port IDs, and whose values are `input` objects.
+- `outputs` (required): The outputs of the board. An object whose keys are
+  output port IDs, and whose values are `output` objects.
+- `id`: An identifier for the board when used as a component. Required if
+  bundling into a kit.
+- `title`: Display name for the board.
+- `description`: Description for the board.
+- `version`: Semver version of the board.
+- `metadata`: Additional data including `icon` and `tags`.
+
+```ts
+import { board } from "@breadboard-ai/build";
+
+export default board({
+  id: "poem-writer",
+  title: "Poem Writer",
+  description: "Write a poem with Gemini.",
+  inputs: { topic, stanzas },
+  outputs: { poem },
+});
+```
+
+> [!NOTE]
+>
+> All inputs and outputs of a board must be passed to the `board` function, or
+> else an error is thrown. The reason you are required to specify both inputs
+> and outputs (as opposed to the API discovering one from the other
+> automatically), is to allow TypeScript to understand the full input/output
+> signature of your boards _at compile time_. This ensures that you will see
+> schema mismatch errors as soon as possible when calling one component from
+> another.
+
+## Full Example
+
+The following example puts together all of the concepts discussed above:
+
+```ts
+import { board, input, output } from "@breadboard-ai/build";
+import { prompt } from "@google-labs/template-kit";
+import { geminiText } from "@google-labs/gemini-kit";
+
+const topic = input({
+  description: "What should the poem be about?",
+  examples: ["Coffee in the morning", "The mind of a cat"],
+});
+
+const stanzas = input({
+  type: "number",
+  description: "How many stanzas should the poem have?",
+  default: 4,
+});
+
+const poemPrompt = prompt`
+  Write a poem about ${topic} with ${stanzas} stanzas.`;
+
+const poemWriter = geminiText({
+  text: poemPrompt,
+  model: "gemini-1.5-flash-latest",
+});
+
+const poem = output(poemWriter.outputs.text, {
+  title: "Poem",
+  description: "The poem that Gemini generated.",
+});
+
+export default board({
+  id: "poem-writer",
+  title: "Poem Writer",
+  description: "Write a poem with Gemini.",
+  inputs: { topic, stanzas },
+  outputs: { poem },
+});
+```
+
+## Serializing Boards
 
 The `serialize` function takes a `BoardDefinition` (the result of calling the
 [`board`](#board) function), and generates a JSON-serializable object in
@@ -130,8 +228,15 @@ The `serialize` function takes a `BoardDefinition` (the result of calling the
 
 ```ts
 import { serialize } from "@breadboard-ai/build";
-import { myBoard } from "./my-board.js";
+import poemWriter from "./poem-writer.js";
 
-const bgl = serialize(myBoard);
+const bgl = serialize(poemWriter);
 console.log(JSON.stringify(bgl, null, 2));
 ```
+
+## TODO
+
+- Loops
+- Converge
+- Constant/Optional
+- Polymorphic I/O


### PR DESCRIPTION
Covers declaring outputs and boards, pulls things together with a full example, and refines some of the existing docs.

Part of https://github.com/breadboard-ai/breadboard/issues/2687