### PR TITLE
[bbrt] Persist conversation turns to session storage

### DIFF
--- a/packages/bbrt/src/components/chat-message.ts
+++ b/packages/bbrt/src/components/chat-message.ts
@@ -14,7 +14,7 @@ import type {
   BBRTTurn,
   BBRTUserTurnContent,
   BBRTUserTurnToolResponses,
-} from "../llm/conversation.js";
+} from "../llm/conversation-types.js";
 import { typingEffect } from "../util/typing-effect.js";
 import "./error-message.js";
 import "./markdown.js";

--- a/packages/bbrt/src/components/tool-call.ts
+++ b/packages/bbrt/src/components/tool-call.ts
@@ -7,7 +7,7 @@
 import { SignalWatcher } from "@lit-labs/signals";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
-import type { BBRTToolCall } from "../llm/conversation.js";
+import type { BBRTToolCall } from "../llm/conversation-types.js";
 
 @customElement("bbrt-tool-call")
 export class BBRTToolCallEl extends SignalWatcher(LitElement) {

--- a/packages/bbrt/src/components/tool-palette.ts
+++ b/packages/bbrt/src/components/tool-palette.ts
@@ -8,19 +8,13 @@ import { SignalWatcher } from "@lit-labs/signals";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
-import { Signal } from "signal-polyfill";
-import type { SignalArray } from "signal-utils/array";
 import type { SignalSet } from "signal-utils/set";
-import type { ToolProvider } from "../tools/tool-provider.js";
 import type { BBRTTool } from "../tools/tool.js";
 
 @customElement("bbrt-tool-palette")
 export class BBRTToolPalette extends SignalWatcher(LitElement) {
   @property({ attribute: false })
-  toolProviders?: SignalArray<ToolProvider>;
-
-  @property({ attribute: false })
-  activeTools?: Signal.State<Set<BBRTTool>>;
+  availableTools?: SignalSet<BBRTTool>;
 
   @property({ attribute: false })
   activeToolIds?: SignalSet<string>;
@@ -50,10 +44,6 @@ export class BBRTToolPalette extends SignalWatcher(LitElement) {
     :first-child {
       margin-top: 0;
     }
-    h3 {
-      font-weight: normal;
-      color: #666;
-    }
     img {
       height: 16px;
       max-width: 16px;
@@ -64,22 +54,15 @@ export class BBRTToolPalette extends SignalWatcher(LitElement) {
   `;
 
   override render() {
-    if (this.toolProviders === undefined) {
+    if (this.availableTools === undefined) {
       return nothing;
     }
     return html`
       <ul>
-        ${this.toolProviders.map(this.#renderProviders)}
+        ${[...this.availableTools].map(this.#renderTool)}
       </ul>
     `;
   }
-
-  #renderProviders = (provider: ToolProvider) => html`
-    <h3>${provider.name}</h3>
-    <ul>
-      ${provider.tools().map(this.#renderTool)}
-    </ul>
-  `;
 
   #renderTool = (tool: BBRTTool) => html`
     <li

--- a/packages/bbrt/src/drivers/driver-interface.ts
+++ b/packages/bbrt/src/drivers/driver-interface.ts
@@ -5,7 +5,7 @@
  */
 
 import type { BBRTChunk } from "../llm/chunk.js";
-import type { BBRTTurn } from "../llm/conversation.js";
+import type { BBRTTurn } from "../llm/conversation-types.js";
 import type { BBRTTool } from "../tools/tool.js";
 import type { Result } from "../util/result.js";
 

--- a/packages/bbrt/src/drivers/gemini.ts
+++ b/packages/bbrt/src/drivers/gemini.ts
@@ -5,7 +5,7 @@
  */
 
 import type { BBRTChunk } from "../llm/chunk.js";
-import type { BBRTTurn } from "../llm/conversation.js";
+import type { BBRTTurn } from "../llm/conversation-types.js";
 import type { BBRTTool } from "../tools/tool.js";
 import type { Result } from "../util/result.js";
 import { streamJsonArrayItems } from "../util/stream-json-array-items.js";

--- a/packages/bbrt/src/drivers/openai.ts
+++ b/packages/bbrt/src/drivers/openai.ts
@@ -5,7 +5,7 @@
  */
 
 import type { BBRTChunk } from "../llm/chunk.js";
-import type { BBRTTurn } from "../llm/conversation.js";
+import type { BBRTTurn } from "../llm/conversation-types.js";
 import type { BBRTTool } from "../tools/tool.js";
 import { JsonDataStreamTransformer } from "../util/json-data-stream-transformer.js";
 import type { Result } from "../util/result.js";

--- a/packages/bbrt/src/llm/conversation-restore.ts
+++ b/packages/bbrt/src/llm/conversation-restore.ts
@@ -1,0 +1,133 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Signal } from "signal-polyfill";
+import { SignalArray } from "signal-utils/array";
+import type { SignalSet } from "signal-utils/set";
+import type { BBRTTool } from "../tools/tool.js";
+import { BufferedMultiplexStream } from "../util/buffered-multiplex-stream.js";
+import type {
+  SerializableBBRTToolCall,
+  SerializableBBRTToolResponse,
+  SerializableBBRTTurn,
+} from "./conversation-serialization-types.js";
+import type {
+  BBRTToolCall,
+  BBRTToolResponse,
+  BBRTTurn,
+} from "./conversation-types.js";
+
+export function restoreTurns(
+  turns: SerializableBBRTTurn[],
+  availableTools: SignalSet<BBRTTool>
+): BBRTTurn[] {
+  // TODO(aomarks) Tools should already be a map.
+  const availableToolsMap = new Map(
+    [...availableTools].map((tool) => [tool.metadata.id, tool])
+  );
+  return turns.map((turn) => restoreTurn(turn, availableToolsMap));
+}
+
+function restoreTurn(
+  turn: SerializableBBRTTurn,
+  availableTools: Map<string, BBRTTool>
+): BBRTTurn {
+  if (turn.kind === "user-content") {
+    return {
+      kind: turn.kind,
+      role: turn.role,
+      status: new Signal.State(turn.status),
+      content: turn.content,
+    };
+  } else if (turn.kind === "user-tool-responses") {
+    return {
+      kind: turn.kind,
+      role: turn.role,
+      status: new Signal.State(turn.status),
+      responses: turn.responses.map((response) =>
+        restoreToolResponse(response, availableTools)
+      ),
+    };
+  } else if (turn.kind === "model") {
+    const content = BufferedMultiplexStream.finished(turn.content);
+    return {
+      kind: turn.kind,
+      role: turn.role,
+      status: new Signal.State(turn.status),
+      content,
+      toolCalls: turn.toolCalls
+        ? new SignalArray(
+            [...turn.toolCalls].map((call) =>
+              restoreToolCall(call, availableTools)
+            )
+          )
+        : undefined,
+      // TODO(aomarks) Lossy errors, see serialize file.
+      error: turn.error,
+    };
+  } else if (turn.kind === "error") {
+    return {
+      kind: "error",
+      role: turn.role,
+      status: new Signal.State(turn.status),
+      // TODO(aomarks) Lossy errors, see serialize file.
+      error: turn.error,
+    };
+  }
+  turn satisfies never;
+  const msg =
+    `Internal Error: Unhandled turn kind: ` +
+    `${JSON.stringify((turn as BBRTTurn).kind)})`;
+  console.error(msg);
+  throw new Error(msg);
+}
+
+function restoreToolResponse(
+  response: SerializableBBRTToolResponse,
+  availableTools: Map<string, BBRTTool>
+): BBRTToolResponse {
+  const tool = availableTools.get(response.toolId);
+  if (tool === undefined) {
+    const msg =
+      `Internal Error: Tool ${response.toolId} not found` +
+      ` during state restoration`;
+    console.error(msg);
+    throw new Error(msg);
+  }
+  const invocation = tool.invoke(response.args);
+  invocation.state.set(response.invocationState);
+  return {
+    id: response.id,
+    tool,
+    invocation,
+    args: response.args,
+    response: response.response,
+  };
+}
+
+function restoreToolCall(
+  call: SerializableBBRTToolCall,
+  availableTools: Map<string, BBRTTool>
+): BBRTToolCall {
+  const tool = availableTools.get(call.toolId);
+  if (tool === undefined) {
+    const msg =
+      `Internal Error: Tool ${call.toolId} not found` +
+      ` during state restoration`;
+    console.error(msg);
+    throw new Error(msg);
+  }
+  const invocation = tool.invoke(call.args);
+  // TODO(aomarks) Feels like there is some unnecessary duplication between tool
+  // responses and calls. Refactor the data structures a bit?
+  invocation.state.set(call.invocationState);
+  return {
+    id: call.id,
+    tool,
+    args: call.args,
+    invocation,
+  };
+}

--- a/packages/bbrt/src/llm/conversation-serialization-types.ts
+++ b/packages/bbrt/src/llm/conversation-serialization-types.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { InvokeResult, ToolInvocationState } from "../tools/tool.js";
+
+export type SerializableBBRTTurn =
+  | SerializableBBRTUserTurn
+  | SerializableBBRTModelTurn
+  | SerializableBBRTErrorTurn;
+
+export type SerializableBBRTUserTurn =
+  | SerializableBBRTUserTurnContent
+  | SerializableBBRTUserTurnToolResponses;
+
+export type SerializableBBRTTurnStatus =
+  | "pending"
+  | "streaming"
+  | "using-tools"
+  | "done"
+  | "error";
+
+export interface SerializableBBRTUserTurnContent {
+  kind: "user-content";
+  role: "user";
+  status: SerializableBBRTTurnStatus;
+  content: string;
+}
+
+export interface SerializableBBRTUserTurnToolResponses {
+  kind: "user-tool-responses";
+  role: "user";
+  status: SerializableBBRTTurnStatus;
+  responses: SerializableBBRTToolResponse[];
+}
+
+export interface SerializableBBRTModelTurn {
+  kind: "model";
+  role: "model";
+  status: SerializableBBRTTurnStatus;
+  content: string[];
+  toolCalls?: Array<SerializableBBRTToolCall>;
+  error?: unknown;
+}
+
+export interface SerializableBBRTErrorTurn {
+  kind: "error";
+  role: "user" | "model";
+  status: SerializableBBRTTurnStatus;
+  error: string;
+}
+
+export interface SerializableBBRTToolCall {
+  id: string;
+  toolId: string;
+  args: unknown;
+  invocationState: ToolInvocationState;
+}
+
+export interface SerializableBBRTToolResponse {
+  id: string;
+  toolId: string;
+  invocationState: ToolInvocationState;
+  args: unknown;
+  response: InvokeResult;
+}

--- a/packages/bbrt/src/llm/conversation-serialization.ts
+++ b/packages/bbrt/src/llm/conversation-serialization.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { InvokeResult, ToolInvocationState } from "../tools/tool.js";
+import type {
+  SerializableBBRTToolCall,
+  SerializableBBRTToolResponse,
+  SerializableBBRTTurn,
+} from "./conversation-serialization-types.js";
+import type {
+  BBRTToolCall,
+  BBRTToolResponse,
+  BBRTTurn,
+} from "./conversation-types.js";
+
+export function serializeTurns(turns: BBRTTurn[]): SerializableBBRTTurn[] {
+  return turns.map(serializeTurn);
+}
+
+function serializeTurn(turn: BBRTTurn): SerializableBBRTTurn {
+  // TODO(aomarks) It would be really nice if we stored turns in a fully (or at
+  // least more easily) serializable way so that we didn't need all this logic.
+  if (turn.kind === "user-content") {
+    return {
+      kind: turn.kind,
+      role: turn.role,
+      status: turn.status.get(),
+      content: turn.content,
+    };
+  } else if (turn.kind === "user-tool-responses") {
+    return {
+      kind: turn.kind,
+      role: turn.role,
+      status: turn.status.get(),
+      responses: turn.responses.map(serializeToolResponse),
+    };
+  } else if (turn.kind === "model") {
+    return {
+      kind: turn.kind,
+      role: turn.role,
+      status: turn.status.get(),
+      // TODO(aomarks) This is not great. We need a guarantee that the content
+      // stream is exhausted.
+      content: turn.content.buffer,
+      toolCalls: turn.toolCalls
+        ? [...turn.toolCalls].map(serializeToolCall)
+        : undefined,
+      // TODO(aomarks) This is lossy. We should have a utility that converts any
+      // error to something serializable; see the logic in
+      // components/error-message.ts (maybe we can move it out of there).
+      error: turn.error ? String(turn.error) : turn.error,
+    };
+  } else if (turn.kind === "error") {
+    return {
+      kind: "error",
+      role: turn.role,
+      status: turn.status.get(),
+      // TODO(aomarks) Lossy errors again, see above.
+      error: String(turn.error),
+    };
+  }
+  turn satisfies never;
+  const msg =
+    `Internal Error: Unhandled turn kind: ` +
+    `${JSON.stringify((turn as BBRTTurn).kind)})`;
+  console.error(msg);
+  throw new Error(msg);
+}
+
+function serializeToolResponse(
+  response: BBRTToolResponse
+): SerializableBBRTToolResponse {
+  return {
+    id: response.id,
+    invocationState: serializeInvocationState(response.invocation.state.get()),
+    toolId: response.tool.metadata.id,
+    args: response.args,
+    response: serializeResponseResult(response.response),
+  };
+}
+
+function serializeToolCall(call: BBRTToolCall): SerializableBBRTToolCall {
+  return {
+    id: call.id,
+    toolId: call.tool.metadata.id,
+    args: call.args,
+    invocationState: serializeInvocationState(call.invocation.state.get()),
+  };
+}
+
+function serializeResponseResult(
+  result: InvokeResult<unknown>
+): InvokeResult<unknown> {
+  const clone = structuredClone(result);
+  for (const artifact of clone.artifacts) {
+    // TODO(aomarks) This is bad. See also below.
+    artifact.inlineData.data = "";
+  }
+  return clone;
+}
+
+function serializeInvocationState(
+  state: ToolInvocationState
+): ToolInvocationState {
+  if (state.status !== "success") {
+    return state;
+  }
+  const clone = structuredClone(state);
+  for (const artifact of clone.value.artifacts) {
+    // TODO(aomarks) See above.
+    artifact.inlineData.data = "";
+  }
+  return clone;
+}

--- a/packages/bbrt/src/llm/conversation-types.ts
+++ b/packages/bbrt/src/llm/conversation-types.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Signal } from "signal-polyfill";
+import { SignalArray } from "signal-utils/array";
+import type { BBRTTool, InvokeResult, ToolInvocation } from "../tools/tool.js";
+import type { BufferedMultiplexStream } from "../util/buffered-multiplex-stream.js";
+
+export type BBRTTurn = BBRTUserTurn | BBRTModelTurn | BBRTErrorTurn;
+
+export type BBRTUserTurn = BBRTUserTurnContent | BBRTUserTurnToolResponses;
+
+export type BBRTTurnStatus =
+  | "pending"
+  | "streaming"
+  | "using-tools"
+  | "done"
+  | "error";
+
+export interface BBRTUserTurnContent {
+  kind: "user-content";
+  role: "user";
+  status: Signal.State<BBRTTurnStatus>;
+  content: string;
+}
+
+export interface BBRTUserTurnToolResponses {
+  kind: "user-tool-responses";
+  role: "user";
+  status: Signal.State<BBRTTurnStatus>;
+  responses: BBRTToolResponse[];
+}
+
+export interface BBRTModelTurn {
+  kind: "model";
+  role: "model";
+  status: Signal.State<BBRTTurnStatus>;
+  content: BufferedMultiplexStream<string>;
+  toolCalls?: SignalArray<BBRTToolCall>;
+  error?: unknown;
+}
+
+export interface BBRTErrorTurn {
+  kind: "error";
+  role: "user" | "model";
+  status: Signal.State<BBRTTurnStatus>;
+  error: unknown;
+}
+
+export interface BBRTToolCall {
+  id: string;
+  tool: BBRTTool;
+  args: unknown;
+  invocation: ToolInvocation;
+}
+
+export interface BBRTToolResponse {
+  id: string;
+  tool: BBRTTool;
+  invocation: ToolInvocation;
+  args: unknown;
+  response: InvokeResult;
+}

--- a/packages/bbrt/src/llm/conversation.ts
+++ b/packages/bbrt/src/llm/conversation.ts
@@ -8,69 +8,20 @@ import { Signal } from "signal-polyfill";
 import { SignalArray } from "signal-utils/array";
 import type { SignalSet } from "signal-utils/set";
 import type { BBRTDriver } from "../drivers/driver-interface.js";
-import type { BBRTTool, InvokeResult, ToolInvocation } from "../tools/tool.js";
+import type { BBRTTool, ToolInvocation } from "../tools/tool.js";
 import { BufferedMultiplexStream } from "../util/buffered-multiplex-stream.js";
 import { Lock } from "../util/lock.js";
 import type { Result } from "../util/result.js";
 import { transposeResults } from "../util/transpose-results.js";
 import { waitForState } from "../util/wait-for-state.js";
 import type { BBRTChunk } from "./chunk.js";
-
-export type BBRTTurn = BBRTUserTurn | BBRTModelTurn | BBRTErrorTurn;
-
-export type BBRTUserTurn = BBRTUserTurnContent | BBRTUserTurnToolResponses;
-
-export type BBRTTurnStatus =
-  | "pending"
-  | "streaming"
-  | "using-tools"
-  | "done"
-  | "error";
-
-export interface BBRTUserTurnContent {
-  kind: "user-content";
-  role: "user";
-  status: Signal.State<BBRTTurnStatus>;
-  content: string;
-}
-
-export interface BBRTUserTurnToolResponses {
-  kind: "user-tool-responses";
-  role: "user";
-  status: Signal.State<BBRTTurnStatus>;
-  responses: BBRTToolResponse[];
-}
-
-export interface BBRTModelTurn {
-  kind: "model";
-  role: "model";
-  status: Signal.State<BBRTTurnStatus>;
-  content: AsyncIterable<string>;
-  toolCalls?: SignalArray<BBRTToolCall>;
-  error?: unknown;
-}
-
-export interface BBRTErrorTurn {
-  kind: "error";
-  role: "user" | "model";
-  status: Signal.State<BBRTTurnStatus>;
-  error: unknown;
-}
-
-export interface BBRTToolCall {
-  id: string;
-  tool: BBRTTool;
-  args: unknown;
-  invocation: ToolInvocation;
-}
-
-export interface BBRTToolResponse {
-  id: string;
-  tool: BBRTTool;
-  invocation: ToolInvocation;
-  args: unknown;
-  response: InvokeResult;
-}
+import type {
+  BBRTModelTurn,
+  BBRTToolCall,
+  BBRTToolResponse,
+  BBRTTurn,
+  BBRTTurnStatus,
+} from "./conversation-types.js";
 
 export class BBRTConversation {
   readonly turns = new SignalArray<BBRTTurn>();

--- a/packages/bbrt/src/tools/activate-tool.ts
+++ b/packages/bbrt/src/tools/activate-tool.ts
@@ -159,7 +159,7 @@ class ActivateToolInvocation implements ToolInvocation<Outputs> {
 
   async #findTool(name: string): Promise<BBRTTool | undefined> {
     for (const provider of this.#toolProviders) {
-      for (const tool of provider.tools()) {
+      for (const tool of await provider.tools()) {
         if (tool.metadata.id === name) {
           return tool;
         }

--- a/packages/bbrt/src/tools/tool-provider.ts
+++ b/packages/bbrt/src/tools/tool-provider.ts
@@ -4,10 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { SignalArray } from "signal-utils/array";
 import type { BBRTTool } from "../tools/tool.js";
 
 export interface ToolProvider {
   name: string;
-  tools(): SignalArray<BBRTTool>;
+  tools(): Promise<BBRTTool[]>;
 }

--- a/packages/bbrt/src/util/buffered-multiplex-stream.ts
+++ b/packages/bbrt/src/util/buffered-multiplex-stream.ts
@@ -10,22 +10,35 @@ type State = "unstarted" | "started" | "ended";
 
 export class BufferedMultiplexStream<T> {
   readonly #source: AsyncIterable<T>;
-  readonly #buffer: T[] = [];
-  #state: State = "unstarted";
+  // TODO(aomarks) Should not be public.
+  readonly buffer: T[] = [];
+  // TODO(aomarks) Should not be public.
+  state: State = "unstarted";
   #nextTick = new Deferred<void>();
 
   constructor(source: AsyncIterable<T>) {
     this.#source = source;
   }
 
+  static finished<T>(values: Iterable<T>) {
+    // TODO(aomarks) Shouldn't need this constructor. It's only because of
+    // weirdness in our serialization scheme.
+    const stream = new BufferedMultiplexStream<T>((async function* () {})());
+    stream.state = "ended";
+    for (const value of values) {
+      stream.buffer.push(value);
+    }
+    return stream;
+  }
+
   async *[Symbol.asyncIterator](): AsyncIterableIterator<T> {
     void this.#startBufferingIfNeeded();
     let i = 0;
     while (true) {
-      while (i < this.#buffer.length) {
-        yield this.#buffer[i++]!;
+      while (i < this.buffer.length) {
+        yield this.buffer[i++]!;
       }
-      if (this.#state === "ended") {
+      if (this.state === "ended") {
         return;
       }
       await this.#nextTick.promise;
@@ -38,15 +51,15 @@ export class BufferedMultiplexStream<T> {
   }
 
   async #startBufferingIfNeeded() {
-    if (this.#state !== "unstarted") {
+    if (this.state !== "unstarted") {
       return;
     }
-    this.#state = "started";
+    this.state = "started";
     for await (const value of this.#source) {
-      this.#buffer.push(value);
+      this.buffer.push(value);
       this.#tick();
     }
-    this.#state = "ended";
+    this.state = "ended";
     this.#tick();
   }
 }


### PR DESCRIPTION
This will need a big cleanup, and requires too much manual fiddling with serialization, but now the conversation is persisted across reloads in session storage (which is particularly useful during development, but will be useful in other ways later too).