### PR TITLE
[Breadboard] Change name of option to createLoader

### DIFF
--- a/.changeset/curly-rabbits-end.md
+++ b/.changeset/curly-rabbits-end.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard": patch
+---
+
+Change option name

--- a/packages/breadboard/src/loader/index.ts
+++ b/packages/breadboard/src/loader/index.ts
@@ -10,10 +10,10 @@ import { DefaultGraphProvider } from "./default.js";
 
 export const createLoader = (
   graphProviders?: GraphProvider[],
-  opts?: { disableDefaultLoader?: boolean }
+  opts?: { disableDefaultProvider?: boolean }
 ): GraphLoader => {
   const providers = [...(graphProviders ?? [])];
-  if (!opts?.disableDefaultLoader) {
+  if (!opts?.disableDefaultProvider) {
     providers.push(new DefaultGraphProvider());
   }
   return new Loader(providers);


### PR DESCRIPTION
Change from `disableDefaultLoader` to `disableDefaultProvider` to match the vocabulary used in the codebase.

Fixes #3314