### PR TITLE
[unified-server] Clean up tsconfig

### DIFF
--- a/packages/unified-server/tsconfig.json
+++ b/packages/unified-server/tsconfig.json
@@ -1,25 +1,16 @@
 {
   "compilerOptions": {
-    "allowJs": true,
-    "composite": false,
-    "declaration": true,
-    "declarationMap": true,
-    "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "incremental": true,
-    "inlineSources": false,
-    "isolatedModules": true,
     "lib": ["ES2022", "DOM"],
     "module": "NodeNext",
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
     "outDir": "./dist",
     "preserveWatchOutput": true,
+    "resolveJsonModule": true,
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "target": "ES2022",
-    "resolveJsonModule": true
+    "target": "ES2022"
   },
   "include": ["src/**/*", "tests/**/*"]
 }


### PR DESCRIPTION
The current tsconfig for unified server was mostly cargo-culted from other tsconfigs in the repo. In preparation for writing the bundling logic in #4442, I thought I'd take a look and see which options were necessary, and which seemed redundant.

In some cases, options seemed redundant. In some cases, they were set to their default values anyway.

Have confirmed that everything build and runs successfully with these changes.