### PR TITLE
polish 18

### DIFF
--- a/.changeset/long-apples-fetch.md
+++ b/.changeset/long-apples-fetch.md
@@ -1,0 +1,7 @@
+---
+"@breadboard-ai/visual-editor": patch
+"@google-labs/breadboard": patch
+"@breadboard-ai/shared-ui": patch
+---
+
+A cornucopia of fixes and polish

--- a/packages/breadboard/src/handler.ts
+++ b/packages/breadboard/src/handler.ts
@@ -100,7 +100,9 @@ export async function getGraphHandlerFromMutableGraph(
     return undefined;
   }
   const store = mutable.store;
-  const result = store.addByURL(type, [], {}).mutable;
+  const result = store.addByURL(type, [], {
+    outerGraph: mutable.graph,
+  }).mutable;
   return new GraphBasedNodeHandler({ graph: result.graph }, type);
 }
 

--- a/packages/breadboard/src/inspector/graph-store.ts
+++ b/packages/breadboard/src/inspector/graph-store.ts
@@ -34,14 +34,16 @@ import { createBuiltInKit } from "./graph/kits.js";
 import { graphUrlLike } from "../utils/graph-url-like.js";
 import { getGraphUrl, getGraphUrlComponents } from "../loader/loader.js";
 
-export { GraphStore, makeTerribleOptions, contextFromStore };
+export { GraphStore, makeTerribleOptions, contextFromMutableGraph };
 
-function contextFromStore(store: MutableGraphStore): NodeHandlerContext {
+function contextFromMutableGraph(mutable: MutableGraph): NodeHandlerContext {
+  const store = mutable.store;
   return {
     kits: [...store.kits],
     loader: store.loader,
     sandbox: store.sandbox,
     graphStore: store,
+    outerGraph: mutable.graph,
   };
 }
 

--- a/packages/breadboard/src/inspector/graph/describer-manager.ts
+++ b/packages/breadboard/src/inspector/graph/describer-manager.ts
@@ -40,7 +40,7 @@ import { GraphDescriptorHandle } from "./graph-descriptor-handle.js";
 import { combineSchemas, removeProperty } from "../../schema.js";
 import { Result } from "../../editor/types.js";
 import { invokeGraph } from "../../run/invoke-graph.js";
-import { contextFromStore } from "../graph-store.js";
+import { contextFromMutableGraph } from "../graph-store.js";
 import { SchemaDiffer } from "../../utils/schema-differ.js";
 import { UpdateEvent } from "./event.js";
 
@@ -114,7 +114,7 @@ class NodeTypeDescriberManager implements DescribeResultCacheArgs {
   ): Promise<NodeDescriberFunction | undefined> {
     let handler: NodeHandler | undefined;
     try {
-      handler = await getHandler(type, contextFromStore(this.mutable.store));
+      handler = await getHandler(type, contextFromMutableGraph(this.mutable));
     } catch (e) {
       console.warn(`Error getting describer for node type ${type}`, e);
     }

--- a/packages/breadboard/src/inspector/graph/kits.ts
+++ b/packages/breadboard/src/inspector/graph/kits.ts
@@ -308,11 +308,9 @@ class CustomNodeType implements InspectableNodeType {
   }
 
   currentMetadata(): NodeHandlerMetadata {
-    const graph = this.#mutable.store.addByURL(
-      this.#type,
-      [this.#mutable.id],
-      {}
-    ).mutable;
+    const graph = this.#mutable.store.addByURL(this.#type, [this.#mutable.id], {
+      outerGraph: this.#mutable.graph,
+    }).mutable;
     return toNodeHandlerMetadata(graph.graph);
   }
 

--- a/packages/breadboard/src/inspector/graph/kits.ts
+++ b/packages/breadboard/src/inspector/graph/kits.ts
@@ -5,7 +5,7 @@
  */
 
 import { toNodeHandlerMetadata } from "../../graph-based-node-handler.js";
