### PR TITLE
[shared-ui/visual-editor] Tweak readonly state

### DIFF
--- a/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
@@ -585,7 +585,7 @@ export class UI extends LitElement {
           <button
             id="run"
             title="Run this board"
-            ?disabled=${this.failedToLoad || !this.graph}
+            ?disabled=${this.failedToLoad || !this.graph || this.readOnly}
             @click=${() => {
               this.selectedNodeIds.length = 0;
               if (this.status === STATUS.STOPPED) {

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -345,7 +345,9 @@ export class Main extends LitElement {
                 );
               }
 
-              if (this.tab.graph.url) {
+              // TODO: Confirm run URL.
+              const isRun = this.tab.graph.url?.startsWith("run://");
+              if (this.tab.graph.url && !isRun) {
                 this.#setUrlParam("board", this.tab.graph.url);
                 const base = new URL(window.location.href);
                 const decodedUrl = decodeURIComponent(base.href);


### PR DESCRIPTION
Further tweaks:

1. Don't track runs in the recent boards list and don't update the board URL
2. Switch off the ability to run the board when the tab is read only

Improves #3153 