### PR TITLE
Add a createCustomLoader function.

### DIFF
--- a/packages/breadboard/src/loader/index.ts
+++ b/packages/breadboard/src/loader/index.ts
@@ -13,4 +13,10 @@ export const createLoader = (graphProviders?: GraphProvider[]): GraphLoader => {
   return new Loader(providers);
 };
 
+export const createCustomLoader = (
+  graphProviders: GraphProvider[]
+): GraphLoader => {
+  return new Loader([...graphProviders]);
+};
+
 export { SENTINEL_BASE_URL } from "./loader.js";


### PR DESCRIPTION
Allows specifying a loader that *does not* include the
DefaultGraphProvider
