### PR TITLE
[shared-ui] [drive] Fix bug related to event handling with Google Drive input widget

### DIFF
--- a/.changeset/plenty-lobsters-shop.md
+++ b/.changeset/plenty-lobsters-shop.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/shared-ui": patch
+---
+
+Fix bug relating to input events with Google Drive input widgets

--- a/packages/shared-ui/src/elements/google-drive/google-drive-file-id.ts
+++ b/packages/shared-ui/src/elements/google-drive/google-drive-file-id.ts
@@ -6,8 +6,8 @@
 
 import { LitElement, css, html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import { InputPlugin } from "../../plugins/input-plugin.js";
 import { type InputEnterEvent } from "../../events/events.js";
+import { InputChangeEvent, InputPlugin } from "../../plugins/input-plugin.js";
 import "../connection/connection-input.js";
 import { loadDrivePicker } from "./google-apis.js";
 
@@ -134,6 +134,7 @@ export class GoogleDriveFileId extends LitElement {
         console.log(`Shared 1 Google Drive file with Breadboard`);
         if (result.docs.length > 0) {
           this.value = result.docs[0].id;
+          this.dispatchEvent(new InputChangeEvent(this.value));
         }
       }
     }
@@ -150,5 +151,6 @@ export class GoogleDriveFileId extends LitElement {
 
   #onQueryInput(event: { target: HTMLTextAreaElement }) {
     this.value = event.target.value;
+    this.dispatchEvent(new InputChangeEvent(this.value));
   }
 }

--- a/packages/shared-ui/src/elements/input/delegating-input.ts
+++ b/packages/shared-ui/src/elements/input/delegating-input.ts
@@ -10,15 +10,15 @@ import { Task } from "@lit/task";
 import type { JSONSchema4 } from "json-schema";
 import { html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators.js";
+import {
+  type Environment,
+  environmentContext,
+} from "../../contexts/environment.js";
 import type {
   InputChangeEvent,
   InputPlugin,
   InputWidget,
 } from "../../plugins/input-plugin.js";
-import {
-  type Environment,
-  environmentContext,
-} from "../../contexts/environment.js";
 
 /**
  * An input widget which doesn't render anything directly, but instead matches
@@ -114,10 +114,7 @@ export class DelegatingInput
     // widget element via the #widget task, since we can assume it already knows
     // about the value it just dispatched an event for.
     this.#value = event.value;
-    if (!event.composed || !event.bubbles) {
-      // Our parent element won't receive the event unless we re-emit it.
-      this.dispatchEvent(event);
-    }
+    this.dispatchEvent(new Event("input"));
   };
 }
 


### PR DESCRIPTION
A recent refactoring I did (adding `delegated-input`) broke some event handling around the Google Drive input widgets. This fixes it!