### PR TITLE
[gemini-kit] Expand the JSON schema type for gemini text instruction

### DIFF
--- a/.changeset/bright-dolls-reflect.md
+++ b/.changeset/bright-dolls-reflect.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/gemini-kit": patch
+---
+
+Expand the JSON schema type for gemini text instruction

--- a/packages/gemini-kit/src/boards/gemini-generator.ts
+++ b/packages/gemini-kit/src/boards/gemini-generator.ts
@@ -75,7 +75,7 @@ const functionDeclaration = object({
 });
 
 const systemInstruction = input({
-  type: annotate("string", {
+  type: annotate(anyOf("string", object({ parts: array(partType) })), {
     behavior: ["config"],
   }),
   title: "System Instruction",


### PR DESCRIPTION
It only allowed string before, but parts are ok too.