### PR TITLE
[unified-server] Remove tests from global test run

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,8 +79,7 @@
         "./packages/palm-kit:test",
         "./packages/python-wasm:test",
         "./packages/schema:test",
-        "./packages/template-kit:test",
-        "./packages/unified-server:test"
+        "./packages/template-kit:test"
       ]
     },
     "lint": {

--- a/packages/unified-server/package.json
+++ b/packages/unified-server/package.json
@@ -38,6 +38,7 @@
     "build:tsc": {
       "command": "tsc",
       "dependencies": [
+        "../board-server:build",
         "../connection-server:build"
       ]
     },


### PR DESCRIPTION
This works around the error seen in #4249 by removing the tests from the CI run.

This is acceptable for now because the current unified server tests are just dummies that "assert true" to verify that they are run. We should add these tests back to the global run when #4249 is fixed.