### PR TITLE
[all] [dev] Make linting depend on tsc

### DIFF
--- a/archive/breadboard-extension/package.json
+++ b/archive/breadboard-extension/package.json
@@ -143,9 +143,10 @@
       "env": {
         "FORCE_COLOR": "1"
       },
+      "dependencies": [
+        "build:tsc"
+      ],
       "files": [
-        "src/**/*.ts",
-        "tests/**/*.ts",
         ".eslintrc",
         "../../.eslintrc.json"
       ],

--- a/archive/breadboard-server/package.json
+++ b/archive/breadboard-server/package.json
@@ -60,9 +60,10 @@
       "env": {
         "FORCE_COLOR": "1"
       },
+      "dependencies": [
+        "build:tsc"
+      ],
       "files": [
-        "src/**/*.ts",
-        "tests/**/*.ts",
         ".eslintrc",
         "../../.eslintrc.json"
       ],

--- a/archive/create-breadboard-kit/package.json
+++ b/archive/create-breadboard-kit/package.json
@@ -54,8 +54,10 @@
       "env": {
         "FORCE_COLOR": "1"
       },
+      "dependencies": [
+        "build:tsc"
+      ],
       "files": [
-        "src/**/*.ts",
         ".eslintrc",
         "../../.eslintrc.json"
       ],

--- a/archive/create-breadboard/package.json
+++ b/archive/create-breadboard/package.json
@@ -41,8 +41,10 @@
       "env": {
         "FORCE_COLOR": "1"
       },
+      "dependencies": [
+        "build:tsc"
+      ],
       "files": [
-        "src/**/*.ts",
         ".eslintrc",
         "../../.eslintrc.json"
       ],

--- a/archive/graph-integrity/package.json
+++ b/archive/graph-integrity/package.json
@@ -60,9 +60,10 @@
       "env": {
         "FORCE_COLOR": "1"
       },
+      "dependencies": [
+        "build:tsc"
+      ],
       "files": [
-        "src/**/*.ts",
-        "tests/**/*.ts",
         ".eslintrc",
         "../../.eslintrc.json"
       ],

--- a/archive/graph-playground/package.json
+++ b/archive/graph-playground/package.json
@@ -92,10 +92,10 @@
       "env": {
         "FORCE_COLOR": "1"
       },
+      "dependencies": [
+        "build:tsc"
+      ],
       "files": [
-        "src/**/*.ts",
-        "wild/**/*.ts",
-        "tests/**/*.ts",
         ".eslintrc",
         "../../.eslintrc.json"
       ],

--- a/archive/node-nursery/package.json
+++ b/archive/node-nursery/package.json
@@ -60,9 +60,10 @@
       "env": {
         "FORCE_COLOR": "1"
       },
+      "dependencies": [
+        "build:tsc"
+      ],
       "files": [
-        "src/**/*.ts",
-        "tests/**/*.ts",
         ".eslintrc",
         "../../.eslintrc.json"
       ],

--- a/archive/pinecone-kit/package.json
+++ b/archive/pinecone-kit/package.json
@@ -75,9 +75,10 @@
       "env": {
         "FORCE_COLOR": "1"
       },
+      "dependencies": [
+        "build:tsc"
+      ],
       "files": [
-        "src/**/*.ts",
-        "tests/**/*.ts",
         ".eslintrc",
         "../../.eslintrc.json"
       ],

--- a/packages/agent-kit/package.json
+++ b/packages/agent-kit/package.json
@@ -101,9 +101,10 @@
       "env": {
         "FORCE_COLOR": "1"
       },
+      "dependencies": [
+        "build:tsc"
+      ],
       "files": [
-        "src/**/*.ts",
-        "tests/**/*.ts",
         ".eslintrc",
         "../../.eslintrc.json"
       ],

--- a/packages/breadboard-cli/package.json
+++ b/packages/breadboard-cli/package.json
@@ -89,9 +89,10 @@
       "env": {
         "FORCE_COLOR": "1"
       },
+      "dependencies": [
+        "build:tsc"
+      ],
       "files": [
-        "src/**/*.ts",
-        "tests/**/*.ts",
         ".eslintrc",
         "../../.eslintrc.json"
       ],

--- a/packages/breadboard/package.json
+++ b/packages/breadboard/package.json
@@ -101,9 +101,10 @@
       "env": {
         "FORCE_COLOR": "1"
       },
+      "dependencies": [
+        "build:tsc"
+      ],
       "files": [
-        "src/**/*.ts",
-        "tests/**/*.ts",
         ".eslintrc",
         "../../.eslintrc.json"
       ],

