### PR TITLE
graph operations

### DIFF
--- a/.changeset/thin-eggs-whisper.md
+++ b/.changeset/thin-eggs-whisper.md
@@ -1,0 +1,7 @@
+---
+"@google-labs/breadboard": minor
+"@breadboard-ai/visual-editor": patch
+"@breadboard-ai/shared-ui": patch
+---
+
+Migrate to use `InspectableGraph.edit` for subgraph add/remove/replace.

--- a/packages/breadboard/src/editor/graph.ts
+++ b/packages/breadboard/src/editor/graph.ts
@@ -38,6 +38,7 @@ import {
   toDeclarativeGraph,
   toImperativeGraph,
 } from "../run/run-imperative-graph.js";
+import { AddGraph } from "./operations/add-graph.js";
 
 const validImperativeEdits: EditSpec["type"][] = [
   "addmodule",
@@ -58,6 +59,7 @@ const operations = new Map<EditSpec["type"], EditOperation>([
   ["addmodule", new AddModule()],
   ["removemodule", new RemoveModule()],
   ["changemodule", new ChangeModule()],
+  ["addgraph", new AddGraph()],
 ]);
 
 export class Graph implements EditableGraph {
@@ -377,7 +379,12 @@ export class Graph implements EditableGraph {
       editableToDelete.#makeIndependent();
     }
     this.#updateGraph(false, [], []);
-    return { success: true, affectedNodes: [], affectedModules: [] };
+    return {
+      success: true,
+      affectedNodes: [],
+      affectedModules: [],
+      affectedGraphs: [id],
+    };
   }
 
   replaceGraph(id: GraphIdentifier, graph: GraphDescriptor): boolean {

--- a/packages/breadboard/src/editor/graph.ts
+++ b/packages/breadboard/src/editor/graph.ts
@@ -84,7 +84,7 @@ export class Graph implements EditableGraph {
     }
     this.#parent = parent || null;
     if (parent) {
-      // Embedded subgraphs can not have subgraphs.
+      // Subgraphs can not have subgraphs.
       this.#graphs = null;
     } else {
       this.#graphs = Object.fromEntries(
@@ -195,7 +195,7 @@ export class Graph implements EditableGraph {
 
   version() {
     if (this.#parent) {
-      throw new Error("Embedded subgraphs can not be versioned.");
+      throw new Error("Subgraphs can not be versioned.");
     }
     return this.#version;
   }
@@ -304,14 +304,14 @@ export class Graph implements EditableGraph {
 
   getGraph(id: GraphIdentifier) {
     if (!this.#graphs) {
-      throw new Error("Embedded graphs can't contain subgraphs.");
+      throw new Error("Subgraphs can't contain subgraphs.");
     }
     return this.#graphs[id] || null;
   }
 
   addGraph(id: GraphIdentifier, graph: GraphDescriptor): EditableGraph | null {
     if (!this.#graphs) {
-      throw new Error("Embedded graphs can't contain subgraphs.");
+      throw new Error("Subgraphs can't contain subgraphs.");
     }
 
     if (this.#graphs[id]) {
@@ -327,7 +327,7 @@ export class Graph implements EditableGraph {
 
   removeGraph(id: GraphIdentifier): SingleEditResult {
     if (!this.#graphs) {
-      throw new Error("Embedded graphs can't contain subgraphs.");
+      throw new Error("Subgraphs can't contain subgraphs.");
     }
 
     if (!this.#graphs[id]) {
@@ -348,7 +348,7 @@ export class Graph implements EditableGraph {
     graph: GraphDescriptor
   ): EditableGraph | null {
     if (!this.#graphs) {
-      throw new Error("Embedded graphs can't contain subgraphs.");
+      throw new Error("Subgraphs can't contain subgraphs.");
     }
 
     const old = this.#graphs[id];

--- a/packages/breadboard/src/editor/graph.ts
+++ b/packages/breadboard/src/editor/graph.ts
@@ -337,7 +337,8 @@ export class Graph implements EditableGraph {
       throw new Error("Subgraphs can't contain subgraphs.");
     }
 
-    if (this.#graphs.get(id)) {
+    const subGraphs = this.#graph.graphs;
+    if (subGraphs?.[id]) {
       return false;
     }
 
@@ -367,6 +368,9 @@ export class Graph implements EditableGraph {
       };
     }
     delete subGraphs[id];
+    if (!Object.keys(subGraphs).length) {
+      delete this.#graph.graphs;
+    }
     const editableToDelete = this.#graphs.get(id);
     if (editableToDelete) {
       this.#graphs.delete(id);

--- a/packages/breadboard/src/editor/graph.ts
+++ b/packages/breadboard/src/editor/graph.ts
@@ -39,6 +39,7 @@ import {
   toImperativeGraph,
 } from "../run/run-imperative-graph.js";
 import { AddGraph } from "./operations/add-graph.js";
+import { RemoveGraph } from "./operations/remove-graph.js";
 
 const validImperativeEdits: EditSpec["type"][] = [
   "addmodule",
@@ -60,6 +61,7 @@ const operations = new Map<EditSpec["type"], EditOperation>([
   ["removemodule", new RemoveModule()],
   ["changemodule", new ChangeModule()],
   ["addgraph", new AddGraph()],
+  ["removegraph", new RemoveGraph()],
 ]);
 
 export class Graph implements EditableGraph {

--- a/packages/breadboard/src/editor/graph.ts
+++ b/packages/breadboard/src/editor/graph.ts
@@ -334,22 +334,6 @@ export class Graph implements EditableGraph {
     return editableGraph;
   }
 
-  addGraph(id: GraphIdentifier, graph: GraphDescriptor): boolean {
-    if (!this.#graphs) {
-      throw new Error("Subgraphs can't contain subgraphs.");
-    }
-
-    const subGraphs = this.#graph.graphs;
-    if (subGraphs?.[id]) {
-      return false;
-    }
-
-    this.#graph.graphs ??= {};
-    this.#graph.graphs[id] = graph;
-    this.#updateGraph(false, [], []);
-    return true;
-  }
-
   graphId() {
     return this.#graphId;
   }

--- a/packages/breadboard/src/editor/graph.ts
+++ b/packages/breadboard/src/editor/graph.ts
@@ -340,67 +340,6 @@ export class Graph implements EditableGraph {
     return this.#graphId;
   }
 
-  removeGraph(id: GraphIdentifier): SingleEditResult {
-    if (!this.#graphs) {
-      throw new Error("Subgraphs can't contain subgraphs.");
-    }
-
-    const subGraphs = this.#graph.graphs;
-
-    if (!subGraphs || !subGraphs[id]) {
-      const error = `Subgraph with id "${id}" does not exist`;
-      this.#dispatchNoChange(error);
-      return {
-        success: false,
-        error,
-      };
-    }
-    delete subGraphs[id];
-    if (!Object.keys(subGraphs).length) {
-      delete this.#graph.graphs;
-    }
-    const editableToDelete = this.#graphs.get(id);
-    if (editableToDelete) {
-      this.#graphs.delete(id);
-      editableToDelete.#makeIndependent();
-    }
-    this.#updateGraph(false, [], []);
-    return {
-      success: true,
-      affectedNodes: [],
-      affectedModules: [],
-      affectedGraphs: [id],
-    };
-  }
-
-  replaceGraph(id: GraphIdentifier, graph: GraphDescriptor): boolean {
-    if (!this.#graphs) {
-      throw new Error("Subgraphs can't contain subgraphs.");
-    }
-
-    const subGraphs = this.#graph.graphs;
-
-    if (!subGraphs) {
-      return false;
-    }
-
-    const old = subGraphs[id];
-    if (!old) {
-      return false;
-    } else {
-      const oldEditable = this.#graphs.get(id);
-      if (oldEditable) {
-        oldEditable.#makeIndependent();
-        this.#graphs.delete(id);
-      }
-    }
-    subGraphs[id] = graph;
-
-    this.#updateGraph(false, [], []);
-
-    return true;
-  }
-
   raw() {
     return this.#imperativeMain
       ? toImperativeGraph(this.#imperativeMain, this.#graph)

--- a/packages/breadboard/src/editor/index.ts
+++ b/packages/breadboard/src/editor/index.ts
@@ -12,7 +12,7 @@ export const editGraph = (
   graph: GraphDescriptor,
   options: EditableGraphOptions = {}
 ): EditableGraph => {
-  return new Graph(graph, options, null);
+  return new Graph(graph, options, "", null);
 };
 
 export { blank, blankLLMContent } from "./blank.js";

--- a/packages/breadboard/src/editor/operations/add-edge.ts
+++ b/packages/breadboard/src/editor/operations/add-edge.ts
@@ -85,6 +85,7 @@ export class AddEdge implements EditOperation {
       success: true,
       affectedNodes: [edge.from, edge.to],
       affectedModules: [],
+      affectedGraphs: [],
     };
   }
 
@@ -115,6 +116,7 @@ export class AddEdge implements EditOperation {
       success: true,
       affectedNodes: [edge.from, edge.to],
       affectedModules: [],
+      affectedGraphs: [],
     };
   }
 }

--- a/packages/breadboard/src/editor/operations/add-edge.ts
+++ b/packages/breadboard/src/editor/operations/add-edge.ts
@@ -103,10 +103,13 @@ export class AddEdge implements EditOperation {
     if (!can.success) {
       return can;
     }
+
+    const graphId = inspector.graphId();
+
     edge = fixUpStarEdge(edge);
     edge = fixupConstantEdge(edge);
     // TODO: Figure out how to make this work in multi-edit mode.
-    store.edgeStore.add(edge);
+    store.edgeStore.add(edge, graphId);
     graph.edges.push(edge);
     return {
       success: true,

--- a/packages/breadboard/src/editor/operations/add-graph.ts
+++ b/packages/breadboard/src/editor/operations/add-graph.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  EditOperation,
+  EditOperationContext,
+  EditSpec,
+  SingleEditResult,
+} from "../types.js";
+
+export { AddGraph };
+
+class AddGraph implements EditOperation {
+  do(edit: EditSpec, context: EditOperationContext): Promise<SingleEditResult> {
+    if (edit.type !== "addgraph") {
+      throw new Error(
+        `Editor API integrity error: expected type "addgraph", received "${edit.type}" instead.`
+      );
+    }
+    const { graph, inspector, store } = context;
+    // Check to see if a graph by this id already exists
+    // Check to see if this is a subgraph
+    throw new Error("not implemented");
+  }
+}

--- a/packages/breadboard/src/editor/operations/add-graph.ts
+++ b/packages/breadboard/src/editor/operations/add-graph.ts
@@ -14,15 +14,32 @@ import {
 export { AddGraph };
 
 class AddGraph implements EditOperation {
-  do(edit: EditSpec, context: EditOperationContext): Promise<SingleEditResult> {
+  async do(
+    edit: EditSpec,
+    context: EditOperationContext
+  ): Promise<SingleEditResult> {
     if (edit.type !== "addgraph") {
       throw new Error(
         `Editor API integrity error: expected type "addgraph", received "${edit.type}" instead.`
       );
     }
-    const { graph, inspector, store } = context;
-    // Check to see if a graph by this id already exists
-    // Check to see if this is a subgraph
-    throw new Error("not implemented");
+    const { id, graph: subgraph } = edit;
+    const { graph } = context;
+
+    if (graph.graphs?.[id]) {
+      return {
+        success: false,
+        error: `Failed to add graph: "${id}" already exists.`,
+      };
+    }
+    graph.graphs ??= {};
+    graph.graphs[id] = subgraph;
+
+    return {
+      success: true,
+      affectedModules: [],
+      affectedNodes: [],
+      affectedGraphs: [id],
+    };
   }
 }

--- a/packages/breadboard/src/editor/operations/add-module.ts
+++ b/packages/breadboard/src/editor/operations/add-module.ts
@@ -25,7 +25,12 @@ export class AddModule implements EditOperation {
         error: `Unable to add module: module with id "${id}" already exists`,
       };
     }
-    return { success: true, affectedNodes: [], affectedModules: [id] };
+    return {
+      success: true,
+      affectedNodes: [],
+      affectedModules: [id],
+      affectedGraphs: [],
+    };
   }
 
   async do(
@@ -47,6 +52,11 @@ export class AddModule implements EditOperation {
     graph.modules ??= {};
     graph.modules[id] = module;
 
-    return { success: true, affectedNodes: [], affectedModules: [id] };
+    return {
+      success: true,
+      affectedNodes: [],
+      affectedModules: [id],
+      affectedGraphs: [],
+    };
   }
 }

--- a/packages/breadboard/src/editor/operations/add-node.ts
+++ b/packages/breadboard/src/editor/operations/add-node.ts
@@ -48,13 +48,14 @@ export class AddNode implements EditOperation {
     }
     const node = spec.node;
     const { graph, inspector, store } = context;
+    const graphId = inspector.graphId();
     const can = await this.can(node, inspector);
     if (!can.success) {
       return can;
     }
 
     graph.nodes.push(node);
-    store.nodeStore.add(node, "");
+    store.nodeStore.add(node, graphId);
     return { success: true, affectedNodes: [node.id], affectedModules: [] };
   }
 }

--- a/packages/breadboard/src/editor/operations/add-node.ts
+++ b/packages/breadboard/src/editor/operations/add-node.ts
@@ -54,7 +54,7 @@ export class AddNode implements EditOperation {
     }
 
     graph.nodes.push(node);
-    store.nodeStore.add(node);
+    store.nodeStore.add(node, "");
     return { success: true, affectedNodes: [node.id], affectedModules: [] };
   }
 }

--- a/packages/breadboard/src/editor/operations/add-node.ts
+++ b/packages/breadboard/src/editor/operations/add-node.ts
@@ -34,7 +34,12 @@ export class AddNode implements EditOperation {
       };
     }
 
-    return { success: true, affectedNodes: [], affectedModules: [] };
+    return {
+      success: true,
+      affectedNodes: [],
+      affectedModules: [],
+      affectedGraphs: [],
+    };
   }
 
   async do(
@@ -56,6 +61,11 @@ export class AddNode implements EditOperation {
 
     graph.nodes.push(node);
     store.nodeStore.add(node, graphId);
-    return { success: true, affectedNodes: [node.id], affectedModules: [] };
+    return {
+      success: true,
+      affectedNodes: [node.id],
+      affectedModules: [],
+      affectedGraphs: [],
+    };
   }
 }

--- a/packages/breadboard/src/editor/operations/change-configuration.ts
+++ b/packages/breadboard/src/editor/operations/change-configuration.ts
@@ -25,7 +25,12 @@ export class ChangeConfiguration implements EditOperation {
         error: `Unable to update configuration: node with id "${id}" does not exist`,
       };
     }
-    return { success: true, affectedNodes: [], affectedModules: [] };
+    return {
+      success: true,
+      affectedNodes: [],
+      affectedModules: [],
+      affectedGraphs: [],
+    };
   }
 
   async do(
@@ -60,6 +65,11 @@ export class ChangeConfiguration implements EditOperation {
         };
       }
     }
-    return { success: true, affectedNodes: [id], affectedModules: [] };
+    return {
+      success: true,
+      affectedNodes: [id],
+      affectedModules: [],
+      affectedGraphs: [],
+    };
   }
 }

--- a/packages/breadboard/src/editor/operations/change-edge.ts
+++ b/packages/breadboard/src/editor/operations/change-edge.ts
@@ -24,7 +24,12 @@ export class ChangeEdge implements EditOperation {
     inspector: InspectableGraph
   ): Promise<SingleEditResult> {
     if (edgesEqual(from, to)) {
-      return { success: true, affectedNodes: [], affectedModules: [] };
+      return {
+        success: true,
+        affectedNodes: [],
+        affectedModules: [],
+        affectedGraphs: [],
+      };
     }
     const canRemoveOp = new RemoveEdge();
     const canRemove = await canRemoveOp.can(from, inspector);
@@ -32,7 +37,12 @@ export class ChangeEdge implements EditOperation {
     const canAddOp = new AddEdge();
     const canAdd = await canAddOp.can(to, inspector);
     if (!canAdd.success) return canAdd;
-    return { success: true, affectedNodes: [], affectedModules: [] };
+    return {
+      success: true,
+      affectedNodes: [],
+      affectedModules: [],
+      affectedGraphs: [],
+    };
   }
 
   async do(
@@ -58,6 +68,7 @@ export class ChangeEdge implements EditOperation {
         noChange: true,
         affectedNodes: [],
         affectedModules: [],
+        affectedGraphs: [],
       };
     }
     const fixedUpEdge = fixUpStarEdge(from);
@@ -75,6 +86,7 @@ export class ChangeEdge implements EditOperation {
       success: true,
       affectedNodes: [edge.from, edge.to],
       affectedModules: [],
+      affectedGraphs: [],
     };
   }
 }

--- a/packages/breadboard/src/editor/operations/change-graph-metadata.ts
+++ b/packages/breadboard/src/editor/operations/change-graph-metadata.ts
@@ -30,6 +30,7 @@ export class ChangeGraphMetadata implements EditOperation {
       visualOnly,
       affectedNodes: [],
       affectedModules: [],
+      affectedGraphs: [],
     };
   }
 }

