### PR TITLE
fix run details

### DIFF
--- a/.changeset/olive-cycles-enjoy.md
+++ b/.changeset/olive-cycles-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/shared-ui": patch
+---
+
+Recognize that sometimes there are no prior runs when initializing RunDetails.

--- a/packages/shared-ui/src/utils/top-graph-observer/run-details.ts
+++ b/packages/shared-ui/src/utils/top-graph-observer/run-details.ts
@@ -28,7 +28,7 @@ export class RunDetails {
   async initialize() {
     const runs = await this.#observer.runs();
     // Take inputs from the previous run.
-    this.#lastRunInputs = runs[1].inputs();
+    this.#lastRunInputs = runs.at(1)?.inputs() || null;
   }
 
   lastRunInput(id: NodeIdentifier): InputValues | null {


### PR DESCRIPTION
- **When initalizing run details, recognize that previous runs might not exist.**
- **docs(changeset): Recognize that sometimes there are no prior runs when initializing RunDetails.**
