### PR TITLE
run module fixes

### DIFF
--- a/.changeset/little-bees-dance.md
+++ b/.changeset/little-bees-dance.md
@@ -1,0 +1,6 @@
+---
+"@google-labs/breadboard": patch
+"@breadboard-ai/shared-ui": patch
+---
+
+Feed compiled JS from TS compiler.

--- a/packages/breadboard/src/traversal/iterator.ts
+++ b/packages/breadboard/src/traversal/iterator.ts
@@ -31,7 +31,11 @@ export class TraversalMachineIterator
       this.#current.state.useInputs(descriptor.id, this.#current.inputs);
 
       if (outputs && outputs.$error) {
-        const $error = outputs.$error as ErrorCapability;
+        const $error = (
+          typeof outputs.$error === "string"
+            ? { error: new Error(outputs.$error) }
+            : outputs.$error
+        ) as ErrorCapability;
         outputs.$error = {
           descriptor,
           ...($error as object),

--- a/packages/shared-ui/src/elements/module-editor/module-editor.ts
+++ b/packages/shared-ui/src/elements/module-editor/module-editor.ts
@@ -258,10 +258,8 @@ export class ModuleEditor extends LitElement {
         declaration: true,
         rootDir: ".",
         noLib: true,
-        noEmit: true,
         verbatimModuleSyntax: true,
         allowJs: true,
-        allowImportingTsExtensions: true,
         paths: {
           "*": ["./*"],
         },


### PR DESCRIPTION
- **Allow `$error` to be a string.**
- **Start emitting js files so that we can read them back.**
- **docs(changeset): Feed compiled JS from TS compiler.**
