### PR TITLE
feat: Adds flyway database migrations to board server

### DIFF
--- a/packages/board-server/Dockerfile
+++ b/packages/board-server/Dockerfile
@@ -15,12 +15,14 @@ RUN npm run build
 # Production stage
 FROM node:20-slim
 
-ARG STORAGE_BACKEND
+ARG STORAGE_BACKEND="sqlite"
 ARG ALLOWED_ORIGINS=""
+ARG SQLITE_DB_PATH="board-server.db"
 
 ENV NODE_ENV=production
 ENV STORAGE_BACKEND="${STORAGE_BACKEND}"
 ENV ALLOWED_ORIGINS="${ALLOWED_ORIGINS}"
+ENV SQLITE_DB_PATH="${SQLITE_DB_PATH}"
 
 WORKDIR /app
 
@@ -30,9 +32,24 @@ COPY --from=build /build/packages/board-server/src ./src
 COPY --from=build /build/packages/board-server/package.json ./
 COPY --from=build /build/packages/board-server/public ./public
 
+# Install necessary tools, Java, and Flyway CLI, then copy migration scripts if STORAGE_BACKEND is sqlite
+RUN apt-get update && apt-get install -y wget tar default-jre && \
+    if [ "$STORAGE_BACKEND" = "sqlite" ]; then \
+    wget -qO- https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/9.8.1/flyway-commandline-9.8.1-linux-x64.tar.gz | tar xvz && \
+    ln -s /app/flyway-9.8.1/flyway /usr/local/bin && \
+    mkdir -p /flyway/sql && \
+    cp -r /app/src/migrations/* /flyway/sql/; \
+    fi && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # Install production dependencies and tsx
 RUN npm install --only=production && \
     npm install -g tsx
 
 EXPOSE 3000
-CMD ["node", "dist/server/index.js", "--host=0.0.0.0" ]
+
+# Run Flyway migrate before starting the application if STORAGE_BACKEND is sqlite
+CMD if [ "$STORAGE_BACKEND" = "sqlite" ]; then \
+    flyway -url="jdbc:sqlite:${SQLITE_DB_PATH}" -locations=filesystem:/flyway/sql migrate; \
+    fi && \
+    node dist/server/index.js --host=0.0.0.0

--- a/packages/board-server/README.md
+++ b/packages/board-server/README.md
@@ -21,6 +21,14 @@ export STORAGE_BACKEND=sqlite
 export SQLITE_DB_PATH=/path/to/board-server.db
 ```
 
+## Initialize the database for local SQLite development
+
+In `sqlite` mode, the board server uses Flyway for database migrations. To initialize the database using docker, run the following command:
+
+```
+npm run migrate
+```
+
 ## Building with docker
 
 The board server can be run as a self-contained docker image.

--- a/packages/board-server/package.json
+++ b/packages/board-server/package.json
@@ -23,7 +23,8 @@
     "dev": "npm run dev:nowatch --watch",
     "dev:nowatch": "wireit",
     "test": "wireit",
-    "test:integration": "wireit"
+    "test:integration": "wireit",
+    "migrate": "docker run --rm -v \"$(pwd)/src/migrations:/flyway/sql/migrations\" flyway/flyway -url=jdbc:sqlite:board-server.db -locations=filesystem:/flyway/sql/migrations migrate"
   },
   "wireit": {
     "build": {

--- a/packages/board-server/src/migrations/V1__initial_schema.sql
+++ b/packages/board-server/src/migrations/V1__initial_schema.sql
@@ -1,0 +1,41 @@
+-- V1__initial_schema.sql
+CREATE TABLE IF NOT EXISTS reanimation_states (
+  id TEXT PRIMARY KEY,
+  user TEXT NOT NULL,
+  state TEXT NOT NULL,
+  timestamp INTEGER NOT NULL,
+  expire_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS users (
+  id TEXT PRIMARY KEY,        
+  api_key TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE IF NOT EXISTS workspaces (
+  id TEXT PRIMARY KEY
+);
+
+CREATE TABLE IF NOT EXISTS boards (
+  workspace_id TEXT,
+  board_id TEXT,
+  title TEXT,
+  tags TEXT,
+  graph TEXT,
+  PRIMARY KEY (workspace_id, board_id),
+  FOREIGN KEY (workspace_id) REFERENCES workspaces(id)
+);
+
+CREATE TABLE IF NOT EXISTS invites (
+  workspace_id TEXT,
+  board_id TEXT,
+  invite TEXT,
+  expire_at INTEGER,
+  PRIMARY KEY (workspace_id, board_id, invite),
+  FOREIGN KEY (workspace_id, board_id) REFERENCES boards(workspace_id, board_id)
+);
+
+CREATE TABLE IF NOT EXISTS configuration (
+  key TEXT PRIMARY KEY,
+  value TEXT
+);

--- a/packages/board-server/src/server/storage-providers/sqlite.ts
+++ b/packages/board-server/src/server/storage-providers/sqlite.ts
@@ -10,50 +10,6 @@ export class SQLiteStorageProvider implements RunBoardStateStore, BoardServerSto
   
     constructor(dbPath: string) {
       this.db = new Database(dbPath);
-  
-      // Initialize tables
-      this.db.exec(`
-        CREATE TABLE IF NOT EXISTS reanimation_states (
-          id TEXT PRIMARY KEY,
-          user TEXT NOT NULL,
-          state TEXT NOT NULL,
-          timestamp INTEGER NOT NULL,
-          expire_at INTEGER NOT NULL
-        );
-        
-        CREATE TABLE IF NOT EXISTS users (
-          id TEXT PRIMARY KEY,        
-          api_key TEXT NOT NULL UNIQUE
-        );
-        
-        CREATE TABLE IF NOT EXISTS workspaces (
-          id TEXT PRIMARY KEY
-        );
-  
-        CREATE TABLE IF NOT EXISTS boards (
-          workspace_id TEXT,
-          board_id TEXT,
-          title TEXT,
-          tags TEXT,
-          graph TEXT,
-          PRIMARY KEY (workspace_id, board_id),
-          FOREIGN KEY (workspace_id) REFERENCES workspaces(id)
-        );
-  
-        CREATE TABLE IF NOT EXISTS invites (
-          workspace_id TEXT,
-          board_id TEXT,
-          invite TEXT,
-          expire_at INTEGER,
-          PRIMARY KEY (workspace_id, board_id, invite),
-          FOREIGN KEY (workspace_id, board_id) REFERENCES boards(workspace_id, board_id)
-        );
-        
-        CREATE TABLE IF NOT EXISTS configuration (
-          key TEXT PRIMARY KEY,
-          value TEXT
-        );
-      `);
     }
   
     async saveReanimationState(user: string, state: ReanimationState): Promise<string> {


### PR DESCRIPTION
Fixes #2947 

Adds support for database migrations in SQLite mode using flyway. 

- Breaks migrations out into `src/migrations`
- Migrations are straightforward SQL files, when we need to make a change, we can write a new SQL file to migrate existing databases to a new schema.
- We can also write rollback files to roll database versions backwards.
- Flyway maintains an internal state table in SQLite to track the database version.
- Migrations are baked into the container image, and will be automatically applied when rolling out a container with migrations that aren't included in the local DB.
- Includes a script to initialise and migrate the database at local development time in package.json
