### PR TITLE
[shared-ui] Fix layout reset bug

### DIFF
--- a/.changeset/shy-grapes-raise.md
+++ b/.changeset/shy-grapes-raise.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/shared-ui": patch
+---
+
+Fix layout reset bug

--- a/packages/shared-ui/src/elements/editor/graph-renderer.ts
+++ b/packages/shared-ui/src/elements/editor/graph-renderer.ts
@@ -1043,6 +1043,7 @@ export class GraphRenderer extends LitElement {
       }
 
       graph.clearNodeLayoutPositions();
+      graph.storeCommentLayoutPositions();
       graph.layout();
 
       this.#emitGraphNodeVisualInformation(graph);

--- a/packages/shared-ui/src/elements/editor/graph.ts
+++ b/packages/shared-ui/src/elements/editor/graph.ts
@@ -786,6 +786,22 @@ export class Graph extends PIXI.Container {
     return this.#layout.get(node);
   }
 
+  storeCommentLayoutPositions() {
+    for (const child of this.children) {
+      if (!(child instanceof GraphComment)) {
+        continue;
+      }
+
+      this.setNodeLayoutPosition(
+        child.label,
+        "comment",
+        this.toGlobal(child.position),
+        child.collapsed,
+        false
+      );
+    }
+  }
+
   setNodeLayoutPosition(
     node: string,
     type: "comment" | "node",
@@ -1068,6 +1084,7 @@ export class Graph extends PIXI.Container {
 
       const childPosition = this.graph.getNodeLayoutPosition(child.label);
       if (!childPosition) {
+        console.log("Child has no position", child.label);
         continue;
       }
 


### PR DESCRIPTION
I noticed that comments no drag as part of a group after a layout reset. It turns out we were removing all the layout information but only restoring the the non-comment nodes with dagre. Since the comments have no edges we can't use dagre, but we can just restore their existing layout info, which is what this PR does.