### PR TITLE
[shared-ui] Avoid updating graph-renderer when the port tooltip changes

### DIFF
--- a/packages/shared-ui/src/elements/editor/graph-renderer.ts
+++ b/packages/shared-ui/src/elements/editor/graph-renderer.ts
@@ -627,6 +627,10 @@ export class GraphRenderer extends LitElement {
   }
 
   protected shouldUpdate(changedProperties: PropertyValues): boolean {
+    if (changedProperties.has("_portTooltip")) {
+      return false;
+    }
+
     if (changedProperties.has("topGraphUrl")) {
       return true;
     }


### PR DESCRIPTION
Fixes #3911