### PR TITLE
[build] Improve describe() behavior of polymorphic boards

### DIFF
--- a/.changeset/twelve-impalas-change.md
+++ b/.changeset/twelve-impalas-change.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Improvements to the describe() behavior of boards built with the Build API that are polymorphic.

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -75,7 +75,8 @@
     "test": {
       "command": "find dist/test -name '*_test.js' | xargs node --test --enable-source-maps --test-reporter spec",
       "dependencies": [
-        "build:tsc"
+        "build:tsc",
+        "../core-kit:build:tsc"
       ],
       "files": [],
       "output": []
@@ -83,7 +84,8 @@
     "test:only": {
       "command": "find dist/test -name '*_test.js' | xargs node --test --test-only --enable-source-maps --test-reporter spec",
       "dependencies": [
-        "build:tsc"
+        "build:tsc",
+        "../core-kit:build:tsc"
       ],
       "files": [],
       "output": []

--- a/packages/build/src/test/board_test.ts
+++ b/packages/build/src/test/board_test.ts
@@ -8,7 +8,7 @@
 
 import { defineNodeType, input, output } from "@breadboard-ai/build";
 import { test } from "node:test";
-import { board } from "../internal/board/board.js";
+import { board, inputNode, outputNode } from "../internal/board/board.js";
 import assert from "node:assert/strict";
 
 const inStr = input();
@@ -251,6 +251,57 @@ test("describe board", async () => {
           description: "outStr description",
         },
       },
+    },
+  });
+});
+
+test("polymorphic describe", async () => {
+  const str = input();
+  const num = input({ type: "number" });
+  const bool = input({ type: "boolean" });
+  const testBoard = board({
+    inputs: [
+      inputNode({ foo: str, bar: num }, { id: "in1" }),
+      inputNode({ foo: str, bar: bool, baz: num }),
+    ],
+    outputs: [
+      outputNode({ foo: num, bar: bool }, { id: "out1" }),
+      outputNode({ foo: num, bar: str, baz: bool }),
+    ],
+  });
+  const description = await testBoard.describe();
+  assert.deepEqual(description, {
+    inputSchema: {
+      type: "object",
+      properties: {
+        foo: {
+          type: "string",
+        },
+        bar: {
+          type: ["number", "boolean"],
+        },
+        baz: {
+          type: "number",
+        },
+      },
+      required: ["foo", "bar"],
+      additionalProperties: false,
+    },
+    outputSchema: {
+      type: "object",
+      properties: {
+        foo: {
+          type: "number",
+        },
+        bar: {
+          type: ["boolean", "string"],
+        },
+        baz: {
+          type: "boolean",
+        },
+      },
+      required: ["foo", "bar"],
+      additionalProperties: false,
     },
   });
 });


### PR DESCRIPTION
The `describe()` function for boards created with the Build API didn't do a great job at expressing polymorphism (it just sort of naively flattened out all the properties). Now it does something a bit smarter.