### PR TITLE
[build] Add starInputs function to get a handle on the "*" input port of a board

### DIFF
--- a/.changeset/empty-guests-serve.md
+++ b/.changeset/empty-guests-serve.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Add starInputs function to get a handle on the "\*" input port of a board

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -12,6 +12,7 @@ export { loopback } from "./internal/board/loopback.js";
 export { optionalEdge } from "./internal/board/optional.js";
 export { output } from "./internal/board/output.js";
 export { serialize } from "./internal/board/serialize.js";
+export { starInputs } from "./internal/board/star-inputs.js";
 export { unsafeCast } from "./internal/board/unsafe-cast.js";
 export {
   // TODO() Not quite sure about exporting and/or the name of

--- a/packages/build/src/internal/board/star-inputs.ts
+++ b/packages/build/src/internal/board/star-inputs.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { brand, isBranded } from "../common/brand.js";
+import type {
+  BreadboardType,
+  ConvertBreadboardType,
+  JsonSerializable,
+} from "../type-system/type.js";
+
+/**
+ * Initialization parameters for {@link starInputs}.
+ */
+export interface StarInputsInit<T extends BreadboardType> {
+  type: T;
+}
+
+/**
+ * Get a handle to the "star ports" from a board's input components.
+ */
+export function starInputs<T extends BreadboardType>({
+  type,
+}: StarInputsInit<T>): StarInputs<ConvertBreadboardType<T>> {
+  return new StarInputs(type);
+}
+
+export type { StarInputs };
+
+class StarInputs<
+  T extends JsonSerializable | undefined = JsonSerializable | undefined,
+> {
+  readonly [brand] = "StarInputs";
+  readonly type: BreadboardType;
+
+  constructor(type: BreadboardType) {
+    this.type = type;
+  }
+}
+
+/**
+ * Test whether the given object is a Breadboard {@link StarInputs}.
+ */
+export function isStarInputs(value: unknown): value is StarInputs {
+  return isBranded(value, "StarInputs");
+}

--- a/packages/build/src/internal/define/definition.ts
+++ b/packages/build/src/internal/define/definition.ts
@@ -53,6 +53,7 @@ import { object } from "../type-system/object.js";
 import { normalizeBreadboardError } from "../common/error.js";
 import type { Convergence } from "../board/converge.js";
 import type { SerializableBoard } from "../common/serializable.js";
+import type { StarInputs } from "../board/star-inputs.js";
 
 export interface Definition<
   /* Static Inputs   */ SI extends { [K: string]: JsonSerializable },
@@ -473,6 +474,7 @@ type StrictInstantiateArgs<
     title?: string;
     description?: string;
   };
+  "*"?: StarInputs<DI>;
 } & {
   [K in keyof Omit<SI, OI | "$id" | "$metadata">]: IM[K extends keyof IM
     ? K
@@ -487,7 +489,7 @@ type StrictInstantiateArgs<
 } & {
   [K in keyof Omit<
     A,
-    keyof SI | "$id" | "$metadata"
+    keyof SI | "$id" | "$metadata" | "*"
   >]: DI extends JsonSerializable ? InstantiateArg<DI> : never;
 };
 

--- a/packages/build/src/test/star-inputs_test.ts
+++ b/packages/build/src/test/star-inputs_test.ts
@@ -1,0 +1,137 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* eslint-disable @typescript-eslint/ban-ts-comment */
+
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  array,
+  board,
+  defineNodeType,
+  input,
+  inputNode,
+  serialize,
+  starInputs,
+} from "../index.js";
+
+test("StarInputs type parameterization", () => {
+  // $ExpectType StarInputs<string>
+  starInputs({ type: "string" });
+
+  // $ExpectType StarInputs<number[]>
+  starInputs({ type: array("number") });
+});
+
+/**
+ * A discrete component for testing that takes all * inputs and joins them.
+ */
+const lineCombiner = defineNodeType({
+  name: "lineCombiner",
+  inputs: { "*": { type: "string" } },
+  outputs: { joined: { type: "string" } },
+  invoke: ({ ...lines }) => ({
+    joined: Object.values(lines).join(),
+  }),
+});
+
+/**
+ * A discrete component for testing that takes an array of inputs and joins them
+ * (it doesn't have a "*" port).
+ */
+const nonDynamicLineCombiner = defineNodeType({
+  name: "lineCombiner",
+  inputs: { lines: { type: array("string") } },
+  outputs: { joined: { type: "string" } },
+  invoke: ({ lines }) => ({
+    joined: Object.values(lines).join(),
+  }),
+});
+
+test("can pass to dynamic discrete component", () => {
+  const lines = starInputs({ type: "string" });
+  lineCombiner({ "*": lines });
+});
+
+test.skip("error to pass to non-dynamic discrete component", () => {
+  const starLines = starInputs({ type: "string" });
+  const arrayLines = input({ type: array("string") });
+  nonDynamicLineCombiner({
+    lines: arrayLines,
+    // TODO(aomarks) @ts-expect-error
+    "*": starLines,
+  });
+});
+
+test.skip("error to pass wrong type to discrete component", () => {
+  const notLines = starInputs({ type: "number" });
+  // TODO(aomarks) @ts-expect-error
+  lineCombiner({ "*": notLines });
+});
+
+test("can pass to inputNode", () => {
+  const starLines = starInputs({ type: "string" });
+  // $ExpectType InputNode<{ "*": string; }>
+  inputNode({ "*": starLines });
+});
+
+test.skip("can only pass to inputNode as *", () => {
+  const starLines = starInputs({ type: "string" });
+  // TODO(aomarks) @ts-expect-error
+  inputNode({ foo: starLines });
+});
+
+test("can pass as board shorthand", () => {
+  const starLines = starInputs({ type: "string" });
+  // $ExpectType BoardDefinition<{ "*": string; }, {}>
+  board({ inputs: { "*": starLines }, outputs: {} });
+});
+
+test.skip("can only pass to board shorthand as *", () => {
+  const starLines = starInputs({ type: "string" });
+  // TODO(aomarks) @ts-expect-error
+  board({ inputs: { foo: starLines }, outputs: {} });
+});
+
+test("can serialize when passed to discrete component", () => {
+  const lines = starInputs({ type: "string" });
+  const { joined } = lineCombiner({ "*": lines }).outputs;
+  const testBoard = board({ inputs: { "*": lines }, outputs: { joined } });
+  const bgl = serialize(testBoard);
+  console.log(JSON.stringify(bgl));
+  assert.deepEqual(bgl, {
+    edges: [
+      { from: "input-0", to: "lineCombiner-0", out: "*", in: "*" },
+      { from: "lineCombiner-0", to: "output-0", out: "joined", in: "joined" },
+    ],
+    nodes: [
+      {
+        id: "input-0",
+        type: "input",
+        configuration: {
+          schema: {
+            type: "object",
+            properties: {},
+            required: [],
+            additionalProperties: { type: "string" },
+          },
+        },
+      },
+      {
+        id: "output-0",
+        type: "output",
+        configuration: {
+          schema: {
+            type: "object",
+            properties: { joined: { type: "string" } },
+            required: ["joined"],
+          },
+        },
+      },
+      { id: "lineCombiner-0", type: "lineCombiner", configuration: {} },
+    ],
+  });
+});

--- a/packages/website/src/docs/build/build.md
+++ b/packages/website/src/docs/build/build.md
@@ -400,3 +400,4 @@ export default board({
 - Optional
 - Kits
 - Casting
+- Star Inputs


### PR DESCRIPTION
This is not currently supported in all positions, but does let you grab the `*` port of a board and wire that into a discrete component.