### PR TITLE
transforms

### DIFF
--- a/.changeset/wise-monkeys-dress.md
+++ b/.changeset/wise-monkeys-dress.md
@@ -1,0 +1,7 @@
+---
+"@google-labs/breadboard": minor
+"@breadboard-ai/visual-editor": patch
+"@breadboard-ai/shared-ui": patch
+---
+
+Introduce Edit Transforms and start using them.

--- a/packages/breadboard/package.json
+++ b/packages/breadboard/package.json
@@ -93,7 +93,7 @@
         "build:tsc"
       ],
       "files": [
-        "tests/node/*.ts",
+        "tests/node/**/*.ts",
         "tests/bgl/*.bgl.json"
       ],
       "output": []

--- a/packages/breadboard/src/editor/graph.ts
+++ b/packages/breadboard/src/editor/graph.ts
@@ -249,7 +249,7 @@ export class Graph implements EditableGraph {
     return this.#applyEdits(async () => {
       return {
         success: true,
-        spec: [edits, label],
+        spec: { edits, label },
       };
     }, dryRun);
   }
@@ -331,7 +331,7 @@ export class Graph implements EditableGraph {
     if (!result.success) {
       error = result.error;
     } else {
-      const [edits, editLabel] = result.spec;
+      const { edits, label: editLabel } = result.spec;
       label = editLabel;
       for (const edit of edits) {
         if (this.#shouldDiscardEdit(edit)) {

--- a/packages/breadboard/src/editor/graph.ts
+++ b/packages/breadboard/src/editor/graph.ts
@@ -194,7 +194,7 @@ export class Graph implements EditableGraph {
 
   async apply(transform: EditTransform, dryRun = false): Promise<EditResult> {
     return this.#applyEdits((context) => {
-      return transform.createSpec(context);
+      return transform.apply(context);
     }, dryRun);
   }
 

--- a/packages/breadboard/src/editor/graph.ts
+++ b/packages/breadboard/src/editor/graph.ts
@@ -18,6 +18,9 @@ import {
   EditOperationContext,
   EditResultLogEntry,
   EditHistory,
+  EditableGraphSelection,
+  EditTransform,
+  EditableGraphSelectionResult,
 } from "./types.js";
 import { ChangeEvent, ChangeRejectEvent } from "./events.js";
 import { AddEdge } from "./operations/add-edge.js";
@@ -40,6 +43,7 @@ import {
 } from "../run/run-imperative-graph.js";
 import { AddGraph } from "./operations/add-graph.js";
 import { RemoveGraph } from "./operations/remove-graph.js";
+import { computeSelection } from "./selection.js";
 
 const validImperativeEdits: EditSpec["type"][] = [
   "addmodule",
@@ -348,5 +352,9 @@ export class Graph implements EditableGraph {
 
   inspect() {
     return this.#inspector;
+  }
+
+  apply(transform: EditTransform): Promise<EditResult> {
+    throw new Error("Not implemented");
   }
 }

--- a/packages/breadboard/src/editor/index.ts
+++ b/packages/breadboard/src/editor/index.ts
@@ -12,7 +12,7 @@ export const editGraph = (
   graph: GraphDescriptor,
   options: EditableGraphOptions = {}
 ): EditableGraph => {
-  return new Graph(graph, options, "", null);
+  return new Graph(graph, options);
 };
 
 export { blank, blankLLMContent } from "./blank.js";

--- a/packages/breadboard/src/editor/operations/add-edge.ts
+++ b/packages/breadboard/src/editor/operations/add-edge.ts
@@ -17,6 +17,7 @@ import {
   fixupConstantEdge,
   unfixUpStarEdge,
 } from "../../inspector/edge.js";
+import { toSubgraphContext } from "../subgraph-context.js";
 
 export class AddEdge implements EditOperation {
   async can(
@@ -99,13 +100,17 @@ export class AddEdge implements EditOperation {
       );
     }
     let edge = spec.edge;
-    const { graph, inspector, store } = context;
+    const { graphId } = spec;
+
+    const subgraphContext = toSubgraphContext(context, graphId);
+    if (!subgraphContext.success) {
+      return subgraphContext;
+    }
+    const { graph, inspector, store } = subgraphContext.result;
     const can = await this.can(edge, inspector);
     if (!can.success) {
       return can;
     }
-
-    const graphId = inspector.graphId();
 
     edge = fixUpStarEdge(edge);
     edge = fixupConstantEdge(edge);

--- a/packages/breadboard/src/editor/operations/add-node.ts
+++ b/packages/breadboard/src/editor/operations/add-node.ts
@@ -12,6 +12,7 @@ import {
   SingleEditResult,
 } from "../types.js";
 import { InspectableGraph } from "../../inspector/types.js";
+import { toSubgraphContext } from "../subgraph-context.js";
 
 export class AddNode implements EditOperation {
   async can(
@@ -51,9 +52,13 @@ export class AddNode implements EditOperation {
         `Editor API integrity error: expected type "addnode", received "${spec.type}" instead.`
       );
     }
-    const node = spec.node;
-    const { graph, inspector, store } = context;
-    const graphId = inspector.graphId();
+    const { node, graphId } = spec;
+    const subgraphContext = toSubgraphContext(context, graphId);
+    if (!subgraphContext.success) {
+      return subgraphContext;
+    }
+
+    const { graph, inspector, store } = subgraphContext.result;
     const can = await this.can(node, inspector);
     if (!can.success) {
       return can;

--- a/packages/breadboard/src/editor/operations/change-configuration.ts
+++ b/packages/breadboard/src/editor/operations/change-configuration.ts
@@ -12,6 +12,7 @@ import {
   SingleEditResult,
 } from "../types.js";
 import { InspectableGraph } from "../../inspector/types.js";
+import { toSubgraphContext } from "../subgraph-context.js";
 
 export class ChangeConfiguration implements EditOperation {
   async can(
@@ -42,14 +43,19 @@ export class ChangeConfiguration implements EditOperation {
         `Editor API integrity error: expected type "changeconfiguration", received "${spec.type}" instead.`
       );
     }
-    const { id, configuration, reset = false } = spec;
+    const { id, configuration, graphId, reset = false } = spec;
     if (!configuration) {
       return {
         success: false,
         error: "Configuration wasn't supplied.",
       };
     }
-    const { inspector } = context;
+    const subgraphContext = toSubgraphContext(context, graphId);
+    if (!subgraphContext.success) {
+      return subgraphContext;
+    }
+
+    const { inspector } = subgraphContext.result;
     const can = await this.can(id, inspector);
     if (!can.success) {
       return can;

--- a/packages/breadboard/src/editor/operations/change-edge.ts
+++ b/packages/breadboard/src/editor/operations/change-edge.ts
@@ -16,6 +16,7 @@ import { RemoveEdge } from "./remove-edge.js";
 import { AddEdge } from "./add-edge.js";
 import { edgesEqual, findEdgeIndex } from "../edge.js";
 import { fixUpStarEdge } from "../../inspector/edge.js";
+import { toSubgraphContext } from "../subgraph-context.js";
 
 export class ChangeEdge implements EditOperation {
   async can(
@@ -54,10 +55,14 @@ export class ChangeEdge implements EditOperation {
         `Editor API integrity error: expected type "changeedge", received "${spec.type}" instead.`
       );
     }
-    const from = spec.from;
-    const to = spec.to;
+    const { from, to, graphId } = spec;
+    const subgraphContext = toSubgraphContext(context, graphId);
 
-    const { graph, inspector } = context;
+    if (!subgraphContext.success) {
+      return subgraphContext;
+    }
+
+    const { graph, inspector } = subgraphContext.result;
     const can = await this.can(from, to, inspector);
     if (!can.success) {
       return can;

--- a/packages/breadboard/src/editor/operations/change-graph-metadata.ts
+++ b/packages/breadboard/src/editor/operations/change-graph-metadata.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { toSubgraphContext } from "../subgraph-context.js";
 import {
   EditOperation,
   EditOperationContext,
@@ -21,8 +22,13 @@ export class ChangeGraphMetadata implements EditOperation {
         `Editor API integrity error: expected type "changegraphmetadata", received "${spec.type}" instead.`
       );
     }
-    const { metadata } = spec;
-    const { graph } = context;
+    const { metadata, graphId } = spec;
+    const subgraphContext = toSubgraphContext(context, graphId);
+    if (!subgraphContext.success) {
+      return subgraphContext;
+    }
+
+    const { graph } = subgraphContext.result;
     const visualOnly = graph.metadata === metadata;
     graph.metadata = metadata;
     return {

--- a/packages/breadboard/src/editor/operations/change-metadata.ts
+++ b/packages/breadboard/src/editor/operations/change-metadata.ts
@@ -12,6 +12,7 @@ import {
   SingleEditResult,
 } from "../types.js";
 import { InspectableGraph } from "../../inspector/types.js";
+import { toSubgraphContext } from "../subgraph-context.js";
 
 export class ChangeMetadata implements EditOperation {
   async can(
@@ -50,8 +51,13 @@ export class ChangeMetadata implements EditOperation {
         `Editor API integrity error: expected type "changemetadata", received "${spec.type}" instead.`
       );
     }
-    const { id, metadata, reset = false } = spec;
-    const { inspector } = context;
+    const { id, metadata, graphId, reset = false } = spec;
+    const subgraphContext = toSubgraphContext(context, graphId);
+    if (!subgraphContext.success) {
+      return subgraphContext;
+    }
+
+    const { inspector } = subgraphContext.result;
     const can = await this.can(id, inspector);
     if (!can.success) return can;
     const node = inspector.nodeById(id);

--- a/packages/breadboard/src/editor/operations/remove-edge.ts
+++ b/packages/breadboard/src/editor/operations/remove-edge.ts
@@ -14,6 +14,7 @@ import {
 import { InspectableGraph } from "../../inspector/types.js";
 import { fixUpStarEdge } from "../../inspector/edge.js";
 import { findEdgeIndex } from "../edge.js";
+import { toSubgraphContext } from "../subgraph-context.js";
 
 export class RemoveEdge implements EditOperation {
   async can(
@@ -44,12 +45,16 @@ export class RemoveEdge implements EditOperation {
       );
     }
     let edge = spec.edge;
-    const { graph, inspector, store } = context;
+    const { graphId } = spec;
+    const subgraphContext = toSubgraphContext(context, graphId);
+    if (!subgraphContext.success) {
+      return subgraphContext;
+    }
+    const { graph, inspector, store } = subgraphContext.result;
     const can = await this.can(edge, inspector);
     if (!can.success) {
       return can;
     }
-    const graphId = inspector.graphId();
     edge = fixUpStarEdge(edge);
     const edges = graph.edges;
     const index = findEdgeIndex(graph, edge);

--- a/packages/breadboard/src/editor/operations/remove-node.ts
+++ b/packages/breadboard/src/editor/operations/remove-node.ts
@@ -12,6 +12,7 @@ import {
   SingleEditResult,
 } from "../types.js";
 import { InspectableGraph } from "../../inspector/types.js";
+import { toSubgraphContext } from "../subgraph-context.js";
 
 export class RemoveNode implements EditOperation {
   async can(
@@ -42,14 +43,16 @@ export class RemoveNode implements EditOperation {
         `Editor API integrity error: expected type "removenode", received "${spec.type}" instead.`
       );
     }
-    const id = spec.id;
-    const { graph, inspector, store } = context;
+    const { id, graphId } = spec;
+    const subgraphContext = toSubgraphContext(context, graphId);
+    if (!subgraphContext.success) {
+      return subgraphContext;
+    }
+    const { graph, inspector, store } = subgraphContext.result;
     const can = await this.can(id, inspector);
     if (!can.success) {
       return can;
     }
-
-    const graphId = inspector.graphId();
 
     // Remove any edges that are connected to the removed node.
     graph.edges = graph.edges.filter((edge) => {

--- a/packages/breadboard/src/editor/selection.ts
+++ b/packages/breadboard/src/editor/selection.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Edge, NodeIdentifier } from "@breadboard-ai/types";
+import { EditableGraphSelectionResult } from "./types.js";
+import { InspectableGraph } from "../inspector/types.js";
+
+export { computeSelection };
+
+/**
+ * Creates a selection: a list of nodes and edges that will are associated
+ * with the given list of node identifiers within the graph.
+ * The selection is transient in that it only applies to the current version
+ * of the graph and becomes invalid as soon as the graph mutates.
+ *
+ * @param nodes -- nodes to include in the selection
+ */
+function computeSelection(
+  graph: InspectableGraph,
+  nodes: NodeIdentifier[]
+): EditableGraphSelectionResult {
+  // First, let's make sure that all nodes are present in graph.
+  const allPresent = nodes.every((id) => graph.nodeById(id));
+  if (!allPresent) {
+    return {
+      success: false,
+      error: "Can't create selection: some nodes aren't in the graph",
+    };
+  }
+  // Now, let's get all the edges connected to these nodes.
+  const n = new Set(nodes);
+  const edges: Edge[] = [];
+  const dangling: Edge[] = [];
+  graph.raw().edges.forEach((edge) => {
+    const { from, to } = edge;
+    const hasFrom = n.has(from);
+    const hasTo = n.has(to);
+    if (hasFrom && hasTo) {
+      edges.push(edge);
+    } else if (hasFrom || hasTo) {
+      dangling.push(edge);
+    }
+  });
+
+  return {
+    success: true,
+    nodes,
+    edges,
+    dangling,
+  };
+}

--- a/packages/breadboard/src/editor/subgraph-context.ts
+++ b/packages/breadboard/src/editor/subgraph-context.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GraphIdentifier } from "@breadboard-ai/types";
+import { EditOperationContext, Result } from "./types.js";
+import { GraphStoreMutator } from "../inspector/types.js";
+
+export { toSubgraphContext };
+
+function toSubgraphContext(
+  context: EditOperationContext,
+  graphId: GraphIdentifier
+): Result<EditOperationContext> {
+  if (!graphId) return { success: true, result: context };
+
+  const { graph, inspector } = context;
+  const subgraph = graph.graphs?.[graphId];
+  const subgraphInspector = inspector.graphs()?.[graphId];
+  if (!subgraph || !subgraphInspector)
+    return {
+      success: false,
+      error: "Unable to get subgraph edit context.",
+    };
+
+  return {
+    success: true,
+    result: {
+      graph: subgraph,
+      inspector: subgraphInspector,
+      store: subgraphInspector as unknown as GraphStoreMutator,
+    },
+  };
+}

--- a/packages/breadboard/src/editor/subgraph-context.ts
+++ b/packages/breadboard/src/editor/subgraph-context.ts
@@ -31,6 +31,7 @@ function toSubgraphContext(
       graph: subgraph,
       inspector: subgraphInspector,
       store: subgraphInspector as unknown as GraphStoreMutator,
+      apply: context.apply,
     },
   };
 }

--- a/packages/breadboard/src/editor/transforms/isolate-selection.ts
+++ b/packages/breadboard/src/editor/transforms/isolate-selection.ts
@@ -30,10 +30,7 @@ class IsolateSelectionTransform implements EditTransform {
     const { inspector } = context;
     const selection = computeSelection(inspector, this.#nodes);
     if (!selection.success) {
-      return {
-        success: false,
-        error: selection.error,
-      };
+      return selection;
     }
     const { dangling } = selection;
     const edits: RemoveEdgeSpec[] = dangling.map((edge) => ({

--- a/packages/breadboard/src/editor/transforms/isolate-selection.ts
+++ b/packages/breadboard/src/editor/transforms/isolate-selection.ts
@@ -39,9 +39,11 @@ class IsolateSelectionTransform implements EditTransform {
       graphId: this.#graphId,
     }));
 
-    return {
-      success: true,
-      spec: { edits, label: "Isolating Selection" },
-    };
+    const result = await context.apply(edits, "Isolating Selection");
+    if (!result.success) {
+      return result;
+    }
+
+    return { success: true };
   }
 }

--- a/packages/breadboard/src/editor/transforms/isolate-selection.ts
+++ b/packages/breadboard/src/editor/transforms/isolate-selection.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { NodeIdentifier } from "@breadboard-ai/types";
+import { GraphIdentifier, NodeIdentifier } from "@breadboard-ai/types";
 import {
   EditOperationContext,
   EditTransform,
@@ -17,9 +17,11 @@ export { IsolateSelectionTransform };
 
 class IsolateSelectionTransform implements EditTransform {
   #nodes: NodeIdentifier[];
+  #graphId: GraphIdentifier;
 
-  constructor(nodes: NodeIdentifier[]) {
+  constructor(nodes: NodeIdentifier[], graphId: GraphIdentifier) {
     this.#nodes = nodes;
+    this.#graphId = graphId;
   }
 
   async createSpec(
@@ -37,6 +39,7 @@ class IsolateSelectionTransform implements EditTransform {
     const edits: RemoveEdgeSpec[] = dangling.map((edge) => ({
       type: "removeedge",
       edge,
+      graphId: this.#graphId,
     }));
 
     return {

--- a/packages/breadboard/src/editor/transforms/isolate-selection.ts
+++ b/packages/breadboard/src/editor/transforms/isolate-selection.ts
@@ -24,9 +24,7 @@ class IsolateSelectionTransform implements EditTransform {
     this.#graphId = graphId;
   }
 
-  async createSpec(
-    context: EditOperationContext
-  ): Promise<EditTransformResult> {
+  async apply(context: EditOperationContext): Promise<EditTransformResult> {
     const { inspector } = context;
     const selection = computeSelection(inspector, this.#nodes);
     if (!selection.success) {

--- a/packages/breadboard/src/editor/transforms/isolate-selection.ts
+++ b/packages/breadboard/src/editor/transforms/isolate-selection.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { NodeIdentifier } from "@breadboard-ai/types";
+import {
+  EditOperationContext,
+  EditTransform,
+  EditTransformResult,
+  RemoveEdgeSpec,
+} from "../types.js";
+import { computeSelection } from "../selection.js";
+
+export { IsolateSelectionTransform };
+
+class IsolateSelectionTransform implements EditTransform {
+  #nodes: NodeIdentifier[];
+
+  constructor(nodes: NodeIdentifier[]) {
+    this.#nodes = nodes;
+  }
+
+  async createSpec(
+    context: EditOperationContext
+  ): Promise<EditTransformResult> {
+    const { inspector } = context;
+    const selection = computeSelection(inspector, this.#nodes);
+    if (!selection.success) {
+      return {
+        success: false,
+        error: selection.error,
+      };
+    }
+    const { dangling } = selection;
+    const edits: RemoveEdgeSpec[] = dangling.map((edge) => ({
+      type: "removeedge",
+      edge,
+    }));
+
+    return {
+      success: true,
+      spec: [edits, "Isolating Selection"],
+    };
+  }
+}

--- a/packages/breadboard/src/editor/transforms/isolate-selection.ts
+++ b/packages/breadboard/src/editor/transforms/isolate-selection.ts
@@ -41,7 +41,7 @@ class IsolateSelectionTransform implements EditTransform {
 
     return {
       success: true,
-      spec: [edits, "Isolating Selection"],
+      spec: { edits, label: "Isolating Selection" },
     };
   }
 }

--- a/packages/breadboard/src/editor/transforms/merge-graph.ts
+++ b/packages/breadboard/src/editor/transforms/merge-graph.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GraphIdentifier } from "@breadboard-ai/types";
+import {
+  EditOperationContext,
+  EditTransform,
+  EditTransformResult,
+} from "../types.js";
+import { toSubgraphContext } from "../subgraph-context.js";
+import { MoveToGraphTransform } from "./move-to-graph.js";
+
+export { MergeGraphTransform };
+
+class MergeGraphTransform implements EditTransform {
+  #source: GraphIdentifier;
+  #mergeInto: GraphIdentifier;
+
+  constructor(source: GraphIdentifier, mergeInto: GraphIdentifier) {
+    this.#source = source;
+    this.#mergeInto = mergeInto;
+  }
+
+  async apply(context: EditOperationContext): Promise<EditTransformResult> {
+    const sourceContext = toSubgraphContext(context, this.#source);
+    if (!sourceContext.success) {
+      return sourceContext;
+    }
+
+    const all = sourceContext.result.graph.nodes.map((node) => node.id);
+
+    const moving = await new MoveToGraphTransform(
+      all,
+      this.#source,
+      this.#mergeInto
+    ).apply(context);
+
+    if (!moving.success) {
+      return moving;
+    }
+
+    const removingGraph = await context.apply(
+      [{ type: "removegraph", id: this.#source }],
+      ""
+    );
+    if (!removingGraph.success) {
+      return removingGraph;
+    }
+
+    return { success: true };
+  }
+}

--- a/packages/breadboard/src/editor/transforms/move-to-graph.ts
+++ b/packages/breadboard/src/editor/transforms/move-to-graph.ts
@@ -87,18 +87,17 @@ class MoveToGraphTransform implements EditTransform {
 
     const label = `Moving ${this.#nodes.length} nodes from ${this.#friendlyGraphName(this.#source)} to ${this.#friendlyGraphName(this.#source)}`;
 
+    const result = await context.apply(
+      [...nodeAdditions, ...edgeAdditions, ...edgeRemovals, ...nodeRemovals],
+      label
+    );
+
+    if (!result.success) {
+      return result;
+    }
+
     return {
       success: true,
-      spec: {
-        edits: [
-          ...isolatedSelection.spec.edits,
-          ...nodeAdditions,
-          ...edgeAdditions,
-          ...edgeRemovals,
-          ...nodeRemovals,
-        ],
-        label,
-      },
     };
   }
 }

--- a/packages/breadboard/src/editor/transforms/move-to-graph.ts
+++ b/packages/breadboard/src/editor/transforms/move-to-graph.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GraphIdentifier, NodeIdentifier } from "@breadboard-ai/types";
+import {
+  AddEdgeSpec,
+  AddNodeSpec,
+  EditOperationContext,
+  EditTransform,
+  EditTransformResult,
+  RemoveEdgeSpec,
+  RemoveNodeSpec,
+} from "../types.js";
+import { IsolateSelectionTransform } from "./isolate-selection.js";
+import { toSubgraphContext } from "../subgraph-context.js";
+import { computeSelection } from "../selection.js";
+
+export { MoveToGraphTransform };
+
+class MoveToGraphTransform implements EditTransform {
+  #nodes: NodeIdentifier[];
+  #source: GraphIdentifier;
+  #destination: GraphIdentifier;
+
+  constructor(
+    nodes: NodeIdentifier[],
+    source: GraphIdentifier,
+    destination: GraphIdentifier
+  ) {
+    this.#nodes = nodes;
+    this.#source = source;
+    this.#destination = destination;
+  }
+
+  #friendlyGraphName(id: GraphIdentifier) {
+    return id ? `graph "${id}"` : "main graph";
+  }
+
+  async createSpec(
+    context: EditOperationContext
+  ): Promise<EditTransformResult> {
+    const sourceContext = toSubgraphContext(context, this.#source);
+    if (!sourceContext.success) {
+      return sourceContext;
+    }
+    const isolatedSelection = await new IsolateSelectionTransform(
+      this.#nodes,
+      this.#source
+    ).createSpec(sourceContext.result);
+    if (!isolatedSelection.success) {
+      return isolatedSelection;
+    }
+
+    const sourceInspector = sourceContext.result.inspector;
+
+    const selection = computeSelection(sourceInspector, this.#nodes);
+    if (!selection.success) {
+      return selection;
+    }
+
+    const nodeAdditions: AddNodeSpec[] = selection.nodes.map((id) => ({
+      type: "addnode",
+      node: sourceInspector.nodeById(id)!.descriptor,
+      graphId: this.#destination,
+    }));
+
+    const edgeAdditions: AddEdgeSpec[] = selection.edges.map((edge) => ({
+      type: "addedge",
+      edge,
+      graphId: this.#destination,
+    }));
+
+    const nodeRemovals: RemoveNodeSpec[] = selection.nodes.map((id) => ({
+      type: "removenode",
+      id,
+      graphId: this.#source,
+    }));
+
+    const edgeRemovals: RemoveEdgeSpec[] = selection.edges.map((edge) => ({
+      type: "removeedge",
+      edge,
+      graphId: this.#source,
+    }));
+
+    const label = `Moving ${this.#nodes.length} nodes from ${this.#friendlyGraphName(this.#source)} to ${this.#friendlyGraphName(this.#source)}`;
+
+    return {
+      success: true,
+      spec: {
+        edits: [
+          ...isolatedSelection.spec.edits,
+          ...nodeAdditions,
+          ...edgeAdditions,
+          ...edgeRemovals,
+          ...nodeRemovals,
+        ],
+        label,
+      },
+    };
+  }
+}

--- a/packages/breadboard/src/editor/transforms/move-to-graph.ts
+++ b/packages/breadboard/src/editor/transforms/move-to-graph.ts
@@ -39,9 +39,7 @@ class MoveToGraphTransform implements EditTransform {
     return id ? `graph "${id}"` : "main graph";
   }
 
-  async createSpec(
-    context: EditOperationContext
-  ): Promise<EditTransformResult> {
+  async apply(context: EditOperationContext): Promise<EditTransformResult> {
     const sourceContext = toSubgraphContext(context, this.#source);
     if (!sourceContext.success) {
       return sourceContext;
@@ -49,7 +47,7 @@ class MoveToGraphTransform implements EditTransform {
     const isolatedSelection = await new IsolateSelectionTransform(
       this.#nodes,
       this.#source
-    ).createSpec(sourceContext.result);
+    ).apply(sourceContext.result);
     if (!isolatedSelection.success) {
       return isolatedSelection;
     }

--- a/packages/breadboard/src/editor/transforms/move-to-new-graph.ts
+++ b/packages/breadboard/src/editor/transforms/move-to-new-graph.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GraphIdentifier, NodeIdentifier } from "@breadboard-ai/types";
+import {
+  EditOperationContext,
+  EditTransform,
+  EditTransformResult,
+} from "../types.js";
+import { MoveToGraphTransform } from "./move-to-graph.js";
+
+export { MoveToNewGraphTransform };
+
+class MoveToNewGraphTransform implements EditTransform {
+  #nodes: NodeIdentifier[];
+  #source: GraphIdentifier;
+  #destination: GraphIdentifier;
+  #title: string;
+  #description: string;
+
+  constructor(
+    nodes: NodeIdentifier[],
+    source: GraphIdentifier,
+    destination: GraphIdentifier,
+    title: string,
+    description: string = ""
+  ) {
+    this.#nodes = nodes;
+    this.#source = source;
+    this.#destination = destination;
+    this.#title = title;
+    this.#description = description;
+  }
+
+  async apply(context: EditOperationContext): Promise<EditTransformResult> {
+    const addingGraph = await context.apply(
+      [
+        {
+          type: "addgraph",
+          id: this.#destination,
+          graph: {
+            title: this.#title,
+            description: this.#description,
+            nodes: [],
+            edges: [],
+          },
+        },
+      ],
+      ""
+    );
+    if (!addingGraph.success) {
+      return addingGraph;
+    }
+
+    const moveToGraph = await new MoveToGraphTransform(
+      this.#nodes,
+      this.#source,
+      this.#destination
+    ).apply(context);
+
+    if (!moveToGraph.success) {
+      return moveToGraph;
+    }
+
+    return { success: true };
+  }
+}

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -210,6 +210,12 @@ export type EditableGraph = {
   edit(edits: EditSpec[], label: string, dryRun?: boolean): Promise<EditResult>;
 
   /**
+   * Applies an edit transform to the graph.
+   * @param transform -- the edit transform to apply
+   */
+  apply(transform: EditTransform): Promise<EditResult>;
+
+  /**
    * Provides a way to manage the history of the graph.
    */
   history(): EditHistory;
@@ -325,3 +331,25 @@ export type EditResult = {
 );
 
 export type EditableEdgeSpec = Edge;
+
+export type EditTransform = {
+  createSpec(editor: EditableGraph): Promise<EditTransformSpec>;
+};
+
+export type EditTransformSpec = [
+  edits: EditSpec[],
+  label: string,
+  dryRun?: boolean,
+];
+
+export type EditableGraphSelectionResult =
+  | ({
+      success: true;
+    } & EditableGraphSelection)
+  | { success: false; error: string };
+
+export type EditableGraphSelection = {
+  nodes: NodeIdentifier[];
+  edges: Edge[];
+  dangling: Edge[];
+};

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -327,7 +327,7 @@ export type EditResult = {
 export type EditableEdgeSpec = Edge;
 
 export type EditTransform = {
-  createSpec(context: EditOperationContext): Promise<EditTransformResult>;
+  apply(context: EditOperationContext): Promise<EditTransformResult>;
 };
 
 export type EditTransformResult =

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -147,12 +147,6 @@ export type AddGraphSpec = {
   graph: GraphDescriptor;
 };
 
-export type ReplaceGraphSpec = {
-  type: "replacegraph";
-  id: GraphIdentifier;
-  graph: GraphDescriptor;
-};
-
 export type RemoveGraphSpec = {
   type: "removegraph";
   id: GraphIdentifier;

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -158,10 +158,16 @@ export type RemoveGraphSpec = {
   id: GraphIdentifier;
 };
 
+export type EditOperationConductor = (
+  edits: EditSpec[],
+  editLabel: string
+) => Promise<Result<undefined>>;
+
 export type EditOperationContext = {
   graph: GraphDescriptor;
   inspector: InspectableGraph;
   store: GraphStoreMutator;
+  apply: EditOperationConductor;
 };
 
 export type EditOperation = {
@@ -324,17 +330,9 @@ export type EditTransform = {
   createSpec(context: EditOperationContext): Promise<EditTransformResult>;
 };
 
-export type EditTransformSpec = { edits: EditSpec[]; label: string };
-
 export type EditTransformResult =
-  | {
-      success: false;
-      error: string;
-    }
-  | {
-      success: true;
-      spec: EditTransformSpec;
-    };
+  | { success: false; error: string }
+  | { success: true };
 
 export type EditableGraphSelectionResult =
   | ({

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -333,14 +333,20 @@ export type EditResult = {
 export type EditableEdgeSpec = Edge;
 
 export type EditTransform = {
-  createSpec(editor: EditableGraph): Promise<EditTransformSpec>;
+  createSpec(context: EditOperationContext): Promise<EditTransformResult>;
 };
 
-export type EditTransformSpec = [
-  edits: EditSpec[],
-  label: string,
-  dryRun?: boolean,
-];
+export type EditTransformSpec = [edits: EditSpec[], label: string];
+
+export type EditTransformResult =
+  | {
+      success: false;
+      error: string;
+    }
+  | {
+      success: true;
+      spec: EditTransformSpec;
+    };
 
 export type EditableGraphSelectionResult =
   | ({

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -336,7 +336,7 @@ export type EditTransform = {
   createSpec(context: EditOperationContext): Promise<EditTransformResult>;
 };
 
-export type EditTransformSpec = [edits: EditSpec[], label: string];
+export type EditTransformSpec = { edits: EditSpec[]; label: string };
 
 export type EditTransformResult =
   | {

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -58,6 +58,7 @@ export type EditableGraphEventMap = {
 export type AddNodeSpec = {
   type: "addnode";
   node: EditableNodeSpec;
+  graphId: GraphIdentifier;
 };
 
 export type AddModuleSpec = {
@@ -69,6 +70,7 @@ export type AddModuleSpec = {
 export type RemoveNodeSpec = {
   type: "removenode";
   id: NodeIdentifier;
+  graphId: GraphIdentifier;
 };
 
 export type RemoveModuleSpec = {
@@ -79,11 +81,13 @@ export type RemoveModuleSpec = {
 export type AddEdgeSpec = {
   type: "addedge";
   edge: EditableEdgeSpec;
+  graphId: GraphIdentifier;
 };
 
 export type RemoveEdgeSpec = {
   type: "removeedge";
   edge: EditableEdgeSpec;
+  graphId: GraphIdentifier;
 };
 
 /**
@@ -96,12 +100,14 @@ export type ChangeEdgeSpec = {
   type: "changeedge";
   from: EditableEdgeSpec;
   to: EditableEdgeSpec;
+  graphId: GraphIdentifier;
 };
 
 export type ChangeConfigurationSpec = {
   type: "changeconfiguration";
   id: NodeIdentifier;
   configuration: NodeConfiguration;
+  graphId: GraphIdentifier;
   /**
    * If set to `true`, the configuration will be set to the value specified in
    * `configuration`. If set to `false`, the value will be merged with the
@@ -114,6 +120,7 @@ export type ChangeMetadataSpec = {
   type: "changemetadata";
   id: NodeIdentifier;
   metadata: NodeMetadata;
+  graphId: GraphIdentifier;
   /**
    * If set to `true`, the metadata will be set to the value specified in
    * `metadata`. If set to `false`, the value will be merged with the
@@ -131,6 +138,7 @@ export type ChangeModuleSpec = {
 export type ChangeGraphMetadataSpec = {
   type: "changegraphmetadata";
   metadata: GraphMetadata;
+  graphId: GraphIdentifier;
 };
 
 export type AddGraphSpec = {
@@ -188,19 +196,6 @@ export type EditableGraph = {
   version(): number;
 
   /**
-   * Returns parent graph, if any.
-   * This value will be non-null only for graphs (subgraphs) that are embedded
-   * within a graph.
-   */
-  parent(): EditableGraph | null;
-
-  /**
-   * Returns the id of this graph. If this is a main graph,
-   * the value will be "". Otherwise, it will be the id of this subgraph.
-   */
-  graphId(): GraphIdentifier;
-
-  /**
    * Performs an edit operation on the graph.
    * @param edits -- a list of changes to apply
    * @param label -- a user-friendly description of the edit, which also
@@ -220,16 +215,9 @@ export type EditableGraph = {
    */
   history(): EditHistory;
 
-  /**
-   * Retrieves a subgraph of this graph.
-   * @param id -- id of the subgraph
-   * @throws when used on an embedded subgraph.
-   */
-  getGraph(id: GraphIdentifier): EditableGraph | null;
-
   raw(): GraphDescriptor;
 
-  inspect(): InspectableGraph;
+  inspect(id: GraphIdentifier | null): InspectableGraph;
 };
 
 export type EditHistoryController = {
@@ -359,3 +347,13 @@ export type EditableGraphSelection = {
   edges: Edge[];
   dangling: Edge[];
 };
+
+export type Result<R> =
+  | {
+      success: false;
+      error: string;
+    }
+  | {
+      success: true;
+      result: R;
+    };

--- a/packages/breadboard/src/index.ts
+++ b/packages/breadboard/src/index.ts
@@ -127,3 +127,8 @@ export { sequenceEntryToHarnessRunResult } from "./inspector/run/conversions.js"
 
 export { addSandboxedRunModule } from "./sandboxed-run-module.js";
 export { blankImperative } from "./run/run-imperative-graph.js";
+
+export { IsolateSelectionTransform } from "./editor/transforms/isolate-selection.js";
+export { MoveToGraphTransform } from "./editor/transforms/move-to-graph.js";
+export { MoveToNewGraphTransform } from "./editor/transforms/move-to-new-graph.js";
+export { MergeGraphTransform } from "./editor/transforms/merge-graph.js";

--- a/packages/breadboard/tests/editor/configuration.ts
+++ b/packages/breadboard/tests/editor/configuration.ts
@@ -10,7 +10,8 @@ import { testEditGraph } from "./graph.js";
 
 test("editGraph correctly edits node configuration", async (t) => {
   const graph = testEditGraph();
-  const old = graph.inspect().nodeById("node0")?.descriptor?.configuration;
+  const graphId = "";
+  const old = graph.inspect("").nodeById("node0")?.descriptor?.configuration;
 
   t.deepEqual(old, undefined);
 
@@ -20,13 +21,14 @@ test("editGraph correctly edits node configuration", async (t) => {
         type: "changeconfiguration",
         id: "node0",
         configuration: { title: "hello " },
+        graphId,
       },
     ],
     "test"
   );
 
   t.is(result.success, true);
-  t.deepEqual(graph.inspect().nodeById("node0")?.descriptor?.configuration, {
+  t.deepEqual(graph.inspect("").nodeById("node0")?.descriptor?.configuration, {
     title: "hello ",
   });
 
@@ -36,13 +38,14 @@ test("editGraph correctly edits node configuration", async (t) => {
         type: "changeconfiguration",
         id: "node0",
         configuration: { description: "world" },
+        graphId,
       },
     ],
     "test"
   );
 
   t.is(changeResult.success, true);
-  t.deepEqual(graph.inspect().nodeById("node0")?.descriptor?.configuration, {
+  t.deepEqual(graph.inspect("").nodeById("node0")?.descriptor?.configuration, {
     title: "hello ",
     description: "world",
   });
@@ -54,12 +57,13 @@ test("editGraph correctly edits node configuration", async (t) => {
         id: "node0",
         configuration: { title: "goodbye" },
         reset: true,
+        graphId,
       },
     ],
     "test"
   );
   t.is(resetResult.success, true);
-  t.deepEqual(graph.inspect().nodeById("node0")?.descriptor?.configuration, {
+  t.deepEqual(graph.inspect("").nodeById("node0")?.descriptor?.configuration, {
     title: "goodbye",
   });
 });

--- a/packages/breadboard/tests/editor/graph.ts
+++ b/packages/breadboard/tests/editor/graph.ts
@@ -71,6 +71,7 @@ export const testEditGraph = () => {
 
 test("editor API successfully tests for node addition", async (t) => {
   const graph = testEditGraph();
+  const graphId = "";
 
   {
     const result = await graph.edit(
@@ -81,6 +82,7 @@ test("editor API successfully tests for node addition", async (t) => {
             id: "node1",
             type: "foo",
           },
+          graphId,
         },
       ],
       "add node",
@@ -98,6 +100,7 @@ test("editor API successfully tests for node addition", async (t) => {
             id: "node0",
             type: "foo",
           },
+          graphId,
         },
       ],
       "add node",
@@ -115,6 +118,7 @@ test("editor API successfully tests for node addition", async (t) => {
             id: "node1",
             type: "unknown type",
           },
+          graphId,
         },
       ],
       "add node",
@@ -127,6 +131,7 @@ test("editor API successfully tests for node addition", async (t) => {
 
 test("editor API successfully adds a node", async (t) => {
   const graph = testEditGraph();
+  const graphId = "";
 
   const result = await graph.edit(
     [
@@ -136,6 +141,7 @@ test("editor API successfully adds a node", async (t) => {
           id: "node1",
           type: "foo",
         },
+        graphId,
       },
     ],
     "add node"
@@ -152,10 +158,11 @@ test("editor API successfully adds a node", async (t) => {
 
 test("editor API successfully tests for node removal", async (t) => {
   const graph = testEditGraph();
+  const graphId = "";
 
   {
     const result = await graph.edit(
-      [{ type: "removenode", id: "node0" }],
+      [{ type: "removenode", id: "node0", graphId }],
       "remove node",
       true
     );
@@ -164,7 +171,7 @@ test("editor API successfully tests for node removal", async (t) => {
   }
   {
     const result = await graph.edit(
-      [{ type: "removenode", id: "node1" }],
+      [{ type: "removenode", id: "node1", graphId }],
       "remove node",
       true
     );
@@ -175,9 +182,10 @@ test("editor API successfully tests for node removal", async (t) => {
 
 test("editor API successfully removes a node", async (t) => {
   const graph = testEditGraph();
+  const graphId = "";
   {
     const result = await graph.edit(
-      [{ type: "removenode", id: "node0" }],
+      [{ type: "removenode", id: "node0", graphId }],
       "remove node"
     );
 
@@ -196,7 +204,7 @@ test("editor API successfully removes a node", async (t) => {
 
   {
     const result = await graph.edit(
-      [{ type: "addnode", node: { id: "node0", type: "foo" } }],
+      [{ type: "addnode", node: { id: "node0", type: "foo" }, graphId }],
       "add node",
       true
     );
@@ -206,6 +214,7 @@ test("editor API successfully removes a node", async (t) => {
 
 test("editor API successfully tests for edge addition", async (t) => {
   const graph = testEditGraph();
+  const graphId = "";
 
   {
     const result = await graph.edit(
@@ -213,6 +222,7 @@ test("editor API successfully tests for edge addition", async (t) => {
         {
           type: "addedge",
           edge: { from: "node0", out: "out", to: "node2", in: "in" },
+          graphId,
         },
       ],
       "add edge",
@@ -227,6 +237,7 @@ test("editor API successfully tests for edge addition", async (t) => {
         {
           type: "addedge",
           edge: { from: "node0", out: "out", to: "node0", in: "in" },
+          graphId,
         },
       ],
       "add edge",
@@ -241,6 +252,7 @@ test("editor API successfully tests for edge addition", async (t) => {
         {
           type: "addedge",
           edge: { from: "node0", out: "out", to: "node0", in: "baz" },
+          graphId,
         },
       ],
       "add edge",
@@ -255,6 +267,7 @@ test("editor API successfully tests for edge addition", async (t) => {
         {
           type: "addedge",
           edge: { from: "unknown node", out: "out", to: "node2", in: "in" },
+          graphId,
         },
       ],
       "add edge",
@@ -269,6 +282,7 @@ test("editor API successfully tests for edge addition", async (t) => {
         {
           type: "addedge",
           edge: { from: "node0", out: "out", to: "unknown node", in: "in" },
+          graphId,
         },
       ],
       "add edge",
@@ -281,6 +295,7 @@ test("editor API successfully tests for edge addition", async (t) => {
 
 test("editor API successfully adds an edge", async (t) => {
   const graph = testEditGraph();
+  const graphId = "";
 
   {
     const result = await graph.edit(
@@ -288,6 +303,7 @@ test("editor API successfully adds an edge", async (t) => {
         {
           type: "addedge",
           edge: { from: "node0", out: "out", to: "node2", in: "in" },
+          graphId,
         },
       ],
       "add edge"
@@ -310,6 +326,7 @@ test("editor API successfully adds an edge", async (t) => {
         {
           type: "addedge",
           edge: { from: "node0", out: "out", to: "node2", in: "in" },
+          graphId,
         },
       ],
       "add edge",
@@ -322,6 +339,7 @@ test("editor API successfully adds an edge", async (t) => {
 
 test("editor API successfully tests for edge removal", async (t) => {
   const graph = testEditGraph();
+  const graphId = "";
 
   {
     const result = await graph.edit(
@@ -329,6 +347,7 @@ test("editor API successfully tests for edge removal", async (t) => {
         {
           type: "removeedge",
           edge: { from: "node0", out: "out", to: "node0", in: "in" },
+          graphId,
         },
       ],
       "remove edge",
@@ -343,6 +362,7 @@ test("editor API successfully tests for edge removal", async (t) => {
         {
           type: "removeedge",
           edge: { from: "node0", out: "out", to: "node0", in: "baz" },
+          graphId,
         },
       ],
       "remove edge",
@@ -357,6 +377,7 @@ test("editor API successfully tests for edge removal", async (t) => {
         {
           type: "removeedge",
           edge: { from: "unknown node", out: "out", to: "node0", in: "in" },
+          graphId,
         },
       ],
       "remove edge",
@@ -376,6 +397,7 @@ test("editor API successfully tests for edge removal", async (t) => {
             to: "unknown node",
             in: "in",
           },
+          graphId,
         },
       ],
       "test",
@@ -388,6 +410,7 @@ test("editor API successfully tests for edge removal", async (t) => {
 
 test("editor API successfully removes an edge", async (t) => {
   const graph = testEditGraph();
+  const graphId = "";
 
   {
     const result = await graph.edit(
@@ -395,6 +418,7 @@ test("editor API successfully removes an edge", async (t) => {
         {
           type: "removeedge",
           edge: { from: "node0", out: "out", to: "node0", in: "in" },
+          graphId,
         },
       ],
       "test"
@@ -414,6 +438,7 @@ test("editor API successfully removes an edge", async (t) => {
         {
           type: "removeedge",
           edge: { from: "node0", out: "out", to: "node0", in: "in" },
+          graphId,
         },
       ],
       "test",
@@ -426,6 +451,7 @@ test("editor API successfully removes an edge", async (t) => {
 
 test("editor API allows adding built-in nodes", async (t) => {
   const graph = testEditGraph();
+  const graphId = "";
 
   {
     const result = await graph.edit(
@@ -436,6 +462,7 @@ test("editor API allows adding built-in nodes", async (t) => {
             id: "node1",
             type: "input",
           },
+          graphId,
         },
       ],
       "test"
@@ -456,6 +483,7 @@ test("editor API allows adding built-in nodes", async (t) => {
         {
           type: "addnode",
           node: { id: "node3", type: "output" },
+          graphId,
         },
       ],
       "test"
@@ -473,8 +501,9 @@ test("editor API allows adding built-in nodes", async (t) => {
 
 test("editor API allows changing edge", async (t) => {
   const graph = testEditGraph();
+  const graphId = "";
 
-  const before = graph.inspect().edges()[0];
+  const before = graph.inspect("").edges()[0];
 
   const result = await graph.edit(
     [
@@ -482,6 +511,7 @@ test("editor API allows changing edge", async (t) => {
         type: "changeedge",
         from: { from: "node0", out: "out", to: "node0", in: "in" },
         to: { from: "node0", out: "out", to: "node2", in: "in" },
+        graphId,
       },
     ],
     "test"
@@ -495,16 +525,17 @@ test("editor API allows changing edge", async (t) => {
     [["node0", "node2"]]
   );
 
-  const after = graph.inspect().edges()[0];
+  const after = graph.inspect("").edges()[0];
   t.assert(before === after);
 });
 
 test("editor API does not allow connecting a specific output port to a star port", async (t) => {
   const graph = testEditGraph();
+  const graphId = "";
 
   const edgeSpec = { from: "node0", out: "out", to: "node2", in: "*" };
   const result = await graph.edit(
-    [{ type: "addedge", edge: edgeSpec }],
+    [{ type: "addedge", edge: edgeSpec, graphId }],
     "test",
     true
   );

--- a/packages/breadboard/tests/editor/metadata.ts
+++ b/packages/breadboard/tests/editor/metadata.ts
@@ -30,11 +30,12 @@ const testEditGraph = () => {
 
 test("editGraph correctly edits node metadata", async (t) => {
   const graph = testEditGraph();
-  const metadata = graph.inspect().nodeById("node0")?.descriptor?.metadata;
+  const graphId = "";
+  const metadata = graph.inspect("").nodeById("node0")?.descriptor?.metadata;
   t.is(metadata, undefined);
 
   const result = await graph.edit(
-    [{ type: "changemetadata", id: "node0", metadata: {} }],
+    [{ type: "changemetadata", id: "node0", metadata: {}, graphId }],
     "test",
     true
   );
@@ -42,13 +43,13 @@ test("editGraph correctly edits node metadata", async (t) => {
 
   const newMetadata = { title: "bar" };
   const changeResult = await graph.edit(
-    [{ type: "changemetadata", id: "node0", metadata: newMetadata }],
+    [{ type: "changemetadata", id: "node0", metadata: newMetadata, graphId }],
     "test"
   );
   t.is(changeResult.success, true);
   t.is(graph.version(), 1);
 
-  const changedMetadata = graph.inspect().nodeById("node0")
+  const changedMetadata = graph.inspect("").nodeById("node0")
     ?.descriptor?.metadata;
   t.deepEqual(changedMetadata, newMetadata);
 
@@ -58,6 +59,7 @@ test("editGraph correctly edits node metadata", async (t) => {
         type: "changemetadata",
         id: "nonexistentNode",
         metadata: { title: "baz" },
+        graphId,
       },
     ],
     "test"
@@ -68,11 +70,12 @@ test("editGraph correctly edits node metadata", async (t) => {
 
 test("editGraph correctly edits visual node metadata", async (t) => {
   const graph = testEditGraph();
-  const metadata = graph.inspect().nodeById("node0")?.descriptor?.metadata;
+  const graphId = "";
+  const metadata = graph.inspect("").nodeById("node0")?.descriptor?.metadata;
   t.is(metadata, undefined);
 
   const result = await graph.edit(
-    [{ type: "changemetadata", id: "node0", metadata: {} }],
+    [{ type: "changemetadata", id: "node0", metadata: {}, graphId }],
     "test",
     true
   );
@@ -83,13 +86,13 @@ test("editGraph correctly edits visual node metadata", async (t) => {
     t.true(evt.visualOnly);
   });
   const changeResult = await graph.edit(
-    [{ type: "changemetadata", id: "node0", metadata: newMetadata }],
+    [{ type: "changemetadata", id: "node0", metadata: newMetadata, graphId }],
     "test"
   );
   t.is(changeResult.success, true);
   t.is(graph.version(), 1);
 
-  const changedMetadata = graph.inspect().nodeById("node0")
+  const changedMetadata = graph.inspect("").nodeById("node0")
     ?.descriptor?.metadata;
   t.deepEqual(changedMetadata, newMetadata);
 
@@ -99,6 +102,7 @@ test("editGraph correctly edits visual node metadata", async (t) => {
         type: "changemetadata",
         id: "nonexistentNode",
         metadata: { title: "baz" },
+        graphId,
       },
     ],
     "test"
@@ -109,20 +113,27 @@ test("editGraph correctly edits visual node metadata", async (t) => {
 
 test("editGraph correctly distinguishes between `reset` and incremental graph metadata changes", async (t) => {
   const graph = testEditGraph();
+  const graphId = "";
 
   const result = await graph.edit(
     [
-      { type: "changemetadata", id: "node0", metadata: { title: "hello" } },
+      {
+        type: "changemetadata",
+        id: "node0",
+        metadata: { title: "hello" },
+        graphId,
+      },
       {
         type: "changemetadata",
         id: "node0",
         metadata: { visual: { x: 8, y: 10 } },
+        graphId,
       },
     ],
     "test"
   );
   t.is(result.success, true);
-  const changedMetadata = graph.inspect().nodeById("node0")
+  const changedMetadata = graph.inspect("").nodeById("node0")
     ?.descriptor?.metadata;
   t.deepEqual(changedMetadata, { title: "hello", visual: { x: 8, y: 10 } });
 });

--- a/packages/breadboard/tests/editor/module.ts
+++ b/packages/breadboard/tests/editor/module.ts
@@ -15,7 +15,7 @@ test("Can add modules", async (t) => {
   );
 
   t.truthy(result.success);
-  const modules = graph.inspect().modules();
+  const modules = graph.inspect("").modules();
   t.is(Object.keys(modules).length, 1);
   t.deepEqual(modules["mod1"].code(), "Hello, World!");
 });
@@ -41,7 +41,7 @@ test("Can change modules", async (t) => {
   );
 
   t.truthy(changeResult.success);
-  const modules = graph.inspect().modules();
+  const modules = graph.inspect("").modules();
   t.is(Object.keys(modules).length, 1);
   t.deepEqual(modules["mod1"].code(), "Hello, Updated World!");
 });
@@ -62,6 +62,6 @@ test("Can delete modules", async (t) => {
 
   t.truthy(removeResult.success);
 
-  const modules = graph.inspect().modules();
+  const modules = graph.inspect("").modules();
   t.is(Object.keys(modules).length, 0);
 });

--- a/packages/breadboard/tests/editor/multi.ts
+++ b/packages/breadboard/tests/editor/multi.ts
@@ -9,8 +9,9 @@ import { testEditGraph } from "./graph.js";
 
 test("Multi-edit returns a last failed edit's error message", async (t) => {
   const graph = testEditGraph();
+  const graphId = "";
   const result = await graph.edit(
-    [{ type: "addnode", node: { id: "node0", type: "foo" } }],
+    [{ type: "addnode", node: { id: "node0", type: "foo" }, graphId }],
     "test",
     true
   );
@@ -40,16 +41,17 @@ test("Multi-edit can do multiple successful edits", async (t) => {
       graphChangeRejectDispatched = true;
     });
     const oldVersion = graph.version();
+    const graphId = "";
     const result = await graph.edit(
       [
-        { type: "addnode", node: { id: "node-1", type: "foo" } },
-        { type: "addnode", node: { id: "node-2", type: "foo" } },
-        { type: "addnode", node: { id: "node-3", type: "foo" } },
+        { type: "addnode", node: { id: "node-1", type: "foo" }, graphId },
+        { type: "addnode", node: { id: "node-2", type: "foo" }, graphId },
+        { type: "addnode", node: { id: "node-3", type: "foo" }, graphId },
       ],
       "test"
     );
     t.true(result.success);
-    const inspector = graph.inspect();
+    const inspector = graph.inspect("");
     t.assert(inspector.nodeById("node-1"));
     t.assert(inspector.nodeById("node-2"));
     t.assert(inspector.nodeById("node-3"));
@@ -68,17 +70,18 @@ test("Multi-edit can do multiple successful edits", async (t) => {
       graphChangeRejectDispatched = true;
     });
     const oldVersion = graph.version();
+    const graphId = "";
     const result = await graph.edit(
       [
-        { type: "addnode", node: { id: "node-1", type: "foo" } },
-        { type: "addnode", node: { id: "node-2", type: "foo" } },
-        { type: "addnode", node: { id: "node-3", type: "foo" } },
+        { type: "addnode", node: { id: "node-1", type: "foo" }, graphId },
+        { type: "addnode", node: { id: "node-2", type: "foo" }, graphId },
+        { type: "addnode", node: { id: "node-3", type: "foo" }, graphId },
       ],
       "test",
       true
     );
     t.true(result.success);
-    const inspector = graph.inspect();
+    const inspector = graph.inspect("");
     t.assert(!inspector.nodeById("node-1"));
     t.assert(!inspector.nodeById("node-2"));
     t.assert(!inspector.nodeById("node-3"));
@@ -100,11 +103,12 @@ test("Multi-edit gracefully fails", async (t) => {
       graphChangeRejectDispatched = true;
     });
     const oldVersion = graph.version();
+    const graphId = "";
     const result = await graph.edit(
       [
-        { type: "addnode", node: { id: "node-1", type: "foo" } },
-        { type: "addnode", node: { id: "node0", type: "foo" } },
-        { type: "addnode", node: { id: "node-3", type: "foo" } },
+        { type: "addnode", node: { id: "node-1", type: "foo" }, graphId },
+        { type: "addnode", node: { id: "node0", type: "foo" }, graphId },
+        { type: "addnode", node: { id: "node-3", type: "foo" }, graphId },
       ],
       "test"
     );
@@ -118,7 +122,7 @@ test("Multi-edit gracefully fails", async (t) => {
       t.fail();
       return;
     }
-    const inspector = graph.inspect();
+    const inspector = graph.inspect("");
     t.assert(!inspector.nodeById("node-1"));
     t.assert(!inspector.nodeById("node-3"));
     t.assert(oldVersion === graph.version());
@@ -136,11 +140,12 @@ test("Multi-edit gracefully fails", async (t) => {
       graphChangeRejectDispatched = true;
     });
     const oldVersion = graph.version();
+    const graphId = "";
     const result = await graph.edit(
       [
-        { type: "addnode", node: { id: "node-1", type: "foo" } },
-        { type: "addnode", node: { id: "node-1", type: "foo" } },
-        { type: "addnode", node: { id: "node-3", type: "foo" } },
+        { type: "addnode", node: { id: "node-1", type: "foo" }, graphId },
+        { type: "addnode", node: { id: "node-1", type: "foo" }, graphId },
+        { type: "addnode", node: { id: "node-3", type: "foo" }, graphId },
       ],
       "test"
     );
@@ -154,7 +159,7 @@ test("Multi-edit gracefully fails", async (t) => {
       t.fail();
       return;
     }
-    const inspector = graph.inspect();
+    const inspector = graph.inspect("");
     t.assert(!inspector.nodeById("node-1"));
     t.assert(!inspector.nodeById("node-3"));
     t.assert(oldVersion === graph.version());

--- a/packages/breadboard/tests/node/editor/isolate-selection.ts
+++ b/packages/breadboard/tests/node/editor/isolate-selection.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from "node:test";
+import { testEditGraph } from "./test-graph.js";
+import { deepStrictEqual, ok } from "node:assert";
+import { IsolateSelectionTransform } from "../../../src/editor/transforms/isolate-selection.js";
+
+describe("isolate selection transform", () => {
+  it("correctly removes dangling nodes", async () => {
+    const graph = testEditGraph();
+    const edited = await graph.edit(
+      [
+        {
+          type: "addedge",
+          edge: { from: "node0", to: "node2", out: "*", in: "" },
+        },
+      ],
+      ""
+    );
+    ok(edited.success);
+
+    {
+      const transform = new IsolateSelectionTransform(["node0"]);
+      const transformed = await graph.apply(transform);
+      ok(transformed.success);
+      const expected = testEditGraph().raw();
+      deepStrictEqual(graph.raw(), expected);
+    }
+  });
+
+  it("correctly rejects spurious nodes", async () => {
+    const graph = testEditGraph();
+
+    const transform = new IsolateSelectionTransform(["node4"]);
+    const transformed = await graph.apply(transform);
+    ok(!transformed.success);
+    const expected = testEditGraph().raw();
+    deepStrictEqual(graph.raw(), expected);
+  });
+});

--- a/packages/breadboard/tests/node/editor/isolate-selection.ts
+++ b/packages/breadboard/tests/node/editor/isolate-selection.ts
@@ -17,6 +17,7 @@ describe("isolate selection transform", () => {
         {
           type: "addedge",
           edge: { from: "node0", to: "node2", out: "*", in: "" },
+          graphId: "",
         },
       ],
       ""
@@ -24,7 +25,7 @@ describe("isolate selection transform", () => {
     ok(edited.success);
 
     {
-      const transform = new IsolateSelectionTransform(["node0"]);
+      const transform = new IsolateSelectionTransform(["node0"], "");
       const transformed = await graph.apply(transform);
       ok(transformed.success);
       const expected = testEditGraph().raw();
@@ -35,7 +36,7 @@ describe("isolate selection transform", () => {
   it("correctly rejects spurious nodes", async () => {
     const graph = testEditGraph();
 
-    const transform = new IsolateSelectionTransform(["node4"]);
+    const transform = new IsolateSelectionTransform(["node4"], "");
     const transformed = await graph.apply(transform);
     ok(!transformed.success);
     const expected = testEditGraph().raw();

--- a/packages/breadboard/tests/node/editor/merge-graph.ts
+++ b/packages/breadboard/tests/node/editor/merge-graph.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from "node:test";
+import { testEditGraph, testSubGraph } from "./test-graph.js";
+import { deepStrictEqual, ok as nodeOk } from "node:assert";
+import { MergeGraphTransform } from "../../../src/editor/transforms/merge-graph.js";
+
+function ok(result: { success: true } | { success: false; error: string }) {
+  return nodeOk(result.success, !result.success ? result.error : "");
+}
+
+describe("Merging graphs", async () => {
+  await it("Correctly merges subgraph", async () => {
+    const editor = testEditGraph();
+    const addingSubgraph = await editor.edit(
+      [
+        { type: "addgraph", graph: testSubGraph(), id: "foo" },
+        { type: "addnode", node: { type: "foo", id: "node1" }, graphId: "foo" },
+      ],
+      ""
+    );
+    ok(addingSubgraph);
+    const merging = await editor.apply(new MergeGraphTransform("foo", ""));
+    ok(merging);
+
+    const graph = editor.raw();
+    deepStrictEqual(graph.nodes.length, 3);
+    deepStrictEqual(graph.graphs, undefined);
+  });
+});

--- a/packages/breadboard/tests/node/editor/move-to-graph.ts
+++ b/packages/breadboard/tests/node/editor/move-to-graph.ts
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from "node:test";
+import { testEditGraph, testSubGraph } from "./test-graph.js";
+import { deepStrictEqual, ok as nodeOk } from "node:assert";
+import { MoveToGraphTransform } from "../../../src/editor/transforms/move-to-graph.js";
+
+function ok(result: { success: true } | { success: false; error: string }) {
+  return nodeOk(result.success, !result.success ? result.error : "");
+}
+
+describe("Move-to-graph transform", async () => {
+  await it("moves nodes from main graph to sub-graph", async () => {
+    const editor = testEditGraph();
+    const addingSubgraph = await editor.edit(
+      [
+        { type: "addgraph", graph: testSubGraph(), id: "foo" },
+        {
+          type: "addedge",
+          edge: { from: "node0", to: "node2", out: "out", in: "in" },
+          graphId: "",
+        },
+      ],
+      ""
+    );
+    ok(addingSubgraph);
+    const moving = await editor.apply(
+      new MoveToGraphTransform(["node0"], "", "foo")
+    );
+    ok(moving);
+    const graph = editor.raw();
+    deepStrictEqual(graph.nodes.length, 1);
+    deepStrictEqual(graph.edges.length, 0);
+    deepStrictEqual(graph.graphs?.foo.nodes.length, 1);
+    deepStrictEqual(graph.graphs?.foo.edges.length, 1);
+  });
+
+  await it("moves nodes from sub-graph to main graph", async () => {
+    const editor = testEditGraph();
+    const addingSubgraph = await editor.edit(
+      [
+        { type: "addgraph", graph: testSubGraph(), id: "foo" },
+        {
+          type: "addnode",
+          node: { id: "node10", type: "foo" },
+          graphId: "foo",
+        },
+        {
+          type: "addnode",
+          node: { id: "node11", type: "foo" },
+          graphId: "foo",
+        },
+        {
+          type: "addedge",
+          edge: { from: "node10", to: "node11", out: "out", in: "in" },
+          graphId: "foo",
+        },
+      ],
+      ""
+    );
+    ok(addingSubgraph);
+    const moving = await editor.apply(
+      new MoveToGraphTransform(["node10"], "foo", "")
+    );
+    ok(moving);
+    const graph = editor.raw();
+    deepStrictEqual(graph.nodes.length, 3);
+    deepStrictEqual(graph.edges.length, 1);
+    deepStrictEqual(graph.graphs?.foo.nodes.length, 1);
+    deepStrictEqual(graph.graphs?.foo.edges.length, 0);
+  });
+
+  await it("moves nodes between sub-graphs", async () => {
+    const editor = testEditGraph();
+    const addingSubgraph = await editor.edit(
+      [
+        { type: "addgraph", graph: testSubGraph(), id: "foo" },
+        { type: "addgraph", graph: testSubGraph(), id: "bar" },
+        {
+          type: "addnode",
+          node: { id: "node10", type: "foo" },
+          graphId: "foo",
+        },
+        {
+          type: "addnode",
+          node: { id: "node11", type: "foo" },
+          graphId: "foo",
+        },
+        {
+          type: "addedge",
+          edge: { from: "node10", to: "node11", out: "out", in: "in" },
+          graphId: "foo",
+        },
+      ],
+      ""
+    );
+    ok(addingSubgraph);
+    const moving = await editor.apply(
+      new MoveToGraphTransform(["node10", "node11"], "foo", "bar")
+    );
+    ok(moving);
+    const graph = editor.raw();
+    deepStrictEqual(graph.nodes.length, 2);
+    deepStrictEqual(graph.edges.length, 1);
+    deepStrictEqual(graph.graphs?.foo.nodes.length, 0);
+    deepStrictEqual(graph.graphs?.foo.edges.length, 0);
+    deepStrictEqual(graph.graphs?.bar.nodes.length, 2);
+    deepStrictEqual(graph.graphs?.bar.edges.length, 1);
+  });
+});

--- a/packages/breadboard/tests/node/editor/move-to-new-graph.ts
+++ b/packages/breadboard/tests/node/editor/move-to-new-graph.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from "node:test";
+import { testEditGraph, testSubGraph } from "./test-graph.js";
+import { deepStrictEqual, ok as nodeOk } from "node:assert";
+import { MoveToNewGraphTransform } from "../../../src/editor/transforms/move-to-new-graph.js";
+
+function ok(result: { success: true } | { success: false; error: string }) {
+  return nodeOk(result.success, !result.success ? result.error : "");
+}
+
+function notOk(result: { success: true } | { success: false; error: string }) {
+  return nodeOk(!result.success, !result.success ? result.error : "");
+}
+
+describe("Move-to-new-graph transform", async () => {
+  await it("correctly creates a new subgraph", async () => {
+    const editor = testEditGraph();
+    const moving = await editor.apply(
+      new MoveToNewGraphTransform(["node0"], "", "foo", "Hello", "World")
+    );
+    ok(moving);
+    const graph = editor.raw();
+    deepStrictEqual(graph.nodes.length, 1);
+    deepStrictEqual(graph.edges.length, 0);
+    deepStrictEqual(graph.graphs?.foo.nodes.length, 1);
+    deepStrictEqual(graph.graphs?.foo.edges.length, 1);
+    deepStrictEqual(graph.graphs?.foo.title, "Hello");
+    deepStrictEqual(graph.graphs?.foo.description, "World");
+  });
+
+  await it("errors out when duplicating subgraph", async () => {
+    const editor = testEditGraph();
+    const addingSubgraph = await editor.edit(
+      [
+        { type: "addgraph", graph: testSubGraph(), id: "foo" },
+        {
+          type: "addedge",
+          edge: { from: "node0", to: "node2", out: "out", in: "in" },
+          graphId: "",
+        },
+      ],
+      ""
+    );
+    ok(addingSubgraph);
+    const moving = await editor.apply(
+      new MoveToNewGraphTransform(["node0"], "", "foo", "Hello", "World")
+    );
+    notOk(moving);
+  });
+
+  await it("errors out when moving non-existent nodes", async () => {
+    const editor = testEditGraph();
+    const moving = await editor.apply(
+      new MoveToNewGraphTransform(["node1"], "", "foo", "Hello", "World")
+    );
+    notOk(moving);
+  });
+});

--- a/packages/breadboard/tests/node/editor/selection.ts
+++ b/packages/breadboard/tests/node/editor/selection.ts
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from "node:test";
+import { testEditGraph } from "./test-graph.js";
+import { computeSelection } from "../../../src/editor/selection.js";
+import { deepStrictEqual, ok } from "node:assert";
+
+describe("Computing selection", async () => {
+  it("reports an error when trying to select non-existent node", () => {
+    const graph = testEditGraph();
+    const inspectable = graph.inspect();
+    const selection = computeSelection(inspectable, ["foo"]);
+    ok(!selection.success);
+  });
+
+  it("computes single-node selection", () => {
+    const graph = testEditGraph();
+    const inspectable = graph.inspect();
+    {
+      const selection = computeSelection(inspectable, ["node0"]);
+      deepStrictEqual(selection, {
+        success: true,
+        nodes: ["node0"],
+        edges: [{ from: "node0", out: "out", to: "node0", in: "in" }],
+        dangling: [],
+      });
+    }
+    {
+      const selection = computeSelection(inspectable, ["node2"]);
+      deepStrictEqual(selection, {
+        success: true,
+        nodes: ["node2"],
+        edges: [],
+        dangling: [],
+      });
+    }
+    {
+      const selection = computeSelection(inspectable, ["node2"]);
+      deepStrictEqual(selection, {
+        success: true,
+        nodes: ["node2"],
+        edges: [],
+        dangling: [],
+      });
+    }
+  });
+
+  await it("computes dangling edges", async () => {
+    const graph = testEditGraph();
+    const edited = await graph.edit(
+      [
+        {
+          type: "addedge",
+          edge: { from: "node0", to: "node2", out: "*", in: "" },
+        },
+      ],
+      ""
+    );
+    ok(edited.success);
+    const inspectable = graph.inspect();
+    {
+      const selection = computeSelection(inspectable, ["node0"]);
+      deepStrictEqual(selection, {
+        success: true,
+        nodes: ["node0"],
+        edges: [{ from: "node0", out: "out", to: "node0", in: "in" }],
+        dangling: [{ from: "node0", out: "*", to: "node2", in: "" }],
+      });
+    }
+  });
+});

--- a/packages/breadboard/tests/node/editor/selection.ts
+++ b/packages/breadboard/tests/node/editor/selection.ts
@@ -12,14 +12,14 @@ import { deepStrictEqual, ok } from "node:assert";
 describe("Computing selection", async () => {
   it("reports an error when trying to select non-existent node", () => {
     const graph = testEditGraph();
-    const inspectable = graph.inspect();
+    const inspectable = graph.inspect("");
     const selection = computeSelection(inspectable, ["foo"]);
     ok(!selection.success);
   });
 
   it("computes single-node selection", () => {
     const graph = testEditGraph();
-    const inspectable = graph.inspect();
+    const inspectable = graph.inspect("");
     {
       const selection = computeSelection(inspectable, ["node0"]);
       deepStrictEqual(selection, {
@@ -56,12 +56,13 @@ describe("Computing selection", async () => {
         {
           type: "addedge",
           edge: { from: "node0", to: "node2", out: "*", in: "" },
+          graphId: "",
         },
       ],
       ""
     );
     ok(edited.success);
-    const inspectable = graph.inspect();
+    const inspectable = graph.inspect("");
     {
       const selection = computeSelection(inspectable, ["node0"]);
       deepStrictEqual(selection, {

--- a/packages/breadboard/tests/node/editor/test-graph.ts
+++ b/packages/breadboard/tests/node/editor/test-graph.ts
@@ -19,7 +19,7 @@ function testSubGraph(): GraphDescriptor {
 
 function testEditGraph() {
   return editGraph(
-    structuredClone({
+    {
       nodes: [
         {
           id: "node0",
@@ -31,7 +31,7 @@ function testEditGraph() {
         },
       ],
       edges: [{ from: "node0", out: "out", to: "node0", in: "in" }],
-    }),
+    },
     {
       kits: [
         {

--- a/packages/shared-ui/src/elements/editor/editor.ts
+++ b/packages/shared-ui/src/elements/editor/editor.ts
@@ -821,7 +821,7 @@ export class Editor extends LitElement {
         if (this.#readingFromClipboard) {
           return;
         }
-
+        const graphId = this.subGraphId || "";
         this.#graphRenderer.deselectAllChildren();
 
         try {
@@ -972,7 +972,7 @@ export class Editor extends LitElement {
             node.metadata.visual.x = layout.x;
             node.metadata.visual.y = layout.y;
 
-            edits.push({ type: "addnode", node });
+            edits.push({ type: "addnode", node, graphId });
           }
 
           for (const edge of graph.edges) {
@@ -1007,7 +1007,7 @@ export class Editor extends LitElement {
             }
 
             this.#graphRenderer.addToAutoSelect(edgeToString(newEdge));
-            edits.push({ type: "addedge", edge: newEdge });
+            edits.push({ type: "addedge", edge: newEdge, graphId });
           }
 
           if (graph.metadata && graph.metadata.comments) {
@@ -1079,6 +1079,7 @@ export class Editor extends LitElement {
             edits.push({
               type: "changegraphmetadata",
               metadata: breadboardGraph.metadata,
+              graphId,
             });
           }
 
@@ -1124,6 +1125,7 @@ export class Editor extends LitElement {
         `(${curr.id}, {x: ${curr.x}, y: ${curr.y}, collapsed: ${curr.expansionState}})`
       );
     }, "");
+    const graphId = moveEvt.subGraphId || "";
     const editsEvt = new MultiEditEvent(
       moveEvt.nodes.map((node) => {
         switch (node.type) {
@@ -1136,6 +1138,7 @@ export class Editor extends LitElement {
 
             return {
               type: "changemetadata",
+              graphId,
               id: node.id,
               metadata: {
                 ...metadata,
@@ -1168,6 +1171,7 @@ export class Editor extends LitElement {
 
             return {
               type: "changegraphmetadata",
+              graphId,
               metadata,
             };
           }
@@ -1253,10 +1257,13 @@ export class Editor extends LitElement {
       evt as GraphEntityRemoveEvent;
     const edits: EditSpec[] = [];
 
+    const graphId = subGraphId || "";
+
     // Remove edges first.
     for (const edge of edges) {
       edits.push({
         type: "removeedge",
+        graphId,
         edge: {
           from: edge.from.descriptor.id,
           to: edge.to.descriptor.id,
@@ -1268,7 +1275,7 @@ export class Editor extends LitElement {
 
     // Remove nodes.
     for (const id of nodes) {
-      edits.push({ type: "removenode", id });
+      edits.push({ type: "removenode", id, graphId });
     }
 
     // Remove comments.
@@ -1284,6 +1291,7 @@ export class Editor extends LitElement {
       edits.push({
         type: "changegraphmetadata",
         metadata: graph.metadata,
+        graphId,
       });
     }
 

--- a/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
@@ -181,7 +181,7 @@ export class UI extends LitElement {
           .items.get("Show subgraphs inline")?.value
       : false;
 
-    const graph = this.editor?.inspect() || null;
+    const graph = this.editor?.inspect("") || null;
     let capabilities: false | GraphProviderCapabilities = false;
     let extendedCapabilities: false | GraphProviderExtendedCapabilities = false;
     for (const boardServer of this.boardServers) {

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -1527,7 +1527,7 @@ export class Main extends LitElement {
 
     const nodeConfig = this.#runtime.edit
       .getEditor(this.tab)
-      ?.inspect()
+      ?.inspect("")
       ?.nodeById(id)
       ?.configuration();
 
@@ -2586,7 +2586,7 @@ export class Main extends LitElement {
               ?inert=${showingOverlay}
               .readOnly=${this.tab?.readOnly ?? true}
               .graph=${this.tab?.graph ?? null}
-              .editor=${this.#runtime.edit.getEditor(this.tab, this.subGraphId)}
+              .editor=${this.#runtime.edit.getEditor(this.tab)}
               .subGraphId=${this.tab?.subGraphId ?? null}
               .moduleId=${this.tab?.moduleId ?? null}
               .run=${runs[0] ?? null}
@@ -2998,8 +2998,7 @@ export class Main extends LitElement {
                 this.#runtime.edit.multiEdit(
                   this.tab,
                   evt.edits,
-                  evt.description,
-                  evt.subGraphId
+                  evt.description
                 );
               }}
               @bbnodecreate=${(evt: BreadboardUI.Events.NodeCreateEvent) => {

--- a/packages/website/src/docs/editor.md
+++ b/packages/website/src/docs/editor.md
@@ -34,7 +34,7 @@ The editor API provides one method for applying edits to the graph: `edit`. This
 // Adds a node with id = "foo" and type = "type".
 // Returns `Promise<EditResult>`.
 const result = await graph.edit(
-  [{ type: "addnode", node: { id: "foo", type: "type" } }],
+  [{ type: "addnode", node: { id: "foo", type: "type" }, graphId: "" }],
   `Create Node "foo"`
 );
 if (!result.success) {
@@ -51,7 +51,7 @@ When `dryRun` is set to `true`, the method will not perform the actual edit, but
 // just checks to see if such a node could be added.
 // Returns `Promise<EditResult>`.
 const result = await graph.edit(
-  [{ type: "addnode", node: { id: "foo", type: "type" } }],
+  [{ type: "addnode", node: { id: "foo", type: "type" }, graphId: "" }],
   "Adding Node (dry run)",
   true
 );
@@ -69,8 +69,8 @@ Multiple changes to the graph are performed as one atomic unit when specified in
 // .. and a node with id = "bar" and type = "type" as one atomic operation.
 // Returns `Promise<EditResult>`.
 const result = await graph.edit([
-  { type: "addnode", node: { id: "foo", type: "type" } },
-  { type: "addnode", node: { id: "bar", type: "type" } },
+  { type: "addnode", node: { id: "foo", type: "type" }, graphId: "" },
+  { type: "addnode", node: { id: "bar", type: "type" }, graphId: "" },
 ]);
 if (!result.success) {
   console.warn("Adding node failed with this error", result.error);
@@ -90,7 +90,7 @@ const graph = edit(bgl, { kits: [asRuntime(Core), asRunTime(JSONKit)] });
 
 ## Editing a graph
 
-There are the six edit operations that we can perform on the graph:
+Here are all the edit operations that we can perform on the graph:
 
 - `addnode` -- add a new node to the graph
 
@@ -100,11 +100,23 @@ There are the six edit operations that we can perform on the graph:
 
 - `removeedge` -- remove an edge from the graph
 
+- `changeedge` -- mutate an existing edge in place, without changing its identity.
+
 - `changeconfiguration` -- change configuration of a node
 
 - `changemetadata` -- change metadata (title, description, etc.) of a node
 
-- `changegraphmetadata` - change graph metadata.
+- `changegraphmetadata` -- change graph metadata.
+
+- `addmodule` -- add a new module to the graph.
+
+- `removemodule` -- remove existing module from the graph.
+
+- `changemodule` -- update an existing modeul within the graph.
+
+- `addgraph` - add a new sub-graph to the graph.
+
+- `removegraph` - remove a sub-graph from this graph.
 
 ## Starting a new graph
 
@@ -191,85 +203,60 @@ When the `edit` call has a label that's different from the previous call, a new 
 ```ts
 // Creates a new history entry.
 const result = await graph.edit(
-  [{ type: "addnode", node: { id: "foo", type: "type" } }],
+  [{ type: "addnode", node: { id: "foo", type: "type" }, graphId: "" }],
   `Create Node "foo"`
 );
 // Different label, creates another history entry.
 const result = await graph.edit(
-  [{ type: "changemetadata", id: "foo", metadata: { title: "F" } }],
+  [
+    {
+      type: "changemetadata",
+      id: "foo",
+      metadata: { title: "F" },
+      graphId: "",
+    },
+  ],
   `Editing metadata for node "foo"`
 );
 // Label is the same as the previous call, no new entry created.
 const result = await graph.edit(
-  [{ type: "changemetadata", id: "foo", metadata: { title: "Fo" } }],
+  [
+    {
+      type: "changemetadata",
+      id: "foo",
+      metadata: { title: "Fo" },
+      graphId: "",
+    },
+  ],
   `Editing metadata for node "foo"`
 );
 // Label is the same as the previous call, no new entry created.
 const result = await graph.edit(
-  [{ type: "changemetadata", id: "foo", metadata: { title: "Foo" } }],
+  [
+    {
+      type: "changemetadata",
+      id: "foo",
+      metadata: { title: "Foo" },
+      graphId: "",
+    },
+  ],
   `Editing metadata for node "foo"`
 );
 // Different label, creates another history entry.
 const result = await graph.edit(
-  [{ type: "addnode", node: { id: "bar", type: "type" } }],
+  [{ type: "addnode", node: { id: "bar", type: "type" }, graphId: "" }],
   `Create Node "bar"`
 );
 ```
 
 ## Editing subgraphs
 
-Since every graph may have **embedded subgraphs** in it, we can use the Editor API to access and edit these subgraphs as well. Every subgraph has an identifier that is unique among all subgraphs within their graph. The API uses this id to add, remove, replace subgraphs and manages the `EditableGraph` instances for subgraphs.
+Since every graph may have **embedded subgraphs** in it, we can use the Editor API to access and edit these subgraphs as well. Every subgraph has an identifier that is unique among all subgraphs within their graph. The API uses this id to add, remove, replace subgraphs.
 
-```ts
-// Returns an `EditableGraph` instance or `null` if not found.
-const subgraph = graph.getGraph("foo");
-if (subgraph) {
-  // Edit the subgraph
-  // ...
-}
+The `graphId` property in the edit operations provides a way to identify
+the particular subgraph on which it operates.
 
-// Attempts to add a new subgraph and returns `EditResult`.
-// Returns null if a subgraph with this id already exists,
-// and an `EditableGraph` instance otherwise.
-const newSubgraph = graph.addGraph("bar", blank());
-if (!newSubgraph) {
-  console.log("A graph with id 'bar' already exists.");
-}
-
-// Attempts to remove the subgraph and returns `EditResult`.
-// Will fail if a subgraph with this id does not exist.
-const result = graph.removeGraph("bar");
-if (result.success) {
-  console.log("Yay, removed subgraph 'bar'.");
-} else {
-  console.log("The subgraph 'bar' does not exist".)
-}
-
-// Attempts to replace a subgraph and returns `EditResult`.
-// Returns null if a subgraph with this id does not exist,
-// and an `EditableGraph` instance of the new subgraph otherwise.
-const replaced = graph.replaceGraph("foo", blank());
-if (!replaced) {
-  console.log("A graph with id 'foo' does not exist.")
-}
-```
-
-To find out if a particular `EditableGraph` instance is an embedded subgraph, use the `parent()` method:
-
-```ts
-// If subgraph, returns `EditableGraph` instance of the parent graph.
-const parentGraph = subgraph.parent();
-if (parentGraph) {
-  console.log("A subgraph!");
-} else {
-  console.log("Not a subgraph");
-}
-```
-
-Because they are part of a larger graph, subgraphs do not have their own versions and attempting to call the `version()` method on a subgraph will throw an error.
-
-Subgraphs may not contain other subgraphs, so in the same fashion as `version()`, the `getGraph`, `addGraph`, `replaceGraph`, and `removeGraph` will throw
-when called on a subgraph.
+The id of the main graph is an empty string: `""`.
 
 ## Accessing the graph
 
@@ -286,15 +273,16 @@ The `raw()` method will correctly serialize all of graph's subgraph and reflect 
 
 ## Inspecting the graph
 
-Because the graph constantly changes, it can be tedious to keep track of the latest changes and keep creating new instances of `InspectableGraph`. To help with that, there's an `inspect` method on the `EditableGraph`:
+Because the graph constantly changes, it can be tedious to keep track of the latest changes and keep creating new instances of `InspectableGraph`. To help with that, there's an `inspect` method on the `EditableGraph`.
+
+The `inspect` method takes a graph identifier, allow easy access to a
+particular sub-graph's `InspectableGraph` instance.
 
 ```ts
 // Guaranteed to be inspecting the latest graph.
 // Returns `InspectableGraph`.
-const inspectableGraph = graph.inspect();
+const inspectableGraph = graph.inspect("");
 ```
-
-In term of lifecycle, the `InspectableGraph` changes more frequently than the `EditableGraph`. So, hang on to the `EditableGraph` instance and use it to create `InspectableGraph` instances. It will cache them for you, only creating a new inspector when the graph changes.
 
 ## Listening to changes
 


### PR DESCRIPTION
- **Introduce `computeSelection`.**
- **Add `IsolateSelectionTransform`.**
- **Massage API a bit.**
- **Flatten `EditableGraph`: it now operates on graphs and subgraphs.**
- **Introduce `MoveToGraph` transform.**
- **Switch transforms to be iteratively applied.**
- **Introduce `MoveToNewGraph` transform.**
- **Introduce `MergeGraphTransform`.**
- **docs(changeset): Introduce Edit Transforms and start using them.**
