### PR TITLE
fix run blob crash

### DIFF
--- a/.changeset/hip-guests-pretend.md
+++ b/.changeset/hip-guests-pretend.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard": patch
+---
+
+Fix the asBlob crash when replaying runs.

--- a/packages/breadboard/src/inspector/run/run.ts
+++ b/packages/breadboard/src/inspector/run/run.ts
@@ -84,11 +84,13 @@ export class RunObserver implements InspectableRunObserver {
                 );
 
                 run.dataStoreKey = `${url}-${timestamp}`;
-                if (!this.#options.skipDataStore) {
-                  // Ensure that we release old blobs if we've encountered this
-                  // run before.
-                  this.#options.dataStore?.releaseGroup(run.dataStoreKey);
-                  this.#options.dataStore?.createGroup(run.dataStoreKey);
+                const { dataStore, skipDataStore } = this.#options;
+                if (!skipDataStore && dataStore) {
+                  // If a group with this key already exists, let's just
+                  // keep adding to it. Otherwise, let create a new one.
+                  if (!dataStore.has(run.dataStoreKey)) {
+                    this.#options.dataStore?.createGroup(run.dataStoreKey);
+                  }
                 }
               }
             } else if (result.type === "graphend") {


### PR DESCRIPTION
- **Be forgiving about group ids by the same name.**
- **docs(changeset): Fix the asBlob crash when replaying runs.**
