### PR TITLE
[shared-ui/llm-output] Add "Save to Drive" button to App view content

### DIFF
--- a/.changeset/clever-spoons-draw.md
+++ b/.changeset/clever-spoons-draw.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/shared-ui": patch
+---
+
+Add "Save to Drive" button to App view content

--- a/package-lock.json
+++ b/package-lock.json
@@ -27188,6 +27188,7 @@
         "@dagrejs/dagre": "^1.1.4",
         "@google-labs/breadboard": "^0.31.0",
         "@google-labs/breadboard-schema": "^1.11.0",
+        "@google-labs/core-kit": "^0.17.1",
         "@lit/context": "^1.1.3",
         "@lit/task": "^1.0.1",
         "@pixi/math-extras": "^7.4.2",

--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -42,6 +42,7 @@
         "../breadboard:build",
         "../build:build",
         "../connection-client:build",
+        "../core-kit:build",
         "../data-store:build",
         "../schema:build",
         "../jsandbox:build",
@@ -53,6 +54,7 @@
         "../breadboard:build:tsc",
         "../build:build:tsc",
         "../connection-client:build",
+        "../core-kit:build",
         "../data-store:build:tsc",
         "../schema:build:tsc",
         "../types:build:tsc"
@@ -129,6 +131,7 @@
     "@dagrejs/dagre": "^1.1.4",
     "@google-labs/breadboard": "^0.31.0",
     "@google-labs/breadboard-schema": "^1.11.0",
+    "@google-labs/core-kit": "^0.17.1",
     "@lit/context": "^1.1.3",
     "@lit/task": "^1.0.1",
     "@pixi/math-extras": "^7.4.2",

--- a/packages/shared-ui/src/elements/google-drive/append-to-doc-using-drive-kit.ts
+++ b/packages/shared-ui/src/elements/google-drive/append-to-doc-using-drive-kit.ts
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { TokenVendor } from "@breadboard-ai/connection-client";
+import GoogleDriveKit from "@breadboard-ai/google-drive-kit/google-drive.kit.json" with { type: "json" };
+import { WebSandbox } from "@breadboard-ai/jsandbox/web";
+import type {
+  GraphDescriptor,
+  LLMContent,
+  NodeValue,
+} from "@breadboard-ai/types";
+import {
+  addSandboxedRunModule,
+  asRuntimeKit,
+  createDefaultDataStore,
+  createLoader,
+  type OutputValues,
+} from "@google-labs/breadboard";
+import { createRunner } from "@google-labs/breadboard/harness";
+import CoreKit from "@google-labs/core-kit";
+import webSandboxWasm from "/sandbox.wasm?url";
+
+/**
+ * Finds or creates a Google Doc in the root of the signed-in user's Google
+ * Drive using the title as a key, and appends the given content to it.
+ */
+export async function appendToDocUsingDriveKit(
+  context: LLMContent,
+  title: string,
+  tokenVendor: TokenVendor
+): Promise<{ fileId: string; url: string }> {
+  const runner = createRunner({
+    url: window.location.href,
+    kits: addSandboxedRunModule(
+      new WebSandbox(new URL(webSandboxWasm, window.location.href)),
+      [asRuntimeKit(CoreKit)]
+    ),
+    runner: GoogleDriveKit.graphs.appendToDoc as GraphDescriptor,
+    loader: createLoader(),
+    store: createDefaultDataStore(),
+    interactiveSecrets: true,
+  });
+
+  const outputs = await new Promise<OutputValues[]>((resolve, reject) => {
+    const outputs: OutputValues[] = [];
+    runner.addEventListener("input", () => {
+      void runner.run({ context: [context as NodeValue], title });
+    });
+    runner.addEventListener("output", (event) => {
+      outputs.push(event.data.outputs);
+    });
+    runner.addEventListener("end", () => {
+      resolve(outputs);
+    });
+    runner.addEventListener("error", (event) => {
+      reject(event.data.error);
+    });
+    runner.addEventListener("secret", async (event) => {
+      const secrets = await getSecrets(event.data.keys, tokenVendor);
+      void runner.run(secrets);
+    });
+    void runner.run();
+  });
+
+  if (outputs.length !== 1) {
+    throw new Error(`Expected 1 output, got ${JSON.stringify(outputs)}`);
+  }
+  const first: { id?: unknown } = outputs[0];
+  const fileId = first.id;
+  if (!fileId || typeof fileId !== "string") {
+    throw new Error(
+      `Expected {"id": "<fileId>"}, got ${JSON.stringify(first)}`
+    );
+  }
+  return {
+    fileId,
+    url: `https://docs.google.com/document/d/${fileId}/edit`,
+  };
+}
+
+async function getSecrets(
+  names: string[],
+  tokenVendor: TokenVendor
+): Promise<Record<string, string>> {
+  return Object.fromEntries(
+    await Promise.all(
+      names.map(async (name) => [name, await getSecret(name, tokenVendor)])
+    )
+  );
+}
+
+async function getSecret(
+  name: string,
+  tokenVendor: TokenVendor
+): Promise<string> {
+  if (name.startsWith("connection:")) {
+    const connectionId = name.slice("connection:".length);
+    const token = tokenVendor.getToken(connectionId);
+    if (token.state === "valid") {
+      return token.grant.access_token;
+    } else if (token.state === "expired") {
+      return (await token.refresh()).grant.access_token;
+    } else if (token.state === "signedout") {
+      throw new Error(
+        `You must sign in to ${JSON.stringify(connectionId)} through settings.`
+      );
+    } else {
+      throw new Error(`Unexpected token state`, token satisfies never);
+    }
+  } else {
+    throw new Error(
+      `Unexpected non-connection secret ${JSON.stringify(name)}.`
+    );
+  }
+}


### PR DESCRIPTION
Adds a "Save to Drive" button to content displayed in the App view. Clicking it invokes the "Append to Doc" board from GoogleDriveKit, and pops up a link in a toast.

Does not support images yet.

<img width="300" alt="Screenshot 2025-01-21 at 5 02 39 PM" src="https://github.com/user-attachments/assets/f1b69d85-1c33-4f5d-87b1-a7d83d894bcb" />
