### PR TITLE
[board-server] Use express.json

### DIFF
--- a/.changeset/polite-kings-sip.md
+++ b/.changeset/polite-kings-sip.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/board-server": patch
+---
+
+Use common express middleware

--- a/packages/board-server/src/server.ts
+++ b/packages/board-server/src/server.ts
@@ -25,6 +25,8 @@ const DEFAULT_HOST = "localhost";
 export function createServer(config: ServerConfig): Express {
   const server = express();
 
+  server.use(express.json());
+
   server.get("/", async (req, res) => serveHome(config, req, res));
 
   server.use("/blobs", serveBlobsAPI(config));

--- a/packages/board-server/src/server/blobs/create.ts
+++ b/packages/board-server/src/server/blobs/create.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { IncomingMessage, ServerResponse } from "http";
-import { getBody } from "../common.js";
+import type { Request, Response } from "express";
+
 import { badRequest, serverError } from "../errors.js";
 import { isLLMContent, ok } from "@google-labs/breadboard";
 import type { LLMContent } from "@breadboard-ai/types";
@@ -15,12 +15,8 @@ import type { ServerConfig } from "../config.js";
 
 export { createBlob };
 
-async function createBlob(
-  config: ServerConfig,
-  req: IncomingMessage,
-  res: ServerResponse
-) {
-  const body = await getBody(req);
+async function createBlob(config: ServerConfig, req: Request, res: Response) {
+  const body = req.body;
   const { serverUrl, storageBucket } = config;
   if (!body) {
     badRequest(res, "No body provided");

--- a/packages/board-server/src/server/boards/create.ts
+++ b/packages/board-server/src/server/boards/create.ts
@@ -30,25 +30,17 @@ async function create(req: Request, res: Response): Promise<void> {
     store = getStore();
   }
 
-  const chunks: string[] = [];
+  const createRequest = req.body as CreateRequest;
+  const name = createRequest.name;
+  const result = await store!.create(userStore, name, !!createRequest.dryRun);
 
-  req.on("data", (chunk) => {
-    chunks.push(chunk.toString());
-  });
-
-  req.on("end", async () => {
-    const request = JSON.parse(chunks.join("")) as CreateRequest;
-    const name = request.name;
-    const result = await store!.create(userStore, name, !!request.dryRun);
-
-    if (result.success) {
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ path: result.path }));
-    } else {
-      res.writeHead(400, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ error: result.error }));
-    }
-  });
+  if (result.success) {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ path: result.path }));
+  } else {
+    res.writeHead(400, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: result.error }));
+  }
 }
 
 export default create;

--- a/packages/board-server/src/server/boards/invite-update.ts
+++ b/packages/board-server/src/server/boards/invite-update.ts
@@ -9,7 +9,6 @@ import type { Request, Response } from "express";
 import { ok } from "@google-labs/breadboard";
 
 import { authenticateAndGetUserStore } from "../auth.js";
-import { getBody } from "../common.js";
 import { getStore } from "../store.js";
 import type { BoardServerStore } from "../types.js";
 
@@ -28,20 +27,8 @@ async function updateInvite(req: Request, res: Response): Promise<void> {
     store = getStore();
   }
 
-  const body = await getBody(req);
-  if (!body) {
-    // create new invite
-    const result = await store.createInvite(userStore, fullPath);
-    let responseBody;
-    if (!result.success) {
-      responseBody = { error: result.error };
-    } else {
-      responseBody = { invite: result.invite };
-    }
-    res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(JSON.stringify(responseBody));
-    return;
-  } else {
+  const body = req.body;
+  if (body.delete) {
     // delete invite
     const del = body as { delete: string };
     if (!del.delete) {
@@ -57,6 +44,18 @@ async function updateInvite(req: Request, res: Response): Promise<void> {
     }
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify(responseBody));
+  } else {
+    // create new invite
+    const result = await store.createInvite(userStore, fullPath);
+    let responseBody;
+    if (!result.success) {
+      responseBody = { error: result.error };
+    } else {
+      responseBody = { invite: result.invite };
+    }
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(responseBody));
+    return;
   }
 }
 

--- a/packages/board-server/src/server/boards/invoke.ts
+++ b/packages/board-server/src/server/boards/invoke.ts
@@ -6,7 +6,6 @@
 
 import type { Request, Response } from "express";
 
-import { getBody } from "../common.js";
 import type { ServerConfig } from "../config.js";
 import { secretsKit } from "../proxy/secrets.js";
 
