### PR TITLE
proxy origin tunnel

### DIFF
--- a/.changeset/nine-zoos-suffer.md
+++ b/.changeset/nine-zoos-suffer.md
@@ -1,0 +1,7 @@
+---
+"@breadboard-ai/visual-editor": minor
+"@breadboard-ai/board-server": minor
+"@google-labs/breadboard": minor
+---
+
+Teach Visual Editor to use board server's node proxy to run boards.

--- a/packages/breadboard/src/harness/secrets.ts
+++ b/packages/breadboard/src/harness/secrets.ts
@@ -4,32 +4,96 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SecretResult } from "./types.js";
+import type { HarnessRunResult, RunConfig, SecretResult } from "./types.js";
 import { KitBuilder } from "../kits/builder.js";
 import { timestamp } from "../timestamp.js";
-import { asRuntimeKit } from "../index.js";
-import { OutputValues } from "../types.js";
+import { asRuntimeKit, callHandler } from "../index.js";
+import type {
+  InputValues,
+  Kit,
+  NodeHandler,
+  NodeTypeIdentifier,
+  OutputValues,
+} from "../types.js";
 import { ClientRunResult } from "../remote/types.js";
 
-export const createSecretAskingKit = (
+/**
+ * Get all secret handlers from the given kits.
+ * This is used to create a fallback list for secret asking.
+ */
+const secretHandlersFromKits = (kits: Kit[]): NodeHandler[] => {
+  const secretHandlers = [];
+  for (const kit of kits) {
+    for (const [key, handler] of Object.entries(kit.handlers)) {
+      if (key === "secrets") {
+        secretHandlers.push(handler);
+      }
+    }
+  }
+  return secretHandlers;
+};
+
+export const configureSecretAsking = (
+  interactiveSecrets: RunConfig["interactiveSecrets"],
+  existingKits: Kit[],
+  next: (data: HarnessRunResult) => Promise<void>
+): Kit[] => {
+  if (interactiveSecrets === true) {
+    return [createSecretAskingKit(next), ...existingKits];
+  } else if (interactiveSecrets === "fallback") {
+    return [
+      createSecretAskingKit(next, secretHandlersFromKits(existingKits)),
+      ...existingKits,
+    ];
+  } else {
+    return existingKits;
+  }
+};
+
+const interactiveSecretsHandler = (
   next: (result: ClientRunResult<SecretResult>) => Promise<void>
 ) => {
+  return async (inputs: InputValues) => {
+    const { keys } = inputs as { keys: string[] };
+    if (!keys) return {};
+    let outputs = {};
+    await next({
+      type: "secret",
+      data: { keys, timestamp: timestamp() },
+      reply: async (value) => {
+        outputs = value.inputs;
+      },
+    });
+    return outputs as OutputValues;
+  };
+};
+
+const fallbackHandler = (
+  nodeType: NodeTypeIdentifier,
+  handlers: NodeHandler[]
+) => {
+  const handler: NodeHandler = async (inputs, context) => {
+    for (const handler of handlers) {
+      const outputs = await callHandler(handler, inputs, context);
+      if (outputs && !outputs["$error"]) {
+        return outputs;
+      }
+    }
+    throw new Error(`No handler found for type "${nodeType}"`);
+  };
+  return handler;
+};
+
+export const createSecretAskingKit = (
+  next: (result: ClientRunResult<SecretResult>) => Promise<void>,
+  fallback?: NodeHandler[]
+) => {
+  const interactive = interactiveSecretsHandler(next);
+  const secrets = fallback
+    ? fallbackHandler("secrets", [...fallback, interactive])
+    : interactive;
   const secretAskingKit = new KitBuilder({
     url: "secret-asking-kit",
-  }).build({
-    secrets: async (inputs) => {
-      const { keys } = inputs as { keys: string[] };
-      if (!keys) return {};
-      let outputs = {};
-      await next({
-        type: "secret",
-        data: { keys, timestamp: timestamp() },
-        reply: async (value) => {
-          outputs = value.inputs;
-        },
-      });
-      return outputs as OutputValues;
-    },
-  });
+  }).build({ secrets });
   return asRuntimeKit(secretAskingKit);
 };

--- a/packages/breadboard/src/harness/secrets.ts
+++ b/packages/breadboard/src/harness/secrets.ts
@@ -15,7 +15,7 @@ import type {
   NodeTypeIdentifier,
   OutputValues,
 } from "../types.js";
-import { ClientRunResult } from "../remote/types.js";
+import type { ClientRunResult } from "../remote/types.js";
 
 /**
  * Get all secret handlers from the given kits.

--- a/packages/breadboard/src/harness/types.ts
+++ b/packages/breadboard/src/harness/types.ts
@@ -206,8 +206,11 @@ export type RunConfig = {
    * the `secret` result will start showing up in the run results whenever
    * the secret is asked for. Otherwise, the `secrets` node will try to find
    * the secrets on its own.
+   *
+   * When set to `"fallback"`, the secrets will be asked for interactively
+   * only if the secrets node is not able to find the secrets on its own.
    */
