### PR TITLE
[board-server] Add a skeleton integration test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4739,6 +4739,12 @@
       "integrity": "sha512-ag0BfJLZf6CQz8VIuRIEYQ5Ggwk/82uvTQf27RcpyDNbY0Vw49LIPqAxk5tqYfrCs9xDaIMvl4aj7ZopnYL8bA==",
       "dev": true
     },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true
+    },
     "node_modules/@types/cookies": {
       "version": "0.9.0",
       "dev": true,
@@ -4954,6 +4960,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true
+    },
     "node_modules/@types/mime": {
       "version": "1.3.5",
       "license": "MIT"
@@ -5063,6 +5075,28 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.9",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.9.tgz",
+      "integrity": "sha512-pTVjI73witn+9ILmoJdajHGW2jkSaOzhiFYF1Rd3EQ94kymLqB9PjD9ISg7WaALC7+dCHT0FGe9T2LktLq/3GQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.2.tgz",
+      "integrity": "sha512-137ypx2lk/wTQbW6An6safu9hXmajAifU/s7szAHLN/FeIm5w7yR0Wkl9fdJMRSHwOn4HLAI0DaB2TOORuhPDg==",
+      "dev": true,
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
@@ -8799,6 +8833,15 @@
       "version": "1.0.1",
       "license": "MIT"
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "license": "MIT",
@@ -8924,6 +8967,12 @@
     "node_modules/cookie-signature": {
       "version": "1.0.6",
       "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true
     },
     "node_modules/cookies": {
       "version": "0.9.1",
@@ -9595,6 +9644,16 @@
       "integrity": "sha512-JwAYQgEvm3yD45CHB+RmF5kMbWtXBaOGwuxa87sZogHcLCv8c/IqnThaoQ1y60d7pXWjSKWQphPEc+1rAScVdg==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
     },
     "node_modules/diff": {
       "version": "4.0.2",
@@ -11319,6 +11378,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true
+    },
     "node_modules/fast-uri": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
@@ -11740,6 +11805,20 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.2.tgz",
+      "integrity": "sha512-Jqc1btCy3QzRbJaICGwKcBfGWuLADRerLzDqi2NwSt/UkXLsHJw2TVResiaoBufHVHy9aSgClOHCeJsSsFLTbg==",
+      "dev": true,
+      "dependencies": {
+        "dezalgo": "^1.0.4",
+        "hexoid": "^2.0.0",
+        "once": "^1.4.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -12410,6 +12489,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hexoid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hexoid/-/hexoid-2.0.0.tgz",
+      "integrity": "sha512-qlspKUK7IlSQv2o+5I7yhUd7TxlOG2Vr5LTa3ve2XSNVKAL/n/u/7KLvKmFNimomDIKvZFXWHv0T12mv7rT8Aw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/hosted-git-info": {
@@ -20558,6 +20646,38 @@
       "version": "4.1.2",
       "license": "MIT"
     },
+    "node_modules/superagent": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-9.0.2.tgz",
+      "integrity": "sha512-xuW7dzkUpcJq7QnhOsnNUgtYp3xRwpt2F7abdRYIpCsAt0hhUqia0EdxyXZQQpNmGtsCzYHryaKSV3q3GJnq7w==",
+      "dev": true,
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^3.5.1",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/supertap": {
       "version": "3.0.1",
       "dev": true,
@@ -20570,6 +20690,19 @@
       },
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.0.0.tgz",
+      "integrity": "sha512-qlsr7fIC0lSddmA3tzojvzubYxvlGtzumcdHgPwbFWMISQwL22MhM2Y3LNt+6w9Yyx7559VW5ab70dgphm8qQA==",
+      "dev": true,
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/supports-color": {
@@ -22910,9 +23043,11 @@
         "@types/better-sqlite3": "^7.6.12",
         "@types/cors": "^2.8.17",
         "@types/node": "^22.0.0",
+        "@types/supertest": "^6.0.2",
         "@types/uuid": "^10.0.0",
         "esbuild": "^0.25.0",
         "eslint": "^8.57.1",
+        "supertest": "^7.0.0",
         "typescript": "^5.7.3",
         "wireit": "^0.15.0-pre.1"
       }

--- a/packages/board-server/firebase.json
+++ b/packages/board-server/firebase.json
@@ -1,0 +1,11 @@
+{
+  "emulators": {
+    "firestore": {
+      "port": 8080
+    },
+    "ui": {
+      "enabled": true
+    },
+    "singleProjectMode": true
+  }
+}

--- a/packages/board-server/package.json
+++ b/packages/board-server/package.json
@@ -173,7 +173,7 @@
       "output": []
     },
     "test:integration": {
-      "command": "export GOOGLE_APPLICATION_CREDENTIALS=foo && export GOOGLE_CLOUD_PROJECT=foo && export STORAGE_BACKEND=sqlite && export SQLITE_DB_PATH=test.db && node --test --enable-source-maps --test-reporter tap dist/tests/integration/board-api.test.js",
+      "command": "firebase emulators:exec 'node --test --test-reporter=spec dist_test/tests/integration/board-server.test.js'",
       "dependencies": [
         "build:tests",
         "build:vite",
@@ -214,9 +214,11 @@
     "@types/better-sqlite3": "^7.6.12",
     "@types/cors": "^2.8.17",
     "@types/node": "^22.0.0",
+    "@types/supertest": "^6.0.2",
     "@types/uuid": "^10.0.0",
     "esbuild": "^0.25.0",
     "eslint": "^8.57.1",
+    "supertest": "^7.0.0",
     "typescript": "^5.7.3",
     "wireit": "^0.15.0-pre.1"
   },

--- a/packages/board-server/tests/integration/board-server.test.ts
+++ b/packages/board-server/tests/integration/board-server.test.ts
@@ -1,0 +1,199 @@
+import type { Express } from "express";
+import assert from "node:assert";
+import { before, suite, test } from "node:test";
+import request from "supertest";
+import { createServer as createViteServer } from "vite";
+
+import { createServer, createServerConfig } from "../../src/server.js";
+import { createAccount, getStore } from "../../src/server/store.js";
+
+// TODO There's no type defined for this. There probably should be.
+type User = { account: string; api_key: string };
+
+suite("Board Server integration test", () => {
+  let server: Express;
+  let user: User;
+
+  before(async () => {
+    const allowedOrigins = "";
+    const viteDevServer = await createViteServer({
+      server: { middlewareMode: true },
+      appType: "custom",
+      optimizeDeps: { esbuildOptions: { target: "esnext" } },
+    });
+    const config = createServerConfig(allowedOrigins, viteDevServer);
+    server = createServer(config);
+    user = await createAccount("test-user", "test-api-key");
+  });
+
+  suite("Info API", () => {
+    test("GET / -> 200", async () => {
+      const response = await request(server).get("/");
+      assert.equal(response.status, 200);
+    });
+  });
+
+  suite("Me API", () => {
+    test("GET /me -> 401", async () => {
+      const response = await request(server).get("/me");
+      assert.equal(response.status, 401);
+    });
+
+    test("GET /me?API_KEY -> 200", async () => {
+      const response = await request(server).get(`/me?API_KEY=${user.api_key}`);
+      assert.equal(response.status, 200);
+    });
+  });
+
+  suite("Boards API", () => {
+    test("OPTIONS /boards -> 204", async () => {
+      const response = await request(server).options(`/boards`);
+      assert.equal(response.status, 204);
+    });
+
+    test("GET /boards -> 401", async () => {
+      const response = await request(server).get("/boards");
+      assert.equal(response.status, 401);
+    });
+
+    test("GET /boards?API_KEY -> 200", async () => {
+      const response = await request(server).get(
+        `/boards?API_KEY=${user.api_key}`
+      );
+      assert.equal(response.status, 200);
+    });
+
+    test("POST /boards -> 401", async () => {
+      const response = await request(server).post("/boards");
+      assert.equal(response.status, 401);
+    });
+
+    test("POST /boards?API_KEY -> 200", async () => {
+      const response = await request(server)
+        .post(`/boards?API_KEY=${user.api_key}`)
+        .send({ name: "board" });
+
+      assert.equal(response.status, 200);
+    });
+
+    test("GET /boards/@:user/:name.json", async () => {
+      const store = getStore();
+      const board = await store.create(user.account, "test-board", false);
+
+      const response = await request(server).get(
+        `/boards/${board.path}?API_KEY=${user.api_key}`
+      );
+
+      assert.equal(response.status, 200);
+    });
+
+    test("POST /boards/@:user/:name.json", async () => {
+      const store = getStore();
+      const board = await store.create(user.account, "test-board", false);
+
+      const response = await request(server)
+        .post(`/boards/${board.path}?API_KEY=${user.api_key}`)
+        .send({ nodes: [], edges: [] });
+
+      assert.equal(response.status, 200);
+    });
+
+    // TODO Make this work. It tries to serve /index.html on the host machine, which fails
+    test.skip("GET /boards/@:user/:name.app", async () => {
+      const store = getStore();
+      const board = await store.create(user.account, "test-board", false);
+      const path = board.path!.replace(".json", ".app");
+
+      const response = await request(server).get(
+        `/boards/${path}?API_KEY=${user.api_key}`
+      );
+
+      assert.equal(response.status, 200);
+    });
+
+    // TODO Make this work. It tries to serve /api.html on the host machine, which fails
+    test.skip("GET /boards/@:user/:name.api", async () => {
+      const store = getStore();
+      const board = await store.create(user.account, "test-board", false);
+      const path = board.path!.replace(".json", ".api");
+
+      const response = await request(server).get(
+        `/boards/${path}?API_KEY=${user.api_key}`
+      );
+
+      assert.equal(response.status, 200);
+    });
+
+    test("POST /boards/@:user/:name.api/invoke", async () => {
+      const store = getStore();
+      const board = await store.create(user.account, "test-board", false);
+      await store.update(user.account, "test-board", {
+        nodes: [{ type: "input", id: "input" }],
+        edges: [],
+      });
+      const path = board.path!.replace(".json", ".api");
+
+      const response = await request(server)
+        .post(`/boards/${path}/invoke`)
+        .send({ $key: user.api_key });
+
+      assert.equal(response.status, 200);
+    });
+
+    // This test succeeds, but also hangs the test runner with no apparent error
+    test.skip("POST /boards/@:user/:name.api/describe", async () => {
+      const store = getStore();
+      const board = await store.create(user.account, "test-board", false);
+      const path = board.path!.replace(".json", ".api");
+
+      const response = await request(server)
+        .post(`/boards/${path}/describe`)
+        .send({});
+
+      assert.equal(response.status, 200);
+    });
+
+    test("POST /boards/@:user/:name.api/run", async () => {
+      const store = getStore();
+      const board = await store.create(user.account, "test-board", false);
+      const path = board.path!.replace(".json", ".api");
+
+      const response = await request(server)
+        .post(`/boards/${path}/run`)
+        .send({});
+
+      assert.equal(response.status, 200);
+    });
+
+    test("GET /boards/@:user/:name.invite", async () => {
+      const store = getStore();
+      const board = await store.create(user.account, "test-board", false);
+      const path = board.path!.replace(".json", ".invite");
+
+      const response = await request(server).get(
+        `/boards/${path}?API_KEY=${user.api_key}`
+      );
+
+      assert.equal(response.status, 200);
+    });
+
+    test("POST /boards/@:user/:name.invite", async () => {
+      const store = getStore();
+      const board = await store.create(user.account, "test-board", false);
+      const path = board.path!.replace(".json", ".invite");
+
+      const response = await request(server).post(
+        `/boards/${path}?API_KEY=${user.api_key}`
+      );
+
+      assert.equal(response.status, 200);
+    });
+
+    // This test makes an HTTP call to the Drive API. Can't run this in a test.
+    test.todo("POST /boards/@:user/:name.json/assets/drive:id");
+  });
+
+  // TODO Figure out how to test these endpoint
+  suite.todo("Proxy API", () => {});
+  suite.todo("Blobs API", () => {});
+});


### PR DESCRIPTION
This is a basic test that simply tests the routing logic for board server. It only asserts on the response status code, and does not inspect responses, nor check for side effects.

This is a basic level of test coverage needed to get some confidence in an ExpressJS refactor of the routing logic.

The process of writing this test exposed a number of bugs and confusing behaviors. Specifically, the SQLite storage provider doesn't seem to work as expected. This test can be used as a basis for getting it up and running again.

Part of #3172 