### PR TITLE
Add webpackIgnore everywhere vite-ignore is used.

### DIFF
--- a/.changeset/rude-forks-speak.md
+++ b/.changeset/rude-forks-speak.md
@@ -1,0 +1,6 @@
+---
+"@google-labs/breadboard": patch
+"@google-labs/core-kit": patch
+---
+
+Add webpackIgnore to server-only code

--- a/packages/breadboard/src/kits/load.ts
+++ b/packages/breadboard/src/kits/load.ts
@@ -117,7 +117,11 @@ export const load = async (url: URL): Promise<Kit> => {
       }
     } else {
       // Assume that this is a URL to a JS file.
-      const module = await import(/* @vite-ignore */ url.href);
+      const module = await import(
+        /* @vite-ignore */
+        /* webpackIgnore: true */
+        url.href
+      );
       if (module.default == undefined) {
         throw new Error(`Module ${url} does not have a default export.`);
       }

--- a/packages/breadboard/src/loader/default.ts
+++ b/packages/breadboard/src/loader/default.ts
@@ -25,7 +25,11 @@ export const loadFromFile = async (path: string) => {
     const { readFile } = require("node:fs/promises");
     readFileFn = readFile;
   } else {
-    const { readFile } = await import(/* vite-ignore */ "node:fs/promises");
+    const { readFile } = await import(
+      /* vite-ignore */
+      /* webpackIgnore: true */
+      "node:fs/promises"
+    );
     readFileFn = readFile;
   }
 

--- a/packages/core-kit/src/nodes/run-javascript.ts
+++ b/packages/core-kit/src/nodes/run-javascript.ts
@@ -92,7 +92,8 @@ const runInServiceWorker: ScriptRunner = async ({
   functionName,
   args,
 }) => {
-  // @vite-ignore
+  /* @vite-ignore */
+  /* webpackIgnore: true */
   const body = `return (async function() { \n${code};\nreturn await ${functionName}(${args}) })();`;
   // Very very sorry.
   const f = new Function(body);


### PR DESCRIPTION
This allows Breadboard to be imported in webpack projects without causing module import errors in client-side code.

Fixes #3511
