### PR TITLE
fixes upon fixes

### DIFF
--- a/.changeset/metal-bikes-push.md
+++ b/.changeset/metal-bikes-push.md
@@ -1,0 +1,5 @@
+---
+"@google-labs/breadboard": patch
+---
+
+Undo the change to use GraphStore for custom graph describers, as it breaks Agent Kit.

--- a/packages/breadboard/src/inspector/graph/describer-manager.ts
+++ b/packages/breadboard/src/inspector/graph/describer-manager.ts
@@ -375,8 +375,10 @@ class GraphDescriberManager {
       }
       const base = this.handle.url();
 
+      const loader = this.mutable.store.loader;
+
       // try loading the describer graph.
-      const loadResult = await this.mutable.store.load(customDescriber, {
+      const loadResult = await loader.load(customDescriber, {
         base,
         board: this.handle.graph(),
         outerGraph: this.handle.graph(),
@@ -399,7 +401,7 @@ class GraphDescriberManager {
         {
           base,
           kits: [...this.mutable.store.kits],
-          loader: this.mutable.store,
+          loader,
         }
       )) as NodeDescriberResult;
       if ("$error" in result) {


### PR DESCRIPTION
- **Undo the change in describer manager -- breaks Agent Kit.**
- **docs(changeset): Undo the change to use GraphStore for custom graph describers, as it breaks Agent Kit.**
