### PR TITLE
[shared-ui] Remove list mode

### DIFF
--- a/.changeset/tall-adults-drop.md
+++ b/.changeset/tall-adults-drop.md
@@ -1,0 +1,6 @@
+---
+"@breadboard-ai/visual-editor": patch
+"@breadboard-ai/shared-ui": patch
+---
+
+Remove list mode

--- a/packages/shared-ui/src/elements/editor/editor.ts
+++ b/packages/shared-ui/src/elements/editor/editor.ts
@@ -786,6 +786,18 @@ export class Editor extends LitElement {
 
   #onDragOver(evt: DragEvent) {
     evt.preventDefault();
+
+    if (!this.#graphRendererRef.value) {
+      return;
+    }
+
+    const pointer = {
+      x: evt.pageX - this.#left + window.scrollX,
+      y: evt.pageY - this.#top - window.scrollY - RIBBON_HEIGHT,
+    };
+
+    this.#graphRendererRef.value.removeSubGraphHighlights();
+    this.#graphRendererRef.value.highlightSubGraphId(pointer);
   }
 
   #onDrop(evt: DragEvent) {
@@ -801,6 +813,8 @@ export class Editor extends LitElement {
       return;
     }
 
+    this.#graphRendererRef.value.removeSubGraphHighlights();
+
     const id = createRandomID(type);
     const configuration = getDefaultConfiguration(type);
     const pointer = {
@@ -810,8 +824,10 @@ export class Editor extends LitElement {
 
     const location =
       this.#graphRendererRef.value.toContainerCoordinates(pointer);
+    const subGraph = this.#graphRendererRef.value.toSubGraphId(pointer);
+
     this.dispatchEvent(
-      new NodeCreateEvent(id, type, this.subGraphId, configuration, {
+      new NodeCreateEvent(id, type, subGraph, configuration, {
         visual: {
           x: location.x - 100,
           y: location.y - 50,

--- a/packages/shared-ui/src/elements/editor/graph-renderer.ts
+++ b/packages/shared-ui/src/elements/editor/graph-renderer.ts
@@ -915,6 +915,49 @@ export class GraphRenderer extends LitElement {
     return this.#container.toLocal(point);
   }
 
+  highlightSubGraphId(point: PIXI.PointData) {
+    let target: Graph | null = null;
+    for (const graph of this.#container.children) {
+      if (!(graph instanceof Graph)) {
+        continue;
+      }
+
+      graph.highlightDragOver = false;
+      if (graph.getBounds().containsPoint(point.x, point.y)) {
+        target = graph;
+        break;
+      }
+    }
+
+    if (target) {
+      target.highlightDragOver = true;
+    }
+  }
+
+  removeSubGraphHighlights() {
+    for (const graph of this.#container.children) {
+      if (!(graph instanceof Graph)) {
+        continue;
+      }
+
+      graph.highlightDragOver = false;
+    }
+  }
+
+  toSubGraphId(point: PIXI.PointData): GraphIdentifier | null {
+    for (const child of this.#container.children) {
+      if (!(child instanceof Graph)) {
+        continue;
+      }
+
+      if (child.getBounds().containsPoint(point.x, point.y)) {
+        return child.subGraphId;
+      }
+    }
+
+    return null;
+  }
+
   #targetContainerMatrix = new PIXI.Matrix();
   #setTargetContainerMatrixFromBounds(bounds: PIXI.Bounds) {
     this.#targetContainerMatrix.identity();

--- a/packages/shared-ui/src/elements/editor/graph.ts
+++ b/packages/shared-ui/src/elements/editor/graph.ts
@@ -84,6 +84,7 @@ export class Graph extends PIXI.Container {
   #collapseNodesByDefault = false;
   #showNodePreviewValues = false;
   #showNodeTypeDescriptions = false;
+  #highlightDragOver = false;
   #subGraphId: string | null = null;
   #subGraphTitle: string | null = null;
   #subGraphTitleLabel: PIXI.Text | null = null;
@@ -997,6 +998,15 @@ export class Graph extends PIXI.Container {
     return this.#edgeValues;
   }
 
+  set highlightDragOver(highlightDragOver: boolean) {
+    this.#highlightDragOver = highlightDragOver;
+    this.#isDirty = true;
+  }
+
+  get highlightDragOver() {
+    return this.#highlightDragOver;
+  }
+
   set subGraphId(subGraphId: string | null) {
     if (subGraphId === this.#subGraphId) {
       return;
@@ -1276,7 +1286,7 @@ export class Graph extends PIXI.Container {
 
     this.#subGraphOutline.setStrokeStyle({
       color: this.#subGraphBorderColor,
-      width: 1,
+      width: this.#highlightDragOver ? 3 : 1,
       alpha: 1,
     });
     this.#subGraphOutline.beginPath();

--- a/packages/shared-ui/src/elements/module-editor/module-editor.ts
+++ b/packages/shared-ui/src/elements/module-editor/module-editor.ts
@@ -16,7 +16,7 @@ import {
 import { LitElement, html, css, nothing, PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { createRef, Ref, ref } from "lit/directives/ref.js";
-import { CodeEditor, GraphRenderer, ModuleRibbonMenu } from "../elements";
+import { CodeEditor, ModuleRibbonMenu } from "../elements";
 import {
   GraphIdentifier,
   ModuleCode,
@@ -279,8 +279,6 @@ export class ModuleEditor extends LitElement {
 
   #moduleRibbonMenuRef: Ref<ModuleRibbonMenu> = createRef();
   #codeEditorRef: Ref<CodeEditor> = createRef();
-  #graphVersion = 1;
-  #graphRenderer = new GraphRenderer();
   #compilationEnvironment: CompilationEnvironment = {
     language: "javascript",
     moduleId: null,

--- a/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
@@ -52,7 +52,6 @@ import { Editor } from "../elements.js";
 import { classMap } from "lit/directives/class-map.js";
 import { map } from "lit/directives/map.js";
 
-const MODE_KEY = "bb-ui-controller-outline-mode";
 const SIDE_NAV_ITEM_KEY = "bb-ui-side-nav-item";
 
 @customElement("bb-ui-controller")
@@ -112,7 +111,7 @@ export class UI extends LitElement {
   history: EditHistory | null = null;
 
   @property()
-  mode: "list" | "tree" = "list";
+  mode = "tree" as const;
 
   @property()
   sideNavItem: string | null = "components";
@@ -140,11 +139,6 @@ export class UI extends LitElement {
 
   connectedCallback(): void {
     super.connectedCallback();
-
-    const mode = globalThis.localStorage.getItem(MODE_KEY);
-    if (mode === "list" || mode === "tree") {
-      this.mode = mode;
-    }
 
     const sideNavItem = globalThis.localStorage.getItem(SIDE_NAV_ITEM_KEY);
     if (sideNavItem) {
@@ -450,10 +444,6 @@ export class UI extends LitElement {
                 .mode=${this.mode}
                 .selectionState=${this.selectionState}
                 .graphTopologyUpdateId=${this.graphTopologyUpdateId}
-                @bboutlinemodechange=${() => {
-                  this.mode = this.mode === "list" ? "tree" : "list";
-                  globalThis.localStorage.setItem(MODE_KEY, this.mode);
-                }}
               ></bb-workspace-outline>`;
             }
           )}`;

--- a/packages/shared-ui/src/elements/workspace-outline/workspace-outline.ts
+++ b/packages/shared-ui/src/elements/workspace-outline/workspace-outline.ts
@@ -22,7 +22,6 @@ import {
   ModuleDeleteEvent,
   NodeConfigurationUpdateRequestEvent,
   NodePartialUpdateEvent,
-  OutlineModeChangeEvent,
   OverflowMenuActionEvent,
   SubGraphDeleteEvent,
   WorkspaceSelectionStateEvent,
@@ -74,7 +73,7 @@ export class WorkspaceOutline extends LitElement {
   renderId = "";
 
   @property({ reflect: true })
-  mode: "list" | "tree" = "tree";
+  mode = "tree" as const;
 
   @property()
   selectionState: WorkspaceSelectionStateWithChangeId | null = null;
@@ -845,8 +844,7 @@ export class WorkspaceOutline extends LitElement {
               @click=${(evt: PointerEvent) => {
                 const isMac = navigator.platform.indexOf("Mac") === 0;
                 const isCtrlCommand = isMac ? evt.metaKey : evt.ctrlKey;
-                const replaceExistingSelection =
-                  this.mode === "list" || !isCtrlCommand;
+                const replaceExistingSelection = !isCtrlCommand;
 
                 this.#changeWorkspaceItem(
                   subGraphId,
@@ -913,7 +911,6 @@ export class WorkspaceOutline extends LitElement {
                 const graphButton = html`<bb-slide-board-selector
                   .graph=${this.graph}
                   .value=${portSubGraphId}
-                  ?list=${this.mode === "list"}
                   ?tree=${this.mode === "tree"}
                   @bbboardchosen=${(evt: BoardChosenEvent) => {
                     this.dispatchEvent(
@@ -1024,7 +1021,6 @@ export class WorkspaceOutline extends LitElement {
               @click=${(evt: PointerEvent) => {
                 const showZoom =
                   main === undefined &&
-                  this.mode === "list" &&
                   this.selectionState?.selectionState.graphs.size === 0 &&
                   this.selectionState.selectionState.modules.size === 0;
 
@@ -1108,8 +1104,7 @@ export class WorkspaceOutline extends LitElement {
 
               const isMac = navigator.platform.indexOf("Mac") === 0;
               const isCtrlCommand = isMac ? evt.metaKey : evt.ctrlKey;
-              const replaceExistingSelection =
-                this.mode === "list" || !isCtrlCommand;
+              const replaceExistingSelection = !isCtrlCommand;
 
               const subGraphId = subItem.type === "declarative" ? id : null;
               const moduleId = subItem.type === "imperative" ? id : null;
@@ -1439,19 +1434,6 @@ export class WorkspaceOutline extends LitElement {
             placeholder="Search for an item"
             type="search"
           />
-          <button
-            id="view-toggle"
-            class=${classMap({ [this.mode]: true })}
-            @click=${() => {
-              this.dispatchEvent(
-                new OutlineModeChangeEvent(
-                  this.mode === "list" ? "tree" : "list"
-                )
-              );
-            }}
-          >
-            Toggle
-          </button>
         </div>
         <div id="outline">${this.#renderOutline()}</div>
       </div>

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -3398,8 +3398,8 @@ export class Main extends LitElement {
 
                 this.#runtime.select.selectNode(
                   this.tab.id,
-                  this.#runtime.util.createWorkspaceSelectionChangeId(),
-                  this.tab.subGraphId ?? MAIN_BOARD_ID,
+                  this.#runtime.select.generateId(),
+                  evt.subGraphId ?? MAIN_BOARD_ID,
                   evt.id
                 );
               }}


### PR DESCRIPTION
Given the bugs it's generating I'm feeling like we should remove the 'list' mode from the workspace outline and find better ways to keep top level graphs clean and clear.

To that end this PR removes the mode and also fixes the drag-to-subgraph bug.

Fixes: #3934
Fixes: #3905