### PR TITLE
sign in plumbing

### DIFF
--- a/.changeset/warm-crabs-look.md
+++ b/.changeset/warm-crabs-look.md
@@ -1,0 +1,8 @@
+---
+"@breadboard-ai/connection-client": minor
+"@breadboard-ai/connection-server": minor
+"@breadboard-ai/visual-editor": minor
+"@breadboard-ai/shared-ui": minor
+---
+
+Introduce sign in plumbing to Visuale Editor runtime.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15640,6 +15640,15 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/keygrip": {
       "version": "1.1.0",
       "dev": true,
@@ -27079,7 +27088,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "cors": "^2.8.5",
-        "express": "^4.21.2"
+        "express": "^4.21.2",
+        "jwt-decode": "^4.0.0"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",

--- a/packages/connection-client/src/token-vendor.ts
+++ b/packages/connection-client/src/token-vendor.ts
@@ -98,6 +98,9 @@ export class TokenVendorImpl {
       expires_in: jsonRes.expires_in,
       issue_time: now,
       refresh_token: expiredGrant.refresh_token,
+      id: expiredGrant.id,
+      picture: expiredGrant.picture,
+      name: expiredGrant.name,
     };
     await this.#store.set(connectionId, JSON.stringify(updatedGrant));
     return { state: "valid", grant: updatedGrant };

--- a/packages/connection-client/src/types.ts
+++ b/packages/connection-client/src/types.ts
@@ -79,6 +79,9 @@ export interface TokenGrant {
   expires_in: number;
   refresh_token: string;
   issue_time: number;
+  picture?: string;
+  name?: string;
+  id?: string;
 }
 
 export type RefreshResponse =

--- a/packages/connection-client/src/types.ts
+++ b/packages/connection-client/src/types.ts
@@ -68,6 +68,9 @@ export type GrantResponse =
       access_token: string;
       expires_in: number;
       refresh_token: string;
+      picture?: string;
+      name?: string;
+      id?: string;
     };
 
 export interface TokenGrant {

--- a/packages/connection-server/package.json
+++ b/packages/connection-server/package.json
@@ -87,6 +87,7 @@
   },
   "dependencies": {
     "cors": "^2.8.5",
-    "express": "^4.21.2"
+    "express": "^4.21.2",
+    "jwt-decode": "^4.0.0"
   }
 }

--- a/packages/connection-server/src/api/grant.ts
+++ b/packages/connection-server/src/api/grant.ts
@@ -7,6 +7,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import type { ServerConfig } from "../config.js";
 import { badRequestJson, internalServerError, okJson } from "../responses.js";
