### PR TITLE
[connection-server] Factor server creation into a function 

### DIFF
--- a/.changeset/twenty-years-leave.md
+++ b/.changeset/twenty-years-leave.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/connection-server": patch
+---
+
+refactor connection server startup

--- a/packages/connection-server/src/index.ts
+++ b/packages/connection-server/src/index.ts
@@ -4,10 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import express from "express";
 import { env } from "node:process";
 import { loadConnections, type ServerConfig } from "./config.js";
-import { startServer } from "./server.js";
+import { createServer } from "./server.js";
 
 const configPath = process.env["CONNECTIONS_FILE"];
 const config: ServerConfig = {
@@ -42,13 +41,22 @@ if (config.allowedOrigins.length === 0) {
 `
   );
 }
-const host = env.HOST || "localhost";
 const port = env.PORT ? Number(env.PORT) : 5555;
 
-const app = express();
-
 try {
-  startServer(port, config);
+  const app = createServer(config);
+
+  app.listen(port, () => {
+    console.info(
+      `
+┌─────────────────────────────────────────────────────────────────────────┐
+│ Breadboard Connection Server                                            │
+├─────────────────────────────────────────────────────────────────────────┘
+│ Listening on port ${port}...
+└──────────────────────────────────────────────────────────────────────────
+`
+    );
+  });
 } catch (e) {
   console.error(e);
   if ((e as { code?: string }).code === "EADDRINUSE") {

--- a/packages/connection-server/src/server.ts
+++ b/packages/connection-server/src/server.ts
@@ -13,7 +13,7 @@ import { list } from "./api/list.js";
 import { refresh } from "./api/refresh.js";
 import type { ServerConfig } from "./config.js";
 
-export function startServer(port: number, config: ServerConfig) {
+export function createServer(config: ServerConfig) {
   const app = express();
 
   app.use(
@@ -41,15 +41,5 @@ export function startServer(port: number, config: ServerConfig) {
     refresh(req, res, config)
   );
 
-  app.listen(port, () => {
-    console.info(
-      `
-┌─────────────────────────────────────────────────────────────────────────┐
-│ Breadboard Connection Server                                            │
-├─────────────────────────────────────────────────────────────────────────┘
-│ Listening on port ${port}...
-└──────────────────────────────────────────────────────────────────────────
-`
-    );
-  });
+  return app;
 }

--- a/packages/connection-server/src/server.ts
+++ b/packages/connection-server/src/server.ts
@@ -5,7 +5,7 @@
  */
 
 import cors from "cors";
-import express from "express";
+import express, { type Express } from "express";
 import type { Request, Response } from "express";
 
 import { grant } from "./api/grant.js";
@@ -13,7 +13,7 @@ import { list } from "./api/list.js";
 import { refresh } from "./api/refresh.js";
 import type { ServerConfig } from "./config.js";
 
-export function createServer(config: ServerConfig) {
+export function createServer(config: ServerConfig): Express {
   const app = express();
 
   app.use(


### PR DESCRIPTION
Change the startServer function to createServer, and then start it from
the main startup routine.

This allows the app creation to be accessed by external callers, who can
then embed it in other contexts (like the unified server)

Part of #3913 