### PR TITLE
[build] Incremental work towards better backwards compatibility for kits

### DIFF
--- a/.changeset/perfect-rice-destroy.md
+++ b/.changeset/perfect-rice-destroy.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": minor
+---
+
+The kit function now takes components as an object instead of an array.

--- a/.changeset/stale-chefs-train.md
+++ b/.changeset/stale-chefs-train.md
@@ -1,0 +1,6 @@
+---
+"@breadboard-ai/google-drive-kit": patch
+"@breadboard-ai/python-wasm": patch
+---
+
+Switch to new style of declaring components in kits.

--- a/packages/build/src/internal/define/definition.ts
+++ b/packages/build/src/internal/define/definition.ts
@@ -80,17 +80,19 @@ export interface Definition<
   >;
 }
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
 export type GenericDiscreteComponent = Definition<
-  { [K: string]: JsonSerializable },
-  { [K: string]: JsonSerializable },
-  JsonSerializable | undefined,
-  JsonSerializable | undefined,
-  string,
-  boolean,
-  string | false,
-  string | false,
-  { [K: string]: InputMetadata }
+  any,
+  any,
+  any,
+  any,
+  any,
+  any,
+  any,
+  any,
+  any
 >;
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
 export function isDiscreteComponent(
   value: object

--- a/packages/build/src/internal/kit.ts
+++ b/packages/build/src/internal/kit.ts
@@ -26,12 +26,12 @@ export interface KitOptions {
   version: string;
   url: string;
   tags?: KitTag[];
-  components: Array<GenericDiscreteComponent | BoardDefinition>;
+  components: Record<string, GenericDiscreteComponent | BoardDefinition>;
 }
 
 export function kit(options: KitOptions): KitConstructor<Kit> {
   const handlers: Record<string, NodeHandler> = Object.fromEntries(
-    options.components.map((component) => {
+    Object.values(options.components).map((component) => {
       if (isDiscreteComponent(component)) {
         return [component.id, component];
       } else {

--- a/packages/build/src/internal/kit.ts
+++ b/packages/build/src/internal/kit.ts
@@ -37,8 +37,14 @@ export interface KitOptions<T extends ComponentManifest> {
 export function kit<T extends ComponentManifest>(
   options: KitOptions<T>
 ): KitConstructor<Kit> & T {
+  const componentsWithIds = Object.fromEntries(
+    Object.entries(options.components).map(([id, component]) => [
+      id,
+      { ...component, id },
+    ])
+  );
   const handlers: Record<string, NodeHandler> = Object.fromEntries(
-    Object.values(options.components).map((component) => {
+    Object.values(componentsWithIds).map((component) => {
       if (isDiscreteComponent(component)) {
         return [component.id, component];
       } else {
@@ -49,7 +55,8 @@ export function kit<T extends ComponentManifest>(
         return [
           component.id,
           // TODO(aomarks) Should this just be the invoke() method on Board?
-          makeBoardComponentHandler(component),
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          makeBoardComponentHandler(component as any),
         ];
       }
     })
@@ -67,7 +74,10 @@ export function kit<T extends ComponentManifest>(
     url = options.url;
     tags = options.tags ?? [];
   };
-  return Object.assign(result, options.components);
+  return Object.assign(
+    result,
+    componentsWithIds
+  ) as KitConstructor<Kit> as KitConstructor<Kit> & T;
 }
 
 function makeBoardComponentHandler(board: BoardDefinition): NodeHandler {

--- a/packages/build/src/test/kit_test.ts
+++ b/packages/build/src/test/kit_test.ts
@@ -17,7 +17,11 @@ const discreteComponent = defineNodeType({
   invoke: () => ({}),
 });
 
-const boardComponent = board({ id: "foo", inputs: {}, outputs: {} });
+const boardComponent = board({
+  id: "boardComponent",
+  inputs: {},
+  outputs: {},
+});
 
 test("kit takes discrete component", () => {
   // $ExpectType KitConstructor<Kit> & { foo: Definition<{}, {}, undefined, undefined, never, false, false, false, {}>; }
@@ -32,6 +36,7 @@ test("kit takes discrete component", () => {
     // $ExpectType Definition<{}, {}, undefined, undefined, never, false, false, false, {}>
     k.foo
   );
+  assert.equal(k.foo.id, "foo");
 });
 
 test("kit takes board component", () => {
@@ -47,4 +52,5 @@ test("kit takes board component", () => {
     // $ExpectType BoardDefinition<{}, {}>
     k.bar
   );
+  assert.equal(k.bar.id, "bar");
 });

--- a/packages/build/src/test/kit_test.ts
+++ b/packages/build/src/test/kit_test.ts
@@ -7,24 +7,34 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { board } from "../internal/board/board.js";
+import { input } from "../internal/board/input.js";
 import { defineNodeType } from "../internal/define/define.js";
 import { kit } from "../internal/kit.js";
 
 const discreteComponent = defineNodeType({
   name: "discreteComponent",
-  inputs: {},
-  outputs: {},
-  invoke: () => ({}),
+  inputs: {
+    str: {
+      type: "string",
+    },
+  },
+  outputs: {
+    str: {
+      type: "string",
+    },
+  },
+  invoke: ({ str }) => ({ str }),
 });
 
+const num = input({ type: "number" });
 const boardComponent = board({
   id: "boardComponent",
-  inputs: {},
-  outputs: {},
+  inputs: { num },
+  outputs: { num },
 });
 
 test("kit takes discrete component", () => {
-  // $ExpectType KitConstructor<Kit> & { foo: Definition<{}, {}, undefined, undefined, never, false, false, false, {}>; }
+  // $ExpectType KitConstructor<Kit> & { foo: Definition<{ str: string; }, { str: string; }, undefined, undefined, never, false, false, false, { str: { board: false; }; }>; }
   const k = kit({
     title: "",
     url: "",
@@ -33,14 +43,14 @@ test("kit takes discrete component", () => {
     components: { foo: discreteComponent },
   });
   assert.ok(
-    // $ExpectType Definition<{}, {}, undefined, undefined, never, false, false, false, {}>
+    // $ExpectType Definition<{ str: string; }, { str: string; }, undefined, undefined, never, false, false, false, { str: { board: false; }; }>
     k.foo
   );
   assert.equal(k.foo.id, "foo");
 });
 
 test("kit takes board component", () => {
-  // $ExpectType KitConstructor<Kit> & { bar: BoardDefinition<{}, {}>; }
+  // $ExpectType KitConstructor<Kit> & { bar: BoardDefinition<{ num: number; }, { num: number; }>; }
   const k = kit({
     title: "",
     url: "",
@@ -49,7 +59,7 @@ test("kit takes board component", () => {
     components: { bar: boardComponent },
   });
   assert.ok(
-    // $ExpectType BoardDefinition<{}, {}>
+    // $ExpectType BoardDefinition<{ num: number; }, { num: number; }>
     k.bar
   );
   assert.equal(k.bar.id, "bar");

--- a/packages/build/src/test/kit_test.ts
+++ b/packages/build/src/test/kit_test.ts
@@ -25,7 +25,7 @@ test("kit takes discrete component", () => {
     url: "",
     version: "",
     description: "",
-    components: [discreteComponent],
+    components: { foo: discreteComponent },
   });
 });
 
@@ -36,6 +36,6 @@ test("kit takes board component", () => {
     url: "",
     version: "",
     description: "",
-    components: [boardComponent],
+    components: { bar: boardComponent },
   });
 });

--- a/packages/build/src/test/kit_test.ts
+++ b/packages/build/src/test/kit_test.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { test } from "node:test";
+import { kit } from "../internal/kit.js";
+import { defineNodeType } from "../internal/define/define.js";
+import { board } from "../internal/board/board.js";
+
+const discreteComponent = defineNodeType({
+  name: "discreteComponent",
+  inputs: {},
+  outputs: {},
+  invoke: () => ({}),
+});
+
+const boardComponent = board({ id: "foo", inputs: {}, outputs: {} });
+
+test("kit takes discrete component", () => {
+  // $ExpectType KitConstructor<Kit>
+  kit({
+    title: "",
+    url: "",
+    version: "",
+    description: "",
+    components: [discreteComponent],
+  });
+});
+
+test("kit takes board component", () => {
+  // $ExpectType KitConstructor<Kit>
+  kit({
+    title: "",
+    url: "",
+    version: "",
+    description: "",
+    components: [boardComponent],
+  });
+});

--- a/packages/build/src/test/kit_test.ts
+++ b/packages/build/src/test/kit_test.ts
@@ -4,10 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import assert from "node:assert/strict";
 import { test } from "node:test";
-import { kit } from "../internal/kit.js";
-import { defineNodeType } from "../internal/define/define.js";
 import { board } from "../internal/board/board.js";
+import { defineNodeType } from "../internal/define/define.js";
+import { kit } from "../internal/kit.js";
 
 const discreteComponent = defineNodeType({
   name: "discreteComponent",
@@ -19,23 +20,31 @@ const discreteComponent = defineNodeType({
 const boardComponent = board({ id: "foo", inputs: {}, outputs: {} });
 
 test("kit takes discrete component", () => {
-  // $ExpectType KitConstructor<Kit>
-  kit({
+  // $ExpectType KitConstructor<Kit> & { foo: Definition<{}, {}, undefined, undefined, never, false, false, false, {}>; }
+  const k = kit({
     title: "",
     url: "",
     version: "",
     description: "",
     components: { foo: discreteComponent },
   });
+  assert.ok(
+    // $ExpectType Definition<{}, {}, undefined, undefined, never, false, false, false, {}>
+    k.foo
+  );
 });
 
 test("kit takes board component", () => {
-  // $ExpectType KitConstructor<Kit>
-  kit({
+  // $ExpectType KitConstructor<Kit> & { bar: BoardDefinition<{}, {}>; }
+  const k = kit({
     title: "",
     url: "",
     version: "",
     description: "",
     components: { bar: boardComponent },
   });
+  assert.ok(
+    // $ExpectType BoardDefinition<{}, {}>
+    k.bar
+  );
 });

--- a/packages/google-drive-kit/src/index.ts
+++ b/packages/google-drive-kit/src/index.ts
@@ -15,5 +15,5 @@ export default kit({
   description:
     "Nodes for reading & writing to files in Google Drive, including Docs and Sheets",
   version: "0.0.1",
-  components: [getFileContent, listFiles, exportFile],
+  components: { getFileContent, listFiles, exportFile },
 });

--- a/packages/python-wasm/src/index.ts
+++ b/packages/python-wasm/src/index.ts
@@ -12,5 +12,5 @@ export default kit({
   description: "An example kit",
   version: "0.1.0",
   url: "npm:@breadboard-ai/python-wasm",
-  components: [runPython],
+  components: { runPython },
 });


### PR DESCRIPTION
The `kit` function from the Build API already produces a kit that is backwards-compatible in terms of loading into the runtime/visual editor; but it can't yet be used within the old API. This would be helpful for incremental migration.

This PR is an initial step in that direction.