### PR TITLE
[shared-ui/visual-editor] Teach runtime about tab types

### DIFF
--- a/.changeset/tricky-tools-reflect.md
+++ b/.changeset/tricky-tools-reflect.md
@@ -1,0 +1,6 @@
+---
+"@breadboard-ai/visual-editor": patch
+"@breadboard-ai/shared-ui": patch
+---
+
+Teach runtime about tab types

--- a/packages/shared-ui/src/elements/board-details/board-details.ts
+++ b/packages/shared-ui/src/elements/board-details/board-details.ts
@@ -18,6 +18,9 @@ export class BoardDetails extends LitElement {
   expanded = false;
 
   @property()
+  readOnly = false;
+
+  @property()
   boardTitle: string | null = null;
 
   @property()
@@ -34,9 +37,6 @@ export class BoardDetails extends LitElement {
 
   @property()
   boardHelp: GraphMetadata["help"] | null = null;
-
-  @property()
-  active = true;
 
   @property()
   subGraphId: string | null = null;
@@ -252,7 +252,7 @@ export class BoardDetails extends LitElement {
           type="text"
           placeholder="The title for this board"
           required
-          ?disabled=${!this.active}
+          ?disabled=${this.readOnly}
           .value=${this.boardTitle || ""}
         />
 
@@ -263,7 +263,7 @@ export class BoardDetails extends LitElement {
           type="text"
           placeholder="The semver version for this board, e.g. 0.0.1"
           required
-          ?disabled=${!this.active}
+          ?disabled=${this.readOnly}
           .value=${this.boardVersion || ""}
         />
 
@@ -271,7 +271,7 @@ export class BoardDetails extends LitElement {
         <textarea
           name="description"
           placeholder="The description for this board"
-          ?disabled=${!this.active}
+          ?disabled=${this.readOnly}
           .value=${this.boardDescription || ""}
         ></textarea>
 
@@ -302,7 +302,7 @@ export class BoardDetails extends LitElement {
                     }}
                     name="status"
                     .value=${this.boardPublished ? "published" : "draft"}
-                    ?disabled=${!this.active}
+                    ?disabled=${this.readOnly}
                   >
                     <option value="draft" ?selected=${!this.boardPublished}>
                       Draft
@@ -323,7 +323,7 @@ export class BoardDetails extends LitElement {
                     type="checkbox"
                     .value="on"
                     ?checked=${this.boardIsTool}
-                    ?disabled=${!this.active}
+                    ?disabled=${this.readOnly}
                   />
                 </div>
               `

--- a/packages/shared-ui/src/elements/editor/editor.ts
+++ b/packages/shared-ui/src/elements/editor/editor.ts
@@ -1463,7 +1463,7 @@ export class Editor extends LitElement {
 
     return html`${until(this.#processGraph())}
       ${
-        this.showControls && this.graph !== null
+        this.showControls && this.graph !== null && !this.readOnly
           ? html` <div id="controls">
                 <button
                   title="Zoom to fit"

--- a/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
@@ -449,6 +449,7 @@ export class UI extends LitElement {
       ],
       () => {
         return html`<bb-board-details
+          .readOnly=${this.readOnly}
           .boardTitle=${boardTitle}
           .boardVersion=${boardVersion}
           .boardDescription=${boardDescription}

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -345,9 +345,10 @@ export class Main extends LitElement {
                 );
               }
 
-              // TODO: Confirm descriptor URL.
-              const isRun = this.tab.graph.url?.startsWith("descriptor://");
-              if (this.tab.graph.url && !isRun) {
+              if (
+                this.tab.graph.url &&
+                this.tab.type === Runtime.Types.TabType.URL
+              ) {
                 this.#setUrlParam("board", this.tab.graph.url);
                 const base = new URL(window.location.href);
                 const decodedUrl = decodeURIComponent(base.href);
@@ -478,7 +479,7 @@ export class Main extends LitElement {
 
         // Start the board or show the welcome panel.
         if (boardFromUrl) {
-          this.#runtime.board.loadFromURL(boardFromUrl);
+          this.#runtime.board.createTabFromURL(boardFromUrl);
           return;
         } else {
           this.showWelcomePanel = true;
@@ -552,7 +553,7 @@ export class Main extends LitElement {
             return;
           }
 
-          this.#runtime.board.loadFromDescriptor(descriptor);
+          this.#runtime.board.createTabFromDescriptor(descriptor);
         } catch (err) {
           this.toast(
             "Unable to paste board",
@@ -704,7 +705,7 @@ export class Main extends LitElement {
     const runGraph = topGraphObserver.current()?.graph ?? null;
     if (runGraph) {
       runGraph.title = evt.nodeTitle;
-      this.#runtime.board.loadFromDescriptor(
+      this.#runtime.board.createTabFromRun(
         runGraph,
         topGraphObserver,
         observers.runObserver,
@@ -1092,7 +1093,11 @@ export class Main extends LitElement {
 
   async #changeBoard(url: string, createNewTab = false) {
     try {
-      this.#runtime.board.loadFromURL(url, this.tab?.graph.url, createNewTab);
+      this.#runtime.board.createTabFromURL(
+        url,
+        this.tab?.graph.url,
+        createNewTab
+      );
     } catch (err) {
       this.toast(
         `Unable to load file: ${url}`,
@@ -1146,7 +1151,7 @@ export class Main extends LitElement {
               const descriptor = topGraphObserver?.current()?.graph ?? null;
 
               if (descriptor) {
-                this.#runtime.board.loadFromDescriptor(
+                this.#runtime.board.createTabFromRun(
                   descriptor,
                   topGraphObserver,
                   runObserver,
@@ -1166,7 +1171,7 @@ export class Main extends LitElement {
             }
           });
         } else {
-          this.#runtime.board.loadFromDescriptor(runData);
+          this.#runtime.board.createTabFromDescriptor(runData);
         }
       } catch (err) {
         console.warn(err);
@@ -1177,9 +1182,9 @@ export class Main extends LitElement {
 
   #attemptBoardStart(evt: BreadboardUI.Events.StartEvent) {
     if (evt.url) {
-      this.#runtime.board.loadFromURL(evt.url);
+      this.#runtime.board.createTabFromURL(evt.url);
     } else if (evt.descriptor) {
-      this.#runtime.board.loadFromDescriptor(evt.descriptor);
+      this.#runtime.board.createTabFromDescriptor(evt.descriptor);
     }
   }
 

--- a/packages/visual-editor/src/runtime/types.ts
+++ b/packages/visual-editor/src/runtime/types.ts
@@ -12,6 +12,12 @@ import {
   RunStore,
 } from "@google-labs/breadboard";
 
+export enum TabType {
+  URL,
+  DESCRIPTOR,
+  RUN,
+}
+
 export type TabId = `${string}-${string}-${string}-${string}-${string}`;
 export type TabURL = string;
 export type TabName = string;
@@ -23,6 +29,7 @@ export interface Tab {
   subGraphId: string | null;
   version: number;
   readOnly: boolean;
+  type: TabType;
 }
 
 export interface VERuntimeConfig {


### PR DESCRIPTION
Includes a quick fix for switching off graph edit & board edit controls when in `readOnly` mode, too.