--- a/packages/breadboard/src/editor/operations/change-metadata.ts
+++ b/packages/breadboard/src/editor/operations/change-metadata.ts
@@ -25,7 +25,12 @@ export class ChangeMetadata implements EditOperation {
         error: `Unable to change metadata: node with id "${id}" does not exist`,
       };
     }
-    return { success: true, affectedNodes: [], affectedModules: [] };
+    return {
+      success: true,
+      affectedNodes: [],
+      affectedModules: [],
+      affectedGraphs: [],
+    };
   }
 
   #isVisualOnly(incoming: NodeMetadata, existing: NodeMetadata): boolean {
@@ -68,6 +73,12 @@ export class ChangeMetadata implements EditOperation {
       };
     }
     const affectedNodes = visualOnly ? [] : [id];
-    return { success: true, visualOnly, affectedNodes, affectedModules: [] };
+    return {
+      success: true,
+      visualOnly,
+      affectedNodes,
+      affectedModules: [],
+      affectedGraphs: [],
+    };
   }
 }

--- a/packages/breadboard/src/editor/operations/change-module.ts
+++ b/packages/breadboard/src/editor/operations/change-module.ts
@@ -25,7 +25,12 @@ export class ChangeModule implements EditOperation {
         error: `Unable to update module: module with id "${id}" does not exist`,
       };
     }
