### PR TITLE
[code-build] Emit a legacy script instead of module

### DIFF
--- a/.changeset/lucky-snails-repair.md
+++ b/.changeset/lucky-snails-repair.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/build-code": patch
+---
+
+Emit a legacy script instead of module

--- a/package-lock.json
+++ b/package-lock.json
@@ -25089,6 +25089,7 @@
         "build-code": "bin/build-code"
       },
       "devDependencies": {
+        "@google-labs/breadboard": "^0.27.0",
         "eslint": "^8.57.1",
         "typescript": "^5.6.2",
         "wireit": "^0.14.9"

--- a/packages/build-code/package.json
+++ b/packages/build-code/package.json
@@ -114,6 +114,7 @@
     "typescript-json-schema": "^0.65.1"
   },
   "devDependencies": {
+    "@google-labs/breadboard": "^0.27.0",
     "eslint": "^8.57.1",
     "typescript": "^5.6.2",
     "wireit": "^0.14.9"

--- a/packages/build-code/src/test/generate_test.ts
+++ b/packages/build-code/src/test/generate_test.ts
@@ -12,6 +12,8 @@ import { test } from "node:test";
 import type { Config } from "../config.js";
 import { generate } from "../generate.js";
 import { testDataDir } from "./test-data-dir.js";
+import { coreKit } from "@google-labs/core-kit";
+import { invokeGraph } from "@google-labs/breadboard";
 
 test("generates module", async () => {
   const fooPath = join(testDataDir, "str-is-foo.ts");
@@ -43,7 +45,7 @@ test("generates module with regex escaping", async () => {
   assert.equal(actual, expected);
 });
 
-test("serializes to BGL", async () => {
+{
   const { strIsFoo } = await import("./testdata/generated/str-is-foo.js");
   const str = input();
   const fooInst = strIsFoo({
@@ -55,42 +57,44 @@ test("serializes to BGL", async () => {
     inputs: { str },
     outputs: { isFoo: fooInst.outputs.bool },
   });
-  const actual = serialize(myBoard);
-  const expected = {
-    edges: [
-      { from: "input-0", to: "runJavascript-0", out: "str", in: "str" },
-      { from: "runJavascript-0", to: "output-0", out: "bool", in: "isFoo" },
-    ],
-    nodes: [
-      {
-        id: "input-0",
-        type: "input",
-        configuration: {
-          schema: {
-            type: "object",
-            properties: { str: { type: "string" } },
-            required: ["str"],
+
+  test("serializes to BGL", async () => {
+    const actual = serialize(myBoard);
+    const expected = {
+      edges: [
+        { from: "input-0", to: "runJavascript-0", out: "str", in: "str" },
+        { from: "runJavascript-0", to: "output-0", out: "bool", in: "isFoo" },
+      ],
+      nodes: [
+        {
+          id: "input-0",
+          type: "input",
+          configuration: {
+            schema: {
+              type: "object",
+              properties: { str: { type: "string" } },
+              required: ["str"],
+            },
           },
         },
-      },
-      {
-        id: "output-0",
-        type: "output",
-        configuration: {
-          schema: {
-            type: "object",
-            properties: { isFoo: { type: "boolean" } },
-            required: ["isFoo"],
+        {
+          id: "output-0",
+          type: "output",
+          configuration: {
+            schema: {
+              type: "object",
+              properties: { isFoo: { type: "boolean" } },
+              required: ["isFoo"],
+            },
           },
         },
-      },
-      {
-        id: "runJavascript-0",
-        type: "runJavascript",
-        configuration: {
-          raw: true,
-          name: "run",
-          code: `// src/test/testdata/util.ts
+        {
+          id: "runJavascript-0",
+          type: "runJavascript",
+          configuration: {
+            raw: true,
+            name: "run",
+            code: `// src/test/testdata/util.ts
 /**
  * @license
  * Copyright 2024 Google LLC
@@ -109,43 +113,53 @@ function strIsFoo(str) {
 var run = ({ str }) => {
   return { bool: strIsFoo(str) };
 };
-export {
-  run
-};
 `,
-          numArr: [1, 2, 3],
-          deepObj: { foo: { bar: "bar" } },
-          inputSchema: {
-            type: "object",
-            properties: {
-              str: { type: "string" },
-              opt: { type: "string" },
-              numArr: { type: "array", items: { type: "number" } },
-              deepObj: {
-                type: "object",
-                properties: {
-                  foo: {
-                    type: "object",
-                    properties: { bar: { type: "string" } },
-                    required: ["bar"],
+            numArr: [1, 2, 3],
+            deepObj: { foo: { bar: "bar" } },
+            inputSchema: {
+              type: "object",
+              properties: {
+                str: { type: "string" },
+                opt: { type: "string" },
+                numArr: { type: "array", items: { type: "number" } },
+                deepObj: {
+                  type: "object",
+                  properties: {
+                    foo: {
+                      type: "object",
+                      properties: { bar: { type: "string" } },
+                      required: ["bar"],
+                    },
                   },
+                  required: ["foo"],
                 },
-                required: ["foo"],
               },
+              required: ["deepObj", "numArr", "str"],
             },
-            required: ["deepObj", "numArr", "str"],
-          },
-          outputSchema: {
-            type: "object",
-            properties: {
-              bool: { type: "boolean" },
-              opt: { type: "string" },
+            outputSchema: {
+              type: "object",
+              properties: {
+                bool: { type: "boolean" },
+                opt: { type: "string" },
+              },
+              required: ["bool"],
             },
-            required: ["bool"],
           },
         },
-      },
-    ],
-  };
-  assert.deepEqual(actual, expected);
-});
+      ],
+    };
+    assert.deepEqual(actual, expected);
+  });
+
+  test("is executable", async () => {
+    const bgl = serialize(myBoard);
+
+    const result1 = await invokeGraph(bgl, { str: "foo" }, { kits: [coreKit] });
+    assert.equal(result1.$error, undefined);
+    assert.equal(result1.isFoo, true);
+
+    const result2 = await invokeGraph(bgl, { str: "bar" }, { kits: [coreKit] });
+    assert.equal(result2.$error, undefined);
+    assert.equal(result2.isFoo, false);
+  });
+}

--- a/packages/build-code/src/test/testdata/generated/regex.ts
+++ b/packages/build-code/src/test/testdata/generated/regex.ts
@@ -24,9 +24,6 @@ var run = ({ before }) => {
   });
   return { after: JSON.stringify(all) };
 };
-export {
-  run
-};
 `,
   inputSchema: {
     type: "object",

--- a/packages/build-code/src/test/testdata/generated/str-is-foo.ts
+++ b/packages/build-code/src/test/testdata/generated/str-is-foo.ts
@@ -25,9 +25,6 @@ function strIsFoo(str) {
 var run = ({ str }) => {
   return { bool: strIsFoo(str) };
 };
-export {
-  run
-};
 `,
   inputSchema: {
     type: "object",


### PR DESCRIPTION
runJavascript doesn't support javascript modules, so we'll have to emit a legacy script for now. Doing this by asking esbuild for an iife. We also need to strip the iife wrapper from that output, because runJavascript also has some regexp logic (convertToNamedFunction) which I think mis-parses the iife wrapper and breaks the code.

Also adds a test that the generated boards are truly executable!