### PR TITLE
[board-server] Move routing logic into a router module

### DIFF
--- a/packages/board-server/src/index.ts
+++ b/packages/board-server/src/index.ts
@@ -7,11 +7,8 @@
 import { createServer } from "http";
 import { createServer as createViteServer } from "vite";
 import { env } from "process";
-import { serveContent } from "./server/common.js";
-import { serveBoardsAPI } from "./server/boards/index.js";
-import { serveProxyAPI } from "./server/proxy/index.js";
-import { serveInfoAPI } from "./server/info/index.js";
-import { serveHome } from "./server/home/index.js";
+
+import { makeRouter } from "./router.js";
 
 const PORT = env.PORT || 3000;
 const HOST = env.HOST || "localhost";
@@ -26,27 +23,7 @@ const vite = IS_PROD
       optimizeDeps: { esbuildOptions: { target: "esnext" } },
     });
 
-const server = createServer(async (req, res) => {
-  const url = new URL(req.url || "", HOSTNAME);
-
-  if (await serveHome(req, res)) {
-    return;
-  }
-
-  if (await serveProxyAPI(req, res)) {
-    return;
-  }
-
-  if (await serveInfoAPI(req, res)) {
-    return;
-  }
-
-  if (await serveBoardsAPI(url, vite, req, res)) {
-    return;
-  }
-
-  serveContent(vite, req, res);
-});
+const server = createServer(makeRouter(HOSTNAME, vite));
 
 server.listen(PORT, () => {
   console.info(`Running on "${HOSTNAME}"...`);

--- a/packages/board-server/src/router.ts
+++ b/packages/board-server/src/router.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { ViteDevServer } from "vite";
+
+import { serveContent } from "./server/common.js";
+import { serveBoardsAPI } from "./server/boards/index.js";
+import { serveProxyAPI } from "./server/proxy/index.js";
+import { serveInfoAPI } from "./server/info/index.js";
+import { serveHome } from "./server/home/index.js";
+
+export function makeRouter(hostname: string, vite: ViteDevServer | null) {
+  return async function router(
+    req: IncomingMessage,
+    res: ServerResponse
+  ): Promise<void> {
+    const url = new URL(req.url || "", hostname);
+
+    if (await serveHome(req, res)) {
+      return;
+    }
+
+    if (await serveProxyAPI(req, res)) {
+      return;
+    }
+
+    if (await serveInfoAPI(req, res)) {
+      return;
+    }
+
+    if (await serveBoardsAPI(url, vite, req, res)) {
+      return;
+    }
+
+    serveContent(vite, req, res);
+  };
+}


### PR DESCRIPTION
Part of #2896

This is a first step toward reworking the server routing logic for board server
to look more like connection server. The two servers employ very different
patterns. Especially if we want eventually to unify them, it would make sense to
have them follow the same basic patterns.

Next step is to create a Config object in board server similar to what
connection server uses. This is what would contain the ALLOWED_ORIGINS
environment variable.