-import { getGraphHandlerFromStore } from "../../handler.js";
+import { getGraphHandlerFromMutableGraph } from "../../handler.js";
 import {
   GraphDescriptor,
   Kit,
@@ -294,7 +294,7 @@ class CustomNodeType implements InspectableNodeType {
   constructor(type: string, mutable: MutableGraph) {
     this.#type = type;
     this.#mutable = mutable;
-    this.#handlerPromise = getGraphHandlerFromStore(type, mutable.store);
+    this.#handlerPromise = getGraphHandlerFromMutableGraph(type, mutable);
   }
 
   async #readMetadata() {

--- a/packages/breadboard/src/run/node-invoker.ts
+++ b/packages/breadboard/src/run/node-invoker.ts
@@ -63,7 +63,12 @@ export class NodeInvoker {
     const { kits = [], base = SENTINEL_BASE_URL, state } = this.#context;
     let outputs: OutputValues | undefined = undefined;
 
-    const handler = await getHandler(descriptor.type, this.#context);
+    const outerGraph = this.#graph.graph;
+
+    const handler = await getHandler(descriptor.type, {
+      ...this.#context,
+      outerGraph,
+    });
 
     const newContext: NodeHandlerContext = {
       ...this.#context,
@@ -73,7 +78,7 @@ export class NodeInvoker {
       // if this.#graph is a subgraph.
       // Or it equals to "board" it this is not a subgraph
       // TODO: Make this more elegant.
-      outerGraph: this.#graph.graph,
+      outerGraph,
       base,
       kits,
       requestInput: this.#requestedInputs.createHandler(

--- a/packages/shared-ui/src/elements/editor/graph.ts
+++ b/packages/shared-ui/src/elements/editor/graph.ts
@@ -599,7 +599,7 @@ export class Graph extends PIXI.Container {
           nodePortBeingEdited.label !== "" &&
           topTarget instanceof GraphNode &&
           topTarget !== nodeBeingEdited &&
-          isSameGraph
+          !isSameGraph
         ) {
           const targetAllowsAdHocPorts =
             (nodePortBeingEdited.type === GraphNodePortType.IN &&
@@ -790,8 +790,10 @@ export class Graph extends PIXI.Container {
       // Also check that the user isn't trying to attach a star port to a named
       // port.
       if (
-        (targetEdgeDescriptor.out === "*" && targetEdgeDescriptor.in !== "*") ||
-        (targetEdgeDescriptor.out !== "*" && targetEdgeDescriptor.in === "*")
+        !creatingAdHocEdge &&
+        ((targetEdgeDescriptor.out === "*" &&
+          targetEdgeDescriptor.in !== "*") ||
+          (targetEdgeDescriptor.out !== "*" && targetEdgeDescriptor.in === "*"))
       ) {
         canMakeWireModification = false;
       }

--- a/packages/visual-editor/src/runtime/util.ts
+++ b/packages/visual-editor/src/runtime/util.ts
@@ -543,10 +543,12 @@ export function generateAddEditSpecFromDescriptor(
         edits.push({ type: "addedge", edge, graphId });
       }
 
+      const existingMetadata = structuredClone(targetGraph.metadata() ?? {});
+      let updateGraphMetadata = false;
+
       // Comments.
       const comments = sourceGraph.metadata?.comments;
       if (comments) {
-        const existingMetadata = structuredClone(targetGraph.metadata() ?? {});
         existingMetadata.comments ??= [];
         for (const sourceComment of comments) {
           const comment = structuredClone(sourceComment);
@@ -559,8 +561,18 @@ export function generateAddEditSpecFromDescriptor(
             graphOffset
           );
           existingMetadata.comments.push(comment);
+          updateGraphMetadata = true;
         }
+      }
 
+      // Also copy "describer", if present
+      const describer = sourceGraph.metadata?.describer;
+      if (describer) {
+        existingMetadata.describer = describer;
+        updateGraphMetadata = true;
+      }
+
+      if (updateGraphMetadata) {
         edits.push({
           type: "changegraphmetadata",
           metadata: { ...existingMetadata },

--- a/packages/visual-editor/src/runtime/util.ts
+++ b/packages/visual-editor/src/runtime/util.ts
@@ -39,7 +39,8 @@ export function isBoardArrayBehavior(schema: Schema): boolean {
 }
 
 export function edgeToString(edge: Edge): string {
-  return `${edge.from}:${edge.out}->${edge.to}:${edge.in}`;
+  const edgeIn = edge.out === "*" ? "*" : edge.in;
+  return `${edge.from}:${edge.out}->${edge.to}:${edgeIn}`;
 }
 
 export function inspectableEdgeToString(edge: InspectableEdge): string {


### PR DESCRIPTION
- **Carry over custom describer when pasting a graph.**
- **Make relative module/graph URLs droppable.**
- **Pass `outerGraph` correctly to make module-based types runnable again.**
- **Teach `GraphBasedNodeHandler` to describe module types.**
- **Supply proper loading context when retrieving component types.**
- **Supply proper loader context when retrieving type metadata.**
- **Allow deleting star edges.**
- **Make ad hoc wiring work again.**
- **docs(changeset): A cornucopia of fixes and polish**
