### PR TITLE
[board-server] fix: copy `scripts` folder into docker build

### DIFF
--- a/packages/board-server/Dockerfile
+++ b/packages/board-server/Dockerfile
@@ -29,6 +29,7 @@ COPY --from=build /build/packages/board-server/dist ./dist
 COPY --from=build /build/packages/board-server/src ./src
 COPY --from=build /build/packages/board-server/package.json ./
 COPY --from=build /build/packages/board-server/public ./public
+COPY --from=build /build/packages/board-server/scripts ./scripts
 
 # Install production dependencies and tsx
 RUN npm install --only=production && \


### PR DESCRIPTION
Copies the scripts folder into the docker build, so that (as per the ReadMe) you can run:

```
docker exec -it board-server /bin/bash
# npm run add <username> # add a user and copy your API key
```
