### PR TITLE
[board-server] Use Express for routing

### DIFF
--- a/.changeset/twelve-towns-study.md
+++ b/.changeset/twelve-towns-study.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/board-server": patch
+---
+
+Preliminary expressJS migration

--- a/packages/board-server/src/router.ts
+++ b/packages/board-server/src/router.ts
@@ -9,11 +9,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { serveBoardsAPI } from "./server/boards/index.js";
 import { serveContent } from "./server/common.js";
 import type { ServerConfig } from "./server/config.js";
-import { serveHome } from "./server/home/index.js";
-import { serveInfoAPI } from "./server/info/index.js";
-import { serveProxyAPI } from "./server/proxy/index.js";
 import { serverError } from "./server/errors.js";
-import { serveMeAPI } from "./server/info/me.js";
 import { serveBlobsAPI } from "./server/blobs/index.js";
 
 const handleError = (err: Error, res: ServerResponse) => {
@@ -29,22 +25,6 @@ export function makeRouter(serverConfig: ServerConfig) {
     res: ServerResponse
   ): Promise<void> {
     try {
-      if (await serveHome(serverConfig, req, res)) {
-        return;
-      }
-
-      if (await serveProxyAPI(serverConfig, req, res)) {
-        return;
-      }
-
-      if (await serveInfoAPI(req, res)) {
-        return;
-      }
-
-      if (await serveMeAPI(serverConfig, req, res)) {
-        return;
-      }
-
       if (await serveBoardsAPI(serverConfig, req, res)) {
         return;
       }

--- a/packages/board-server/src/server.ts
+++ b/packages/board-server/src/server.ts
@@ -8,7 +8,13 @@ import express, { type Express } from "express";
 import type { ViteDevServer } from "vite";
 
 import { makeRouter } from "./router.js";
+
 import type { ServerConfig } from "./server/config.js";
+import { serveBlobsAPI } from "./server/blobs/index.js";
+import { serveHome } from "./server/home/index.js";
+import { serveInfoAPI } from "./server/info/index.js";
+import { serveMeAPI } from "./server/info/me.js";
+import { serveProxyAPI } from "./server/proxy/index.js";
 
 export type { ServerConfig };
 
@@ -17,7 +23,21 @@ const DEFAULT_HOST = "localhost";
 
 export function createServer(config: ServerConfig): Express {
   const server = express();
+
+  server.get("/", async (req, res) => serveHome(config, req, res));
+
+  server.post("/proxy", async (req, res) => serveProxyAPI(config, req, res));
+
+  server.get("/info", serveInfoAPI);
+
+  server.get("/me", async (req, res) => serveMeAPI(config, req, res));
+
+  server.get("blobs/:blobId?/:modifier?", async (req, res) => {
+    serveBlobsAPI(config, req, res);
+  });
+
   server.use(makeRouter(config));
+
   return server;
 }
 

--- a/packages/board-server/src/server.ts
+++ b/packages/board-server/src/server.ts
@@ -10,7 +10,6 @@ import type { ViteDevServer } from "vite";
 import { makeRouter } from "./router.js";
 
 import type { ServerConfig } from "./server/config.js";
-import { serveBlobsAPI } from "./server/blobs/index.js";
 import { serveHome } from "./server/home/index.js";
 import { serveInfoAPI } from "./server/info/index.js";
 import { serveMeAPI } from "./server/info/me.js";
@@ -31,10 +30,6 @@ export function createServer(config: ServerConfig): Express {
   server.get("/info", serveInfoAPI);
 
   server.get("/me", async (req, res) => serveMeAPI(config, req, res));
-
-  server.get("blobs/:blobId?/:modifier?", async (req, res) => {
-    serveBlobsAPI(config, req, res);
-  });
 
   server.use(makeRouter(config));
 

--- a/packages/board-server/src/server/errors.ts
+++ b/packages/board-server/src/server/errors.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+// TODO expressify
+
 import { ServerResponse } from "http";
 
 export const serverError = (res: ServerResponse, error: string) => {

--- a/packages/board-server/src/server/home/index.ts
+++ b/packages/board-server/src/server/home/index.ts
@@ -4,23 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { IncomingMessage, ServerResponse } from "http";
-import packageInfo from "../../../package.json" with { type: "json" };
+import type { Request, Response } from "express";
 
+import packageInfo from "../../../package.json" with { type: "json" };
 import { getStore } from "../store.js";
 import type { ServerConfig } from "../config.js";
 
 export const serveHome = async (
   config: ServerConfig,
-  req: IncomingMessage,
-  res: ServerResponse
-): Promise<boolean> => {
-  // The "localhost" here isn't used for anything, it's just a placeholder to
-  // help us parse the rest of the URL.
-  const url = new URL(req.url ?? "", "http://localhost");
-  if (url.pathname !== "/") {
-    return false;
-  }
+  _req: Request,
+  res: Response
+) => {
   const store = getStore();
   const info = await store.getServerInfo();
 
@@ -51,5 +45,4 @@ export const serveHome = async (
         <p>Version: ${packageInfo.version}</p>
       </body>
     </html>`);
-  return true;
 };

--- a/packages/board-server/src/server/info/index.ts
+++ b/packages/board-server/src/server/info/index.ts
@@ -22,23 +22,9 @@ const DEFAULT_SERVER_INFO: ServerInfo = {
   },
 };
 
-export const serveInfoAPI = async (
-  req: IncomingMessage,
-  res: ServerResponse
-): Promise<boolean> => {
-  const path = req.url;
-  const isInfo = path === "/info";
-  if (!isInfo) {
-    return false;
-  }
-
+export async function serveInfoAPI(req: IncomingMessage, res: ServerResponse) {
   if (!corsAll(req, res)) {
-    return true;
-  }
-
-  if (req.method !== "GET") {
-    methodNotAllowed(res, "Only GET is allowed for /info");
-    return true;
+    return;
   }
 
   const store = getStore();
@@ -47,6 +33,4 @@ export const serveInfoAPI = async (
 
   res.setHeader("Content-Type", "application/json");
   res.end(JSON.stringify({ ...info, version }));
-
-  return true;
-};
+}

--- a/packages/board-server/src/server/info/me.ts
+++ b/packages/board-server/src/server/info/me.ts
@@ -6,7 +6,6 @@
 
 import type { IncomingMessage, ServerResponse } from "http";
 import { getStore } from "../store.js";
-import { methodNotAllowed } from "../errors.js";
 import { cors } from "../cors.js";
 import type { ServerConfig } from "../config.js";
 import { authenticateAndGetUserStore } from "../auth.js";
@@ -19,20 +18,9 @@ async function serveMeAPI(
   config: ServerConfig,
   req: IncomingMessage,
   res: ServerResponse
-): Promise<boolean> {
-  const path = new URL(req.url!, "http://localhost").pathname;
-  const isMe = path === "/me";
-  if (!isMe) {
-    return false;
-  }
-
+): Promise<void> {
   if (!cors(req, res, config.allowedOrigins)) {
-    return true;
-  }
-
-  if (req.method !== "GET") {
-    methodNotAllowed(res, "Only GET is allowed for /me");
-    return true;
+    return;
   }
 
   let store: BoardServerStore | undefined = undefined;
@@ -42,11 +30,9 @@ async function serveMeAPI(
     return store;
   });
   if (!ok(userStore)) {
-    return true;
+    return;
   }
 
   res.setHeader("Content-Type", "application/json");
   res.end(JSON.stringify({ username: userStore }));
-
-  return true;
 }


### PR DESCRIPTION
Moves the handlers for root, /me, /proxy, and /info to express.

Get rid of the path and method matching logic in those handlers. That's not handled by the Express middleware.

Part of #3172 