### PR TITLE
[unified-server] Update NODE_ENV on Dockerfile

### DIFF
--- a/packages/unified-server/Dockerfile
+++ b/packages/unified-server/Dockerfile
@@ -5,5 +5,7 @@ COPY . .
 RUN npm install --save-dev @types/express
 RUN npm run build
 
+ENV NODE_ENV="production"
 EXPOSE 3000
+
 CMD ["node", "dist/src/server/main.js"]


### PR DESCRIPTION
This value has to be set to "production" to prevent ViteExpress from
trying to use the Vite dev server to serve client-side artifacts.

Part of #3913
