### PR TITLE
Add a couple of missing wireit dependency graph edges

### DIFF
--- a/packages/example-boards/package.json
+++ b/packages/example-boards/package.json
@@ -63,7 +63,8 @@
         "FORCE_COLOR": "1"
       },
       "dependencies": [
-        "typescript-files-and-deps"
+        "typescript-files-and-deps",
+        "generate:graphs"
       ],
       "files": [],
       "output": [

--- a/packages/google-drive-kit/package.json
+++ b/packages/google-drive-kit/package.json
@@ -70,6 +70,7 @@
         "../build:build:tsc",
         "../core-kit:build:tsc",
         "../template-kit:build:tsc",
+        "../connection-client:build:tsc",
         "generate:js-components"
       ],
       "files": [


### PR DESCRIPTION
Doesn't directly address https://github.com/breadboard-ai/breadboard/issues/4249, but should fix the failure from https://github.com/breadboard-ai/breadboard/actions/runs/13021227644/job/36322130934

```
src/example-board-server.ts:25:30 - error TS2307: Cannot find module '@breadboard-ai/example-boards/playground-boards.json' or its corresponding type declarations.

25 import playgroundBoards from "@breadboard-ai/example-boards/playground-boards.json" assert { type: "json" };
```

cc @timswanson-google 