### PR TITLE
[build] Serialize nested components with their kit-name if they are instantiated via a kit (fixed version)

### DIFF
--- a/.changeset/thick-knives-sin.md
+++ b/.changeset/thick-knives-sin.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Components imported through kit objects are now serialized directly with "type" instead of via an invoke node.

--- a/packages/build/src/internal/board/board.ts
+++ b/packages/build/src/internal/board/board.ts
@@ -47,6 +47,7 @@ import type {
   RemoveReadonly,
 } from "../common/type-util.js";
 import type { StarInputs } from "./star-inputs.js";
+import type { KitBinding } from "../kit.js";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unused-vars */
@@ -337,13 +338,15 @@ class BoardDefinitionImpl<
   }
 
   instantiate(
-    values: ValuesOrOutputPorts<ExtractPortTypes<IPORTS>>
+    values: ValuesOrOutputPorts<ExtractPortTypes<IPORTS>>,
+    kitBinding?: KitBinding
   ): OldBoardInstance<IPORTS, OPORTS> {
     return new OldBoardInstance(
       this.#inputs,
       this.#outputs,
       values,
-      this.definition!
+      this.definition!,
+      kitBinding
     );
   }
 
@@ -482,17 +485,20 @@ export class OldBoardInstance<
   readonly outputs: OPORTS;
   readonly values: ValuesOrOutputPorts<ExtractPortTypes<IPORTS>>;
   readonly definition: OldBoardDefinition<IPORTS, OPORTS>;
+  readonly __kitBinding?: KitBinding;
 
   constructor(
     inputs: IPORTS,
     outputs: OPORTS,
     values: ValuesOrOutputPorts<ExtractPortTypes<IPORTS>>,
-    definition: OldBoardDefinition<IPORTS, OPORTS>
+    definition: OldBoardDefinition<IPORTS, OPORTS>,
+    kitBinding?: KitBinding
   ) {
     this.inputs = inputs;
     this.outputs = this.#tagOutputs(outputs);
     this.values = values;
     this.definition = definition;
+    this.__kitBinding = kitBinding;
   }
 
   /**

--- a/packages/build/src/internal/board/serialize.ts
+++ b/packages/build/src/internal/board/serialize.ts
@@ -358,10 +358,19 @@ export function serialize(board: SerializableBoard): GraphDescriptor {
       return descriptor.id;
     }
     let type, metadata, thisNodeId;
+    let isBoardInstanceBoundToKit = false;
     if (isBoardInstance(node)) {
-      type = "invoke";
-      metadata = undefined;
-      thisNodeId = nextIdForType("invoke");
+      const kitBinding = node.__kitBinding;
+      if (kitBinding) {
+        isBoardInstanceBoundToKit = true;
+        type = kitBinding.id;
+        metadata = undefined;
+        thisNodeId = nextIdForType(type);
+      } else {
+        type = "invoke";
+        metadata = undefined;
+        thisNodeId = nextIdForType("invoke");
+      }
     } else {
       const cast = node as SerializableNode;
       type = cast.type;
@@ -387,7 +396,7 @@ export function serialize(board: SerializableBoard): GraphDescriptor {
     nodes.set(node, descriptor);
 
     const configurationEntries: Array<[string, NodeValue]> = [];
-    if (isBoardInstance(node)) {
+    if (isBoardInstance(node) && !isBoardInstanceBoundToKit) {
       configurationEntries.push([
         "$board",
         `#${embedBoardAndReturnItsId(node.definition)}`,

--- a/packages/build/src/internal/define/definition.ts
+++ b/packages/build/src/internal/define/definition.ts
@@ -54,6 +54,7 @@ import { normalizeBreadboardError } from "../common/error.js";
 import type { Convergence } from "../board/converge.js";
 import type { SerializableBoard } from "../common/serializable.js";
 import type { StarInputs } from "../board/star-inputs.js";
+import type { KitBinding } from "../kit.js";
 
 export interface Definition<
   /* Static Inputs   */ SI extends { [K: string]: JsonSerializable },
@@ -165,7 +166,8 @@ export class DefinitionImpl<
   }
 
   instantiate<A extends LooseInstantiateArgs>(
-    args: A & StrictInstantiateArgs<SI, OI, DI, A, IM>
+    args: A & StrictInstantiateArgs<SI, OI, DI, A, IM>,
+    kitBinding?: KitBinding
   ): Instance<
     InstanceInputs<SI, DI, A>,
     InstanceOutputs<SI, SO, DO, R, A>,
