### PR TITLE
modules bgl kit

### DIFF
--- a/.changeset/fresh-crabs-tie.md
+++ b/.changeset/fresh-crabs-tie.md
@@ -1,0 +1,11 @@
+---
+"@google-labs/node-nursery-web": minor
+"@google-labs/breadboard-cli": minor
+"@breadboard-ai/visual-editor": minor
+"@google-labs/breadboard": minor
+"@breadboard-ai/build-code": minor
+"@google-labs/core-kit": minor
+"@breadboard-ai/build": minor
+---
+
+Allow subgraphs to access modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "./packages/node-proxy-server/functions"
       ],
       "dependencies": {
-        "@rollup/rollup-darwin-arm64": "^4.26.0",
         "express": "^4.21.1",
         "json-schema": "^0.4.0",
         "litegraph.js": "^0.7.18",
@@ -24859,7 +24858,7 @@
       "dependencies": {
         "@breadboard-ai/build": "0.10.5",
         "@breadboard-ai/import": "0.1.12",
-        "@breadboard-ai/visual-editor": "^1.22.1",
+        "@breadboard-ai/visual-editor": "1.22.1",
         "@google-labs/breadboard": "^0.29.0",
         "@google-labs/core-kit": "^0.16.0",
         "@google-labs/template-kit": "^0.3.14",

--- a/packages/board-server/src/api-view/api-view.ts
+++ b/packages/board-server/src/api-view/api-view.ts
@@ -272,11 +272,11 @@ export class ApiExplorer extends LitElement {
     const loader = createLoader([]);
     const base = new URL(window.location.href);
     const graph = await loader.load(url, { base });
-    if (!graph) {
+    if (!graph.success) {
       // TODO: Better error handling, maybe a toast?
       throw new Error(`Unable to load graph: ${url}`);
     }
-    const runner = graph;
+    const runner = graph.graph;
     const { title, description } = runner;
 
     if (title) {

--- a/packages/breadboard-cli/package.json
+++ b/packages/breadboard-cli/package.json
@@ -161,7 +161,7 @@
   "dependencies": {
     "@breadboard-ai/build": "0.10.5",
     "@breadboard-ai/import": "0.1.12",
-    "@breadboard-ai/visual-editor": "^1.22.1",
+    "@breadboard-ai/visual-editor": "1.22.1",
     "@google-labs/breadboard": "^0.29.0",
     "@google-labs/core-kit": "^0.16.0",
     "@google-labs/template-kit": "^0.3.14",

--- a/packages/breadboard-cli/src/commands/lib/loaders/json.ts
+++ b/packages/breadboard-cli/src/commands/lib/loaders/json.ts
@@ -4,9 +4,9 @@ import { pathToFileURL } from "url";
 
 export class JSONLoader extends Loader {
   async load(filePath: string): Promise<GraphDescriptor | null> {
-    const graph = await createLoader().load(filePath, {
+    const loadResult = await createLoader().load(filePath, {
       base: new URL(pathToFileURL(process.cwd()).toString()),
     });
-    return graph;
+    return loadResult.success ? loadResult.graph : null;
   }
 }

--- a/packages/breadboard-cli/src/commands/run.ts
+++ b/packages/breadboard-cli/src/commands/run.ts
@@ -35,10 +35,13 @@ async function runBoard(
     ? new VerboseLoggingProbe(async (data) => console.log(data))
     : undefined;
 
-  for await (const stop of runGraph(board, {
-    kits,
-    probe,
-  })) {
+  for await (const stop of runGraph(
+    { graph: board },
+    {
+      kits,
+      probe,
+    }
+  )) {
     if (stop.type === "input") {
       const nodeInputs = stop.inputArguments;
       // we won't mutate the inputs.

--- a/packages/breadboard/src/capability.ts
+++ b/packages/breadboard/src/capability.ts
@@ -72,26 +72,26 @@ export const graphDescriptorFromCapability = async (
         `The "board" Capability is a URL, but no loader was supplied.`
       );
     }
-    const graph = await context.loader.load(capability.url, context);
-    if (!graph) {
+    const loaderResult = await context.loader.load(capability.url, context);
+    if (!loaderResult.success || !loaderResult.graph) {
       throw new Error(
         `Unable to load "board" Capability with the URL of ${capability.url}.`
       );
     }
-    return graph;
+    return loaderResult.graph;
   } else if (isUnresolvedPathBoardCapability(capability)) {
     if (!context?.loader) {
       throw new Error(
         `The "board" Capability is a URL, but no loader was supplied.`
       );
     }
-    const graph = await context.loader.load(capability.path, context);
-    if (!graph) {
+    const loaderResult = await context.loader.load(capability.path, context);
+    if (!loaderResult.success || !loaderResult.graph) {
       throw new Error(
         `Unable to load "board" Capability with the path of ${capability.path}.`
       );
     }
-    return graph;
+    return loaderResult.graph;
   }
   throw new Error(
     `Unsupported type of "board" Capability. Perhaps the supplied board isn't actually a GraphDescriptor?`
@@ -108,9 +108,11 @@ export const getGraphDescriptor = async (
   if (!board) return undefined;
 
   if (typeof board === "string") {
-    const graph = await context?.loader?.load(board, context);
-    if (!graph) throw new Error(`Unable to load graph from "${board}"`);
-    return graph;
+    const loaderResult = await context?.loader?.load(board, context);
+    if (!loaderResult?.success || !loaderResult.graph) {
+      throw new Error(`Unable to load graph from "${board}"`);
+    }
+    return loaderResult.graph;
   } else if (isBreadboardCapability(board)) {
     return graphDescriptorFromCapability(board, context);
   } else if (isGraphDescriptor(board)) {

--- a/packages/breadboard/src/handler.ts
+++ b/packages/breadboard/src/handler.ts
@@ -161,10 +161,13 @@ async function getGraphHandlerInternal(
   if (!loader) {
     throw new Error(`Cannot load graph for type "${type}" without a loader.`);
   }
-  const graph = await loader.load(type, context);
-  if (!graph) {
-    throw new Error(`Cannot load graph for type "${type}"`);
+  const loadResult = await loader.load(type, context);
+  if (!loadResult.success) {
+    throw new Error(
+      `Cannot load graph for type "${type}": ${loadResult.error}`
+    );
   }
+  const graph = loadResult.graph;
   return {
     invoke: async (inputs, context) => {
       const base = context.board?.url && new URL(context.board?.url);

--- a/packages/breadboard/src/handler.ts
+++ b/packages/breadboard/src/handler.ts
@@ -5,7 +5,7 @@
  */
 
 import { inspect } from "./inspector/index.js";
-import { SENTINEL_BASE_URL } from "./loader/loader.js";
+import { resolveGraph, SENTINEL_BASE_URL } from "./loader/loader.js";
 import { invokeGraph } from "./run/invoke-graph.js";
 import type {
   GraphDescriptor,
@@ -167,7 +167,9 @@ async function getGraphHandlerInternal(
       `Cannot load graph for type "${type}": ${loadResult.error}`
     );
   }
-  const graph = loadResult.graph;
+
+  const graph = resolveGraph(loadResult);
+
   return {
     invoke: async (inputs, context) => {
       const base = context.board?.url && new URL(context.board?.url);
@@ -178,7 +180,7 @@ async function getGraphHandlerInternal(
           }
         : { ...context };
 
-      return await invokeGraph(graph, inputs, invocationContext);
+      return await invokeGraph(loadResult, inputs, invocationContext);
     },
     describe: async (inputs, _inputSchema, _outputSchema, context) => {
       if (!context) {

--- a/packages/breadboard/src/harness/local.ts
+++ b/packages/breadboard/src/harness/local.ts
@@ -10,12 +10,7 @@ import { asyncGen, runGraph } from "../index.js";
 import { createLoader } from "../loader/index.js";
 import { LastNode } from "../remote/types.js";
 import { timestamp } from "../timestamp.js";
-import {
-  BreadboardRunResult,
-  ErrorObject,
-  GraphDescriptor,
-  Kit,
-} from "../types.js";
+import { BreadboardRunResult, ErrorObject, GraphToRun, Kit } from "../types.js";
 import { Diagnostics } from "./diagnostics.js";
 import { extractError } from "./error.js";
 import { HarnessRunResult, RunConfig } from "./types.js";
@@ -106,7 +101,7 @@ const maybeSaveResult = (result: BreadboardRunResult, last?: LastNode) => {
   return last;
 };
 
-const load = async (config: RunConfig): Promise<GraphDescriptor> => {
+const load = async (config: RunConfig): Promise<GraphToRun> => {
   const base = baseURL(config);
   const loader = config.loader || createLoader();
   const loadResult = await loader.load(config.url, { base });
@@ -115,12 +110,14 @@ const load = async (config: RunConfig): Promise<GraphDescriptor> => {
       `Unable to load graph from "${config.url}": ${loadResult.error}`
     );
   }
-  return loadResult.graph;
+  return loadResult;
 };
 
 export async function* runLocally(config: RunConfig, kits: Kit[]) {
   yield* asyncGen<HarnessRunResult>(async (next) => {
-    const runner = config.runner || (await load(config));
+    const graphToRun: GraphToRun = config.runner
+      ? { graph: config.runner }
+      : await load(config);
     const loader = config.loader || createLoader();
     const store = config.store || createDefaultDataStore();
     const { base, signal, inputs, state, start, stopAfter } = config;
@@ -135,7 +132,7 @@ export async function* runLocally(config: RunConfig, kits: Kit[]) {
           })
         : undefined;
 
-      for await (const data of runGraph(runner, {
+      for await (const data of runGraph(graphToRun, {
         probe,
         kits,
         loader,

--- a/packages/breadboard/src/harness/local.ts
+++ b/packages/breadboard/src/harness/local.ts
@@ -109,11 +109,13 @@ const maybeSaveResult = (result: BreadboardRunResult, last?: LastNode) => {
 const load = async (config: RunConfig): Promise<GraphDescriptor> => {
   const base = baseURL(config);
   const loader = config.loader || createLoader();
-  const graph = await loader.load(config.url, { base });
-  if (!graph) {
-    throw new Error(`Unable to load graph from "${config.url}"`);
+  const loadResult = await loader.load(config.url, { base });
+  if (!loadResult.success) {
+    throw new Error(
+      `Unable to load graph from "${config.url}": ${loadResult.error}`
+    );
   }
-  return graph;
+  return loadResult.graph;
 };
 
 export async function* runLocally(config: RunConfig, kits: Kit[]) {

--- a/packages/breadboard/src/harness/serve.ts
+++ b/packages/breadboard/src/harness/serve.ts
@@ -119,11 +119,13 @@ export const serve = async (config: ServeConfig | Promise<ServeConfig>) => {
   const url = await getBoardURL(config, factory);
   const base = baseURL(config);
   const loader = createLoader();
-  const graph = await loader.load(url, { base });
-  if (!graph) {
-    throw new Error(`Unable to load graph from "${config.url}"`);
+  const loadResult = await loader.load(url, { base });
+  if (!loadResult.success) {
+    throw new Error(
+      `Unable to load graph from "${config.url}": ${loadResult.error}`
+    );
   }
-  return server.serve(graph, !!config.diagnostics, { kits });
+  return server.serve(loadResult.graph, !!config.diagnostics, { kits });
 };
 
 /**

--- a/packages/breadboard/src/inspector/graph.ts
+++ b/packages/breadboard/src/inspector/graph.ts
@@ -534,6 +534,7 @@ class Graph implements InspectableGraphWithStore {
 
     this.#cache.describe.clear(visualOnly, affectedNodes);
     this.#graph = graph;
+    this.#graphs = null;
   }
 
   resetGraph(graph: GraphDescriptor): void {

--- a/packages/breadboard/src/inspector/graph.ts
+++ b/packages/breadboard/src/inspector/graph.ts
@@ -448,14 +448,9 @@ class Graph implements InspectableGraphWithStore {
         outerGraph: this.#graph,
       });
       if (!loadResult.success) {
+        const error = `Could not load custom describer graph ${customDescriber}: ${loadResult.error}`;
+        console.warn(error);
         return loadResult;
-      }
-      const { graph: describerGraph } = loadResult;
-      if (!describerGraph) {
-        console.warn(
-          `Could not load custom describer graph ${customDescriber}`
-        );
-        return { success: false };
       }
       const { inputSchema: $inputSchema, outputSchema: $outputSchema } =
         await this.#describeWithStaticAnalysis();
@@ -465,7 +460,7 @@ class Graph implements InspectableGraphWithStore {
       // delete $outputSchema.properties?.inputSchema;
       // delete $outputSchema.properties?.outputSchema;
       const result = (await invokeGraph(
-        describerGraph,
+        loadResult,
         { ...inputs, $inputSchema, $outputSchema },
         {
           base,

--- a/packages/breadboard/src/inspector/graph.ts
+++ b/packages/breadboard/src/inspector/graph.ts
@@ -442,11 +442,15 @@ class Graph implements InspectableGraphWithStore {
       const base = this.#url;
 
       // try loading the describer graph.
-      const describerGraph = await loader.load(customDescriber, {
+      const loadResult = await loader.load(customDescriber, {
         base,
         board: this.#graph,
         outerGraph: this.#graph,
       });
+      if (!loadResult.success) {
+        return loadResult;
+      }
+      const { graph: describerGraph } = loadResult;
       if (!describerGraph) {
         console.warn(
           `Could not load custom describer graph ${customDescriber}`

--- a/packages/breadboard/src/kits/load.ts
+++ b/packages/breadboard/src/kits/load.ts
@@ -30,14 +30,10 @@ const setBaseURL = (base: URL, key: string, graph: GraphDescriptor) => {
 };
 
 class GraphDescriptorNodeHandler implements NodeHandlerObject {
-  #base: URL;
-  #type: string;
   #graph: GraphDescriptor;
   metadata: NodeHandlerMetadata;
 
   constructor(base: URL, type: string, graph: GraphDescriptor) {
-    this.#base = base;
-    this.#type = type;
     this.#graph = setBaseURL(base, type, graph);
     this.describe = this.describe.bind(this);
     this.invoke = this.invoke.bind(this);
@@ -70,9 +66,6 @@ class GraphDescriptorNodeHandler implements NodeHandlerObject {
 
 const createHandlersFromManifest = (base: URL, graph: GraphDescriptor) => {
   const graphs = graph.graphs!;
-  if (!graph.exports) {
-    console.log("NO GRAPH EXPORTS", graph);
-  }
   const exports = graph.exports!.map((e) => {
     if (e.startsWith("#")) {
       return e.slice(1);

--- a/packages/breadboard/src/kits/load.ts
+++ b/packages/breadboard/src/kits/load.ts
@@ -60,7 +60,7 @@ class GraphDescriptorNodeHandler implements NodeHandlerObject {
   }
 
   async invoke(inputs: InputValues, context: NodeHandlerContext) {
-    return await invokeGraph(this.#graph, inputs, context);
+    return await invokeGraph({ graph: this.#graph }, inputs, context);
   }
 }
 

--- a/packages/breadboard/src/loader/loader.ts
+++ b/packages/breadboard/src/loader/loader.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { GraphDescriptor, SubGraphs } from "../types.js";
+import type { GraphDescriptor, GraphToRun, SubGraphs } from "../types.js";
 import type {
   GraphProvider,
   GraphLoader,
@@ -13,6 +13,14 @@ import type {
 } from "./types.js";
 
 export const SENTINEL_BASE_URL = new URL("sentinel://sentinel/sentinel");
+
+export { resolveGraph };
+
+function resolveGraph(graphToRun: GraphToRun): GraphDescriptor {
+  return graphToRun.subGraphId
+    ? graphToRun.graph.graphs![graphToRun.subGraphId]
+    : graphToRun.graph;
+}
 
 export const removeHash = (url: URL): URL => {
   const newURL = new URL(url.href);

--- a/packages/breadboard/src/loader/loader.ts
+++ b/packages/breadboard/src/loader/loader.ts
@@ -9,6 +9,7 @@ import type {
   GraphProvider,
   GraphLoader,
   GraphLoaderContext,
+  GraphLoaderResult,
 } from "./types.js";
 
 export const SENTINEL_BASE_URL = new URL("sentinel://sentinel/sentinel");
@@ -38,7 +39,7 @@ export class Loader implements GraphLoader {
     this.#graphProviders = graphProviders;
   }
 
-  async #loadWithProviders(url: URL): Promise<GraphDescriptor | null> {
+  async #loadWithProviders(url: URL): Promise<GraphLoaderResult> {
     for (const provider of this.#graphProviders) {
       const capabilities = provider.canProvide(url);
       if (capabilities === false) {
@@ -50,44 +51,43 @@ export class Loader implements GraphLoader {
           typeof response == "string" ? JSON.parse(response) : response;
         if (graph !== null) {
           graph.url = url.href;
-          return graph;
+          return { success: true, graph };
         }
       }
     }
-    console.warn(`Unable to load graph from "${url.href}"`);
-    return null;
+    const error = `Unable to load graph from "${url.href}"`;
+    console.warn(error);
+    return { success: false, error };
   }
 
-  async #loadOrWarn(url: URL): Promise<GraphDescriptor | null> {
-    const graph = await this.#loadWithProviders(url);
-    if (!graph) {
-      return null;
-    }
-    return graph;
+  async #loadOrWarn(url: URL): Promise<GraphLoaderResult> {
+    return this.#loadWithProviders(url);
   }
 
   #getSubgraph(
     url: URL | null,
     hash: string,
     subgraphs?: SubGraphs
-  ): GraphDescriptor | null {
+  ): GraphLoaderResult {
     if (!subgraphs) {
-      console.warn(`No subgraphs to load "#${hash}" from`);
-      return null;
+      const error = `No subgraphs to load "#${hash}" from`;
+      console.warn(error);
+      return { success: false, error };
     }
     const graph = subgraphs[hash];
     if (!graph) {
-      console.warn(`No subgraph found for hash: #${hash}`);
-      return null;
+      const error = `No subgraph found for hash: #${hash}`;
+      console.warn(error);
+      return { success: false, error };
     }
     if (url) graph.url = url.href;
-    return graph;
+    return { success: true, graph };
   }
 
   async load(
     path: string,
     context: GraphLoaderContext
-  ): Promise<GraphDescriptor | null> {
+  ): Promise<GraphLoaderResult> {
     const supergraph = context.outerGraph;
     // This is a special case, when we don't have URLs to resolve against.
     // We are a hash path, and we are inside of a supergraph that doesn't
@@ -96,15 +96,7 @@ export class Loader implements GraphLoader {
     const isEphemeralSupergraph =
       path.startsWith("#") && supergraph && !supergraph.url;
     if (isEphemeralSupergraph) {
-      const graph = this.#getSubgraph(
-        null,
-        path.substring(1),
-        supergraph.graphs
-      );
-      if (!graph) {
-        console.warn(`Unable to load graph from "${path}"`);
-      }
-      return graph;
+      return this.#getSubgraph(null, path.substring(1), supergraph.graphs);
     }
 
     const base = baseURLFromContext(context);
@@ -130,14 +122,14 @@ export class Loader implements GraphLoader {
       }
     }
     // Otherwise, load the graph and then get its subgraph.
-    const loadedSupergraph = await this.#loadOrWarn(removeHash(url));
-    if (!loadedSupergraph) {
-      return null;
+    const loadedSupergraphResult = await this.#loadOrWarn(removeHash(url));
+    if (!loadedSupergraphResult.success) {
+      return loadedSupergraphResult;
     }
     return this.#getSubgraph(
       url,
       url.hash.substring(1),
-      loadedSupergraph.graphs
+      loadedSupergraphResult.graph.graphs
     );
   }
 }

--- a/packages/breadboard/src/loader/types.ts
+++ b/packages/breadboard/src/loader/types.ts
@@ -6,12 +6,11 @@
 
 import {
   GraphDescriptor,
-  GraphIdentifier,
   GraphTag,
   NodeConfiguration,
   NodeIdentifier,
 } from "@breadboard-ai/types";
-import { Kit } from "../types.js";
+import { GraphToRun, Kit } from "../types.js";
 
 export type GraphProviderItem = {
   url: string;
@@ -254,11 +253,9 @@ export type GraphLoaderContext = {
  * it returns the main graph and the id of the subgraph
  */
 export type GraphLoaderResult =
-  | {
+  | ({
       success: true;
-      graph: GraphDescriptor;
-      subGraphId?: GraphIdentifier;
-    }
+    } & GraphToRun)
   | {
       success: false;
       error: string;

--- a/packages/breadboard/src/loader/types.ts
+++ b/packages/breadboard/src/loader/types.ts
@@ -6,6 +6,7 @@
 
 import {
   GraphDescriptor,
+  GraphIdentifier,
   GraphTag,
   NodeConfiguration,
   NodeIdentifier,
@@ -249,6 +250,21 @@ export type GraphLoaderContext = {
 };
 
 /**
+ * Returns the result of loading the graph. When we're loading the subgraph,
+ * it returns the main graph and the id of the subgraph
+ */
+export type GraphLoaderResult =
+  | {
+      success: true;
+      graph: GraphDescriptor;
+      subGraphId?: GraphIdentifier;
+    }
+  | {
+      success: false;
+      error: string;
+    };
+
+/**
  * Represents a loader for `GraphDescriptor` instances. This is the main
  * interface for loading graphs in Breadboard.
  */
@@ -262,7 +278,7 @@ export type GraphLoader = {
   load: (
     path: string,
     context: GraphLoaderContext
-  ) => Promise<GraphDescriptor | null>;
+  ) => Promise<GraphLoaderResult>;
 };
 
 /**

--- a/packages/breadboard/src/remote/run.ts
+++ b/packages/breadboard/src/remote/run.ts
@@ -68,7 +68,7 @@ export class RunServer {
     };
 
     try {
-      for await (const stop of runGraph(runner, servingContext)) {
+      for await (const stop of runGraph({ graph: runner }, servingContext)) {
         if (stop.type === "input") {
           const { node, inputArguments, timestamp, path, invocationId } = stop;
           const bubbled = invocationId == -1;

--- a/packages/breadboard/src/run/invoke-graph.ts
+++ b/packages/breadboard/src/run/invoke-graph.ts
@@ -5,9 +5,8 @@
  */
 
 import { timestamp } from "../timestamp.js";
-import type { RunArguments } from "../types.js";
+import type { GraphToRun, RunArguments } from "../types.js";
 import type {
-  GraphDescriptor,
   InputValues,
   OutputValues,
   TraversalResult,
@@ -20,11 +19,12 @@ import { runGraph } from "./run-graph.js";
  * for more details.
  */
 export async function invokeGraph(
-  graph: GraphDescriptor,
+  graphToRun: GraphToRun,
   inputs: InputValues,
   context: RunArguments = {},
   resumeFrom?: TraversalResult
 ): Promise<OutputValues> {
+  const graph = graphToRun.graph;
   const args = { ...inputs, ...graph.args };
   const { probe } = context;
 
@@ -41,7 +41,11 @@ export async function invokeGraph(
         }
       : context;
 
-    for await (const result of runGraph(graph, adjustedContext, resumeFrom)) {
+    for await (const result of runGraph(
+      graphToRun,
+      adjustedContext,
+      resumeFrom
+    )) {
       if (result.type === "input") {
         // Pass the inputs to the board. If there are inputs bound to the
         // board (e.g. from a lambda node that had incoming wires), they will

--- a/packages/breadboard/src/run/node-invoker.ts
+++ b/packages/breadboard/src/run/node-invoker.ts
@@ -62,7 +62,10 @@ export class NodeInvoker {
       ...this.#context,
       descriptor,
       board: this.#graph,
-      // TODO: Remove this, since it is now the same as `board`.
+      // This is important: outerGraph is the value of the parent graph
+      // if this.#graph is a subgraph.
+      // Or it equals to "board" it this is not a subgraph
+      // TODO: Make this more elegant.
       outerGraph: this.#graph,
       base,
       kits,

--- a/packages/breadboard/src/run/run-graph.ts
+++ b/packages/breadboard/src/run/run-graph.ts
@@ -46,7 +46,7 @@ export async function* runGraph(
 
   const lifecycle = state?.lifecycle();
   yield* asyncGen<BreadboardRunResult>(async (next) => {
-    const nodeInvoker = new NodeInvoker(args, graph, next);
+    const nodeInvoker = new NodeInvoker(args, graphToRun, next);
 
     lifecycle?.dispatchGraphStart(graph.url!, invocationPath);
 

--- a/packages/breadboard/src/run/run-graph.ts
+++ b/packages/breadboard/src/run/run-graph.ts
@@ -4,24 +4,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {
-  GraphDescriptor,
-  OutputValues,
-  TraversalResult,
-} from "@breadboard-ai/types";
+import type { OutputValues, TraversalResult } from "@breadboard-ai/types";
 import { bubbleUpInputsIfNeeded, bubbleUpOutputsIfNeeded } from "../bubble.js";
 import { resolveBoardCapabilities } from "../capability.js";
 import { InputStageResult, OutputStageResult } from "../run.js";
 import { cloneState } from "../serialization.js";
 import { timestamp } from "../timestamp.js";
 import { TraversalMachine } from "../traversal/machine.js";
-import type { BreadboardRunResult, RunArguments } from "../types.js";
+import type {
+  BreadboardRunResult,
+  GraphToRun,
+  RunArguments,
+} from "../types.js";
 import { asyncGen } from "../utils/async-gen.js";
 import { NodeInvoker } from "./node-invoker.js";
 import {
   isImperativeGraph,
   toDeclarativeGraph,
 } from "./run-imperative-graph.js";
+import { resolveGraph } from "../loader/loader.js";
 
 /**
  * Runs a graph in "run" mode. See
@@ -29,13 +30,15 @@ import {
  * for more details.
  */
 export async function* runGraph(
-  graph: GraphDescriptor,
+  graphToRun: GraphToRun,
   args: RunArguments = {},
   resumeFrom?: TraversalResult
 ): AsyncGenerator<BreadboardRunResult> {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { inputs: initialInputs, start, stopAfter, ...context } = args;
   const { probe, state, invocationPath = [] } = context;
+
+  let graph = resolveGraph(graphToRun);
 
   if (isImperativeGraph(graph)) {
     graph = toDeclarativeGraph(graph);

--- a/packages/breadboard/src/sandboxed-run-module.ts
+++ b/packages/breadboard/src/sandboxed-run-module.ts
@@ -81,7 +81,7 @@ function addSandboxedRunModule(sandbox: Sandbox, kits: Kit[]): Kit[] {
       handlers: {
         runModule: {
           invoke: async ({ $module, ...rest }, context) => {
-            const moduleDeclaration = context.board?.modules;
+            const moduleDeclaration = context.outerGraph?.modules;
             if (!moduleDeclaration) {
               return {
                 $error: `Unable to run module: no modules found within board ${context.board?.url || "uknown board"}`,

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -19,6 +19,7 @@ import type {
   StoredDataCapabilityPart,
   TraversalResult,
   Probe,
+  GraphIdentifier,
 } from "@breadboard-ai/types";
 import { GraphLoader } from "./loader/types.js";
 import { DataStore } from "./data/types.js";
@@ -695,3 +696,12 @@ export type ConfigOrGraph =
   | OptionalIdConfiguration
   | BreadboardCapability
   | GraphDescriptor;
+
+/**
+ * The main argument to runGraph. Provides a way to point at a subgraph
+ * within a graph, while making the whole graph available.
+ */
+export type GraphToRun = {
+  graph: GraphDescriptor;
+  subGraphId?: GraphIdentifier;
+};

--- a/packages/breadboard/tests/board.ts
+++ b/packages/breadboard/tests/board.ts
@@ -33,7 +33,7 @@ test("correctly passes inputs and outputs to included boards", async (t) => {
     );
 
   const result = await invokeGraph(
-    board,
+    { graph: board },
     { hello: "world" },
     { kits: [nestedKit] }
   );
@@ -62,7 +62,7 @@ test("correctly passes inputs and outputs to included boards with a probe", asyn
     );
 
   const result = await invokeGraph(
-    board,
+    { graph: board },
     { hello: "world" },
     { kits: [nestedKit] }
   );
@@ -77,21 +77,33 @@ test("allows pausing and resuming the board", async (t) => {
   input.wire("<-", kit.noop());
   input.wire("*->", kit.noop().wire("*->", board.output().wire("*->", input)));
   {
-    for await (const stop of runGraph(board, { kits: [kit] }, result)) {
+    for await (const stop of runGraph(
+      { graph: board },
+      { kits: [kit] },
+      result
+    )) {
       t.is(stop.type, "input");
       result = stop;
       break;
     }
   }
   {
-    for await (const stop of runGraph(board, { kits: [kit] }, result?.state)) {
+    for await (const stop of runGraph(
+      { graph: board },
+      { kits: [kit] },
+      result?.state
+    )) {
       t.is(stop.type, "output");
       result = stop;
       break;
     }
   }
   {
-    for await (const stop of runGraph(board, { kits: [kit] }, result?.state)) {
+    for await (const stop of runGraph(
+      { graph: board },
+      { kits: [kit] },
+      result?.state
+    )) {
       t.is(stop.type, "input");
       result = stop;
       break;
@@ -129,7 +141,7 @@ test("when $error is set, all other outputs are ignored, named", async (t) => {
     kit.noop().wire("$error->", board.output())
   );
   const result = await invokeGraph(
-    board,
+    { graph: board },
     {},
     {
       kits: [kit],
@@ -146,7 +158,7 @@ test("when $error is set, all other outputs are ignored, with *", async (t) => {
   const output = board.output();
   noop.wire("*->", output);
   noop.wire("$error->", output);
-  const result = await invokeGraph(board, {}, { kits: [kit] });
+  const result = await invokeGraph({ graph: board }, {}, { kits: [kit] });
   t.is(result.foo, undefined);
   t.like(result.$error, { kind: "error" });
 });

--- a/packages/breadboard/tests/helpers/_test-kit.ts
+++ b/packages/breadboard/tests/helpers/_test-kit.ts
@@ -65,15 +65,25 @@ export const TestKit = new KitBuilder({
       const base = context.base || new URL(import.meta.url);
 
       if ($board) {
-        const board =
-          ($board as BreadboardCapability).kind === "board"
-            ? await getGraphDescriptor($board as BreadboardCapability, context)
-            : typeof $board === "string"
-              ? await context.loader?.load($board, {
-                  base,
-                  outerGraph: context.outerGraph,
-                })
-              : undefined;
+        let board;
+        if (($board as BreadboardCapability).kind === "board") {
+          board = await getGraphDescriptor(
+            $board as BreadboardCapability,
+            context
+          );
+        } else if (typeof $board === "string") {
+          const loadResult = await context.loader?.load($board, {
+            base,
+            outerGraph: context.outerGraph,
+          });
+          if (!loadResult?.success) {
+            board = undefined;
+          } else {
+            board = loadResult.graph;
+          }
+        } else {
+          board = undefined;
+        }
 
         if (!board) throw new Error("Must provide valid $board to invoke");
 
@@ -84,10 +94,12 @@ export const TestKit = new KitBuilder({
         const runnableBoard = board
           ? await getGraphDescriptor(board, context)
           : path
-            ? await context.loader?.load(path, {
-                base,
-                outerGraph: context.outerGraph,
-              })
+            ? unwrap(
+                await context.loader?.load(path, {
+                  base,
+                  outerGraph: context.outerGraph,
+                })
+              )
             : undefined;
 
         if (!runnableBoard)
@@ -235,6 +247,7 @@ import {
   NewOutputValues,
   NewNodeFactory as NodeFactory,
   invokeGraph,
+  GraphLoaderResult,
 } from "../../src/index.js";
 import { getGraphDescriptor } from "../../src/capability.js";
 
@@ -262,3 +275,10 @@ export const makeMirrorUniverseKit = () =>
   addKit(MirrorUniverseKit) as unknown as {
     reverser: NodeFactory<{ [key: string]: string }, { [key: string]: string }>;
   };
+
+function unwrap(
+  result: GraphLoaderResult | undefined
+): GraphDescriptor | undefined {
+  if (result && result.success) return result.graph;
+  return undefined;
+}

--- a/packages/breadboard/tests/helpers/_test-kit.ts
+++ b/packages/breadboard/tests/helpers/_test-kit.ts
@@ -53,7 +53,7 @@ export const TestKit = new KitBuilder({
     if (!graph) {
       throw new Error("Must provide a graph to include");
     }
-    return await invokeGraph(graph, inputs, context);
+    return await invokeGraph({ graph }, inputs, context);
   },
   /**
    * This is a primitive implementation of the `invoke` node in Core Kit,
@@ -87,7 +87,7 @@ export const TestKit = new KitBuilder({
 
         if (!board) throw new Error("Must provide valid $board to invoke");
 
-        return await invokeGraph(board, args, context);
+        return await invokeGraph({ graph: board }, args, context);
       } else {
         const { board, path, ...args } = inputs;
 
@@ -105,7 +105,7 @@ export const TestKit = new KitBuilder({
         if (!runnableBoard)
           throw new Error("Must provide valid board to invoke");
 
-        return await invokeGraph(runnableBoard, args, context);
+        return await invokeGraph({ graph: runnableBoard }, args, context);
       }
     },
     describe: async (inputs?: InputValues): Promise<NodeDescriberResult> => {

--- a/packages/breadboard/tests/inspector/describe.ts
+++ b/packages/breadboard/tests/inspector/describe.ts
@@ -16,8 +16,8 @@ const load = async (url: string) => {
   const base = BASE_URL;
   const loader = createLoader();
   const result = await loader.load(url, { base });
-  if (!result) return undefined;
-  return inspectableGraph(result);
+  if (!result.success) return undefined;
+  return inspectableGraph(result.graph);
 };
 
 test("simple graph description works as expected", async (t) => {

--- a/packages/breadboard/tests/inspector/traversal.ts
+++ b/packages/breadboard/tests/inspector/traversal.ts
@@ -16,8 +16,8 @@ const load = async (url: string) => {
   const base = BASE_URL;
   const loader = createLoader();
   const result = await loader.load(url, { base });
-  if (!result) return undefined;
-  return inspectableGraph(result);
+  if (!result.success) return undefined;
+  return inspectableGraph(result.graph);
 };
 
 test("inspector API can traverse simplest.json", async (t) => {

--- a/packages/breadboard/tests/kits.ts
+++ b/packages/breadboard/tests/kits.ts
@@ -44,7 +44,7 @@ test("KitBuilder can call a function that returns a string", async (t) => {
   echoNode.wire("result->an_output", board.output());
 
   const output = await invokeGraph(
-    board,
+    { graph: board },
     {
       an_input: "hello world",
     },
@@ -78,7 +78,7 @@ test("KitBuilder can call a function that returns an object", async (t) => {
   echoNode.wire("out->an_output", board.output());
 
   const output = await invokeGraph(
-    board,
+    { graph: board },
     {
       an_input: "hello world",
     },
@@ -115,7 +115,7 @@ test("KitBuilder can call a function that has more than one input", async (t) =>
   addNode.wire("result->", board.output());
 
   const output = await invokeGraph(
-    board,
+    { graph: board },
     {
       a: 1,
       b: 2,
@@ -157,7 +157,7 @@ test("KitBuilder can call a function from an external import", async (t) => {
   validateNode.wire("errors->", board.output());
 
   const output = await invokeGraph(
-    board,
+    { graph: board },
     {
       a: { hello: "world" },
       b: { type: "object" },
@@ -230,7 +230,7 @@ test("KitBuilder can call platform functions that contain 0 arguments", async (t
   // result because it's just a string from a dynamic function
   random.wire("result->", board.output());
 
-  const output = await invokeGraph(board, {}, { kits: [myKit] });
+  const output = await invokeGraph({ graph: board }, {}, { kits: [myKit] });
 
   // We really need to pick a library with more than one function.
   t.true(typeof output["result"] === "number");
@@ -255,7 +255,7 @@ test("KitBuilder can call platform functions that accept a splat", async (t) => 
   input.wire("___args->", min.wire("result->", board.output()));
 
   const output = await invokeGraph(
-    board,
+    { graph: board },
     {
       ___args: [1, 2, 3, 4, 5],
     },

--- a/packages/breadboard/tests/new/grammar/serialize-and-run-with-old-runner.ts
+++ b/packages/breadboard/tests/new/grammar/serialize-and-run-with-old-runner.ts
@@ -22,7 +22,9 @@ async function serializeAndRunGraph(
   inputs: InputValues
 ): Promise<OutputValues> {
   const board = await graph.serialize();
-  return invokeGraph(board, inputs, { kits: [asRuntimeKit(TestKit)] });
+  return invokeGraph({ graph: board }, inputs, {
+    kits: [asRuntimeKit(TestKit)],
+  });
 }
 
 test("simplest graph", async (t) => {

--- a/packages/breadboard/tests/node/scripted-run.ts
+++ b/packages/breadboard/tests/node/scripted-run.ts
@@ -55,7 +55,7 @@ export async function interruptibleScriptedRun(
     };
     let outputCount = 0;
     let interrupted = false;
-    for await (const result of runGraph(graph, args)) {
+    for await (const result of runGraph({ graph }, args)) {
       const { type } = result;
       const expectedRunResult = scriptEntry;
       deepStrictEqual(

--- a/packages/breadboard/tests/node/test-kit.ts
+++ b/packages/breadboard/tests/node/test-kit.ts
@@ -21,7 +21,7 @@ export const testKit: Kit = {
           throw new Error("No board provided for the `invoke` handler");
         }
         const graph = await getGraphDescriptor($board, context);
-        if (!graph) {
+        if (!graph.success) {
           throw new Error(
             "Unable to get graph descriptor from the board in `invoke` handler"
           );
@@ -34,7 +34,7 @@ export const testKit: Kit = {
             }
           : { ...context };
 
-        return invokeGraph({ graph }, args, invocationContext);
+        return invokeGraph(graph, args, invocationContext);
       },
     },
     map: {
@@ -44,7 +44,7 @@ export const testKit: Kit = {
           throw new Error("No board provided for the `map` handler");
         }
         const graph = await getGraphDescriptor(board, context);
-        if (!graph) {
+        if (!graph.success) {
           throw new Error(
             "Unable to get graph descriptor from the board in `map` handler"
           );
@@ -70,7 +70,7 @@ export const testKit: Kit = {
               invocationPath: [...(context?.invocationPath || []), index],
             };
             const outputs = await invokeGraph(
-              { graph },
+              graph,
               { item, index, list },
               newContext
             );
@@ -86,7 +86,7 @@ export const testKit: Kit = {
                 invocationPath: [...(context?.invocationPath || []), index],
               };
               const outputs = await invokeGraph(
-                { graph },
+                graph,
                 { item, index, list },
                 newContext
               );

--- a/packages/breadboard/tests/node/test-kit.ts
+++ b/packages/breadboard/tests/node/test-kit.ts
@@ -34,7 +34,7 @@ export const testKit: Kit = {
             }
           : { ...context };
 
-        return invokeGraph(graph, args, invocationContext);
+        return invokeGraph({ graph }, args, invocationContext);
       },
     },
     map: {
@@ -70,7 +70,7 @@ export const testKit: Kit = {
               invocationPath: [...(context?.invocationPath || []), index],
             };
             const outputs = await invokeGraph(
-              graph,
+              { graph },
               { item, index, list },
               newContext
             );
@@ -86,7 +86,7 @@ export const testKit: Kit = {
                 invocationPath: [...(context?.invocationPath || []), index],
               };
               const outputs = await invokeGraph(
-                graph,
+                { graph },
                 { item, index, list },
                 newContext
               );

--- a/packages/breadboard/tests/node/utils/handler.ts
+++ b/packages/breadboard/tests/node/utils/handler.ts
@@ -23,9 +23,12 @@ describe("getGraphHandler", () => {
         async load(url: string) {
           ok(url === "https://example.com/1");
           return {
-            nodes: {},
-            edges: {},
-          } as GraphDescriptor;
+            success: true,
+            graph: {
+              nodes: {},
+              edges: {},
+            } as GraphDescriptor,
+          };
         },
       },
     });
@@ -38,7 +41,7 @@ describe("getGraphHandler", () => {
       loader: {
         async load(url: string) {
           ok(url === "https://example.com/2");
-          return simple as GraphDescriptor;
+          return { success: true, graph: simple as GraphDescriptor };
         },
       },
     });
@@ -54,7 +57,7 @@ describe("getGraphHandler", () => {
       loader: {
         async load(url: string) {
           ok(url === "https://example.com/3");
-          return simple as GraphDescriptor;
+          return { success: true, graph: simple as GraphDescriptor };
         },
       },
     });

--- a/packages/breadboard/tests/remote/proxy.ts
+++ b/packages/breadboard/tests/remote/proxy.ts
@@ -85,7 +85,11 @@ test("ProxyClient creates functional proxy kits", async (t) => {
     .input({ hello: "world" })
     .wire("*", kit.reverser().wire("*", board.output()));
   const kits = [client.createProxyKit(["reverser"]), kit];
-  const outputs = await invokeGraph(board, { hello: "world" }, { kits });
+  const outputs = await invokeGraph(
+    { graph: board },
+    { hello: "world" },
+    { kits }
+  );
   t.deepEqual(outputs, { hello: "dlorw" });
 });
 
@@ -114,7 +118,11 @@ test("ProxyServer can be configured to tunnel nodes", async (t) => {
         kit.test().wire("*", kit.reverser().wire("*", board.output()))
       );
     const kits = [client.createProxyKit(["test", "reverser"]), kit];
-    const outputs = await invokeGraph(board, { hello: "world" }, { kits });
+    const outputs = await invokeGraph(
+      { graph: board },
+      { hello: "world" },
+      { kits }
+    );
     t.deepEqual(outputs, { hello: "dlrow" });
   }
   {
@@ -154,7 +162,11 @@ test("ProxyServer can be configured to tunnel nodes", async (t) => {
         kit.test().wire("*", kit.reverser().wire("*", board.output()))
       );
     const kits = [client.createProxyKit(["test", "reverser"]), kit];
-    const outputs = await invokeGraph(board, { hello: "world" }, { kits });
+    const outputs = await invokeGraph(
+      { graph: board },
+      { hello: "world" },
+      { kits }
+    );
     t.deepEqual(outputs, { hello: "DEKCOLB_EULAV" });
   }
 });
@@ -178,7 +190,11 @@ test("ProxyServer and ProxyClient correctly handle streams", async (t) => {
       .input({ hello: "world" })
       .wire("*", kit.streamer().wire("*", board.output()));
     const kits = [client.createProxyKit(["streamer"]), kit];
-    const outputs = await invokeGraph(board, { hello: "world" }, { kits });
+    const outputs = await invokeGraph(
+      { graph: board },
+      { hello: "world" },
+      { kits }
+    );
     t.like(outputs, { stream: { kind: "stream" } });
     const stream = (outputs.stream as StreamCapability<string>).stream;
     const reader = stream.getReader();
@@ -211,7 +227,11 @@ test("ProxyServer and ProxyClient correctly handle streams", async (t) => {
       .input({ hello: "world" })
       .wire("*", kit.streamer().wire("*", board.output()));
     const kits = [client.createProxyKit(["streamer"]), kit];
-    const outputs = await invokeGraph(board, { hello: "world" }, { kits });
+    const outputs = await invokeGraph(
+      { graph: board },
+      { hello: "world" },
+      { kits }
+    );
     t.like(outputs, { stream: { kind: "stream" } });
     const stream = (outputs.stream as StreamCapability<string>).stream;
     const reader = stream.getReader();

--- a/packages/breadboard/tests/remote/worker.ts
+++ b/packages/breadboard/tests/remote/worker.ts
@@ -38,7 +38,11 @@ test("Worker transports can handle ProxyServer and ProxyClient", async (t) => {
     .input({ hello: "world" })
     .wire("*", kit.reverser().wire("*", board.output()));
   const kits = [client.createProxyKit(["reverser"]), kit];
-  const outputs = await invokeGraph(board, { hello: "world" }, { kits });
+  const outputs = await invokeGraph(
+    { graph: board },
+    { hello: "world" },
+    { kits }
+  );
   t.deepEqual(outputs, { hello: "dlorw" });
 });
 
@@ -76,7 +80,11 @@ test("Worker transports can handle proxy tunnels", async (t) => {
         kit.test().wire("*", kit.reverser().wire("*", board.output()))
       );
     const kits = [client.createProxyKit(["test", "reverser"]), kit];
-    const outputs = await invokeGraph(board, { hello: "world" }, { kits });
+    const outputs = await invokeGraph(
+      { graph: board },
+      { hello: "world" },
+      { kits }
+    );
     t.deepEqual(outputs, { hello: "dlrow" });
   }
   {
@@ -116,7 +124,11 @@ test("Worker transports can handle proxy tunnels", async (t) => {
         kit.test().wire("*", kit.reverser().wire("*", board.output()))
       );
     const kits = [client.createProxyKit(["test", "reverser"]), kit];
-    const outputs = await invokeGraph(board, { hello: "world" }, { kits });
+    const outputs = await invokeGraph(
+      { graph: board },
+      { hello: "world" },
+      { kits }
+    );
     t.deepEqual(outputs, { hello: "DEKCOLB_EULAV" });
   }
 });

--- a/packages/breadboard/tests/run.ts
+++ b/packages/breadboard/tests/run.ts
@@ -51,7 +51,7 @@ test("correctly saves and loads", async (t) => {
   input.wire("<-", kit.noop());
   input.wire("*->", kit.noop().wire("*->", board.output().wire("*->", input)));
   {
-    for await (const stop of runGraph(board, { kits: [kit] })) {
+    for await (const stop of runGraph({ graph: board }, { kits: [kit] })) {
       t.is(stop.type, "input");
       runResult = stop.save();
       break;
@@ -59,7 +59,7 @@ test("correctly saves and loads", async (t) => {
   }
   {
     for await (const stop of runGraph(
-      board,
+      { graph: board },
       { kits: [kit] },
       RunResult.load(runResult)?.state
     )) {
@@ -70,7 +70,7 @@ test("correctly saves and loads", async (t) => {
   }
   {
     for await (const stop of runGraph(
-      board,
+      { graph: board },
       { kits: [kit] },
       RunResult.load(runResult)?.state
     )) {
@@ -88,7 +88,7 @@ test("correctly detects exit node", async (t) => {
   const input = board.input();
   input.wire("*->", kit.noop().wire("*->", board.output()));
 
-  const generator = runGraph(board, { kits: [kit] });
+  const generator = runGraph({ graph: board }, { kits: [kit] });
 
   {
     const stop = await generator.next();

--- a/packages/build-code/src/test/generate_test.ts
+++ b/packages/build-code/src/test/generate_test.ts
@@ -154,11 +154,19 @@ var run = ({ str }) => {
   test("is executable", async () => {
     const bgl = serialize(myBoard);
 
-    const result1 = await invokeGraph(bgl, { str: "foo" }, { kits: [coreKit] });
+    const result1 = await invokeGraph(
+      { graph: bgl },
+      { str: "foo" },
+      { kits: [coreKit] }
+    );
     assert.equal(result1.$error, undefined);
     assert.equal(result1.isFoo, true);
 
-    const result2 = await invokeGraph(bgl, { str: "bar" }, { kits: [coreKit] });
+    const result2 = await invokeGraph(
+      { graph: bgl },
+      { str: "bar" },
+      { kits: [coreKit] }
+    );
     assert.equal(result2.$error, undefined);
     assert.equal(result2.isFoo, false);
   });

--- a/packages/build/src/internal/kit.ts
+++ b/packages/build/src/internal/kit.ts
@@ -112,7 +112,7 @@ function makeBoardComponentHandler(
     },
     describe: board.describe.bind(board),
     async invoke(inputs: InputValues, context: NodeHandlerContext) {
-      return invokeGraph({ ...serialized, url }, inputs, context);
+      return invokeGraph({ graph: { ...serialized, url } }, inputs, context);
     },
   };
 }
@@ -130,7 +130,7 @@ async function makeGraphDescriptorComponentHandler(
     },
     describe: () => Promise.resolve(description),
     async invoke(inputs: InputValues, context: NodeHandlerContext) {
-      return invokeGraph(descriptor, inputs, context);
+      return invokeGraph({ graph: descriptor }, inputs, context);
     },
   };
 }

--- a/packages/core-kit/src/nodes/curry.ts
+++ b/packages/core-kit/src/nodes/curry.ts
@@ -52,10 +52,10 @@ export default defineNodeType({
     } catch {
       // This is a describer, so it must always return some valid value.
     }
-    if (descriptor === undefined) {
+    if (!descriptor || !descriptor.success) {
       return { inputs: { "*": "unknown" } };
     }
-    const { inputSchema } = await inspect(descriptor).describe();
+    const { inputSchema } = await inspect(descriptor.graph).describe();
     return {
       inputs: unsafeSchema({
         ...inputSchema,

--- a/packages/core-kit/src/nodes/import.ts
+++ b/packages/core-kit/src/nodes/import.ts
@@ -11,6 +11,7 @@ import type {
   NodeHandlerContext,
   GraphDescriptor,
   OutputValues,
+  GraphLoaderResult,
 } from "@google-labs/breadboard";
 import { loadGraphFromPath } from "../utils.js";
 
@@ -57,12 +58,13 @@ export default {
   ): Promise<OutputValues> => {
     const { path, graph, ...args } = inputs as ImportNodeInputs;
 
-    const board = graph
-      ? graph
+    const result: GraphLoaderResult | undefined = graph
+      ? { success: true, graph }
       : path
         ? await loadGraphFromPath(path, context)
         : undefined;
-    if (!board) throw Error("No board provided");
+    if (!result?.success) throw Error("No board provided");
+    const board = result.graph;
     board.args = args;
 
     return { board: { kind: "board", board } as BreadboardCapability };

--- a/packages/core-kit/src/nodes/include.ts
+++ b/packages/core-kit/src/nodes/include.ts
@@ -11,6 +11,7 @@ import type {
   NodeHandlerContext,
   BreadboardCapability,
   GraphDescriptor,
+  GraphLoaderResult,
 } from "@google-labs/breadboard";
 import { getGraphDescriptor, invokeGraph } from "@google-labs/breadboard";
 import { SchemaBuilder } from "@google-labs/breadboard/kits";
@@ -77,16 +78,16 @@ export default {
     // TODO: Please fix the $ref/path mess.
     const source = path || $ref || "";
 
-    const runnableBoard = board
+    const runnableBoard: GraphLoaderResult = board
       ? await getGraphDescriptor(board, context)
       : graph
-        ? graph
+        ? { success: true, graph }
         : await loadGraphFromPath(source, context);
 
-    if (!runnableBoard) {
+    if (!runnableBoard.success) {
       throw new Error("Must provide valid board to include");
     }
 
-    return await invokeGraph({ graph: runnableBoard }, args, context);
+    return await invokeGraph(runnableBoard, args, context);
   },
 };

--- a/packages/core-kit/src/nodes/include.ts
+++ b/packages/core-kit/src/nodes/include.ts
@@ -87,6 +87,6 @@ export default {
       throw new Error("Must provide valid board to include");
     }
 
-    return await invokeGraph(runnableBoard, args, context);
+    return await invokeGraph({ graph: runnableBoard }, args, context);
   },
 };

--- a/packages/core-kit/src/nodes/invoke.ts
+++ b/packages/core-kit/src/nodes/invoke.ts
@@ -164,6 +164,6 @@ export default defineNodeType({
         }
       : { ...context, start, stopAfter };
 
-    return await invokeGraph(board, args, invocationContext);
+    return await invokeGraph({ graph: board }, args, invocationContext);
   },
 });

--- a/packages/core-kit/src/nodes/map.ts
+++ b/packages/core-kit/src/nodes/map.ts
@@ -61,7 +61,11 @@ const invokeGraphPerItem = async (
     base: base || context?.base,
     invocationPath: [...(context?.invocationPath || []), index],
   };
-  const outputs = await invokeGraph(graph, { item, index, list }, newContext);
+  const outputs = await invokeGraph(
+    { graph },
+    { item, index, list },
+    newContext
+  );
   // TODO(aomarks) Map functions have an "item" input, but not an "item"
   // output. Instead, all outputs become the map result. That's a bit
   // weird, since it means you can't e.g. map a string to a string; only a

--- a/packages/core-kit/src/nodes/map.ts
+++ b/packages/core-kit/src/nodes/map.ts
@@ -15,7 +15,7 @@ import type { Expand } from "@breadboard-ai/build/internal/common/type-util.js";
 import type { JsonSerializable } from "@breadboard-ai/build/internal/type-system/type.js";
 import {
   getGraphDescriptor,
-  GraphDescriptor,
+  GraphToRun,
   invokeGraph,
   NodeHandlerContext,
   OutputValues,
@@ -46,7 +46,7 @@ type ExtractOutputTypes<B extends BoardOutputPorts> = {
 };
 
 const invokeGraphPerItem = async (
-  graph: GraphDescriptor,
+  graph: GraphToRun,
   item: JsonSerializable,
   index: number,
   list: JsonSerializable,
@@ -61,11 +61,7 @@ const invokeGraphPerItem = async (
     base: base || context?.base,
     invocationPath: [...(context?.invocationPath || []), index],
   };
-  const outputs = await invokeGraph(
-    { graph },
-    { item, index, list },
-    newContext
-  );
+  const outputs = await invokeGraph(graph, { item, index, list }, newContext);
   // TODO(aomarks) Map functions have an "item" input, but not an "item"
   // output. Instead, all outputs become the map result. That's a bit
   // weird, since it means you can't e.g. map a string to a string; only a
@@ -127,7 +123,7 @@ const mapNode = defineNodeType({
       throw new Error(`Expected list to be an array, but got ${list}`);
     }
     const graph = await getGraphDescriptor(board, context);
-    if (!graph) return { list };
+    if (!graph.success) return { list };
     let result: OutputValues[];
     const runSerially = !!context.state;
     if (runSerially) {

--- a/packages/core-kit/src/nodes/reduce.ts
+++ b/packages/core-kit/src/nodes/reduce.ts
@@ -58,7 +58,7 @@ export default defineNodeType({
         invocationPath: [...(context?.invocationPath || []), index++],
       };
       const { accumulator } = await invokeGraph(
-        runnableBoard,
+        { graph: runnableBoard },
         { item, accumulator: result },
         newContext
       );

--- a/packages/core-kit/src/nodes/reduce.ts
+++ b/packages/core-kit/src/nodes/reduce.ts
@@ -49,7 +49,7 @@ export default defineNodeType({
       throw new Error(`Expected list to be an array, but got ${list}`);
     }
     const runnableBoard = await getRunner(board, context);
-    if (!runnableBoard) return { accumulator };
+    if (!runnableBoard.success) return { accumulator };
     let result = accumulator;
     let index = 0;
     for (const item of list) {
@@ -58,7 +58,7 @@ export default defineNodeType({
         invocationPath: [...(context?.invocationPath || []), index++],
       };
       const { accumulator } = await invokeGraph(
-        { graph: runnableBoard },
+        runnableBoard,
         { item, accumulator: result },
         newContext
       );

--- a/packages/core-kit/src/utils.ts
+++ b/packages/core-kit/src/utils.ts
@@ -15,9 +15,10 @@ export const loadGraphFromPath = async (
   path: string,
   context: NodeHandlerContext
 ) => {
-  const graph = await context.loader?.load(path, context);
-  if (!graph) throw new Error(`Unable to load graph from "${path}"`);
-  return graph;
+  const loaderResult = await context.loader?.load(path, context);
+  if (!loaderResult?.success)
+    throw new Error(`Unable to load graph from "${path}"`);
+  return loaderResult.graph;
 };
 
 type GetGraphDescriptorThrottler = Throttler<

--- a/packages/core-kit/tests/map.ts
+++ b/packages/core-kit/tests/map.ts
@@ -34,7 +34,7 @@ test("sending a real board to a map", async (t) => {
   input.wire("list->", map);
   map.wire("list->", board.output());
   const outputs = await invokeGraph(
-    board,
+    { graph: board },
     { list: [1, 2, 3] },
     {
       kits: [core],

--- a/packages/core-kit/tests/reduce.ts
+++ b/packages/core-kit/tests/reduce.ts
@@ -54,7 +54,7 @@ test("using reduce as part of a board", async (t) => {
   })();
 
   const result = await invokeGraph(
-    serialize(outerBoard),
+    { graph: serialize(outerBoard) },
     { value: 4 },
     { kits: [asRuntimeKit(Core)], loader: createLoader() }
   );

--- a/packages/node-nursery-web/src/nodes/transform-stream.ts
+++ b/packages/node-nursery-web/src/nodes/transform-stream.ts
@@ -40,7 +40,7 @@ const getTransformer = async (
     return {
       async transform(chunk, controller) {
         const inputs = { chunk };
-        const result = await invokeGraph(runnableBoard, inputs, {
+        const result = await invokeGraph({ graph: runnableBoard }, inputs, {
           ...context,
           // TODO: figure out how to send diagnostics from streams transformer.
           probe: undefined,

--- a/packages/node-nursery-web/src/nodes/transform-stream.ts
+++ b/packages/node-nursery-web/src/nodes/transform-stream.ts
@@ -32,7 +32,7 @@ const getTransformer = async (
       board as BreadboardCapability,
       context
     );
-    if (!runnableBoard) throw new Error("Invalid board");
+    if (!runnableBoard.success) throw new Error("Invalid board");
     // Because stream transformers run outside of the normal board lifecycle,
     // they will not have access to `probe` capabilities and thus will not
     // send diagnostics back.
@@ -40,7 +40,7 @@ const getTransformer = async (
     return {
       async transform(chunk, controller) {
         const inputs = { chunk };
-        const result = await invokeGraph({ graph: runnableBoard }, inputs, {
+        const result = await invokeGraph(runnableBoard, inputs, {
           ...context,
           // TODO: figure out how to send diagnostics from streams transformer.
           probe: undefined,

--- a/packages/visual-editor/src/runtime/board.ts
+++ b/packages/visual-editor/src/runtime/board.ts
@@ -446,9 +446,11 @@ export class Board extends EventTarget {
 
         if (boardServer && this.boardServers) {
           kits = (boardServer as BoardServer).kits ?? this.kits;
-          graph = await this.boardServers.loader.load(url, { base });
+          const loadResult = await this.boardServers.loader.load(url, { base });
+          graph = loadResult.success ? loadResult.graph : null;
         } else {
-          graph = await this.loader.load(url, { base });
+          const loadResult = await this.loader.load(url, { base });
+          graph = loadResult.success ? loadResult.graph : null;
         }
       }
 

--- a/packages/visual-editor/src/runtime/run.ts
+++ b/packages/visual-editor/src/runtime/run.ts
@@ -256,7 +256,7 @@ export class Run extends EventTarget {
       loader: loader,
       store: this.dataStore,
     };
-    const result = await invokeGraph(loadResult.graph, inputs, args);
+    const result = await invokeGraph(loadResult, inputs, args);
     return { success: true, result: result.config as NodeConfiguration };
   }
 }

--- a/packages/visual-editor/src/runtime/run.ts
+++ b/packages/visual-editor/src/runtime/run.ts
@@ -245,21 +245,18 @@ export class Run extends EventTarget {
     inputs: InputValues,
     settings: BreadboardUI.Types.SettingsStore | null
   ): Promise<Result<OutputValues>> {
-    const sideboard = await loader.load(url, {
+    const loadResult = await loader.load(url, {
       base: new URL(window.location.href),
     });
-    if (!sideboard) {
-      return {
-        success: false,
-        error: `Unable to load sidebard at "${url}`,
-      };
+    if (!loadResult.success) {
+      return loadResult;
     }
     const args: RunArguments = {
       kits: [sideboardSecretsKit(settings), ...kits],
       loader: loader,
       store: this.dataStore,
     };
-    const result = await invokeGraph(sideboard, inputs, args);
+    const result = await invokeGraph(loadResult.graph, inputs, args);
     return { success: true, result: result.config as NodeConfiguration };
   }
 }


### PR DESCRIPTION
- **Remove spurious logging and unused code.**
- **Update inspectable subgraphs on edit.**
- **Store parent on `InspectableGraph` to allow modules to run in subgraphs.**
- **Try plumbing outerGraph.**
- **Change `GraphLoader.load` to return `GraphLoaderResult`.**
- **Introduce `GraphToRun` and make `runGraph` take it instead of `GraphDescriptor`.**
- **Start passing `GraphLoaderResult` pretty much everywhere.**
- **Switch `GraphLoader` to return supergraph and subGraphId.**
- **Correctly resolve `outerGraph` in `NodeInvoker`.**
- **docs(changeset): Allow subgraphs to access modules**
