### PR TITLE
[bbrt] Serve at <visual-editor>/experimental/bbrt/

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19894,6 +19894,7 @@
       "version": "4.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "find-up": "^4.0.0"
       },
@@ -26527,6 +26528,7 @@
       "version": "1.23.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@breadboard-ai/bbrt": "^0.0.1",
         "@breadboard-ai/board-server-management": "1.19.1",
         "@breadboard-ai/board-server-utils": "0.1.6",
         "@breadboard-ai/build": "0.11.0",

--- a/packages/board-server/experimental/bbrt/index.html
+++ b/packages/board-server/experimental/bbrt/index.html
@@ -18,6 +18,8 @@
   </head>
   <body>
     <bbrt-main></bbrt-main>
-    <script type="module" src="./bootstrap.js"></script>
+    <script type="module">
+      import "@breadboard-ai/bbrt/bootstrap.js";
+    </script>
   </body>
 </html>

--- a/packages/board-server/vite.config.ts
+++ b/packages/board-server/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
         index: "./index.html",
         api: "./api.html",
         oauth: "./oauth/index.html",
+        bbrt: "./experimental/bbrt/index.html",
       },
       formats: ["es"],
     },

--- a/packages/visual-editor/.gitignore
+++ b/packages/visual-editor/.gitignore
@@ -3,3 +3,4 @@
 public/pyodide*
 public/python*
 public/sandbox.wasm
+public/bbrt*

--- a/packages/visual-editor/app.test.yaml
+++ b/packages/visual-editor/app.test.yaml
@@ -7,6 +7,9 @@ handlers:
   - url: /oauth/
     static_files: dist/oauth/index.html
     upload: dist/oauth/index.html
+  - url: /experimental/bbrt/
+    static_files: dist/experimental/bbrt/index.html
+    upload: dist/experimental/bbrt/index.html
   - url: /(.*)
     static_files: dist/\1
     upload: dist/(.*)

--- a/packages/visual-editor/app.yaml
+++ b/packages/visual-editor/app.yaml
@@ -6,6 +6,9 @@ handlers:
   - url: /oauth/
     static_files: dist/oauth/index.html
     upload: dist/oauth/index.html
+  - url: /experimental/bbrt/
+    static_files: dist/experimental/bbrt/index.html
+    upload: dist/experimental/bbrt/index.html
   - url: /(.*)
     static_files: dist/\1
     upload: dist/(.*)

--- a/packages/visual-editor/experimental/bbrt/index.html
+++ b/packages/visual-editor/experimental/bbrt/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>bbrt</title>
+    <style>
+      body {
+        margin: 0;
+      }
+      bbrt-main {
+        position: fixed;
+        height: 100vh;
+        width: 100vw;
+        top: 0;
+        left: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <bbrt-main></bbrt-main>
+    <script type="module">
+      import "@breadboard-ai/bbrt/bootstrap.js";
+    </script>
+  </body>
+</html>

--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -40,12 +40,14 @@
     "build": "wireit",
     "build:vite": "wireit",
     "build:tsc": "wireit",
-    "copy-example-boards": "wireit"
+    "copy-example-boards": "wireit",
+    "copy-bbrt-assets": "wireit"
   },
   "wireit": {
     "build": {
       "dependencies": [
         "../agent-kit:build",
+        "../bbrt:build",
         "../breadboard:build",
         "../board-server-management:build",
         "../board-server-utils:build",
@@ -69,6 +71,7 @@
     "typescript-files-and-deps": {
       "dependencies": [
         "../agent-kit:build:tsc",
+        "../bbrt:build:tsc",
         "../breadboard:build:tsc",
         "../board-server-management:build:tsc",
         "../board-server-utils:build:tsc",
@@ -125,6 +128,10 @@
         {
           "script": "copy-light-kits",
           "cascade": false
+        },
+        {
+          "script": "copy-bbrt-assets",
+          "cascade": false
         }
       ],
       "files": [
@@ -132,6 +139,7 @@
         ".env*",
         "*.html",
         "oauth/",
+        "experimental/",
         "public/"
       ],
       "output": [
@@ -150,6 +158,10 @@
         },
         {
           "script": "copy-light-kits",
+          "cascade": false
+        },
+        {
+          "script": "copy-bbrt-assets",
           "cascade": false
         },
         {
@@ -181,6 +193,10 @@
         },
         {
           "script": "copy-light-kits",
+          "cascade": false
+        },
+        {
+          "script": "copy-bbrt-assets",
           "cascade": false
         },
         {
@@ -219,14 +235,27 @@
         "../agent-kit:build",
         "../google-drive-kit:build"
       ],
-      "files": [],
+      "files": [
+        "src/copy-light-kits.ts"
+      ],
       "output": [
         "public/*.kit.json"
       ]
     },
+    "copy-bbrt-assets": {
+      "command": "tsx src/copy-bbrt-assets.ts",
+      "files": [
+        "src/copy-bbrt-assets.ts"
+      ],
+      "output": [
+        "public/bbrt/"
+      ]
+    },
     "copy-pyoide-assets": {
       "command": "tsx src/copy-pyodide-assets.ts",
-      "files": [],
+      "files": [
+        "src/copy-pyodide-assets.ts"
+      ],
       "output": [
         "public/python_stdlib.zip",
         "public/pyodide*"
@@ -294,6 +323,7 @@
     "vitest": "^2.1.5"
   },
   "dependencies": {
+    "@breadboard-ai/bbrt": "^0.0.1",
     "@breadboard-ai/board-server-management": "1.19.1",
     "@breadboard-ai/board-server-utils": "0.1.6",
     "@breadboard-ai/build": "0.11.0",

--- a/packages/visual-editor/src/copy-bbrt-assets.ts
+++ b/packages/visual-editor/src/copy-bbrt-assets.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { cp } from "fs/promises";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const MODULE_DIR = dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = join(MODULE_DIR, "..");
+const PUBLIC_DIR = join(ROOT_DIR, "public");
+const BBRT_DIR = dirname(
+  new URL(import.meta.resolve("@breadboard-ai/bbrt/package.json")).pathname
+);
+
+await cp(join(BBRT_DIR, "images"), join(PUBLIC_DIR, "bbrt", "images"), {
+  recursive: true,
+});

--- a/packages/visual-editor/vite.config.ts
+++ b/packages/visual-editor/vite.config.ts
@@ -5,7 +5,6 @@
  */
 
 import { config } from "dotenv";
-import { resolve } from "path";
 import { defineConfig } from "vitest/config";
 
 export const buildCustomAllowList = (value?: string) => {
@@ -22,6 +21,7 @@ export default defineConfig((_) => {
           worker: "src/worker.ts",
           sample: "./index.html",
           oauth: "./oauth/index.html",
+          bbrt: "./experimental/bbrt/index.html",
           "palm-kit": "src/palm-kit.ts",
           "core-kit": "src/core-kit.ts",
           "json-kit": "src/json-kit.ts",


### PR DESCRIPTION
This is a pretty light integration for now, just serving at the same origin as the visual editor under `experimental/bbrt`, otherwise decoupled.