### PR TITLE
config unaware

### DIFF
--- a/.changeset/popular-sloths-hug.md
+++ b/.changeset/popular-sloths-hug.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/shared-ui": minor
+---
+
+Add support for "Configured" in property schema editor.

--- a/packages/shared-ui/src/elements/input/schema-editor/schema-editor.ts
+++ b/packages/shared-ui/src/elements/input/schema-editor/schema-editor.ts
@@ -960,6 +960,9 @@ export class SchemaEditor extends LitElement {
             property.behavior = property.behavior?.filter(
               (item) => item !== "config"
             );
+            if (property.behavior && !property.behavior?.length) {
+              delete property.behavior;
+            }
           }
         }
       }

--- a/packages/shared-ui/src/elements/input/schema-editor/schema-editor.ts
+++ b/packages/shared-ui/src/elements/input/schema-editor/schema-editor.ts
@@ -709,6 +709,15 @@ export class SchemaEditor extends LitElement {
             id="${id}-description"
             .value="${value.description || ""}"
           ></textarea>
+
+          <label for="${id}-config">Configured</label>
+          <input
+            name="${id}-config"
+            id="${id}-config"
+            type="checkbox"
+            ?checked=${value.behavior?.includes("config")}
+          />
+
           <button class="show-less" @click=${() => this.#toggleExpanded(id)}>
             Show less
           </button>
@@ -760,6 +769,9 @@ export class SchemaEditor extends LitElement {
         ) as HTMLTextAreaElement | null;
         const inRequired = form.querySelector(
           `#${id}-required`
+        ) as HTMLInputElement | null;
+        const inConfig = form.querySelector(
+          `#${id}-config`
         ) as HTMLInputElement | null;
 
         const oldType = property.type;
@@ -938,6 +950,17 @@ export class SchemaEditor extends LitElement {
           }
 
           schema.required = [...required];
+        }
+
+        if (inConfig) {
+          if (inConfig.checked) {
+            property.behavior = property.behavior || [];
+            property.behavior.push("config");
+          } else {
+            property.behavior = property.behavior?.filter(
+              (item) => item !== "config"
+            );
+          }
         }
       }
 


### PR DESCRIPTION
- **Teach `filterConfigByMode` to be more loose with components unaware of `config` behavior.**
- **Add "Configured" checkbox to schema editor.**
- **Remove behavior property when empty.**
- **docs(changeset): Add support for "Configured" in property schema editor.**
