### PR TITLE
more fixes

### DIFF
--- a/.changeset/rotten-lamps-jam.md
+++ b/.changeset/rotten-lamps-jam.md
@@ -1,0 +1,6 @@
+---
+"@google-labs/breadboard": patch
+"@breadboard-ai/jsandbox": patch
+---
+
+Fix the replay and runModule telemetry bugs.

--- a/packages/breadboard/src/inspector/graph/graph.ts
+++ b/packages/breadboard/src/inspector/graph/graph.ts
@@ -50,6 +50,10 @@ class Graph implements InspectableGraph {
     return this.#descriptor();
   }
 
+  mainGraphDescriptor(): GraphDescriptor {
+    return this.#mutable.graph;
+  }
+
   imperative(): boolean {
     return !!this.main();
   }

--- a/packages/breadboard/src/inspector/run/conversions.ts
+++ b/packages/breadboard/src/inspector/run/conversions.ts
@@ -177,7 +177,8 @@ async function* eventsAsHarnessRunResults(
     switch (type) {
       case "graphstart": {
         const { graphStart, path, graph: inspectableGraph, edges } = data;
-        const graph = inspectableGraph?.raw() as GraphDescriptor;
+        const graph =
+          inspectableGraph?.mainGraphDescriptor() as GraphDescriptor;
         const graphId = inspectableGraph?.graphId() || "";
         yield {
           type,

--- a/packages/breadboard/src/inspector/run/serializer.ts
+++ b/packages/breadboard/src/inspector/run/serializer.ts
@@ -67,7 +67,7 @@ export class RunSerializer {
     let graph: GraphDescriptor | null = null;
     let index: number;
     if (!this.#seenGraphs.has(mainGraphId)) {
-      graph = entry.graph?.raw() || null;
+      graph = entry.graph?.mainGraphDescriptor() || null;
       index = this.#graphIndex++;
       this.#seenGraphs.set(mainGraphId, index);
     } else {

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -254,6 +254,10 @@ export type InspectableGraph = {
    */
   raw(): GraphDescriptor;
   /**
+   * Returns the main graph's descriptor
+   */
+  mainGraphDescriptor(): GraphDescriptor;
+  /**
    * Returns this graph's metadata, if exists.
    */
   metadata(): GraphMetadata | undefined;

--- a/packages/jsandbox/src/capabilities.ts
+++ b/packages/jsandbox/src/capabilities.ts
@@ -35,10 +35,19 @@ class Capabilities {
     if (metadata) {
       delete parsedInputs.$metadata;
     }
-    await installed.telemetry?.startCapability(name, parsedInputs, metadata);
-    const outputs = await capability(parsedInputs);
+    const path =
+      (await installed.telemetry?.startCapability(
+        name,
+        parsedInputs,
+        metadata
+      )) || 0;
+    const outputs = await capability(
+      parsedInputs,
+      installed.telemetry?.invocationPath(path) || []
+    );
     await installed.telemetry?.endCapability(
       name,
+      path,
       parsedInputs,
       outputs as OutputValues
     );

--- a/packages/jsandbox/src/types.ts
+++ b/packages/jsandbox/src/types.ts
@@ -19,7 +19,10 @@ export type DescriberOutputs = { inputSchema: unknown; outputSchema: unknown };
 export type InvokeInputs = Values;
 export type InvokeOutputs = Values;
 
-export type Capability = (inputs: Values) => Promise<Values | void>;
+export type Capability = (
+  inputs: Values,
+  path: number[]
+) => Promise<Values | void>;
 
 export type CapabilitySpec = {
   fetch?: Capability;


### PR DESCRIPTION
- **Introduce `InspectableGraph.mainGraphDescriptor` and use it in inspect run API.**
- **Teach runModule machinery to correctly record telemetry.**
- **docs(changeset): Fix the replay and runModule telemetry bugs.**
