### PR TITLE
snapshot node type metadata

### DIFF
--- a/.changeset/dry-tables-study.md
+++ b/.changeset/dry-tables-study.md
@@ -1,0 +1,7 @@
+---
+"@breadboard-ai/visual-editor": minor
+"@google-labs/breadboard": minor
+"@breadboard-ai/shared-ui": minor
+---
+
+Make retrieving type metadata sync.

--- a/packages/breadboard/src/graph-based-node-handler.ts
+++ b/packages/breadboard/src/graph-based-node-handler.ts
@@ -13,6 +13,7 @@ import {
   NodeDescriberContext,
   NodeDescriberResult,
   NodeHandlerContext,
+  NodeHandlerMetadata,
   NodeHandlerObject,
   NodeTypeIdentifier,
   Schema,
@@ -20,7 +21,7 @@ import {
 import { hash } from "./utils/hash.js";
 import { Throttler } from "./utils/throttler.js";
 
-export { GraphBasedNodeHandler };
+export { GraphBasedNodeHandler, toNodeHandlerMetadata };
 
 type NodeDescriberThrottler = Throttler<
   [InputValues | undefined, GraphDescriptor, NodeDescriberContext],
@@ -47,6 +48,8 @@ class GraphBasedNodeHandler implements NodeHandlerObject {
     this.#graph = graph;
     this.#type = type;
     this.#descriptor = resolveGraph(graph);
+    this.invoke = this.invoke.bind(this);
+    this.describe = this.describe.bind(this);
   }
 
   async invoke(inputs: InputValues, context: NodeHandlerContext) {
@@ -89,14 +92,18 @@ class GraphBasedNodeHandler implements NodeHandlerObject {
   }
 
   get metadata() {
-    return filterEmptyValues({
-      title: this.#descriptor.title,
-      description: this.#descriptor.description,
-      url: this.#descriptor.url,
-      icon: this.#descriptor.metadata?.icon,
-      help: this.#descriptor.metadata?.help,
-    });
+    return toNodeHandlerMetadata(this.#descriptor);
   }
+}
+
+function toNodeHandlerMetadata(graph: GraphDescriptor): NodeHandlerMetadata {
+  return filterEmptyValues({
+    title: graph.title,
+    description: graph.description,
+    url: graph.url,
+    icon: graph.metadata?.icon,
+    help: graph.metadata?.help,
+  });
 }
 
 async function describeGraph(

--- a/packages/breadboard/src/graph-based-node-handler.ts
+++ b/packages/breadboard/src/graph-based-node-handler.ts
@@ -1,0 +1,141 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { resolveGraph } from "./loader/loader.js";
+import { invokeGraph } from "./run/invoke-graph.js";
+import {
+  GraphDescriptor,
+  GraphToRun,
+  InputValues,
+  NodeDescriberContext,
+  NodeDescriberResult,
+  NodeHandlerContext,
+  NodeHandlerObject,
+  NodeTypeIdentifier,
+  Schema,
+} from "./types.js";
+import { hash } from "./utils/hash.js";
+import { Throttler } from "./utils/throttler.js";
+
+export { GraphBasedNodeHandler };
+
+type NodeDescriberThrottler = Throttler<
+  [InputValues | undefined, GraphDescriptor, NodeDescriberContext],
+  NodeDescriberResult
+>;
+
+type DescribeThrottlerWithHash = {
+  throttler: NodeDescriberThrottler;
+  hash: number;
+};
+
+const DESCRIBE_THROTTLE_DELAY = 5000;
+const DESCRIBE_RESULT_CACHE = new Map<
+  NodeTypeIdentifier,
+  DescribeThrottlerWithHash
+>();
+
+class GraphBasedNodeHandler implements NodeHandlerObject {
+  #graph: GraphToRun;
+  #type: NodeTypeIdentifier;
+  #descriptor: GraphDescriptor;
+
+  constructor(graph: GraphToRun, type: NodeTypeIdentifier) {
+    this.#graph = graph;
+    this.#type = type;
+    this.#descriptor = resolveGraph(graph);
+  }
+
+  async invoke(inputs: InputValues, context: NodeHandlerContext) {
+    const base = context.board?.url && new URL(context.board?.url);
+    const invocationContext = base
+      ? {
+          ...context,
+          base,
+        }
+      : { ...context };
+
+    return await invokeGraph(this.#graph, inputs, invocationContext);
+  }
+
+  async describe(
+    inputs?: InputValues,
+    _inputSchema?: Schema,
+    _outputSchema?: Schema,
+    context?: NodeDescriberContext
+  ) {
+    if (!context) {
+      return { inputSchema: {}, outputSchema: {} };
+    }
+    const inputsHash = hash(inputs);
+    let describeThrottler = DESCRIBE_RESULT_CACHE.get(this.#type);
+    if (!describeThrottler || describeThrottler.hash !== inputsHash) {
+      describeThrottler = {
+        throttler: new Throttler(describeGraph, DESCRIBE_THROTTLE_DELAY),
+        hash: inputsHash,
+      };
+
+      DESCRIBE_RESULT_CACHE.set(this.#type, describeThrottler);
+    }
+    return describeThrottler.throttler.call(
+      {},
+      inputs,
+      this.#descriptor,
+      context
+    );
+  }
+
+  get metadata() {
+    return filterEmptyValues({
+      title: this.#descriptor.title,
+      description: this.#descriptor.description,
+      url: this.#descriptor.url,
+      icon: this.#descriptor.metadata?.icon,
+      help: this.#descriptor.metadata?.help,
+    });
+  }
+}
+
+async function describeGraph(
+  inputs: InputValues | undefined,
+  graph: GraphDescriptor,
+  context: NodeDescriberContext
+) {
+  const graphStore = context?.graphStore;
+  if (!graphStore) {
+    return emptyDescriberResult();
+  }
+  const adding = graphStore.addByDescriptor(graph);
+  if (!adding.success) {
+    return emptyDescriberResult();
+  }
+  const inspectableGraph = graphStore.inspect(adding.result, "");
+  if (!inspectableGraph) {
+    return emptyDescriberResult();
+  }
+  const result = await inspectableGraph.describe(inputs);
+  return result;
+}
+
+/**
+ * A utility function to filter out empty (null or undefined) values from
+ * an object.
+ *
+ * @param obj -- The object to filter.
+ * @returns -- The object with empty values removed.
+ */
+function filterEmptyValues<T extends Record<string, unknown>>(obj: T): T {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([, value]) => !!value)
+  ) as T;
+}
+
+function emptyDescriberResult(): NodeDescriberResult {
+  return {
+    inputSchema: { type: "object" },
+    outputSchema: { type: "object" },
+  };
+}

--- a/packages/breadboard/src/handler.ts
+++ b/packages/breadboard/src/handler.ts
@@ -4,14 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { resolveGraph, SENTINEL_BASE_URL } from "./loader/loader.js";
-import { invokeGraph } from "./run/invoke-graph.js";
+import { GraphBasedNodeHandler } from "./graph-based-node-handler.js";
+import { SENTINEL_BASE_URL } from "./loader/loader.js";
 import type {
-  GraphDescriptor,
   InputValues,
   Kit,
-  NodeDescriberContext,
-  NodeDescriberResult,
   NodeHandler,
   NodeHandlerContext,
   NodeHandlerFunction,
@@ -21,7 +18,6 @@ import type {
   OutputValues,
 } from "./types.js";
 import { graphUrlLike } from "./utils/graph-url-like.js";
-import { hash } from "./utils/hash.js";
 import { Throttler } from "./utils/throttler.js";
 
 const getHandlerFunction = (handler: NodeHandler): NodeHandlerFunction => {
@@ -29,13 +25,6 @@ const getHandlerFunction = (handler: NodeHandler): NodeHandlerFunction => {
   if (handler instanceof Function) return handler;
   throw new Error("Invalid handler");
 };
-
-function emptyDescriberResult(): NodeDescriberResult {
-  return {
-    inputSchema: { type: "object" },
-    outputSchema: { type: "object" },
-  };
-}
 
 export const callHandler = async (
   handler: NodeHandler,
@@ -99,45 +88,16 @@ export async function getHandler(
   throw new Error(`No handler for node type "${type}"`);
 }
 
-/**
- * A utility function to filter out empty (null or undefined) values from
- * an object.
- *
- * @param obj -- The object to filter.
- * @returns -- The object with empty values removed.
- */
-function filterEmptyValues<T extends Record<string, unknown>>(obj: T): T {
-  return Object.fromEntries(
-    Object.entries(obj).filter(([, value]) => !!value)
-  ) as T;
-}
-
 type GraphHandlerThrottler = Throttler<
   [NodeTypeIdentifier, NodeHandlerContext],
   NodeHandlerObject | undefined
 >;
 
-type NodeDescriberThrottler = Throttler<
-  [InputValues | undefined, GraphDescriptor, NodeDescriberContext],
-  NodeDescriberResult
->;
-
 const HANDLER_THROTTLE_DELAY = 10000;
-const DESCRIBE_THROTTLE_DELAY = 5000;
 
 const GRAPH_HANDLER_CACHE = new Map<
   NodeTypeIdentifier,
   GraphHandlerThrottler
->();
-
-type DescribeThrottlerWithHash = {
-  throttler: NodeDescriberThrottler;
-  hash: number;
-};
-
-const DESCRIBE_RESULT_CACHE = new Map<
-  NodeTypeIdentifier,
-  DescribeThrottlerWithHash
 >();
 
 export async function getGraphHandler(
@@ -174,63 +134,5 @@ async function getGraphHandlerInternal(
     );
   }
 
-  const graph = resolveGraph(loadResult);
-
-  return {
-    invoke: async (inputs, context) => {
-      const base = context.board?.url && new URL(context.board?.url);
-      const invocationContext = base
-        ? {
-            ...context,
-            base,
-          }
-        : { ...context };
-
-      return await invokeGraph(loadResult, inputs, invocationContext);
-    },
-    describe: async (inputs, _inputSchema, _outputSchema, context) => {
-      if (!context) {
-        return { inputSchema: {}, outputSchema: {} };
-      }
-      const inputsHash = hash(inputs);
-      let describeThrottler = DESCRIBE_RESULT_CACHE.get(type);
-      if (!describeThrottler || describeThrottler.hash !== inputsHash) {
-        describeThrottler = {
-          throttler: new Throttler(describeGraph, DESCRIBE_THROTTLE_DELAY),
-          hash: inputsHash,
-        };
-
-        DESCRIBE_RESULT_CACHE.set(type, describeThrottler);
-      }
-      return describeThrottler.throttler.call({}, inputs, graph, context);
-    },
-    metadata: filterEmptyValues({
-      title: graph.title,
-      description: graph.description,
-      url: graph.url,
-      icon: graph.metadata?.icon,
-      help: graph.metadata?.help,
-    }),
-  } as NodeHandlerObject;
-}
-
-async function describeGraph(
-  inputs: InputValues | undefined,
-  graph: GraphDescriptor,
-  context: NodeDescriberContext
-) {
-  const graphStore = context?.graphStore;
-  if (!graphStore) {
-    return emptyDescriberResult();
-  }
-  const adding = graphStore.addByDescriptor(graph);
-  if (!adding.success) {
-    return emptyDescriberResult();
-  }
-  const inspectableGraph = graphStore.inspect(adding.result, "");
-  if (!inspectableGraph) {
-    return emptyDescriberResult();
-  }
-  const result = await inspectableGraph.describe(inputs);
-  return result;
+  return new GraphBasedNodeHandler(loadResult, type);
 }

--- a/packages/breadboard/src/handler.ts
+++ b/packages/breadboard/src/handler.ts
@@ -5,6 +5,7 @@
  */
 
 import { GraphBasedNodeHandler } from "./graph-based-node-handler.js";
+import { MutableGraphStore } from "./inspector/types.js";
 import { SENTINEL_BASE_URL } from "./loader/loader.js";
 import type {
   InputValues,
@@ -85,6 +86,20 @@ export async function getHandler(
     return kitHandler;
   }
   throw new Error(`No handler for node type "${type}"`);
+}
+
+export async function getGraphHandlerFromStore(
+  type: NodeTypeIdentifier,
+  store: MutableGraphStore
+): Promise<NodeHandlerObject | undefined> {
+  const nodeTypeUrl = graphUrlLike(type)
+    ? new URL(type, SENTINEL_BASE_URL)
+    : undefined;
+  if (!nodeTypeUrl) {
+    return undefined;
+  }
+  const result = store.getByURL(type, [], {});
+  return new GraphBasedNodeHandler({ graph: result.graph }, type);
 }
 
 export async function getGraphHandler(

--- a/packages/breadboard/src/handler.ts
+++ b/packages/breadboard/src/handler.ts
@@ -18,7 +18,6 @@ import type {
   OutputValues,
 } from "./types.js";
 import { graphUrlLike } from "./utils/graph-url-like.js";
-import { Throttler } from "./utils/throttler.js";
 
 const getHandlerFunction = (handler: NodeHandler): NodeHandlerFunction => {
   if ("invoke" in handler && handler.invoke) return handler.invoke;
@@ -88,33 +87,7 @@ export async function getHandler(
   throw new Error(`No handler for node type "${type}"`);
 }
 
-type GraphHandlerThrottler = Throttler<
-  [NodeTypeIdentifier, NodeHandlerContext],
-  NodeHandlerObject | undefined
->;
-
-const HANDLER_THROTTLE_DELAY = 10000;
-
-const GRAPH_HANDLER_CACHE = new Map<
-  NodeTypeIdentifier,
-  GraphHandlerThrottler
->();
-
 export async function getGraphHandler(
-  type: NodeTypeIdentifier,
-  context: NodeHandlerContext
-): Promise<NodeHandlerObject | undefined> {
-  let throttler;
-  if (!GRAPH_HANDLER_CACHE.has(type)) {
-    throttler = new Throttler(getGraphHandlerInternal, HANDLER_THROTTLE_DELAY);
-    GRAPH_HANDLER_CACHE.set(type, throttler);
-  } else {
-    throttler = GRAPH_HANDLER_CACHE.get(type)!;
-  }
-  return throttler.call({}, type, context);
-}
-
-async function getGraphHandlerInternal(
   type: NodeTypeIdentifier,
   context: NodeHandlerContext
 ): Promise<NodeHandlerObject | undefined> {

--- a/packages/breadboard/src/inspector/graph/describer-manager.ts
+++ b/packages/breadboard/src/inspector/graph/describer-manager.ts
@@ -105,7 +105,7 @@ class NodeTypeDescriberManager implements DescribeResultCacheArgs {
       return;
     }
     this.mutable.store.dispatchEvent(
-      new UpdateEvent(this.mutable.id, graphId, nodeId)
+      new UpdateEvent(this.mutable.id, graphId, nodeId, [])
     );
   }
 

--- a/packages/breadboard/src/inspector/graph/event.ts
+++ b/packages/breadboard/src/inspector/graph/event.ts
@@ -21,7 +21,8 @@ class UpdateEvent extends Event implements GraphStoreUpdateEvent {
   constructor(
     public readonly mainGraphId: MainGraphIdentifier,
     public readonly graphId: GraphIdentifier,
-    public readonly nodeId: NodeIdentifier
+    public readonly nodeId: NodeIdentifier,
+    public readonly affectedGraphs: MainGraphIdentifier[]
   ) {
     super(UpdateEvent.eventName, { ...eventInit });
   }

--- a/packages/breadboard/src/inspector/graph/kits.ts
+++ b/packages/breadboard/src/inspector/graph/kits.ts
@@ -23,6 +23,7 @@ import {
   InspectableNodePorts,
   InspectableNodeType,
   MutableGraph,
+  MutableGraphStore,
   NodeTypeDescriberOptions,
 } from "../types.js";
 import { collectPortsForType, filterSidePorts } from "./ports.js";
@@ -75,7 +76,7 @@ const createCustomTypesKit = (
         url: "",
       },
       nodeTypes: uniqueTypes.map((type) => {
-        return new CustomNodeType(type, mutable);
+        return new CustomNodeType(type, mutable.store);
       }),
     },
   ];
@@ -108,7 +109,7 @@ export const createGraphNodeType = (
   type: NodeTypeIdentifier,
   mutable: MutableGraph
 ): InspectableNodeType => {
-  return new CustomNodeType(type, mutable);
+  return new CustomNodeType(type, mutable.store);
 };
 
 const collectNodeTypes = (
@@ -119,7 +120,7 @@ const collectNodeTypes = (
     .sort()
     .map(([type, handler]) => {
       if (graphUrlLike(type)) {
-        return new CustomNodeType(type, mutable);
+        return new CustomNodeType(type, mutable.store);
       }
       return new KitNodeType(type, handler);
     });
@@ -220,12 +221,9 @@ class CustomNodeType implements InspectableNodeType {
   #metadata: NodeHandlerMetadata | null = null;
   #handlerPromise: Promise<NodeHandlerObject | undefined> | null = null;
 
-  constructor(type: string, mutable: MutableGraph) {
+  constructor(type: string, store: MutableGraphStore) {
     this.#type = type;
-    this.#handlerPromise = getGraphHandler(
-      type,
-      contextFromStore(mutable.store)
-    );
+    this.#handlerPromise = getGraphHandler(type, contextFromStore(store));
   }
 
   async #readMetadata() {

--- a/packages/breadboard/src/inspector/graph/kits.ts
+++ b/packages/breadboard/src/inspector/graph/kits.ts
@@ -5,7 +5,7 @@
  */
 
 import { toNodeHandlerMetadata } from "../../graph-based-node-handler.js";
-import { getGraphHandler } from "../../handler.js";
+import { getGraphHandlerFromStore } from "../../handler.js";
 import {
   GraphDescriptor,
   NodeDescriberResult,
@@ -17,7 +17,6 @@ import {
   NodeTypeIdentifier,
 } from "../../types.js";
 import { graphUrlLike } from "../../utils/graph-url-like.js";
-import { contextFromStore } from "../graph-store.js";
 import {
   InspectableKit,
   InspectableKitCache,
@@ -229,10 +228,7 @@ class CustomNodeType implements InspectableNodeType {
   constructor(type: string, mutable: MutableGraph) {
     this.#type = type;
     this.#mutable = mutable;
-    this.#handlerPromise = getGraphHandler(
-      type,
-      contextFromStore(mutable.store)
-    );
+    this.#handlerPromise = getGraphHandlerFromStore(type, mutable.store);
   }
 
   async #readMetadata() {

--- a/packages/breadboard/src/inspector/graph/virtual-node.ts
+++ b/packages/breadboard/src/inspector/graph/virtual-node.ts
@@ -102,6 +102,11 @@ class VirtualNode implements InspectableNode {
           title: this.#type,
         };
       },
+      currentMetadata: () => {
+        return {
+          title: this.#type,
+        };
+      },
       type: () => {
         return this.#type;
       },

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -581,6 +581,12 @@ export type InspectableNodeType = {
    * Returns the metadata, associated with this node type.
    */
   metadata(): Promise<NodeHandlerMetadata>;
+
+  /**
+   * Same as above, but not async. The data may be stale. Listen to the
+   * `update` events on GraphStore to get fresh metadata.
+   */
+  currentMetadata(): NodeHandlerMetadata;
   /**
    * Returns the type of the node.
    */
@@ -705,6 +711,7 @@ export type GraphStoreArgs = Required<InspectableGraphOptions>;
 
 export type GraphStoreUpdateEvent = Event & {
   mainGraphId: MainGraphIdentifier;
+  affectedGraphs: MainGraphIdentifier[];
   graphId: GraphIdentifier;
   nodeId: NodeIdentifier;
 };
@@ -721,6 +728,12 @@ export type MutableGraphStore = TypedEventTargetType<GraphsStoreEventMap> & {
   readonly loader: GraphLoader;
 
   load(url: string, options: GraphLoaderContext): Promise<Result<GraphHandle>>;
+
+  getByURL(
+    url: string,
+    dependencies: MainGraphIdentifier[],
+    context: GraphLoaderContext
+  ): MutableGraph;
   addByDescriptor(graph: GraphDescriptor): Result<MainGraphIdentifier>;
   editByDescriptor(
     graph: GraphDescriptor,

--- a/packages/shared-ui/src/elements/editor/editor.ts
+++ b/packages/shared-ui/src/elements/editor/editor.ts
@@ -334,17 +334,17 @@ export class Editor extends LitElement {
     }
   `;
 
-  async #inspectableGraphToConfig(
+  #inspectableGraphToConfig(
     url: string,
     subGraphId: string | null,
     selectedGraph: InspectableGraph
-  ): Promise<GraphOpts> {
+  ): GraphOpts {
     const ports = new Map<string, InspectableNodePorts>();
     const typeMetadata = new Map<string, NodeHandlerMetadata>();
     for (const node of selectedGraph.nodes()) {
       ports.set(node.descriptor.id, node.currentPorts());
       try {
-        typeMetadata.set(node.descriptor.type, await node.type().metadata());
+        typeMetadata.set(node.descriptor.type, node.type().currentMetadata());
       } catch (err) {
         // In the event of failing to get the type info, suggest removing the
         // node from the graph.
@@ -400,12 +400,12 @@ export class Editor extends LitElement {
 
     let shouldAnimate = true;
 
-    const handleGraph = async (
+    const handleGraph = (
       url: string,
       subGraphId: GraphIdentifier | null,
       selectedGraph: InspectableGraph
     ) => {
-      const opts = await this.#inspectableGraphToConfig(
+      const opts = this.#inspectableGraphToConfig(
         url,
         subGraphId,
         selectedGraph
@@ -436,11 +436,11 @@ export class Editor extends LitElement {
 
     const url = this.graph.raw().url ?? "no-url";
     if (this.showSubgraphsInline) {
-      await handleGraph(url, null, this.graph);
+      handleGraph(url, null, this.graph);
 
       const subGraphs = Object.entries(this.graph.graphs() ?? {});
       for (const [id, graph] of subGraphs) {
-        await handleGraph(url, id, graph);
+        handleGraph(url, id, graph);
       }
     } else {
       if (!this.selectionState) {
@@ -464,7 +464,7 @@ export class Editor extends LitElement {
           }
         }
 
-        await handleGraph(url, subGraphId, selectedGraph);
+        handleGraph(url, subGraphId, selectedGraph);
       }
     }
 

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -436,7 +436,11 @@ export class Main extends LitElement {
 
         this.#graphStore.addEventListener("update", (evt) => {
           const { mainGraphId } = evt;
-          if (mainGraphId !== this.tab?.mainGraphId) {
+          const current = this.tab?.mainGraphId;
+          if (
+            !current ||
+            (mainGraphId !== current && !evt.affectedGraphs.includes(current))
+          ) {
             return;
           }
           this.#graphTopologyUpdateId++;


### PR DESCRIPTION
- **Write more tests for SnapshotUpdater.**
- **Switch `GraphStore` to store Snapshotupdaters.**
- **Pass MutableGraphStore rather than MutableGraph to CustomNodeType.**
- **Split GraphBasedNodeHandler into separate class.**
- **Remove handler throttling and caching.**
- **Start dispatch update for node type metadata changes.**
- **Introduce and start using `currentMetadata`.**
- **docs(changeset): Make retrieving type metadata sync.**
