### PR TITLE
[build] Set input port to empty string when wiring star ports

### DIFF
--- a/.changeset/curly-garlics-train.md
+++ b/.changeset/curly-garlics-train.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+When wiring star output to a node, the input port needs to be empty string instead of star.

--- a/packages/build/src/internal/board/serialize.ts
+++ b/packages/build/src/internal/board/serialize.ts
@@ -467,9 +467,14 @@ export function serialize(board: SerializableBoard): GraphDescriptor {
           if (inputNodeInfo !== undefined) {
             addEdge(
               inputNodeInfo.nodeId,
-              inputNodeInfo.portName,
+              "*",
               thisNodeId,
-              portName,
+              // TODO(aomarks) Kind of weird. If the input port is also "*",
+              // then the runtime seems to just stop. Only "" works. However, if
+              // you paste some BGL with "" into the Visual Editor it errors,
+              // and the docs say that star ports "can only be wired to other
+              // star ports".
+              "",
               wasConstant,
               wasOptional
             );

--- a/packages/build/src/test/star-inputs_test.ts
+++ b/packages/build/src/test/star-inputs_test.ts
@@ -104,7 +104,7 @@ test("can serialize when passed to discrete component", () => {
   console.log(JSON.stringify(bgl));
   assert.deepEqual(bgl, {
     edges: [
-      { from: "input-0", to: "lineCombiner-0", out: "*", in: "*" },
+      { from: "input-0", to: "lineCombiner-0", out: "*", in: "" },
       { from: "lineCombiner-0", to: "output-0", out: "joined", in: "joined" },
     ],
     nodes: [

--- a/packages/core-kit/tests/code_test.ts
+++ b/packages/core-kit/tests/code_test.ts
@@ -319,7 +319,7 @@ test("can pass star ports with *", (t) => {
   );
   t.deepEqual(bgl, {
     edges: [
-      { from: "input-0", to: "runJavascript-0", out: "*", in: "*" },
+      { from: "input-0", to: "runJavascript-0", out: "*", in: "" },
       { from: "input-0", to: "runJavascript-0", out: "foo", in: "foo" },
       { from: "runJavascript-0", to: "output-0", out: "sum", in: "sum" },
     ],


### PR DESCRIPTION
If the input port is also "*", then the runtime seems to just stop. Only "" works. However, if you paste some BGL with "" into the Visual Editor it errors, and the docs say that star ports "can only be wired to other star ports". Seems a bit odd, but I'll go with the one that works in the runtime, which is empty string.