### PR TITLE
[connection-server] Accept only GET requests

### DIFF
--- a/packages/connection-server/src/server.ts
+++ b/packages/connection-server/src/server.ts
@@ -23,23 +23,21 @@ export function startServer(port: number, config: ServerConfig) {
       // seems to be 24 hours.
       // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age
       maxAge: 24 * 60 * 60,
-      methods: "GET",
       origin: config.allowedOrigins,
     })
   );
 
-  // TODO: #3172 - Error handling
-  // TODO: #3172 - Handle HTTP verbs individually
+  // TODO: #3172 - Common error handling
 
-  app.all("/list", async (req: Request, res: Response) =>
+  app.get("/list", async (req: Request, res: Response) =>
     list(req, res, config)
   );
 
-  app.all("/grant", async (req: Request, res: Response) =>
+  app.get("/grant", async (req: Request, res: Response) =>
     grant(req, res, config)
   );
 
-  app.all("/refresh", async (req: Request, res: Response) =>
+  app.get("/refresh", async (req: Request, res: Response) =>
     refresh(req, res, config)
   );
 


### PR DESCRIPTION
Previously connection server was accepting all requests, but setting
Access-Control-Allowed-Methods to "GET". So it's clear that it's
intended only to be used with GET requests.

Arguably, however, `grant` and `refresh` requests should be POST
requests. They don't alter state on the connection server itself, but
they do cause outgoing POST requests, so it makes sense.

Also for `grant` requests specifically, the params include a refresh
token, which is a sensitive value that should not appear in the search
query of a URL. In the POST body it would be encrypted, and less
vulnerable to sniffing attacks.

Part of #3172
