### PR TITLE
[shared-ui] Various fixes to graph rendering

### DIFF
--- a/packages/shared-ui/src/elements/editor/graph.ts
+++ b/packages/shared-ui/src/elements/editor/graph.ts
@@ -477,7 +477,9 @@ export class Graph extends PIXI.Container {
       // Update the edge if either of the nodes is collapsed.
       const fromNodePortsOut = outPortDisambiguation || [];
       const possiblePortsOut: InspectablePort[] = fromNode.collapsed
-        ? fromNodePortsOut.filter((port) => !port.star && port.name !== "")
+        ? fromNodePortsOut.filter(
+            (port) => !port.star && port.name !== "" && port.name !== "$error"
+          )
         : fromNodePortsOut.filter(
             (port) =>
               !port.star && port.name !== "" && port.name === targetOutPortName


### PR DESCRIPTION
Fixes #3477 but also:

1. You can use the middle mouse button to move the graph
2. You can now switch from selection to move mid-action and back again
3. `$error` outputs are excluded from node disambiguation overlays