### PR TITLE
[shared-ui] Delay initial render

### DIFF
--- a/.changeset/lemon-cameras-look.md
+++ b/.changeset/lemon-cameras-look.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/shared-ui": patch
+---
+
+Delay initial non-animation render

--- a/packages/shared-ui/src/elements/editor/editor.ts
+++ b/packages/shared-ui/src/elements/editor/editor.ts
@@ -473,7 +473,14 @@ export class Editor extends LitElement {
       shouldAnimate = false;
     }
 
-    this.#graphRenderer.moveToSelection(shouldAnimate);
+    if (shouldAnimate) {
+      this.#graphRenderer.moveToSelection(true);
+    } else {
+      requestAnimationFrame(() => {
+        this.#graphRenderer.moveToSelection(false);
+      });
+    }
+
     return this.#graphRenderer;
   }
 


### PR DESCRIPTION
Fixes #3899

Looks like the initial matrix calculation is off because of the render call order so it renders everything reallllllly small. This is a short-term fix for now because I'd like to get to the bottom of why this is happening.