### PR TITLE
fix snapshot bugs

### DIFF
--- a/.changeset/chilled-baboons-sleep.md
+++ b/.changeset/chilled-baboons-sleep.md
@@ -1,0 +1,6 @@
+---
+"@breadboard-ai/visual-editor": patch
+"@google-labs/breadboard": patch
+---
+
+Fix the update-loop-of-death

--- a/packages/breadboard/src/inspector/run/describe-cache.ts
+++ b/packages/breadboard/src/inspector/run/describe-cache.ts
@@ -44,6 +44,18 @@ class DescribeResultCache implements InspectableDescriberResultCache {
     } as SnapshotUpdaterArgs<NodeDescriberResult>;
   }
 
+  #createInertSnapshotArgs(
+    graphId: GraphIdentifier,
+    nodeId: NodeIdentifier,
+    inputs?: InputValues
+  ) {
+    return {
+      initial: () => this.args.initial(graphId, nodeId),
+      latest: () => this.args.latest(graphId, nodeId, inputs),
+      willUpdate() {},
+    } as SnapshotUpdaterArgs<NodeDescriberResult>;
+  }
+
   get(
     id: NodeIdentifier,
     graphId: GraphIdentifier,
@@ -53,7 +65,7 @@ class DescribeResultCache implements InspectableDescriberResultCache {
       // bypass cache when there are inputs. We can't cache these
       // describer results ... yet.
       return new SnapshotUpdater(
-        this.#createSnapshotArgs(graphId, id, inputs)
+        this.#createInertSnapshotArgs(graphId, id, inputs)
       ).snapshot();
     }
     const hash = computeHash({ id, graphId });

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -249,7 +249,8 @@ export class Main extends LitElement {
 
   // Monotonically increases whenever the graph topology of a graph in the
   // current tab changes. Graph topology == any non-visual change to the graph.
-  #graphTopologyUpdateId: number = 0;
+  @state()
+  graphTopologyUpdateId: number = 0;
 
   #globalCommands: BreadboardUI.Types.Command[] = [
     {
@@ -443,7 +444,7 @@ export class Main extends LitElement {
           ) {
             return;
           }
-          this.#graphTopologyUpdateId++;
+          this.graphTopologyUpdateId++;
         });
 
         this.#runtime.edit.addEventListener(
@@ -2822,7 +2823,7 @@ export class Main extends LitElement {
               .tabURLs=${tabURLs}
               .selectionState=${this.#selectionState}
               .visualChangeId=${this.#lastVisualChangeId}
-              .graphTopologyUpdateId=${this.#graphTopologyUpdateId}
+              .graphTopologyUpdateId=${this.graphTopologyUpdateId}
               @bbeditorpositionchange=${(
                 evt: BreadboardUI.Events.EditorPointerPositionChangeEvent
               ) => {


### PR DESCRIPTION
- **Elevate `graphTopologyUpdateId` to component state.**
- **Make sure that the snapshots created by runtime are inert (don't update topology)**
- **docs(changeset): Fix the update-loop-of-death**
