### PR TITLE
llm-output - rendering text/html in an iframe.

### DIFF
--- a/packages/shared-ui/src/elements/output/llm-output/llm-output.ts
+++ b/packages/shared-ui/src/elements/output/llm-output/llm-output.ts
@@ -459,6 +459,10 @@ export class LLMOutput extends LitElement {
 
                 return cache(html`${until(audioHandler)}`);
               }
+              if (part.inlineData.mimeType.startsWith("text/html")) {
+                return cache(
+                  html`<iframe srcdoc="${part.inlineData.data}" frameBorder="0"></iframe>`);
+              }              
               if (part.inlineData.mimeType.startsWith("video")) {
                 return cache(html`<video src="${url}" controls />`);
               }


### PR DESCRIPTION
llm-output - rendering text/html in an iframe.
This currently doesn't differenciate between an html piece and an html page.
Depending how trustworthy the source is, the former may be rendered inside the widget.

- [ X ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR
