### PR TITLE
[board-server] Adds github actions workflow for board server docker builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -108,7 +108,7 @@ jobs:
             type=gha,ref=${{ needs.setup.outputs.board_server_sqlite_image_name }}
             type=registry,ref=${{ needs.setup.outputs.board_server_sqlite_image_path }}
           cache-to: type=gha,mode=max,ref=${{ needs.setup.outputs.board_server_sqlite_image_name }}
-          push: false
+          push: true
           provenance: true
           tags: >
             ${{ needs.setup.outputs.board_server_sqlite_image_path }}:${{ github.sha }},
@@ -166,7 +166,7 @@ jobs:
           cache-to: |
             type=gha,mode=max,ref=${{ needs.setup.outputs.board_server_firestore_image_name }}
             type=registry,mode=max,ref=${{ needs.setup.outputs.board_server_firestore_image_path }}
-          push: false
+          push: true
           provenance: true
           tags: >
             ${{ needs.setup.outputs.board_server_firestore_image_path }}:${{ github.sha }},

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,187 @@
+name: Docker Build
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  REGISTRY: ghcr.io
+  EXECUTION_IMAGE: debian:bookworm-slim
+  BOARD_SERVER_SQLITE_IMAGE_NAME: board-server-sqlite
+  BOARD_SERVER_FIRESTORE_IMAGE_NAME: board-server-firestore
+  ALLOWED_ORIGINS: "*"
+jobs:
+  setup:
+    name: Setup
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Compute short hash
+        id: short_hash
+        run: |
+          SHORT_HASH=$(git rev-parse --short ${{ github.sha }})
+          echo "SHORT_HASH=${SHORT_HASH}" >>${GITHUB_OUTPUT}
+
+      - name: Lowercase repository owner
+        id: lowercase_repo_owner
+        run: |
+          echo "REPO_OWNER=${REPO_OWNER,,}" >>${GITHUB_OUTPUT}
+        env:
+          REPO_OWNER: "${{ github.repository_owner }}"
+
+      - name: Scoped board server sqlite image name
+        id: scoped_board_server_sqlite_image_name
+        run: |
+          IMAGE_NAME=${{ steps.lowercase_repo_owner.outputs.REPO_OWNER }}/${{ env.BOARD_SERVER_SQLITE_IMAGE_NAME }}
+          echo "IMAGE_NAME=${IMAGE_NAME}" >>${GITHUB_OUTPUT}
+
+      - name: Board server sqlite image path
+        id: board_server_sqlite_image_path
+        run: |
+          echo "IMAGE_PATH=${{ env.REGISTRY }}/${{ steps.scoped_board_server_sqlite_image_name.outputs.IMAGE_NAME }}" >>${GITHUB_OUTPUT}
+
+      - name: Board server firestore image name
+        id: board_server_firestore_image_name
+        run: |
+          echo "IMAGE_NAME=${{ steps.lowercase_repo_owner.outputs.REPO_OWNER }}/${{ env.BOARD_SERVER_FIRESTORE_IMAGE_NAME }}" >>${GITHUB_OUTPUT}
+
+      - name: Board server firestore image path
+        id: board_server_firestore_image_path
+        run: |
+          echo "IMAGE_PATH=${{ env.REGISTRY }}/${{ steps.board_server_firestore_image_name.outputs.IMAGE_NAME }}" >>${GITHUB_OUTPUT}
+
+      - name: Get package version
+        id: package_version
+        run: |
+          VERSION=$(node -p "require('./packages/board-server/package.json').version")
+          echo "VERSION=${VERSION}" >> ${GITHUB_OUTPUT}
+
+    outputs:
+      repo_owner: ${{ steps.lowercase_repo_owner.outputs.REPO_OWNER }}
+      short_hash: ${{ steps.short_hash.outputs.SHORT_HASH }}
+
+      board_server_sqlite_image_name: ${{ steps.scoped_board_server_sqlite_image_name.outputs.IMAGE_NAME }}
+      board_server_sqlite_image_path: ${{ steps.board_server_sqlite_image_path.outputs.IMAGE_PATH }}
+
+      board_server_firestore_image_name: ${{ steps.board_server_firestore_image_name.outputs.IMAGE_NAME }}
+      board_server_firestore_image_path: ${{ steps.board_server_firestore_image_path.outputs.IMAGE_PATH }}
+
+      package_version: ${{ steps.package_version.outputs.VERSION }}
+
+  board-server-sqlite-image:
+    name: Build board server sqlite image
+    needs:
+      - setup
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Registry Auth
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Image and push
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./packages/board-server/Dockerfile
+          cache-from: |
+            type=gha,ref=${{ needs.setup.outputs.board_server_sqlite_image_name }}
+            type=registry,ref=${{ needs.setup.outputs.board_server_sqlite_image_path }}
+          cache-to: type=gha,mode=max,ref=${{ needs.setup.outputs.board_server_sqlite_image_name }}
+          push: false
+          provenance: true
+          tags: >
+            ${{ needs.setup.outputs.board_server_sqlite_image_path }}:${{ github.sha }},
+            ${{ needs.setup.outputs.board_server_sqlite_image_path }}:${{ needs.setup.outputs.short_hash }},
+            ${{ needs.setup.outputs.board_server_sqlite_image_path }}:${{ needs.setup.outputs.package_version }},
+            ${{ needs.setup.outputs.board_server_sqlite_image_path }}:latest
+          build-args: |
+            STORAGE_BACKEND=sqlite
+            ALLOWED_ORIGINS=${{ env.ALLOWED_ORIGINS }}
+          build-contexts: |
+            breadboard=.
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ needs.setup.outputs.board_server_sqlite_image_path }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+
+  board-server-firestore-image:
+    name: Build board server firestore image
+    needs:
+      - setup
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Registry Auth
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Image and push
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./packages/board-server/Dockerfile
+          cache-from: |
+            type=gha,ref=${{ needs.setup.outputs.board_server_firestore_image_name }}
+            type=registry,ref=${{ needs.setup.outputs.board_server_firestore_image_path }}
+          cache-to: |
+            type=gha,mode=max,ref=${{ needs.setup.outputs.board_server_firestore_image_name }}
+            type=registry,mode=max,ref=${{ needs.setup.outputs.board_server_firestore_image_path }}
+          push: false
+          provenance: true
+          tags: >
+            ${{ needs.setup.outputs.board_server_firestore_image_path }}:${{ github.sha }},
+            ${{ needs.setup.outputs.board_server_firestore_image_path }}:${{ needs.setup.outputs.short_hash }},
+            ${{ needs.setup.outputs.board_server_firestore_image_path }}:${{ needs.setup.outputs.package_version }},
+            ${{ needs.setup.outputs.board_server_firestore_image_path }}:latest
+          build-args: |
+            STORAGE_BACKEND=firestore
+            ALLOWED_ORIGINS=${{ env.ALLOWED_ORIGINS }}
+          build-contexts: |
+            breadboard=.
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ needs.setup.outputs.board_server_firestore_image_path }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,6 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  EXECUTION_IMAGE: debian:bookworm-slim
   BOARD_SERVER_SQLITE_IMAGE_NAME: board-server-sqlite
   BOARD_SERVER_FIRESTORE_IMAGE_NAME: board-server-firestore
   ALLOWED_ORIGINS: ""

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,7 +10,7 @@ env:
   EXECUTION_IMAGE: debian:bookworm-slim
   BOARD_SERVER_SQLITE_IMAGE_NAME: board-server-sqlite
   BOARD_SERVER_FIRESTORE_IMAGE_NAME: board-server-firestore
-  ALLOWED_ORIGINS: "*"
+  ALLOWED_ORIGINS: ""
 jobs:
   setup:
     name: Setup


### PR DESCRIPTION
Fixes #2948

- Builds containers for sqlite and firestore flavoured versions of the board server
- Tags with sha, short hash, board server semver and latest
- Publishes to: (may want to modify these to some existing google org repo?)
  - ghcr.io/breadboard-ai/board-server-sqlite
  - ghcr.io/breadboard-ai/board-server-firestore
- Generates attestations for the containers and also publishes these to ghcr