### PR TITLE
[unified-server] Remove unneeded dependencies

### DIFF
--- a/packages/unified-server/package.json
+++ b/packages/unified-server/package.json
@@ -65,10 +65,7 @@
       ]
     },
     "docker-build": {
-      "command": "docker build --build-context=breadboard=../.. --tag=unified-server .",
-      "dependencies": [
-        "build"
-      ]
+      "command": "docker build --build-context=breadboard=../.. --tag=unified-server ."
     },
     "docker-clean": {
       "command": "docker image rm unified-server"
@@ -77,10 +74,7 @@
       "command": "docker logs unified-server"
     },
     "docker-run": {
-      "command": "docker run --name=unified-server --publish=3000:3000 --detach --rm unified-server",
-      "dependencies": [
-        "docker-build"
-      ]
+      "command": "docker run --name=unified-server --publish=3000:3000 --detach --rm unified-server"
     },
     "docker-stop": {
       "command": "docker stop unified-server"


### PR DESCRIPTION
`docker-build` does not need `build` because the build is run when the image is built.

Forcing `docker-run` to depend on `docker-build` can take time when the caller might not want to build a new image. The user should just run `docker-build` and `docker-run` in sequence if they want to build a new image. As written, `docker-run` will just take whatever image is tagged with `unified-server:latest`.

Part of #4355 
