### PR TITLE
run node

### DIFF
--- a/.changeset/six-lemons-lick.md
+++ b/.changeset/six-lemons-lick.md
@@ -1,0 +1,7 @@
+---
+"@breadboard-ai/visual-editor": minor
+"@google-labs/breadboard": minor
+"@breadboard-ai/shared-ui": minor
+---
+
+Implement "Re-run from this node" feature.

--- a/packages/breadboard/src/harness/local.ts
+++ b/packages/breadboard/src/harness/local.ts
@@ -8,8 +8,6 @@ import { createDefaultDataStore } from "../data/index.js";
 import { asyncGen, runGraph } from "../index.js";
 import { createLoader } from "../loader/index.js";
 import { LastNode } from "../remote/types.js";
-import type { RunStackEntry } from "../run/types.js";
-import { saveRunnerState } from "../serialization.js";
 import { timestamp } from "../timestamp.js";
 import {
   BreadboardRunResult,
@@ -48,20 +46,6 @@ const fromRunnerResult = <Result extends BreadboardRunResult>(
   const { type, node, timestamp, invocationId } = result;
   const bubbled = invocationId == -1;
 
-  const saveState = async (): Promise<RunStackEntry[]> => {
-    const runState = result.runState;
-    if (runState) {
-      return runState;
-    }
-    return [
-      {
-        url: undefined,
-        path: [invocationId],
-        state: saveRunnerState(type, result.state),
-      },
-    ];
-  };
-
   if (type === "input") {
     const { inputArguments, path } = result;
     return {
@@ -70,7 +54,6 @@ const fromRunnerResult = <Result extends BreadboardRunResult>(
       reply: async (value) => {
         result.inputs = value.inputs;
       },
-      saveState,
     } as HarnessRunResult;
   } else if (type === "output") {
     const { outputs, path } = result;
@@ -80,7 +63,6 @@ const fromRunnerResult = <Result extends BreadboardRunResult>(
       reply: async () => {
         // Do nothing
       },
-      saveState,
     } as HarnessRunResult;
   }
   throw new Error(`Unknown result type "${type}".`);

--- a/packages/breadboard/src/harness/local.ts
+++ b/packages/breadboard/src/harness/local.ts
@@ -22,18 +22,11 @@ import { HarnessRunResult, RunConfig } from "./types.js";
 import { baseURL } from "./url.js";
 
 const fromProbe = <Probe extends ProbeMessage>(probe: Probe) => {
-  const loadStateIfAny = () => {
-    if (probe.type === "nodestart") {
-      return probe.state;
-    }
-    return undefined;
-  };
-  const state = loadStateIfAny();
   const data = structuredClone(probe.data);
   return {
     type: probe.type,
     data,
-    state,
+    result: probe.type === "nodestart" ? probe.result : undefined,
     reply: async () => {
       // Do nothing
     },

--- a/packages/breadboard/src/harness/types.ts
+++ b/packages/breadboard/src/harness/types.ts
@@ -34,6 +34,7 @@ import type {
   NodeStartResponse,
   Schema,
   EdgeResponse,
+  NodeIdentifier,
 } from "../types.js";
 import {
   TypedEventTargetType,
@@ -225,6 +226,12 @@ export type RunConfig = {
    * edges will be used.
    */
   start?: StartLabel;
+  /**
+   * The id of the node to stop the run after. In combination with `state`, can
+   * be used to run parts of the board.
+   * If not specified, runs the whole board.
+   */
+  stopAfter?: NodeIdentifier;
 };
 
 export type RunEventMap = {

--- a/packages/breadboard/src/index.ts
+++ b/packages/breadboard/src/index.ts
@@ -119,3 +119,8 @@ export type * from "./run/types.js";
 export { createRunStateManager } from "./run/index.js";
 export { invokeGraph } from "./run/invoke-graph.js";
 export { runGraph } from "./run/run-graph.js";
+
+/**
+ * Conversion helpers
+ */
+export { sequenceEntryToHarnessRunResult } from "./inspector/run/conversions.js";

--- a/packages/breadboard/src/inspector/run/conversions.ts
+++ b/packages/breadboard/src/inspector/run/conversions.ts
@@ -50,6 +50,7 @@ function sequenceEntryToHarnessRunResult(
         node,
         inputs,
         start: timestamp,
+        traversalResult,
       } = data.event as InspectableRunNodeEvent;
       return {
         type,
@@ -59,6 +60,7 @@ function sequenceEntryToHarnessRunResult(
           path: trimPath(path),
           timestamp,
         },
+        result: traversalResult,
         async reply() {},
       };
     }
@@ -180,7 +182,9 @@ async function* eventsAsHarnessRunResults(
           node,
           inputs,
           start: timestamp,
+          traversalResult,
         } = data.event as InspectableRunNodeEvent;
+        console.log("🌻 TRAVERSAL RESULT", traversalResult);
         yield {
           type,
           data: {
@@ -189,6 +193,7 @@ async function* eventsAsHarnessRunResults(
             path: trimPath(path),
             timestamp,
           },
+          result: traversalResult,
           async reply() {},
         };
         break;

--- a/packages/breadboard/src/inspector/run/conversions.ts
+++ b/packages/breadboard/src/inspector/run/conversions.ts
@@ -11,7 +11,7 @@ import {
 } from "../types.js";
 import { HarnessRunResult } from "../../harness/types.js";
 
-export { eventsAsHarnessRunResults };
+export { eventsAsHarnessRunResults, sequenceEntryToHarnessRunResult };
 
 export const eventIdFromEntryId = (entryId?: string): string => {
   return `e-${entryId || "0"}`;
@@ -29,6 +29,126 @@ export const pathFromId = (id: string): number[] => {
   return id.length ? id.split("-").map((s) => parseInt(s, 10)) : [];
 };
 
+function sequenceEntryToHarnessRunResult(
+  entry: InspectableRunSequenceEntry,
+  trimPath: (path: number[]) => number[] = (path) => path
+): HarnessRunResult | null {
+  const [type, data] = entry;
+  switch (type) {
+    case "graphstart": {
+      const { graphStart, path, graph: inspectableGraph, edges } = data;
+      const graph = inspectableGraph?.raw() as GraphDescriptor;
+      return {
+        type,
+        data: { timestamp: graphStart, path: trimPath(path), graph, edges },
+        async reply() {},
+      };
+    }
+    case "nodestart": {
+      const { path } = data;
+      const {
+        node,
+        inputs,
+        start: timestamp,
+      } = data.event as InspectableRunNodeEvent;
+      return {
+        type,
+        data: {
+          node: node.descriptor,
+          inputs,
+          path: trimPath(path),
+          timestamp,
+        },
+        async reply() {},
+      };
+    }
+    case "nodeend": {
+      const { path } = data;
+      const {
+        node,
+        inputs,
+        outputs,
+        end: timestamp,
+      } = data.event as InspectableRunNodeEvent;
+      return {
+        type,
+        data: {
+          node: node.descriptor,
+          inputs,
+          outputs: outputs || {},
+          path: trimPath(path),
+          timestamp: timestamp || 0,
+        },
+        async reply() {},
+      };
+    }
+    case "graphend": {
+      const { path } = data;
+      const { graphEnd: timestamp } = data;
+      return {
+        type,
+        data: { path: trimPath(path), timestamp: timestamp || 0 },
+        async reply() {},
+      };
+    }
+    case "error": {
+      const { graphStart: timestamp } = data;
+      return {
+        type,
+        data: { error: "TODO: Store actual error object", timestamp },
+        async reply() {},
+      };
+    }
+    case "input": {
+      const { path } = data;
+      const {
+        node,
+        inputs: inputArguments,
+        bubbled,
+        start: timestamp,
+      } = data.event as InspectableRunNodeEvent;
+      return {
+        type,
+        data: {
+          node: node.descriptor,
+          inputArguments,
+          bubbled,
+          path: trimPath(path),
+          timestamp,
+        },
+        async reply() {},
+      };
+    }
+    case "output": {
+      const { path } = data;
+      const {
+        node,
+        outputs,
+        bubbled,
+        start: timestamp,
+      } = data.event as InspectableRunNodeEvent;
+      return {
+        type,
+        data: {
+          node: node.descriptor,
+          outputs: outputs || {},
+          bubbled,
+          path: trimPath(path),
+          timestamp,
+        },
+        async reply() {},
+      };
+    }
+    case "secret": {
+      return null;
+    }
+    default: {
+      throw new Error("Unknown event type: " + type);
+    }
+  }
+}
+
+// TODO: Use sequenceEntryToHarnessRunResult
 async function* eventsAsHarnessRunResults(
   events: InspectableRunSequenceEntry[]
 ): AsyncGenerator<HarnessRunResult> {

--- a/packages/breadboard/src/inspector/run/conversions.ts
+++ b/packages/breadboard/src/inspector/run/conversions.ts
@@ -4,6 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { GraphDescriptor } from "@breadboard-ai/types";
+import {
+  InspectableRunNodeEvent,
+  InspectableRunSequenceEntry,
+} from "../types.js";
+import { HarnessRunResult } from "../../harness/types.js";
+
+export { eventsAsHarnessRunResults };
+
 export const eventIdFromEntryId = (entryId?: string): string => {
   return `e-${entryId || "0"}`;
 };
@@ -19,3 +28,146 @@ export const idFromPath = (path: number[]): string => {
 export const pathFromId = (id: string): number[] => {
   return id.length ? id.split("-").map((s) => parseInt(s, 10)) : [];
 };
+
+async function* eventsAsHarnessRunResults(
+  events: InspectableRunSequenceEntry[]
+): AsyncGenerator<HarnessRunResult> {
+  const first = events[0];
+  let endPath: number[] = [];
+  if (first[0] !== "graphstart") {
+    throw new Error(
+      "Expected a graphstart event at the beginning of the timeline"
+    );
+  } else {
+    endPath = first[1].path;
+  }
+  for await (const result of events) {
+    const [type, data] = result;
+    switch (type) {
+      case "graphstart": {
+        const { graphStart, path, graph: inspectableGraph, edges } = data;
+        const graph = inspectableGraph?.raw() as GraphDescriptor;
+        yield {
+          type,
+          data: { timestamp: graphStart, path: trimPath(path), graph, edges },
+          async reply() {},
+        };
+        break;
+      }
+      case "nodestart": {
+        const { path } = data;
+        const {
+          node,
+          inputs,
+          start: timestamp,
+        } = data.event as InspectableRunNodeEvent;
+        yield {
+          type,
+          data: {
+            node: node.descriptor,
+            inputs,
+            path: trimPath(path),
+            timestamp,
+          },
+          async reply() {},
+        };
+        break;
+      }
+      case "nodeend": {
+        const { path } = data;
+        const {
+          node,
+          inputs,
+          outputs,
+          end: timestamp,
+        } = data.event as InspectableRunNodeEvent;
+        yield {
+          type,
+          data: {
+            node: node.descriptor,
+            inputs,
+            outputs: outputs || {},
+            path: trimPath(path),
+            timestamp: timestamp || 0,
+          },
+          async reply() {},
+        };
+        break;
+      }
+      case "graphend": {
+        const { path } = data;
+        const { graphEnd: timestamp } = data;
+        yield {
+          type,
+          data: { path: trimPath(path), timestamp: timestamp || 0 },
+          async reply() {},
+        };
+        if (path.join(".") === endPath.join(".")) {
+          return;
+        }
+        break;
+      }
+      case "error": {
+        const { graphStart: timestamp } = data;
+        yield {
+          type,
+          data: { error: "TODO: Store actual error object", timestamp },
+          async reply() {},
+        };
+        break;
+      }
+      case "input": {
+        const { path } = data;
+        const {
+          node,
+          inputs: inputArguments,
+          bubbled,
+          start: timestamp,
+        } = data.event as InspectableRunNodeEvent;
+        yield {
+          type,
+          data: {
+            node: node.descriptor,
+            inputArguments,
+            bubbled,
+            path: trimPath(path),
+            timestamp,
+          },
+          async reply() {},
+        };
+        break;
+      }
+      case "output": {
+        const { path } = data;
+        const {
+          node,
+          outputs,
+          bubbled,
+          start: timestamp,
+        } = data.event as InspectableRunNodeEvent;
+        yield {
+          type,
+          data: {
+            node: node.descriptor,
+            outputs: outputs || {},
+            bubbled,
+            path: trimPath(path),
+            timestamp,
+          },
+          async reply() {},
+        };
+        break;
+      }
+      case "secret": {
+        break;
+      }
+      default: {
+        throw new Error("Unknown event type: " + type);
+      }
+    }
+  }
+
+  function trimPath(path: number[]) {
+    return path.slice(endPath.length);
+  }
+}

--- a/packages/breadboard/src/inspector/run/conversions.ts
+++ b/packages/breadboard/src/inspector/run/conversions.ts
@@ -184,7 +184,6 @@ async function* eventsAsHarnessRunResults(
           start: timestamp,
           traversalResult,
         } = data.event as InspectableRunNodeEvent;
-        console.log("🌻 TRAVERSAL RESULT", traversalResult);
         yield {
           type,
           data: {

--- a/packages/breadboard/src/inspector/run/event-manager.ts
+++ b/packages/breadboard/src/inspector/run/event-manager.ts
@@ -329,7 +329,7 @@ export class EventManager {
           }
           if (event.id === id) {
             const reanimationState = manager.reanimationState();
-            reanimationState.history = this.#sequence.slice(0, index);
+            reanimationState.history = this.#sequence.slice(0, index + 1);
             return reanimationState;
           }
           break;

--- a/packages/breadboard/src/inspector/run/event-manager.ts
+++ b/packages/breadboard/src/inspector/run/event-manager.ts
@@ -142,6 +142,8 @@ export class EventManager {
       throw new Error(`Expected an existing entry for ${JSON.stringify(path)}`);
     }
 
+    console.log("🌻 node", node.id, "traversal result", result);
+
     const event = new RunNodeEvent(entry, node.id, timestamp, inputs, result);
     event.hidden = shouldSkipEvent(
       this.#options,

--- a/packages/breadboard/src/inspector/run/event-manager.ts
+++ b/packages/breadboard/src/inspector/run/event-manager.ts
@@ -142,8 +142,6 @@ export class EventManager {
       throw new Error(`Expected an existing entry for ${JSON.stringify(path)}`);
     }
 
-    console.log("🌻 node", node.id, "traversal result", result);
-
     const event = new RunNodeEvent(entry, node.id, timestamp, inputs, result);
     event.hidden = shouldSkipEvent(
       this.#options,

--- a/packages/breadboard/src/inspector/run/event-manager.ts
+++ b/packages/breadboard/src/inspector/run/event-manager.ts
@@ -15,6 +15,7 @@ import {
   NodeEndResponse,
   NodeStartResponse,
   OutputResponse,
+  TraversalResult,
 } from "../../types.js";
 import { inspectableGraph } from "../graph.js";
 import {
@@ -46,6 +47,8 @@ import {
   idFromPath,
   pathFromId,
 } from "./conversions.js";
+import { ReanimationState } from "../../run/types.js";
+import { LifecycleManager } from "../../run/lifecycle.js";
 
 const shouldSkipEvent = (
   options: RunObserverOptions,
@@ -131,7 +134,7 @@ export class EventManager {
     entry.edges.push({ ...data, value });
   }
 
-  #addNodestart(data: NodeStartResponse) {
+  #addNodestart(data: NodeStartResponse, result?: TraversalResult) {
     const { node, timestamp, inputs, path } = data;
     const entry = this.#pathRegistry.create(path);
 
@@ -139,7 +142,7 @@ export class EventManager {
       throw new Error(`Expected an existing entry for ${JSON.stringify(path)}`);
     }
 
-    const event = new RunNodeEvent(entry, node.id, timestamp, inputs);
+    const event = new RunNodeEvent(entry, node.id, timestamp, inputs, result);
     event.hidden = shouldSkipEvent(
       this.#options,
       node,
@@ -261,7 +264,7 @@ export class EventManager {
       case "graphend":
         return this.#addGraphend(result.data);
       case "nodestart":
-        return this.#addNodestart(result.data);
+        return this.#addNodestart(result.data, result.result);
       case "input":
         return this.#addInput(result.data);
       case "output":
@@ -304,5 +307,42 @@ export class EventManager {
     const path = pathFromId(entryId);
     const entry = this.#pathRegistry.find(path);
     return entry?.event || null;
+  }
+
+  async reanimationStateAt(id: EventIdentifier): Promise<ReanimationState> {
+    const manager = new LifecycleManager();
+    for (const [index, entry] of this.#sequence.entries()) {
+      const [type, data] = entry;
+      switch (type) {
+        case "graphstart": {
+          // TODO: Figure out if I need to do anything about the URL here.
+          manager.dispatchGraphStart("", data.path);
+          break;
+        }
+        case "nodestart": {
+          const event = data.event as RunNodeEvent;
+          const traversalResult = event.traversalResult;
+          if (!traversalResult) {
+            console.warn(`No traversal result for ${data.event?.id}`);
+          } else {
+            manager.dispatchNodeStart(traversalResult, data.path);
+          }
+          if (event.id === id) {
+            const reanimationState = manager.reanimationState();
+            reanimationState.history = this.#sequence.slice(0, index);
+            return reanimationState;
+          }
+          break;
+        }
+        case "nodeend": {
+          // const event = data.event as RunNodeEvent;
+          // manager.dispatchNodeEnd(event.outputs!, data.path);
+          break;
+        }
+      }
+    }
+    throw new Error(
+      `The event identifier "${id}" was not found in event sequence`
+    );
   }
 }

--- a/packages/breadboard/src/inspector/run/nested-run.ts
+++ b/packages/breadboard/src/inspector/run/nested-run.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GraphDescriptor } from "@breadboard-ai/types";
 import { HarnessRunResult } from "../../harness/types.js";
 import type {
   EventIdentifier,
@@ -15,7 +14,11 @@ import type {
   InspectableRunNodeEvent,
   PathRegistryEntry,
 } from "../types.js";
-import { entryIdFromEventId, pathFromId } from "./conversions.js";
+import {
+  entryIdFromEventId,
+  eventsAsHarnessRunResults,
+  pathFromId,
+} from "./conversions.js";
 
 /**
  * Meant to be a very lightweight wrapper around the
@@ -72,143 +75,6 @@ export class NestedRun implements InspectableRun {
       return;
     }
     const timeline = sequence.slice(start);
-    const first = timeline[0];
-    let endPath: number[] = [];
-    if (first[0] !== "graphstart") {
-      throw new Error(
-        "Expected a graphstart event at the beginning of the timeline"
-      );
-    } else {
-      endPath = first[1].path;
-    }
-    for await (const result of timeline) {
-      const [type, data] = result;
-      switch (type) {
-        case "graphstart": {
-          const { graphStart, path, graph: inspectableGraph, edges } = data;
-          const graph = inspectableGraph?.raw() as GraphDescriptor;
-          yield {
-            type,
-            data: { timestamp: graphStart, path: trimPath(path), graph, edges },
-            async reply() {},
-          };
-          break;
-        }
-        case "nodestart": {
-          const { path } = data;
-          const {
-            node,
-            inputs,
-            start: timestamp,
-          } = data.event as InspectableRunNodeEvent;
-          yield {
-            type,
-            data: {
-              node: node.descriptor,
-              inputs,
-              path: trimPath(path),
-              timestamp,
-            },
-            async reply() {},
-          };
-          break;
-        }
-        case "nodeend": {
-          const { path } = data;
-          const {
-            node,
-            inputs,
-            outputs,
-            end: timestamp,
-          } = data.event as InspectableRunNodeEvent;
-          yield {
-            type,
-            data: {
-              node: node.descriptor,
-              inputs,
-              outputs: outputs || {},
-              path: trimPath(path),
-              timestamp: timestamp || 0,
-            },
-            async reply() {},
-          };
-          break;
-        }
-        case "graphend": {
-          const { path } = data;
-          const { graphEnd: timestamp } = data;
-          yield {
-            type,
-            data: { path: trimPath(path), timestamp: timestamp || 0 },
-            async reply() {},
-          };
-          if (path.join(".") === endPath.join(".")) {
-            return;
-          }
-          break;
-        }
-        case "error": {
-          const { graphStart: timestamp } = data;
-          yield {
-            type,
-            data: { error: "TODO: Store actual error object", timestamp },
-            async reply() {},
-          };
-          break;
-        }
-        case "input": {
-          const { path } = data;
-          const {
-            node,
-            inputs: inputArguments,
-            bubbled,
-            start: timestamp,
-          } = data.event as InspectableRunNodeEvent;
-          yield {
-            type,
-            data: {
-              node: node.descriptor,
-              inputArguments,
-              bubbled,
-              path: trimPath(path),
-              timestamp,
-            },
-            async reply() {},
-          };
-          break;
-        }
-        case "output": {
-          const { path } = data;
-          const {
-            node,
-            outputs,
-            bubbled,
-            start: timestamp,
-          } = data.event as InspectableRunNodeEvent;
-          yield {
-            type,
-            data: {
-              node: node.descriptor,
-              outputs: outputs || {},
-              bubbled,
-              path: trimPath(path),
-              timestamp,
-            },
-            async reply() {},
-          };
-          break;
-        }
-        case "secret": {
-          break;
-        }
-        default: {
-          throw new Error("Unknown event type: " + type);
-        }
-      }
-    }
-
-    function trimPath(path: number[]) {
-      return path.slice(endPath.length);
-    }
+    yield* eventsAsHarnessRunResults(timeline);
   }
 }

--- a/packages/breadboard/src/inspector/run/run-node-event.ts
+++ b/packages/breadboard/src/inspector/run/run-node-event.ts
@@ -5,7 +5,12 @@
  */
 
 import type { HarnessRunResult } from "../../harness/types.js";
-import type { InputValues, NodeIdentifier, OutputValues } from "../../types.js";
+import type {
+  InputValues,
+  NodeIdentifier,
+  OutputValues,
+  TraversalResult,
+} from "../../types.js";
 import type {
   EventIdentifier,
   InspectableGraph,
@@ -42,11 +47,17 @@ export class RunNodeEvent implements InspectableRunNodeEvent {
    */
   #node: InspectableNode | null = null;
 
+  /**
+   * The TraversalResult associated with with this event
+   */
+  traversalResult?: TraversalResult;
+
   constructor(
     entry: PathRegistryEntry,
     id: NodeIdentifier,
     start: number,
-    inputs: InputValues
+    inputs: InputValues,
+    traversalResult?: TraversalResult
   ) {
     if (!entry.parent) {
       throw new Error(
@@ -69,6 +80,7 @@ export class RunNodeEvent implements InspectableRunNodeEvent {
     this.result = null;
     this.bubbled = false;
     this.hidden = false;
+    this.traversalResult = traversalResult;
   }
 
   get id(): EventIdentifier {

--- a/packages/breadboard/src/inspector/run/run.ts
+++ b/packages/breadboard/src/inspector/run/run.ts
@@ -145,7 +145,6 @@ export class RunObserver implements InspectableRunObserver {
 
   async observe(result: HarnessRunResult): Promise<void> {
     if (result.type === "graphstart") {
-      console.log("🌻 graphstar", result);
       const { path, timestamp } = result.data;
       if (path.length === 0) {
         this.#url = result.data.graph.url ?? "no-url-graph";
@@ -166,7 +165,6 @@ export class RunObserver implements InspectableRunObserver {
         }
 
         this.#runs.unshift(run);
-        console.log("🌻 graphstar add new run", this.#runs);
 
         if (this.#options.runStore) {
           await this.#options.runStore.truncate(this.#url, this.#runLimit);
@@ -228,7 +226,6 @@ export class RunObserver implements InspectableRunObserver {
 
   async append(history: InspectableRunSequenceEntry[]): Promise<void> {
     for await (const result of eventsAsHarnessRunResults(history)) {
-      console.log("🌻 appending", result);
       await this.observe(result);
     }
   }

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -30,6 +30,7 @@ import {
   NodeValue,
   OutputValues,
   Schema,
+  TraversalResult,
 } from "../types.js";
 import {
   DataStore,
@@ -37,6 +38,7 @@ import {
   SerializedDataStoreGroup,
 } from "../data/types.js";
 import { SequenceEntry } from "./run/serializer.js";
+import { ReanimationState } from "../run/types.js";
 
 export type GraphVersion = number;
 
@@ -660,6 +662,13 @@ export type InspectableRunObserver = {
     o: unknown,
     options?: SerializedRunLoadingOptions
   ): Promise<InspectableRunLoadResult>;
+
+  /**
+   * Appends previously observed events to runs and creates
+   * new runs if needed.
+   * @param history -- inspectable run events to append
+   */
+  append(history: InspectableRunSequenceEntry[]): Promise<void>;
 };
 
 /**
@@ -771,6 +780,11 @@ export type InspectableRunNodeEvent = {
    * this node was (is being) invoked.
    */
   runs: InspectableRun[];
+
+  /**
+   * The TraversalResult associated with with this event
+   */
+  traversalResult?: TraversalResult;
 };
 
 /**
@@ -916,6 +930,13 @@ export type InspectableRun = {
    * the run.
    */
   replay(): AsyncGenerator<HarnessRunResult>;
+  /**
+   * Return the ReanimationState at a given event Id. Useful for starting
+   * a run from a given point in the run.
+   * Optional, since not all InspectableRun implemenations can offer this
+   * capability.
+   */
+  reanimationStateAt?(id: EventIdentifier): Promise<ReanimationState>;
 };
 
 /**
@@ -931,9 +952,11 @@ export type RunSerializationOptions = {
 };
 
 export type SequenceView = {
-  sequence: SequenceEntry[];
+  sequence: InspectableRunSequenceEntry[];
   start: number;
 };
+
+export type InspectableRunSequenceEntry = SequenceEntry;
 
 export type PathRegistryEntry = {
   path: number[];

--- a/packages/breadboard/src/remote/run.ts
+++ b/packages/breadboard/src/remote/run.ts
@@ -60,7 +60,7 @@ export class RunServer {
             const { type, data } = message;
             const response = [type, stubOutStreams(data)];
             if (type == "nodestart") {
-              response.push(message.state);
+              response.push(message.result);
             }
             await responses.write(response as RemoteMessage);
           })

--- a/packages/breadboard/src/remote/types.ts
+++ b/packages/breadboard/src/remote/types.ts
@@ -221,7 +221,6 @@ type ClientRunResultFromMessage<ResponseMessage> = ResponseMessage extends [
   ? {
       type: ResponseMessage[0];
       data: ResponseMessage[1];
-      saveState?: RunStateFunction;
     } & ReplyFunction
   : never;
 

--- a/packages/breadboard/src/remote/types.ts
+++ b/packages/breadboard/src/remote/types.ts
@@ -24,6 +24,7 @@ import {
   OutputResponse,
   OutputValues,
   SkipProbeMessage,
+  TraversalResult,
 } from "../types.js";
 
 /**
@@ -211,8 +212,6 @@ type ReplyFunction = {
   reply: (chunk: AnyRunRequestMessage[1]) => Promise<void>;
 };
 
-export type RunStateFunction = () => Promise<RunState>;
-
 type ClientRunResultFromMessage<ResponseMessage> = ResponseMessage extends [
   string,
   object,
@@ -221,6 +220,7 @@ type ClientRunResultFromMessage<ResponseMessage> = ResponseMessage extends [
   ? {
       type: ResponseMessage[0];
       data: ResponseMessage[1];
+      result?: TraversalResult;
     } & ReplyFunction
   : never;
 

--- a/packages/breadboard/src/run/reanimator.ts
+++ b/packages/breadboard/src/run/reanimator.ts
@@ -43,8 +43,6 @@ export class Reanimator implements ReanimationController {
     this.#inputs = undefined;
     const replayOutputs = entry.outputs ? [entry.outputs] : [];
 
-    console.log("🌻 reanimator enter:", replayOutputs, replayOutputs.length);
-
     // Always return the new instance:
     // wraps the actual ReanimationFrame, if any.
     return new FrameReanimator({

--- a/packages/breadboard/src/run/reanimator.ts
+++ b/packages/breadboard/src/run/reanimator.ts
@@ -43,6 +43,8 @@ export class Reanimator implements ReanimationController {
     this.#inputs = undefined;
     const replayOutputs = entry.outputs ? [entry.outputs] : [];
 
+    console.log("🌻 reanimator enter:", replayOutputs, replayOutputs.length);
+
     // Always return the new instance:
     // wraps the actual ReanimationFrame, if any.
     return new FrameReanimator({

--- a/packages/breadboard/src/run/run-graph.ts
+++ b/packages/breadboard/src/run/run-graph.ts
@@ -143,7 +143,7 @@ export async function* runGraph(
           path: path(),
           timestamp: timestamp(),
         },
-        state: lifecycle?.state(),
+        result,
       });
 
       let outputs: OutputValues | undefined = undefined;

--- a/packages/breadboard/src/run/run-graph.ts
+++ b/packages/breadboard/src/run/run-graph.ts
@@ -17,6 +17,7 @@ import type {
 } from "../types.js";
 import { asyncGen } from "../utils/async-gen.js";
 import { NodeInvoker } from "./node-invoker.js";
+import { cloneState } from "../serialization.js";
 
 /**
  * Runs a graph in "run" mode. See
@@ -143,7 +144,7 @@ export async function* runGraph(
           path: path(),
           timestamp: timestamp(),
         },
-        result,
+        result: cloneState(result),
       });
 
       let outputs: OutputValues | undefined = undefined;

--- a/packages/breadboard/src/run/types.ts
+++ b/packages/breadboard/src/run/types.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { InspectableRunSequenceEntry } from "../inspector/types.js";
 import type {
   Edge,
   NodeIdentifier,
@@ -99,6 +100,11 @@ export type ReanimationStateVisits = [NodeIdentifier, number[]][];
 export type ReanimationState = {
   states?: ReanimationStateCache;
   visits?: ReanimationStateVisits;
+  /**
+   * A run that consists of the events that preceded the point at which
+   * the reanimation state was captured.
+   */
+  history?: InspectableRunSequenceEntry[];
 };
 
 export type ReanimationMode =

--- a/packages/breadboard/src/serialization.ts
+++ b/packages/breadboard/src/serialization.ts
@@ -5,6 +5,7 @@
  */
 
 import { MachineResult } from "./traversal/result.js";
+import { MachineEdgeState } from "./traversal/state.js";
 import { TraversalResult } from "./types.js";
 
 export const replacer = (key: string, value: unknown) => {
@@ -34,4 +35,33 @@ export const loadRunnerState = (s: string) => {
   const { state: o, type } = JSON.parse(s, reviver);
   const state = MachineResult.fromObject(o);
   return { state, type };
+};
+
+export const cloneState = (result: TraversalResult): TraversalResult => {
+  const {
+    descriptor,
+    inputs,
+    missingInputs,
+    current,
+    opportunities,
+    newOpportunities,
+    state,
+    outputs,
+    partialOutputs,
+  } = result;
+  const clonedValueState = new MachineEdgeState();
+  clonedValueState.constants = structuredClone(state.constants);
+  clonedValueState.state = structuredClone(state.state);
+  const clone = new MachineResult(
+    descriptor,
+    inputs,
+    [...missingInputs],
+    current,
+    [...opportunities],
+    [...newOpportunities],
+    clonedValueState,
+    partialOutputs
+  );
+  clone.outputs = outputs;
+  return clone;
 };

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -504,7 +504,7 @@ export type SkipProbeMessage = {
 export type NodeStartProbeMessage = {
   type: "nodestart";
   data: NodeStartResponse;
-  state?: RunState;
+  result?: TraversalResult;
 };
 
 export type NodeEndProbeMessage = {

--- a/packages/breadboard/tests/node/run/local-runner.ts
+++ b/packages/breadboard/tests/node/run/local-runner.ts
@@ -267,6 +267,7 @@ describe("LocalRunner", async () => {
       async observe() {
         observed = true;
       },
+      async append() {},
     });
     const result = await runner.run();
     ok(observed);
@@ -290,6 +291,7 @@ describe("LocalRunner", async () => {
       observe() {
         throw new Error("I'm an observer that throws an error");
       },
+      async append() {},
     });
     const result = await runner.run();
     ok(!result);

--- a/packages/shared-ui/src/utils/top-graph-observer/top-graph-observer.ts
+++ b/packages/shared-ui/src/utils/top-graph-observer/top-graph-observer.ts
@@ -411,9 +411,16 @@ export class TopGraphObserver {
         case "graphend":
           this.#graphEnd(toEvent(entry));
           break;
-        case "nodestart":
+        case "nodestart": {
+          const edges = entry[1].edges;
+          for (const edge of edges) {
+            this.#edge({
+              data: edge,
+            } as unknown as RunEdgeEvent);
+          }
           this.#nodeStart(toEvent(entry));
           break;
+        }
         case "nodeend":
           this.#nodeEnd(toEvent(entry));
           break;

--- a/packages/shared-ui/src/utils/top-graph-observer/top-graph-observer.ts
+++ b/packages/shared-ui/src/utils/top-graph-observer/top-graph-observer.ts
@@ -401,7 +401,7 @@ export class TopGraphObserver {
         case "graphstart": {
           const { path, edges } = data;
           if (path.length === 0 && edges) {
-            for (const edge of edges as InspectableRunEdge[]) {
+            for (const edge of edges) {
               this.#edgeValues.set(edge.edge, edge.value);
             }
           }

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -428,6 +428,11 @@ export class Main extends LitElement {
                 break;
               }
 
+              case "skip": {
+                console.log("🌻 skipping", evt.runEvt.data);
+                break;
+              }
+
               case "graphstart": {
                 // Noop.
                 break;
@@ -2271,8 +2276,8 @@ export class Main extends LitElement {
                   );
                   return;
                 }
-                const lastRun = (await runObserver.runs())?.at(-1);
-                if (!lastRun) {
+                const firstRun = (await runObserver.runs())?.at(0);
+                if (!firstRun) {
                   console.warn("TODO: Implement running node with no last run");
                   return;
                 }
@@ -2281,7 +2286,7 @@ export class Main extends LitElement {
                 const configResult = await getRunNodeConfig(
                   evt.id,
                   undefined,
-                  lastRun
+                  firstRun
                 );
                 if (!configResult.success) {
                   return;

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -429,7 +429,7 @@ export class Main extends LitElement {
               }
 
               case "skip": {
-                console.log("🌻 skipping", evt.runEvt.data);
+                // Noop.
                 break;
               }
 
@@ -2281,7 +2281,6 @@ export class Main extends LitElement {
                   console.warn("TODO: Implement running node with no last run");
                   return;
                 }
-                console.log("🌻💖 RUNNING NODE =====");
                 // TODO: Feed changed `inputs` here.
                 const configResult = await getRunNodeConfig(
                   evt.id,

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -2292,8 +2292,6 @@ export class Main extends LitElement {
                   return;
                 }
                 const { config, history } = configResult.result;
-                console.log("🌻 config", config);
-                console.log("🌻 history", history);
 
                 if (!this.tab?.graph?.url) {
                   return;

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -2276,6 +2276,7 @@ export class Main extends LitElement {
                   console.warn("TODO: Implement running node with no last run");
                   return;
                 }
+                console.log("🌻💖 RUNNING NODE =====");
                 // TODO: Feed changed `inputs` here.
                 const configResult = await getRunNodeConfig(
                   evt.id,
@@ -2286,7 +2287,8 @@ export class Main extends LitElement {
                   return;
                 }
                 const { config, history } = configResult.result;
-                console.log("config", config);
+                console.log("🌻 config", config);
+                console.log("🌻 history", history);
 
                 if (!this.tab?.graph?.url) {
                   return;

--- a/packages/visual-editor/src/runtime/run.ts
+++ b/packages/visual-editor/src/runtime/run.ts
@@ -204,7 +204,6 @@ export class Run extends EventTarget {
     });
 
     if (history) {
-      console.log("🌻 history", history);
       await runObserver.append(history);
       topGraphObserver.startWith(history);
     }

--- a/packages/visual-editor/src/runtime/run.ts
+++ b/packages/visual-editor/src/runtime/run.ts
@@ -112,7 +112,7 @@ export class Run extends EventTarget {
     const runner = this.#createBoardRunner(config, abortController);
     this.#runs.set(tabId, runner);
 
-    const { harnessRunner, runObserver } = runner;
+    const { harnessRunner, runObserver, topGraphObserver } = runner;
     harnessRunner.addEventListener("start", (evt: RunLifecycleEvent) => {
       this.dispatchEvent(
         new RuntimeBoardRunEvent(tabId, evt, harnessRunner, abortController)
@@ -205,6 +205,7 @@ export class Run extends EventTarget {
 
     if (history) {
       await runObserver.append(history);
+      topGraphObserver.startWith(history);
     }
     harnessRunner.run();
   }

--- a/packages/visual-editor/src/runtime/run.ts
+++ b/packages/visual-editor/src/runtime/run.ts
@@ -204,6 +204,7 @@ export class Run extends EventTarget {
     });
 
     if (history) {
+      console.log("🌻 history", history);
       await runObserver.append(history);
       topGraphObserver.startWith(history);
     }

--- a/packages/visual-editor/src/runtime/run.ts
+++ b/packages/visual-editor/src/runtime/run.ts
@@ -8,6 +8,7 @@ import {
   createRunObserver,
   DataStore,
   InspectableRunObserver,
+  InspectableRunSequenceEntry,
   Kit,
   RunStore,
 } from "@google-labs/breadboard";
@@ -100,14 +101,18 @@ export class Run extends EventTarget {
     return { topGraphObserver, runObserver };
   }
 
-  runBoard(tabId: TabId, config: RunConfig) {
+  async runBoard(
+    tabId: TabId,
+    config: RunConfig,
+    history?: InspectableRunSequenceEntry[]
+  ) {
     const abortController = new AbortController();
     config = { ...config, kits: this.kits, signal: abortController.signal };
 
     const runner = this.#createBoardRunner(config, abortController);
     this.#runs.set(tabId, runner);
 
-    const { harnessRunner } = runner;
+    const { harnessRunner, runObserver } = runner;
     harnessRunner.addEventListener("start", (evt: RunLifecycleEvent) => {
       this.dispatchEvent(
         new RuntimeBoardRunEvent(tabId, evt, harnessRunner, abortController)
@@ -198,6 +203,9 @@ export class Run extends EventTarget {
       );
     });
 
+    if (history) {
+      await runObserver.append(history);
+    }
     harnessRunner.run();
   }
 

--- a/packages/visual-editor/src/utils/past-run-observer.ts
+++ b/packages/visual-editor/src/utils/past-run-observer.ts
@@ -27,5 +27,8 @@ function createPastRunObserver(run: InspectableRun): InspectableRunObserver {
     load: async () => {
       throw new Error("Attempting to load in read-only tab.");
     },
+    append: async () => {
+      throw new Error("Do not append to a past run observer.");
+    },
   };
 }

--- a/packages/visual-editor/src/utils/run-node.ts
+++ b/packages/visual-editor/src/utils/run-node.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { InputValues, NodeIdentifier } from "@breadboard-ai/types";
+import {
+  createRunStateManager,
+  ReanimationState,
+  type InspectableRun,
+} from "@google-labs/breadboard";
+import { RunConfig } from "@google-labs/breadboard/harness";
+import { Result, RunNodeConfig } from "./types";
+
+export { getRunNodeConfig };
+
+function error<T>(message: string): Result<T> {
+  console.warn(message);
+  return {
+    success: false,
+    error: message,
+  };
+}
+
+async function getRunNodeConfig(
+  nodeId: NodeIdentifier,
+  inputs: InputValues | undefined,
+  run: InspectableRun
+): Promise<Result<Partial<RunNodeConfig>>> {
+  // Might have multiple of those.
+  const targets = run.events.filter(
+    (event) => event.type === "node" && event.node.descriptor.id === nodeId
+  );
+  // For now, take the last one. Eventually, let the user pick.
+  const target = targets.at(-1);
+  if (!target) {
+    return error("Unable to find the node in the run. Likely a bug somewhere.");
+  }
+  const reanimationState: ReanimationState | undefined =
+    await run.reanimationStateAt?.(target.id);
+  if (!reanimationState) {
+    return error(`Unable to create resume point for target "${target.id}"`);
+  }
+  const history = reanimationState.history;
+  const config: Partial<RunConfig> = {
+    state: createRunStateManager(reanimationState, inputs),
+    stopAfter: nodeId,
+  };
+  return { success: true, result: { config, history } };
+
+  // Stop at target
+  // Run node and stop
+}

--- a/packages/visual-editor/src/utils/types.ts
+++ b/packages/visual-editor/src/utils/types.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { InspectableRunSequenceEntry } from "@google-labs/breadboard";
+import { RunConfig } from "@google-labs/breadboard/harness";
+
+export type Result<T> =
+  | {
+      success: true;
+      result: T;
+    }
+  | {
+      success: false;
+      error: string;
+    };
+
+export type RunNodeConfig = {
+  config: Partial<RunConfig>;
+  history: InspectableRunSequenceEntry[];
+};


### PR DESCRIPTION
- **Remove unused `saveState` member of ClientRunResult message.**
- **Sketching out run node infra.**
- **Off by one.**
- **Pre-populate TGO.**
- **Pass traversal result from run events.**
- **Properly clone TraversalResult.**
- **It's not last run, it's first run!**
- **Allow starting from inputs.**
- **Populate edge values.**
- **Make it build again.**
- **Remove unnecessary cast.**
- **Remove logging.**
- **docs(changeset): Implement "Re-run from this node" feature.**
