### PR TITLE
[board-server] Use res.locals to store board info

### DIFF
--- a/.changeset/neat-boxes-read.md
+++ b/.changeset/neat-boxes-read.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/board-server": patch
+---
+
+update board route handling

--- a/packages/board-server/src/server/boards/assets-drive.ts
+++ b/packages/board-server/src/server/boards/assets-drive.ts
@@ -60,10 +60,10 @@ function success(res: ServerResponse, fileUri: string) {
 }
 
 async function handleAssetsDriveRequest(
-  driveId: string,
   req: Request,
   res: Response
 ): Promise<void> {
+  const driveId = req.params["driveId"] ?? "";
   const args = getConnectionArgs(req);
   if (!ok(args) || !("token" in args)) {
     res.writeHead(401, { "Content-Type": "application/json" });

--- a/packages/board-server/src/server/boards/delete.ts
+++ b/packages/board-server/src/server/boards/delete.ts
@@ -12,11 +12,8 @@ import { badRequest } from "../errors.js";
 import { getStore } from "../store.js";
 import type { BoardServerStore } from "../types.js";
 
-async function del(
-  boardPath: string,
-  req: Request,
-  res: Response
-): Promise<void> {
+async function del(req: Request, res: Response): Promise<void> {
+  const boardPath = res.locals.boardId.fullPath;
   let store: BoardServerStore | undefined = undefined;
 
   const userStore = await authenticateAndGetUserStore(req, res, () => {

--- a/packages/board-server/src/server/boards/describe.ts
+++ b/packages/board-server/src/server/boards/describe.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Response } from "express";
+import type { Request, Response } from "express";
 
 import {
   createGraphStore,
@@ -37,11 +37,8 @@ function emptyDescriberResult(): NodeDescriberResult {
   };
 }
 
-async function describe(
-  user: string,
-  name: string,
-  res: Response
-): Promise<void> {
+async function describe(_req: Request, res: Response): Promise<void> {
+  const { user, name } = res.locals.boardId;
   const store = getStore();
   const board = JSON.parse(await store.get(user!, name!)) as
     | GraphDescriptor

--- a/packages/board-server/src/server/boards/get.ts
+++ b/packages/board-server/src/server/boards/get.ts
@@ -11,7 +11,9 @@ import { serverError } from "../errors.js";
 import { authenticate } from "../auth.js";
 import { ok } from "@google-labs/breadboard";
 
-async function get(user: string, name: string, req: Request, res: Response) {
+async function get(req: Request, res: Response) {
+  const { user, name } = res.locals.boardId;
+
   const store = getStore();
 
   const board = await store.get(user, name);

--- a/packages/board-server/src/server/boards/invite-list.ts
+++ b/packages/board-server/src/server/boards/invite-list.ts
@@ -11,11 +11,8 @@ import { authenticateAndGetUserStore } from "../auth.js";
 import { getStore } from "../store.js";
 import type { BoardServerStore } from "../types.js";
 
-async function inviteList(
-  boardPath: string,
-  req: Request,
-  res: Response
-): Promise<void> {
+async function inviteList(req: Request, res: Response): Promise<void> {
+  const { fullPath } = res.locals.boardId;
   let store: BoardServerStore | undefined = undefined;
 
   const userStore = await authenticateAndGetUserStore(req, res, () => {
@@ -30,7 +27,7 @@ async function inviteList(
     store = getStore();
   }
 
-  const result = await store.listInvites(userStore, boardPath);
+  const result = await store.listInvites(userStore, fullPath);
   let responseBody;
   if (!result.success) {
     // TODO: Be nice and return a proper error code

--- a/packages/board-server/src/server/boards/invite-update.ts
+++ b/packages/board-server/src/server/boards/invite-update.ts
@@ -12,11 +12,11 @@ import { getStore } from "../store.js";
 import type { BoardServerStore } from "../types.js";
 
 async function updateInvite(
-  boardPath: string,
   req: Request,
   res: Response,
   body: unknown
 ): Promise<void> {
+  let { fullPath } = res.locals.boardId;
   let store: BoardServerStore | undefined = undefined;
 
   const userStore = await authenticateAndGetUserStore(req, res, () => {
@@ -32,7 +32,7 @@ async function updateInvite(
 
   if (!body) {
     // create new invite
-    const result = await store.createInvite(userStore, boardPath);
+    const result = await store.createInvite(userStore, fullPath);
     let responseBody;
     if (!result.success) {
       responseBody = { error: result.error };
@@ -48,7 +48,7 @@ async function updateInvite(
     if (!del.delete) {
       return;
     }
-    const result = await store.deleteInvite(userStore, boardPath, del.delete);
+    const result = await store.deleteInvite(userStore, fullPath, del.delete);
     let responseBody;
     if (!result.success) {
       // TODO: Be nice and return a proper error code

--- a/packages/board-server/src/server/boards/invoke.ts
+++ b/packages/board-server/src/server/boards/invoke.ts
@@ -12,13 +12,11 @@ import { secretsKit } from "../proxy/secrets.js";
 import { invokeBoard } from "./utils/invoke-board.js";
 
 async function invokeHandler(
-  boardPath: string,
-  user: string,
-  name: string,
   url: URL,
   res: Response,
   body: unknown
 ): Promise<void> {
+  const { user, name, fullPath } = res.locals.boardId;
   const inputs = body as Record<string, any>;
   const keyVerificationResult = await verifyKey(user, name, inputs);
   if (!keyVerificationResult.success) {
@@ -28,7 +26,7 @@ async function invokeHandler(
   }
   const result = await invokeBoard({
     url: url.href,
-    path: boardPath,
+    path: fullPath,
     inputs,
     loader: loadFromStore,
     kitOverrides: [secretsKit],

--- a/packages/board-server/src/server/boards/post.ts
+++ b/packages/board-server/src/server/boards/post.ts
@@ -11,12 +11,8 @@ import { authenticateAndGetUserStore } from "../auth.js";
 import { badRequest } from "../errors.js";
 import { getStore } from "../store.js";
 
-async function post(
-  boardPath: string,
-  req: Request,
-  res: Response,
-  body: unknown
-): Promise<void> {
+async function post(req: Request, res: Response, body: unknown): Promise<void> {
+  const boardPath = res.locals.boardId.fullPath;
   let store;
 
   const userPath = await authenticateAndGetUserStore(req, res, () => {

--- a/packages/board-server/src/server/boards/run.ts
+++ b/packages/board-server/src/server/boards/run.ts
@@ -14,13 +14,11 @@ import { getStore } from "../store.js";
 import type { RemoteMessage } from "@google-labs/breadboard/remote";
 
 async function runHandler(
-  boardPath: string,
-  user: string,
-  name: string,
   url: URL,
   res: Response,
   body: unknown
 ): Promise<void> {
+  const { user, name, fullPath } = res.locals.boardId;
   const {
     $next: next,
     $diagnostics: diagnostics,
@@ -65,7 +63,7 @@ async function runHandler(
 
   await runBoard({
     url: url.href,
-    path: boardPath,
+    path: fullPath,
     user: keyVerificationResult.user!,
     inputs,
     loader: loadFromStore,


### PR DESCRIPTION
Store the board info, extracted from the path, on the Response.locals object so that it doesn't need to be passed down to handler functions.

The goal is to eliminate as much logic as possible from boards/index, so that it's really just a router. This doesn't do the whole job, but is a step forward.
