### PR TITLE
[board-server] [unified-server] Fix output clobbering bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
         "./packages/palm-kit:test",
         "./packages/python-wasm:test",
         "./packages/schema:test",
-        "./packages/template-kit:test"
+        "./packages/template-kit:test",
+        "./packages/unified-server:test"
       ]
     },
     "lint": {

--- a/packages/board-server/.gitignore
+++ b/packages/board-server/.gitignore
@@ -1,1 +1,2 @@
 public/sandbox.wasm
+dist_test/

--- a/packages/board-server/package.json
+++ b/packages/board-server/package.json
@@ -120,7 +120,7 @@
       ]
     },
     "build:tests": {
-      "command": "tsc -b --pretty",
+      "command": "tsc -b tsconfig.test.json --pretty",
       "env": {
         "FORCE_COLOR": "1"
       },
@@ -144,7 +144,7 @@
         "../../core/tsconfig/base.json"
       ],
       "output": [
-        "dist/"
+        "dist_test/"
       ],
       "clean": "if-file-deleted"
     },
@@ -152,7 +152,7 @@
       "command": "rm -f test.db"
     },
     "test": {
-      "command": "node --test --enable-source-maps --test-reporter spec dist/tests/*.js",
+      "command": "node --test --enable-source-maps --test-reporter spec dist_test/tests/*.js",
       "dependencies": [
         "build:tests"
       ],

--- a/packages/board-server/package.json
+++ b/packages/board-server/package.json
@@ -140,7 +140,7 @@
         "tests/**/*.ts",
         "tests/*.json",
         "tests/boards/*.bgl.json",
-        "tsconfig.json",
+        "tsconfig.test.json",
         "../../core/tsconfig/base.json"
       ],
       "output": [

--- a/packages/board-server/package.json
+++ b/packages/board-server/package.json
@@ -80,7 +80,8 @@
         "package.json"
       ],
       "output": [
-        "dist/server/index.js"
+        "dist/server",
+        "dist/scripts"
       ],
       "dependencies": [
         "../breadboard:build",

--- a/packages/board-server/tsconfig.test.json
+++ b/packages/board-server/tsconfig.test.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "outDir": "dist_test",
+    "tsBuildInfoFile": "dist_test/.tsbuildinfo",
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["node"],
+    "lib": ["ES2022", "DOM"],
+    "incremental": true,
+    "declaration": true,
+    "sourceMap": true,
+    "inlineSources": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "verbatimModuleSyntax": true,
+    "useUnknownInCatchVariables": true,
+    "experimentalDecorators": true,
+    "useDefineForClassFields": false,
+    "resolveJsonModule": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts", "tests/**/*.json"],
+  "exclude": []
+}


### PR DESCRIPTION
Should fix https://github.com/breadboard-ai/breadboard/issues/4249

The `build:tests` and `build:esbuild` scripts in the `board-server` package were both writing to the same place (`dist/`), with each deleting the output of the other (in the case of `build:tests`, deleting the whole `dist/` folder).

https://github.com/google/wireit/issues/65 is a long-standing feature request for wireit that would let us detect cases like this automatically