### PR TITLE
[unified-server] Update .gitignore to use explicit root paths

### DIFF
--- a/packages/unified-server/.gitignore
+++ b/packages/unified-server/.gitignore
@@ -1,6 +1,7 @@
-public
+/icons/
+/langs/
+/oauth/
+/public/
+/secrets/
+
 /index.html
-oauth/
-icons
-secrets
-langs


### PR DESCRIPTION
The paths as written exclude matching files anywhere in the tree. We're explicitly trying to exclude files at the root level.