### PR TITLE
[shared-ui] Prevent accidental wiring of configurable ports outside of "advanced" mode

### DIFF
--- a/.changeset/eleven-berries-rhyme.md
+++ b/.changeset/eleven-berries-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/shared-ui": patch
+---
+
+Prevent accidental wiring of configurable ports outside of "advanced" mode

--- a/packages/shared-ui/src/elements/editor/graph-node-reference.ts
+++ b/packages/shared-ui/src/elements/editor/graph-node-reference.ts
@@ -131,7 +131,5 @@ export class GraphNodeReference extends PIXI.Container {
 
     this.#title.x = 10 - w;
     this.#title.y = 5;
-
-    // TODO: Render the line to the target.
   }
 }

--- a/packages/shared-ui/src/elements/editor/graph-node.ts
+++ b/packages/shared-ui/src/elements/editor/graph-node.ts
@@ -1359,8 +1359,15 @@ export class GraphNode extends PIXI.Container {
         continue;
       }
       const { port, label, nodePort } = portItem;
+      const isBoard =
+        isBoardBehavior(port.schema) || isBoardArrayBehavior(port.schema);
+      const hidePortBubble =
+        (isConfigurableBehavior(port.schema) || port.configured) &&
+        !isBoard &&
+        this.#expansionState !== "advanced";
+
       nodePort.label = port.name;
-      nodePort.radius = this.#portRadius;
+      nodePort.radius = hidePortBubble ? 0 : this.#portRadius;
       nodePort.x = 0;
       nodePort.y = portY + this.#textSize * 0.5 + 0.5;
       nodePort.overrideStatus = null;
