### PR TITLE
[visual-editor, shared-ui] Move SettingsStore into shared-ui

### DIFF
--- a/.changeset/moody-olives-learn.md
+++ b/.changeset/moody-olives-learn.md
@@ -1,0 +1,7 @@
+---
+"@breadboard-ai/visual-editor": minor
+"@breadboard-ai/board-server": minor
+"@breadboard-ai/shared-ui": minor
+---
+
+Move SettingsStore into @breadboard-ai/shared-ui package

--- a/packages/board-server/experimental/editor.html
+++ b/packages/board-server/experimental/editor.html
@@ -11,7 +11,7 @@
   <script type="module">
     import * as pkg from ".././package.json";
     import { Main } from "../../visual-editor/src/index.ts";
-    import { SettingsStore } from "../../visual-editor/src/data/settings-store.ts";
+    import { SettingsStore } from "../../shared-ui/src/data/settings-store.ts";
 
     const config = {
       settings: SettingsStore.instance(),

--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -12,6 +12,10 @@
       "default": "./dist/elements/connection/connection-broker.js",
       "types": "./dist/elements/connection/connection-broker.d.ts"
     },
+    "./data/settings-store.js": {
+      "default": "./dist/data/settings-store.js",
+      "types": "./dist/data/settings-store.d.ts"
+    },
     "./editor": {
       "types": "./dist/elements/editor/editor.d.ts",
       "default": "./dist/elements/editor/editor.js"

--- a/packages/shared-ui/src/data/settings-store.ts
+++ b/packages/shared-ui/src/data/settings-store.ts
@@ -5,14 +5,14 @@
  */
 
 import * as idb from "idb";
-import * as BreadboardUI from "@breadboard-ai/shared-ui";
+import * as BreadboardUI_Types from "../types/types.js";
 
-interface SettingsDB extends BreadboardUI.Types.SettingsList, idb.DBSchema {}
+interface SettingsDB extends BreadboardUI_Types.SettingsList, idb.DBSchema {}
 
 const SETTINGS_NAME = "settings";
 const SETTINGS_VERSION = 7;
 
-export class SettingsStore implements BreadboardUI.Types.SettingsStore {
+export class SettingsStore implements BreadboardUI_Types.SettingsStore {
   static #instance: SettingsStore;
   static instance() {
     if (!this.#instance) {
@@ -21,8 +21,8 @@ export class SettingsStore implements BreadboardUI.Types.SettingsStore {
     return this.#instance;
   }
 
-  #settings: BreadboardUI.Types.Settings = {
-    [BreadboardUI.Types.SETTINGS_TYPE.GENERAL]: {
+  #settings: BreadboardUI_Types.Settings = {
+    [BreadboardUI_Types.SETTINGS_TYPE.GENERAL]: {
       configuration: {
         extensible: false,
         description: `General Breadboard settings`,
@@ -188,7 +188,7 @@ export class SettingsStore implements BreadboardUI.Types.SettingsStore {
         ],
       ]),
     },
-    [BreadboardUI.Types.SETTINGS_TYPE.SECRETS]: {
+    [BreadboardUI_Types.SETTINGS_TYPE.SECRETS]: {
       configuration: {
         extensible: true,
         description: `Secrets that you want to store locally, such as API keys. When calling an API, the API provider's applicable privacy policy and terms apply. Please note that items in this list should have unique names. `,
@@ -197,7 +197,7 @@ export class SettingsStore implements BreadboardUI.Types.SettingsStore {
       },
       items: new Map([]),
     },
-    [BreadboardUI.Types.SETTINGS_TYPE.INPUTS]: {
+    [BreadboardUI_Types.SETTINGS_TYPE.INPUTS]: {
       configuration: {
         extensible: true,
         description: `Inputs that the boards ask for in the middle of the run (also known as "bubbled inputs"), such as model names`,
@@ -206,7 +206,7 @@ export class SettingsStore implements BreadboardUI.Types.SettingsStore {
       },
       items: new Map([]),
     },
-    [BreadboardUI.Types.SETTINGS_TYPE.NODE_PROXY_SERVERS]: {
+    [BreadboardUI_Types.SETTINGS_TYPE.NODE_PROXY_SERVERS]: {
       configuration: {
         extensible: true,
         description:
@@ -216,7 +216,7 @@ export class SettingsStore implements BreadboardUI.Types.SettingsStore {
       },
       items: new Map([]),
     },
-    [BreadboardUI.Types.SETTINGS_TYPE.CONNECTIONS]: {
+    [BreadboardUI_Types.SETTINGS_TYPE.CONNECTIONS]: {
       configuration: {
         extensible: false,
         description:
@@ -233,24 +233,24 @@ export class SettingsStore implements BreadboardUI.Types.SettingsStore {
     return structuredClone(this.#settings);
   }
 
-  getSection(section: BreadboardUI.Types.SETTINGS_TYPE) {
+  getSection(section: BreadboardUI_Types.SETTINGS_TYPE) {
     return this.#settings[section];
   }
 
-  getItem(section: BreadboardUI.Types.SETTINGS_TYPE, name: string) {
+  getItem(section: BreadboardUI_Types.SETTINGS_TYPE, name: string) {
     return this.#settings[section].items.get(name);
   }
 
   private constructor() {}
 
-  async save(settings: BreadboardUI.Types.Settings) {
+  async save(settings: BreadboardUI_Types.Settings) {
     const settingsDb = await idb.openDB<SettingsDB>(
       SETTINGS_NAME,
       SETTINGS_VERSION
     );
 
     for (const [store, data] of Object.entries(settings)) {
-      const settingsStore = store as BreadboardUI.Types.SETTINGS_TYPE;
+      const settingsStore = store as BreadboardUI_Types.SETTINGS_TYPE;
       if (settingsDb.objectStoreNames.contains(settingsStore)) {
         await settingsDb.clear(settingsStore);
       }
@@ -278,7 +278,7 @@ export class SettingsStore implements BreadboardUI.Types.SettingsStore {
         upgrade(db) {
           settingsFound = false;
           for (const groupName of Object.keys(settings)) {
-            const name = groupName as BreadboardUI.Types.SETTINGS_TYPE;
+            const name = groupName as BreadboardUI_Types.SETTINGS_TYPE;
             if (db.objectStoreNames.contains(name)) continue;
             db.createObjectStore(name, {
               keyPath: "id",
@@ -298,7 +298,7 @@ export class SettingsStore implements BreadboardUI.Types.SettingsStore {
         }
 
         if (
-          store === BreadboardUI.Types.SETTINGS_TYPE.GENERAL &&
+          store === BreadboardUI_Types.SETTINGS_TYPE.GENERAL &&
           !this.#settings[store].items.get(item.name)
         ) {
           skippedSettings = true;

--- a/packages/visual-editor/index.html
+++ b/packages/visual-editor/index.html
@@ -36,7 +36,9 @@
       await StringsHelper.initFrom(LANGUAGE_PACK);
 
       const { Main } = await import("./src/index.ts");
-      const { SettingsStore } = await import("./src/data/settings-store.ts");
+      const { SettingsStore } = await import(
+        "@breadboard-ai/shared-ui/data/settings-store.js"
+      );
 
       const config = {
         settings: SettingsStore.instance(),

--- a/packages/visual-editor/src/data/node-proxy-servers.ts
+++ b/packages/visual-editor/src/data/node-proxy-servers.ts
@@ -5,7 +5,7 @@
  */
 
 import { HarnessProxyConfig, RunConfig } from "@google-labs/breadboard/harness";
-import { SettingsStore } from "./settings-store";
+import { SettingsStore } from "@breadboard-ai/shared-ui/data/settings-store.js";
 import * as BreadboardUI from "@breadboard-ai/shared-ui";
 
 type SettingEntry = {

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -40,7 +40,7 @@ import {
 } from "@breadboard-ai/data-store";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
-import { SettingsStore } from "./data/settings-store";
+import { SettingsStore } from "@breadboard-ai/shared-ui/data/settings-store.js";
 import { addNodeProxyServerConfig } from "./data/node-proxy-servers";
 import { provide } from "@lit/context";
 import { RecentBoardStore } from "./data/recent-boards";

--- a/packages/visual-editor/src/utils/secrets-helper.ts
+++ b/packages/visual-editor/src/utils/secrets-helper.ts
@@ -5,7 +5,7 @@
  */
 
 import { InputValues } from "@google-labs/breadboard";
-import { SettingsStore } from "../data/settings-store";
+import { SettingsStore } from "@breadboard-ai/shared-ui/data/settings-store.js";
 import * as BreadboardUI from "@breadboard-ai/shared-ui";
 
 export class SecretsHelper {

--- a/packages/visual-editor/src/utils/settings-helper.ts
+++ b/packages/visual-editor/src/utils/settings-helper.ts
@@ -5,7 +5,7 @@
  */
 
 import * as BreadboardUI from "@breadboard-ai/shared-ui";
-import { SettingsStore } from "../data/settings-store";
+import { SettingsStore } from "@breadboard-ai/shared-ui/data/settings-store.js";
 
 export class SettingsHelperImpl implements BreadboardUI.Types.SettingsHelper {
   #store: SettingsStore;


### PR DESCRIPTION
It's a very useful class (I needed it for bbrt) and there's already some settings related stuff in shared-ui, so it seems to fit.