### PR TITLE
[shared-ui] Try to ensure that contenteditable behaves correctly

### DIFF
--- a/.changeset/olive-foxes-hang.md
+++ b/.changeset/olive-foxes-hang.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/shared-ui": patch
+---
+
+Try to ensure that contenteditable behaves correctly


### PR DESCRIPTION
After an emotionally torrid time, I have this PR which ensures that:

1) &nbsp; text nodes exist around chiclets at all times.
2) the user can't add a new line between an &nbsp; and a chiclet

Since in both cases the rendering of chiclets / contenteditable spans goes awry if such cases obtain.