### PR TITLE
Update wireit version for better error reporting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "rollup-plugin-dts": "^6.1.1",
         "syncpack": "^13.0.0",
         "typescript": "^5.6.3",
-        "wireit": "^0.14.9"
+        "wireit": "^0.14.10"
       },
       "optionalDependencies": {
         "@rollup/rollup-darwin-arm64": "^4.27.4",
@@ -25491,10 +25491,14 @@
       }
     },
     "node_modules/wireit": {
-      "version": "0.14.9",
-      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.14.9.tgz",
-      "integrity": "sha512-hFc96BgyslfO1WGSzQqOVYd5N3TB+4u9w70L9GHR/T7SYjvFmeznkYMsRIjMLhPcVabCEYPW1vV66wmIVDs+dQ==",
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/wireit/-/wireit-0.14.10.tgz",
+      "integrity": "sha512-Y9wiNU92PcyfTcXRYzqjmilKl4Yfg30Jk/dwTN0e64JCkzoIP2QVo6gc8fjYK0gpL0/pq2IW+iMlknHLmLV+MQ==",
       "dev": true,
+      "workspaces": [
+        "vscode-extension",
+        "website"
+      ],
       "dependencies": {
         "brace-expansion": "^4.0.0",
         "chokidar": "^3.5.3",
@@ -25890,7 +25894,7 @@
         "@web/test-runner-playwright": "^0.11.0",
         "typescript": "^5.6.3",
         "vite": "^6.0.11",
-        "wireit": "^0.14.9"
+        "wireit": "^0.14.10"
       }
     },
     "packages/bbrt/node_modules/@types/node": {
@@ -25941,7 +25945,7 @@
         "esbuild": "^0.24.0",
         "eslint": "^8.57.1",
         "typescript": "^5.6.3",
-        "wireit": "^0.14.9"
+        "wireit": "^0.14.10"
       }
     },
     "packages/board-server-management": {
@@ -26214,7 +26218,7 @@
         "@types/node": "^22.0.0",
         "eslint": "^8.57.1",
         "typescript": "^5.6.3",
-        "wireit": "^0.14.9"
+        "wireit": "^0.14.10"
       }
     },
     "packages/build-code": {
@@ -26238,7 +26242,7 @@
         "@google-labs/breadboard": "^0.31.0",
         "eslint": "^8.57.1",
         "typescript": "^5.6.3",
-        "wireit": "^0.14.9"
+        "wireit": "^0.14.10"
       }
     },
     "packages/build-legacy": {
@@ -26314,7 +26318,7 @@
         "@types/node": "^22.0.0",
         "eslint": "^8.57.1",
         "typescript": "^5.6.3",
-        "wireit": "^0.14.9"
+        "wireit": "^0.14.10"
       }
     },
     "packages/connection-server": {
@@ -26331,7 +26335,7 @@
         "@types/node": "^22.0.0",
         "eslint": "^8.57.1",
         "typescript": "^5.6.3",
-        "wireit": "^0.14.9"
+        "wireit": "^0.14.10"
       }
     },
     "packages/core-kit": {
@@ -26557,7 +26561,7 @@
         "@types/node": "^22.0.0",
         "eslint": "^8.57.1",
         "typescript": "^5.6.3",
-        "wireit": "^0.14.9"
+        "wireit": "^0.14.10"
       }
     },
     "packages/graph-integrity": {
@@ -26707,7 +26711,7 @@
         "eslint": "^8.57.1",
         "tsx": "^4.19.2",
         "typescript": "^5.6.3",
-        "wireit": "^0.14.9"
+        "wireit": "^0.14.10"
       }
     },
     "packages/json-kit": {
@@ -26963,7 +26967,7 @@
       "devDependencies": {
         "eslint": "^8.57.1",
         "typescript": "^5.6.3",
-        "wireit": "^0.14.9"
+        "wireit": "^0.14.10"
       }
     },
     "packages/remote-board-server": {
@@ -27119,7 +27123,7 @@
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@typescript-eslint/parser": "^7.18.0",
         "typescript": "^5.6.3",
-        "wireit": "^0.14.9"
+        "wireit": "^0.14.10"
       }
     },
     "packages/unified-server": {
@@ -27141,7 +27145,7 @@
         "@typescript-eslint/parser": "^7.18.0",
         "ava": "^5.2.0",
         "typescript": "^5.6.3",
-        "wireit": "^0.14.9"
+        "wireit": "^0.14.10"
       }
     },
     "packages/v-deprecated-breadboard-ui": {
@@ -27266,7 +27270,7 @@
         "markdown-it-github-alerts": "^0.3.0",
         "markdown-it-github-headings": "^2.0.1",
         "rollup-plugin-import-assert": "^3.0.1",
-        "wireit": "^0.14.9"
+        "wireit": "^0.14.10"
       }
     },
     "packages/website/node_modules/rollup": {

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "rollup-plugin-dts": "^6.1.1",
     "syncpack": "^13.0.0",
     "typescript": "^5.6.3",
-    "wireit": "^0.14.9"
+    "wireit": "^0.14.10"
   },
   "workspaces": [
     "./core/*",

--- a/packages/bbrt/package.json
+++ b/packages/bbrt/package.json
@@ -152,6 +152,6 @@
     "@web/test-runner-playwright": "^0.11.0",
     "typescript": "^5.6.3",
     "vite": "^6.0.11",
-    "wireit": "^0.14.9"
+    "wireit": "^0.14.10"
   }
 }

