### PR TITLE
[build] Add rawInput function

### DIFF
--- a/.changeset/nervous-ads-raise.md
+++ b/.changeset/nervous-ads-raise.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build": patch
+---
+
+Add rawInput function

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -7,7 +7,7 @@
 export { board, inputNode, outputNode } from "./internal/board/board.js";
 export { constant } from "./internal/board/constant.js";
 export { converge } from "./internal/board/converge.js";
-export { input } from "./internal/board/input.js";
+export { input, rawInput } from "./internal/board/input.js";
 export { loopback } from "./internal/board/loopback.js";
 export { optionalEdge } from "./internal/board/optional.js";
 export { output } from "./internal/board/output.js";

--- a/packages/build/src/internal/board/input.ts
+++ b/packages/build/src/internal/board/input.ts
@@ -7,6 +7,8 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
 import type { BroadenBasicType, Defined } from "../common/type-util.js";
+import { defineNodeType } from "../define/define.js";
+import { jsonSchema } from "../type-system/json-schema.js";
 import type {
   BreadboardType,
   ConvertBreadboardType,
@@ -229,3 +231,46 @@ export function isSpecialInput(value: unknown): value is GenericSpecialInput {
     "__SpecialInputBrand" in value
   );
 }
+
+/**
+ * Usually, inputs are created with the {@link input} and {@link inputNode}
+ * functions, which abstract Breadboard inputs to make them more powerful and
+ * ergonomic while using the Build API.
+ *
+ * This `rawInput` function, in contrast, creates an input component that
+ * behaves like a totally normal component that happens to have the type
+ * "input".
+ *
+ * This gives you full freedom to wire an input node up in arbitrary ways in a
+ * board, for example if you need the schema to be provided by the output of
+ * another component, rather than being statically defined.
+ *
+ * Note that you will need to use {@link unsafeOutput} to access any output
+ * ports of this component.
+ */
+export const rawInput = defineNodeType({
+  name: "input",
+  inputs: {
+    schema: {
+      type: jsonSchema,
+    },
+  },
+  outputs: {
+    "*": {
+      type: "unknown",
+    },
+  },
+  describe: () => {
+    // TODO(aomarks) Replace this with Breadboard interfaces when they exist.
+    //
+    // These definitions are stubs. They exist only so that we have a way to
+    // declare input and output nodes using the Build API. Every runtime is
+    // responsible for providing its own real implementation of "input" and
+    // "output". So,  we throw here and below in case this implementations
+    // somehow make their way into a runtime environment.
+    throw new Error("Unexpected call to stub input describe()");
+  },
+  invoke: () => {
+    throw new Error("Unexpected call to stub input invoke()");
+  },
+});

--- a/packages/build/src/internal/board/serialize.ts
+++ b/packages/build/src/internal/board/serialize.ts
@@ -92,7 +92,6 @@ export function serialize(board: SerializableBoard): GraphDescriptor {
       | InputWithDefault<JsonSerializable | undefined>
     >
   >;
-  let i = 0;
   const magicInputResolutions = new Map<
     GenericSpecialInput,
     { nodeId: string; portName: string }
@@ -104,10 +103,8 @@ export function serialize(board: SerializableBoard): GraphDescriptor {
     );
     let iterationInputId: string | undefined = undefined;
     const autoId = () => {
-      if (iterationInputId == undefined) {
-        iterationInputId;
-        iterationInputId = `input-${i}`;
-        i++;
+      if (iterationInputId === undefined) {
+        iterationInputId = nextIdForType("input");
       }
       return iterationInputId;
     };
@@ -189,7 +186,6 @@ export function serialize(board: SerializableBoard): GraphDescriptor {
   const outputsArray = Array.isArray(board.outputsForSerialization)
     ? board.outputsForSerialization
     : [board.outputsForSerialization];
-  let j = 0;
   for (const outputs of outputsArray) {
     // Recursively traverse the graph starting from outputs.
     const sortedBoardOutputs = Object.entries(outputs).sort(
@@ -198,10 +194,8 @@ export function serialize(board: SerializableBoard): GraphDescriptor {
     );
     let iterationOutputId: string | undefined = undefined;
     const autoId = () => {
-      if (iterationOutputId == undefined) {
-        iterationOutputId;
-        iterationOutputId = `output-${j}`;
-        j++;
+      if (iterationOutputId === undefined) {
+        iterationOutputId = nextIdForType("output");
       }
       return iterationOutputId;
     };

--- a/packages/build/src/test/input_test.ts
+++ b/packages/build/src/test/input_test.ts
@@ -15,12 +15,17 @@ import {
   output,
   serialize,
 } from "../index.js";
-import { input, type GenericSpecialInput } from "../internal/board/input.js";
+import { inputNode } from "../internal/board/board.js";
+import {
+  input,
+  rawInput,
+  type GenericSpecialInput,
+} from "../internal/board/input.js";
+import { jsonSchema } from "../internal/type-system/json-schema.js";
 import type {
   BreadboardType,
   JsonSerializable,
 } from "../internal/type-system/type.js";
-import { inputNode } from "../internal/board/board.js";
 
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 
@@ -504,6 +509,77 @@ test("input directly to output with description", () => {
             required: ["barOut", "fooOut"],
           },
         },
+      },
+    ],
+  });
+});
+
+test("can create and serialize a raw input", () => {
+  const schema = input({ type: jsonSchema });
+  // $ExpectType Instance<{ schema: Schema; }, {}, JsonSerializable, false, false, false>
+  const raw = rawInput({ $metadata: { title: "A regular old input" }, schema });
+  const bgl = serialize(
+    board({
+      inputs: { schema },
+      outputs: {
+        foo: raw.unsafeOutput("foo"),
+      },
+    })
+  );
+  assert.deepEqual(bgl, {
+    edges: [
+      { from: "input-0", to: "input-1", out: "schema", in: "schema" },
+      { from: "input-1", to: "output-0", out: "foo", in: "foo" },
+    ],
+    nodes: [
+      {
+        id: "input-0",
+        type: "input",
+        configuration: {
+          schema: {
+            type: "object",
+            properties: {
+              schema: {
+                jsonSchema: {
+                  type: "object",
+                  properties: {},
+                  required: [],
+                  additionalProperties: true,
+                  behavior: ["json-schema"],
+                },
+              },
+            },
+            required: ["schema"],
+          },
+        },
+      },
+      {
+        id: "output-0",
+        type: "output",
+        configuration: {
+          schema: {
+            type: "object",
+            properties: {
+              foo: {
+                type: [
+                  "array",
+                  "boolean",
+                  "null",
+                  "number",
+                  "object",
+                  "string",
+                ],
+              },
+            },
+            required: ["foo"],
+          },
+        },
+      },
+      {
+        id: "input-1",
+        type: "input",
+        configuration: {},
+        metadata: { title: "A regular old input" },
       },
     ],
   });


### PR DESCRIPTION
Usually, inputs are created with the `input` and `inputNode` functions, which abstract Breadboard inputs to make them more powerful and ergonomic while using the Build API.

This `rawInput` function, in contrast, creates an input component that behaves like a totally normal component that happens to have the type "input".

This gives you full freedom to wire an input node up in arbitrary ways in a board, for example if you need the schema to be provided by the output of another component, rather than being statically defined.

Note that you will need to use `unsafeOutput` to access any output ports of this component.