### PR TITLE
no default llm input array

### DIFF
--- a/.changeset/rude-laws-swim.md
+++ b/.changeset/rude-laws-swim.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/shared-ui": patch
+---
+
+Provide a single empty LLM Content to `bb-llm-input-array` when no default.

--- a/packages/shared-ui/src/elements/input/user-input.ts
+++ b/packages/shared-ui/src/elements/input/user-input.ts
@@ -442,8 +442,15 @@ export class UserInput extends LitElement {
                 if (isLLMContentArrayBehavior(input.schema)) {
                   let value: LLMContent[] | null =
                     (input.value as LLMContent[]) ?? null;
+                  // First, check to see if the default value is available and
+                  // use that if the value is not set.
                   if (!value && isLLMContentArray(defaultValue)) {
                     value = defaultValue;
+                  }
+                  // Finally, if there is no default value, set the value to an
+                  // array consisting of a single empty LLMContent.
+                  if (!value || value.length === 0) {
+                    value = [{ role: "user", parts: [] }];
                   }
 
                   const allow = createAllowListFromProperty(input.schema);


### PR DESCRIPTION
- **Provide a single empty LLMContent to `bb-llm-input-array` when no value is supplied.**
- **docs(changeset): Provide a single empty LLM Content to `bb-llm-input-array` when no default.**
