### PR TITLE
inspectable graph update event

### DIFF
--- a/.changeset/sour-clocks-begin.md
+++ b/.changeset/sour-clocks-begin.md
@@ -1,0 +1,7 @@
+---
+"@breadboard-ai/visual-editor": minor
+"@google-labs/breadboard": minor
+"@breadboard-ai/shared-ui": minor
+---
+
+Start using `currentPorts` and `update` event in VE.

--- a/packages/breadboard/src/inspector/graph-store.ts
+++ b/packages/breadboard/src/inspector/graph-store.ts
@@ -16,6 +16,7 @@ import { MutableGraphImpl } from "./graph/mutable-graph.js";
 import {
   GraphHandle,
   GraphStoreArgs,
+  GraphStoreEventTarget,
   InspectableGraph,
   InspectableGraphOptions,
   MainGraphIdentifier,
@@ -26,6 +27,7 @@ import { hash } from "../utils/hash.js";
 import { Kit, NodeHandlerContext } from "../types.js";
 import { Sandbox } from "@breadboard-ai/jsandbox";
 import { createLoader } from "../loader/index.js";
+import { TypedEventTarget } from "../utils/typed-event-target.js";
 
 export { GraphStore, makeTerribleOptions, contextFromStore };
 
@@ -52,7 +54,10 @@ function makeTerribleOptions(
   };
 }
 
