### PR TITLE
sync run

### DIFF
--- a/.changeset/long-months-flash.md
+++ b/.changeset/long-months-flash.md
@@ -1,0 +1,7 @@
+---
+"@breadboard-ai/visual-editor": patch
+"@google-labs/breadboard": patch
+"@breadboard-ai/shared-ui": patch
+---
+
+Synchronize activity log with visual editor when component is edited.

--- a/packages/breadboard/src/inspector/run/event-manager.ts
+++ b/packages/breadboard/src/inspector/run/event-manager.ts
@@ -45,6 +45,7 @@ import { SerializedDataStoreGroup } from "../../data/types.js";
 import {
   entryIdFromEventId,
   eventIdFromEntryId,
+  eventsAsHarnessRunResults,
   idFromPath,
   pathFromId,
 } from "./conversions.js";
@@ -300,6 +301,10 @@ export class EventManager {
 
   serializer() {
     return this.#serializer;
+  }
+
+  async *replay() {
+    yield* eventsAsHarnessRunResults(this.#sequence);
   }
 
   getEventById(id: EventIdentifier): InspectableRunEvent | null {

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -668,6 +668,13 @@ export type InspectableRunObserver = {
    * @param history -- inspectable run events to append
    */
   append(history: InspectableRunSequenceEntry[]): Promise<void>;
+
+  /**
+   * Replays the current run as a new run, stopping at the first encountered in
+   * a given list of nodes.
+   * If no run exists, does nothing.
+   */
+  replay(stopAt: NodeIdentifier[]): Promise<void>;
 };
 
 /**

--- a/packages/breadboard/tests/node/run/local-runner.ts
+++ b/packages/breadboard/tests/node/run/local-runner.ts
@@ -254,6 +254,7 @@ describe("LocalRunner", async () => {
         observed = true;
       },
       async append() {},
+      async replay() {},
     });
     const result = await runner.run();
     ok(observed);
@@ -278,6 +279,7 @@ describe("LocalRunner", async () => {
         throw new Error("I'm an observer that throws an error");
       },
       async append() {},
+      async replay() {},
     });
     const result = await runner.run();
     ok(!result);

--- a/packages/shared-ui/src/utils/top-graph-observer/edge-value-store.ts
+++ b/packages/shared-ui/src/utils/top-graph-observer/edge-value-store.ts
@@ -163,6 +163,18 @@ export class EdgeValueStore {
     this.#outgoingEdges.delete(id);
   }
 
+  unconsume(id: NodeIdentifier) {
+    const edges = this.#incomingEdges.get(id);
+    if (!edges) return;
+
+    for (const edge of edges) {
+      const last = this.#values.get(this.#keyFromEdge(edge))?.at(-1);
+      if (last) {
+        last.status = "stored";
+      }
+    }
+  }
+
   clone() {
     return new EdgeValueStore(
       this.#values,

--- a/packages/shared-ui/src/utils/top-graph-observer/top-graph-observer.ts
+++ b/packages/shared-ui/src/utils/top-graph-observer/top-graph-observer.ts
@@ -472,8 +472,8 @@ export class TopGraphObserver {
       return;
     }
     const nodes = new Set(affectedNodes);
-    let stopHere: number | undefined = undefined;
-    for (const [index, entry] of this.#log.entries()) {
+    let stopHere: LogEntry | undefined = undefined;
+    for (const entry of this.#log) {
       if (entry.type === "error") continue;
       if (entry instanceof UserNodeEntry) continue;
 
@@ -482,7 +482,7 @@ export class TopGraphObserver {
 
       if (stopHere === undefined) {
         if (nodes.has(id)) {
-          stopHere = index;
+          stopHere = entry;
           this.#edgeValues.unconsume(id);
           this.#edgeValues.delete(id);
           this.#nodeActivity.delete(id);
@@ -495,7 +495,7 @@ export class TopGraphObserver {
     }
     if (stopHere !== undefined) {
       this.#currentResult = null;
-      this.#currentNode = null;
+      this.#currentNode = stopHere.type === "node" ? stopHere : null;
       this.#edgeValues = this.#edgeValues.clone();
     }
   }

--- a/packages/shared-ui/src/utils/top-graph-observer/top-graph-observer.ts
+++ b/packages/shared-ui/src/utils/top-graph-observer/top-graph-observer.ts
@@ -483,6 +483,7 @@ export class TopGraphObserver {
       if (stopHere === undefined) {
         if (nodes.has(id)) {
           stopHere = index;
+          this.#edgeValues.unconsume(id);
           this.#edgeValues.delete(id);
           this.#nodeActivity.delete(id);
         }

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -316,6 +316,7 @@ export class Main extends LitElement {
             const observers = this.#runtime.run.getObservers(evt.tabId);
             if (observers) {
               observers.topGraphObserver?.updateAffected(evt.affectedNodes);
+              observers.runObserver?.replay(evt.affectedNodes);
             }
 
             const shouldAutoSave = this.#settings?.getItem(

--- a/packages/visual-editor/src/utils/past-run-observer.ts
+++ b/packages/visual-editor/src/utils/past-run-observer.ts
@@ -7,6 +7,7 @@
 import {
   InspectableRun,
   InspectableRunObserver,
+  NodeIdentifier,
 } from "@google-labs/breadboard";
 
 export { createPastRunObserver };
@@ -29,6 +30,19 @@ function createPastRunObserver(run: InspectableRun): InspectableRunObserver {
     },
     append: async () => {
       throw new Error("Do not append to a past run observer.");
+    },
+    async replay(stopAt: NodeIdentifier[]): Promise<void> {
+      for await (const result of run.replay()) {
+        await this.observe(result);
+        const { type, data } = result;
+        if (
+          type === "nodestart" &&
+          data.path.length === 1 &&
+          stopAt.includes(data.node.id)
+        ) {
+          break;
+        }
+      }
     },
   };
 }


### PR DESCRIPTION
- **Make current runs replayable.**
- **Add InspectableRunObserver.replay**
- **Revert edge value status to "stored" when rewinding TGO.**
- **Set the currentNode to the right value when rewinding TGO.**
- **docs(changeset): Synchronize activity log with visual editor when component is edited.**
