### PR TITLE
assets and at

### DIFF
--- a/.changeset/tough-frogs-do.md
+++ b/.changeset/tough-frogs-do.md
@@ -1,0 +1,6 @@
+---
+"@google-labs/breadboard": patch
+"@breadboard-ai/shared-ui": patch
+---
+
+Additional plumbing to make assets work in all places.

--- a/packages/breadboard/src/data/common.ts
+++ b/packages/breadboard/src/data/common.ts
@@ -10,6 +10,8 @@ import type {
   FunctionResponseCapabilityPart,
   InlineDataCapabilityPart,
   LLMContent,
+  NodeValue,
+  OutputValues,
   StoredDataCapabilityPart,
   TextCapabilityPart,
 } from "@breadboard-ai/types";
@@ -258,4 +260,54 @@ export async function transformDataParts(
     transformed.push({ parts, role });
   }
   return transformed;
+}
+
+export function convertStoredPartsToAbsoluteUrls(
+  values: OutputValues,
+  graphUrl?: string
+): OutputValues {
+  const result: OutputValues = {};
+
+  if (!graphUrl) return values;
+
+  const url = parseUrl(graphUrl);
+
+  for (const [key, value] of Object.entries(values)) {
+    result[key] = convertValue(value);
+  }
+  return result;
+
+  function convertValue(contents: NodeValue): NodeValue {
+    const converted: LLMContent[] = [];
+    if (!isLLMContentArray(contents)) return contents;
+
+    for (const content of contents) {
+      const role = content.role || "user";
+      const parts: DataPart[] = [];
+      for (const part of content.parts) {
+        let convertedPart = part;
+        if ("storedData" in part) {
+          if (part.storedData.handle.startsWith(".")) {
+            convertedPart = {
+              storedData: {
+                handle: new URL(part.storedData.handle, url).href,
+                mimeType: part.storedData.mimeType,
+              },
+            };
+          }
+        }
+        parts.push(convertedPart);
+      }
+      converted.push({ parts, role });
+    }
+    return converted as NodeValue;
+  }
+}
+
+function parseUrl(s: string): URL | undefined {
+  try {
+    return new URL(s);
+  } catch (e) {
+    return;
+  }
 }

--- a/packages/breadboard/src/data/common.ts
+++ b/packages/breadboard/src/data/common.ts
@@ -169,7 +169,7 @@ export async function retrieveAsBlob(
   }
 
   let { handle } = part.storedData;
-  if (handle.startsWith(".")) {
+  if (handle.startsWith(".") && graphUrl) {
     handle = new URL(handle, graphUrl).href;
   }
   const response = await fetch(handle);
@@ -177,9 +177,10 @@ export async function retrieveAsBlob(
 }
 
 export async function toInlineDataPart(
-  part: StoredDataCapabilityPart
+  part: StoredDataCapabilityPart,
+  graphUrl?: URL
 ): Promise<InlineDataCapabilityPart> {
-  const raw = await retrieveAsBlob(part);
+  const raw = await retrieveAsBlob(part, graphUrl);
   const mimeType = part.storedData.mimeType;
   const data = await asBase64(raw);
   return { inlineData: { mimeType, data } };

--- a/packages/breadboard/src/data/default-run-store.ts
+++ b/packages/breadboard/src/data/default-run-store.ts
@@ -34,6 +34,7 @@ export class DefaultRunStore implements RunStore {
   }
 
   async write(url: RunURL, timestamp: RunTimestamp, result: HarnessRunResult) {
+    const graphUrl = getGraphUrl(url);
     const store = this.#runs.get(url);
     if (!store) {
       throw new Error("Unable to find the store");
@@ -59,7 +60,7 @@ export class DefaultRunStore implements RunStore {
               continue;
             }
 
-            output.parts[i] = await toInlineDataPart(part);
+            output.parts[i] = await toInlineDataPart(part, graphUrl);
           }
         }
       }
@@ -114,5 +115,13 @@ export class DefaultRunStore implements RunStore {
     }
 
     return this.#runs.get(url)!;
+  }
+}
+
+function getGraphUrl(url: RunURL): URL | undefined {
+  try {
+    return new URL(url);
+  } catch (e) {
+    return;
   }
 }

