### PR TITLE
[build] Allow new kits to be used in old boards

### DIFF
--- a/.changeset/strange-cheetahs-admire.md
+++ b/.changeset/strange-cheetahs-admire.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Adds a legacy() function to the result of calling kit(). It's a function that asynchronously returns a kit that is automatically built with and type for the old API, allowing new API kits to be used directly in old boards.

--- a/packages/build/src/internal/kit.ts
+++ b/packages/build/src/internal/kit.ts
@@ -4,28 +4,40 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {
-  InputValues,
-  Kit,
-  KitConstructor,
-  NodeHandler,
-  NodeHandlerContext,
-  NodeHandlerFunction,
+import {
+  addKit,
+  Board,
+  type BreadboardNode,
+  type ConfigOrGraph,
+  type InputValues,
+  type Kit,
+  type KitConstructor,
+  type NewNodeFactory,
+  type NodeHandler,
+  type NodeHandlerContext,
+  type NodeHandlerFunction,
+  type NodeHandlers,
+  type NewNodeValue,
 } from "@google-labs/breadboard";
+import type {
+  KitTag,
+  SubGraphs,
+} from "@google-labs/breadboard-schema/graph.js";
+import { GraphToKitAdapter, KitBuilder } from "@google-labs/breadboard/kits";
 import type { BoardDefinition } from "./board/board.js";
 import { serialize } from "./board/serialize.js";
 import {
   isDiscreteComponent,
+  type Definition,
   type GenericDiscreteComponent,
 } from "./define/definition.js";
-import type { KitTag } from "@google-labs/breadboard-schema/graph.js";
 
 type ComponentManifest = Record<
   string,
   GenericDiscreteComponent | BoardDefinition
 >;
 
-export interface KitOptions<T extends ComponentManifest> {
+export interface KitOptions<T extends ComponentManifest = ComponentManifest> {
   title: string;
   description: string;
   version: string;
@@ -36,11 +48,11 @@ export interface KitOptions<T extends ComponentManifest> {
 
 export function kit<T extends ComponentManifest>(
   options: KitOptions<T>
-): KitConstructor<Kit> & T {
+): KitConstructor<Kit> & T & { legacy(): Promise<LegacyKit<T>> } {
   const componentsWithIds = Object.fromEntries(
     Object.entries(options.components).map(([id, component]) => [
       id,
-      { ...component, id },
+      bindComponentToKit(component, id),
     ])
   );
   const handlers: Record<string, NodeHandler> = Object.fromEntries(
@@ -48,10 +60,6 @@ export function kit<T extends ComponentManifest>(
       if (isDiscreteComponent(component)) {
         return [component.id, component];
       } else {
-        if (!component.id) {
-          // TODO(aomarks) Make id required.
-          throw new Error("To be added to a kit, boards must have an id.");
-        }
         return [
           component.id,
           // TODO(aomarks) Should this just be the invoke() method on Board?
@@ -74,10 +82,11 @@ export function kit<T extends ComponentManifest>(
     url = options.url;
     tags = options.tags ?? [];
   };
-  return Object.assign(
-    result,
-    componentsWithIds
-  ) as KitConstructor<Kit> as KitConstructor<Kit> & T;
+  return Object.assign(result, {
+    ...componentsWithIds,
+    legacy: () => makeLegacyKit<T>(options),
+  }) as KitConstructor<Kit> as KitConstructor<Kit> &
+    T & { legacy: () => Promise<LegacyKit<T>> };
 }
 
 function makeBoardComponentHandler(board: BoardDefinition): NodeHandler {
@@ -112,3 +121,80 @@ function findInvokeFunctionFromContext(
   }
   return undefined;
 }
+
+/**
+ * Components don't have ids until they are added to a kit. This function
+ * returns a proxy of the component that adds an "id" property.
+ */
+function bindComponentToKit<
+  T extends GenericDiscreteComponent | BoardDefinition,
+>(component: T, id: string): T & { id: string } {
+  return new Proxy(component, {
+    get(target, prop) {
+      return prop === "id"
+        ? id
+        : (target as object as Record<string | symbol, unknown>)[prop];
+    },
+  }) as T & { id: string };
+}
+
+/**
+ * We also expose a "legacy" property, an async function which returns a version
+ * of this Kit that can be used directly in the old API.
+ */
+async function makeLegacyKit<T extends ComponentManifest>({
+  title,
+  description,
+  version,
+  url,
+  components,
+}: KitOptions): Promise<LegacyKit<T>> {
+  const kitBoard = new Board({ title, description, version });
+  const { Core } = await import(
+    // Cast to prevent TypeScript from trying to import these types (we don't
+    // want to depend on them in the type system because it's a circular
+    // dependency).
+    "@google-labs/core-kit" as string
+  );
+  const core = kitBoard.addKit(Core) as object as {
+    invoke: (config?: ConfigOrGraph) => BreadboardNode<unknown, unknown>;
+  };
+  const handlers: NodeHandlers = {};
+  const adapter = await GraphToKitAdapter.create(kitBoard, url, []);
+  const graphs: SubGraphs = {};
+  for (const [id, component] of Object.entries(components)) {
+    if (isDiscreteComponent(component)) {
+      handlers[id] = component;
+    } else {
+      core.invoke({
+        $id: id,
+        $board: `#${id}`,
+        $metadata: {
+          title: component.title,
+          description: component.description,
+          ...component.metadata,
+        },
+      });
+      graphs[id] = serialize(component);
+      handlers[id] = adapter.handlerForNode(id);
+    }
+  }
+  kitBoard.graphs = graphs;
+  const builder = new KitBuilder(adapter.populateDescriptor({ url }));
+  return addKit(builder.build(handlers)) as object as Promise<LegacyKit<T>>;
+}
+
+type LegacyKit<T extends ComponentManifest> = {
+  [K in keyof T]: LegacyNodeSignature<T[K]>;
+};
+
+type LegacyNodeSignature<T extends GenericDiscreteComponent | BoardDefinition> =
+  T extends
+    | BoardDefinition<infer I, infer O>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    | Definition<infer I, infer O, any, any, any, any, any, any, any>
+    ? NewNodeFactory<
+        { [K in keyof I]: NewNodeValue },
+        { [K in keyof O]: NewNodeValue }
+      >
+    : never;

--- a/packages/build/src/test/kit_test.ts
+++ b/packages/build/src/test/kit_test.ts
@@ -10,8 +10,9 @@ import { board } from "../internal/board/board.js";
 import { input } from "../internal/board/input.js";
 import { defineNodeType } from "../internal/define/define.js";
 import { kit } from "../internal/kit.js";
+import { board as oldBoard } from "@google-labs/breadboard";
 
-const discreteComponent = defineNodeType({
+const testDiscrete = defineNodeType({
   name: "discreteComponent",
   inputs: {
     str: {
@@ -26,41 +27,128 @@ const discreteComponent = defineNodeType({
   invoke: ({ str }) => ({ str }),
 });
 
-const num = input({ type: "number" });
-const boardComponent = board({
+const numInput = input({ type: "number" });
+const testBoard = board({
   id: "boardComponent",
-  inputs: { num },
-  outputs: { num },
+  inputs: { num: numInput },
+  outputs: { num: numInput },
 });
 
-test("kit takes discrete component", () => {
-  // $ExpectType KitConstructor<Kit> & { foo: Definition<{ str: string; }, { str: string; }, undefined, undefined, never, false, false, false, { str: { board: false; }; }>; }
-  const k = kit({
-    title: "",
-    url: "",
-    version: "",
-    description: "",
-    components: { foo: discreteComponent },
-  });
+const testKit = kit({
+  title: "test_title",
+  url: "test_url",
+  version: "test_version",
+  description: "test_description",
+  components: {
+    foo: testDiscrete,
+    bar: testBoard,
+  },
+});
+
+test("kit handles discrete component", () => {
   assert.ok(
     // $ExpectType Definition<{ str: string; }, { str: string; }, undefined, undefined, never, false, false, false, { str: { board: false; }; }>
-    k.foo
+    testKit.foo
   );
-  assert.equal(k.foo.id, "foo");
+  assert.equal(testKit.foo.id, "foo");
 });
 
-test("kit takes board component", () => {
-  // $ExpectType KitConstructor<Kit> & { bar: BoardDefinition<{ num: number; }, { num: number; }>; }
-  const k = kit({
-    title: "",
-    url: "",
-    version: "",
-    description: "",
-    components: { bar: boardComponent },
-  });
+test("kit handles board component", () => {
   assert.ok(
     // $ExpectType BoardDefinition<{ num: number; }, { num: number; }>
-    k.bar
+    testKit.bar
   );
-  assert.equal(k.bar.id, "bar");
+  assert.equal(testKit.bar.id, "bar");
+});
+
+test("can invoke discrete component through board with old API", async () => {
+  const legacyTestKit = await testKit.legacy();
+  const oldBoardInstance = await oldBoard(() => {
+    const node = legacyTestKit.foo({ str: "foo" });
+    return {
+      str: node.str,
+    };
+  });
+  const bgl = await oldBoardInstance.serialize();
+  assert.deepEqual(bgl, {
+    nodes: [
+      {
+        id: "output-2",
+        type: "output",
+        configuration: {
+          schema: {
+            type: "object",
+            properties: {
+              str: {
+                title: "str",
+                type: "string",
+              },
+            },
+          },
+        },
+      },
+      {
+        id: "foo-3",
+        type: "foo",
+        configuration: {
+          str: "foo",
+        },
+      },
+    ],
+    edges: [
+      {
+        from: "foo-3",
+        out: "str",
+        to: "output-2",
+        in: "str",
+      },
+    ],
+    graphs: {},
+  });
+});
+
+test("can invoke board component through board with old API", async () => {
+  const legacyTestKit = await testKit.legacy();
+  const oldBoardInstance = await oldBoard(() => {
+    const bb = legacyTestKit.bar({ num: 32 });
+    return {
+      num: bb.num,
+    };
+  });
+  const bgl = await oldBoardInstance.serialize();
+  assert.deepEqual(bgl, {
+    nodes: [
+      {
+        id: "output-2",
+        type: "output",
+        configuration: {
+          schema: {
+            type: "object",
+            properties: {
+              num: {
+                title: "num",
+                type: "number",
+              },
+            },
+          },
+        },
+      },
+      {
+        id: "bar-3",
+        type: "bar",
+        configuration: {
+          num: 32,
+        },
+      },
+    ],
+    edges: [
+      {
+        from: "bar-3",
+        out: "num",
+        to: "output-2",
+        in: "num",
+      },
+    ],
+    graphs: {},
+  });
 });


### PR DESCRIPTION
This PR adds a `legacy()` function to the result of calling `kit()` in the Build API. It's a function that asynchronously returns a kit that is automatically built with and typed for the old API, allowing new API kits to be used directly in old boards.

Example of how it will be used:

```ts
import { board } from "@google-labs/breadboard";
import geminiKit from "@google-labs/gemini-kit";

const { geminiText } = await geminiKit.legacy();

export default await board(() => {
  const result = geminiText({ prompt: "foo" });
  return {
    result: result.text,
  };
});
```