### PR TITLE
[bbrt] Formalize Driver as the interface that drives the main conversation

### DIFF
--- a/packages/bbrt/src/components/driver-selector.ts
+++ b/packages/bbrt/src/components/driver-selector.ts
@@ -8,12 +8,15 @@ import { SignalWatcher } from "@lit-labs/signals";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import type { Signal } from "signal-polyfill";
-import type { BBRTModel } from "../llm/model.js";
+import type { BBRTDriver } from "../drivers/driver-interface.js";
 
-@customElement("bbrt-model-selector")
-export class BBRTModelSelector extends SignalWatcher(LitElement) {
+@customElement("bbrt-driver-selector")
+export class BBRTDriverSelector extends SignalWatcher(LitElement) {
   @property({ attribute: false })
-  model?: Signal.State<BBRTModel>;
+  available?: BBRTDriver[];
+
+  @property({ attribute: false })
+  active?: Signal.State<BBRTDriver>;
 
   static override styles = css`
     :host {
@@ -35,34 +38,32 @@ export class BBRTModelSelector extends SignalWatcher(LitElement) {
   `;
 
   override render() {
-    if (this.model === undefined) {
+    if (this.active === undefined || this.available === undefined) {
       return nothing;
     }
-    const model = this.model.get();
+    const { name, icon } = this.active.get();
     return html`
       <button
-        @click=${this.#cycleModel}
-        title="Using ${model}. Click to cycle models."
+        @click=${this.#cycle}
+        title="Using ${name}. Click to cycle models."
       >
-        <img
-          alt="Using model ${model}"
-          src="/bbrt/images/${model}-logomark.svg"
-        />
+        <img alt="Using model ${name}" src=${icon} />
       </button>
     `;
   }
 
-  #cycleModel() {
-    if (this.model === undefined) {
+  #cycle() {
+    if (this.active === undefined || this.available === undefined) {
       return;
     }
-    // TODO(aomarks) Make this more configurable.
-    this.model.set(this.model.get() === "openai" ? "gemini" : "openai");
+    const indexOfActive = this.available.indexOf(this.active.get());
+    const nextIndex = (indexOfActive + 1) % this.available.length;
+    this.active.set(this.available[nextIndex]!);
   }
 }
 
 declare global {
   interface HTMLElementTagNameMap {
-    "bbrt-model-selector": BBRTModelSelector;
+    "bbrt-driver-selector": BBRTDriverSelector;
   }
 }

--- a/packages/bbrt/src/drivers/driver-interface.ts
+++ b/packages/bbrt/src/drivers/driver-interface.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { BBRTChunk } from "../llm/chunk.js";
+import type { BBRTTurn } from "../llm/conversation.js";
+import type { BBRTTool } from "../tools/tool.js";
+import type { Result } from "../util/result.js";
+
+/**
+ * A _driver_ implements interactions with a language model for the primary
+ * conversation.
+ */
+export interface BBRTDriver {
+  readonly name: string;
+  readonly icon: string;
+
+  executeTurn(
+    request: BBRTTurn[],
+    tools: BBRTTool[]
+  ): Promise<Result<AsyncIterableIterator<BBRTChunk>>>;
+}

--- a/packages/bbrt/src/tools/list-tools.ts
+++ b/packages/bbrt/src/tools/list-tools.ts
@@ -9,7 +9,7 @@ import { Signal } from "signal-polyfill";
 import type { BreadboardServer } from "../breadboard/breadboard-server.js";
 import { makeToolSafeName } from "../breadboard/make-tool-safe-name.js";
 import "../components/content.js";
-import type { GeminiFunctionDeclaration } from "../llm/gemini.js";
+import type { GeminiFunctionDeclaration } from "../drivers/gemini.js";
 import type { EmptyObject } from "../util/empty-object.js";
 import { resultify, type Result } from "../util/result.js";
 import type {


### PR DESCRIPTION
Introduces a `Driver` interface: an object that executes a turn (i.e. it provides the connection to the language model). For now, this just needs a name, an icon, and the ability to execute a turn. It is easier now to see how a Breadboard itself could be a Driver.