### PR TITLE
[Breadboard] Move the provision of the default graph provider

### DIFF
--- a/packages/breadboard/src/loader/index.ts
+++ b/packages/breadboard/src/loader/index.ts
@@ -6,9 +6,11 @@
 
 import { Loader } from "./loader.js";
 import { GraphLoader, GraphProvider } from "./types.js";
+import { DefaultGraphProvider } from "./default.js";
 
 export const createLoader = (graphProviders?: GraphProvider[]): GraphLoader => {
-  return new Loader(graphProviders ?? []);
+  const providers = [...(graphProviders ?? []), new DefaultGraphProvider()];
+  return new Loader(providers);
 };
 
 export { SENTINEL_BASE_URL } from "./loader.js";

--- a/packages/breadboard/src/loader/loader.ts
+++ b/packages/breadboard/src/loader/loader.ts
@@ -10,7 +10,6 @@ import type {
   GraphLoader,
   GraphLoaderContext,
 } from "./types.js";
-import { DefaultGraphProvider } from "./default.js";
 
 export const SENTINEL_BASE_URL = new URL("sentinel://sentinel/sentinel");
 
@@ -36,7 +35,7 @@ export class Loader implements GraphLoader {
   #graphProviders: GraphProvider[];
 
   constructor(graphProviders: GraphProvider[]) {
-    this.#graphProviders = [...graphProviders, new DefaultGraphProvider()];
+    this.#graphProviders = graphProviders;
   }
 
   async #loadWithProviders(url: URL): Promise<GraphDescriptor | null> {


### PR DESCRIPTION
Part of #3314 

This is a no-op change, since this is the only caller of the constructor for `Loader`

Add the DefaultGraphProvider in createLoader instead of the constructor for Loader. This allows us to add logic in `createLoader` which conditionally adds the default provider.

We're not copying `providers` in the constructor because `createLoader` is its only caller. It should be safe to store the original array without copying.
