### PR TITLE
graph port label calc

### DIFF
--- a/.changeset/twelve-hounds-smile.md
+++ b/.changeset/twelve-hounds-smile.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/shared-ui": patch
+---
+
+Calculate dimensions when assigning port in `GraphPortLabel`.

--- a/packages/shared-ui/src/elements/editor/graph-port-label.ts
+++ b/packages/shared-ui/src/elements/editor/graph-port-label.ts
@@ -189,6 +189,11 @@ export class GraphPortLabel extends PIXI.Container {
       return;
     }
 
+    // Value preview may change the dimensions. Let's compute them now,
+    // because we may be computing dimensions for the node, and it needs
+    // the new values.
+    this.#calculateDimensions();
+
     this.isConfigurable = isConfigurablePort(port, this.#expansionState);
   }
 


### PR DESCRIPTION
- **Calculate dimensions when assigning ports on GraphPortLabel.**
- **docs(changeset): Calculate dimensions when assigning port in `GraphPortLabel`.**