--- a/packages/breadboard/src/data/index.ts
+++ b/packages/breadboard/src/data/index.ts
@@ -34,6 +34,7 @@ export {
   toInlineDataPart,
   toStoredDataPart,
   transformDataParts,
+  convertStoredPartsToAbsoluteUrls,
 } from "./common.js";
 
 export { transformBlobs } from "./file-system/blob-transform.js";

--- a/packages/breadboard/src/index.ts
+++ b/packages/breadboard/src/index.ts
@@ -127,6 +127,7 @@ export {
   createFileSystem,
   assetsFromGraphDescriptor,
   transformDataParts,
+  convertStoredPartsToAbsoluteUrls,
 } from "./data/index.js";
 
 export { ok, err } from "./data/file-system/utils.js";

--- a/packages/breadboard/src/sandboxed-run-module.ts
+++ b/packages/breadboard/src/sandboxed-run-module.ts
@@ -223,7 +223,11 @@ function addSandboxedRunModule(sandbox: Sandbox, kits: Kit[]): Kit[] {
               modules
             );
             const inputs = context.store
-              ? ((await inflateData(context.store, rest)) as InputValues)
+              ? ((await inflateData(
+                  context.store,
+                  rest,
+                  context.base
+                )) as InputValues)
               : rest;
             const result = await module.invoke(
               $module as string,

--- a/packages/shared-ui/src/elements/board-activity/board-activity.ts
+++ b/packages/shared-ui/src/elements/board-activity/board-activity.ts
@@ -49,6 +49,9 @@ import { icons } from "../../styles/icons.js";
 
 @customElement("bb-board-activity")
 export class BoardActivity extends LitElement {
+  @property()
+  accessor graphUrl: URL | null = null;
+
   @property({ reflect: false })
   accessor run: InspectableRun | null = null;
 
@@ -485,6 +488,7 @@ export class BoardActivity extends LitElement {
       if (typeof nodeValue === "object") {
         if (isLLMContentArray(nodeValue)) {
           value = html`<bb-llm-output-array
+            .graphUrl=${this.graphUrl}
             .showModeToggle=${false}
             .showEntrySelector=${false}
             .showExportControls=${type !== "input"}
@@ -508,6 +512,7 @@ export class BoardActivity extends LitElement {
           value = nodeValue.parts.length
             ? html`<bb-llm-output
                 .showExportControls=${type !== "input"}
+                .graphUrl=${this.graphUrl}
                 .lite=${true}
                 .clamped=${false}
                 .value=${nodeValue}

--- a/packages/shared-ui/src/elements/editor/graph-node-output.ts
+++ b/packages/shared-ui/src/elements/editor/graph-node-output.ts
@@ -11,6 +11,7 @@ import MarkdownIt from "markdown-it";
 import {
   isInlineData,
   isLLMContentArray,
+  isStoredData,
   isTextCapabilityPart,
 } from "@google-labs/breadboard";
 import { GraphAssets } from "./graph-assets";
@@ -328,6 +329,30 @@ export class GraphNodeOutput extends PIXI.Container {
                 const canvas = document.createElement("canvas");
                 const img = new Image();
                 img.src = `data:${part.inlineData.mimeType};base64,${part.inlineData.data}`;
+                img.onload = () => {
+                  canvas.width = img.naturalWidth;
+                  canvas.height = img.naturalHeight;
+                  canvas.getContext("2d")?.drawImage(img, 0, 0);
+
+                  const texture = PIXI.Texture.from(canvas);
+                  const item = new PIXI.Sprite(texture);
+                  const ratio = MAX_IMAGE_WIDTH / texture.width;
+                  item.scale.x = ratio;
+                  item.scale.y = ratio;
+                  item.label = `${id}-${idx}`;
+
+                  item.x = (MAX_CONTENT_WIDTH - item.width) / 2;
+
+                  resolve(item);
+                };
+              } else {
+                resolve(null);
+              }
+            } else if (isStoredData(part)) {
+              if (part.storedData.mimeType.startsWith("image")) {
+                const canvas = document.createElement("canvas");
+                const img = new Image();
+                img.src = part.storedData.handle;
                 img.onload = () => {
                   canvas.width = img.naturalWidth;
                   canvas.height = img.naturalHeight;

--- a/packages/shared-ui/src/elements/editor/graph-renderer.ts
+++ b/packages/shared-ui/src/elements/editor/graph-renderer.ts
@@ -40,6 +40,7 @@ import {
 } from "./types.js";
 import { Graph } from "./graph.js";
 import {
+  convertStoredPartsToAbsoluteUrls,
   GraphIdentifier,
   InspectableEdge,
   InspectableEdgeType,
@@ -104,9 +105,6 @@ enum MODE {
 
 @customElement("bb-graph-renderer")
 export class GraphRenderer extends LitElement {
-  @property()
-  accessor graph: InspectableGraph | null = null;
-
   @property()
   accessor run: InspectableRun | null = null;
 
@@ -1905,7 +1903,13 @@ export class GraphRenderer extends LitElement {
         valuesByNode.set(event.node.descriptor.id, values);
       }
 
-      values.push(event.outputs);
+      values.push(
+        event.outputs,
+        convertStoredPartsToAbsoluteUrls(
+          event.outputs,
+          this.topGraphUrl || undefined
+        ) as OutputValues
+      );
     }
 
     for (const graph of this.#container.children) {

--- a/packages/shared-ui/src/elements/output/llm-output/llm-output-array.ts
+++ b/packages/shared-ui/src/elements/output/llm-output/llm-output-array.ts
@@ -14,6 +14,9 @@ import { LLMOutput } from "./llm-output.js";
 @customElement("bb-llm-output-array")
 export class LLMOutputArray extends LitElement {
   @property()
+  accessor graphUrl: URL | null = null;
+
+  @property()
   accessor values: LLMContent[] | null = null;
 
   @property()
@@ -229,6 +232,7 @@ export class LLMOutputArray extends LitElement {
                       ? ref(this.#activeLLMContentRef)
                       : nothing}
                     class=${classMap({ visible: idx === this.selected })}
+                    .graphUrl=${this.graphUrl}
                     .value=${item}
                     .clamped=${this.clamped}
                     .lite=${this.lite}

--- a/packages/shared-ui/src/elements/overlay/board-activity.ts
+++ b/packages/shared-ui/src/elements/overlay/board-activity.ts
@@ -23,6 +23,9 @@ const PERSIST_KEY = "bb-board-activity-overlay-persist";
 @customElement("bb-board-activity-overlay")
 export class BoardActivityOverlay extends LitElement {
   @property()
+  accessor graphUrl: URL | null = null;
+
+  @property()
   accessor run: InspectableRun | null = null;
 
   @property()
@@ -182,6 +185,7 @@ export class BoardActivityOverlay extends LitElement {
         <div id="container">
           <bb-board-activity
             class=${classMap({ collapsed: this.debugEvent !== null })}
+            .graphUrl=${this.graphUrl}
             .run=${this.run}
             .events=${events}
             .eventPosition=${eventPosition}

--- a/packages/shared-ui/src/elements/overlay/node-configurator.ts
+++ b/packages/shared-ui/src/elements/overlay/node-configurator.ts
@@ -676,6 +676,7 @@ export class NodeConfigurationOverlay extends LitElement {
                 if (typeof outputValue === "object") {
                   if (isLLMContentArray(outputValue)) {
                     value = html`<bb-llm-output-array
+                      .graphUrl=${this.graph?.url}
                       .clamped=${false}
                       .showModeToggle=${false}
                       .showEntrySelector=${false}
@@ -699,6 +700,7 @@ export class NodeConfigurationOverlay extends LitElement {
                     value = outputValue.parts.length
                       ? html`<bb-llm-output
                           .clamped=${false}
+                          .graphUrl=${this.graph?.url}
                           .lite=${true}
                           .showExportControls=${true}
                           .value=${outputValue}

--- a/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
@@ -659,12 +659,15 @@ export class UI extends LitElement {
         const nextNodeId =
           this.topGraphResult?.currentNode?.descriptor.id ?? null;
 
+        const graphUrl = this.graph?.url ? new URL(this.graph.url) : null;
+
         sideNavItem = html`${guard(
           [run, events, eventPosition, this.debugEvent],
           () =>
             html` <div id="board-console-container">
               <bb-board-activity
                 class=${classMap({ collapsed: this.debugEvent !== null })}
+                .graphUrl=${graphUrl}
                 .run=${run}
                 .events=${events}
                 .eventPosition=${eventPosition}


### PR DESCRIPTION
- **Teach DefaultRunStore to resolve stored data URLs relative to Graph URL.**
- **Teach LLM Outputs about relative blob URLs.**
- **Teach `graph-node-output` to preview blob assets.**
- **Provide proper URL when inflating data prior to running modules.**
- **docs(changeset): Additional plumbing to make assets work in all places.**
