### PR TITLE
[website] Add instructions for adding users to board server

### DIFF
--- a/packages/website/src/docs/guides/breadboard-from-scratch.md
+++ b/packages/website/src/docs/guides/breadboard-from-scratch.md
@@ -246,6 +246,12 @@ will be prompted to do so.
 Each user who wishes to connect to a Board Server is identified by an API key.
 These keys are created by an admin with write access to the `board-server` DB.
 
+Acquire application-default credentials:
+
+```sh
+gcloud auth application-default login
+```
+
 From the repository root:
 
 ```sh


### PR DESCRIPTION
The caller needs to request application-default credentials in order for
the operation to succeed.

Part of #2675
