### PR TITLE
deprecate inspect graph

### DIFF
--- a/.changeset/five-weeks-explain.md
+++ b/.changeset/five-weeks-explain.md
@@ -1,0 +1,11 @@
+---
+"@google-labs/breadboard": minor
+"@breadboard-ai/visual-editor": patch
+"@breadboard-ai/board-server": patch
+"@breadboard-ai/data-store": patch
+"@breadboard-ai/shared-ui": patch
+"@breadboard-ai/jsandbox": patch
+"@breadboard-ai/types": patch
+---
+
+Remove the use of `inspect` inside `packages/breadboard`.

--- a/packages/board-server/src/api-view/api-view.ts
+++ b/packages/board-server/src/api-view/api-view.ts
@@ -19,6 +19,7 @@ import { loadKits } from "./utils/kit-loader.js";
 import {
   createLoader,
   createRunObserver,
+  GraphStore,
   type BoardServer,
   type GraphProvider,
   type InputValues,
@@ -68,7 +69,7 @@ export class ApiExplorer extends LitElement {
   runStore = getRunStore();
 
   #kits: Kit[] = [];
-  #runObserver: InspectableRunObserver = createRunObserver({
+  #runObserver: InspectableRunObserver = createRunObserver(new GraphStore({}), {
     dataStore: this.dataStore,
     runStore: this.runStore,
   });

--- a/packages/board-server/src/express/boards/run.ts
+++ b/packages/board-server/src/express/boards/run.ts
@@ -1,16 +1,16 @@
-import type { Request, Response } from 'express';
-import { getStore } from '../../server/store.js';
-import { verifyKey } from '../../server/boards/utils/verify-key.js';
-import { runBoard, timestamp } from '../../server/boards/utils/run-board.js';
-import { loadFromStore } from '../../server/boards/utils/board-server-provider.js';
-import { secretsKit } from '../../server/proxy/secrets.js';
-import type { RemoteMessage } from '@google-labs/breadboard/remote';
-import { asyncHandler } from '../support.js';
+import type { Request, Response } from "express";
+import { getStore } from "../../server/store.js";
+import { verifyKey } from "../../server/boards/utils/verify-key.js";
+import { runBoard, timestamp } from "../../server/boards/utils/run-board.js";
+import { loadFromStore } from "../../server/boards/utils/board-server-provider.js";
+import { secretsKit } from "../../server/proxy/secrets.js";
+import type { RemoteMessage } from "@google-labs/breadboard/remote";
+import { asyncHandler } from "../support.js";
 const run = async (req: Request, res: Response) => {
   const { user, boardName } = req.params;
   const API_ENTRY = "/boards";
   const boardPath = `@${user}/${boardName}`;
-  const url = new URL(`${req.protocol}://${req.get('host')}${req.originalUrl}`);
+  const url = new URL(`${req.protocol}://${req.get("host")}${req.originalUrl}`);
   url.pathname = `${API_ENTRY}/${boardPath}`;
   url.search = "";
   const href = url.href.endsWith(".json") ? url.href : `${url.href}.json`;
@@ -33,7 +33,7 @@ const run = async (req: Request, res: Response) => {
   const board = await store.get(user!, boardName!);
 
   if (!board) {
-    res.status(404).json({ error: 'Board not found' });
+    res.status(404).json({ error: "Board not found" });
     return;
   }
 
@@ -46,6 +46,7 @@ const run = async (req: Request, res: Response) => {
         path: [],
         timestamp: timestamp(),
         graph: { nodes: [], edges: [] },
+        graphId: "",
       },
     ]);
     await writer.write([

--- a/packages/board-server/src/server/boards/run.ts
+++ b/packages/board-server/src/server/boards/run.ts
@@ -35,6 +35,7 @@ const runHandler: ApiHandler = async (parsed, req, res, body) => {
         path: [],
         timestamp: timestamp(),
         graph: { nodes: [], edges: [] },
+        graphId: "",
       },
     ]);
     await writer.write([

--- a/packages/breadboard/src/harness/remote-runner.ts
+++ b/packages/breadboard/src/harness/remote-runner.ts
@@ -97,6 +97,7 @@ export class HttpClient {
         path: [],
         timestamp: timestamp(),
         graph: emptyGraph(),
+        graphId: "",
       },
     ]);
 

--- a/packages/breadboard/src/inspector/graph/mutable-graph.ts
+++ b/packages/breadboard/src/inspector/graph/mutable-graph.ts
@@ -9,48 +9,33 @@ import {
   GraphIdentifier,
   ModuleIdentifier,
 } from "@breadboard-ai/types";
-import {
-  InspectableDescriberResultCache,
-  InspectableEdgeCache,
-  InspectableGraph,
-  InspectableGraphCache,
-  InspectableGraphOptions,
-  InspectableKitCache,
-  InspectableModuleCache,
-  InspectableNodeCache,
-  MutableGraph,
-  MainGraphIdentifier,
-} from "../types.js";
-import { Node } from "./node.js";
-import { Edge } from "./edge.js";
-import { ModuleCache } from "./module.js";
-import { DescribeResultCache } from "../run/describe-cache.js";
-import { KitCache } from "./kits.js";
-import { GraphCache } from "./graph-cache.js";
-import { Graph } from "./graph.js";
-import { EdgeCache } from "./edge-cache.js";
-import { NodeCache } from "./node-cache.js";
 import { AffectedNode } from "../../editor/types.js";
 import {
   isImperativeGraph,
   toDeclarativeGraph,
 } from "../../run/run-imperative-graph.js";
