### PR TITLE
reference unresolved capability

### DIFF
--- a/.changeset/cuddly-toys-change.md
+++ b/.changeset/cuddly-toys-change.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/visual-editor": patch
+---
+
+Teach visual editor to create runtime-resolvable references.

--- a/packages/visual-editor/src/runtime/edit.ts
+++ b/packages/visual-editor/src/runtime/edit.ts
@@ -800,6 +800,15 @@ export class Edit extends EventTarget {
       graphId = "";
     }
 
+    if (typeof value === "string") {
+      // Convert to `UnresolvedPathBoardCapability`, so that it is resolved
+      // at runtime.
+      // This is important for ensuring that relative URLs are resolved
+      // relative to where they are invoked from, rather than to where they
+      // are used.
+      value = { kind: "board", path: value };
+    }
+
     const node = editableGraph.inspect(graphId).nodeById(nodeId);
     const port = node
       ?.currentPorts()


### PR DESCRIPTION
- **When creating a reference, convert it to an `UnresolvedPathBoardCapability`**
- **docs(changeset): Teach visual editor to create runtime-resolvable references.**
