### PR TITLE
bgl exports

### DIFF
--- a/.changeset/wild-plums-destroy.md
+++ b/.changeset/wild-plums-destroy.md
@@ -1,0 +1,7 @@
+---
+"@breadboard-ai/visual-editor": minor
+"@google-labs/breadboard": minor
+"@breadboard-ai/shared-ui": minor
+---
+
+Teach Breadboard to recognize and edit BGL exports.

--- a/package-lock.json
+++ b/package-lock.json
@@ -25656,7 +25656,7 @@
       "dependencies": {
         "@breadboard-ai/build": "0.11.0",
         "@breadboard-ai/import": "0.1.13",
-        "@breadboard-ai/visual-editor": "1.24.3",
+        "@breadboard-ai/visual-editor": "1.24.4",
         "@google-labs/breadboard": "^0.30.0",
         "@google-labs/core-kit": "^0.17.0",
         "@google-labs/template-kit": "^0.3.15",
@@ -27267,7 +27267,7 @@
     },
     "packages/visual-editor": {
       "name": "@breadboard-ai/visual-editor",
-      "version": "1.24.3",
+      "version": "1.24.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@breadboard-ai/bbrt": "0.0.1",

--- a/packages/breadboard-cli/package.json
+++ b/packages/breadboard-cli/package.json
@@ -161,7 +161,7 @@
   "dependencies": {
     "@breadboard-ai/build": "0.11.0",
     "@breadboard-ai/import": "0.1.13",
-    "@breadboard-ai/visual-editor": "1.24.3",
+    "@breadboard-ai/visual-editor": "1.24.4",
     "@google-labs/breadboard": "^0.30.0",
     "@google-labs/core-kit": "^0.17.0",
     "@google-labs/template-kit": "^0.3.15",

--- a/packages/breadboard/src/editor/graph.ts
+++ b/packages/breadboard/src/editor/graph.ts
@@ -44,12 +44,14 @@ import { AddGraph } from "./operations/add-graph.js";
 import { RemoveGraph } from "./operations/remove-graph.js";
 import { MutableGraphImpl } from "../inspector/graph/mutable-graph.js";
 import { MutableGraph } from "../inspector/types.js";
+import { ToggleExport } from "./operations/toggle-export.js";
 
 const validImperativeEdits: EditSpec["type"][] = [
   "addmodule",
   "changegraphmetadata",
   "removemodule",
   "changemodule",
+  "toggleexport",
 ];
 
 const operations = new Map<EditSpec["type"], EditOperation>([
@@ -66,6 +68,7 @@ const operations = new Map<EditSpec["type"], EditOperation>([
   ["changemodule", new ChangeModule()],
   ["addgraph", new AddGraph()],
   ["removegraph", new RemoveGraph()],
+  ["toggleexport", new ToggleExport()],
 ]);
 
 export class Graph implements EditableGraph {

--- a/packages/breadboard/src/editor/operations/toggle-export.ts
+++ b/packages/breadboard/src/editor/operations/toggle-export.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GraphIdentifier, ModuleIdentifier } from "@breadboard-ai/types";
+import {
+  EditOperation,
+  EditOperationContext,
+  EditSpec,
+  SingleEditResult,
+} from "../types.js";
+
+export class ToggleExport implements EditOperation {
+  async do(
+    spec: EditSpec,
+    context: EditOperationContext
+  ): Promise<SingleEditResult> {
+    if (spec.type !== "toggleexport") {
+      throw new Error(
+        `Editor API integrity error: expected type "toggleexport", received "${spec.type}" instead.`
+      );
+    }
+    const { id, exportType: type } = spec;
+    const { mutable } = context;
+
+    let exportId;
+    const affectedGraphs: GraphIdentifier[] = [];
+    const affectedModules: ModuleIdentifier[] = [];
+
+    if (type === "imperative") {
+      // toggle module export.
+      const moduleId = id as ModuleIdentifier;
+      if (!mutable.graph.modules?.[moduleId]) {
+        return {
+          success: false,
+          error: `Unable to toggle export: module "${moduleId}" does not exist.`,
+        };
+      }
+      exportId = `#module:${id}`;
+      affectedModules.push(id);
+    } else {
+      // toggle graph export.
+      const graphId = id as GraphIdentifier;
+      if (graphId !== "" && !mutable.graph.graphs?.[graphId]) {
+        return {
+          success: false,
+          error: `Unable to toggle export: graph "${graphId}" does not exist.`,
+        };
+      }
+      exportId = `#${id}`;
+      affectedGraphs.push(id);
+    }
+
+    const exports = new Set(mutable.graph.exports || []);
+    if (exports.has(exportId)) {
+      exports.delete(exportId);
+    } else {
+      exports.add(exportId);
+    }
+    mutable.graph.exports = [...exports];
+    return {
+      success: true,
+      affectedNodes: [],
+      affectedModules,
+      affectedGraphs,
+    };
+  }
+}

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -152,6 +152,12 @@ export type RemoveGraphSpec = {
   id: GraphIdentifier;
 };
 
+export type ToggleExportSpec = {
+  type: "toggleexport";
+  id: GraphIdentifier | ModuleIdentifier;
+  exportType: "imperative" | "declarative";
+};
+
 export type EditOperationConductor = (
   edits: EditSpec[],
   editLabel: string
@@ -180,7 +186,8 @@ export type EditSpec =
   | ChangeGraphMetadataSpec
   | ChangeModuleSpec
   | AddGraphSpec
-  | RemoveGraphSpec;
+  | RemoveGraphSpec
+  | ToggleExportSpec;
 
 export type EditableGraph = {
   addEventListener<Key extends keyof EditableGraphEventMap>(

--- a/packages/breadboard/src/graph-based-node-handler.ts
+++ b/packages/breadboard/src/graph-based-node-handler.ts
@@ -99,18 +99,44 @@ class GraphBasedNodeHandler implements NodeHandlerObject {
   }
 
   get metadata() {
-    return toNodeHandlerMetadata(this.#descriptor);
+    return toNodeHandlerMetadata(this.#graph, this.#type);
   }
 }
 
-function toNodeHandlerMetadata(graph: GraphDescriptor): NodeHandlerMetadata {
-  return filterEmptyValues({
-    title: graph.title,
-    description: graph.description,
-    url: graph.url,
-    icon: graph.metadata?.icon,
-    help: graph.metadata?.help,
-  });
+function toNodeHandlerMetadata(
+  graphToRun: GraphToRun,
+  url: NodeTypeIdentifier
+): NodeHandlerMetadata | undefined {
+  const graph = graphToRun.graph;
+  if (graphToRun.moduleId) {
+    const module = graph.modules?.[graphToRun.moduleId];
+    if (!module) return undefined;
+    const {
+      title = graphToRun.moduleId,
+      description,
+      icon,
+      help,
+    } = module.metadata || {};
+    return filterEmptyValues({ title, description, url, icon, help });
+  } else if (graphToRun.subGraphId) {
+    const descriptor = graph.graphs?.[graphToRun.subGraphId];
+    if (!descriptor) return undefined;
+    return filterEmptyValues({
+      title: descriptor.title,
+      description: descriptor.description,
+      url,
+      icon: descriptor.metadata?.icon,
+      help: descriptor.metadata?.help,
+    });
+  } else {
+    return filterEmptyValues({
+      title: graph.title,
+      description: graph.description,
+      url: graph.url,
+      icon: graph.metadata?.icon,
+      help: graph.metadata?.help,
+    });
+  }
 }
 
 /**

--- a/packages/breadboard/src/handler.ts
+++ b/packages/breadboard/src/handler.ts
@@ -102,8 +102,15 @@ export async function getGraphHandlerFromMutableGraph(
   const store = mutable.store;
   const result = store.addByURL(type, [], {
     outerGraph: mutable.graph,
-  }).mutable;
-  return new GraphBasedNodeHandler({ graph: result.graph }, type);
+  });
+  return new GraphBasedNodeHandler(
+    {
+      graph: result.mutable.graph,
+      subGraphId: result.graphId,
+      moduleId: result.moduleId,
+    },
+    type
+  );
 }
 
 export async function getGraphHandler(

--- a/packages/breadboard/src/inspector/graph-store.ts
+++ b/packages/breadboard/src/inspector/graph-store.ts
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { GraphDescriptor, GraphIdentifier } from "@breadboard-ai/types";
+import {
+  GraphDescriptor,
+  GraphIdentifier,
+  KitDescriptor,
+} from "@breadboard-ai/types";
 import { Graph as GraphEditor } from "../editor/graph.js";
 import {
   EditableGraph,
@@ -104,10 +108,28 @@ class GraphStore
           help: descriptor.metadata?.help,
           id: mainGraphId,
         });
-        return {
-          mainGraph: mutable.legacyKitMetadata || mainGraphMetadata,
-          ...mainGraphMetadata,
-        };
+        const exports: GraphStoreEntry[] = [];
+        if (descriptor.exports) {
+          for (const e of descriptor.exports) {
+            exports.push({
+              title: e,
+              url: `${descriptor.url}${e}`,
+              icon: descriptor.metadata?.icon,
+              tags: descriptor.metadata?.tags,
+              help: descriptor.metadata?.help,
+              mainGraph: mainGraphMetadata,
+            });
+          }
+        } else {
+          exports.push({
+            mainGraph:
+              (mutable.legacyKitMetadata as KitDescriptor & {
+                id: MainGraphIdentifier;
+              }) || mainGraphMetadata,
+            ...mainGraphMetadata,
+          });
+        }
+        return exports;
       })
       .filter(Boolean) as GraphStoreEntry[];
     return [...this.#legacyKits, ...graphs];

--- a/packages/breadboard/src/inspector/graph/graph-queries.ts
+++ b/packages/breadboard/src/inspector/graph/graph-queries.ts
@@ -7,6 +7,7 @@
 import {
   GraphDescriptor,
   GraphIdentifier,
+  ModuleIdentifier,
   NodeIdentifier,
   NodeTypeIdentifier,
 } from "@breadboard-ai/types";
@@ -21,6 +22,8 @@ import { createGraphNodeType } from "./kits.js";
 import { VirtualNode } from "./virtual-node.js";
 
 export { GraphQueries };
+
+const MODULE_EXPORT_PREFIX = "#module:";
 
 /**
  * Encapsulates common graph operations.
@@ -89,5 +92,25 @@ class GraphQueries {
       return undefined;
     }
     return createGraphNodeType(id, this.#cache);
+  }
+
+  moduleExports(): Set<ModuleIdentifier> {
+    const exports = this.#cache.graph.exports;
+    if (!exports) return new Set();
+    return new Set(
+      exports
+        .filter((e) => e.startsWith(MODULE_EXPORT_PREFIX))
+        .map((e) => e.slice(MODULE_EXPORT_PREFIX.length))
+    );
+  }
+
+  graphExports(): Set<GraphIdentifier> {
+    const exports = this.#cache.graph.exports;
+    if (!exports) return new Set();
+    return new Set(
+      exports
+        .filter((e) => !e.startsWith(MODULE_EXPORT_PREFIX))
+        .map((e) => e.slice(1))
+    );
   }
 }

--- a/packages/breadboard/src/inspector/graph/graph.ts
+++ b/packages/breadboard/src/inspector/graph/graph.ts
@@ -129,4 +129,12 @@ class Graph implements InspectableGraph {
   graphId(): GraphIdentifier {
     return this.#graphId;
   }
+
+  moduleExports(): Set<ModuleIdentifier> {
+    return new GraphQueries(this.#mutable, this.#graphId).moduleExports();
+  }
+
+  graphExports(): Set<GraphIdentifier> {
+    return new GraphQueries(this.#mutable, this.#graphId).graphExports();
+  }
 }

--- a/packages/breadboard/src/inspector/graph/kits.ts
+++ b/packages/breadboard/src/inspector/graph/kits.ts
@@ -8,6 +8,7 @@ import { toNodeHandlerMetadata } from "../../graph-based-node-handler.js";
 import { getGraphHandlerFromMutableGraph } from "../../handler.js";
 import {
   GraphDescriptor,
+  GraphToRun,
   Kit,
   NodeDescriberResult,
   NodeDescriptor,
@@ -311,7 +312,10 @@ class CustomNodeType implements InspectableNodeType {
     const graph = this.#mutable.store.addByURL(this.#type, [this.#mutable.id], {
       outerGraph: this.#mutable.graph,
     }).mutable;
-    return toNodeHandlerMetadata(graph.graph);
+    const graphToRun: GraphToRun = {
+      graph: graph.graph,
+    };
+    return toNodeHandlerMetadata(graphToRun, this.#type) || {};
   }
 
   async metadata(): Promise<NodeHandlerMetadata> {

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -342,6 +342,14 @@ export type InspectableGraph = {
    * this is a `DeclarativeGraph` instance.
    */
   main(): string | undefined;
+  /**
+   * Returns all module exports
+   */
+  moduleExports(): Set<ModuleIdentifier>;
+  /**
+   * Returns all graph exports
+   */
+  graphExports(): Set<GraphIdentifier>;
 };
 
 /**

--- a/packages/shared-ui/src/elements/overflow-menu/overflow-menu.ts
+++ b/packages/shared-ui/src/elements/overflow-menu/overflow-menu.ts
@@ -208,6 +208,14 @@ export class OverflowMenu extends LitElement {
       background-image: var(--bb-icon-minimize);
     }
 
+    button.checked {
+      background-image: var(--bb-icon-check);
+    }
+
+    button.unchecked {
+      background-image: var(--bb-icon-check-inverted);
+    }
+
     button.error {
       background-image: var(--bb-icon-error);
       color: var(--bb-warning-600);

--- a/packages/shared-ui/src/elements/overlay/board-details.ts
+++ b/packages/shared-ui/src/elements/overlay/board-details.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { LitElement, html, css, PropertyValues } from "lit";
+import { LitElement, html, css, PropertyValues, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { Overlay } from "./overlay.js";
 import { createRef, ref, Ref } from "lit/directives/ref.js";
@@ -42,6 +42,9 @@ export class BoardDetailsOverlay extends LitElement {
 
   @property()
   subGraphId: string | null = null;
+
+  @property()
+  moduleId: string | null = null;
 
   @property()
   location = { x: 100, y: 100, addHorizontalClickClearance: true };
@@ -445,7 +448,8 @@ export class BoardDetailsOverlay extends LitElement {
         data.get("status") as "published" | "draft" | null,
         data.get("tool") === "on",
         data.get("component") === "on",
-        this.subGraphId
+        this.subGraphId,
+        this.moduleId
       )
     );
   }
@@ -550,15 +554,17 @@ export class BoardDetailsOverlay extends LitElement {
                 .value=${this.boardTitle || ""}
               />
 
-              <label for="version">Version</label>
-              <input
-                id="version"
-                name="version"
-                pattern="\\d+\\.\\d+\\.\\d+"
-                type="text"
-                required
-                .value=${this.boardVersion || ""}
-              />
+              ${this.moduleId === null
+                ? html` <label for="version">Version</label>
+                    <input
+                      id="version"
+                      name="version"
+                      pattern="\\d+\\.\\d+\\.\\d+"
+                      type="text"
+                      required
+                      .value=${this.boardVersion || ""}
+                    />`
+                : nothing}
 
               <label for="description">Description</label>
               <textarea
@@ -567,63 +573,73 @@ export class BoardDetailsOverlay extends LitElement {
                 .value=${this.boardDescription || ""}
               ></textarea>
 
-              <label for="status">Status</label>
-              <select
-                @input=${(evt: Event) => {
-                  if (!(evt.target instanceof HTMLSelectElement)) {
-                    return;
-                  }
+              ${this.moduleId === null
+                ? html` <label for="status">Status</label>
+                    <select
+                      @input=${(evt: Event) => {
+                        if (!(evt.target instanceof HTMLSelectElement)) {
+                          return;
+                        }
 
-                  if (this.boardPublished && evt.target.value !== "published") {
-                    if (
-                      !confirm(
-                        "This board was published. Unpublishing it may break other boards. Are you sure?"
-                      )
-                    ) {
-                      evt.preventDefault();
-                      evt.target.value = "published";
-                    }
-                  }
-                }}
-                id="status"
-                name="status"
-                .value=${this.boardPublished ? "published" : "draft"}
-              >
-                <option value="draft" ?selected=${!this.boardPublished}>
-                  Draft
-                </option>
-                <option value="published" ?selected=${this.boardPublished}>
-                  Published
-                </option>
-              </select>
+                        if (
+                          this.boardPublished &&
+                          evt.target.value !== "published"
+                        ) {
+                          if (
+                            !confirm(
+                              "This board was published. Unpublishing it may break other boards. Are you sure?"
+                            )
+                          ) {
+                            evt.preventDefault();
+                            evt.target.value = "published";
+                          }
+                        }
+                      }}
+                      id="status"
+                      name="status"
+                      .value=${this.boardPublished ? "published" : "draft"}
+                    >
+                      <option value="draft" ?selected=${!this.boardPublished}>
+                        Draft
+                      </option>
+                      <option
+                        value="published"
+                        ?selected=${this.boardPublished}
+                      >
+                        Published
+                      </option>
+                    </select>
 
-              <label class="component" for="is-component">Component</label>
-              <div class="additional-items">
-                <input
-                  id="is-component"
-                  name="component"
-                  type="checkbox"
-                  .value="on"
-                  .checked=${this.boardIsComponent}
-                />
-                <label for="is-component"
-                  >Show this in the Board Server Components list?</label
-                >
-              </div>
+                    <label class="component" for="is-component"
+                      >Component</label
+                    >
+                    <div class="additional-items">
+                      <input
+                        id="is-component"
+                        name="component"
+                        type="checkbox"
+                        .value="on"
+                        .checked=${this.boardIsComponent}
+                      />
+                      <label for="is-component"
+                        >Show this in the Board Server Components list?</label
+                      >
+                    </div>
 
-              <label for="is-tool">Tool</label>
-              <div class="additional-items">
-                <input
-                  id="is-tool"
-                  name="tool"
-                  type="checkbox"
-                  .value="on"
-                  .checked=${this.boardIsComponent}
-                />
-                <label for="is-tool"
-                  >Show this as a tool for Specialists?</label
-                >
-              </div>
+                    <label for="is-tool">Tool</label>
+                    <div class="additional-items">
+                      <input
+                        id="is-tool"
+                        name="tool"
+                        type="checkbox"
+                        .value="on"
+                        .checked=${this.boardIsComponent}
+                      />
+                      <label for="is-tool"
+                        >Show this as a tool for Specialists?</label
+                      >
+                    </div>`
+                : nothing}
             </form>
           </div>
         </div>

--- a/packages/shared-ui/src/elements/workspace-outline/workspace-outline.ts
+++ b/packages/shared-ui/src/elements/workspace-outline/workspace-outline.ts
@@ -777,9 +777,15 @@ export class WorkspaceOutline
       module: InspectableModule,
       exported: boolean
     ): Outline => {
+      let title = module.metadata().title;
+      if (!title || title === id) {
+        title = id;
+      } else {
+        title = `${title} (${id})`;
+      }
       return {
         type: "imperative",
-        title: module.metadata().title ?? id,
+        title,
         items: {
           nodes: [],
           ports: new Map(),

--- a/packages/shared-ui/src/elements/workspace-outline/workspace-outline.ts
+++ b/packages/shared-ui/src/elements/workspace-outline/workspace-outline.ts
@@ -1342,6 +1342,13 @@ export class WorkspaceOutline
                           value: id,
                         });
                       }
+                    } else {
+                      actions.push({
+                        title: "Edit Module Information",
+                        name: "edit-module-details",
+                        icon: "edit-board-details",
+                        value: id,
+                      });
                     }
 
                     actions.push(

--- a/packages/shared-ui/src/events/events.ts
+++ b/packages/shared-ui/src/events/events.ts
@@ -547,6 +547,21 @@ export class ModuleCreateEvent extends Event {
 }
 
 /**
+ * Exports management
+ */
+
+export class ToggleExportEvent extends Event {
+  static eventName = "bbtoggleexport";
+
+  constructor(
+    public readonly exportId: ModuleIdentifier | GraphIdentifier,
+    public readonly exportType: "imperative" | "declarative"
+  ) {
+    super(ToggleExportEvent.eventName, { ...eventInit });
+  }
+}
+
+/**
  * Board Servers
  */
 

--- a/packages/shared-ui/src/events/events.ts
+++ b/packages/shared-ui/src/events/events.ts
@@ -116,7 +116,8 @@ export class BoardInfoUpdateEvent extends Event {
     public readonly status: "published" | "draft" | null = null,
     public readonly isTool: boolean | null = null,
     public readonly isComponent: boolean | null = null,
-    public readonly subGraphId: string | null = null
+    public readonly subGraphId: string | null = null,
+    public readonly moduleId: string | null = null
   ) {
     super(BoardInfoUpdateEvent.eventName, { ...eventInit });
   }

--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@breadboard-ai/visual-editor",
-  "version": "1.24.3",
+  "version": "1.24.4",
   "description": "The Visual Editor for Breadboard",
   "main": "./build/index.js",
   "exports": {

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -62,7 +62,12 @@ import {
 } from "@breadboard-ai/connection-client";
 
 import { sandbox } from "./sandbox";
-import { InputValues, Module, ModuleIdentifier } from "@breadboard-ai/types";
+import {
+  GraphIdentifier,
+  InputValues,
+  Module,
+  ModuleIdentifier,
+} from "@breadboard-ai/types";
 import { KeyboardCommand, KeyboardCommandDeps } from "./commands/types";
 import {
   CopyCommand,
@@ -1815,6 +1820,17 @@ export class Main extends LitElement {
     this.#runtime.edit.createModule(this.tab, moduleId, newModule);
   }
 
+  #attemptToggleExport(
+    id: ModuleIdentifier | GraphIdentifier,
+    type: "imperative" | "declarative"
+  ) {
+    if (!this.tab) {
+      return;
+    }
+
+    this.#runtime.edit.toggleExport(this.tab, id, type);
+  }
+
   #showBoardEditOverlay(
     tab = this.tab,
     x: number | null,
@@ -3349,6 +3365,11 @@ export class Main extends LitElement {
                   evt.code,
                   evt.metadata
                 );
+              }}
+              @bbtoggleexport=${(
+                evt: BreadboardUI.Events.ToggleExportEvent
+              ) => {
+                this.#attemptToggleExport(evt.exportId, evt.exportType);
               }}
               @bbnoderunrequest=${async (
                 evt: BreadboardUI.Events.NodeRunRequestEvent

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -190,6 +190,7 @@ export class Main extends LitElement {
     isTool: boolean | null;
     isComponent: boolean | null;
     subGraphId: string | null;
+    moduleId: string | null;
     x: number | null;
     y: number | null;
   } | null = null;
@@ -338,7 +339,8 @@ export class Main extends LitElement {
           this.tab,
           100,
           50,
-          this.tab?.subGraphId ?? null
+          this.tab?.subGraphId ?? null,
+          null
         );
       },
     },
@@ -1629,6 +1631,14 @@ export class Main extends LitElement {
         evt.isTool,
         evt.isComponent
       );
+    }
+    if (evt.moduleId) {
+      await this.#runtime.edit.updateModuleInfo(
+        tab,
+        evt.moduleId,
+        evt.title,
+        evt.description
+      );
     } else {
       this.#runtime.edit.updateBoardInfo(
         tab,
@@ -1835,9 +1845,34 @@ export class Main extends LitElement {
     tab = this.tab,
     x: number | null,
     y: number | null,
-    subGraphId: string | null
+    subGraphId: string | null,
+    moduleId: string | null
   ) {
     if (!tab) {
+      return;
+    }
+
+    if (moduleId) {
+      const module = tab.graph.modules?.[moduleId];
+      if (!module) {
+        return;
+      }
+
+      const { metadata } = module;
+
+      this.boardEditOverlayInfo = {
+        tabId: tab.id,
+        description: metadata?.description ?? "",
+        isTool: false,
+        isComponent: false,
+        published: false,
+        subGraphId,
+        moduleId,
+        title: metadata?.title ?? "",
+        version: "",
+        x,
+        y,
+      };
       return;
     }
 
@@ -1856,6 +1891,7 @@ export class Main extends LitElement {
       isComponent: metadata?.tags?.includes("component") ?? false,
       published: metadata?.tags?.includes("published") ?? false,
       subGraphId,
+      moduleId,
       title: title ?? "",
       version: version ?? "",
       x,
@@ -1989,6 +2025,7 @@ export class Main extends LitElement {
             .boardIsTool=${this.boardEditOverlayInfo.isTool}
             .boardIsComponent=${this.boardEditOverlayInfo.isComponent}
             .subGraphId=${this.boardEditOverlayInfo.subGraphId}
+            .moduleId=${this.boardEditOverlayInfo.moduleId}
             .location=${location}
             @bboverlaydismissed=${() => {
               this.boardEditOverlayInfo = null;
@@ -2620,7 +2657,7 @@ export class Main extends LitElement {
 
               switch (actionEvt.action) {
                 case "edit-board-details": {
-                  this.#showBoardEditOverlay(tab, x, y, null);
+                  this.#showBoardEditOverlay(tab, x, y, null, null);
                   break;
                 }
 
@@ -2941,7 +2978,8 @@ export class Main extends LitElement {
                           this.tab,
                           evt.clientX,
                           evt.clientY,
-                          this.tab.subGraphId
+                          this.tab.subGraphId,
+                          null
                         );
                       }}
                     >
@@ -3260,6 +3298,18 @@ export class Main extends LitElement {
                       this.tab,
                       evt.x ?? null,
                       evt.y ?? null,
+                      evt.value,
+                      null
+                    );
+                    break;
+                  }
+
+                  case "edit-module-details": {
+                    this.#showBoardEditOverlay(
+                      this.tab,
+                      evt.x ?? null,
+                      evt.y ?? null,
+                      null,
                       evt.value
                     );
                     break;

--- a/packages/visual-editor/src/runtime/edit.ts
+++ b/packages/visual-editor/src/runtime/edit.ts
@@ -341,6 +341,34 @@ export class Edit extends EventTarget {
     // editableGraph.replaceGraph(subGraphId, subGraphDescriptor);
   }
 
+  async updateModuleInfo(
+    tab: Tab | null,
+    moduleId: string,
+    title: string,
+    description: string
+  ) {
+    const editableGraph = this.getEditor(tab);
+    if (!editableGraph) {
+      this.dispatchEvent(
+        new RuntimeErrorEvent("Unable to edit module; no active board")
+      );
+      return;
+    }
+
+    const module = editableGraph.inspect("").moduleById(moduleId);
+    if (!module) {
+      return null;
+    }
+
+    const code = module.code();
+    const metadata = { ...module.metadata() };
+
+    metadata.title = title;
+    metadata.description = description;
+
+    this.editModule(tab, moduleId, code, metadata);
+  }
+
   deleteComment(tab: Tab | null, id: string) {
     if (!tab) {
       this.dispatchEvent(new RuntimeErrorEvent("Unable to find tab"));

--- a/packages/visual-editor/src/runtime/edit.ts
+++ b/packages/visual-editor/src/runtime/edit.ts
@@ -655,6 +655,23 @@ export class Edit extends EventTarget {
     );
   }
 
+  toggleExport(
+    tab: Tab,
+    id: ModuleIdentifier | GraphIdentifier,
+    exportType: "imperative" | "declarative"
+  ) {
+    const editableGraph = this.getEditor(tab);
+    if (!editableGraph) {
+      this.dispatchEvent(new RuntimeErrorEvent("Unable to edit graph"));
+      return null;
+    }
+
+    editableGraph.edit(
+      [{ type: "toggleexport", exportType, id }],
+      `Toggle export for ${exportType} graph "${id}"`
+    );
+  }
+
   updateBoardInfo(
     tab: Tab | null,
     title: string,


### PR DESCRIPTION
- **Make it possible to add/remove exports in BGL (and add a typical for me gross UI).**
- **Hacky support for exports in `GraphStore.graphs`.**
- **Add support for editing module metadata.**
- **Teach inspector to get metadata for sub-graphs and modules.**
- **Display both title and id for modules in project view.**
- **docs(changeset): Teach Breadboard to recognize and edit BGL exports.**
