### PR TITLE
graph store graphs

### DIFF
--- a/.changeset/famous-cats-turn.md
+++ b/.changeset/famous-cats-turn.md
@@ -1,0 +1,10 @@
+---
+"@google-labs/breadboard": minor
+"@breadboard-ai/visual-editor": patch
+"@breadboard-ai/shared-ui": patch
+"@breadboard-ai/manifest": patch
+"@google-labs/breadboard-schema": patch
+"@breadboard-ai/types": patch
+---
+
+Introduce `GraphStore.graphs()`.

--- a/packages/breadboard/src/inspector/graph-store.ts
+++ b/packages/breadboard/src/inspector/graph-store.ts
@@ -106,20 +106,36 @@ class GraphStore
   }
 
   #populateLegacyKits(kits: Kit[]) {
-    return kits.flatMap((kit) =>
+    const all = kits.flatMap((kit) =>
       Object.entries(kit.handlers).map(([type, handler]) => {
         const metadata: NodeHandlerMetadata =
           "metadata" in handler ? handler.metadata || {} : {};
-        return {
-          url: type,
-          mainGraph: filterEmptyValues({
-            title: kit.title,
-            description: kit.description,
-            tags: kit.tags,
-          }),
-          ...metadata,
-        };
+        return [
+          type,
+          {
+            url: type,
+            mainGraph: filterEmptyValues({
+              title: kit.title,
+              description: kit.description,
+              tags: kit.tags,
+            }),
+            ...metadata,
+          },
+        ] as [type: string, info: GraphHandleToBeNamed];
       })
+    );
+    return Object.values(
+      all.reduce(
+        (collated, [type, info]) => {
+          // Intentionally do the reverse of what goes on
+          // in `handlersFromKits`: last info wins,
+          // because here, we're collecting info, rather
+          // than handlers and the last info is the one
+          // that typically has the right stuff.
+          return { ...collated, [type]: info };
+        },
+        {} as Record<string, GraphHandleToBeNamed>
+      )
     );
   }
 