--- a/packages/build-legacy/package.json
+++ b/packages/build-legacy/package.json
@@ -91,8 +91,10 @@
     },
     "lint": {
       "command": "eslint src/ --ext .ts",
+      "dependencies": [
+        "build:tsc"
+      ],
       "files": [
-        "src/**/*.ts",
         ".eslintrc",
         "../../.eslintrc.json"
       ],

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -100,8 +100,10 @@
     },
     "lint": {
       "command": "eslint src/ --ext .ts",
+      "dependencies": [
+        "build:tsc"
+      ],
       "files": [
-        "src/**/*.ts",
         ".eslintrc",
         "../../.eslintrc.json"
       ],

--- a/packages/connection-server/package.json
+++ b/packages/connection-server/package.json
@@ -64,8 +64,10 @@
     },
     "lint": {
       "command": "eslint src/ --ext .ts",
+      "dependencies": [
+        "build:tsc"
+      ],
       "files": [
-        "src/**/*.ts",
         ".eslintrc",
         "../../.eslintrc.json"
       ],

--- a/packages/core-kit/package.json
+++ b/packages/core-kit/package.json
@@ -81,9 +81,10 @@
       "env": {
         "FORCE_COLOR": "1"
       },
+      "dependencies": [
+        "build:tsc"
+      ],
       "files": [
-        "src/**/*.ts",
-        "tests/**/*.ts",
         ".eslintrc",
         "../../.eslintrc.json"
       ],

--- a/packages/data-store/package.json
+++ b/packages/data-store/package.json
@@ -94,9 +94,10 @@
       "env": {
         "FORCE_COLOR": "1"
       },
+      "dependencies": [
+        "build:tsc"
+      ],
       "files": [
-        "src/**/*.ts",
-        "tests/**/*.ts",
         ".eslintrc",
         "../../.eslintrc.json"
       ],

--- a/packages/discovery-types/package.json
+++ b/packages/discovery-types/package.json
@@ -56,9 +56,10 @@
       "env": {
         "FORCE_COLOR": "1"
       },
+      "dependencies": [
+        "build:tsc"
+      ],
       "files": [
-        "src/**/*.ts",
-        "tests/**/*.ts",
         ".eslintrc",
         "../../.eslintrc.json"
       ],

--- a/packages/example-boards/package.json
+++ b/packages/example-boards/package.json
@@ -104,8 +104,10 @@
       "env": {
         "FORCE_COLOR": "1"
       },
+      "dependencies": [
+        "build:tsc"
+      ],
       "files": [
-        "src/**/*.ts",
         ".eslintrc",
         "../../.eslintrc.json"
       ],

--- a/packages/gemini-kit/package.json
+++ b/packages/gemini-kit/package.json
@@ -63,9 +63,10 @@
       "env": {
         "FORCE_COLOR": "1"
       },
+      "dependencies": [
+        "build:tsc"
+      ],
       "files": [
-        "src/**/*.ts",
-        "tests/**/*.ts",
         ".eslintrc",
         "../../.eslintrc.json"
       ],

--- a/packages/google-drive-kit/package.json
+++ b/packages/google-drive-kit/package.json
@@ -105,8 +105,10 @@
     },
     "lint": {
       "command": "eslint src/ --ext .ts",
+      "dependencies": [
+        "build:tsc"
+      ],
       "files": [
-        "src/**/*.ts",
         ".eslintrc",
         "../../.eslintrc.json"
       ],

--- a/packages/import/package.json
+++ b/packages/import/package.json
@@ -80,9 +80,10 @@
       "env": {
         "FORCE_COLOR": "1"
       },
+      "dependencies": [
+        "build"
+      ],
       "files": [
-        "src/**/*.ts",
-        "tests/**/*.ts",
         ".eslintrc",
         "../../.eslintrc.json"
       ],

--- a/packages/json-kit/package.json
+++ b/packages/json-kit/package.json
@@ -65,9 +65,10 @@
       "env": {
         "FORCE_COLOR": "1"
       },
+      "dependencies": [
+        "build:tsc"
+      ],
       "files": [
-        "src/**/*.ts",
-        "tests/**/*.ts",
         ".eslintrc",
         "../../.eslintrc.json"
       ],

--- a/packages/node-nursery-web/package.json
+++ b/packages/node-nursery-web/package.json
@@ -60,9 +60,10 @@
       "env": {
         "FORCE_COLOR": "1"
       },
+      "dependencies": [
+        "build:tsc"
+      ],
       "files": [
-        "src/**/*.ts",
-        "tests/**/*.ts",
         ".eslintrc",
         "../../.eslintrc.json"
       ],

--- a/packages/node-proxy-server/package.json
+++ b/packages/node-proxy-server/package.json
@@ -41,6 +41,9 @@
       "env": {
         "FORCE_COLOR": "1"
       },
+      "dependencies": [
+        "build"
+      ],
       "files": [
         "src/**/*.ts",
         ".eslintrc",

--- a/packages/palm-kit/package.json
+++ b/packages/palm-kit/package.json
@@ -58,8 +58,6 @@
         "FORCE_COLOR": "1"
       },
       "files": [
-        "src/**/*.ts",
-        "tests/**/*.ts",
         ".eslintrc",
         "../../.eslintrc.json"
       ],

--- a/packages/python-wasm/package.json
+++ b/packages/python-wasm/package.json
@@ -100,8 +100,10 @@
     },
     "lint": {
       "command": "eslint src/ --ext .ts",
+      "dependencies": [
+        "build:tsc"
+      ],
       "files": [
-        "src/**/*.ts",
         ".eslintrc",
         "../../.eslintrc.json"
       ],

--- a/packages/template-kit/package.json
+++ b/packages/template-kit/package.json
@@ -69,9 +69,10 @@
       "env": {
         "FORCE_COLOR": "1"
       },
+      "dependencies": [
+        "build:tsc"
+      ],
       "files": [
-        "src/**/*.ts",
-        "tests/**/*.ts",
         ".eslintrc",
         "../../.eslintrc.json"
       ],


### PR DESCRIPTION
There was some bad lint caching behavior happening, because each package's lint command was only checking whether its own package files changed. We need to actually build the typescript of all dependencies first, or else when the linter reads the types of those deps, they might be out of sync. Depending on `tsc:build` is the easier way to do that.