### PR TITLE
guard port value

### DIFF
--- a/.changeset/cool-squids-happen.md
+++ b/.changeset/cool-squids-happen.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/shared-ui": patch
+---
+
+Guard for empty port values in workspace outline preview.

--- a/packages/shared-ui/src/elements/workspace-outline/workspace-outline.ts
+++ b/packages/shared-ui/src/elements/workspace-outline/workspace-outline.ts
@@ -908,7 +908,9 @@ export class WorkspaceOutline
     }
 
     if (isBoardBehavior(port.schema)) {
-      return this.#toBoardName(port.value as GraphIdentifier);
+      const value = port.value;
+      if (!value) return "Unset";
+      return this.#toBoardName(value as GraphIdentifier);
     }
 
     if (isBoardArrayBehavior(port.schema) && Array.isArray(port.value)) {


### PR DESCRIPTION
- **Guard for undefined port value in workspace outline previews.**
- **docs(changeset): Guard for empty port values in workspace outline preview.**
