### PR TITLE
Fixed typo in Run API doc

### DIFF
--- a/packages/website/src/docs/reference/run-api.md
+++ b/packages/website/src/docs/reference/run-api.md
@@ -164,7 +164,7 @@ const config: RunConfig = {
 };
 
 // Create the runner
-const runner = createRunner(graph);
+const runner = createRunner(config);
 
 // Function to handle user input
 async function getUserInput(schema: Schema): Promise<void> {


### PR DESCRIPTION
Fixes #3062 

Just a fix for a small typo in the Run API doc where the `createRunner(...)` function needs to be passed the config object.