### PR TITLE
format error better

### DIFF
--- a/.changeset/cuddly-windows-glow.md
+++ b/.changeset/cuddly-windows-glow.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard": patch
+---
+
+Change for shape rather than instance when formatting errors.

--- a/packages/breadboard/src/harness/error.ts
+++ b/packages/breadboard/src/harness/error.ts
@@ -33,8 +33,8 @@ export const formatRunError = (e: unknown) => {
   if (typeof error === "string") {
     return error;
   }
-  if (error instanceof Error) {
-    return error.message;
+  if ("message" in (error as Error)) {
+    return (error as Error).message;
   }
   return JSON.stringify(error);
 };


### PR DESCRIPTION
- **Instead of checking for instance, check for shape when formatting errors.**
- **docs(changeset): Change for shape rather than instance when formatting errors.**