-    return { success: true, affectedNodes: [], affectedModules: [id] };
+    return {
+      success: true,
+      affectedNodes: [],
+      affectedModules: [id],
+      affectedGraphs: [],
+    };
   }
 
   async do(
@@ -50,6 +55,7 @@ export class ChangeModule implements EditOperation {
       success: true,
       affectedNodes: [],
       affectedModules: [spec.id],
+      affectedGraphs: [],
       visualOnly: false,
     };
   }

--- a/packages/breadboard/src/editor/operations/remove-edge.ts
+++ b/packages/breadboard/src/editor/operations/remove-edge.ts
@@ -30,6 +30,7 @@ export class RemoveEdge implements EditOperation {
       success: true,
       affectedNodes: [spec.from, spec.to],
       affectedModules: [],
+      affectedGraphs: [],
     };
   }
 
@@ -58,6 +59,7 @@ export class RemoveEdge implements EditOperation {
       success: true,
       affectedNodes: [edge.from, edge.to],
       affectedModules: [],
+      affectedGraphs: [],
     };
   }
 }

--- a/packages/breadboard/src/editor/operations/remove-edge.ts
+++ b/packages/breadboard/src/editor/operations/remove-edge.ts
@@ -48,11 +48,12 @@ export class RemoveEdge implements EditOperation {
     if (!can.success) {
       return can;
     }
+    const graphId = inspector.graphId();
     edge = fixUpStarEdge(edge);
     const edges = graph.edges;
     const index = findEdgeIndex(graph, edge);
     const foundEdge = edges.splice(index, 1)[0];
-    store.edgeStore.remove(foundEdge);
+    store.edgeStore.remove(foundEdge, graphId);
     return {
       success: true,
       affectedNodes: [edge.from, edge.to],

--- a/packages/breadboard/src/editor/operations/remove-graph.ts
+++ b/packages/breadboard/src/editor/operations/remove-graph.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  EditOperation,
+  EditOperationContext,
+  EditSpec,
+  SingleEditResult,
+} from "../types.js";
+
+export { RemoveGraph };
+
+class RemoveGraph implements EditOperation {
+  async do(
+    edit: EditSpec,
+    context: EditOperationContext
+  ): Promise<SingleEditResult> {
+    if (edit.type !== "removegraph") {
+      throw new Error(
+        `Editor API integrity error: expected type "removegraph", received "${edit.type}" instead.`
+      );
+    }
+    const { id } = edit;
+    const { graph } = context;
+
+    if (!graph.graphs || !graph.graphs?.[id]) {
+      return {
+        success: false,
+        error: `Failed to remove graph: "${id}" does not exist.`,
+      };
+    }
+    delete graph.graphs[id];
+    if (!Object.keys(graph.graphs).length) {
+      delete graph.graphs;
+    }
+
+    return {
+      success: true,
+      affectedModules: [],
+      affectedNodes: [],
+      affectedGraphs: [id],
+    };
+  }
+}

--- a/packages/breadboard/src/editor/operations/remove-module.ts
+++ b/packages/breadboard/src/editor/operations/remove-module.ts
@@ -28,6 +28,7 @@ export class RemoveModule implements EditOperation {
       success: true,
       affectedNodes: [],
       affectedModules: [id],
+      affectedGraphs: [],
     };
   }
 
@@ -60,6 +61,7 @@ export class RemoveModule implements EditOperation {
       success: true,
       affectedNodes: [],
       affectedModules: [id],
+      affectedGraphs: [],
     };
   }
 }

--- a/packages/breadboard/src/editor/operations/remove-node.ts
+++ b/packages/breadboard/src/editor/operations/remove-node.ts
@@ -25,7 +25,12 @@ export class RemoveNode implements EditOperation {
         error: `Unable to remove node: node with id "${id}" does not exist`,
       };
     }
-    return { success: true, affectedNodes: [id], affectedModules: [] };
+    return {
+      success: true,
+      affectedNodes: [id],
+      affectedModules: [],
+      affectedGraphs: [],
+    };
   }
 
   async do(
@@ -57,6 +62,11 @@ export class RemoveNode implements EditOperation {
     // Remove the node from the graph.
     graph.nodes = graph.nodes.filter((node) => node.id != id);
     store.nodeStore.remove(id, graphId);
-    return { success: true, affectedNodes: [id], affectedModules: [] };
+    return {
+      success: true,
+      affectedNodes: [id],
+      affectedModules: [],
+      affectedGraphs: [],
+    };
   }
 }

--- a/packages/breadboard/src/editor/operations/remove-node.ts
+++ b/packages/breadboard/src/editor/operations/remove-node.ts
@@ -44,17 +44,19 @@ export class RemoveNode implements EditOperation {
       return can;
     }
 
+    const graphId = inspector.graphId();
+
     // Remove any edges that are connected to the removed node.
     graph.edges = graph.edges.filter((edge) => {
       const shouldRemove = edge.from === id || edge.to === id;
       if (shouldRemove) {
-        store.edgeStore.remove(edge);
+        store.edgeStore.remove(edge, graphId);
       }
       return !shouldRemove;
     });
     // Remove the node from the graph.
     graph.nodes = graph.nodes.filter((node) => node.id != id);
