### PR TITLE
only modifiable in save

### DIFF
--- a/.changeset/five-tools-vanish.md
+++ b/.changeset/five-tools-vanish.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/shared-ui": patch
+---
+
+Filter out board servers that can't be written into in Save overlay.

--- a/packages/shared-ui/src/elements/overlay/save-as.ts
+++ b/packages/shared-ui/src/elements/overlay/save-as.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { LitElement, html, css, PropertyValueMap } from "lit";
+import { LitElement, html, css, PropertyValueMap, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import {
   GraphBoardServerSaveBoardEvent,
@@ -337,12 +337,15 @@ export class SaveAsOverlay extends LitElement {
 
         <label>Board Server</label>
         <select name="board-server" .value=${this.selectedBoardServer}>
-          ${map(this.boardServers, (boardSerer) => {
-            const stores = [...boardSerer.items()].filter(
+          ${map(this.boardServers, (boardServer) => {
+            if (!boardServer.extendedCapabilities().modify) {
+              return nothing;
+            }
+            const stores = [...boardServer.items()].filter(
               ([, store]) => store.permission === "granted"
             );
             return html`${map(stores, ([location, store]) => {
-              const value = `${boardSerer.name}::${store.url ?? location}`;
+              const value = `${boardServer.name}::${store.url ?? location}`;
               const isSelectedOption = value === selected;
               return html`<option
                 ?disabled=${store.permission !== "granted"}


### PR DESCRIPTION
- **Only show modifiable board servers in Save dialog.**
- **docs(changeset): Filter out board servers that can't be written into in Save overlay.**
