### PR TITLE
[board-server] Add a margin to the newest edge entry in the app view

### DIFF
--- a/.changeset/chilly-gifts-push.md
+++ b/.changeset/chilly-gifts-push.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/board-server": patch
+---
+
+Add a margin to the newest edge entry in the app view

--- a/packages/board-server/src/app/elements/activity-log/activity-log-lite.ts
+++ b/packages/board-server/src/app/elements/activity-log/activity-log-lite.ts
@@ -143,6 +143,10 @@ export class ActivityLogLite extends LitElement {
       animation: fadeAndSlideIn 0.3s cubic-bezier(0, 0, 0.3, 1) forwards;
     }
 
+    .edge.newest {
+      margin-bottom: var(--bb-grid-size-16);
+    }
+
     .edge.empty {
       height: 0;
       display: flex;


### PR DESCRIPTION
Noticed that the mobile view doesn't have enough scroll distance so the bottom of newest edge output is cropped. This PR fixes it.