+import { jwtDecode, type JwtPayload } from "jwt-decode";
 
 interface GrantRequest {
   connection_id: string;
@@ -23,6 +24,9 @@ type GrantResponse =
       access_token: string;
       expires_in: number;
       refresh_token: string;
+      picture?: string;
+      name?: string;
+      id?: string;
     };
 
 /**
@@ -87,10 +91,14 @@ export async function grant(
     tokenResponse.refresh_token &&
     tokenResponse.expires_in >= 0
   ) {
+    const { picture, name, id } = decodeIdToken(tokenResponse.id_token);
     return okJson(res, {
       access_token: tokenResponse.access_token,
       expires_in: tokenResponse.expires_in,
       refresh_token: tokenResponse.refresh_token,
+      picture,
+      name,
+      id,
     } satisfies GrantResponse);
   }
 
@@ -124,6 +132,7 @@ type TokenEndpointGrantResponse =
       refresh_token?: string;
       expires_in: number;
       error?: undefined;
+      id_token?: string;
     }
   | {
       error: string;
@@ -139,4 +148,27 @@ type TokenEndpointGrantResponse =
 function inferOriginFromHostname(host?: string) {
   if (!host) throw new Error("Unable to infer origin: no host");
   return host.startsWith("localhost") ? `http://${host}` : `https://${host}`;
+}
+
+type DecodeIdTokenResponse = {
+  picture?: string;
+  name?: string;
+  id?: string;
+};
+
+function decodeIdToken(id_token?: string): DecodeIdTokenResponse {
+  if (!id_token) return {};
+  try {
+    const decoded = jwtDecode(id_token) as JwtPayload & {
+      name?: string;
+      picture?: string;
+    };
+    return {
+      id: decoded.sub,
+      name: decoded.name,
+      picture: decoded.picture,
+    };
+  } catch (e) {
+    return {};
+  }
 }

--- a/packages/shared-ui/src/elements/connection/connection-common.ts
+++ b/packages/shared-ui/src/elements/connection/connection-common.ts
@@ -22,6 +22,9 @@ export type GrantResponse =
       access_token: string;
       expires_in: number;
       refresh_token: string;
+      picture?: string;
+      name?: string;
+      id?: string;
     };
 
 export interface TokenGrant {
@@ -30,6 +33,9 @@ export interface TokenGrant {
   expires_in: number;
   refresh_token: string;
   issue_time: number;
+  picture?: string;
+  name?: string;
+  id?: string;
 }
 
 export type RefreshResponse =

--- a/packages/shared-ui/src/elements/connection/connection-signin.ts
+++ b/packages/shared-ui/src/elements/connection/connection-signin.ts
@@ -260,6 +260,9 @@ export class ConnectionSignin extends LitElement {
       expires_in: grantResponse.expires_in,
       refresh_token: grantResponse.refresh_token,
       issue_time: now,
+      name: grantResponse.name,
+      picture: grantResponse.picture,
+      id: grantResponse.id,
     };
     await this.settingsHelper.set(
       SETTINGS_TYPE.CONNECTIONS,

--- a/packages/visual-editor/src/runtime/auth.ts
+++ b/packages/visual-editor/src/runtime/auth.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TokenGrant, TokenVendor } from "@breadboard-ai/connection-client";
+
+export { SigninManager };
+
+const SIGN_IN_CONNECTION_ID = "$sign-in";
+
+/**
+ * The three states are:
+ *
+ * - "signedout" -- the user is not yet signed in or has signed out, but the
+ *                  runtime is configured to use sign in.
+ * - "valid" -- the user is currently signed in.
+ * - "anonymous" -- the runtime is not configured to use the sign in.
+ */
+export type SigninState = "signedout" | "valid" | "anonymous";
+
+class SigninManager {
+  readonly state: SigninState;
+  readonly picture?: string;
+  readonly id?: string;
+  readonly name?: string;
+
+  constructor(state: SigninState, grant?: TokenGrant) {
+    this.state = state;
+    this.picture = grant?.picture;
+    this.id = grant?.id;
+    this.name = grant?.name;
+  }
+
+  static async create(tokenVendor?: TokenVendor) {
+    if (!tokenVendor) {
+      return new SigninManager("anonymous");
+    }
+    const token = tokenVendor.getToken(SIGN_IN_CONNECTION_ID);
+    const { state } = token;
+    if (state === "signedout") {
+      return new SigninManager(state);
+    }
+    let grant: TokenGrant;
+    if (state === "expired") {
+      const refreshed = await token.refresh();
+      grant = refreshed.grant;
+    } else {
+      grant = token.grant;
+    }
+
+    if (!grant.id || !grant.name || !grant.picture) {
+      return new SigninManager("anonymous");
+    }
+
+    return new SigninManager("valid", grant);
+  }
+}

--- a/packages/visual-editor/src/runtime/runtime.ts
+++ b/packages/visual-editor/src/runtime/runtime.ts
@@ -34,6 +34,7 @@ export * as Types from "./types.js";
 import { sandbox } from "../sandbox";
 import { Select } from "./select.js";
 import { StateManager } from "./state.js";
+import { SigninManager } from "./auth.js";
 
 function withRunModule(kits: Kit[]): Kit[] {
   return addSandboxedRunModule(sandbox, kits);
@@ -47,6 +48,7 @@ export async function create(config: RuntimeConfig): Promise<{
   select: Select;
   state: StateManager;
   util: typeof Util;
+  signin: SigninManager;
 }> {
   const kits = withRunModule(loadKits());
 
@@ -107,6 +109,7 @@ export async function create(config: RuntimeConfig): Promise<{
     select: new Select(),
     util: Util,
     kits,
+    signin: await SigninManager.create(config.tokenVendor),
   } as const;
 
   return runtime;


### PR DESCRIPTION
- **Plumb the profile data from connection server to client.**
- **Introduce `runtime.signin` to manage sign in.**
- **docs(changeset): Introduce sign in plumbing to Visuale Editor runtime.**