@@ -1371,8 +1378,6 @@ export class GraphNode extends PIXI.Container {
         isConfigurableBehavior(port.schema) &&
         this.#expansionState !== "advanced";
 
-      const isBoard =
-        isBoardBehavior(port.schema) || isBoardArrayBehavior(port.schema);
       nodePort.showBoardReferenceMarker =
         isBoard && this.#showBoardReferenceMarkers;
 

--- a/packages/shared-ui/src/elements/editor/graph-node.ts
+++ b/packages/shared-ui/src/elements/editor/graph-node.ts
@@ -31,7 +31,11 @@ import { GraphPortLabel as GraphNodePortLabel } from "./graph-port-label.js";
 import { ComponentActivityItem } from "../../types/types.js";
 import { GraphNodeActivityMarker } from "./graph-node-activity-marker.js";
 import { GraphNodeReferenceContainer } from "./graph-node-reference-container.js";
-import { isBoardArrayBehavior, isBoardBehavior } from "../../utils/index.js";
+import {
+  isBoardArrayBehavior,
+  isBoardBehavior,
+  isConfigurableBehavior,
+} from "../../utils/index.js";
 
 const borderColor = getGlobalColor("--bb-neutral-500");
 const nodeTextColor = getGlobalColor("--bb-neutral-900");
@@ -1333,6 +1337,7 @@ export class GraphNode extends PIXI.Container {
 
     let portStartY = 0;
     if (this.#titleText) {
+      this.#titleText.eventMode = "none";
       this.#titleText.x = titleStartX;
       this.#titleText.y = this.#padding;
       this.addChild(this.#titleText);
@@ -1362,6 +1367,9 @@ export class GraphNode extends PIXI.Container {
       nodePort.status = port.status;
       nodePort.configured = port.configured && port.edges.length === 0;
       nodePort.visible = true;
+      nodePort.readOnly =
+        isConfigurableBehavior(port.schema) &&
+        this.#expansionState !== "advanced";
 
       const isBoard =
         isBoardBehavior(port.schema) || isBoardArrayBehavior(port.schema);

--- a/packages/shared-ui/src/elements/editor/graph-node.ts
+++ b/packages/shared-ui/src/elements/editor/graph-node.ts
@@ -1364,7 +1364,8 @@ export class GraphNode extends PIXI.Container {
       const hidePortBubble =
         (isConfigurableBehavior(port.schema) || port.configured) &&
         !isBoard &&
-        this.#expansionState !== "advanced";
+        this.#expansionState !== "advanced" &&
+        port.edges.length === 0;
 
       nodePort.label = port.name;
       nodePort.radius = hidePortBubble ? 0 : this.#portRadius;

--- a/packages/shared-ui/src/elements/editor/graph-renderer.ts
+++ b/packages/shared-ui/src/elements/editor/graph-renderer.ts
@@ -26,6 +26,8 @@ import {
   WorkspaceSelectionStateEvent,
   WorkspaceVisualUpdateEvent,
   DragConnectorStartEvent,
+  ToastEvent,
+  ToastType,
 } from "../../events/events.js";
 import { GRAPH_OPERATIONS, GraphOpts, MoveToSelection } from "./types.js";
 import { Graph } from "./graph.js";
@@ -1969,6 +1971,10 @@ export class GraphRenderer extends LitElement {
 
     graph.on(GRAPH_OPERATIONS.GRAPH_REFERENCE_LOAD, (reference) => {
       this.dispatchEvent(new StartEvent(reference));
+    });
+
+    graph.on(GRAPH_OPERATIONS.WARN_USER, (message: string) => {
+      this.dispatchEvent(new ToastEvent(message, ToastType.WARNING));
     });
 
     graph.on(

--- a/packages/shared-ui/src/elements/editor/types.ts
+++ b/packages/shared-ui/src/elements/editor/types.ts
@@ -54,6 +54,7 @@ export enum GRAPH_OPERATIONS {
   GRAPH_REFERENCE_TOGGLE_SELECTED = "graphreferenceselected",
   GRAPH_REFERENCE_GOTO = "graphreferencegoto",
   GRAPH_REFERENCE_LOAD = "graphreferenceload",
+  WARN_USER = "warnuser",
 }
 
 export enum GraphNodePortType {

--- a/packages/shared-ui/src/utils/behaviors.ts
+++ b/packages/shared-ui/src/utils/behaviors.ts
@@ -18,27 +18,27 @@ export function isBoardArrayBehavior(schema: Schema): boolean {
   return schema.items.behavior?.includes("board") ?? false;
 }
 
-export function isPortSpecBehavior(schema: Schema) {
-  return schema.behavior?.includes("ports-spec");
+export function isPortSpecBehavior(schema: Schema): boolean {
+  return schema.behavior?.includes("ports-spec") ?? false;
 }
 
-export function isCodeBehavior(schema: Schema) {
-  return schema.behavior?.includes("code");
+export function isCodeBehavior(schema: Schema): boolean {
+  return schema.behavior?.includes("code") ?? false;
 }
 
-export function isLLMContentBehavior(schema: Schema) {
-  return schema.behavior?.includes("llm-content");
+export function isLLMContentBehavior(schema: Schema): boolean {
+  return schema.behavior?.includes("llm-content") ?? false;
 }
 
-export function isModuleBehavior(schema: Schema) {
-  return schema.behavior?.includes("module");
+export function isModuleBehavior(schema: Schema): boolean {
+  return schema.behavior?.includes("module") ?? false;
 }
 
-export function isConfigurableBehavior(schema: Schema) {
-  return schema.behavior?.includes("config");
+export function isConfigurableBehavior(schema: Schema): boolean {
+  return schema.behavior?.includes("config") ?? false;
 }
 
-export function isLLMContentArrayBehavior(schema: Schema) {
+export function isLLMContentArrayBehavior(schema: Schema): boolean {
   if (schema.type !== "array") return false;
   if (Array.isArray(schema.items)) return false;
   if (schema.items?.type !== "object") return false;
@@ -47,7 +47,7 @@ export function isLLMContentArrayBehavior(schema: Schema) {
   return true;
 }
 
-export function isTextBehavior(schema: Schema) {
+export function isTextBehavior(schema: Schema): boolean {
   return schema.type === "string";
 }
 


### PR DESCRIPTION
Fixes #3720

As of this change:

1. We only show configurable ports when:
  a. the port represents a board/board array
  b. the node is set to 'advanced'
  c. there are edges attached to the port
2. We also prevent users from dragging to a configurable port unless the node is in 'advanced' mode