### PR TITLE
[bbrt] Support running breadboard components directly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25514,7 +25514,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
-        "@breadboard-ai/google-drive-kit": "^0.4.0",
+        "@breadboard-ai/google-drive-kit": "0.4.0",
         "@breadboard-ai/shared-ui": "1.21.0",
         "@google-labs/agent-kit": "^0.14.0",
         "@google-labs/breadboard": "^0.30.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25514,6 +25514,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "@breadboard-ai/google-drive-kit": "^0.4.0",
         "@breadboard-ai/shared-ui": "1.21.0",
         "@google-labs/agent-kit": "^0.14.0",
         "@google-labs/breadboard": "^0.30.0",

--- a/packages/bbrt/package.json
+++ b/packages/bbrt/package.json
@@ -61,6 +61,7 @@
         "../breadboard:build",
         "../core-kit:build",
         "../gemini-kit:build",
+        "../google-drive-kit:build",
         "../json-kit:build",
         "../shared-ui:build",
         "../template-kit:build"
@@ -70,6 +71,7 @@
       "command": "tsc --pretty",
       "dependencies": [
         "../agent-kit:build",
+        "../google-drive-kit:build",
         "../breadboard:build:tsc",
         "../core-kit:build:tsc",
         "../gemini-kit:build:tsc",
@@ -125,6 +127,7 @@
     }
   },
   "dependencies": {
+    "@breadboard-ai/google-drive-kit": "^0.4.0",
     "@breadboard-ai/shared-ui": "1.21.0",
     "@google-labs/agent-kit": "^0.14.0",
     "@google-labs/breadboard": "^0.30.0",

--- a/packages/bbrt/package.json
+++ b/packages/bbrt/package.json
@@ -127,7 +127,7 @@
     }
   },
   "dependencies": {
-    "@breadboard-ai/google-drive-kit": "^0.4.0",
+    "@breadboard-ai/google-drive-kit": "0.4.0",
     "@breadboard-ai/shared-ui": "1.21.0",
     "@google-labs/agent-kit": "^0.14.0",
     "@google-labs/breadboard": "^0.30.0",

--- a/packages/bbrt/src/breadboard/breadboard-component-tool.ts
+++ b/packages/bbrt/src/breadboard/breadboard-component-tool.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  type GraphDescriptor,
+  type Kit,
+  type NodeDescriberFunction,
+  type NodeDescriptor,
+  type NodeHandler,
+} from "@google-labs/breadboard";
+import type { ArtifactHandle } from "../artifacts/artifact-interface.js";
+import type { ArtifactStore } from "../artifacts/artifact-store.js";
+import type { SecretsProvider } from "../secrets/secrets-provider.js";
+import type {
+  BBRTTool,
+  BBRTToolAPI,
+  BBRTToolMetadata,
+} from "../tools/tool-types.js";
+import type { JsonSerializableObject } from "../util/json-serializable.js";
+import type { Result } from "../util/result.js";
+import { BreadboardToolInvocation } from "./breadboard-tool.js";
+import { makeToolSafeName } from "./make-tool-safe-name.js";
+
+export class BreadboardComponentTool implements BBRTTool {
+  readonly #kit: Kit;
+  readonly #id: string;
+  readonly #describe?: NodeDescriberFunction;
+  readonly #secrets: SecretsProvider;
+  readonly #artifacts: ArtifactStore;
+  readonly #kits: Kit[];
+
+  constructor(
+    kit: Kit,
+    id: string,
+    handler: NodeHandler,
+    secrets: SecretsProvider,
+    artifacts: ArtifactStore,
+    kits: Kit[]
+  ) {
+    this.#kit = kit;
+    this.#id = id;
+    this.#secrets = secrets;
+    this.#artifacts = artifacts;
+    this.#kits = kits;
+    if ("describe" in handler) {
+      this.#describe = handler.describe;
+    }
+  }
+
+  get metadata(): BBRTToolMetadata {
+    return {
+      id: makeToolSafeName(`${this.#kit.url}_${this.#id}`),
+      title: `${this.#kit.title}: ${this.#id}`,
+      description: "TODO",
+      icon: "/bbrt/images/tool.svg",
+    };
+  }
+
+  async api(): Promise<Result<BBRTToolAPI>> {
+    if (this.#describe) {
+      return { ok: true, value: (await this.#describe()) as BBRTToolAPI };
+    }
+    return {
+      ok: true,
+      value: {
+        inputSchema: {},
+        outputSchema: {},
+      },
+    };
+  }
+
+  execute(args: JsonSerializableObject) {
+    return { result: this.#execute(args) };
+  }
+
+  async #execute(
+    args: JsonSerializableObject
+  ): Promise<
+    Result<{ data: JsonSerializableObject; artifacts: ArtifactHandle[] }>
+  > {
+    const component: NodeDescriptor = {
+      id: "component",
+      type: this.#id,
+      configuration: args,
+    };
+    const bgl: GraphDescriptor = {
+      nodes: [component],
+      edges: [],
+    };
+    const invocation = new BreadboardToolInvocation(
+      args,
+      async () => ({ ok: true, value: bgl }),
+      this.#secrets,
+      this.#artifacts,
+      this.#kits
+    );
+    await invocation.start();
+    const state = invocation.state.get();
+    if (state.status === "success") {
+      return {
+        ok: true,
+        value: {
+          data: state.value.output as JsonSerializableObject,
+          artifacts: state.value.artifacts,
+        },
+      };
+    } else if (state.status === "error") {
+      return { ok: false, error: state.error };
+    } else {
+      state.status satisfies "running" | "unstarted";
+      return { ok: false, error: `Internal error: state was ${state.status}` };
+    }
+  }
+}

--- a/packages/bbrt/src/breadboard/make-tool-safe-name.ts
+++ b/packages/bbrt/src/breadboard/make-tool-safe-name.ts
@@ -9,5 +9,5 @@
  * OpenAI requires [a-zA-Z0-9_\-]{1,??}
  */
 export function makeToolSafeName(path: string) {
-  return path.replace(/[^a-zA-Z0-9_\\-]/g, "").slice(0, 63);
+  return path.replace(/[^a-zA-Z0-9_\\-]/g, "_").slice(0, 63);
 }


### PR DESCRIPTION
Regular breadboard components (e.g. GeminiKit, GoogleDriveKit) can now be executed directly by the main conversation. (Boards from the board server could already be executed).