### PR TITLE
[build] Hoist up common type for anyOf

### DIFF
--- a/.changeset/rare-scissors-train.md
+++ b/.changeset/rare-scissors-train.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+The anyOf function now hoists out any common "type" it finds, to help with code in breadboard that assumes there is always a top-level type (e.g. when visual editor looks for llm-content).

--- a/packages/build/src/internal/type-system/any-of.ts
+++ b/packages/build/src/internal/type-system/any-of.ts
@@ -26,9 +26,29 @@ export function anyOf<
     (member) =>
       typeof member.type === "string" && Object.keys(member).length === 1
   );
+  if (allTypesAreBasic) {
+    return {
+      jsonSchema: {
+        type: types.map((member) => member.type as JSONSchema4TypeName),
+      },
+    };
+  }
+  const uniqueCoreTypes = new Set(types.map(({ type }) => type));
+  if (uniqueCoreTypes.size === 1) {
+    // TODO(aomarks) Remove this when we no longer have this limitation.
+    // This is a no-op according to JSON Schema, but it's helpful in Breadboard
+    // right now because we have some code that assumes there is always a
+    // top-level core "type", and doesn't understand "anyOf". In the case where
+    // all the "anyOf" core types are the same, we can hoist it up to make that
+    // code happy.
+    return {
+      jsonSchema: {
+        type: [...uniqueCoreTypes][0],
+        anyOf: types,
+      },
+    };
+  }
   return {
-    jsonSchema: allTypesAreBasic
-      ? { type: types.map((member) => member.type as JSONSchema4TypeName) }
-      : { anyOf: types },
+    jsonSchema: { anyOf: types },
   };
 }

--- a/packages/build/src/test/type-expressions/anyof_test.ts
+++ b/packages/build/src/test/type-expressions/anyof_test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { anyOf } from "@breadboard-ai/build";
+import { anyOf, object } from "@breadboard-ai/build";
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import {
@@ -37,5 +37,26 @@ test("anyOf", () => {
   type t3 = ConvertBreadboardType<typeof with3>;
   assert.deepEqual(toJSONSchema(with3), {
     type: ["number", "boolean", "string"],
+  });
+});
+
+test("hoists common type", () => {
+  const any = anyOf(object({}), object({}));
+  assert.deepEqual(toJSONSchema(any), {
+    type: "object",
+    anyOf: [
+      {
+        additionalProperties: false,
+        properties: {},
+        required: [],
+        type: "object",
+      },
+      {
+        additionalProperties: false,
+        properties: {},
+        required: [],
+        type: "object",
+      },
+    ],
   });
 });


### PR DESCRIPTION
Now, if you write `anyOf(foo, bar)`, and `foo` and `bar` both have the same `type` (e.g. `"type":"object"`), then that common `type` will get hoisted up. This is helpful for some code in Breadboard that assumes there is always a top-level `type`, even though JSON schema doesn't require that.