### PR TITLE
[bbrt] Better error handling

### DIFF
--- a/packages/bbrt/src/breadboard/breadboard-tool.ts
+++ b/packages/bbrt/src/breadboard/breadboard-tool.ts
@@ -39,6 +39,7 @@ import type {
   ToolInvocationState,
   ToolMetadata,
 } from "../tools/tool.js";
+import { coercePresentableError } from "../util/presentable-error.js";
 import type { Result } from "../util/result.js";
 import { resultify } from "../util/resultify.js";
 import type {
@@ -145,7 +146,10 @@ export class BreadboardToolInvocation implements ToolInvocation<unknown> {
     this.state.set({ status: "running" });
     const bgl = await this.#getBgl();
     if (!bgl.ok) {
-      this.state.set({ status: "error", error: bgl.error });
+      this.state.set({
+        status: "error",
+        error: coercePresentableError(bgl.error),
+      });
       return;
     }
 
@@ -232,13 +236,19 @@ export class BreadboardToolInvocation implements ToolInvocation<unknown> {
     );
 
     if (!runResult.ok) {
-      this.state.set({ status: "error", error: runResult.error });
+      this.state.set({
+        status: "error",
+        error: coercePresentableError(runResult.error),
+      });
       return;
     }
 
     const artifacts = await this.#extractAndStoreArtifacts(store, storeGroupId);
     if (!artifacts.ok) {
-      this.state.set({ status: "error", error: artifacts.error });
+      this.state.set({
+        status: "error",
+        error: coercePresentableError(artifacts.error),
+      });
       return;
     }
     this.state.set({

--- a/packages/bbrt/src/llm/conversation-serialization-types.ts
+++ b/packages/bbrt/src/llm/conversation-serialization-types.ts
@@ -5,6 +5,7 @@
  */
 
 import type { InvokeResult, ToolInvocationState } from "../tools/tool.js";
+import type { PresentableError } from "../util/presentable-error.js";
 
 export type SerializableBBRTTurn =
   | SerializableBBRTUserTurn
@@ -42,14 +43,14 @@ export interface SerializableBBRTModelTurn {
   status: SerializableBBRTTurnStatus;
   content: string[];
   toolCalls?: Array<SerializableBBRTToolCall>;
-  error?: unknown;
+  error?: PresentableError;
 }
 
 export interface SerializableBBRTErrorTurn {
   kind: "error";
   role: "user" | "model";
   status: SerializableBBRTTurnStatus;
-  error: string;
+  error: PresentableError;
 }
 
 export interface SerializableBBRTToolCall {

--- a/packages/bbrt/src/llm/conversation-serialization.ts
+++ b/packages/bbrt/src/llm/conversation-serialization.ts
@@ -47,18 +47,14 @@ function serializeTurn(turn: BBRTTurn): SerializableBBRTTurn {
       toolCalls: turn.toolCalls
         ? [...turn.toolCalls].map(serializeToolCall)
         : undefined,
-      // TODO(aomarks) This is lossy. We should have a utility that converts any
-      // error to something serializable; see the logic in
-      // components/error-message.ts (maybe we can move it out of there).
-      error: turn.error ? String(turn.error) : turn.error,
+      error: turn.error,
     };
   } else if (turn.kind === "error") {
     return {
       kind: "error",
       role: turn.role,
       status: turn.status.get(),
-      // TODO(aomarks) Lossy errors again, see above.
-      error: String(turn.error),
+      error: turn.error,
     };
   }
   turn satisfies never;

--- a/packages/bbrt/src/llm/conversation-types.ts
+++ b/packages/bbrt/src/llm/conversation-types.ts
@@ -8,6 +8,7 @@ import { Signal } from "signal-polyfill";
 import { SignalArray } from "signal-utils/array";
 import type { BBRTTool, InvokeResult, ToolInvocation } from "../tools/tool.js";
 import type { BufferedMultiplexStream } from "../util/buffered-multiplex-stream.js";
+import type { PresentableError } from "../util/presentable-error.js";
 
 export type BBRTTurn = BBRTUserTurn | BBRTModelTurn | BBRTErrorTurn;
 
@@ -40,14 +41,14 @@ export interface BBRTModelTurn {
   status: Signal.State<BBRTTurnStatus>;
   content: BufferedMultiplexStream<string>;
   toolCalls?: SignalArray<BBRTToolCall>;
-  error?: unknown;
+  error?: PresentableError;
 }
 
 export interface BBRTErrorTurn {
   kind: "error";
   role: "user" | "model";
   status: Signal.State<BBRTTurnStatus>;
-  error: unknown;
+  error: PresentableError;
 }
 
 export interface BBRTToolCall {

--- a/packages/bbrt/src/tools/activate-tool.ts
+++ b/packages/bbrt/src/tools/activate-tool.ts
@@ -133,7 +133,7 @@ class ActivateToolInvocation implements ToolInvocation<Outputs> {
         } else {
           this.state.set({
             status: "error",
-            error: "Error finding tool",
+            error: { message: "Error finding tool" },
           });
         }
         break;
@@ -141,7 +141,7 @@ class ActivateToolInvocation implements ToolInvocation<Outputs> {
       case "deny": {
         this.state.set({
           status: "error",
-          error: "User disallowed tool",
+          error: { message: "User disallowed tool" },
         });
         break;
       }
@@ -150,7 +150,7 @@ class ActivateToolInvocation implements ToolInvocation<Outputs> {
         console.error("Unknown result:", result);
         this.state.set({
           status: "error",
-          error: "Internal error",
+          error: { message: "Internal error" },
         });
         break;
       }

--- a/packages/bbrt/src/tools/list-tools.ts
+++ b/packages/bbrt/src/tools/list-tools.ts
@@ -11,6 +11,7 @@ import { makeToolSafeName } from "../breadboard/make-tool-safe-name.js";
 import "../components/content.js";
 import type { GeminiFunctionDeclaration } from "../drivers/gemini-types.js";
 import type { EmptyObject } from "../util/empty-object.js";
+import { coercePresentableError } from "../util/presentable-error.js";
 import type { Result } from "../util/result.js";
 import type {
   BBRTTool,
@@ -100,7 +101,7 @@ class ListToolsInvocation implements ToolInvocation<Outputs> {
       if (!tool.ok) {
         this.state.set({
           status: "error",
-          error: tool.error,
+          error: coercePresentableError(tool.error),
         });
         return;
       }

--- a/packages/bbrt/src/tools/tool.ts
+++ b/packages/bbrt/src/tools/tool.ts
@@ -7,6 +7,7 @@
 import type { JSONSchema7 } from "json-schema";
 import type { Signal } from "signal-polyfill";
 import type { ArtifactHandle } from "../artifacts/artifact-interface.js";
+import type { PresentableError } from "../util/presentable-error.js";
 import type { Result } from "../util/result.js";
 
 export interface BBRTTool<I = unknown, O = unknown> {
@@ -34,7 +35,7 @@ export type ToolInvocationState<O = unknown> =
       status: "success";
       value: InvokeResult<O>;
     }
-  | { status: "error"; error: unknown };
+  | { status: "error"; error: PresentableError };
 
 export interface InvokeResult<O = unknown> {
   readonly output: O;

--- a/packages/bbrt/src/util/presentable-error.ts
+++ b/packages/bbrt/src/util/presentable-error.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface PresentableError {
+  readonly message: string;
+  readonly stack?: string;
+  readonly additional?: PresentableError[];
+}
+
+export function coercePresentableError(error: unknown): PresentableError {
+  if (error instanceof AggregateError && error.errors.length > 0) {
+    return {
+      ...coercePresentableError(error.errors[0]),
+      additional: error.errors.slice(1).map(coercePresentableError),
+    };
+  } else if (error instanceof Error) {
+    let message = error.message ?? "";
+    let stack = error.stack ?? "";
+    const prefixedMessage = `Error: ${message}`;
+    if (stack.startsWith(`${prefixedMessage}\n`)) {
+      // Often times the stack trace contains a full copy of the message, with
+      // an Error: prefix. Remove the redundancy.
+      stack = stack.slice(prefixedMessage.length /* for the \n */ + 1);
+      message = prefixedMessage;
+    }
+    return { message, stack };
+  } else if (
+    // An error-like object (anything with a truthy "message" property).
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    error.message
+  ) {
+    return {
+      message: String(error.message),
+      stack: "stack" in error ? String(error.stack) : undefined,
+      additional:
+        "additional" in error && Array.isArray(error.additional)
+          ? error.additional.map(coercePresentableError)
+          : undefined,
+    };
+  } else if (
+    // A nested error (anything with a truthy "error" property).
+    typeof error === "object" &&
+    error !== null &&
+    "error" in error &&
+    error.error
+  ) {
+    return coercePresentableError(error.error);
+  } else if (typeof error === "string") {
+    return { message: error };
+  } else {
+    return { message: JSON.stringify(error, null, 2) };
+  }
+}


### PR DESCRIPTION
Moves the logic that coerces a nice error out of the error-message component, because that's also good for serialization, so we should do the coercion earlier.