@@ -24,8 +23,7 @@ async function invokeHandler(
   url.pathname = `boards/${fullPath}`;
   url.search = "";
 
-  const body = await getBody(req);
-  const inputs = body as Record<string, any>;
+  const inputs = req.body as Record<string, any>;
   const keyVerificationResult = await verifyKey(user, name, inputs);
   if (!keyVerificationResult.success) {
     res.writeHead(200, { "Content-Type": "application/json" });

--- a/packages/board-server/src/server/boards/post.ts
+++ b/packages/board-server/src/server/boards/post.ts
@@ -11,12 +11,11 @@ import { ok, type GraphDescriptor } from "@google-labs/breadboard";
 import { authenticateAndGetUserStore } from "../auth.js";
 import { badRequest } from "../errors.js";
 import { getStore } from "../store.js";
-import { getBody } from "../common.js";
 
 import del from "./delete.js";
 
 async function post(req: Request, res: Response): Promise<void> {
-  const body = await getBody(req);
+  const body = req.body;
 
   // We handle deletion by accepting a POST request with { delete: true } in the body
   // TODO Don't do this. Use HTTP DELETE instead.

--- a/packages/board-server/src/server/boards/run.ts
+++ b/packages/board-server/src/server/boards/run.ts
@@ -8,7 +8,6 @@ import type { Request, Response } from "express";
 
 import type { RemoteMessage } from "@google-labs/breadboard/remote";
 
-import { getBody } from "../common.js";
 import type { ServerConfig } from "../config.js";
 import { secretsKit } from "../proxy/secrets.js";
 import { getStore } from "../store.js";
@@ -28,12 +27,11 @@ async function runHandler(
   url.pathname = `boards/${fullPath}`;
   url.search = "";
 
-  const body = await getBody(req);
   const {
     $next: next,
     $diagnostics: diagnostics,
     ...inputs
-  } = body as Record<string, any>;
+  } = req.body as Record<string, any>;
   const writer = new WritableStream<RemoteMessage>({
     write(chunk) {
       res.write(`data: ${JSON.stringify(chunk)}\n\n`);

--- a/packages/board-server/src/server/common.ts
+++ b/packages/board-server/src/server/common.ts
@@ -167,25 +167,3 @@ function expandImplicitIndex(urlString: string | undefined) {
   }
   return path;
 }
-
-export async function getBody(req: IncomingMessage): Promise<unknown> {
-  const chunks: string[] = [];
-
-  return new Promise<unknown>((resolve) => {
-    req.on("data", (chunk) => {
-      chunks.push(chunk.toString());
-    });
-
-    req.on("end", () => {
-      const body = chunks.join("");
-      if (!body) {
-        resolve(undefined);
-      }
-      try {
-        resolve(JSON.parse(body));
-      } catch (e) {
-        resolve(undefined);
-      }
-    });
-  });
-}

--- a/packages/board-server/src/server/proxy/index.ts
+++ b/packages/board-server/src/server/proxy/index.ts
@@ -45,19 +45,6 @@ class ResponseAdapter implements ProxyServerResponse {
   }
 }
 
-const extractRequestBody = async (request: Request) => {
-  return new Promise<AnyProxyRequestMessage>((resolve, reject) => {
-    let body = "";
-    request.on("data", (chunk) => {
-      body += chunk.toString();
-    });
-    request.on("end", () => {
-      resolve(JSON.parse(body) as AnyProxyRequestMessage);
-    });
-    request.on("error", reject);
-  });
-};
-
 export function serveProxyAPI(serverConfig: ServerConfig): Router {
   const router = Router();
 
@@ -89,9 +76,8 @@ async function post(
     return;
   }
 
-  const body = await extractRequestBody(req);
   const server = new ProxyServer(
-    new HTTPServerTransport({ body }, new ResponseAdapter(res))
+    new HTTPServerTransport({ body: req.body }, new ResponseAdapter(res))
   );
   const store = createDataStore(serverConfig);
   store.createGroup("run-board");

--- a/packages/board-server/src/server/proxy/index.ts
+++ b/packages/board-server/src/server/proxy/index.ts
@@ -45,6 +45,19 @@ class ResponseAdapter implements ProxyServerResponse {
   }
 }
 
+const extractRequestBody = async (request: Request) => {
+  return new Promise<AnyProxyRequestMessage>((resolve, reject) => {
+    let body = "";
+    request.on("data", (chunk) => {
+      body += chunk.toString();
+    });
+    request.on("end", () => {
+      resolve(JSON.parse(body) as AnyProxyRequestMessage);
+    });
+    request.on("error", reject);
+  });
+};
+
 export function serveProxyAPI(serverConfig: ServerConfig): Router {
   const router = Router();
 
@@ -76,8 +89,9 @@ async function post(
     return;
   }
 
+  const body = await extractRequestBody(req);
   const server = new ProxyServer(
-    new HTTPServerTransport({ body: req.body }, new ResponseAdapter(res))
+    new HTTPServerTransport({ body }, new ResponseAdapter(res))
   );
   const store = createDataStore(serverConfig);
   store.createGroup("run-board");


### PR DESCRIPTION
This is a partial re-revert of #4688 (reverted in #4699)

The original PR caused proxy requests to 400 because the middleware was not setting the `Request.body` attribute.

This is because the request to the proxy endpoint has `Content-Type: text/plain;charset=UTF-8`, so the Express middleware is not recognizing it as a JSON request.

This PR works around the issue by not using the middleware for that request. But the request body is JSON, so if we set the request header correctly, we could use the standard middleware for this endpoint.