--- a/packages/breadboard/src/inspector/graph-store.ts
+++ b/packages/breadboard/src/inspector/graph-store.ts
@@ -108,8 +108,14 @@ class GraphStore
   #populateLegacyKits(kits: Kit[]) {
     const all = kits.flatMap((kit) =>
       Object.entries(kit.handlers).map(([type, handler]) => {
-        const metadata: NodeHandlerMetadata =
+        let metadata: NodeHandlerMetadata =
           "metadata" in handler ? handler.metadata || {} : {};
+        const tags = [...(kit.tags || [])];
+        if (metadata.deprecated) {
+          tags.push("deprecated");
+          metadata = { ...metadata };
+          delete metadata.deprecated;
+        }
         return [
           type,
           {
@@ -117,7 +123,7 @@ class GraphStore
             mainGraph: filterEmptyValues({
               title: kit.title,
               description: kit.description,
-              tags: kit.tags,
+              tags,
             }),
             ...metadata,
           },

--- a/packages/breadboard/src/inspector/graph/kits.ts
+++ b/packages/breadboard/src/inspector/graph/kits.ts
@@ -8,6 +8,7 @@ import { toNodeHandlerMetadata } from "../../graph-based-node-handler.js";
 import { getGraphHandlerFromStore } from "../../handler.js";
 import {
   GraphDescriptor,
+  Kit,
   NodeDescriberResult,
   NodeDescriptor,
   NodeHandler,
@@ -30,9 +31,56 @@ import {
 import { collectPortsForType, filterSidePorts } from "./ports.js";
 import { describeInput, describeOutput } from "./schemas.js";
 
-export { KitCache, collectCustomNodeTypes };
+export { KitCache, collectCustomNodeTypes, createBuiltInKit };
 
-const createBuiltInKit = (): InspectableKit => {
+function unreachableCode() {
+  return function () {
+    throw new Error("This code should be never reached.");
+  };
+}
+
+function createBuiltInKit(): Kit {
+  return {
+    title: "Built-in Kit",
+    description: "A kit containing built-in Breadboard nodes",
+    url: "",
+    handlers: {
+      input: {
+        metadata: {
+          title: "Input",
+          description:
+            "The input node. Use it to request inputs for your board.",
+          help: {
+            url: "https://breadboard-ai.github.io/breadboard/docs/reference/kits/built-in/#the-input-node",
+          },
+        },
+        invoke: unreachableCode(),
+      },
+      output: {
+        metadata: {
+          title: "Output",
+          description:
+            "The output node. Use it to provide outputs from your board.",
+          help: {
+            url: "https://breadboard-ai.github.io/breadboard/docs/reference/kits/built-in/#the-output-node",
+          },
+        },
+        invoke: unreachableCode(),
+      },
+      comment: {
+        metadata: {
+          description:
+            "A comment node. Use this to put additional information on your board",
+          title: "Comment",
+          icon: "edit",
+        },
+        invoke: unreachableCode(),
+      },
+    },
+  };
+}
+
+const createBuiltInInspectableKit = (): InspectableKit => {
   return {
     descriptor: {
       title: "Built-in Kit",
@@ -89,7 +137,7 @@ export const collectKits = (
 ): InspectableKit[] => {
   const kits = mutable.store.kits;
   return [
-    createBuiltInKit(),
+    createBuiltInInspectableKit(),
     ...createCustomTypesKit(graph.nodes, mutable),
     ...kits.map((kit) => {
       const descriptor = {

--- a/packages/breadboard/src/inspector/graph/mutable-graph.ts
+++ b/packages/breadboard/src/inspector/graph/mutable-graph.ts
@@ -7,6 +7,7 @@
 import {
   GraphDescriptor,
   GraphIdentifier,
+  KitDescriptor,
   ModuleIdentifier,
 } from "@breadboard-ai/types";
 import { AffectedNode } from "../../editor/types.js";
@@ -44,6 +45,8 @@ export { MutableGraphImpl };
 class MutableGraphImpl implements MutableGraph {
   readonly store: MutableGraphStore;
   readonly id: MainGraphIdentifier;
+
+  legacyKitMetadata: KitDescriptor | null = null;
 
   graph!: GraphDescriptor;
   graphs!: InspectableGraphCache;

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -6,7 +6,6 @@
 
 import type {
   GraphIdentifier,
-  GraphInlineMetadata,
   GraphMetadata,
   Module,
   ModuleCode,
@@ -696,7 +695,9 @@ export type InspectableGraphCache = {
 
 export type MainGraphIdentifier = UUID;
 
-export type GraphHandleToBeNamed = NodeHandlerMetadata;
+export type GraphHandleToBeNamed = NodeHandlerMetadata & {
+  mainGraph: NodeHandlerMetadata;
+};
 
 export type GraphStoreArgs = Required<InspectableGraphOptions>;
 
@@ -719,6 +720,16 @@ export type MutableGraphStore = TypedEventTargetType<GraphsStoreEventMap> & {
   readonly loader: GraphLoader;
 
   graphs(): GraphHandleToBeNamed[];
+
+  /**
+   * Registers a Kit with the GraphStore.
+   * Currently, only Kits that contain Graph URL-like types
+   * are support.
+   *
+   * @param kit - the kit to register
+   * @param dependences - known dependencies to this kit
+   */
+  registerKit(kit: Kit, dependences: MainGraphIdentifier[]): void;
 
   addByURL(
     url: string,
@@ -780,6 +791,7 @@ export type InspectablePortCache = {
  */
 export type MutableGraph = {
   graph: GraphDescriptor;
+  legacyKitMetadata: KitDescriptor | null;
   readonly id: MainGraphIdentifier;
   readonly graphs: InspectableGraphCache;
   readonly store: MutableGraphStore;

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -6,6 +6,7 @@
 
 import type {
   GraphIdentifier,
+  GraphInlineMetadata,
   GraphMetadata,
   Module,
   ModuleCode,
@@ -695,21 +696,7 @@ export type InspectableGraphCache = {
 
 export type MainGraphIdentifier = UUID;
 
-export type GraphHandle = {
-  id: MainGraphIdentifier;
-} & (
-  | {
-      type: "declarative";
-      /**
-       * The value is "" for the main graph.
-       */
-      graphId: GraphIdentifier;
-    }
-  | {
-      type: "imperative";
-      moduleId: ModuleIdentifier;
-    }
-);
+export type GraphHandleToBeNamed = NodeHandlerMetadata;
 
 export type GraphStoreArgs = Required<InspectableGraphOptions>;
 
@@ -730,6 +717,8 @@ export type MutableGraphStore = TypedEventTargetType<GraphsStoreEventMap> & {
   readonly kits: readonly Kit[];
   readonly sandbox: Sandbox;
   readonly loader: GraphLoader;
+
+  graphs(): GraphHandleToBeNamed[];
 
   addByURL(
     url: string,

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -695,8 +695,8 @@ export type InspectableGraphCache = {
 
 export type MainGraphIdentifier = UUID;
 
-export type GraphHandleToBeNamed = NodeHandlerMetadata & {
-  mainGraph: NodeHandlerMetadata;
+export type GraphStoreEntry = NodeHandlerMetadata & {
+  mainGraph: NodeHandlerMetadata & { id: MainGraphIdentifier };
 };
 
 export type GraphStoreArgs = Required<InspectableGraphOptions>;
@@ -719,7 +719,7 @@ export type MutableGraphStore = TypedEventTargetType<GraphsStoreEventMap> & {
   readonly sandbox: Sandbox;
   readonly loader: GraphLoader;
 
-  graphs(): GraphHandleToBeNamed[];
+  graphs(): GraphStoreEntry[];
 
   /**
    * Registers a Kit with the GraphStore.

--- a/packages/breadboard/tests/node/inspect/graph-store.ts
+++ b/packages/breadboard/tests/node/inspect/graph-store.ts
@@ -15,11 +15,16 @@ describe("GraphStore.graphs", () => {
       kits: [testKit],
     });
     deepStrictEqual(graphStore.graphs(), [
-      { url: "invoke" },
-      { url: "map", title: "Map", tags: ["experimental"] },
-      { url: "promptTemplate" },
-      { url: "runJavascript" },
-      { url: "secrets" },
+      { mainGraph: { title: "Test Kit" }, url: "invoke" },
+      {
+        mainGraph: { title: "Test Kit" },
+        url: "map",
+        title: "Map",
+        tags: ["experimental"],
+      },
+      { mainGraph: { title: "Test Kit" }, url: "promptTemplate" },
+      { url: "runJavascript", mainGraph: { title: "Test Kit" } },
+      { url: "secrets", mainGraph: { title: "Test Kit" } },
     ]);
   });
 
@@ -28,17 +33,27 @@ describe("GraphStore.graphs", () => {
       kits: [testKit],
     });
     graphStore.addByDescriptor({
+      url: "https://example.com/foo",
       title: "Foo",
       nodes: [],
       edges: [],
     });
     deepStrictEqual(graphStore.graphs(), [
-      { url: "invoke" },
-      { url: "map", title: "Map", tags: ["experimental"] },
-      { url: "promptTemplate" },
-      { url: "runJavascript" },
-      { url: "secrets" },
-      { title: "Foo" },
+      { mainGraph: { title: "Test Kit" }, url: "invoke" },
+      {
+        mainGraph: { title: "Test Kit" },
+        url: "map",
+        title: "Map",
+        tags: ["experimental"],
+      },
+      { mainGraph: { title: "Test Kit" }, url: "promptTemplate" },
+      { url: "runJavascript", mainGraph: { title: "Test Kit" } },
+      { url: "secrets", mainGraph: { title: "Test Kit" } },
+      {
+        title: "Foo",
+        url: "https://example.com/foo",
+        mainGraph: { title: "Foo", url: "https://example.com/foo" },
+      },
     ]);
   });
 });

--- a/packages/breadboard/tests/node/inspect/graph-store.ts
+++ b/packages/breadboard/tests/node/inspect/graph-store.ts
@@ -14,18 +14,19 @@ describe("GraphStore.graphs", () => {
     const graphStore = makeTestGraphStore({
       kits: [testKit],
     });
-    deepStrictEqual(graphStore.graphs(), [
-      { mainGraph: { title: "Test Kit" }, url: "invoke" },
-      {
-        mainGraph: { title: "Test Kit" },
-        url: "map",
-        title: "Map",
-        tags: ["experimental"],
-      },
-      { mainGraph: { title: "Test Kit" }, url: "promptTemplate" },
-      { url: "runJavascript", mainGraph: { title: "Test Kit" } },
-      { url: "secrets", mainGraph: { title: "Test Kit" } },
-    ]);
+    deepStrictEqual(
+      graphStore.graphs().map((graph) => graph.url),
+      [
+        "invoke",
+        "map",
+        "promptTemplate",
+        "runJavascript",
+        "secrets",
+        "input",
+        "output",
+        "comment",
+      ]
+    );
   });
 
   it("correctly lists added graphs", () => {
@@ -38,22 +39,19 @@ describe("GraphStore.graphs", () => {
       nodes: [],
       edges: [],
     });
-    deepStrictEqual(graphStore.graphs(), [
-      { mainGraph: { title: "Test Kit" }, url: "invoke" },
-      {
-        mainGraph: { title: "Test Kit" },
-        url: "map",
-        title: "Map",
-        tags: ["experimental"],
-      },
-      { mainGraph: { title: "Test Kit" }, url: "promptTemplate" },
-      { url: "runJavascript", mainGraph: { title: "Test Kit" } },
-      { url: "secrets", mainGraph: { title: "Test Kit" } },
-      {
-        title: "Foo",
-        url: "https://example.com/foo",
-        mainGraph: { title: "Foo", url: "https://example.com/foo" },
-      },
-    ]);
+    deepStrictEqual(
+      graphStore.graphs().map((graph) => graph.url),
+      [
+        "invoke",
+        "map",
+        "promptTemplate",
+        "runJavascript",
+        "secrets",
+        "input",
+        "output",
+        "comment",
+        "https://example.com/foo",
+      ]
+    );
   });
 });

--- a/packages/breadboard/tests/node/inspect/graph-store.ts
+++ b/packages/breadboard/tests/node/inspect/graph-store.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { deepStrictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { makeTestGraphStore } from "../../helpers/_graph-store.js";
+import { testKit } from "../test-kit.js";
+
+describe("GraphStore.graphs", () => {
+  it("correctly lists legacy kits as graphs", () => {
+    const graphStore = makeTestGraphStore({
+      kits: [testKit],
+    });
+    deepStrictEqual(graphStore.graphs(), [
+      { url: "invoke" },
+      { url: "map", title: "Map", tags: ["experimental"] },
+      { url: "promptTemplate" },
+      { url: "runJavascript" },
+      { url: "secrets" },
+    ]);
+  });
+
+  it("correctly lists added graphs", () => {
+    const graphStore = makeTestGraphStore({
+      kits: [testKit],
+    });
+    graphStore.addByDescriptor({
+      title: "Foo",
+      nodes: [],
+      edges: [],
+    });
+    deepStrictEqual(graphStore.graphs(), [
+      { url: "invoke" },
+      { url: "map", title: "Map", tags: ["experimental"] },
+      { url: "promptTemplate" },
+      { url: "runJavascript" },
+      { url: "secrets" },
+      { title: "Foo" },
+    ]);
+  });
+});

--- a/packages/breadboard/tests/node/test-kit.ts
+++ b/packages/breadboard/tests/node/test-kit.ts
@@ -38,6 +38,10 @@ export const testKit: Kit = {
       },
     },
     map: {
+      metadata: {
+        title: "Map",
+        tags: ["experimental"],
+      },
       invoke: async (inputs, context) => {
         const { board, list = [] } = inputs;
         if (!board) {

--- a/packages/breadboard/tests/node/test-kit.ts
+++ b/packages/breadboard/tests/node/test-kit.ts
@@ -12,6 +12,7 @@ import { InputValues, Kit, OutputValues } from "../../src/types.js";
 // in tests/bgl/*.
 
 export const testKit: Kit = {
+  title: "Test Kit",
   url: import.meta.url,
   handlers: {
     invoke: {

--- a/packages/manifest/bbm.schema.json
+++ b/packages/manifest/bbm.schema.json
@@ -394,6 +394,7 @@
 			"description": "A tag that can be associated with a graph.\n- `published`: The graph is published (as opposed to a draft). It may be    used in production and shared with others.\n- `tool`: The graph is intended to be a tool.\n- `experimental`: The graph is experimental and may not be stable.\n- `component`: The graph is intended to be a component.",
 			"enum": [
 				"component",
+				"deprecated",
 				"experimental",
 				"published",
 				"tool"

--- a/packages/schema/breadboard.schema.json
+++ b/packages/schema/breadboard.schema.json
@@ -400,7 +400,8 @@
 				"published",
 				"tool",
 				"experimental",
-				"component"
+				"component",
+				"deprecated"
 			],
 			"description": "A tag that can be associated with a graph.\n- `published`: The graph is published (as opposed to a draft). It may be    used in production and shared with others.\n- `tool`: The graph is intended to be a tool.\n- `experimental`: The graph is experimental and may not be stable.\n- `component`: The graph is intended to be a component."
 		},

--- a/packages/shared-ui/src/elements/component-selector/component-selector.ts
+++ b/packages/shared-ui/src/elements/component-selector/component-selector.ts
@@ -365,6 +365,7 @@ export class ComponentSelector extends LitElement {
     if (!this.graphStore || !this.mainGraphId) {
       return nothing;
     }
+    console.log("🌻 graphs", this.graphStore.graphs());
     const allKits = this.#createKitList(this.graphStore, this.mainGraphId);
 
     const before = allKits.size;

--- a/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
@@ -467,6 +467,7 @@ export class UI extends LitElement {
             html`<h1 id="side-nav-title">Components</h1>
               <bb-component-selector
                 .graphStoreUpdateId=${this.graphStoreUpdateId}
+                .showExperimentalComponents=${showExperimentalComponents}
                 .boardServerKits=${this.boardServerKits}
                 .graphStore=${this.graphStore}
                 .mainGraphId=${this.mainGraphId}

--- a/packages/types/src/graph-descriptor.ts
+++ b/packages/types/src/graph-descriptor.ts
@@ -241,7 +241,12 @@ export type GraphInlineMetadata = {
  * - `experimental`: The graph is experimental and may not be stable.
  * - `component`: The graph is intended to be a component.
  */
-export type GraphTag = "published" | "tool" | "experimental" | "component";
+export type GraphTag =
+  | "published"
+  | "tool"
+  | "experimental"
+  | "component"
+  | "deprecated";
 
 /**
  * Represents graph metadata.

--- a/packages/visual-editor/src/runtime/board.ts
+++ b/packages/visual-editor/src/runtime/board.ts
@@ -464,7 +464,6 @@ export class Board extends EventTarget {
           // requesting the graph file from it.
           await boardServer.ready();
         }
-
         if (boardServer && this.boardServers) {
           kits = (boardServer as BoardServer).kits ?? this.boardServerKits;
           const loadResult = await this.boardServers.loader.load(url, { base });

--- a/packages/visual-editor/src/runtime/runtime.ts
+++ b/packages/visual-editor/src/runtime/runtime.ts
@@ -86,6 +86,15 @@ export async function create(config: RuntimeConfig): Promise<{
     loader,
     sandbox: config.sandbox,
   });
+
+  servers.forEach((server) => {
+    server.ready().then(() => {
+      server.kits.forEach((kit) => {
+        graphStore.registerKit(kit, []);
+      });
+    });
+  });
+
   const boardServers = {
     servers,
     loader,


### PR DESCRIPTION
- **First sketch of `GraphStore.graphs()`.**
- **Introduce `GraphStore.registerKit`.**
- **Move registering kits with GraphStore to runtime.**
- **Nicely dedupe the handlers.**
- **Move `deprecated` to a tag.**
- **Start using `GraphStore.graphs()`.**
- **Plumb `showExperimentalComponents` to `bb-component-selector`.**
- **docs(changeset): Introduce `GraphStore.graphs()`.**
- **Fix unit tests.**
