### PR TITLE
[unified-server] Tell vite to ignore shared-ui BGL changes

### DIFF
--- a/packages/unified-server/vite.config.ts
+++ b/packages/unified-server/vite.config.ts
@@ -47,5 +47,10 @@ export default defineConfig(async ({ mode }): Promise<UserConfig> => {
         deleteOriginalAssets: false,
       }),
     ],
+    server: {
+      watch: {
+        ignored: ["**/shared-ui/src/bgl/**"],
+      },
+    },
   };
 });


### PR DESCRIPTION
Previously when opening or editing a file in shared-ui/src/bgl through the visual editor, vite would notice a change and reload the browser. Now it doesn't, by way of vite watch ignore patterns.