### PR TITLE
[board-server] improve board server dockerfile (#2945)

### DIFF
--- a/packages/board-server/Dockerfile
+++ b/packages/board-server/Dockerfile
@@ -25,8 +25,6 @@ COPY --from=build /build/packages/board-server/dist ./dist
 COPY --from=build /build/packages/board-server/src ./src
 COPY --from=build /build/packages/board-server/package.json ./
 COPY --from=build /build/packages/board-server/public ./public
-COPY --from=build /build/packages/board-server/scripts ./scripts
-COPY --from=build /build/packages/board-server/tsconfig.json ./
 
 # Install production dependencies and tsx
 RUN npm install --only=production && \

--- a/packages/board-server/Dockerfile
+++ b/packages/board-server/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:20 AS build
+FROM node:20-slim AS build
 WORKDIR /build
 
 # Copy the entire monorepo
@@ -31,4 +31,4 @@ RUN npm install --only=production && \
     npm install -g tsx
 
 EXPOSE 3000
-CMD ["node", "dist/server/index.js"]
+CMD ["node", "dist/server/index.js", "--host=0.0.0.0" ]

--- a/packages/board-server/Dockerfile
+++ b/packages/board-server/Dockerfile
@@ -1,11 +1,36 @@
-FROM node:20
-COPY --from=breadboard . /breadboard/
-# For the time being, we will assume container deployments are exclusively sqlite.
-ENV STORAGE_BACKEND "sqlite"
-ENV GOOGLE_CLOUD_PROJECT "n/a"
-ENV ALLOWED_ORIGINS ""
-WORKDIR /breadboard
+# Build stage
+FROM node:20 AS build
+WORKDIR /build
+
+# Copy the entire monorepo
+COPY --from=breadboard / ./
+
+# Install ALL dependencies, including devDependencies
 RUN npm ci
-WORKDIR /breadboard/packages/board-server
+
+# Build the project
+WORKDIR /build/packages/board-server
 RUN npm run build
-CMD ["npm", "run", "serve", "--", "--host=0.0.0.0"]
+
+# Production stage
+FROM node:20-slim
+WORKDIR /app
+ENV NODE_ENV=production
+ENV STORAGE_BACKEND="sqlite"
+ENV GOOGLE_CLOUD_PROJECT="n/a"
+ENV ALLOWED_ORIGINS=""
+
+# Copy necessary files from the build stage
+COPY --from=build /build/packages/board-server/dist ./dist
+COPY --from=build /build/packages/board-server/src ./src
+COPY --from=build /build/packages/board-server/package.json ./
+COPY --from=build /build/packages/board-server/public ./public
+COPY --from=build /build/packages/board-server/scripts ./scripts
+COPY --from=build /build/packages/board-server/tsconfig.json ./
+
+# Install production dependencies and tsx
+RUN npm install --only=production && \
+    npm install -g tsx
+
+EXPOSE 3000
+CMD ["node", "dist/server/index.js"]

--- a/packages/board-server/scripts/build.ts
+++ b/packages/board-server/scripts/build.ts
@@ -6,12 +6,23 @@
 
 import * as esbuild from "esbuild";
 
-await esbuild.build({
-  entryPoints: ["src/index.ts"],
-  bundle: true,
-  platform: "node",
-  external: ["@google-cloud", "import.meta", "vite", "better-sqlite3"],
-  format: "esm",
-  outfile: "dist/server/index.js",
-  sourcemap: true
-});
+await Promise.all([
+  esbuild.build({
+    entryPoints: ["src/index.ts"],
+    bundle: true,
+    platform: "node",
+    external: ["@google-cloud", "import.meta", "vite", "better-sqlite3"],
+    format: "esm",
+    outfile: "dist/server/index.js",
+    sourcemap: true
+  }),
+  esbuild.build({
+    entryPoints: ["scripts/create-account.ts"],
+    bundle: true,
+    platform: "node",
+    format: "esm",
+    outfile: "dist/scripts/create-account.js",
+    sourcemap: true,
+    external: ["@google-cloud", "import.meta", "vite", "better-sqlite3"],
+  })
+]);


### PR DESCRIPTION
Fixes #2945

- [x] Lightweight image not containing the whole repo.
- [x] Uses production build, e.g. node dist/server/index.js.
- [x] Still allows use of the create-account.ts script from inside the container to add users.

```
$ docker run -d -p 3000:3000 --name board-server board-server
d6aa812d042f2fc98a67bedb124d80153d1429fda30e54f54fff3fc989a7c208
$ docker exec -it board-server /bin/bash
root@d6aa812d042f:/app# node dist/scripts/create-account.js wfaithfull
Created account for wfaithfull with API key:
bb-6e52o2r546q6cmu424m544d2p2195t3b444a4m6s2y5q2n2r61
```