-    store.nodeStore.remove(id);
+    store.nodeStore.remove(id, graphId);
     return { success: true, affectedNodes: [id], affectedModules: [] };
   }
 }

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -220,15 +220,6 @@ export type EditableGraph = {
    */
   getGraph(id: GraphIdentifier): EditableGraph | null;
   /**
-   * If does not exist already, adds a subgraph with the specified id.
-   * Fails (returns null) if the subgraph with this id already exists.
-   * @param id - id of the new subgraph
-   * @param graph - the subgraph to add
-   * @returns - `true` if operation succeeded, `false` otherwise.
-   * @throws when used on an embedded subgraph.
-   */
-  addGraph(id: GraphIdentifier, graph: GraphDescriptor): boolean;
-  /**
    * Replaces the subgraph with the specified id. Fails (returns null)
    * if the subgraph with this id does not already exist.
    * @param id - id of the subgraph being replaced

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -224,22 +224,19 @@ export type EditableGraph = {
    * Fails (returns null) if the subgraph with this id already exists.
    * @param id - id of the new subgraph
    * @param graph - the subgraph to add
-   * @returns - the `EditableGraph` instance of the subgraph
+   * @returns - `true` if operation succeeded, `false` otherwise.
    * @throws when used on an embedded subgraph.
    */
-  addGraph(id: GraphIdentifier, graph: GraphDescriptor): EditableGraph | null;
+  addGraph(id: GraphIdentifier, graph: GraphDescriptor): boolean;
   /**
    * Replaces the subgraph with the specified id. Fails (returns null)
    * if the subgraph with this id does not already exist.
    * @param id - id of the subgraph being replaced
    * @param graph - the subgraph with which to replace the existing subgraph
-   * @returns - the `EditableGraph` instance of the newly replaced subgraph.
+   * @returns - `true` if operation succeeded, `false` otherwise.
    * @throws when used on an embedded subgraph.
    */
-  replaceGraph(
-    id: GraphIdentifier,
-    graph: GraphDescriptor
-  ): EditableGraph | null;
+  replaceGraph(id: GraphIdentifier, graph: GraphDescriptor): boolean;
   /**
    * Removes the subgraph with the specified id. Fails if the subgraph does not
    * exist.

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -172,7 +172,8 @@ export type EditSpec =
   | ChangeMetadataSpec
   | ChangeGraphMetadataSpec
   | ChangeModuleSpec
-  | AddGraphSpec;
+  | AddGraphSpec
+  | RemoveGraphSpec;
 
 export type EditableGraph = {
   addEventListener<Key extends keyof EditableGraphEventMap>(

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -171,7 +171,8 @@ export type EditSpec =
   | ChangeConfigurationSpec
   | ChangeMetadataSpec
   | ChangeGraphMetadataSpec
-  | ChangeModuleSpec;
+  | ChangeModuleSpec
+  | AddGraphSpec;
 
 export type EditableGraph = {
   addEventListener<Key extends keyof EditableGraphEventMap>(

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -315,6 +315,7 @@ export type SingleEditResult =
       success: true;
       affectedNodes: NodeIdentifier[];
       affectedModules: ModuleIdentifier[];
+      affectedGraphs: GraphIdentifier[];
       /**
        * Indicates that the edit was successful, and
        * resulted in no change.

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -229,13 +229,6 @@ export type EditableGraph = {
    * @throws when used on an embedded subgraph.
    */
   replaceGraph(id: GraphIdentifier, graph: GraphDescriptor): boolean;
-  /**
-   * Removes the subgraph with the specified id. Fails if the subgraph does not
-   * exist.
-   * @param id - id of the subgraph to remove
-   * @throws when used on an embedded subgraph.
-   */
-  removeGraph(id: GraphIdentifier): SingleEditResult;
 
   raw(): GraphDescriptor;
 

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -220,15 +220,6 @@ export type EditableGraph = {
    * @throws when used on an embedded subgraph.
    */
   getGraph(id: GraphIdentifier): EditableGraph | null;
-  /**
-   * Replaces the subgraph with the specified id. Fails (returns null)
-   * if the subgraph with this id does not already exist.
-   * @param id - id of the subgraph being replaced
-   * @param graph - the subgraph with which to replace the existing subgraph
-   * @returns - `true` if operation succeeded, `false` otherwise.
-   * @throws when used on an embedded subgraph.
-   */
-  replaceGraph(id: GraphIdentifier, graph: GraphDescriptor): boolean;
 
   raw(): GraphDescriptor;
 

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -194,6 +194,12 @@ export type EditableGraph = {
   parent(): EditableGraph | null;
 
   /**
+   * Returns the id of this graph. If this is a main graph,
+   * the value will be "". Otherwise, it will be the id of this subgraph.
+   */
+  graphId(): GraphIdentifier;
+
+  /**
    * Performs an edit operation on the graph.
    * @param edits -- a list of changes to apply
    * @param label -- a user-friendly description of the edit, which also

--- a/packages/breadboard/src/inspector/edge.ts
+++ b/packages/breadboard/src/inspector/edge.ts
@@ -6,6 +6,7 @@
 
 import { Edge as EdgeDescriptor, GraphDescriptor } from "../types.js";
 import {
+  EdgeStoreMutator,
   InspectableEdge,
   InspectableEdgeType,
   InspectableNodeCache,
@@ -115,7 +116,7 @@ class Edge implements InspectableEdge {
   }
 }
 
-export class EdgeCache {
+export class EdgeCache implements EdgeStoreMutator {
   #nodes: InspectableNodeCache;
   #map: Map<EdgeDescriptor, InspectableEdge> = new Map();
 

--- a/packages/breadboard/src/inspector/edge.ts
+++ b/packages/breadboard/src/inspector/edge.ts
@@ -4,10 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Edge as EdgeDescriptor, GraphDescriptor } from "../types.js";
 import {
-  EdgeStoreMutator,
+  Edge as EdgeDescriptor,
+  GraphDescriptor,
+  GraphIdentifier,
+} from "../types.js";
+import {
   InspectableEdge,
+  InspectableEdgeCache,
   InspectableEdgeType,
   InspectableNodeCache,
   InspectablePort,
@@ -53,14 +57,20 @@ export const fixupConstantEdge = (edge: EdgeDescriptor): EdgeDescriptor => {
 class Edge implements InspectableEdge {
   #nodes: InspectableNodeCache;
   #edge: EdgeDescriptor;
+  #graphId: GraphIdentifier;
 
-  constructor(nodes: InspectableNodeCache, edge: EdgeDescriptor) {
+  constructor(
+    nodes: InspectableNodeCache,
+    edge: EdgeDescriptor,
+    graphId: GraphIdentifier
+  ) {
     this.#nodes = nodes;
     this.#edge = edge;
+    this.#graphId = graphId;
   }
 
   get from() {
-    const from = this.#nodes.get(this.#edge.from);
+    const from = this.#nodes.get(this.#edge.from, this.#graphId);
     console.assert(from, "From node not found when getting from.");
     return from!;
   }
@@ -70,7 +80,7 @@ class Edge implements InspectableEdge {
   }
 
   get to() {
-    const to = this.#nodes.get(this.#edge.to);
+    const to = this.#nodes.get(this.#edge.to, this.#graphId);
     console.assert(to, "To node not found when getting to.");
     return to!;
   }
@@ -116,9 +126,9 @@ class Edge implements InspectableEdge {
   }
 }
 
-export class EdgeCache implements EdgeStoreMutator {
+export class EdgeCache implements InspectableEdgeCache {
   #nodes: InspectableNodeCache;
-  #map: Map<EdgeDescriptor, InspectableEdge> = new Map();
+  #map: Map<GraphIdentifier, Map<EdgeDescriptor, InspectableEdge>> = new Map();
 
   constructor(nodes: InspectableNodeCache) {
     this.#nodes = nodes;
@@ -127,42 +137,63 @@ export class EdgeCache implements EdgeStoreMutator {
   populate(graph: GraphDescriptor) {
     // Initialize the edge map from the graph. This is only done once, and all
     // following updates are performed incrementally.
-    return (this.#map = new Map(
-      graph.edges.map((edge) => [edge, new Edge(this.#nodes, edge)])
-    ));
+    const mainGraphEdges = new Map(
+      graph.edges.map((edge) => [edge, new Edge(this.#nodes, edge, "")])
+    );
+    this.#map.set("", mainGraphEdges);
+    Object.entries(graph.graphs || {}).forEach(([graphId, graph]) => {
+      const subGraphEdges = new Map(
+        graph.edges.map((edge) => [edge, new Edge(this.#nodes, edge, graphId)])
+      );
+      this.#map.set(graphId, subGraphEdges);
+    });
   }
 
-  get(edge: EdgeDescriptor): InspectableEdge | undefined {
-    return this.#map.get(edge);
+  get(
+    edge: EdgeDescriptor,
+    graphId: GraphIdentifier
+  ): InspectableEdge | undefined {
+    return this.#map.get(graphId)?.get(edge);
   }
 
-  getOrCreate(edge: EdgeDescriptor): InspectableEdge {
-    let result = this.get(edge);
+  getOrCreate(edge: EdgeDescriptor, graphId: GraphIdentifier): InspectableEdge {
+    let result = this.get(edge, graphId);
     if (result) {
       return result;
     }
-    result = new Edge(this.#nodes, edge);
-    this.add(edge);
+    result = new Edge(this.#nodes, edge, graphId);
+    this.add(edge, graphId);
     return result;
   }
 
-  add(edge: EdgeDescriptor) {
-    console.assert(!this.#map.has(edge), "Edge already exists when adding.");
-    this.#map.set(edge, new Edge(this.#nodes, edge));
+  add(edge: EdgeDescriptor, graphId: GraphIdentifier) {
+    console.assert(
+      !this.#map.get(graphId)?.has(edge),
+      "Edge already exists when adding."
+    );
+    let graphEdges = this.#map.get(graphId);
+    if (!graphEdges) {
+      graphEdges = new Map();
+      this.#map.set(graphId, graphEdges);
+    }
+    graphEdges.set(edge, new Edge(this.#nodes, edge, graphId));
   }
 
-  remove(edge: EdgeDescriptor) {
-    console.assert(this.#map.has(edge), "Edge not found when removing.");
-    this.#map.delete(edge);
+  remove(edge: EdgeDescriptor, graphId: GraphIdentifier) {
+    console.assert(
+      this.#map.get(graphId)?.has(edge),
+      "Edge not found when removing."
+    );
+    this.#map.get(graphId)?.delete(edge);
   }
 
-  has(edge: EdgeDescriptor): boolean {
-    return this.#map.has(edge);
+  has(edge: EdgeDescriptor, graphId: GraphIdentifier): boolean {
+    return !!this.#map.get(graphId)?.has(edge);
   }
 
-  hasByValue(edge: EdgeDescriptor): boolean {
+  hasByValue(edge: EdgeDescriptor, graphId: GraphIdentifier): boolean {
     edge = unfixUpStarEdge(edge);
-    const edges = this.edges();
+    const edges = this.edges(graphId);
     return !!edges.find((e) => {
       return (
         e.from.descriptor.id === edge.from &&
@@ -173,7 +204,7 @@ export class EdgeCache implements EdgeStoreMutator {
     });
   }
 
-  edges(): InspectableEdge[] {
-    return Array.from(this.#map.values());
+  edges(graphId: GraphIdentifier): InspectableEdge[] {
+    return Array.from(this.#map.get(graphId)?.values() || []);
   }
 }

--- a/packages/breadboard/src/inspector/graph.ts
+++ b/packages/breadboard/src/inspector/graph.ts
@@ -574,6 +574,9 @@ class Graph implements InspectableGraphWithStore {
   }
 
   resetGraph(graph: GraphDescriptor): void {
+    if (this.#graphId) {
+      throw new Error("Handling subgraphs isn't yet implemented.");
+    }
     this.#graph = graph;
     const nodes = new NodeCache(this);
     const edges = new EdgeCache(nodes);

--- a/packages/breadboard/src/inspector/node.ts
+++ b/packages/breadboard/src/inspector/node.ts
@@ -172,7 +172,13 @@ export class NodeCache implements InspectableNodeCache {
     this.#typeMap ??= new Map();
     this.#map ??= new Map();
     const graphTypes = getOrCreate(this.#typeMap, graphId, () => new Map());
-    const inspectableNode = new Node(node, this.#graph);
+    const nodeGraph = graphId ? this.#graph.graphs()?.[graphId] : this.#graph;
+    if (!nodeGraph) {
+      throw new Error(
+        `Inspect API Integrity error: unable to find subgraph "${graphId}"`
+      );
+    }
+    const inspectableNode = new Node(node, nodeGraph);
     const type = node.type;
     let list = graphTypes.get(type);
     if (!list) {

--- a/packages/breadboard/src/inspector/node.ts
+++ b/packages/breadboard/src/inspector/node.ts
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GraphDescriptor, NodeMetadata } from "@breadboard-ai/types";
+import {
+  GraphDescriptor,
+  GraphIdentifier,
+  NodeMetadata,
+} from "@breadboard-ai/types";
 import {
   InputValues,
   NodeConfiguration,
@@ -20,10 +24,10 @@ import {
   InspectableEdge,
   InspectableGraph,
   InspectableNode,
+  InspectableNodeCache,
   InspectableNodePorts,
   InspectableNodeType,
   InspectablePortList,
-  NodeStoreMutator,
   NodeTypeDescriberOptions,
 } from "./types.js";
 
@@ -148,32 +152,45 @@ class Node implements InspectableNode {
   }
 }
 
-export class NodeCache implements NodeStoreMutator {
+export class NodeCache implements InspectableNodeCache {
   #graph: InspectableGraph;
-  #map?: Map<NodeIdentifier, InspectableNode>;
-  #typeMap?: Map<NodeTypeIdentifier, InspectableNode[]>;
+  #map?: Map<GraphIdentifier, Map<NodeIdentifier, InspectableNode>>;
+  #typeMap?: Map<GraphIdentifier, Map<NodeTypeIdentifier, InspectableNode[]>>;
 
   constructor(graph: InspectableGraph) {
     this.#graph = graph;
   }
 
   populate(graph: GraphDescriptor) {
-    graph.nodes.forEach((node) => this.#addNodeInternal(node));
+    graph.nodes.forEach((node) => this.#addNodeInternal(node, ""));
+    Object.entries(graph.graphs || {}).forEach(([graphId, graph]) => {
+      graph.nodes.forEach((node) => this.#addNodeInternal(node, graphId));
+    });
   }
 
-  #addNodeInternal(node: NodeDescriptor) {
+  #addNodeInternal(node: NodeDescriptor, graphId: GraphIdentifier) {
     this.#typeMap ??= new Map();
     this.#map ??= new Map();
+    const graphTypes = getOrCreate(this.#typeMap, graphId, () => new Map());
     const inspectableNode = new Node(node, this.#graph);
     const type = node.type;
-    let list = this.#typeMap.get(type);
+    let list = graphTypes.get(type);
     if (!list) {
       list = [];
-      this.#typeMap.set(type, list);
+      graphTypes.set(type, list);
     }
     list.push(inspectableNode);
-    this.#map.set(node.id, inspectableNode);
+    const graphNodes = getOrCreate(this.#map, graphId, () => new Map());
+    graphNodes.set(node.id, inspectableNode);
     return inspectableNode;
+
+    function getOrCreate<K, V>(map: Map<K, V>, key: K, factory: () => V): V {
+      let v = map.get(key);
+      if (v) return v;
+      v = factory();
+      map.set(key, v);
+      return v;
+    }
   }
 
   #ensureNodeMap() {
@@ -183,39 +200,52 @@ export class NodeCache implements NodeStoreMutator {
     return this.#map!;
   }
 
-  byType(type: NodeTypeIdentifier): InspectableNode[] {
+  byType(
+    type: NodeTypeIdentifier,
+    graphId: GraphIdentifier
+  ): InspectableNode[] {
     this.#ensureNodeMap();
-    return this.#typeMap?.get(type) || [];
+    return this.#typeMap?.get(graphId)?.get(type) || [];
   }
 
-  get(id: string): InspectableNode | undefined {
-    return this.#ensureNodeMap().get(id);
+  get(
+    id: NodeIdentifier,
+    graphId: GraphIdentifier
+  ): InspectableNode | undefined {
+    return this.#ensureNodeMap().get(graphId)?.get(id);
   }
 
-  add(node: NodeDescriptor) {
+  add(node: NodeDescriptor, graphId: GraphIdentifier) {
     if (!this.#map) {
       return;
     }
     console.assert(!this.#map.has(node.id), "Node already exists in cache.");
-    this.#addNodeInternal(node);
+    this.#addNodeInternal(node, graphId);
   }
 
-  remove(id: NodeIdentifier) {
+  remove(id: NodeIdentifier, graphId: GraphIdentifier) {
     if (!this.#map) {
       return;
     }
-    const node = this.#map.get(id);
+    const nodeMap = this.#map.get(graphId);
+    if (!nodeMap) {
+      console.error(
+        `Can't remove node "${id}": graph "${graphId}" was not found`
+      );
+      return;
+    }
+    const node = nodeMap.get(id);
     console.assert(node, "Node does not exist in cache.");
     const type = node!.descriptor.type;
-    const list = this.#typeMap?.get(type);
+    const list = this.#typeMap?.get(graphId)?.get(type);
     if (list) {
       const index = list.indexOf(node!);
       list.splice(index, 1);
     }
-    this.#map.delete(id);
+    nodeMap.delete(id);
   }
 
-  nodes(): InspectableNode[] {
-    return Array.from(this.#ensureNodeMap().values());
+  nodes(graphId: GraphIdentifier): InspectableNode[] {
+    return Array.from(this.#ensureNodeMap().get(graphId)?.values() || []);
   }
 }

--- a/packages/breadboard/src/inspector/node.ts
+++ b/packages/breadboard/src/inspector/node.ts
@@ -225,7 +225,6 @@ export class NodeCache implements InspectableNodeCache {
     if (!this.#map) {
       return;
     }
-    console.assert(!this.#map.has(node.id), "Node already exists in cache.");
     this.#addNodeInternal(node, graphId);
   }
 

--- a/packages/breadboard/src/inspector/node.ts
+++ b/packages/breadboard/src/inspector/node.ts
@@ -23,6 +23,7 @@ import {
   InspectableNodePorts,
   InspectableNodeType,
   InspectablePortList,
+  NodeStoreMutator,
   NodeTypeDescriberOptions,
 } from "./types.js";
 
@@ -147,7 +148,7 @@ class Node implements InspectableNode {
   }
 }
 
-export class NodeCache {
+export class NodeCache implements NodeStoreMutator {
   #graph: InspectableGraph;
   #map?: Map<NodeIdentifier, InspectableNode>;
   #typeMap?: Map<NodeTypeIdentifier, InspectableNode[]>;

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -557,9 +557,7 @@ export type InspectableModule = {
 export type InspectableModules = Record<ModuleIdentifier, InspectableModule>;
 
 /**
- * Represents a simple listener for edits to the graph.
- * An instance of this type is returned by the `editReceiver` method of
- * `InspectableGraph`.
+ * Represents a tracker for edits to the graph.
  */
 export type GraphStoreMutator = {
   // TODO: This is probably wrong. A new version of the graph should likely

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -288,9 +288,15 @@ export type InspectableGraph = {
    */
   describe(inputs?: InputValues): Promise<NodeDescriberResult>;
   /**
-   * Returns the subgraphs that are embedded in this graph.
+   * Returns the subgraphs that are embedded in this graph or `undefined` if
+   * this is already a subgraph
    */
-  graphs(): InspectableSubgraphs;
+  graphs(): InspectableSubgraphs | undefined;
+  /**
+   * Returns the id of this graph. If this is a main graph,
+   * the value will be "". Otherwise, it will be the id of this subgraph.
+   */
+  graphId(): GraphIdentifier;
   /**
    * Returns a module by name.
    */
@@ -576,32 +582,31 @@ export type GraphStoreMutator = {
 };
 
 export type NodeStoreMutator = {
-  add(node: NodeDescriptor): void;
-  remove(id: NodeIdentifier): void;
+  add(node: NodeDescriptor, graphId: GraphIdentifier): void;
+  remove(id: NodeIdentifier, graphId: GraphIdentifier): void;
 };
 
 export type EdgeStoreMutator = {
-  add(edge: Edge): void;
-  remove(edge: Edge): void;
+  add(edge: Edge, graphId: GraphIdentifier): void;
+  remove(edge: Edge, graphId: GraphIdentifier): void;
 };
 
 export type InspectableGraphWithStore = InspectableGraph & GraphStoreMutator;
 
-export type InspectableEdgeCache = {
-  get(edge: Edge): InspectableEdge | undefined;
-  getOrCreate(edge: Edge): InspectableEdge;
-  add(edge: Edge): void;
-  remove(edge: Edge): void;
-  hasByValue(edge: Edge): boolean;
-  edges(): InspectableEdge[];
+export type InspectableEdgeCache = EdgeStoreMutator & {
+  get(edge: Edge, graphId: GraphIdentifier): InspectableEdge | undefined;
+  getOrCreate(edge: Edge, graphId: GraphIdentifier): InspectableEdge;
+  hasByValue(edge: Edge, graphId: GraphIdentifier): boolean;
+  edges(graphId: GraphIdentifier): InspectableEdge[];
 };
 
-export type InspectableNodeCache = {
-  byType(type: NodeTypeIdentifier): InspectableNode[];
-  get(id: string): InspectableNode | undefined;
-  add(node: NodeDescriptor): void;
-  remove(id: NodeIdentifier): void;
-  nodes(): InspectableNode[];
+export type InspectableNodeCache = NodeStoreMutator & {
+  byType(type: NodeTypeIdentifier, graphId: GraphIdentifier): InspectableNode[];
+  get(
+    id: NodeIdentifier,
+    graphId: GraphIdentifier
+  ): InspectableNode | undefined;
+  nodes(graphId: GraphIdentifier): InspectableNode[];
 };
 
 export type InspectableModuleCache = {

--- a/packages/breadboard/tests/editor/graph.ts
+++ b/packages/breadboard/tests/editor/graph.ts
@@ -517,39 +517,3 @@ test("editor API correctly works with no subgraphs", (t) => {
   const raw = graph.raw();
   t.falsy(raw.graphs);
 });
-
-// TODO: Port this entirely to edit ops.
-// test("editor API correctly allows adding, removing, replacing subgraphs", (t) => {
-//   const graph = testEditGraph();
-//   const subgraph = testEditGraph().raw();
-
-//   t.true(graph.addGraph("foo", subgraph));
-
-//   t.truthy(graph.raw().graphs);
-
-//   t.is(graph.version(), 1);
-
-//   t.false(graph.addGraph("foo", subgraph));
-
-//   t.true(graph.removeGraph("foo").success);
-//   t.false(graph.removeGraph("foo").success);
-
-//   t.falsy(graph.raw().graphs);
-
-//   t.is(graph.version(), 2);
-
-//   t.false(graph.replaceGraph("foo", subgraph));
-
-//   t.is(graph.version(), 2);
-
-//   t.true(graph.addGraph("foo", subgraph));
-
-//   t.is(graph.version(), 3);
-
-//   t.true(graph.replaceGraph("foo", subgraph));
-
-//   t.is(graph.version(), 4);
-
-//   t.truthy(graph.raw().graphs);
-
-// });

--- a/packages/breadboard/tests/editor/graph.ts
+++ b/packages/breadboard/tests/editor/graph.ts
@@ -518,36 +518,38 @@ test("editor API correctly works with no subgraphs", (t) => {
   t.falsy(raw.graphs);
 });
 
-test("editor API correctly allows adding, removing, replacing subgraphs", (t) => {
-  const graph = testEditGraph();
-  const subgraph = testEditGraph().raw();
+// TODO: Port this entirely to edit ops.
+// test("editor API correctly allows adding, removing, replacing subgraphs", (t) => {
+//   const graph = testEditGraph();
+//   const subgraph = testEditGraph().raw();
 
-  t.true(graph.addGraph("foo", subgraph));
+//   t.true(graph.addGraph("foo", subgraph));
 
-  t.truthy(graph.raw().graphs);
+//   t.truthy(graph.raw().graphs);
 
-  t.is(graph.version(), 1);
+//   t.is(graph.version(), 1);
 
-  t.false(graph.addGraph("foo", subgraph));
+//   t.false(graph.addGraph("foo", subgraph));
 
-  t.true(graph.removeGraph("foo").success);
-  t.false(graph.removeGraph("foo").success);
+//   t.true(graph.removeGraph("foo").success);
+//   t.false(graph.removeGraph("foo").success);
 
-  t.falsy(graph.raw().graphs);
+//   t.falsy(graph.raw().graphs);
 
-  t.is(graph.version(), 2);
+//   t.is(graph.version(), 2);
 
-  t.false(graph.replaceGraph("foo", subgraph));
+//   t.false(graph.replaceGraph("foo", subgraph));
 
-  t.is(graph.version(), 2);
+//   t.is(graph.version(), 2);
 
-  t.true(graph.addGraph("foo", subgraph));
+//   t.true(graph.addGraph("foo", subgraph));
 
-  t.is(graph.version(), 3);
+//   t.is(graph.version(), 3);
 
-  t.true(graph.replaceGraph("foo", subgraph));
+//   t.true(graph.replaceGraph("foo", subgraph));
 
-  t.is(graph.version(), 4);
+//   t.is(graph.version(), 4);
 
-  t.truthy(graph.raw().graphs);
-});
+//   t.truthy(graph.raw().graphs);
+
+// });

--- a/packages/breadboard/tests/editor/graph.ts
+++ b/packages/breadboard/tests/editor/graph.ts
@@ -522,13 +522,13 @@ test("editor API correctly allows adding, removing, replacing subgraphs", (t) =>
   const graph = testEditGraph();
   const subgraph = testEditGraph().raw();
 
-  t.assert(graph.addGraph("foo", subgraph) !== null);
+  t.true(graph.addGraph("foo", subgraph));
 
   t.truthy(graph.raw().graphs);
 
   t.is(graph.version(), 1);
 
-  t.assert(graph.addGraph("foo", subgraph) === null);
+  t.false(graph.addGraph("foo", subgraph));
 
   t.true(graph.removeGraph("foo").success);
   t.false(graph.removeGraph("foo").success);
@@ -537,15 +537,15 @@ test("editor API correctly allows adding, removing, replacing subgraphs", (t) =>
 
   t.is(graph.version(), 2);
 
-  t.assert(graph.replaceGraph("foo", subgraph) === null);
+  t.false(graph.replaceGraph("foo", subgraph));
 
   t.is(graph.version(), 2);
 
-  t.assert(graph.addGraph("foo", subgraph) !== null);
+  t.true(graph.addGraph("foo", subgraph));
 
   t.is(graph.version(), 3);
 
-  t.assert(graph.replaceGraph("foo", subgraph) !== null);
+  t.true(graph.replaceGraph("foo", subgraph));
 
   t.is(graph.version(), 4);
 

--- a/packages/breadboard/tests/inspector/graph.ts
+++ b/packages/breadboard/tests/inspector/graph.ts
@@ -21,8 +21,8 @@ test("inspectableGraph correctly reacts to edits", (t) => {
   );
   const editReceiver = inspectable;
   const edge = { from: "a", to: "b", out: "text", in: "text" };
-  editReceiver.nodeStore.add({ id: "b", type: "bar" });
-  editReceiver.edgeStore.add(edge);
+  editReceiver.nodeStore.add({ id: "b", type: "bar" }, "");
+  editReceiver.edgeStore.add(edge, "");
   graph.nodes.push({ id: "b", type: "bar" });
   graph.edges.push(edge);
 
@@ -34,8 +34,8 @@ test("inspectableGraph correctly reacts to edits", (t) => {
   t.true(inspectable.hasEdge(edge));
   t.is(inspectable.incomingForNode("b")?.[0].from, inspectable.nodeById("a")!);
 
-  editReceiver.nodeStore.remove("b");
-  editReceiver.edgeStore.remove(edge);
+  editReceiver.nodeStore.remove("b", "");
+  editReceiver.edgeStore.remove(edge, "");
   graph.nodes = graph.nodes.filter((n) => n.id !== "b");
   graph.edges = graph.edges.filter((e) => e !== edge);
 

--- a/packages/breadboard/tests/inspector/subgraphs.ts
+++ b/packages/breadboard/tests/inspector/subgraphs.ts
@@ -21,12 +21,13 @@ test("InspectableGraph correctly provides subgraphs", async (t) => {
   };
 
   const inspectable = inspectableGraph(graph);
-  const graphs = inspectable.graphs();
+  const graphs = inspectable.graphs()!;
 
   t.is(Object.values(graphs).length, 1);
   t.true(graphs === inspectable.graphs());
   const subgraph = graphs["#foo"];
   t.truthy(subgraph);
+  t.is(subgraph.graphId(), "#foo");
   const node = subgraph.nodeById("a");
   t.truthy(node);
   t.is(node?.descriptor.type, "foo");

--- a/packages/breadboard/tests/node/editor/subgraphs.ts
+++ b/packages/breadboard/tests/node/editor/subgraphs.ts
@@ -50,4 +50,27 @@ describe("Sub-graph editing operations", async () => {
     const removal = await graph.edit([{ type: "removegraph", id: "foo" }], "");
     ok(!removal.success);
   });
+
+  await it("can replace graph as atomic remove/add", async () => {
+    const graph = testEditGraph();
+    const initialization = await graph.edit(
+      [{ type: "addgraph", graph: testSubGraph(), id: "foo" }],
+      ""
+    );
+    ok(initialization.success);
+    deepStrictEqual(graph.raw().graphs?.foo?.title, "Test Subgraph");
+
+    const newSubGraph = testSubGraph();
+    newSubGraph.title = "Foo";
+
+    const replacement = await graph.edit(
+      [
+        { type: "removegraph", id: "foo" },
+        { type: "addgraph", id: "foo", graph: newSubGraph },
+      ],
+      ""
+    );
+    ok(replacement.success);
+    deepStrictEqual(graph.raw().graphs?.foo?.title, "Foo");
+  });
 });

--- a/packages/breadboard/tests/node/editor/subgraphs.ts
+++ b/packages/breadboard/tests/node/editor/subgraphs.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from "node:test";
+import { testEditGraph, testSubGraph } from "./test-graph.js";
+import { fail, ok } from "assert";
+
+describe("Sub-graph editing operations", async () => {
+  await it("creates a subgraph", async () => {
+    const graph = testEditGraph();
+    // const result = await graph.edit(
+    //   [{ type: "addgraph", graph: testSubGraph(), id: "foo" }],
+    //   "Create a subgraph"
+    // );
+    // ok(result.success);
+    ok(true);
+  });
+});

--- a/packages/breadboard/tests/node/editor/subgraphs.ts
+++ b/packages/breadboard/tests/node/editor/subgraphs.ts
@@ -6,16 +6,28 @@
 
 import { describe, it } from "node:test";
 import { testEditGraph, testSubGraph } from "./test-graph.js";
-import { fail, ok } from "assert";
+import { deepStrictEqual, ok } from "assert";
 
 describe("Sub-graph editing operations", async () => {
   await it("creates a subgraph", async () => {
     const graph = testEditGraph();
-    // const result = await graph.edit(
-    //   [{ type: "addgraph", graph: testSubGraph(), id: "foo" }],
-    //   "Create a subgraph"
-    // );
-    // ok(result.success);
-    ok(true);
+    const result = await graph.edit(
+      [{ type: "addgraph", graph: testSubGraph(), id: "foo" }],
+      ""
+    );
+    ok(result.success);
+    deepStrictEqual(graph.raw().graphs?.foo?.title, "Test Subgraph");
+  });
+
+  await it("does not allow creating duplicate subgraphs", async () => {
+    const graph = testEditGraph();
+    const result = await graph.edit(
+      [
+        { type: "addgraph", graph: testSubGraph(), id: "foo" },
+        { type: "addgraph", graph: testSubGraph(), id: "foo" },
+      ],
+      ""
+    );
+    ok(!result.success);
   });
 });

--- a/packages/breadboard/tests/node/editor/subgraphs.ts
+++ b/packages/breadboard/tests/node/editor/subgraphs.ts
@@ -9,7 +9,7 @@ import { testEditGraph, testSubGraph } from "./test-graph.js";
 import { deepStrictEqual, ok } from "assert";
 
 describe("Sub-graph editing operations", async () => {
-  await it("creates a subgraph", async () => {
+  await it("allows adding subgraphs", async () => {
     const graph = testEditGraph();
     const result = await graph.edit(
       [{ type: "addgraph", graph: testSubGraph(), id: "foo" }],
@@ -19,7 +19,7 @@ describe("Sub-graph editing operations", async () => {
     deepStrictEqual(graph.raw().graphs?.foo?.title, "Test Subgraph");
   });
 
-  await it("does not allow creating duplicate subgraphs", async () => {
+  await it("does not allow adding duplicate subgraphs", async () => {
     const graph = testEditGraph();
     const result = await graph.edit(
       [
@@ -29,5 +29,25 @@ describe("Sub-graph editing operations", async () => {
       ""
     );
     ok(!result.success);
+  });
+
+  await it("removes subgraphs", async () => {
+    const graph = testEditGraph();
+    const addition = await graph.edit(
+      [{ type: "addgraph", graph: testSubGraph(), id: "foo" }],
+      ""
+    );
+    ok(addition.success);
+    deepStrictEqual(graph.raw().graphs?.foo?.title, "Test Subgraph");
+
+    const removal = await graph.edit([{ type: "removegraph", id: "foo" }], "");
+    ok(removal.success);
+    ok(!graph.raw().graphs);
+  });
+
+  await it("doesn't allow removing non-existent subgraphs", async () => {
+    const graph = testEditGraph();
+    const removal = await graph.edit([{ type: "removegraph", id: "foo" }], "");
+    ok(!removal.success);
   });
 });

--- a/packages/breadboard/tests/node/editor/test-graph.ts
+++ b/packages/breadboard/tests/node/editor/test-graph.ts
@@ -1,0 +1,78 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { editGraph } from "../../../src/editor/index.js";
+import { GraphDescriptor, NodeHandler } from "../../../src/types.js";
+
+export { testEditGraph, testSubGraph };
+
+function testSubGraph(): GraphDescriptor {
+  return {
+    title: "Test Subgraph",
+    nodes: [],
+    edges: [],
+  };
+}
+
+function testEditGraph() {
+  return editGraph(
+    structuredClone({
+      nodes: [
+        {
+          id: "node0",
+          type: "foo",
+        },
+        {
+          id: "node2",
+          type: "bar",
+        },
+      ],
+      edges: [{ from: "node0", out: "out", to: "node0", in: "in" }],
+    }),
+    {
+      kits: [
+        {
+          url: "",
+          handlers: {
+            foo: {
+              invoke: async () => {},
+              describe: async () => {
+                return {
+                  inputSchema: {
+                    additionalProperties: false,
+                    properties: {
+                      in: { type: "string" },
+                    },
+                  },
+                  outputSchema: {
+                    additionalProperties: false,
+                    properties: {
+                      out: { type: "string" },
+                    },
+                  },
+                };
+              },
+            } as NodeHandler,
+            bar: {
+              invoke: async () => {},
+              describe: async () => {
+                return {
+                  inputSchema: {},
+                  outputSchema: {
+                    additionalProperties: false,
+                    properties: {
+                      out: { type: "string" },
+                    },
+                  },
+                };
+              },
+            } as NodeHandler,
+          },
+        },
+      ],
+    }
+  );
+}

--- a/packages/shared-ui/src/elements/editor/editor.ts
+++ b/packages/shared-ui/src/elements/editor/editor.ts
@@ -418,7 +418,7 @@ export class Editor extends LitElement {
     let selectedGraph = this.graph;
     if (this.subGraphId) {
       const subgraphs = selectedGraph.graphs();
-      if (subgraphs[this.subGraphId]) {
+      if (subgraphs && subgraphs[this.subGraphId]) {
         selectedGraph = subgraphs[this.subGraphId];
       } else {
         console.warn(`Unable to locate subgraph by name: ${this.subGraphId}`);
@@ -444,7 +444,9 @@ export class Editor extends LitElement {
 
     const subGraphs = new Map<string, GraphOpts>();
     if (this.showSubgraphsInline) {
-      for (const [id, subGraph] of Object.entries(selectedGraph.graphs())) {
+      for (const [id, subGraph] of Object.entries(
+        selectedGraph.graphs() || {}
+      )) {
         const subGraphUrl = `${url}-${id}`;
         const subGraphOpts = await this.#inspectableGraphToConfig(
           subGraphUrl,

--- a/packages/shared-ui/src/elements/node-info/node-configuration.ts
+++ b/packages/shared-ui/src/elements/node-info/node-configuration.ts
@@ -408,7 +408,7 @@ export class NodeConfigurationInfo extends LitElement {
 
         if (subGraphId && typeof subGraphId === "string") {
           const subgraphs = breadboardGraph.graphs();
-          if (subgraphs[subGraphId]) {
+          if (subgraphs && subgraphs[subGraphId]) {
             breadboardGraph = subgraphs[subGraphId];
           } else {
             console.warn(

--- a/packages/shared-ui/src/elements/node-info/node-meta-details.ts
+++ b/packages/shared-ui/src/elements/node-info/node-meta-details.ts
@@ -75,7 +75,7 @@ export class NodeMetaDetails extends LitElement {
 
       if (subGraphId && typeof subGraphId === "string") {
         const subgraphs = graph.graphs();
-        if (subgraphs[subGraphId]) {
+        if (subgraphs && subgraphs[subGraphId]) {
           graph = subgraphs[subGraphId];
         } else {
           console.warn(`Unable to locate subgraph by name: ${this.subGraphId}`);

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -2849,7 +2849,7 @@ export class Main extends LitElement {
               @bbsubgraphcreate=${async (
                 evt: BreadboardUI.Events.SubGraphCreateEvent
               ) => {
-                const result = this.#runtime.edit.createSubGraph(
+                const result = await this.#runtime.edit.createSubGraph(
                   this.tab,
                   evt.subGraphTitle
                 );

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -1387,7 +1387,7 @@ export class Main extends LitElement {
     return this.#attemptBoardSave();
   }
 
-  #handleBoardInfoUpdate(evt: BreadboardUI.Events.BoardInfoUpdateEvent) {
+  async #handleBoardInfoUpdate(evt: BreadboardUI.Events.BoardInfoUpdateEvent) {
     if (!this.tab) {
       this.toast(
         "Unable to edit; no active graph",
@@ -1397,7 +1397,7 @@ export class Main extends LitElement {
     }
 
     if (evt.subGraphId) {
-      this.#runtime.edit.updateSubBoardInfo(
+      await this.#runtime.edit.updateSubBoardInfo(
         this.tab,
         evt.subGraphId,
         evt.title,
@@ -1601,7 +1601,15 @@ export class Main extends LitElement {
       return;
     }
 
-    const { description, title, version, metadata } = this.tab.graph;
+    const graph = this.tab.subGraphId
+      ? this.tab.graph.graphs?.[this.tab.subGraphId]
+      : this.tab.graph;
+
+    if (!graph) {
+      return;
+    }
+
+    const { description, title, version, metadata } = graph;
 
     this.boardEditOverlayInfo = {
       description: description ?? "",
@@ -1848,10 +1856,10 @@ export class Main extends LitElement {
             @bboverlaydismissed=${() => {
               this.boardEditOverlayInfo = null;
             }}
-            @bbboardinfoupdate=${(
+            @bbboardinfoupdate=${async (
               evt: BreadboardUI.Events.BoardInfoUpdateEvent
             ) => {
-              this.#handleBoardInfoUpdate(evt);
+              await this.#handleBoardInfoUpdate(evt);
               this.boardEditOverlayInfo = null;
               this.requestUpdate();
             }}

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -2869,7 +2869,10 @@ export class Main extends LitElement {
               @bbsubgraphdelete=${async (
                 evt: BreadboardUI.Events.SubGraphDeleteEvent
               ) => {
-                this.#runtime.edit.deleteSubGraph(this.tab, evt.subGraphId);
+                await this.#runtime.edit.deleteSubGraph(
+                  this.tab,
+                  evt.subGraphId
+                );
               }}
               @bbsubgraphchosen=${(
                 evt: BreadboardUI.Events.SubGraphChosenEvent

--- a/packages/visual-editor/src/runtime/edit.ts
+++ b/packages/visual-editor/src/runtime/edit.ts
@@ -575,21 +575,24 @@ export class Edit extends EventTarget {
       [{ type: "addgraph", graph: board, id }],
       `Adding subgraph ${subGraphTitle}`
     );
-    if (!editResult) {
+    if (!editResult.success) {
       return null;
     }
 
     return id;
   }
 
-  deleteSubGraph(tab: Tab | null, subGraphId: string) {
+  async deleteSubGraph(tab: Tab | null, subGraphId: string) {
     const editableGraph = this.getEditor(tab);
     if (!editableGraph) {
       this.dispatchEvent(new RuntimeErrorEvent("Unable to delete sub board"));
       return;
     }
 
-    const editResult = editableGraph.removeGraph(subGraphId);
+    const editResult = await editableGraph.edit(
+      [{ type: "removegraph", id: subGraphId }],
+      `Removing subgraph $"{subGraphId}"`
+    );
     if (!editResult.success) {
       return null;
     }

--- a/packages/visual-editor/src/runtime/edit.ts
+++ b/packages/visual-editor/src/runtime/edit.ts
@@ -560,7 +560,7 @@ export class Edit extends EventTarget {
     }
   }
 
-  createSubGraph(tab: Tab | null, subGraphTitle: string) {
+  async createSubGraph(tab: Tab | null, subGraphTitle: string) {
     const editableGraph = this.getEditor(tab);
     if (!editableGraph) {
       this.dispatchEvent(new RuntimeErrorEvent("Unable to create sub board"));
@@ -571,7 +571,10 @@ export class Edit extends EventTarget {
     const board = blankLLMContent();
     board.title = subGraphTitle;
 
-    const editResult = editableGraph.addGraph(id, board);
+    const editResult = await editableGraph.edit(
+      [{ type: "addgraph", graph: board, id }],
+      `Adding subgraph ${subGraphTitle}`
+    );
     if (!editResult) {
       return null;
     }

--- a/packages/visual-editor/src/runtime/edit.ts
+++ b/packages/visual-editor/src/runtime/edit.ts
@@ -269,7 +269,7 @@ export class Edit extends EventTarget {
     return history.redo();
   }
 
-  updateSubBoardInfo(
+  async updateSubBoardInfo(
     tab: Tab | null,
     subGraphId: string,
     title: string,
@@ -306,7 +306,15 @@ export class Edit extends EventTarget {
       isComponent
     );
 
-    editableGraph.replaceGraph(subGraphId, subGraphDescriptor);
+    await editableGraph.edit(
+      [
+        { type: "removegraph", id: subGraphId },
+        { type: "addgraph", id: subGraphId, graph: subGraphDescriptor },
+      ],
+      `Replacing graph "${title}"`
+    );
+
+    // editableGraph.replaceGraph(subGraphId, subGraphDescriptor);
   }
 
   deleteComment(tab: Tab | null, id: string) {


### PR DESCRIPTION
- **Start sketching out graph operations.**
- **Clarify interfaces**
- **Keep a single node/edge cache of graphs and subgraphs.**
- **Pass the subgraph to new Node instance.**
- **Teach EditableGraph to not create new InspectableGraph instances for sub-graphs.**
- **Create EditableGraph subgraph instances lazily.**
- **Fix logic errors in addGraph/removeGraph.**
- **Implement "addgraph" operation.**
- **Remove `EditableGraph.addGraph`.**
- **Add "removegraph" operation.**
- **Remove `EditableGraph.removeGraph`.**
- **Remove `EditableGraph.replaceGraph`.**
- **docs(changeset): Migrate to use `InspectableGraph.edit` for subgraph add/remove/replace.**
