### PR TITLE
[build] Add JSON Schema type

### DIFF
--- a/.changeset/friendly-beds-sort.md
+++ b/.changeset/friendly-beds-sort.md
@@ -1,0 +1,10 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Add a Breadboard Type Expression to represent JSON schema itself.
+
+For now this is using our Schema type, and a generic object schema
+with the json-schema behavior. In the future we can switch this to
+the official JSON Schema types, and a {$ref} schema for the official
+JSON Schema schema.

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -30,6 +30,7 @@ export { anyOf } from "./internal/type-system/any-of.js";
 export { array } from "./internal/type-system/array.js";
 export { enumeration } from "./internal/type-system/enumeration.js";
 export { intersect } from "./internal/type-system/intersect.js";
+export { jsonSchema } from "./internal/type-system/json-schema.js";
 export { object, optional } from "./internal/type-system/object.js";
 export { string } from "./internal/type-system/string.js";
 export { toJSONSchema } from "./internal/type-system/type.js";

--- a/packages/build/src/internal/type-system/json-schema.ts
+++ b/packages/build/src/internal/type-system/json-schema.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { type Schema } from "@google-labs/breadboard";
+import { annotate } from "./annotate.js";
+import { object } from "./object.js";
+import { unsafeType } from "./unsafe.js";
+
+/**
+ * The Breadboard Type Expression for JSON Schema itself. Use this when you need
+ * to declare an input or output port whose type is itself a JSON Schema object.
+ */
+export const jsonSchema = unsafeType<Schema>(
+  // TODO(aomarks) Replace with the official JSONSchema7 type and
+  // { $ref: "https://json-schema.org/draft-07/schema#" }. But we first need to
+  // support $ref schemas more broadly, and possibly align our Schema vs
+  // JSONSchema7 types.
+  annotate(object({}, "unknown"), {
+    behavior: ["json-schema"],
+  })
+);


### PR DESCRIPTION
Adds a Breadboard Type Expression to represent JSON schema itself.

For now this is using our Schema type, and a generic object schema
with the json-schema behavior. In the future we can switch this to
the official JSON Schema types, and a {$ref} schema for the official
JSON Schema schema.