### PR TITLE
[core-kit] Add `test` method to `code` result objects

### DIFF
--- a/.changeset/lemon-numbers-fix.md
+++ b/.changeset/lemon-numbers-fix.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/core-kit": patch
+---
+
+The result of calling code() now includes a test() method which can be used to directly invoke the function. Useful for testing so that you don't need to factor out a separate function.

--- a/packages/core-kit/src/index.ts
+++ b/packages/core-kit/src/index.ts
@@ -33,6 +33,7 @@ export { secret, default as secrets } from "./nodes/secrets.js";
 export { unnest, unnestNode } from "./nodes/unnest.js";
 export { cast, castNode } from "./nodes/cast.js";
 export { default as mapNode, map } from "./nodes/map.js";
+export type { CodeNode } from "./nodes/code.js";
 
 const builder = new KitBuilder({
   title: "Core Kit",

--- a/packages/core-kit/tests/code_test.ts
+++ b/packages/core-kit/tests/code_test.ts
@@ -374,3 +374,14 @@ test("can pass star ports with *", (t) => {
   });
   t.pass();
 });
+
+test("can invoke functions directly with 'test'", (t) => {
+  const num = input({ type: "number" });
+  const increment = code({ num }, { incremented: "number" }, ({ num }) => ({
+    incremented: num + 1,
+  }));
+  // $ExpectType { incremented: number; } | Promise<{ incremented: number; }> | { $error: string | { message: string; }; } | Promise<{ $error: string | { message: string; }; }>
+  const result = increment.test({ num: 3 });
+  t.deepEqual(result, { incremented: 4 });
+  t.pass();
+});


### PR DESCRIPTION
The object you get back from `code` now includes a (properly typed) reference to the configured function that you can call with `codeComponent.test({...})`.