-class GraphStore implements MutableGraphStore {
+class GraphStore
+  extends (EventTarget as TypedEventTarget<GraphStoreEventTarget>)
+  implements MutableGraphStore
+{
   readonly kits: readonly Kit[];
   readonly sandbox: Sandbox;
   readonly loader: GraphLoader;
@@ -61,6 +66,7 @@ class GraphStore implements MutableGraphStore {
   #mutables: Map<MainGraphIdentifier, MutableGraph> = new Map();
 
   constructor(args: GraphStoreArgs) {
+    super();
     this.kits = args.kits;
     this.sandbox = args.sandbox;
     this.loader = args.loader;

--- a/packages/breadboard/src/inspector/graph-store.ts
+++ b/packages/breadboard/src/inspector/graph-store.ts
@@ -27,7 +27,6 @@ import { hash } from "../utils/hash.js";
 import { Kit, NodeHandlerContext } from "../types.js";
 import { Sandbox } from "@breadboard-ai/jsandbox";
 import { createLoader } from "../loader/index.js";
-import { TypedEventTarget } from "../utils/typed-event-target.js";
 
 export { GraphStore, makeTerribleOptions, contextFromStore };
 
@@ -55,7 +54,7 @@ function makeTerribleOptions(
 }
 
 class GraphStore
-  extends (EventTarget as TypedEventTarget<GraphStoreEventTarget>)
+  extends (EventTarget as GraphStoreEventTarget)
   implements MutableGraphStore
 {
   readonly kits: readonly Kit[];

--- a/packages/breadboard/src/inspector/graph/describer-manager.ts
+++ b/packages/breadboard/src/inspector/graph/describer-manager.ts
@@ -104,7 +104,7 @@ class NodeTypeDescriberManager implements DescribeResultCacheArgs {
     if (inputsDiffer.same() && outputsDiffer.same()) {
       return;
     }
-    this.mutable.graphs.get("")?.dispatchEvent(new UpdateEvent());
+    this.mutable.store.dispatchEvent(new UpdateEvent());
 
     // Add change spec to the change list
     // So the change list lives on mutable graph!

--- a/packages/breadboard/src/inspector/graph/describer-manager.ts
+++ b/packages/breadboard/src/inspector/graph/describer-manager.ts
@@ -84,8 +84,8 @@ class NodeTypeDescriberManager implements DescribeResultCacheArgs {
   }
 
   willUpdate(
-    _graphId: GraphIdentifier,
-    _nodeId: NodeIdentifier,
+    graphId: GraphIdentifier,
+    nodeId: NodeIdentifier,
     previous: NodeDescriberResult,
     current: NodeDescriberResult
   ): void {
@@ -104,13 +104,9 @@ class NodeTypeDescriberManager implements DescribeResultCacheArgs {
     if (inputsDiffer.same() && outputsDiffer.same()) {
       return;
     }
-    this.mutable.store.dispatchEvent(new UpdateEvent());
-
-    // Add change spec to the change list
-    // So the change list lives on mutable graph!
-    // Global to main graph.
-    // Dispatch "update" event on the InspectableGraph
-    // this.mutable.graphs.get(graphId).dispatchEvent()
+    this.mutable.store.dispatchEvent(
+      new UpdateEvent(this.mutable.id, graphId, nodeId)
+    );
   }
 
   async #getDescriber(

--- a/packages/breadboard/src/inspector/graph/event.ts
+++ b/packages/breadboard/src/inspector/graph/event.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GraphStoreUpdateEvent } from "../types.js";
+import { GraphIdentifier, NodeIdentifier } from "@breadboard-ai/types";
+import { GraphStoreUpdateEvent, MainGraphIdentifier } from "../types.js";
 
 export { UpdateEvent };
 
@@ -17,7 +18,11 @@ const eventInit = {
 class UpdateEvent extends Event implements GraphStoreUpdateEvent {
   static eventName = "update";
 
-  constructor() {
+  constructor(
+    public readonly mainGraphId: MainGraphIdentifier,
+    public readonly graphId: GraphIdentifier,
+    public readonly nodeId: NodeIdentifier
+  ) {
     super(UpdateEvent.eventName, { ...eventInit });
   }
 }

--- a/packages/breadboard/src/inspector/graph/event.ts
+++ b/packages/breadboard/src/inspector/graph/event.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { InspectableGraphUpdateEvent } from "../types.js";
+import { GraphStoreUpdateEvent } from "../types.js";
 
 export { UpdateEvent };
 
@@ -14,7 +14,7 @@ const eventInit = {
   composed: true,
 };
 
-class UpdateEvent extends Event implements InspectableGraphUpdateEvent {
+class UpdateEvent extends Event implements GraphStoreUpdateEvent {
   static eventName = "update";
 
   constructor() {

--- a/packages/breadboard/src/inspector/graph/graph.ts
+++ b/packages/breadboard/src/inspector/graph/graph.ts
@@ -20,7 +20,6 @@ import {
 import {
   InspectableEdge,
   InspectableGraph,
-  InspectableGraphEventTarget,
   InspectableKit,
   InspectableModules,
   InspectableNode,
@@ -33,15 +32,11 @@ import { GraphQueries } from "./graph-queries.js";
 
 export { Graph };
 
-class Graph
-  extends (EventTarget as InspectableGraphEventTarget)
-  implements InspectableGraph
-{
+class Graph implements InspectableGraph {
   #graphId: GraphIdentifier;
   #mutable: MutableGraph;
 
   constructor(graphId: GraphIdentifier, mutableGraph: MutableGraph) {
-    super();
     this.#graphId = graphId;
     this.#mutable = mutableGraph;
   }

--- a/packages/breadboard/src/inspector/graph/mutable-graph.ts
+++ b/packages/breadboard/src/inspector/graph/mutable-graph.ts
@@ -96,7 +96,6 @@ class MutableGraphImpl implements MutableGraph {
       this.describe.update(affectedNodes);
     }
     this.graph = graph;
-    this.graphs.rebuild(graph);
   }
 
   addSubgraph(subgraph: GraphDescriptor, graphId: GraphIdentifier): void {

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -703,7 +703,11 @@ export type GraphHandle = {
 
 export type GraphStoreArgs = Required<InspectableGraphOptions>;
 
-export type GraphStoreUpdateEvent = Event;
+export type GraphStoreUpdateEvent = Event & {
+  mainGraphId: MainGraphIdentifier;
+  graphId: GraphIdentifier;
+  nodeId: NodeIdentifier;
+};
 
 type GraphsStoreEventMap = {
   update: GraphStoreUpdateEvent;
@@ -711,7 +715,7 @@ type GraphsStoreEventMap = {
 
 export type GraphStoreEventTarget = TypedEventTarget<GraphsStoreEventMap>;
 
-export type MutableGraphStore = TypedEventTargetType<GraphStoreEventTarget> & {
+export type MutableGraphStore = TypedEventTargetType<GraphsStoreEventMap> & {
   readonly kits: readonly Kit[];
   readonly sandbox: Sandbox;
   readonly loader: GraphLoader;

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -247,112 +247,102 @@ export interface ValidateError {
 
 export type InspectableSubgraphs = Record<GraphIdentifier, InspectableGraph>;
 
-export type InspectableGraphUpdateEvent = Event;
-
-type InspectableGraphEventMap = {
-  update: InspectableGraphUpdateEvent;
+export type InspectableGraph = {
+  /**
+   * Returns the underlying `GraphDescriptor` object.
+   * TODO: Replace all uses of it with a proper inspector API.
+   */
+  raw(): GraphDescriptor;
+  /**
+   * Returns this graph's metadata, if exists.
+   */
+  metadata(): GraphMetadata | undefined;
+  /**
+   * Returns the node with the given id, or undefined if no such node exists.
+   * @param id id of the node to find
+   */
+  nodeById(id: NodeIdentifier): InspectableNode | undefined;
+  /**
+   * Returns all nodes in the graph.
+   */
+  nodes(): InspectableNode[];
+  /**
+   * Returns all edges of the graph.
+   */
+  edges(): InspectableEdge[];
+  /**
+   * Returns true if the edge exists in the graph.
+   */
+  hasEdge(edge: Edge): boolean;
+  /**
+   * Returns all kits in the graph.
+   */
+  kits(): InspectableKit[];
+  /**
+   * Returns all nodes of the given type.
+   * @param type type of the nodes to find
+   */
+  nodesByType(type: NodeTypeIdentifier): InspectableNode[];
+  /**
+   * Returns the `InspectableNodeType` for a given node or undefined if the
+   * node does not exist.
+   */
+  typeForNode(id: NodeIdentifier): InspectableNodeType | undefined;
+  /**
+   * Returns the `InspectableNodeType` for a given type or undefined if the type
+   * does not exist.
+   */
+  typeById(id: NodeTypeIdentifier): InspectableNodeType | undefined;
+  /**
+   * Returns the nodes that have an edge to the node with the given id.
+   * @param id id of the node to find incoming nodes for
+   */
+  incomingForNode(id: NodeIdentifier): InspectableEdge[];
+  /**
+   * Returns the nodes that have an edge from the node with the given id.
+   * @param id id of the node to find outgoing nodes for
+   */
+  outgoingForNode(id: NodeIdentifier): InspectableEdge[];
+  /**
+   * Returns a list of entry nodes for the graph.
+   */
+  entries(): InspectableNode[];
+  /**
+   * Returns the API of the graph. This function is designed to match the
+   * output of the `NodeDescriberFunction`.
+   */
+  describe(inputs?: InputValues): Promise<NodeDescriberResult>;
+  /**
+   * Returns the subgraphs that are embedded in this graph or `undefined` if
+   * this is already a subgraph
+   */
+  graphs(): InspectableSubgraphs | undefined;
+  /**
+   * Returns the id of this graph. If this is a main graph,
+   * the value will be "". Otherwise, it will be the id of this subgraph.
+   */
+  graphId(): GraphIdentifier;
+  /**
+   * Returns a module by name.
+   */
+  moduleById(id: ModuleIdentifier): InspectableModule | undefined;
+  /**
+   * Returns the modules that are embedded in this graph.
+   */
+  modules(): InspectableModules;
+  /**
+   * Returns true if the graph represents an `ImperativeGraph` instance.
+   * Imperative `InspectableGraph` will still show nodes and edges, but
+   * it is just a fixed topology that represents how the graph is run.
+   */
+  imperative(): boolean;
+  /**
+   * Returns the name of the designated "main" module if this is an
+   * `ImperativeGraph` instance and `undefined` if it is not yet set or
+   * this is a `DeclarativeGraph` instance.
+   */
+  main(): string | undefined;
 };
-
-export type InspectableGraphEventTarget =
-  TypedEventTarget<InspectableGraphEventMap>;
-
-export type InspectableGraph =
-  TypedEventTargetType<InspectableGraphEventMap> & {
-    /**
-     * Returns the underlying `GraphDescriptor` object.
-     * TODO: Replace all uses of it with a proper inspector API.
-     */
-    raw(): GraphDescriptor;
-    /**
-     * Returns this graph's metadata, if exists.
-     */
-    metadata(): GraphMetadata | undefined;
-    /**
-     * Returns the node with the given id, or undefined if no such node exists.
-     * @param id id of the node to find
-     */
-    nodeById(id: NodeIdentifier): InspectableNode | undefined;
-    /**
-     * Returns all nodes in the graph.
-     */
-    nodes(): InspectableNode[];
-    /**
-     * Returns all edges of the graph.
-     */
-    edges(): InspectableEdge[];
-    /**
-     * Returns true if the edge exists in the graph.
-     */
-    hasEdge(edge: Edge): boolean;
-    /**
-     * Returns all kits in the graph.
-     */
-    kits(): InspectableKit[];
-    /**
-     * Returns all nodes of the given type.
-     * @param type type of the nodes to find
-     */
-    nodesByType(type: NodeTypeIdentifier): InspectableNode[];
-    /**
-     * Returns the `InspectableNodeType` for a given node or undefined if the
-     * node does not exist.
-     */
-    typeForNode(id: NodeIdentifier): InspectableNodeType | undefined;
-    /**
-     * Returns the `InspectableNodeType` for a given type or undefined if the type
-     * does not exist.
-     */
-    typeById(id: NodeTypeIdentifier): InspectableNodeType | undefined;
-    /**
-     * Returns the nodes that have an edge to the node with the given id.
-     * @param id id of the node to find incoming nodes for
-     */
-    incomingForNode(id: NodeIdentifier): InspectableEdge[];
-    /**
-     * Returns the nodes that have an edge from the node with the given id.
-     * @param id id of the node to find outgoing nodes for
-     */
-    outgoingForNode(id: NodeIdentifier): InspectableEdge[];
-    /**
-     * Returns a list of entry nodes for the graph.
-     */
-    entries(): InspectableNode[];
-    /**
-     * Returns the API of the graph. This function is designed to match the
-     * output of the `NodeDescriberFunction`.
-     */
-    describe(inputs?: InputValues): Promise<NodeDescriberResult>;
-    /**
-     * Returns the subgraphs that are embedded in this graph or `undefined` if
-     * this is already a subgraph
-     */
-    graphs(): InspectableSubgraphs | undefined;
-    /**
-     * Returns the id of this graph. If this is a main graph,
-     * the value will be "". Otherwise, it will be the id of this subgraph.
-     */
-    graphId(): GraphIdentifier;
-    /**
-     * Returns a module by name.
-     */
-    moduleById(id: ModuleIdentifier): InspectableModule | undefined;
-    /**
-     * Returns the modules that are embedded in this graph.
-     */
-    modules(): InspectableModules;
-    /**
-     * Returns true if the graph represents an `ImperativeGraph` instance.
-     * Imperative `InspectableGraph` will still show nodes and edges, but
-     * it is just a fixed topology that represents how the graph is run.
-     */
-    imperative(): boolean;
-    /**
-     * Returns the name of the designated "main" module if this is an
-     * `ImperativeGraph` instance and `undefined` if it is not yet set or
-     * this is a `DeclarativeGraph` instance.
-     */
-    main(): string | undefined;
-  };
 
 /**
  * Options to supply to the `inspectableGraph` function.
@@ -713,7 +703,15 @@ export type GraphHandle = {
 
 export type GraphStoreArgs = Required<InspectableGraphOptions>;
 
-export type MutableGraphStore = {
+export type GraphStoreUpdateEvent = Event;
+
+type GraphsStoreEventMap = {
+  update: GraphStoreUpdateEvent;
+};
+
+export type GraphStoreEventTarget = TypedEventTarget<GraphsStoreEventMap>;
+
+export type MutableGraphStore = TypedEventTargetType<GraphStoreEventTarget> & {
   readonly kits: readonly Kit[];
   readonly sandbox: Sandbox;
   readonly loader: GraphLoader;

--- a/packages/shared-ui/src/elements/editor/editor.ts
+++ b/packages/shared-ui/src/elements/editor/editor.ts
@@ -196,6 +196,9 @@ export class Editor extends LitElement {
   visualChangeId: WorkspaceVisualChangeId | null = null;
 
   @property()
+  graphTopologyUpdateId: number = 0;
+
+  @property()
   set showPortTooltips(value: boolean) {
     this.#graphRenderer.showPortTooltips = value;
   }
@@ -339,7 +342,7 @@ export class Editor extends LitElement {
     const ports = new Map<string, InspectableNodePorts>();
     const typeMetadata = new Map<string, NodeHandlerMetadata>();
     for (const node of selectedGraph.nodes()) {
-      ports.set(node.descriptor.id, await node.ports());
+      ports.set(node.descriptor.id, node.currentPorts());
       try {
         typeMetadata.set(node.descriptor.type, await node.type().metadata());
       } catch (err) {

--- a/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
@@ -120,6 +120,9 @@ export class UI extends LitElement {
   @property()
   visualChangeId: WorkspaceVisualChangeId | null = null;
 
+  @property()
+  graphTopologyUpdateId: number = 0;
+
   #graphEditorRef: Ref<Editor> = createRef();
   #moduleEditorRef: Ref<ModuleEditor> = createRef();
 
@@ -274,6 +277,7 @@ export class UI extends LitElement {
         this.mode,
         this.selectionState,
         this.visualChangeId,
+        this.graphTopologyUpdateId,
         collapseNodesByDefault,
         hideSubboardSelectorWhenEmpty,
         showNodeShortcuts,
@@ -313,6 +317,7 @@ export class UI extends LitElement {
           .topGraphResult=${this.topGraphResult}
           .selectionState=${this.selectionState}
           .visualChangeId=${this.visualChangeId}
+          .graphTopologyUpdateId=${this.graphTopologyUpdateId}
         ></bb-editor>`;
       }
     );

--- a/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
@@ -398,19 +398,23 @@ export class UI extends LitElement {
               </button>
             </div>
           </h1>
-          ${guard([graph, this.mode, this.selectionState], () => {
-            return html`<bb-workspace-outline
-              .graph=${graph}
-              .kits=${this.kits}
-              .renderId=${globalThis.crypto.randomUUID()}
-              .mode=${this.mode}
-              .selectionState=${this.selectionState}
-              @bboutlinemodechange=${() => {
-                this.mode = this.mode === "list" ? "tree" : "list";
-                globalThis.localStorage.setItem(MODE_KEY, this.mode);
-              }}
-            ></bb-workspace-outline>`;
-          })}`;
+          ${guard(
+            [graph, this.mode, this.selectionState, this.graphTopologyUpdateId],
+            () => {
+              return html`<bb-workspace-outline
+                .graph=${graph}
+                .kits=${this.kits}
+                .renderId=${globalThis.crypto.randomUUID()}
+                .mode=${this.mode}
+                .selectionState=${this.selectionState}
+                .graphTopologyUpdateId=${this.graphTopologyUpdateId}
+                @bboutlinemodechange=${() => {
+                  this.mode = this.mode === "list" ? "tree" : "list";
+                  globalThis.localStorage.setItem(MODE_KEY, this.mode);
+                }}
+              ></bb-workspace-outline>`;
+            }
+          )}`;
         break;
       }
 

--- a/packages/visual-editor/src/runtime/board.ts
+++ b/packages/visual-editor/src/runtime/board.ts
@@ -352,10 +352,15 @@ export class Board extends EventTarget {
     const moduleId = descriptor.main || null;
 
     const id = globalThis.crypto.randomUUID();
+    const mainGraphId = this.getGraphStore().addByDescriptor(descriptor);
+    if (!mainGraphId.success) {
+      throw new Error(`Unable to add graph: ${mainGraphId.error}`);
+    }
     this.#tabs.set(id, {
       id,
       kits: this.kits,
       name: descriptor.title ?? "Untitled board",
+      mainGraphId: mainGraphId.result,
       graph: descriptor,
       subGraphId: null,
       moduleId,
@@ -394,11 +399,16 @@ export class Board extends EventTarget {
     const moduleId = descriptor.main || null;
 
     const id = globalThis.crypto.randomUUID();
+    const mainGraphId = this.getGraphStore().addByDescriptor(descriptor);
+    if (!mainGraphId.success) {
+      throw new Error(`Unable to add graph: ${mainGraphId.error}`);
+    }
     this.#tabs.set(id, {
       id,
       kits: this.kits,
       name: descriptor.title ?? "Untitled board",
       graph: descriptor,
+      mainGraphId: mainGraphId.result,
       subGraphId: null,
       moduleId,
       version: 1,
@@ -497,12 +507,20 @@ export class Board extends EventTarget {
         subGraphId = null;
       }
 
+      // This is not elegant, since we actually load the graph by URL,
+      // and we should know this mainGraphId by now.
+      // TODO: Make this more elegant.
+      const mainGraphId = this.getGraphStore().addByDescriptor(graph);
+      if (!mainGraphId.success) {
+        throw new Error(`Unable to add graph: ${mainGraphId.error}`);
+      }
       const id = globalThis.crypto.randomUUID();
       this.#tabs.set(id, {
         id,
         kits,
         name: graph.title ?? "Untitled board",
         graph,
+        mainGraphId: mainGraphId.result,
         subGraphId,
         moduleId,
         type: TabType.URL,

--- a/packages/visual-editor/src/runtime/events.ts
+++ b/packages/visual-editor/src/runtime/events.ts
@@ -115,7 +115,7 @@ export class RuntimeSelectionChangeEvent extends Event {
 }
 
 export class RuntimeVisualChangeEvent extends Event {
-  static eventName = "runtimevisualnchange" as const;
+  static eventName = "runtimevisualchange" as const;
 
   constructor(public readonly visualChangeId: WorkspaceVisualChangeId) {
     super(RuntimeVisualChangeEvent.eventName, { ...eventInit });

--- a/packages/visual-editor/src/runtime/types.ts
+++ b/packages/visual-editor/src/runtime/types.ts
@@ -10,6 +10,7 @@ import {
   GraphDescriptor,
   GraphLoader,
   Kit,
+  MainGraphIdentifier,
   MutableGraphStore,
   NodeConfiguration,
   RunStore,
@@ -37,6 +38,7 @@ export interface Tab {
   id: TabId;
   kits: Kit[];
   name: TabName;
+  mainGraphId: MainGraphIdentifier;
   graph: GraphDescriptor;
   subGraphId: string | null;
   moduleId: ModuleIdentifier | null;


### PR DESCRIPTION
- **Do not rebuild graph cache on every update.**
- **Fix a typo.**
- **Move Event dispatching to MutableGraphStore.**
- **Start using `update` event and `currentPorts` (yay) in `bb-editor`.**
- **Convert `bb-workspace-outline` to use `currentPorts`.**
- **docs(changeset): Start using `currentPorts` and `update` event in VE.**
