### PR TITLE
[visual-editor] Switch follow to using Local Storage

### DIFF
--- a/.changeset/healthy-suits-whisper.md
+++ b/.changeset/healthy-suits-whisper.md
@@ -1,0 +1,6 @@
+---
+"@breadboard-ai/visual-editor": patch
+"@breadboard-ai/shared-ui": patch
+---
+
+Switch follow to using Local Storage

--- a/packages/shared-ui/src/elements/editor/editor.ts
+++ b/packages/shared-ui/src/elements/editor/editor.ts
@@ -605,7 +605,9 @@ export class Editor extends LitElement {
     super();
 
     this.zoomToHighlightedNodeDuringRuns =
-      globalThis.sessionStorage.getItem(ZOOM_KEY) === "true" ?? true;
+      globalThis.localStorage.getItem(ZOOM_KEY) === "true" ?? true;
+
+    console.log(this.zoomToHighlightedNodeDuringRuns);
   }
 
   connectedCallback(): void {
@@ -734,6 +736,8 @@ export class Editor extends LitElement {
     if (!changedProperties.has("run")) {
       return;
     }
+
+    console.log(this.zoomToHighlightedNodeDuringRuns);
 
     this.#graphRenderer.zoomToHighlightedNode =
       this.zoomToHighlightedNodeDuringRuns;
@@ -1582,7 +1586,7 @@ export class Editor extends LitElement {
                           !this.zoomToHighlightedNodeDuringRuns;
                         this.zoomToHighlightedNodeDuringRuns = shouldZoom;
                         this.#graphRenderer.zoomToHighlightedNode = shouldZoom;
-                        globalThis.sessionStorage.setItem(
+                        globalThis.localStorage.setItem(
                           ZOOM_KEY,
                           shouldZoom.toString()
                         );

--- a/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
@@ -303,7 +303,6 @@ export class UI extends LitElement {
           .showExperimentalComponents=${showExperimentalComponents}
           .readOnly=${this.readOnly}
           .showReadOnlyOverlay=${true}
-          .zoomToHighlightedNodeDuringRuns=${true}
           @bbmultiedit=${(evt: MultiEditEvent) => {
             const deletedNodes: RemoveNodeSpec[] = evt.edits.filter(
               (edit) => edit.type === "removenode"

--- a/packages/visual-editor/src/providers/indexed-db.ts
+++ b/packages/visual-editor/src/providers/indexed-db.ts
@@ -326,8 +326,6 @@ export class IDBGraphProvider implements GraphProvider {
       title: store.title,
       items,
     });
-
-    console.log(this.#stores);
   }
 
   async #refreshAllItems() {


### PR DESCRIPTION
Noticed that it was getting frustrating to switch off "follow run" whenever I booted up a new tab, so I've made it use local storage instead of session storage.