--- a/packages/board-server/package.json
+++ b/packages/board-server/package.json
@@ -201,7 +201,7 @@
     "esbuild": "^0.24.0",
     "eslint": "^8.57.1",
     "typescript": "^5.6.3",
-    "wireit": "^0.14.9"
+    "wireit": "^0.14.10"
   },
   "dependencies": {
     "@breadboard-ai/connection-client": "0.1.0",

--- a/packages/build-code/package.json
+++ b/packages/build-code/package.json
@@ -117,6 +117,6 @@
     "@google-labs/breadboard": "^0.31.0",
     "eslint": "^8.57.1",
     "typescript": "^5.6.3",
-    "wireit": "^0.14.9"
+    "wireit": "^0.14.10"
   }
 }

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -128,6 +128,6 @@
     "@types/node": "^22.0.0",
     "eslint": "^8.57.1",
     "typescript": "^5.6.3",
-    "wireit": "^0.14.9"
+    "wireit": "^0.14.10"
   }
 }

--- a/packages/connection-client/package.json
+++ b/packages/connection-client/package.json
@@ -60,6 +60,6 @@
     "@types/node": "^22.0.0",
     "eslint": "^8.57.1",
     "typescript": "^5.6.3",
-    "wireit": "^0.14.9"
+    "wireit": "^0.14.10"
   }
 }

--- a/packages/connection-server/package.json
+++ b/packages/connection-server/package.json
@@ -83,7 +83,7 @@
     "@types/node": "^22.0.0",
     "eslint": "^8.57.1",
     "typescript": "^5.6.3",
-    "wireit": "^0.14.9"
+    "wireit": "^0.14.10"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/packages/google-drive-kit/package.json
+++ b/packages/google-drive-kit/package.json
@@ -173,6 +173,6 @@
     "@types/node": "^22.0.0",
     "eslint": "^8.57.1",
     "typescript": "^5.6.3",
-    "wireit": "^0.14.9"
+    "wireit": "^0.14.10"
   }
 }

--- a/packages/jsandbox/package.json
+++ b/packages/jsandbox/package.json
@@ -123,7 +123,7 @@
     "eslint": "^8.57.1",
     "tsx": "^4.19.2",
     "typescript": "^5.6.3",
-    "wireit": "^0.14.9"
+    "wireit": "^0.14.10"
   },
   "dependencies": {
     "@bjorn3/browser_wasi_shim": "^0.3.0"

--- a/packages/python-wasm/package.json
+++ b/packages/python-wasm/package.json
@@ -123,6 +123,6 @@
   "devDependencies": {
     "eslint": "^8.57.1",
     "typescript": "^5.6.3",
-    "wireit": "^0.14.9"
+    "wireit": "^0.14.10"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -50,6 +50,6 @@
     "@types/node": "^22.0.0",
     "typescript": "^5.6.3",
     "@google-labs/tsconfig": "^0.0.1",
-    "wireit": "^0.14.9"
+    "wireit": "^0.14.10"
   }
 }

--- a/packages/unified-server/package.json
+++ b/packages/unified-server/package.json
@@ -101,7 +101,7 @@
     "@typescript-eslint/parser": "^7.18.0",
     "ava": "^5.2.0",
     "typescript": "^5.6.3",
-    "wireit": "^0.14.9"
+    "wireit": "^0.14.10"
   },
   "dependencies": {
     "@breadboard-ai/connection-server": "^0.4.0",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -146,6 +146,6 @@
     "markdown-it-github-alerts": "^0.3.0",
     "markdown-it-github-headings": "^2.0.1",
     "rollup-plugin-import-assert": "^3.0.1",
-    "wireit": "^0.14.9"
+    "wireit": "^0.14.10"
   }
 }


### PR DESCRIPTION
Brings in https://github.com/google/wireit/pull/1270 which does a better job at reporting errors relating to input/output files being unexpectedly deleted as wireit is executing.