### PR TITLE
[unified-server] Tease apart dependencies for faster reload loop

### DIFF
--- a/packages/unified-server/package.json
+++ b/packages/unified-server/package.json
@@ -52,7 +52,8 @@
         "dist/"
       ],
       "dependencies": [
-        "<dependencies>#<this>"
+        "../board-server#build:tsc",
+        "../connection-server#build:tsc"
       ]
     },
     "serve": {
@@ -60,7 +61,14 @@
       "service": true,
       "dependencies": [
         "build:tsc",
-        "copy-assets"
+        {
+          "script": "copy-assets",
+          "cascade": false
+        },
+        {
+          "script": "../visual-editor:build:tsc",
+          "cascade": false
+        }
       ]
     },
     "test": {

--- a/packages/unified-server/package.json
+++ b/packages/unified-server/package.json
@@ -10,6 +10,8 @@
   "scripts": {
     "build": "wireit",
     "build:tsc": "wireit",
+    "build:tsc:client": "wireit",
+    "build:tsc:server": "wireit",
     "build:vite": "wireit",
     "copy-assets": "wireit",
     "dev": "npm run serve --watch",
@@ -43,13 +45,41 @@
       ]
     },
     "build:tsc": {
-      "command": "tsc --pretty",
+      "dependencies": [
+        "build:tsc:client",
+        "build:tsc:server"
+      ]
+    },
+    "build:tsc:client": {
+      "command": "tsc --pretty --project tsconfig.client.json",
       "clean": "if-file-deleted",
       "files": [
-        "src/"
+        "tsconfig.client.json",
+        "src/",
+        "!src/server/"
       ],
       "output": [
-        "dist/"
+        "dist/",
+        "!dist/src/server/",
+        "!dist/tests/",
+        "!dist/server.tsbuildinfo"
+      ],
+      "dependencies": [
+        "../visual-editor#build:tsc"
+      ]
+    },
+    "build:tsc:server": {
+      "command": "tsc --pretty --project tsconfig.server.json",
+      "clean": "if-file-deleted",
+      "files": [
+        "tsconfig.server.json",
+        "src/server/",
+        "tests/"
+      ],
+      "output": [
+        "dist/src/server/",
+        "dist/tests/",
+        "dist/server.tsbuildinfo"
       ],
       "dependencies": [
         "../board-server#build:tsc",
@@ -59,14 +89,17 @@
     "serve": {
       "command": "[ -f ./secrets/local.json ] && export CONNECTIONS_FILE=./secrets/local.json && export GOOGLE_CLOUD_PROJECT=$(gcloud config get-value project) && export FIRESTORE_DB_NAME=unified-server && export STORAGE_BUCKET=bb-blob-store SERVER_URL=http://localhost:3000/board && node --enable-source-maps .",
       "service": true,
+      "files": [
+        "vite.config.ts"
+      ],
       "dependencies": [
-        "build:tsc",
+        "build:tsc:server",
         {
-          "script": "copy-assets",
+          "script": "build:tsc:client",
           "cascade": false
         },
         {
-          "script": "../visual-editor:build:tsc",
+          "script": "copy-assets",
           "cascade": false
         }
       ]

--- a/packages/unified-server/tsconfig.client.json
+++ b/packages/unified-server/tsconfig.client.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "incremental": true,
+    "lib": ["ES2022", "DOM"],
+    "module": "NodeNext",
+    "rootDir": ".",
+    "outDir": "./dist",
+    "tsBuildInfoFile": "./dist/client.tsbuildinfo",
+    "preserveWatchOutput": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/server/**/*"]
+}

--- a/packages/unified-server/tsconfig.server.json
+++ b/packages/unified-server/tsconfig.server.json
@@ -2,9 +2,11 @@
   "compilerOptions": {
     "forceConsistentCasingInFileNames": true,
     "incremental": true,
-    "lib": ["ES2022", "DOM"],
+    "lib": ["ES2022"],
     "module": "NodeNext",
+    "rootDir": ".",
     "outDir": "./dist",
+    "tsBuildInfoFile": "./dist/server.tsbuildinfo",
     "preserveWatchOutput": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
@@ -12,5 +14,5 @@
     "strict": true,
     "target": "ES2022"
   },
-  "include": ["src/**/*", "tests/**/*"]
+  "include": ["src/server/**/*", "tests/**/*"]
 }


### PR DESCRIPTION
Previously, the dev-mode unified-server would restart whenever any client-side code changed. Now, only changes to the implementation of the unified-server itself trigger a restart, not client-side changes. So client-side changes should get picked up more quickly with less page reloading.

The actual change here is to switch the server-to-static-assets dependencies from being regular wireit dependencies (which will cause a server to restart on any change), to non-cascading dependencies (which will keep that dependency fresh, but not restart on changes -- see also https://github.com/google/wireit?tab=readme-ov-file#execution-cascade).

And in order to do that, we also needed to split apart the client from server code a bit in the build graph, including 2 separate tsconfigs.