### PR TITLE
[shared-ui] Show node description in Activity Log outputs

### DIFF
--- a/.changeset/fluffy-waves-exist.md
+++ b/.changeset/fluffy-waves-exist.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/shared-ui": patch
+---
+
+Show node description in Activity Log outputs

--- a/packages/shared-ui/src/elements/activity-log/activity-log.styles.ts
+++ b/packages/shared-ui/src/elements/activity-log/activity-log.styles.ts
@@ -88,6 +88,13 @@ export const styles = css`
     font-weight: 400;
   }
 
+  .activity-entry h2 {
+    font: 400 var(--bb-body-medium) / var(--bb-body-line-height-medium)
+      var(--bb-font-family);
+    color: var(--bb-neutral-600);
+    margin: var(--bb-grid-size) 0 var(--bb-grid-size-2) 0;
+  }
+
   .activity-entry h1 .newest-task {
     font-size: var(--bb-text-medium);
     font-weight: 300;
@@ -268,13 +275,13 @@ export const styles = css`
 
   h1[data-message-id] {
     cursor: pointer;
-    opacity: 0.65;
-    transition: opacity 0.3s cubic-bezier(0, 0, 0.3, 1);
+    opacity: 1;
+    transition: color 0.3s cubic-bezier(0, 0, 0.3, 1);
   }
 
   h1[data-message-id]:hover,
   h1[data-message-id]:focus {
-    opacity: 1;
+    color: var(--bb-ui-800);
     transition-duration: 0.1s;
   }
 
@@ -315,9 +322,12 @@ export const styles = css`
   }
 
   dd {
-    display: block;
-    margin: var(--bb-grid-size-2) 0 var(--bb-grid-size) 0;
-    font-size: var(--bb-text-small);
+    display: flex;
+    align-items: center;
+    font: 600 var(--bb-label-medium) / var(--bb-label-line-height-medium)
+      var(--bb-font-family);
+    padding: var(--bb-grid-size-2) 0 var(--bb-grid-size) 0;
+    margin: 0;
   }
 
   dt {

--- a/packages/shared-ui/src/elements/activity-log/activity-log.ts
+++ b/packages/shared-ui/src/elements/activity-log/activity-log.ts
@@ -436,6 +436,7 @@ export class ActivityLog extends LitElement {
       <h1 ?data-message-idx=${this.showExtendedInfo ? idx : nothing}>
         ${node.title()}
       </h1>
+      ${node.description() ? html`<h2>${node.description()}</h2>` : nothing}
       <bb-user-input
         id="${descriptor.id}"
         .providers=${this.providers}
@@ -614,6 +615,9 @@ export class ActivityLog extends LitElement {
                     >
                       ${node.title()}
                     </h1>
+                    ${node.description()
+                      ? html`<h2>${node.description()}</h2>`
+                      : nothing}
                     ${until(additionalData)} ${this.#createRunInfo(event.runs)}
                   </section>`;
                   break;


### PR DESCRIPTION
Realized we offer the ability to describe nodes but we never use it anywhere. Well, now we do.