### PR TITLE
mutable graph holder

### DIFF
--- a/.changeset/silent-zoos-repeat.md
+++ b/.changeset/silent-zoos-repeat.md
@@ -1,0 +1,8 @@
+---
+"@breadboard-ai/visual-editor": minor
+"@google-labs/breadboard": minor
+"@breadboard-ai/jsandbox": patch
+"@breadboard-ai/types": patch
+---
+
+Introduce `GraphStore`: a top-level holder of all boards.

--- a/packages/breadboard/src/editor/graph.ts
+++ b/packages/breadboard/src/editor/graph.ts
@@ -43,6 +43,7 @@ import {
 import { AddGraph } from "./operations/add-graph.js";
 import { RemoveGraph } from "./operations/remove-graph.js";
 import { MutableGraphImpl } from "../inspector/graph/mutable-graph.js";
+import { MutableGraph } from "../inspector/types.js";
 
 const validImperativeEdits: EditSpec["type"][] = [
   "addmodule",
@@ -69,22 +70,21 @@ const operations = new Map<EditSpec["type"], EditOperation>([
 
 export class Graph implements EditableGraph {
   #version = 0;
-  #options: EditableGraphOptions;
   #mutable: MutableGraphImpl;
   #graph: GraphDescriptor;
   #eventTarget: EventTarget = new EventTarget();
   #history: GraphEditHistory;
   #imperativeMain: string | null = null;
 
-  constructor(graph: GraphDescriptor, options: EditableGraphOptions) {
+  constructor(mutable: MutableGraph, options: EditableGraphOptions) {
+    const graph = mutable.graph;
     if (isImperativeGraph(graph)) {
       this.#imperativeMain = graph.main;
       this.#graph = toDeclarativeGraph(graph);
     } else {
       this.#graph = graph;
     }
-    this.#mutable = new MutableGraphImpl(graph, options);
-    this.#options = options;
+    this.#mutable = mutable;
     this.#version = options.version || 0;
     this.#history = new GraphEditHistory({
       graph: () => {
@@ -265,7 +265,7 @@ export class Graph implements EditableGraph {
 
     if (dryRun) {
       const graph = checkpoint;
-      const mutable = new MutableGraphImpl(graph, this.#options);
+      const mutable = new MutableGraphImpl(graph, this.#mutable.options);
       context = {
         graph,
         mutable,

--- a/packages/breadboard/src/editor/index.ts
+++ b/packages/breadboard/src/editor/index.ts
@@ -4,17 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { MutableGraphImpl } from "../inspector/graph/mutable-graph.js";
-import { GraphDescriptor } from "../types.js";
-import { Graph } from "./graph.js";
-import { EditableGraph, EditableGraphOptions } from "./types.js";
-
-export const editGraph = (
-  graph: GraphDescriptor,
-  options: EditableGraphOptions = {}
-): EditableGraph => {
-  const mutable = new MutableGraphImpl(graph, options);
-  return new Graph(mutable, options);
-};
-
 export { blank, blankLLMContent } from "./blank.js";

--- a/packages/breadboard/src/editor/index.ts
+++ b/packages/breadboard/src/editor/index.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { MutableGraphImpl } from "../inspector/graph/mutable-graph.js";
 import { GraphDescriptor } from "../types.js";
 import { Graph } from "./graph.js";
 import { EditableGraph, EditableGraphOptions } from "./types.js";
@@ -12,7 +13,8 @@ export const editGraph = (
   graph: GraphDescriptor,
   options: EditableGraphOptions = {}
 ): EditableGraph => {
-  return new Graph(graph, options);
+  const mutable = new MutableGraphImpl(graph, options);
+  return new Graph(mutable, options);
 };
 
 export { blank, blankLLMContent } from "./blank.js";

--- a/packages/breadboard/src/index.ts
+++ b/packages/breadboard/src/index.ts
@@ -67,6 +67,8 @@ export type * from "./utils/typed-event-target.js";
  */
 export { getGraphDescriptor } from "./capability.js";
 
+export { GraphStore } from "./inspector/mutable-graph-store.js";
+
 /**
  * The Inspector API.
  */

--- a/packages/breadboard/src/index.ts
+++ b/packages/breadboard/src/index.ts
@@ -80,7 +80,7 @@ export { PortStatus } from "./inspector/types.js";
  * The Editor API.
  */
 export type * from "./editor/types.js";
-export { editGraph as edit, blank, blankLLMContent } from "./editor/index.js";
+export { blank, blankLLMContent } from "./editor/index.js";
 
 /**
  * The Loader API

--- a/packages/breadboard/src/inspector/graph/edge.ts
+++ b/packages/breadboard/src/inspector/graph/edge.ts
@@ -8,8 +8,8 @@ import { Edge as EdgeDescriptor, GraphIdentifier } from "../../types.js";
 import {
   InspectableEdge,
   InspectableEdgeType,
-  InspectableNodeCache,
   InspectablePort,
+  MutableGraph,
   ValidateResult,
 } from "../types.js";
 
@@ -52,16 +52,16 @@ export const fixupConstantEdge = (edge: EdgeDescriptor): EdgeDescriptor => {
 };
 
 class Edge implements InspectableEdge {
-  #nodes: InspectableNodeCache | null;
+  #mutable: MutableGraph | null;
   #edge: EdgeDescriptor;
   #graphId: GraphIdentifier;
 
   constructor(
-    nodes: InspectableNodeCache,
+    mutable: MutableGraph,
     edge: EdgeDescriptor,
     graphId: GraphIdentifier
   ) {
-    this.#nodes = nodes;
+    this.#mutable = mutable;
     this.#edge = edge;
     this.#graphId = graphId;
   }
@@ -71,12 +71,12 @@ class Edge implements InspectableEdge {
   }
 
   get from() {
-    if (!this.#nodes) {
+    if (!this.#mutable) {
       throw new Error(
         `Unable to access "from": this edge was deleted and is no longer part of the graph`
       );
     }
-    const from = this.#nodes.get(this.#edge.from, this.#graphId);
+    const from = this.#mutable.nodes.get(this.#edge.from, this.#graphId);
     console.assert(from, "From node not found when getting from.");
     return from!;
   }
@@ -86,12 +86,12 @@ class Edge implements InspectableEdge {
   }
 
   get to() {
-    if (!this.#nodes) {
+    if (!this.#mutable) {
       throw new Error(
         `Unable to access "to": this edge was deleted and is no longer part of the graph`
       );
     }
-    const to = this.#nodes.get(this.#edge.to, this.#graphId);
+    const to = this.#mutable.nodes.get(this.#edge.to, this.#graphId);
     console.assert(to, "To node not found when getting to.");
     return to!;
   }
@@ -137,10 +137,10 @@ class Edge implements InspectableEdge {
   }
 
   setDeleted() {
-    this.#nodes = null;
+    this.#mutable = null;
   }
 
   deleted(): boolean {
-    return !this.#nodes;
+    return !this.#mutable;
   }
 }

--- a/packages/breadboard/src/inspector/graph/mutable-graph.ts
+++ b/packages/breadboard/src/inspector/graph/mutable-graph.ts
@@ -19,6 +19,7 @@ import {
   InspectableModuleCache,
   InspectableNodeCache,
   MutableGraph,
+  MutableGraphIdentifier,
 } from "../types.js";
 import { Node } from "./node.js";
 import { Edge } from "./edge.js";
@@ -53,6 +54,7 @@ export const inspectableGraph = (
 
 class MutableGraphImpl implements MutableGraph {
   readonly options: InspectableGraphOptions;
+  readonly id: MutableGraphIdentifier;
 
   // @ts-expect-error Initialized in rebuild.
   graph: GraphDescriptor;
@@ -71,6 +73,7 @@ class MutableGraphImpl implements MutableGraph {
 
   constructor(graph: GraphDescriptor, options: InspectableGraphOptions) {
     this.options = options;
+    this.id = crypto.randomUUID();
     this.rebuild(graph);
   }
 

--- a/packages/breadboard/src/inspector/graph/mutable-graph.ts
+++ b/packages/breadboard/src/inspector/graph/mutable-graph.ts
@@ -19,7 +19,7 @@ import {
   InspectableModuleCache,
   InspectableNodeCache,
   MutableGraph,
-  MutableGraphIdentifier,
+  MainGraphIdentifier,
 } from "../types.js";
 import { Node } from "./node.js";
 import { Edge } from "./edge.js";
@@ -54,7 +54,7 @@ export const inspectableGraph = (
 
 class MutableGraphImpl implements MutableGraph {
   readonly options: InspectableGraphOptions;
-  readonly id: MutableGraphIdentifier;
+  readonly id: MainGraphIdentifier;
 
   // @ts-expect-error Initialized in rebuild.
   graph: GraphDescriptor;

--- a/packages/breadboard/src/inspector/graph/mutable-graph.ts
+++ b/packages/breadboard/src/inspector/graph/mutable-graph.ts
@@ -138,7 +138,7 @@ class MutableGraphImpl implements MutableGraph {
       return new Node(descriptor, this, graphId);
     });
     this.edges = new EdgeCache(
-      (edge, graphId) => new Edge(this.nodes, edge, graphId)
+      (edge, graphId) => new Edge(this, edge, graphId)
     );
     this.modules = new ModuleCache();
     this.describe = new DescribeResultCache();

--- a/packages/breadboard/src/inspector/mutable-graph-store.ts
+++ b/packages/breadboard/src/inspector/mutable-graph-store.ts
@@ -57,6 +57,18 @@ class GraphStore implements MutableGraphStore {
     };
   }
 
+  editByDescriptor(
+    graph: GraphDescriptor,
+    options: EditableGraphOptions = {}
+  ): EditableGraph | undefined {
+    const result = this.getOrAdd(graph);
+    if (!result.success) {
+      console.error(`Failed to edityByDescriptor: ${result.error}`);
+      return undefined;
+    }
+    return this.edit(result.result.id, options);
+  }
+
   edit(
     id: MainGraphIdentifier,
     options: EditableGraphOptions = {}

--- a/packages/breadboard/src/inspector/mutable-graph-store.ts
+++ b/packages/breadboard/src/inspector/mutable-graph-store.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GraphDescriptor } from "@breadboard-ai/types";
+import {
+  InspectableGraphOptions,
+  MutableGraph,
+  MutableGraphIdentifier,
+  MutableGraphStore,
+} from "./types.js";
+import { MutableGraphImpl } from "./graph/mutable-graph.js";
+
+export { MutableGraphStoreImpl };
+
+class MutableGraphStoreImpl implements MutableGraphStore {
+  #options: InspectableGraphOptions;
+  #graphs: Map<MutableGraphIdentifier, MutableGraph> = new Map();
+
+  constructor(options: InspectableGraphOptions) {
+    this.#options = options;
+  }
+
+  add(graph: GraphDescriptor): MutableGraph {
+    const mutable = new MutableGraphImpl(graph, this.#options);
+    this.#graphs.set(mutable.id, mutable);
+    return mutable;
+  }
+
+  get(id: MutableGraphIdentifier): MutableGraph | undefined {
+    return this.#graphs.get(id);
+  }
+}

--- a/packages/breadboard/src/inspector/mutable-graph-store.ts
+++ b/packages/breadboard/src/inspector/mutable-graph-store.ts
@@ -4,32 +4,117 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GraphDescriptor } from "@breadboard-ai/types";
+import { GraphDescriptor, GraphIdentifier } from "@breadboard-ai/types";
+import { Graph as GraphEditor } from "../editor/graph.js";
 import {
+  EditableGraph,
+  EditableGraphOptions,
+  Result,
+} from "../editor/types.js";
+import { GraphLoaderContext } from "../loader/types.js";
+import { MutableGraphImpl } from "./graph/mutable-graph.js";
+import {
+  GraphHandle,
+  InspectableGraph,
   InspectableGraphOptions,
+  MainGraphIdentifier,
   MutableGraph,
-  MutableGraphIdentifier,
   MutableGraphStore,
 } from "./types.js";
-import { MutableGraphImpl } from "./graph/mutable-graph.js";
+import { hash } from "../utils/hash.js";
 
-export { MutableGraphStoreImpl };
+export { GraphStore };
 
-class MutableGraphStoreImpl implements MutableGraphStore {
+class GraphStore implements MutableGraphStore {
   #options: InspectableGraphOptions;
-  #graphs: Map<MutableGraphIdentifier, MutableGraph> = new Map();
+  #mainGraphIds: Map<string, MainGraphIdentifier> = new Map();
+  #mutables: Map<MainGraphIdentifier, MutableGraph> = new Map();
 
   constructor(options: InspectableGraphOptions) {
     this.#options = options;
   }
 
-  add(graph: GraphDescriptor): MutableGraph {
-    const mutable = new MutableGraphImpl(graph, this.#options);
-    this.#graphs.set(mutable.id, mutable);
-    return mutable;
+  async load(
+    url: string,
+    options: GraphLoaderContext
+  ): Promise<Result<GraphHandle>> {
+    const loader = this.#options.loader;
+    if (!loader) {
+      return error(`Unable to load "${url}": no loader provided`);
+    }
+    const loading = await loader.load(url, options);
+    if (!loading.success) {
+      return loading;
+    }
+    const { graph, subGraphId: graphId = "" } = loading;
+    const mutable = this.getOrAdd(graph);
+    if (!mutable.success) {
+      return mutable;
+    }
+    return {
+      success: true,
+      result: { type: "declarative", id: mutable.result.id, graphId },
+    };
   }
 
-  get(id: MutableGraphIdentifier): MutableGraph | undefined {
-    return this.#graphs.get(id);
+  edit(
+    id: MainGraphIdentifier,
+    options: EditableGraphOptions = {}
+  ): EditableGraph | undefined {
+    const mutable = this.get(id);
+    if (!mutable) return undefined;
+
+    return new GraphEditor(mutable, options);
   }
+
+  inspect(
+    id: MainGraphIdentifier,
+    graphId: GraphIdentifier
+  ): InspectableGraph | undefined {
+    const mutable = this.get(id);
+    if (!mutable) return undefined;
+
+    return mutable.graphs.get(graphId);
+  }
+
+  getOrAdd(graph: GraphDescriptor): Result<MutableGraph> {
+    let url = graph.url;
+    let graphHash: number | null = null;
+    if (!url) {
+      graphHash = hash(graph);
+      url = `hash:${graphHash}`;
+    }
+
+    // Find graph by URL.
+    const id = this.#mainGraphIds.get(url);
+    if (id) {
+      const existing = this.#mutables.get(id);
+      if (!existing) {
+        return error(`Integrity error: main graph "${id}" not found in store.`);
+      }
+      const same = graphHash !== null || hash(existing.graph) === hash(graph);
+      if (!same) {
+        // When not the same, rebuild the graph on the MutableGraphImpl.
+        existing.rebuild(graph);
+      }
+      return { success: true, result: existing };
+    } else {
+      // Brand new graph
+      const mutable = new MutableGraphImpl(graph, this.#options);
+      this.#mutables.set(mutable.id, mutable);
+      this.#mainGraphIds.set(url, mutable.id);
+      return { success: true, result: mutable };
+    }
+  }
+
+  get(id: MainGraphIdentifier): MutableGraph | undefined {
+    return this.#mutables.get(id);
+  }
+}
+
+function error<T>(message: string): Result<T> {
+  return {
+    success: false,
+    error: message,
+  };
 }

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -672,6 +672,10 @@ export type GraphHandle = {
 
 export type MutableGraphStore = {
   load(url: string, options: GraphLoaderContext): Promise<Result<GraphHandle>>;
+  editByDescriptor(
+    graph: GraphDescriptor,
+    options?: EditableGraphOptions
+  ): EditableGraph | undefined;
   edit(
     id: MainGraphIdentifier,
     options?: EditableGraphOptions

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -13,6 +13,7 @@ import type {
   ModuleMetadata,
   NodeMetadata,
   TraversalResult,
+  UUID,
 } from "@breadboard-ai/types";
 import { HarnessRunResult, SecretResult } from "../harness/types.js";
 import { GraphLoader } from "../loader/types.js";
@@ -42,7 +43,7 @@ import {
 import { SequenceEntry } from "./run/serializer.js";
 import { ReanimationState } from "../run/types.js";
 import { Sandbox } from "@breadboard-ai/jsandbox";
-import { AffectedNode } from "../editor/types.js";
+import { AffectedNode, Result } from "../editor/types.js";
 
 export type GraphVersion = number;
 
@@ -646,12 +647,19 @@ export type InspectableGraphCache = {
   clear(): void;
 };
 
+export type MutableGraphStore = {
+  create(url: GraphDescriptor): Result<MutableGraph>;
+};
+
+export type MutableGraphIdentifier = UUID;
+
 /**
  * A backing store for `InspectableGraph` instances, representing a stable
  * instance of a graph whose properties mutate.
  */
 export type MutableGraph = {
   graph: GraphDescriptor;
+  readonly id: MutableGraphIdentifier;
   readonly graphs: InspectableGraphCache;
   readonly options: InspectableGraphOptions;
   readonly nodes: InspectableNodeCache;

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -43,7 +43,7 @@ import {
 import { SequenceEntry } from "./run/serializer.js";
 import { ReanimationState } from "../run/types.js";
 import { Sandbox } from "@breadboard-ai/jsandbox";
-import { AffectedNode, Result } from "../editor/types.js";
+import { AffectedNode } from "../editor/types.js";
 
 export type GraphVersion = number;
 
@@ -648,7 +648,8 @@ export type InspectableGraphCache = {
 };
 
 export type MutableGraphStore = {
-  create(url: GraphDescriptor): Result<MutableGraph>;
+  add(url: GraphDescriptor): MutableGraph;
+  get(id: MutableGraphIdentifier): MutableGraph | undefined;
 };
 
 export type MutableGraphIdentifier = UUID;

--- a/packages/breadboard/tests/editor/graph.ts
+++ b/packages/breadboard/tests/editor/graph.ts
@@ -6,8 +6,8 @@
 
 import test from "ava";
 
-import { editGraph } from "../../src/editor/index.js";
 import { NodeHandler } from "../../src/types.js";
+import { editGraph } from "../helpers/_editor.js";
 
 export const testEditGraph = () => {
   return editGraph(

--- a/packages/breadboard/tests/editor/metadata.ts
+++ b/packages/breadboard/tests/editor/metadata.ts
@@ -6,8 +6,8 @@
 
 import test from "ava";
 
-import { editGraph } from "../../src/editor/index.js";
 import { NodeMetadata } from "@breadboard-ai/types";
+import { editGraph } from "../helpers/_editor.js";
 
 const testEditGraph = () => {
   return editGraph(

--- a/packages/breadboard/tests/helpers/_editor.ts
+++ b/packages/breadboard/tests/helpers/_editor.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GraphDescriptor } from "@breadboard-ai/types";
+import { EditableGraph, EditableGraphOptions } from "../../src/index.js";
+import { MutableGraphImpl } from "../../src/inspector/graph/mutable-graph.js";
+import { Graph } from "../../src/editor/graph.js";
+
+export const editGraph = (
+  graph: GraphDescriptor,
+  options: EditableGraphOptions = {}
+): EditableGraph => {
+  const mutable = new MutableGraphImpl(graph, options);
+  return new Graph(mutable, options);
+};

--- a/packages/breadboard/tests/node/editor/test-graph.ts
+++ b/packages/breadboard/tests/node/editor/test-graph.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { editGraph } from "../../../src/editor/index.js";
 import { GraphDescriptor, NodeHandler } from "../../../src/types.js";
 import { ok as nodeOk } from "node:assert";
+import { editGraph } from "../../helpers/_editor.js";
 
 export { testEditGraph, testSubGraph, testFilledOutSubGraph, ok, notOk };
 

--- a/packages/jsandbox/src/capabilities.ts
+++ b/packages/jsandbox/src/capabilities.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { OutputValues } from "@breadboard-ai/types";
+import { OutputValues, UUID } from "@breadboard-ai/types";
 import { Telemetry } from "./telemetry.js";
-import { Capability, CapabilitySpec, UUID } from "./types.js";
+import { Capability, CapabilitySpec } from "./types.js";
 
 export { fetch, secrets, invoke, Capabilities };
 

--- a/packages/jsandbox/src/node.ts
+++ b/packages/jsandbox/src/node.ts
@@ -13,7 +13,8 @@ import {
 import { readFile } from "fs/promises";
 import { fileURLToPath } from "node:url";
 import factory from "./factory.js";
-import { ModuleSpec, Sandbox, UUID } from "./types.js";
+import { ModuleSpec, Sandbox } from "./types.js";
+import { UUID } from "@breadboard-ai/types";
 
 export { NodeSandbox };
 

--- a/packages/jsandbox/src/types.ts
+++ b/packages/jsandbox/src/types.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { UUID } from "@breadboard-ai/types";
+
 export type Values = Record<string, unknown>;
 export type ModuleSpec = Record<string, string>;
 export type ModuleMethod = "default" | "describe";
@@ -34,5 +36,3 @@ export type Sandbox = {
     inputs: Record<string, unknown>
   ): Promise<InvokeOutputs | DescriberOutputs>;
 };
-
-export type UUID = `${string}-${string}-${string}-${string}-${string}`;

--- a/packages/jsandbox/src/web.ts
+++ b/packages/jsandbox/src/web.ts
@@ -12,7 +12,8 @@ import {
 } from "@bjorn3/browser_wasi_shim";
 
 import factory from "./factory.js";
-import { InvokeInputs, ModuleSpec, Sandbox, UUID } from "./types.js";
+import { InvokeInputs, ModuleSpec, Sandbox } from "./types.js";
+import { UUID } from "@breadboard-ai/types";
 
 export { WebSandbox };
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -8,3 +8,4 @@ export type * from "./graph-descriptor.js";
 export type * from "./llm-content.js";
 export type * from "./probe.js";
 export type * from "./traversal.js";
+export type * from "./uuid.js";

--- a/packages/types/src/uuid.ts
+++ b/packages/types/src/uuid.ts
@@ -1,0 +1,7 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type UUID = `${string}-${string}-${string}-${string}-${string}`;

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -28,6 +28,7 @@ import {
   InspectableRunSequenceEntry,
   NodeConfiguration,
   SerializedRun,
+  MutableGraphStore,
 } from "@google-labs/breadboard";
 import { getDataStore, getRunStore } from "@breadboard-ai/data-store";
 import { classMap } from "lit/directives/class-map.js";
@@ -225,6 +226,7 @@ export class Main extends LitElement {
   #recentBoardStore = RecentBoardStore.instance();
   #recentBoards: BreadboardUI.Types.RecentBoard[] = [];
   #isSaving = false;
+  #graphStore!: MutableGraphStore;
   #dataStore = getDataStore();
   #runStore = getRunStore();
 
@@ -393,6 +395,7 @@ export class Main extends LitElement {
       })
       .then(() => {
         return Runtime.create({
+          graphStore: this.#graphStore,
           runStore: this.#runStore,
           dataStore: this.#dataStore,
           experiments: {},
@@ -403,6 +406,7 @@ export class Main extends LitElement {
       })
       .then((runtime) => {
         this.#runtime = runtime;
+        this.#graphStore = runtime.board.getGraphStore();
         this.#boardServers = runtime.board.getBoardServers() || [];
 
         this.#runtime.edit.addEventListener(

--- a/packages/visual-editor/src/runtime/board.ts
+++ b/packages/visual-editor/src/runtime/board.ts
@@ -15,6 +15,7 @@ import {
   GraphProvider,
   InspectableRunObserver,
   Kit,
+  MutableGraphStore,
 } from "@google-labs/breadboard";
 import { RuntimeConfigBoardServers, Tab, TabId, TabType } from "./types";
 import {
@@ -194,6 +195,10 @@ export class Board extends EventTarget {
 
   getLoader(): GraphLoader {
     return this.boardServers.loader;
+  }
+
+  getGraphStore(): MutableGraphStore {
+    return this.boardServers.graphStore;
   }
 
   get tabs() {

--- a/packages/visual-editor/src/runtime/edit.ts
+++ b/packages/visual-editor/src/runtime/edit.ts
@@ -6,13 +6,13 @@
 
 import {
   blankLLMContent,
-  edit,
   EditableGraph,
   EditSpec,
   GraphDescriptor,
   GraphLoader,
   GraphProvider,
   Kit,
+  MutableGraphStore,
   NodeConfiguration,
   NodeDescriptor,
   NodeIdentifier,
@@ -57,7 +57,8 @@ export class Edit extends EventTarget {
     public readonly providers: GraphProvider[],
     public readonly loader: GraphLoader,
     public readonly kits: Kit[],
-    public readonly sandbox: Sandbox
+    public readonly sandbox: Sandbox,
+    public readonly graphStore: MutableGraphStore
   ) {
     super();
   }
@@ -69,11 +70,10 @@ export class Edit extends EventTarget {
       return this.#editors.get(tab.id)!;
     }
 
-    const editor = edit(tab.graph, {
-      kits: tab.kits,
-      loader: this.loader,
-      sandbox: this.sandbox,
-    });
+    const editor = this.graphStore.editByDescriptor(tab.graph);
+    if (!editor) {
+      return null;
+    }
     editor.addEventListener("graphchange", (evt) => {
       tab.graph = evt.graph;
       this.dispatchEvent(

--- a/packages/visual-editor/src/runtime/runtime.ts
+++ b/packages/visual-editor/src/runtime/runtime.ts
@@ -4,7 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { asRuntimeKit, createLoader, Kit } from "@google-labs/breadboard";
+import {
+  asRuntimeKit,
+  createLoader,
+  GraphStore,
+  Kit,
+} from "@google-labs/breadboard";
 import { Board } from "./board.js";
 import { Run } from "./run.js";
 import { Edit } from "./edit.js";
@@ -64,14 +69,20 @@ export async function create(config: RuntimeConfig): Promise<{
   }
 
   const loader = createLoader(servers);
+  const graphStore = new GraphStore({
+    kits,
+    loader,
+    sandbox: config.sandbox,
+  });
   const boardServers = {
     servers,
     loader,
+    graphStore,
   };
 
   const runtime = {
     board: new Board([], loader, kits, boardServers, config.tokenVendor),
-    edit: new Edit([], loader, kits, config.sandbox),
+    edit: new Edit([], loader, kits, config.sandbox, graphStore),
     run: new Run(config.dataStore, config.runStore),
     kits,
   } as const;

--- a/packages/visual-editor/src/runtime/types.ts
+++ b/packages/visual-editor/src/runtime/types.ts
@@ -10,6 +10,7 @@ import {
   GraphDescriptor,
   GraphLoader,
   Kit,
+  MutableGraphStore,
   NodeConfiguration,
   RunStore,
 } from "@google-labs/breadboard";
@@ -41,6 +42,7 @@ export interface Tab {
 }
 
 export interface RuntimeConfig {
+  graphStore: MutableGraphStore;
   dataStore: DataStore;
   runStore: RunStore;
   sandbox: Sandbox;
@@ -52,6 +54,7 @@ export interface RuntimeConfig {
 export interface RuntimeConfigBoardServers {
   servers: BoardServer[];
   loader: GraphLoader;
+  graphStore: MutableGraphStore;
 }
 
 export type Result<T> =


### PR DESCRIPTION
- **Switch `Edge` to use `MutableGraph` instead of `NodeCache`.**
- **Move UUID type def to `types` package.**
- **Introduce `MutableGraphStore` and impl.**
- **Switch editable graph constructor to take `MutableGraph`.**
- **Introduce `GraphStore` (v2).**
- **Switch to use `GraphStore`.**
- **Deprecate `edit` API.**
- **docs(changeset): Introduce `GraphStore`: a top-level holder of all boards.**
