### PR TITLE
[bbrt] Much better schema handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25611,8 +25611,11 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@breadboard-ai/shared-ui": "1.21.0",
+        "@google-labs/agent-kit": "^0.14.0",
         "@google-labs/breadboard": "^0.30.0",
         "@google-labs/core-kit": "^0.17.0",
+        "@google-labs/gemini-kit": "^0.10.0",
+        "@google-labs/json-kit": "^0.3.13",
         "@google-labs/template-kit": "^0.3.15",
         "@lit-labs/signals": "^0.1.1",
         "@types/json-schema": "^7.0.15",

--- a/packages/bbrt/package.json
+++ b/packages/bbrt/package.json
@@ -57,8 +57,11 @@
     "build": {
       "dependencies": [
         "build:tsc",
+        "../agent-kit:build",
         "../breadboard:build",
         "../core-kit:build",
+        "../gemini-kit:build",
+        "../json-kit:build",
         "../shared-ui:build",
         "../template-kit:build"
       ]
@@ -66,8 +69,11 @@
     "build:tsc": {
       "command": "tsc --pretty",
       "dependencies": [
+        "../agent-kit:build",
         "../breadboard:build:tsc",
         "../core-kit:build:tsc",
+        "../gemini-kit:build:tsc",
+        "../json-kit:build:tsc",
         "../shared-ui:build:tsc",
         "../template-kit:build:tsc"
       ],
@@ -120,8 +126,11 @@
   },
   "dependencies": {
     "@breadboard-ai/shared-ui": "1.21.0",
+    "@google-labs/agent-kit": "^0.14.0",
     "@google-labs/breadboard": "^0.30.0",
     "@google-labs/core-kit": "^0.17.0",
+    "@google-labs/gemini-kit": "^0.10.0",
+    "@google-labs/json-kit": "^0.3.13",
     "@google-labs/template-kit": "^0.3.15",
     "@lit-labs/signals": "^0.1.1",
     "@types/json-schema": "^7.0.15",

--- a/packages/bbrt/src/breadboard/breadboard-tool.ts
+++ b/packages/bbrt/src/breadboard/breadboard-tool.ts
@@ -4,17 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import AgentKit from "@google-labs/agent-kit/agent.kit.json" assert { type: "json" };
 import {
   asRuntimeKit,
   createDefaultDataStore,
   createLoader,
   type GraphDescriptor,
   type InputValues,
+  type Kit,
   type OutputValues,
   type SerializedStoredData,
 } from "@google-labs/breadboard";
 import { createRunner, type RunConfig } from "@google-labs/breadboard/harness";
+import { kitFromGraphDescriptor } from "@google-labs/breadboard/kits";
 import CoreKit from "@google-labs/core-kit";
+import GeminiKit from "@google-labs/gemini-kit";
+import JSONKit from "@google-labs/json-kit";
 import TemplateKit from "@google-labs/template-kit";
 import { html, nothing } from "lit";
 import { Signal } from "signal-polyfill";
@@ -127,7 +132,13 @@ export class BreadboardToolInvocation implements ToolInvocation<unknown> {
     }
 
     const loader = createLoader();
-    const kits = [asRuntimeKit(CoreKit), asRuntimeKit(TemplateKit)];
+    const kits: Kit[] = [
+      asRuntimeKit(CoreKit),
+      asRuntimeKit(TemplateKit),
+      asRuntimeKit(JSONKit),
+      asRuntimeKit(GeminiKit),
+      kitFromGraphDescriptor(AgentKit as GraphDescriptor)!,
+    ];
 
     const store = createDefaultDataStore();
     const storeGroupID = crypto.randomUUID();

--- a/packages/bbrt/src/breadboard/make-tool-safe-name.ts
+++ b/packages/bbrt/src/breadboard/make-tool-safe-name.ts
@@ -5,9 +5,9 @@
  */
 
 /**
- * Gemini requires [a-zA-Z0-9_\-\.]{1,64}
+ * Gemini requires [a-zA-Z0-9_\-\.]{1,63}
  * OpenAI requires [a-zA-Z0-9_\-]{1,??}
  */
 export function makeToolSafeName(path: string) {
-  return path.replace(/[^a-zA-Z0-9_\\-]/g, "").slice(0, 64);
+  return path.replace(/[^a-zA-Z0-9_\\-]/g, "").slice(0, 63);
 }

--- a/packages/bbrt/src/breadboard/standardize-breadboard-schema.ts
+++ b/packages/bbrt/src/breadboard/standardize-breadboard-schema.ts
@@ -8,31 +8,106 @@ import type { Schema } from "@google-labs/breadboard";
 import type { JSONSchema7 } from "json-schema";
 
 /**
- * Takes a Breadboard input or output schema, which is JSON schema with some
- * additions like "behaviors", and emits a standard JSON Schema.
+ * Takes a Breadboard input or output schema, which is JSON Schema with
+ * additions like the `behaviors` property, and some modifications like
+ * JSON-encoding the `default` property, and emits a standard JSON Schema.
+ *
+ * Note this function removes known-invalid properties, but preserves unknown
+ * properties.
  */
-export function standardizeBreadboardSchema(schema: Schema): JSONSchema7 {
-  return visit(structuredClone(schema));
+export function standardizeBreadboardSchema(breadboard: Schema): JSONSchema7 {
+  return visit(structuredClone(breadboard));
 }
 
-function visit(obj: Schema): JSONSchema7 {
-  if (typeof obj === "object" && obj !== null) {
-    if (obj.type !== undefined) {
-      delete obj.behavior;
-      if (obj.type === "object") {
-        return visitObject(obj);
+function visit(node: Schema): JSONSchema7 {
+  if (typeof node === "object" && node !== null && node.type !== undefined) {
+    // The `llm-content` behavior carries a lot of weight in Breadboard schema;
+    // it's not just an annotation, but actually determines the entire schema.
+    // Replace it with an equivalent real JSON schema.
+    node = expandLlmContent(node);
+
+    // Behaviors are not part of standard JSON Schema.
+    delete node.behavior;
+
+    // Defaults are not JSON-encoded in standard JSON Schema.
+    if (node.type !== "string") {
+      if (typeof node.default === "string") {
+        node.default = JSON.parse(node.default);
+      }
+      if (node.examples !== undefined) {
+        for (let i = 0; i < node.examples.length; i++) {
+          if (typeof node.examples[i] === "string") {
+            node.examples[i] = JSON.parse(node.examples[i]!);
+          }
+        }
       }
     }
+
+    if (node.type === "object") {
+      return visitObject(node);
+    } else if (node.type === "array") {
+      return visitArray(node);
+    }
   }
-  return obj as JSONSchema7;
+  return node as JSONSchema7;
 }
 
 function visitObject(obj: Schema): JSONSchema7 {
   if (obj.properties !== undefined) {
-    for (const [propName, propValue] of Object.entries(obj.properties)) {
-      (obj.properties as Record<string, JSONSchema7>)[propName] =
-        visit(propValue);
+    for (const [name, value] of Object.entries(obj.properties)) {
+      (obj.properties as Record<string, JSONSchema7>)[name] = visit(value);
     }
   }
   return obj as object as JSONSchema7;
+}
+
+function visitArray(arr: Schema): JSONSchema7 {
+  if (Array.isArray(arr.items)) {
+    for (let i = 0; i < arr.items.length; i++) {
+      (arr.items as Array<JSONSchema7>)[i] = visit(arr.items[i]!);
+    }
+  } else if (arr.items !== undefined) {
+    (arr as JSONSchema7).items = visit(arr.items);
+  }
+  return arr as object as JSONSchema7;
+}
+
+const GEMINI_PART_SCHEMA: JSONSchema7 = {
+  type: "object",
+  required: ["text"],
+  properties: {
+    text: { type: "string" },
+    // TODO(aomarks) Add other part types like `inlineData` if needed.
+  },
+};
+
+const GEMINI_CONTENT_SCHEMA: JSONSchema7 = {
+  type: "object",
+  required: ["role", "parts"],
+  properties: {
+    role: {
+      type: "string",
+      enum: ["user", "model"],
+    },
+    parts: {
+      type: "array",
+      items: GEMINI_PART_SCHEMA,
+    },
+  },
+};
+
+const GEMINI_CONTENT_ARRAY_SCHEMA: JSONSchema7 = {
+  type: "array",
+  items: GEMINI_CONTENT_SCHEMA,
+};
+
+function expandLlmContent(node: Schema): Schema {
+  if (node.behavior !== undefined && node.behavior.includes("llm-content")) {
+    if (node.type === "object") {
+      Object.assign(node, GEMINI_CONTENT_SCHEMA);
+    } else if (node.type === "array") {
+      Object.assign(node, GEMINI_CONTENT_ARRAY_SCHEMA);
+    }
+  }
+  return node;
 }

--- a/packages/bbrt/src/components/tool-call.ts
+++ b/packages/bbrt/src/components/tool-call.ts
@@ -4,12 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { SignalWatcher } from "@lit-labs/signals";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import type { BBRTToolCall } from "../llm/conversation.js";
 
 @customElement("bbrt-tool-call")
-export class BBRTToolCallEl extends LitElement {
+export class BBRTToolCallEl extends SignalWatcher(LitElement) {
   @property({ attribute: false })
   toolCall?: BBRTToolCall;
 

--- a/packages/bbrt/src/drivers/adjust-schema-for-gemini.ts
+++ b/packages/bbrt/src/drivers/adjust-schema-for-gemini.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { JSONSchema7, JSONSchema7Definition } from "json-schema";
+import type { GeminiParameterSchema } from "./gemini-types.js";
+
+/**
+ * Gemini only supports a subset of JSON Schema for function calling. See
+ * https://ai.google.dev/api/caching#Schema for details.
+ */
+export function adjustSchemaForGemini(
+  schema: JSONSchema7
+): GeminiParameterSchema | undefined {
+  return visit(structuredClone(schema));
+}
+
+function visit(node: JSONSchema7Definition): GeminiParameterSchema | undefined {
+  if (typeof node === "object" && node !== null && node.type !== undefined) {
+    // Gemini doesn't support these fields.
+    delete node["title"];
+    delete node["default"];
+    delete node["examples"];
+
+    if (node.type === "object") {
+      return visitObject(node);
+    } else if (node.type === "array") {
+      return visitArray(node);
+    }
+  }
+  return node as GeminiParameterSchema;
+}
+
+function visitObject(obj: JSONSchema7): GeminiParameterSchema | undefined {
+  delete obj["additionalProperties"];
+  if (obj.properties !== undefined) {
+    for (const [name, value] of Object.entries(obj.properties)) {
+      const newValue = visit(value);
+      if (newValue === undefined) {
+        delete obj.properties[name];
+      } else {
+        obj.properties[name] = newValue;
+      }
+    }
+  }
+  if (
+    obj.properties === undefined ||
+    Object.keys(obj.properties).length === 0
+  ) {
+    // Gemini can't handle an object with no properties.
+    return undefined;
+  }
+  return obj as object as GeminiParameterSchema;
+}
+
+function visitArray(arr: JSONSchema7): GeminiParameterSchema {
+  if (Array.isArray(arr.items)) {
+    arr.items = arr.items
+      .map((item) => visit(item))
+      .filter((item) => item !== undefined);
+  } else if (arr.items !== undefined) {
+    arr.items = visit(arr.items);
+  }
+  return arr as object as GeminiParameterSchema;
+}

--- a/packages/bbrt/src/drivers/gemini-types.ts
+++ b/packages/bbrt/src/drivers/gemini-types.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface GeminiRequest {
+  contents: GeminiContent[];
+  tools?: Array<{
+    functionDeclarations: GeminiFunctionDeclaration[];
+  }>;
+  toolConfig?: {
+    mode: "auto" | "any" | "none";
+    allowedFunctionNames: string[];
+  };
+}
+
+export interface GeminiContent {
+  role: "user" | "model";
+  parts: GeminiPart[];
+}
+
+export type GeminiPart =
+  | GeminiTextPart
+  | GeminiFunctionCall
+  | GeminiFunctionResponse;
+
+export interface GeminiTextPart {
+  text: string;
+}
+
+export interface GeminiFunctionCall {
+  functionCall: {
+    name: string;
+    args: unknown;
+  };
+}
+
+export interface GeminiFunctionResponse {
+  functionResponse: {
+    name: string;
+    response: unknown;
+  };
+}
+
+export interface GeminiResponse {
+  candidates: GeminiCandidate[];
+}
+
+export interface GeminiCandidate {
+  content: GeminiContent;
+}
+
+export interface GeminiFunctionDeclaration {
+  name: string;
+  description: string;
+  parameters?: GeminiParameterSchema;
+}
+
+export type GeminiParameterSchema = {
+  type?: "string" | "number" | "boolean" | "array" | "object";
+  // TODO(aomarks) nullable is not standard JSON Schema, right? Usually
+  // "required" is how you express that.
+  nullable?: boolean;
+  description?: string;
+  properties?: Record<string, GeminiParameterSchema>;
+  required?: string[];
+  format?: string;
+  enum?: string[];
+  items?: GeminiParameterSchema;
+  minItems?: number;
+  maxItems?: number;
+};

--- a/packages/bbrt/src/drivers/openai-types.ts
+++ b/packages/bbrt/src/drivers/openai-types.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { JSONSchema7 } from "json-schema";
+
+export interface OpenAIChatRequest {
+  stream?: boolean;
+  model: string;
+  messages: OpenAIMessage[];
+  tools?: Array<OpenAITool>;
+  tool_choice?:
+    | "none"
+    | "auto"
+    | "required"
+    | { type: "function"; function: { name: string } };
+}
+
+export type OpenAIMessage =
+  | OpenAISystemMessage
+  | OpenAIUserMessage
+  | OpenAIAssistantMessage
+  | OpenAIToolMessage;
+
+export interface OpenAISystemMessage {
+  role: "system";
+  name?: string;
+  content: string | string[];
+}
+
+export interface OpenAIUserMessage {
+  role: "user";
+  name?: string;
+  content: string | string[];
+}
+
+export interface OpenAIAssistantMessage {
+  role: "assistant";
+  // TODO(aomarks) Actually at least one of content/tool_calls is required.
+  content?: string;
+  tool_calls?: OpenAIToolCall[];
+}
+
+export interface OpenAIToolMessage {
+  role: "tool";
+  content: string | string[];
+  tool_call_id: string;
+}
+
+export type OpenAITool = {
+  type: "function";
+  function: OpenAIFunction;
+};
+
+export interface OpenAIFunction {
+  description?: string;
+  name: string;
+  parameters?: JSONSchema7;
+  strict?: boolean | null;
+}
+
+export interface OpenAIChunk {
+  choices: OpenAIChoice[];
+}
+
+export interface OpenAIChoice {
+  delta: OpenAIDelta;
+  finish_reason: string | null;
+}
+
+export interface OpenAIDelta {
+  content?: string | null;
+  tool_calls?: OpenAIToolCall[];
+}
+
+export interface OpenAIToolCall {
+  // TODO(aomarks) You get index coming in, but it probably shouldn't be there
+  // going out?
+  index: number;
+  id: string;
+  type: "function";
+  function: {
+    name: string;
+    arguments: string;
+  };
+}

--- a/packages/bbrt/src/drivers/openai.ts
+++ b/packages/bbrt/src/drivers/openai.ts
@@ -4,13 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { JSONSchema7 } from "json-schema";
 import type { BBRTChunk } from "../llm/chunk.js";
 import type { BBRTTurn } from "../llm/conversation.js";
 import type { BBRTTool } from "../tools/tool.js";
 import { JsonDataStreamTransformer } from "../util/json-data-stream-transformer.js";
 import type { Result } from "../util/result.js";
 import type { BBRTDriver } from "./driver-interface.js";
+import type {
+  OpenAIAssistantMessage,
+  OpenAIChatRequest,
+  OpenAIChunk,
+  OpenAIMessage,
+  OpenAITool,
+} from "./openai-types.js";
 
 export class OpenAiDriver implements BBRTDriver {
   readonly name = "OpenAI";
@@ -144,87 +150,6 @@ async function* convertOpenAiChunks(
       arguments: JSON.parse(call.jsonArgs) as Record<string, unknown>,
     };
   }
-}
-
-export interface OpenAIChatRequest {
-  stream?: boolean;
-  model: string;
-  messages: OpenAIMessage[];
-  tools?: Array<OpenAITool>;
-  tool_choice?:
-    | "none"
-    | "auto"
-    | "required"
-    | { type: "function"; function: { name: string } };
-}
-
-export type OpenAIMessage =
-  | OpenAISystemMessage
-  | OpenAIUserMessage
-  | OpenAIAssistantMessage
-  | OpenAIToolMessage;
-
-export interface OpenAISystemMessage {
-  role: "system";
-  name?: string;
-  content: string | string[];
-}
-
-export interface OpenAIUserMessage {
-  role: "user";
-  name?: string;
-  content: string | string[];
-}
-
-export interface OpenAIAssistantMessage {
-  role: "assistant";
-  // TODO(aomarks) Actually at least one of content/tool_calls is required.
-  content?: string;
-  tool_calls?: OpenAIToolCall[];
-}
-
-export interface OpenAIToolMessage {
-  role: "tool";
-  content: string | string[];
-  tool_call_id: string;
-}
-
-export type OpenAITool = {
-  type: "function";
-  function: OpenAIFunction;
-};
-
-export interface OpenAIFunction {
-  description?: string;
-  name: string;
-  parameters?: JSONSchema7;
-  strict?: boolean | null;
-}
-
-interface OpenAIChunk {
-  choices: OpenAIChoice[];
-}
-
-interface OpenAIChoice {
-  delta: OpenAIDelta;
-  finish_reason: string | null;
-}
-
-interface OpenAIDelta {
-  content?: string | null;
-  tool_calls?: OpenAIToolCall[];
-}
-
-interface OpenAIToolCall {
-  // TODO(aomarks) You get index coming in, but it probably shouldn't be there
-  // going out?
-  index: number;
-  id: string;
-  type: "function";
-  function: {
-    name: string;
-    arguments: string;
-  };
 }
 
 async function convertTurnsForOpenAi(

--- a/packages/bbrt/src/test/node/adjust-schema-for-gemini_test.ts
+++ b/packages/bbrt/src/test/node/adjust-schema-for-gemini_test.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { JSONSchema7 } from "json-schema";
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { adjustSchemaForGemini } from "../../drivers/adjust-schema-for-gemini.js";
+
+test("removes title, default, examples", () => {
+  const input: JSONSchema7 = {
+    type: "object",
+    properties: {
+      foo: {
+        type: "string",
+        title: "Foo Title",
+        description: "Foo Description",
+        default: "foo",
+        examples: ["foo", "bar"],
+      },
+    },
+  };
+  const expected: JSONSchema7 = {
+    type: "object",
+    properties: {
+      foo: {
+        type: "string",
+        description: "Foo Description",
+      },
+    },
+  };
+  assert.deepEqual(adjustSchemaForGemini(input), expected);
+});
+
+test("removes additionalProperties", () => {
+  const input: JSONSchema7 = {
+    type: "object",
+    additionalProperties: true,
+    properties: {
+      foo: {
+        type: "string",
+      },
+    },
+  };
+  const expected: JSONSchema7 = {
+    type: "object",
+    properties: {
+      foo: {
+        type: "string",
+      },
+    },
+  };
+  assert.deepEqual(adjustSchemaForGemini(input), expected);
+});
+
+test("removes empty objects", () => {
+  const input: JSONSchema7 = {
+    type: "object",
+    properties: {
+      foo: {
+        type: "object",
+      },
+      bar: {
+        type: "object",
+        properties: {},
+      },
+      baz: {
+        type: "string",
+      },
+    },
+  };
+  const expected: JSONSchema7 | undefined = {
+    type: "object",
+    properties: {
+      baz: {
+        type: "string",
+      },
+    },
+  };
+  assert.deepEqual(adjustSchemaForGemini(input), expected);
+});
+
+test("removes empty objects, cascading to top", () => {
+  const input: JSONSchema7 = {
+    type: "object",
+    properties: {
+      foo: {
+        type: "object",
+      },
+    },
+  };
+  const expected: JSONSchema7 | undefined = undefined;
+  assert.deepEqual(adjustSchemaForGemini(input), expected);
+});

--- a/packages/bbrt/src/test/node/standardize-breadboard-schema_test.ts
+++ b/packages/bbrt/src/test/node/standardize-breadboard-schema_test.ts
@@ -19,6 +19,13 @@ test("removes behaviors recursively", () => {
         type: "string",
         behavior: ["code", "deprecated"],
       },
+      bar: {
+        type: "array",
+        items: {
+          type: "number",
+          behavior: ["bubble"],
+        },
+      },
     },
   };
   const expected: JSONSchema7 = {
@@ -26,6 +33,178 @@ test("removes behaviors recursively", () => {
     properties: {
       foo: {
         type: "string",
+      },
+      bar: {
+        type: "array",
+        items: {
+          type: "number",
+        },
+      },
+    },
+  };
+  assert.deepEqual(standardizeBreadboardSchema(input), expected);
+});
+
+test("decode JSON-encoded defaults", () => {
+  const input: Schema = {
+    type: "object",
+    default: '{"foo":42}',
+    properties: {
+      foo: {
+        type: "number",
+        default: "42",
+      },
+      bar: {
+        type: "boolean",
+        default: "true",
+      },
+      baz: {
+        type: "number",
+        default: 47 as unknown as string,
+      },
+    },
+  };
+  const expected: JSONSchema7 = {
+    type: "object",
+    default: { foo: 42 },
+    properties: {
+      foo: {
+        type: "number",
+        default: 42,
+      },
+      bar: {
+        type: "boolean",
+        default: true,
+      },
+      baz: {
+        type: "number",
+        default: 47,
+      },
+    },
+  };
+  assert.deepEqual(standardizeBreadboardSchema(input), expected);
+});
+
+test("decode JSON-encoded examples", () => {
+  const input: Schema = {
+    type: "object",
+    examples: ['{"foo":42}'],
+    properties: {
+      foo: {
+        type: "number",
+        examples: ["42"],
+      },
+      bar: {
+        type: "boolean",
+        examples: ["true", "false"],
+      },
+      baz: {
+        type: "number",
+        examples: [47 as unknown as string],
+      },
+    },
+  };
+  const expected: JSONSchema7 = {
+    type: "object",
+    examples: [{ foo: 42 }],
+    properties: {
+      foo: {
+        type: "number",
+        examples: [42],
+      },
+      bar: {
+        type: "boolean",
+        examples: [true, false],
+      },
+      baz: {
+        type: "number",
+        examples: [47],
+      },
+    },
+  };
+  assert.deepEqual(standardizeBreadboardSchema(input), expected);
+});
+
+test("expand llm-content object behavior to JSON schema", () => {
+  const input: Schema = {
+    type: "object",
+    properties: {
+      foo: {
+        type: "object",
+        behavior: ["llm-content"],
+      },
+    },
+  };
+  const expected: JSONSchema7 = {
+    type: "object",
+    properties: {
+      foo: {
+        type: "object",
+        required: ["role", "parts"],
+        properties: {
+          role: {
+            type: "string",
+            enum: ["user", "model"],
+          },
+          parts: {
+            type: "array",
+            items: {
+              type: "object",
+              required: ["text"],
+              properties: {
+                text: {
+                  type: "string",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+  assert.deepEqual(standardizeBreadboardSchema(input), expected);
+});
+
+test("expand llm-content array behavior to JSON schema", () => {
+  const input: Schema = {
+    type: "object",
+    properties: {
+      foo: {
+        type: "array",
+        items: {
+          type: "object",
+          behavior: ["llm-content"],
+        },
+      },
+    },
+  };
+  const expected: JSONSchema7 = {
+    type: "object",
+    properties: {
+      foo: {
+        type: "array",
+        items: {
+          type: "object",
+          required: ["role", "parts"],
+          properties: {
+            role: {
+              type: "string",
+              enum: ["user", "model"],
+            },
+            parts: {
+              type: "array",
+              items: {
+                type: "object",
+                required: ["text"],
+                properties: {
+                  text: {
+                    type: "string",
+                  },
+                },
+              },
+            },
+          },
+        },
       },
     },
   };

--- a/packages/bbrt/src/tools/list-tools.ts
+++ b/packages/bbrt/src/tools/list-tools.ts
@@ -9,7 +9,7 @@ import { Signal } from "signal-polyfill";
 import type { BreadboardServer } from "../breadboard/breadboard-server.js";
 import { makeToolSafeName } from "../breadboard/make-tool-safe-name.js";
 import "../components/content.js";
-import type { GeminiFunctionDeclaration } from "../drivers/gemini.js";
+import type { GeminiFunctionDeclaration } from "../drivers/gemini-types.js";
 import type { EmptyObject } from "../util/empty-object.js";
 import type { Result } from "../util/result.js";
 import type {
@@ -45,7 +45,10 @@ export class BoardLister implements BBRTTool<Inputs, Outputs> {
     return {
       ok: true,
       value: {
-        inputSchema: {},
+        inputSchema: {
+          type: "object",
+          properties: {},
+        },
         outputSchema: {
           type: "object",
           properties: {


### PR DESCRIPTION
Now handles a wider range of schema, including the llm-content behavior, which gets expanded into full JSON schema.

Also adds more kits to the default set, and ensures that gemini function call IDs are <64 chars instead of <=64 chars.