### PR TITLE
[visual-editor] [board-server] Move `@provide` initial values to constructor due to accessor/lit bug

### DIFF
--- a/packages/board-server/src/app/app.ts
+++ b/packages/board-server/src/app/app.ts
@@ -132,7 +132,7 @@ export class AppView extends LitElement {
   secretsNeeded: string[] | null = null;
 
   @provide({ context: BreadboardUI.Contexts.environmentContext })
-  environment = ENVIRONMENT;
+  environment: BreadboardUI.Contexts.Environment;
 
   @provide({ context: BreadboardUI.Elements.tokenVendorContext })
   tokenVendor!: TokenVendor;
@@ -141,7 +141,7 @@ export class AppView extends LitElement {
   settingsHelper!: AppSettingsHelper;
 
   @provide({ context: visitorStateManagerContext })
-  visitorStateManager = new VisitorStateManager();
+  visitorStateManager: VisitorStateManager;
 
   #toasts = new Map<
     string,
@@ -453,6 +453,11 @@ export class AppView extends LitElement {
 
   constructor() {
     super();
+    // Due to https://github.com/lit/lit/issues/4675, context provider values
+    // must be done in the constructor.
+    this.environment = ENVIRONMENT;
+    this.visitorStateManager = new VisitorStateManager();
+
     this.settingsHelper = new AppSettingsHelper();
     this.tokenVendor = createTokenVendor(
       {

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -213,7 +213,7 @@ export class Main extends LitElement {
   >();
 
   @provide({ context: BreadboardUI.Contexts.environmentContext })
-  accessor environment = ENVIRONMENT;
+  accessor environment: BreadboardUI.Contexts.Environment;
 
   @provide({ context: BreadboardUI.Elements.tokenVendorContext })
   accessor tokenVendor!: TokenVendor;
@@ -379,6 +379,10 @@ export class Main extends LitElement {
   #initialize: Promise<void>;
   constructor(config: MainArguments) {
     super();
+
+    // Due to https://github.com/lit/lit/issues/4675, context provider values
+    // must be done in the constructor.
+    this.environment = ENVIRONMENT;
 
     const boardServerLocation = globalThis.sessionStorage.getItem(
       `${STORAGE_PREFIX}-board-server`


### PR DESCRIPTION
Follow up to https://github.com/breadboard-ai/breadboard/pull/4230 which subtly broke some places we were using the Lit context `@provide` decorator. There is currently a bug (in Lit context, probably?) that means values have to be initialized in the constructor, not in the property declaration. See https://github.com/lit/lit/issues/4675.