### PR TITLE
[unified-server] Change outDir for client-side code

### DIFF
--- a/packages/unified-server/vite.config.ts
+++ b/packages/unified-server/vite.config.ts
@@ -22,6 +22,7 @@ export default defineConfig(async (): Promise<UserConfig> => {
     optimizeDeps: { esbuildOptions: { target: "esnext" } },
     build: {
       target: "esnext",
+      outDir: "dist/client",
       lib: {
         entry: {
           index: "./index.html",


### PR DESCRIPTION
This prevents the problem where the client-side build clobbers the server-side build

Part of #3913