+import { DescribeResultCache } from "../run/describe-cache.js";
+import {
+  InspectableDescriberResultCache,
+  InspectableEdgeCache,
+  InspectableGraphCache,
+  InspectableGraphOptions,
+  InspectableKitCache,
+  InspectableModuleCache,
+  InspectableNodeCache,
+  MainGraphIdentifier,
+  MutableGraph,
+} from "../types.js";
+import { EdgeCache } from "./edge-cache.js";
+import { Edge } from "./edge.js";
+import { GraphCache } from "./graph-cache.js";
+import { Graph } from "./graph.js";
+import { KitCache } from "./kits.js";
+import { ModuleCache } from "./module.js";
+import { NodeCache } from "./node-cache.js";
+import { Node } from "./node.js";
 
 export { MutableGraphImpl };
-
-/**
- *
- * @deprecated This is the old way of getting an InspectableGraph instance.
- * @param graph
- * @param options
- * @returns
- */
-export const inspectableGraph = (
-  graph: GraphDescriptor,
-  options?: InspectableGraphOptions
-): InspectableGraph => {
-  return new Graph("", new MutableGraphImpl(graph, options || {}));
-};
 
 class MutableGraphImpl implements MutableGraph {
   readonly options: InspectableGraphOptions;

--- a/packages/breadboard/src/inspector/index.ts
+++ b/packages/breadboard/src/inspector/index.ts
@@ -9,13 +9,13 @@ export {
   createDefaultDataStore,
 } from "../data/index.js";
 import { GraphDescriptor } from "../types.js";
-import { GraphStore } from "./graph/graph-store.js";
 import { inspectableGraph } from "./graph/mutable-graph.js";
 import { RunObserver } from "./run/run.js";
 import {
   InspectableGraph,
   InspectableGraphOptions,
   InspectableRunObserver,
+  MutableGraphStore,
   RunObserverOptions,
 } from "./types.js";
 
@@ -27,9 +27,9 @@ export const inspect = (
 };
 
 export const createRunObserver = (
+  store: MutableGraphStore,
   options?: RunObserverOptions
 ): InspectableRunObserver => {
-  const store = new GraphStore();
   return new RunObserver(store, options || {});
 };
 

--- a/packages/breadboard/src/inspector/index.ts
+++ b/packages/breadboard/src/inspector/index.ts
@@ -19,6 +19,10 @@ import {
   RunObserverOptions,
 } from "./types.js";
 
+/**
+ *
+ * @deprecated Use GraphStore instead.
+ */
 export const inspect = (
   graph: GraphDescriptor,
   options?: InspectableGraphOptions

--- a/packages/breadboard/src/inspector/index.ts
+++ b/packages/breadboard/src/inspector/index.ts
@@ -9,7 +9,8 @@ export {
   createDefaultDataStore,
 } from "../data/index.js";
 import { GraphDescriptor } from "../types.js";
-import { inspectableGraph } from "./graph/mutable-graph.js";
+import { Graph } from "./graph/graph.js";
+import { MutableGraphImpl } from "./graph/mutable-graph.js";
 import { RunObserver } from "./run/run.js";
 import {
   InspectableGraph,
@@ -27,7 +28,7 @@ export const inspect = (
   graph: GraphDescriptor,
   options?: InspectableGraphOptions
 ): InspectableGraph => {
-  return inspectableGraph(graph, options);
+  return new Graph("", new MutableGraphImpl(graph, options || {}));
 };
 
 export const createRunObserver = (

--- a/packages/breadboard/src/inspector/mutable-graph-store.ts
+++ b/packages/breadboard/src/inspector/mutable-graph-store.ts
@@ -57,6 +57,14 @@ class GraphStore implements MutableGraphStore {
     };
   }
 
+  addByDescriptor(graph: GraphDescriptor): Result<MainGraphIdentifier> {
+    const getting = this.getOrAdd(graph);
+    if (!getting.success) {
+      return getting;
+    }
+    return { success: true, result: getting.result.id };
+  }
+
   editByDescriptor(
     graph: GraphDescriptor,
     options: EditableGraphOptions = {}

--- a/packages/breadboard/src/inspector/run/conversions.ts
+++ b/packages/breadboard/src/inspector/run/conversions.ts
@@ -38,9 +38,16 @@ function sequenceEntryToHarnessRunResult(
     case "graphstart": {
       const { graphStart, path, graph: inspectableGraph, edges } = data;
       const graph = inspectableGraph?.raw() as GraphDescriptor;
+      const graphId = inspectableGraph?.graphId() || "";
       return {
         type,
-        data: { timestamp: graphStart, path: trimPath(path), graph, edges },
+        data: {
+          timestamp: graphStart,
+          graphId,
+          path: trimPath(path),
+          graph,
+          edges,
+        },
         async reply() {},
       };
     }
@@ -171,9 +178,16 @@ async function* eventsAsHarnessRunResults(
       case "graphstart": {
         const { graphStart, path, graph: inspectableGraph, edges } = data;
         const graph = inspectableGraph?.raw() as GraphDescriptor;
+        const graphId = inspectableGraph?.graphId() || "";
         yield {
           type,
-          data: { timestamp: graphStart, path: trimPath(path), graph, edges },
+          data: {
+            timestamp: graphStart,
+            path: trimPath(path),
+            graph,
+            graphId,
+            edges,
+          },
           async reply() {},
         };
         break;

--- a/packages/breadboard/src/inspector/run/event-manager.ts
+++ b/packages/breadboard/src/inspector/run/event-manager.ts
@@ -97,6 +97,7 @@ export class EventManager {
     const mainGraphId = adding.result;
     const entry = this.#pathRegistry.create(path);
     entry.mainGraphId = mainGraphId;
+    entry.graphId = graphId;
     entry.graphStart = timestamp;
     entry.view = {
       // Math: The start index is the length of the sequence before the

--- a/packages/breadboard/src/inspector/run/event-manager.ts
+++ b/packages/breadboard/src/inspector/run/event-manager.ts
@@ -30,12 +30,12 @@ import { RunNodeEvent } from "./run-node-event.js";
 import { RunSerializer, SequenceEntry } from "./serializer.js";
 import {
   EventIdentifier,
-  GraphDescriptorStore,
   InspectableRunEdge,
   InspectableRunErrorEvent,
   InspectableRunEvent,
   InspectableRunNodeEvent,
   InspectableRunSecretEvent,
+  MutableGraphStore,
   PathRegistryEntry,
   RunObserverLogLevel,
   RunObserverOptions,
@@ -52,7 +52,6 @@ import {
 } from "./conversions.js";
 import { ReanimationState } from "../../run/types.js";
 import { LifecycleManager } from "../../run/lifecycle.js";
-import { inspectableGraph } from "../graph/mutable-graph.js";
 
 const shouldSkipEvent = (
   options: RunObserverOptions,
@@ -80,7 +79,7 @@ export class EventManager {
   #sequence: SequenceEntry[] = [];
   #currentNodeEvent: RunNodeEvent | null = null;
 
-  constructor(store: GraphDescriptorStore, options: RunObserverOptions) {
+  constructor(store: MutableGraphStore, options: RunObserverOptions) {
     this.#graphStore = store;
     this.#options = options;
   }
@@ -90,10 +89,14 @@ export class EventManager {
   }
 
   #addGraphstart(data: GraphStartProbeData) {
-    const { path, graph, timestamp } = data;
-    const { id: graphId } = this.#graphStore.add(graph, 0);
+    const { path, graph, graphId = "", timestamp } = data;
+    const adding = this.#graphStore.addByDescriptor(graph);
+    if (!adding.success) {
+      return;
+    }
+    const mainGraphId = adding.result;
     const entry = this.#pathRegistry.create(path);
-    entry.graphId = graphId;
+    entry.mainGraphId = mainGraphId;
     entry.graphStart = timestamp;
     entry.view = {
       // Math: The start index is the length of the sequence before the
@@ -103,10 +106,14 @@ export class EventManager {
     };
     // TODO: Instead of creating a new instance, cache and store them
     // in the GraphStore.
-    entry.graph = inspectableGraph(graph, {
-      kits: this.#options.kits,
-      sandbox: this.#options.sandbox,
-    });
+    const inspector = this.#graphStore.inspect(mainGraphId, graphId);
+    if (inspector) {
+      entry.graph = inspector;
+    } else {
+      throw new Error(
+        `Run API Integrity error: unable to get InspectableGraph for "${mainGraphId}", "${graphId}"`
+      );
+    }
     this.#addToSequence("graphstart", entry);
   }
 

--- a/packages/breadboard/src/inspector/run/loader.ts
+++ b/packages/breadboard/src/inspector/run/loader.ts
@@ -81,7 +81,7 @@ export class RunLoader {
         ? await this.#inflateData(timeline, run.data)
         : timeline;
       const pastRun = new PastRun(runId, timeline, this.#options);
-      await pastRun.initializeBackingRun();
+      await pastRun.initializeBackingRun(this.#options);
       return { success: true, run: pastRun };
     } catch (e) {
       const error = e as Error;

--- a/packages/breadboard/src/inspector/run/loader.ts
+++ b/packages/breadboard/src/inspector/run/loader.ts
@@ -4,17 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { remapData } from "../../data/inflate-deflate.js";
+import { DataStore, SerializedDataStoreGroup } from "../../data/types.js";
 import { HarnessRunResult } from "../../harness/types.js";
-import { replaceSecrets } from "./serializer.js";
 import {
   InspectableRunLoadResult,
+  MutableGraphStore,
   SerializedRun,
   SerializedRunLoadingOptions,
   TimelineEntry,
 } from "../types.js";
-import { DataStore, SerializedDataStoreGroup } from "../../data/types.js";
-import { remapData } from "../../data/inflate-deflate.js";
 import { PastRun } from "./past-run.js";
+import { replaceSecrets } from "./serializer.js";
 
 export const errorResult = (error: string): HarnessRunResult => {
   return {
@@ -30,15 +31,18 @@ export const errorResult = (error: string): HarnessRunResult => {
 };
 
 export class RunLoader {
+  #graphStore: MutableGraphStore;
   #run: SerializedRun;
   #store: DataStore;
   #options: SerializedRunLoadingOptions;
 
   constructor(
+    graphStore: MutableGraphStore,
     store: DataStore,
     o: unknown,
     options: SerializedRunLoadingOptions
   ) {
+    this.#graphStore = graphStore;
     this.#store = store;
     this.#run = o as SerializedRun;
     this.#options = options;
@@ -80,7 +84,7 @@ export class RunLoader {
       timeline = run.data
         ? await this.#inflateData(timeline, run.data)
         : timeline;
-      const pastRun = new PastRun(runId, timeline, this.#options);
+      const pastRun = new PastRun(runId, this.#graphStore, timeline);
       await pastRun.initializeBackingRun(this.#options);
       return { success: true, run: pastRun };
     } catch (e) {

--- a/packages/breadboard/src/inspector/run/nested-run.ts
+++ b/packages/breadboard/src/inspector/run/nested-run.ts
@@ -7,11 +7,11 @@
 import { HarnessRunResult } from "../../harness/types.js";
 import type {
   EventIdentifier,
-  GraphUUID,
   InspectableRun,
   InspectableRunEvent,
   InspectableRunInputs,
   InspectableRunNodeEvent,
+  MainGraphIdentifier,
   PathRegistryEntry,
 } from "../types.js";
 import {
@@ -29,7 +29,7 @@ export class NestedRun implements InspectableRun {
 
   #entry: PathRegistryEntry;
 
-  graphId: GraphUUID;
+  mainGraphId: MainGraphIdentifier;
   start: number;
   end: number | null;
   graphVersion = 0;
@@ -37,7 +37,7 @@ export class NestedRun implements InspectableRun {
   edges = [];
 
   constructor(entry: PathRegistryEntry) {
-    this.graphId = entry.graphId as GraphUUID;
+    this.mainGraphId = entry.mainGraphId!;
     this.start = entry.graphStart;
     this.end = entry.graphEnd;
     this.events = entry.events;

--- a/packages/breadboard/src/inspector/run/past-run.ts
+++ b/packages/breadboard/src/inspector/run/past-run.ts
@@ -14,7 +14,7 @@ import {
   InspectableRunInputs,
   InspectableRunNodeEvent,
   MainGraphIdentifier,
-  SerializedRunLoadingOptions,
+  MutableGraphStore,
   TimelineEntry,
 } from "../types.js";
 import { Replay } from "./replay.js";
@@ -28,10 +28,10 @@ export class PastRun implements InspectableRun {
 
   constructor(
     public readonly dataStoreKey = crypto.randomUUID(),
-    timeline: TimelineEntry[],
-    options: SerializedRunLoadingOptions
+    graphStore: MutableGraphStore,
+    timeline: TimelineEntry[]
   ) {
-    this.#replay = new Replay(timeline, 0, options);
+    this.#replay = new Replay(graphStore, timeline, 0);
   }
 
   async initializeBackingRun(options: InspectableGraphOptions) {

--- a/packages/breadboard/src/inspector/run/past-run.ts
+++ b/packages/breadboard/src/inspector/run/past-run.ts
@@ -5,14 +5,15 @@
  */
 
 import { HarnessRunResult } from "../../harness/types.js";
-import { GraphStore } from "../graph/graph-store.js";
+import { GraphStore } from "../mutable-graph-store.js";
 import {
   EventIdentifier,
-  GraphUUID,
+  InspectableGraphOptions,
   InspectableRun,
   InspectableRunEvent,
   InspectableRunInputs,
   InspectableRunNodeEvent,
+  MainGraphIdentifier,
   SerializedRunLoadingOptions,
   TimelineEntry,
 } from "../types.js";
@@ -33,19 +34,21 @@ export class PastRun implements InspectableRun {
     this.#replay = new Replay(timeline, 0, options);
   }
 
-  async initializeBackingRun() {
-    const observer = new RunObserver(new GraphStore(), { logLevel: "debug" });
+  async initializeBackingRun(options: InspectableGraphOptions) {
+    const observer = new RunObserver(new GraphStore(options), {
+      logLevel: "debug",
+    });
     for await (const result of this.replay()) {
       await observer.observe(result);
     }
     this.#backingRun = (await observer.runs())[0];
   }
 
-  get graphId(): GraphUUID {
+  get mainGraphId(): MainGraphIdentifier {
     if (!this.#backingRun) {
       throw new Error("Uninitialized run: can't yet provide graph IDs");
     }
-    return this.#backingRun.graphId;
+    return this.#backingRun.mainGraphId;
   }
 
   get graphVersion(): number {

--- a/packages/breadboard/src/inspector/run/path-registry.ts
+++ b/packages/breadboard/src/inspector/run/path-registry.ts
@@ -7,12 +7,12 @@
 import { timestamp } from "../../timestamp.js";
 import { OutputValues } from "../../types.js";
 import {
-  GraphUUID,
   InspectableGraph,
   InspectableRunEdge,
   InspectableRunErrorEvent,
   InspectableRunEvent,
   InspectableRunNodeEvent,
+  MainGraphIdentifier,
   PathRegistryEntry,
   SequenceView,
 } from "../types.js";
@@ -29,7 +29,7 @@ export const createSimpleEntry = (
     path,
     parent: null,
     children: [],
-    graphId: null,
+    mainGraphId: null,
     graphStart: 0,
     graphEnd: 0,
     event,
@@ -57,7 +57,7 @@ class Entry implements PathRegistryEntry {
   // secret and error do not have a corresponding `nodeend` event.
   #trackedSidecars: Map<string, InspectableRunEvent> = new Map();
 
-  graphId: GraphUUID | null = null;
+  mainGraphId: MainGraphIdentifier | null = null;
   // Wait until `graphstart` event to set the start time.
   graphStart: number = 0;
   graphEnd: number | null = null;

--- a/packages/breadboard/src/inspector/run/path-registry.ts
+++ b/packages/breadboard/src/inspector/run/path-registry.ts
@@ -5,7 +5,7 @@
  */
 
 import { timestamp } from "../../timestamp.js";
-import { OutputValues } from "../../types.js";
+import { GraphIdentifier, OutputValues } from "../../types.js";
 import {
   InspectableGraph,
   InspectableRunEdge,
@@ -30,6 +30,7 @@ export const createSimpleEntry = (
     parent: null,
     children: [],
     mainGraphId: null,
+    graphId: "",
     graphStart: 0,
     graphEnd: 0,
     event,
@@ -58,6 +59,7 @@ class Entry implements PathRegistryEntry {
   #trackedSidecars: Map<string, InspectableRunEvent> = new Map();
 
   mainGraphId: MainGraphIdentifier | null = null;
+  graphId: GraphIdentifier = "";
   // Wait until `graphstart` event to set the start time.
   graphStart: number = 0;
   graphEnd: number | null = null;

--- a/packages/breadboard/src/inspector/run/run.ts
+++ b/packages/breadboard/src/inspector/run/run.ts
@@ -226,7 +226,12 @@ export class RunObserver implements InspectableRunObserver {
         "No data store provided to RunObserver, unable to load runs"
       );
     }
-    const loader = new RunLoader(this.#options.dataStore, o, options || {});
+    const loader = new RunLoader(
+      this.#store,
+      this.#options.dataStore,
+      o,
+      options || {}
+    );
     const result = await loader.load();
     if (result.success) {
       this.#runs.push(result.run);

--- a/packages/breadboard/src/inspector/run/run.ts
+++ b/packages/breadboard/src/inspector/run/run.ts
@@ -4,33 +4,33 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { DataStore, RunTimestamp, RunURL } from "../../data/types.js";
 import { HarnessRunResult } from "../../harness/types.js";
 import {
   GraphDescriptor,
   NodeConfiguration,
   NodeIdentifier,
 } from "../../types.js";
-import { EventManager } from "./event-manager.js";
-import { RunLoader } from "./loader.js";
 import {
   EventIdentifier,
-  GraphUUID,
-  GraphDescriptorStore,
   InspectableRun,
+  InspectableRunEdge,
   InspectableRunEvent,
+  InspectableRunInputs,
   InspectableRunLoadResult,
+  InspectableRunNodeEvent,
   InspectableRunObserver,
+  InspectableRunSequenceEntry,
+  MainGraphIdentifier,
+  MutableGraphStore,
   RunObserverOptions,
   RunSerializationOptions,
   SerializedRun,
   SerializedRunLoadingOptions,
-  InspectableRunNodeEvent,
-  InspectableRunInputs,
-  InspectableRunEdge,
-  InspectableRunSequenceEntry,
 } from "../types.js";
-import { DataStore, RunTimestamp, RunURL } from "../../data/types.js";
 import { eventsAsHarnessRunResults } from "./conversions.js";
+import { EventManager } from "./event-manager.js";
+import { RunLoader } from "./loader.js";
 
 const isInput = (
   event: InspectableRunEvent
@@ -43,14 +43,14 @@ const isInput = (
 };
 
 export class RunObserver implements InspectableRunObserver {
-  #store: GraphDescriptorStore;
+  #store: MutableGraphStore;
   #options: RunObserverOptions;
   #runs: InspectableRun[] = [];
   #runLimit = 2;
   #url: RunURL | null = null;
   #timestamp: RunTimestamp | null = null;
 
-  constructor(store: GraphDescriptorStore, options: RunObserverOptions) {
+  constructor(store: MutableGraphStore, options: RunObserverOptions) {
     this.#store = store;
     this.#options = options;
   }
@@ -263,7 +263,7 @@ export class Run implements InspectableRun {
 
   #events: EventManager;
 
-  graphId: GraphUUID;
+  mainGraphId: MainGraphIdentifier;
   start: number;
   end: number | null = null;
   graphVersion: number;
@@ -271,7 +271,7 @@ export class Run implements InspectableRun {
 
   constructor(
     timestamp: number,
-    graphStore: GraphDescriptorStore,
+    graphStore: MutableGraphStore,
     graph: GraphDescriptor,
     options: RunObserverOptions
   ) {
@@ -279,7 +279,11 @@ export class Run implements InspectableRun {
     this.#dataStore = options.dataStore || null;
     this.graphVersion = 0;
     this.start = timestamp;
-    this.graphId = graphStore.add(graph, this.graphVersion).id;
+    const adding = graphStore.addByDescriptor(graph);
+    if (!adding.success) {
+      throw new Error(`Run API integrity error: ${adding.error}`);
+    }
+    this.mainGraphId = adding.result;
   }
 
   get events(): InspectableRunEvent[] {

--- a/packages/breadboard/src/inspector/run/serializer.ts
+++ b/packages/breadboard/src/inspector/run/serializer.ts
@@ -74,6 +74,7 @@ export class RunSerializer {
       index = this.#seenGraphs.get(mainGraphId) || 0;
     }
     const edges = entry.edges;
+    const graphId = entry.graphId;
     return [
       "graphstart",
       {
@@ -81,6 +82,7 @@ export class RunSerializer {
         path: entry.path,
         index,
         graph,
+        graphId,
         edges,
       },
     ];

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -672,6 +672,7 @@ export type GraphHandle = {
 
 export type MutableGraphStore = {
   load(url: string, options: GraphLoaderContext): Promise<Result<GraphHandle>>;
+  addByDescriptor(graph: GraphDescriptor): Result<MainGraphIdentifier>;
   editByDescriptor(
     graph: GraphDescriptor,
     options?: EditableGraphOptions
@@ -850,9 +851,18 @@ export type SerializedRunLoadingOptions = {
    */
   secretReplacer?: SerializedRunSecretReplacer;
   /**
-   * Optional, kits that are used with this run.
+   * Optional, a list of kits to use when inspecting the graph. If not
+   * supplied, the graph will be inspected without any kits.
    */
   kits?: Kit[];
+  /**
+   * The loader to use when loading boards.
+   */
+  loader?: GraphLoader;
+  /**
+   * The Javascript Sandbox that will be used to run custom describers.
+   */
+  readonly sandbox?: Sandbox;
 };
 
 export type StoreAdditionResult = {
@@ -1032,7 +1042,7 @@ export type InspectableRun = {
   /**
    * The id of the graph that was run.
    */
-  graphId: GraphUUID;
+  mainGraphId: MainGraphIdentifier;
   /**
    * The version of the graph that was run.
    */
@@ -1131,7 +1141,7 @@ export type PathRegistryEntry = {
   path: number[];
   parent: PathRegistryEntry | null;
   children: PathRegistryEntry[];
-  graphId: GraphUUID | null;
+  mainGraphId: MainGraphIdentifier | null;
   graphStart: number;
   graphEnd: number | null;
   event: InspectableRunEvent | null;

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -1142,6 +1142,7 @@ export type PathRegistryEntry = {
   parent: PathRegistryEntry | null;
   children: PathRegistryEntry[];
   mainGraphId: MainGraphIdentifier | null;
+  graphId: GraphIdentifier;
   graphStart: number;
   graphEnd: number | null;
   event: InspectableRunEvent | null;
@@ -1225,6 +1226,7 @@ export type GraphstartTimelineEntry = [
     path: number[];
     index: number;
     graph: GraphDescriptor | null;
+    graphId: string;
     edges: InspectableRunEdge[];
   },
 ];

--- a/packages/breadboard/src/kits/graph-to-kit.ts
+++ b/packages/breadboard/src/kits/graph-to-kit.ts
@@ -16,7 +16,7 @@ import {
   NodeHandlers,
   NodeIdentifier,
 } from "../types.js";
-import { inspect } from "../index.js";
+import { describe } from "./utils.js";
 
 export class GraphToKitAdapter {
   graph: GraphDescriptor;
@@ -67,11 +67,19 @@ export class GraphToKitAdapter {
         if (this.graph.graphs != undefined && id in this.graph.graphs) {
           const subGraph = this.graph.graphs[id] as GraphDescriptor;
           if (subGraph == undefined) return emptyResult;
-          return await inspect(subGraph).describe();
+          const describing = await describe(this.graph, id);
+          if (!describing.success) {
+            return emptyResult;
+          }
+          return describing.result;
         } else if (node.type === "invoke") {
           const { $board } = node.configuration as { $board?: GraphDescriptor };
           if ($board) {
-            return await inspect($board).describe();
+            const describing = await describe($board, "");
+            if (!describing.success) {
+              return emptyResult;
+            }
+            return describing.result;
           }
         }
 

--- a/packages/breadboard/src/kits/utils.ts
+++ b/packages/breadboard/src/kits/utils.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  GraphDescriptor,
+  GraphIdentifier,
+  InputValues,
+} from "@breadboard-ai/types";
+import { DescriberManager } from "../inspector/graph/describer-manager.js";
+import { MutableGraphImpl } from "../inspector/graph/mutable-graph.js";
+import { NodeDescriberResult } from "../types.js";
+import { Result } from "../editor/types.js";
+import { InspectableGraphOptions } from "../inspector/types.js";
+
+export { describe };
+
+/**
+ * A helper describer function for kits.
+ * @deprecated Convert to use GraphStore instead.
+ */
+async function describe(
+  graph: GraphDescriptor,
+  graphId: GraphIdentifier,
+  options: InspectableGraphOptions = {},
+  inputs?: InputValues
+): Promise<Result<NodeDescriberResult>> {
+  const mutable = new MutableGraphImpl(graph, options);
+  const describer = DescriberManager.create(graphId, mutable);
+  if (!describer.success) {
+    return describer;
+  }
+  return {
+    success: true,
+    result: await describer.result.describe(inputs),
+  };
+}

--- a/packages/breadboard/src/run/run-graph.ts
+++ b/packages/breadboard/src/run/run-graph.ts
@@ -161,7 +161,12 @@ export async function* runGraph(
     if (!resumeFrom) {
       await probe?.report?.({
         type: "graphstart",
-        data: { graph, path: invocationPath, timestamp: timestamp() },
+        data: {
+          graph: graphToRun.graph,
+          graphId: graphToRun.subGraphId || "",
+          path: invocationPath,
+          timestamp: timestamp(),
+        },
       });
     }
 

--- a/packages/breadboard/tests/editor/blank.ts
+++ b/packages/breadboard/tests/editor/blank.ts
@@ -5,7 +5,21 @@
  */
 
 import test from "ava";
-import { blank, inspect } from "../../src/index.js";
+import {
+  blank,
+  GraphDescriptor,
+  InspectableGraph,
+  InspectableGraphOptions,
+} from "../../src/index.js";
+import { Graph } from "../../src/inspector/graph/graph.js";
+import { MutableGraphImpl } from "../../src/inspector/graph/mutable-graph.js";
+
+const inspect = (
+  graph: GraphDescriptor,
+  options?: InspectableGraphOptions
+): InspectableGraph => {
+  return new Graph("", new MutableGraphImpl(graph, options || {}));
+};
 
 test("importBlank creates a nice blank board", async (t) => {
   const b = blank();

--- a/packages/breadboard/tests/inspector/inline-data-run-array.ts
+++ b/packages/breadboard/tests/inspector/inline-data-run-array.ts
@@ -85,6 +85,7 @@ export const results: HarnessRunResult[] = [
         ],
         url: "idb://default/blank-board.bgl.json",
       },
+      graphId: "",
       path: [],
       timestamp: 68300.29999999702,
     },

--- a/packages/breadboard/tests/inspector/inline-data-run.ts
+++ b/packages/breadboard/tests/inspector/inline-data-run.ts
@@ -68,6 +68,7 @@ export const results: HarnessRunResult[] = [
         ],
         kits: [],
       },
+      graphId: "",
       path: [],
       timestamp: 2156.099999964237,
     },

--- a/packages/breadboard/tests/inspector/observer-load.ts
+++ b/packages/breadboard/tests/inspector/observer-load.ts
@@ -12,7 +12,7 @@ import {
   InspectableRunEvent,
   InspectableRunObserver,
 } from "../../src/inspector/types.js";
-import { createRunObserver } from "../../src/index.js";
+import { createRunObserver, GraphStore } from "../../src/index.js";
 import { HarnessRunResult } from "../../src/harness/types.js";
 import { replaceSecrets } from "../../src/inspector/run/serializer.js";
 import {
@@ -87,7 +87,8 @@ const GEMINI_KEY_VALUE = "b576eea9-5ae6-4e9d-9958-e798ad8dbff7";
 const GEMINI_SENTINEL = "103e9083-13fd-46b4-a9ee-683a09e31a26";
 
 test("run save/load: loadRawRun works as expected", async (t) => {
-  const observer = createRunObserver({
+  const store = new GraphStore({});
+  const observer = createRunObserver(store, {
     logLevel: "debug",
   });
   const run1 = await loadRawRun(observer, "ad-writer-2.1.raw.json");
@@ -96,7 +97,8 @@ test("run save/load: loadRawRun works as expected", async (t) => {
 });
 
 test("run save/load: observer.save -> run.load roundtrip", async (t) => {
-  const observer = createRunObserver({
+  const store = new GraphStore({});
+  const observer = createRunObserver(store, {
     logLevel: "debug",
     dataStore: createDefaultDataStore(),
     runStore: createDefaultRunStore(),
@@ -116,7 +118,8 @@ test("run save/load: observer.save -> run.load roundtrip", async (t) => {
 });
 
 test("run save/load: replaceSecrets correctly replaces secrets", async (t) => {
-  const observer = createRunObserver({
+  const store = new GraphStore({});
+  const observer = createRunObserver(store, {
     logLevel: "debug",
   });
   const run1 = await loadRawRun(observer, "ad-writer-2.1.raw.json");
@@ -165,7 +168,8 @@ test("run save/load: replaceSecrets correctly replaces secrets", async (t) => {
 });
 
 test("run load/save: serialization produces consistent size", async (t) => {
-  const observer = createRunObserver({
+  const store = new GraphStore({});
+  const observer = createRunObserver(store, {
     logLevel: "debug",
     dataStore: createDefaultDataStore(),
     runStore: createDefaultRunStore(),
@@ -178,7 +182,7 @@ test("run load/save: serialization produces consistent size", async (t) => {
   }
   const serializedRun = await run.serialize();
   const s = JSON.stringify(serializedRun);
-  t.is(s.length, 1174831);
+  t.is(s.length, 1175253);
   t.true(
     (
       await observer.load(serializedRun, {

--- a/packages/breadboard/tests/inspector/observer-load.ts
+++ b/packages/breadboard/tests/inspector/observer-load.ts
@@ -182,7 +182,7 @@ test("run load/save: serialization produces consistent size", async (t) => {
   }
   const serializedRun = await run.serialize();
   const s = JSON.stringify(serializedRun);
-  t.is(s.length, 1175253);
+  t.is(s.length, 1175695);
   t.true(
     (
       await observer.load(serializedRun, {

--- a/packages/data-store/tests/run/inline-data-run-array.ts
+++ b/packages/data-store/tests/run/inline-data-run-array.ts
@@ -86,6 +86,7 @@ export const results: HarnessRunResult[] = [
         url: "idb://default/blank-board.bgl.json",
       },
       path: [],
+      graphId: "",
       timestamp: 68300.29999999702,
     },
     async reply() {},

--- a/packages/data-store/tests/run/inline-data-run.ts
+++ b/packages/data-store/tests/run/inline-data-run.ts
@@ -69,6 +69,7 @@ export const results: HarnessRunResult[] = [
         kits: [],
       },
       path: [],
+      graphId: "",
       timestamp: 2156.099999964237,
     },
     async reply() {},

--- a/packages/data-store/tests/run/simple-run.ts
+++ b/packages/data-store/tests/run/simple-run.ts
@@ -69,6 +69,7 @@ export const results: HarnessRunResult[] = [
         kits: [],
       },
       path: [],
+      graphId: "",
       timestamp: 2448.5,
     },
     async reply() {},

--- a/packages/jsandbox/src/telemetry.ts
+++ b/packages/jsandbox/src/telemetry.ts
@@ -31,6 +31,7 @@ class Telemetry {
       type: "graphstart",
       data: {
         graph: virtualGraph(),
+        graphId: "",
         path: this.path,
         timestamp: timestamp(),
       },

--- a/packages/shared-ui/src/elements/node-runner/node-runner.ts
+++ b/packages/shared-ui/src/elements/node-runner/node-runner.ts
@@ -10,6 +10,7 @@ import {
   createRunObserver,
   GraphDescriptor,
   GraphLoader,
+  GraphStore,
   InspectableRun,
   InspectableRunObserver,
   Kit,
@@ -233,7 +234,11 @@ export class NodeRunner extends LitElement {
     });
 
     if (!this.#runObserver) {
-      this.#runObserver = createRunObserver({
+      // This is wrong, but we don't use this component at the moment.
+      // We shouldn't create a new GraphStore instance here.
+      // TODO: Pass the graph store from components above?
+      const store = new GraphStore({});
+      this.#runObserver = createRunObserver(store, {
         logLevel: "debug",
         skipDataStore: true,
       });

--- a/packages/types/src/probe.ts
+++ b/packages/types/src/probe.ts
@@ -39,6 +39,7 @@ export type NodeEndResponse = {
 
 export type GraphStartProbeData = {
   graph: GraphDescriptor;
+  graphId: string;
   path: number[];
   timestamp: number;
   edges?: { edge: Edge; value: NodeValue }[];

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -1465,7 +1465,7 @@ export class Main extends LitElement {
       try {
         const runData = JSON.parse(data) as SerializedRun | GraphDescriptor;
         if (isSerializedRun(runData)) {
-          const runObserver = createRunObserver({
+          const runObserver = createRunObserver(this.#graphStore, {
             logLevel: "debug",
             dataStore: this.#dataStore,
             sandbox,

--- a/packages/visual-editor/src/runtime/run.ts
+++ b/packages/visual-editor/src/runtime/run.ts
@@ -13,6 +13,7 @@ import {
   InspectableRunSequenceEntry,
   invokeGraph,
   Kit,
+  MutableGraphStore,
   NodeConfiguration,
   OutputValues,
   RunArguments,
@@ -53,6 +54,7 @@ export class Run extends EventTarget {
   >();
 
   constructor(
+    public readonly graphStore: MutableGraphStore,
     public readonly dataStore: DataStore,
     public readonly runStore: RunStore
   ) {
@@ -213,7 +215,7 @@ export class Run extends EventTarget {
 
   #createBoardRunner(config: RunConfig, abortController: AbortController) {
     const harnessRunner = createRunner(config);
-    const runObserver = createRunObserver({
+    const runObserver = createRunObserver(this.graphStore, {
       logLevel: "debug",
       dataStore: this.dataStore,
       runStore: this.runStore,

--- a/packages/visual-editor/src/runtime/runtime.ts
+++ b/packages/visual-editor/src/runtime/runtime.ts
@@ -83,7 +83,7 @@ export async function create(config: RuntimeConfig): Promise<{
   const runtime = {
     board: new Board([], loader, kits, boardServers, config.tokenVendor),
     edit: new Edit([], loader, kits, config.sandbox, graphStore),
-    run: new Run(config.dataStore, config.runStore),
+    run: new Run(graphStore, config.dataStore, config.runStore),
     kits,
   } as const;
 


### PR DESCRIPTION
- **Add `graphId` to `GraphStartProbeData`.**
- **Start using `GraphStore` in Run API.**
- **Add `graphId` property to `PathRegistryEntry`.**
- **Remove `inspect` use in tests.**
- **Remove `inspectableGraph`.**
- **Deprecate `inspect` within `packages/breadboard`.**
- **docs(changeset): Remove the use of `inspect` inside `packages/breadboard`.**