@@ -186,7 +188,8 @@ export class DefinitionImpl<
       this.#reflective,
       // TODO(aomarks) Fix
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      args as any
+      args as any,
+      kitBinding
     );
   }
 

--- a/packages/build/src/internal/define/instance.ts
+++ b/packages/build/src/internal/define/instance.ts
@@ -15,6 +15,7 @@ import {
   type OutputPortReference,
 } from "../common/port.js";
 import type { SerializableNode } from "../common/serializable.js";
+import type { KitBinding } from "../kit.js";
 import type { BreadboardType, JsonSerializable } from "../type-system/type.js";
 import type {
   DynamicInputPortConfig,
@@ -60,9 +61,10 @@ export class Instance<
     reflective: boolean,
     args: {
       [K: string]: JsonSerializable | OutputPortReference<JsonSerializable>;
-    } & { $id?: string }
+    } & { $id?: string },
+    kitBinding?: KitBinding
   ) {
-    this.type = type;
+    this.type = kitBinding?.id ?? type;
     this.#dynamicInputType = dynamicInputs?.type;
     this.#dynamicOutputType = dynamicOutputs?.type;
     this.#reflective = reflective;

--- a/packages/build/src/internal/kit.ts
+++ b/packages/build/src/internal/kit.ts
@@ -13,11 +13,11 @@ import {
   type Kit,
   type KitConstructor,
   type NewNodeFactory,
+  type NewNodeValue,
   type NodeHandler,
   type NodeHandlerContext,
   type NodeHandlerFunction,
   type NodeHandlers,
-  type NewNodeValue,
 } from "@google-labs/breadboard";
 import type {
   KitTag,
@@ -26,12 +26,12 @@ import type {
 import { GraphToKitAdapter, KitBuilder } from "@google-labs/breadboard/kits";
 import type { BoardDefinition } from "./board/board.js";
 import { serialize } from "./board/serialize.js";
+import type { Expand } from "./common/type-util.js";
 import {
   isDiscreteComponent,
   type Definition,
   type GenericDiscreteComponent,
 } from "./define/definition.js";
-import type { Expand } from "./common/type-util.js";
 
 type ComponentManifest = Record<
   string,
@@ -50,30 +50,11 @@ export interface KitOptions<T extends ComponentManifest = ComponentManifest> {
 export function kit<T extends ComponentManifest>(
   options: KitOptions<T>
 ): KitConstructor<Kit> & T & { legacy(): Promise<Expand<LegacyKit<T>>> } {
-  const componentsWithIds = Object.fromEntries(
-    Object.entries(options.components).map(([id, component]) => [
-      id,
-      bindComponentToKit(component, id),
-    ])
-  );
-  const handlers: Record<string, NodeHandler> = Object.fromEntries(
-    Object.values(componentsWithIds).map((component) => {
-      if (isDiscreteComponent(component)) {
-        return [component.id, component];
-      } else {
-        return [
-          component.id,
-          // TODO(aomarks) Should this just be the invoke() method on Board?
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          makeBoardComponentHandler(component as any),
-        ];
-      }
-    })
-  );
+  const handlers: Record<string, NodeHandler> = {};
 
   // TODO(aomarks) Unclear why this needs to be a class, and why it needs
   // certain fields on both the static and instance sides.
-  const result = class GeneratedBreadboardKit {
+  const kit: KitConstructor<Kit> = class GeneratedBreadboardKit {
     static handlers = handlers;
     static url = options.url;
     handlers = handlers;
@@ -83,10 +64,36 @@ export function kit<T extends ComponentManifest>(
     url = options.url;
     tags = options.tags ?? [];
   };
-  return Object.assign(result, {
-    ...componentsWithIds,
+
+  const kitBoundComponents = Object.fromEntries(
+    Object.entries(options.components).map(([id, component]) => [
+      id,
+      bindComponentToKit(component, { kit, id }),
+    ])
+  );
+
+  Object.assign(
+    handlers,
+    Object.fromEntries(
+      Object.values(kitBoundComponents).map((component) => {
+        if (isDiscreteComponent(component)) {
+          return [component.id, component];
+        } else {
+          return [
+            component.id,
+            // TODO(aomarks) Should this just be the invoke() method on Board?
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            makeBoardComponentHandler(component as any),
+          ];
+        }
+      })
+    )
+  );
+
+  return Object.assign(kit, {
+    ...kitBoundComponents,
     legacy: () => makeLegacyKit<T>(options),
-  }) as KitConstructor<Kit> as KitConstructor<Kit> &
+  }) as KitConstructor<Kit> &
     T & { legacy: () => Promise<Expand<LegacyKit<T>>> };
 }
 
@@ -130,19 +137,31 @@ function findInvokeFunctionFromContext(
 }
 
 /**
- * Components don't have ids until they are added to a kit. This function
- * returns a proxy of the component that adds an "id" property.
+ * Describes the kit that a component is bound to, along with that component's
+ * id within that kit.
+ */
+export interface KitBinding {
+  id: string;
+  kit: KitConstructor<Kit>;
+}
+
+/**
+ * Returns a proxy of a component instance which binds it to a kit.
  */
 function bindComponentToKit<
   T extends GenericDiscreteComponent | BoardDefinition,
->(component: T, id: string): T & { id: string } {
-  return new Proxy(component, {
-    get(target, prop) {
-      return prop === "id"
-        ? id
-        : (target as object as Record<string | symbol, unknown>)[prop];
+>(definition: T, kitBinding: KitBinding): T {
+  return new Proxy(definition, {
+    apply(target, thisArg, args) {
+      // The instantiate functions for both discrete and board components have
+      // an optional final argument called `kitBinding`. Normally it is
+      // undefined, but when called via this proxy we will add the final
+      // argument. Now those instances know which kit they're from, which helps
+      // us serialize them.
+      //  eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return target.apply(thisArg, [...args, kitBinding] as any);
     },
-  }) as T & { id: string };
+  });
 }
 
 /**

--- a/packages/build/src/test/kit_test.ts
+++ b/packages/build/src/test/kit_test.ts
@@ -55,7 +55,6 @@ test("kit handles discrete component", () => {
     // $ExpectType Definition<{ str: string; }, { str: string; }, undefined, undefined, never, false, false, false, { str: { board: false; }; }>
     testKit.foo
   );
-  assert.equal(testKit.foo.id, "foo");
   assert.equal(testKit.foo.metadata.description, "Discrete Description");
 });
 
@@ -64,7 +63,6 @@ test("kit handles board component", () => {
     // $ExpectType BoardDefinition<{ num: number; }, { num: number; }>
     testKit.bar
   );
-  assert.equal(testKit.bar.id, "bar");
   assert.equal(testKit.bar.description, "Board Description");
 });
 
@@ -174,10 +172,10 @@ test("can invoke discrete component with new API", () => {
             type: "object",
             properties: {
               str: {
-                title: "str",
                 type: "string",
               },
             },
+            required: ["str"],
           },
         },
       },
@@ -197,7 +195,6 @@ test("can invoke discrete component with new API", () => {
         in: "str",
       },
     ],
-    graphs: {},
   });
 });
 
@@ -215,10 +212,10 @@ test("can invoke board component with new API", () => {
             type: "object",
             properties: {
               num: {
-                title: "num",
                 type: "number",
               },
             },
+            required: ["num"],
           },
         },
       },
@@ -238,6 +235,5 @@ test("can invoke board component with new API", () => {
         in: "num",
       },
     ],
-    graphs: {},
   });
 });

--- a/packages/build/src/test/kit_test.ts
+++ b/packages/build/src/test/kit_test.ts
@@ -10,7 +10,13 @@ import { board } from "../internal/board/board.js";
 import { input } from "../internal/board/input.js";
 import { defineNodeType } from "../internal/define/define.js";
 import { kit } from "../internal/kit.js";
-import { board as oldBoard } from "@google-labs/breadboard";
+import {
+  board as oldBoard,
+  type Kit,
+  type KitConstructor,
+  type NodeFactory,
+  type NodeHandlerObject,
+} from "@google-labs/breadboard";
 import { serialize } from "../internal/board/serialize.js";
 
 const testDiscrete = defineNodeType({
@@ -48,6 +54,33 @@ const testKit = kit({
     foo: testDiscrete,
     bar: testBoard,
   },
+});
+
+test("is a kit", () => {
+  testKit satisfies Kit & {
+    handlers: { foo: NodeHandlerObject; bar: NodeHandlerObject };
+  };
+  assert.deepEqual(Object.keys(testKit.handlers), ["foo", "bar"]);
+  const { foo, bar } = testKit.handlers;
+  assert.equal(typeof foo.invoke, "function");
+  assert.equal(typeof bar.invoke, "function");
+  assert.equal(typeof foo.describe, "function");
+  assert.equal(typeof bar.describe, "function");
+});
+
+test("is a kit factory for itself", () => {
+  testKit satisfies KitConstructor<
+    Kit & {
+      handlers: { foo: NodeHandlerObject; bar: NodeHandlerObject };
+    }
+  >;
+  const instantiatedTestKit = new testKit(undefined as unknown as NodeFactory);
+  assert.deepEqual(Object.keys(instantiatedTestKit.handlers), ["foo", "bar"]);
+  const { foo, bar } = instantiatedTestKit.handlers;
+  assert.equal(typeof foo.invoke, "function");
+  assert.equal(typeof bar.invoke, "function");
+  assert.equal(typeof foo.describe, "function");
+  assert.equal(typeof bar.describe, "function");
 });
 
 test("kit handles discrete component", () => {

--- a/packages/build/src/test/kit_test.ts
+++ b/packages/build/src/test/kit_test.ts
@@ -11,6 +11,7 @@ import { input } from "../internal/board/input.js";
 import { defineNodeType } from "../internal/define/define.js";
 import { kit } from "../internal/kit.js";
 import { board as oldBoard } from "@google-labs/breadboard";
+import { serialize } from "../internal/board/serialize.js";
 
 const testDiscrete = defineNodeType({
   name: "discreteComponent",
@@ -67,7 +68,7 @@ test("kit handles board component", () => {
   assert.equal(testKit.bar.description, "Board Description");
 });
 
-test("can invoke discrete component through board with old API", async () => {
+test("can invoke discrete component with old API", async () => {
   const legacyTestKit = await testKit.legacy();
   const oldBoardInstance = await oldBoard(() => {
     const node = legacyTestKit.foo({ str: "foo" });
@@ -113,12 +114,12 @@ test("can invoke discrete component through board with old API", async () => {
   });
 });
 
-test("can invoke board component through board with old API", async () => {
+test("can invoke board component with old API", async () => {
   const legacyTestKit = await testKit.legacy();
   const oldBoardInstance = await oldBoard(() => {
-    const bb = legacyTestKit.bar({ num: 32 });
+    const num = legacyTestKit.bar({ num: 32 });
     return {
-      num: bb.num,
+      num,
     };
   });
   const bgl = await oldBoardInstance.serialize();
@@ -152,6 +153,88 @@ test("can invoke board component through board with old API", async () => {
         from: "bar-3",
         out: "num",
         to: "output-2",
+        in: "num",
+      },
+    ],
+    graphs: {},
+  });
+});
+
+test("can invoke discrete component with new API", () => {
+  const str = testKit.foo({ str: "foo" }).outputs.str;
+  const newBoardInstance = board({ inputs: {}, outputs: { str } });
+  const bgl = serialize(newBoardInstance);
+  assert.deepEqual(bgl, {
+    nodes: [
+      {
+        id: "output-0",
+        type: "output",
+        configuration: {
+          schema: {
+            type: "object",
+            properties: {
+              str: {
+                title: "str",
+                type: "string",
+              },
+            },
+          },
+        },
+      },
+      {
+        id: "foo-0",
+        type: "foo",
+        configuration: {
+          str: "foo",
+        },
+      },
+    ],
+    edges: [
+      {
+        from: "foo-0",
+        out: "str",
+        to: "output-0",
+        in: "str",
+      },
+    ],
+    graphs: {},
+  });
+});
+
+test("can invoke board component with new API", () => {
+  const num = testKit.bar({ num: 32 }).outputs.num;
+  const newBoardInstance = board({ inputs: {}, outputs: { num } });
+  const bgl = serialize(newBoardInstance);
+  assert.deepEqual(bgl, {
+    nodes: [
+      {
+        id: "output-0",
+        type: "output",
+        configuration: {
+          schema: {
+            type: "object",
+            properties: {
+              num: {
+                title: "num",
+                type: "number",
+              },
+            },
+          },
+        },
+      },
+      {
+        id: "bar-0",
+        type: "bar",
+        configuration: {
+          num: 32,
+        },
+      },
+    ],
+    edges: [
+      {
+        from: "bar-0",
+        out: "num",
+        to: "output-0",
         in: "num",
       },
     ],


### PR DESCRIPTION
Brings back https://github.com/breadboard-ai/breadboard/pull/3015 (reverted in https://github.com/breadboard-ai/breadboard/pull/3018) but with a fix for a bug.

The bug was that when building the kit, I was using the "id" property of the component object itself as the key, instead of the key that was used to initialize the component within the kit. Combined with a removed get proxy, this meant the key was either undefined, or potentially a different id from how the kit was initialized. Added tests and some safer typing around this.