### PR TITLE
[unified-server] Add docker-run script that doesn't remove the container

### DIFF
--- a/packages/unified-server/package.json
+++ b/packages/unified-server/package.json
@@ -17,6 +17,7 @@
     "docker-clean": "docker image rm unified-server",
     "docker-logs": "docker logs unified-server",
     "docker-run": "docker run --name=unified-server --publish=3000:3000 --detach --rm unified-server",
+    "docker-run:no-rm": "docker run --name=unified-server --publish=3000:3000 --detach unified-server",
     "docker-stop": "docker stop unified-server",
     "lint": "FORCE_COLOR=1 eslint . --ext .ts",
     "serve": "wireit",


### PR DESCRIPTION
This can be useful when a container is failing on startup. Removing it on shutdown erases the logs. Note that you'll need to remove it manually before docker-run can be run again.

Fixes #4355 