-  interactiveSecrets?: boolean;
+  interactiveSecrets?: boolean | "fallback";
   /**
    * The data store to use for storing data.
    */

--- a/packages/breadboard/src/loader/types.ts
+++ b/packages/breadboard/src/loader/types.ts
@@ -195,6 +195,11 @@ export type GraphProvider = {
    */
   startingURL: () => URL | null;
   /**
+   * Given the URL of a board, returns the URL of the node proxy server, if
+   * this provider supports it. If it doesn't, returns `false`.
+   */
+  canProxy?: (url: URL) => Promise<string | false>;
+  /**
    * Provides a way to watch for changes in the store.
    */
   watch: (callback: ChangeNotificationCallback) => void;

--- a/packages/breadboard/src/remote/proxy.ts
+++ b/packages/breadboard/src/remote/proxy.ts
@@ -18,7 +18,6 @@ import { NodeProxyConfig, NodeProxySpec, ProxyServerConfig } from "./config.js";
 import {
   AnyProxyRequestMessage,
   AnyProxyResponseMessage,
-  ClientBidirectionalStream,
   ClientTransport,
   ServerTransport,
 } from "./types.js";

--- a/packages/breadboard/src/remote/proxy.ts
+++ b/packages/breadboard/src/remote/proxy.ts
@@ -144,11 +144,16 @@ export class ProxyClient {
   async proxy(
     node: NodeDescriptor,
     inputs: InputValues,
-    _context: NodeHandlerContext
+    context: NodeHandlerContext
   ): Promise<OutputValues> {
     const stream = this.#transport.createClientStream();
     const writer = stream.writableRequests.getWriter();
     const reader = stream.readableResponses.getReader();
+
+    const store = context.store;
+    inputs = store
+      ? ((await inflateData(store, inputs)) as InputValues)
+      : inputs;
 
     writer.write(["proxy", { node, inputs }]);
     writer.close();

--- a/packages/breadboard/src/remote/tunnel.ts
+++ b/packages/breadboard/src/remote/tunnel.ts
@@ -164,7 +164,7 @@ export const replaceInputs = async (
 // a simple way to identify a tunnelled value.
 // It is also rotating so that the users of the node proxy don't accidentally
 // adopt bad practices of hard-coding the values.
-// Note: the rotation will occasionaly cause errors at the break of the week.
+// Note: the rotation will occasionally cause errors at the break of the week.
 // TODO: Fix the rotation to be window-based or come up with an even better
 // solution.
 const MILLISECONDS_IN_A_WEEK = 1000 * 60 * 60 * 24 * 7;

--- a/packages/visual-editor/src/data/node-proxy-servers.ts
+++ b/packages/visual-editor/src/data/node-proxy-servers.ts
@@ -46,6 +46,10 @@ export const addNodeProxyServerConfig = (
       nodes: ["secrets", "fetch"],
     });
     config.interactiveSecrets = false;
+    console.log(
+      "[Board Server] Using node proxy:",
+      boardServerProxyUrl.replace(/\?API_KEY=.+$/, "")
+    );
   }
   if (!settings) return { ...config, proxy };
 

--- a/packages/visual-editor/src/data/node-proxy-servers.ts
+++ b/packages/visual-editor/src/data/node-proxy-servers.ts
@@ -31,12 +31,21 @@ export const addNodeProxyServerConfig = (
   existingProxy: HarnessProxyConfig[],
   config: RunConfig,
   settings: SettingsStore | null,
-  proxyUrl?: string | undefined
+  proxyUrl: string | undefined,
+  boardServerProxyUrl: string | null
 ): RunConfig => {
   // TODO: Consolidate proxyUrl into settings.
   const proxy = [...existingProxy];
   if (proxyUrl) {
     proxy.push({ location: "python", url: proxyUrl, nodes: PYTHON_NODES });
+  }
+  if (boardServerProxyUrl) {
+    proxy.push({
+      location: "http",
+      url: boardServerProxyUrl,
+      nodes: ["secrets", "fetch"],
+    });
+    config.interactiveSecrets = false;
   }
   if (!settings) return { ...config, proxy };
 

--- a/packages/visual-editor/src/data/node-proxy-servers.ts
+++ b/packages/visual-editor/src/data/node-proxy-servers.ts
@@ -27,6 +27,18 @@ const createNodeProxyConfig = (entry: SettingEntry) => {
   return { location: "http", url, nodes };
 };
 
+const useLocaLSecretsOnly = (settings: SettingsStore | null) => {
+  if (!settings) return false;
+
+  const generalSettings = settings.getSection(
+    BreadboardUI.Types.SETTINGS_TYPE.GENERAL
+  );
+  if (!generalSettings) return false;
+
+  const runLocally = generalSettings.items.get("Use Local Secrets Only");
+  return runLocally && runLocally.value === true;
+};
+
 export const addNodeProxyServerConfig = (
   existingProxy: HarnessProxyConfig[],
   config: RunConfig,
@@ -40,16 +52,22 @@ export const addNodeProxyServerConfig = (
     proxy.push({ location: "python", url: proxyUrl, nodes: PYTHON_NODES });
   }
   if (boardServerProxyUrl) {
-    proxy.push({
-      location: "http",
-      url: boardServerProxyUrl,
-      nodes: ["secrets", "fetch"],
-    });
-    config.interactiveSecrets = "fallback";
-    console.log(
-      "[Board Server] Using node proxy:",
-      boardServerProxyUrl.replace(/\?API_KEY=.+$/, "")
-    );
+    if (useLocaLSecretsOnly(settings)) {
+      console.log(
+        `[Board Server] Ignoring node proxy because "Use Local Secrets Only" is set.`
+      );
+    } else {
+      proxy.push({
+        location: "http",
+        url: boardServerProxyUrl,
+        nodes: ["secrets", "fetch"],
+      });
+      config.interactiveSecrets = "fallback";
+      console.log(
+        "[Board Server] Using node proxy:",
+        boardServerProxyUrl.replace(/\?API_KEY=.+$/, "")
+      );
+    }
   }
   if (!settings) return { ...config, proxy };
 

--- a/packages/visual-editor/src/data/node-proxy-servers.ts
+++ b/packages/visual-editor/src/data/node-proxy-servers.ts
@@ -45,7 +45,7 @@ export const addNodeProxyServerConfig = (
       url: boardServerProxyUrl,
       nodes: ["secrets", "fetch"],
     });
-    config.interactiveSecrets = false;
+    config.interactiveSecrets = "fallback";
     console.log(
       "[Board Server] Using node proxy:",
       boardServerProxyUrl.replace(/\?API_KEY=.+$/, "")

--- a/packages/visual-editor/src/data/settings-store.ts
+++ b/packages/visual-editor/src/data/settings-store.ts
@@ -127,6 +127,15 @@ export class SettingsStore implements BreadboardUI.Types.SettingsStore {
             value: false,
           },
         ],
+        [
+          "Use Local Secrets Only",
+          {
+            name: "Use Local Secrets Only",
+            description:
+              "When unchecked (default), the board server's secrets and locally-stored secrets will be used to run the board from that server. When checked, only locally-stored secrets will be used.",
+            value: false,
+          },
+        ],
       ]),
     },
     [BreadboardUI.Types.SETTINGS_TYPE.SECRETS]: {

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -1142,6 +1142,17 @@ export class Main extends LitElement {
     return this.#providers.find((provider) => provider.canProvide(url)) || null;
   }
 
+  async #getProxyURL(urlString: string): Promise<string | null> {
+    const url = new URL(urlString, window.location.href);
+    for (const provider of this.#providers) {
+      const proxyURL = await provider.canProxy?.(url);
+      if (proxyURL) {
+        return proxyURL;
+      }
+    }
+    return null;
+  }
+
   #confirmUnloadWithUserFirstIfNeeded(evt: Event) {
     if (!this.#boardPendingSave) {
       return;
@@ -1740,7 +1751,8 @@ export class Main extends LitElement {
                         interactiveSecrets: true,
                       },
                       this.#settings,
-                      this.proxyFromUrl
+                      this.proxyFromUrl,
+                      await this.#getProxyURL(this.graph.url)
                     )
                   )
                 );

--- a/packages/visual-editor/src/providers/remote.ts
+++ b/packages/visual-editor/src/providers/remote.ts
@@ -418,4 +418,17 @@ export class RemoteGraphProvider implements GraphProvider {
     // TODO: Maybe query this from the store itself.
     return new URL(url.href.replace(/json$/, "app"));
   }
+
+  async canProxy(url: URL): Promise<string | false> {
+    if (!this.canProvide(url)) {
+      return false;
+    }
+    const store = this.#locations.find((store) =>
+      url.href.startsWith(store.url)
+    );
+    if (!store) {
+      return false;
+    }
+    return `${store.url}/proxy?API_KEY=${store.apiKey}`;
+  }
 }


### PR DESCRIPTION
- **Start reading secrets origin annotations.**
- **Require board API key for node proxy server.**
- **Build secrets tunnel from the list of secrets.**
- **Make sure to inflate inputs before sending to node proxy.**
- **Introduce `GraphProvider.canProxy` and start using it.**
- **Add a console message.**
- **Handle errors in secrets.**
- **Implement "fallback" mode for interactive secrets.**
- **Clean up.**
- **Add a setting to ignore board server.**
- **docs(changeset): Teach Visual Editor to use board server's node proxy to run boards.**
