### PR TITLE
Fix style such that share link does not overflow out of nav container

### DIFF
--- a/packages/shared-ui/src/elements/ui-controller/ui-controller.styles.ts
+++ b/packages/shared-ui/src/elements/ui-controller/ui-controller.styles.ts
@@ -387,6 +387,8 @@ export const styles = css`
           & .url {
             font: 400 var(--bb-body-small) / var(--bb-body-line-height-small)
               var(--bb-font-family);
+            max-width: 200px;
+            overflow: hidden;
             padding: var(--bb-grid-size-2);
             border: 1px solid var(--bb-neutral-300);
             border-radius: var(--bb-grid-size);


### PR DESCRIPTION
Before: 
<img width="1260" alt="Screenshot 2025-02-16 at 12 12 54 PM" src="https://github.com/user-attachments/assets/cef67812-67fd-4bb6-84db-6dd4eb43d562" />

After: 
<img width="1265" alt="Screenshot 2025-02-16 at 12 15 07 PM" src="https://github.com/user-attachments/assets/e9b43eb7-cfc4-4988-87f8-a4574de08c20" />

