### PR TITLE
[board-server] Use correct allowed origin in board server config

### DIFF
--- a/packages/board-server/package.json
+++ b/packages/board-server/package.json
@@ -88,7 +88,7 @@
       "command": "export GOOGLE_CLOUD_PROJECT=$(gcloud config get-value project) && node .",
       "service": true,
       "env": {
-        "ALLOWED_ORIGINS": "http://localhost:3000"
+        "ALLOWED_ORIGINS": "http://localhost:5173"
       },
       "dependencies": [
         "build",


### PR DESCRIPTION
Part of #2896

This value was set incorrectly in #2908. It needs to refer to the visual editor
origin, not the board server itself.
