### PR TITLE
[board-server] Unlink SQLite storage provider

### DIFF
--- a/packages/board-server/src/server/storage-providers/firestore.ts
+++ b/packages/board-server/src/server/storage-providers/firestore.ts
@@ -18,7 +18,6 @@ import {
   INVITE_EXPIRATION_TIME_MS,
 } from "../store.js";
 import type {
-  BoardServerStore,
   CreateInviteResult,
   CreateUserResult,
   ListInviteResult,
@@ -27,9 +26,7 @@ import type {
 
 const REANIMATION_COLLECTION_ID = "resume";
 
-export class FirestoreStorageProvider
-  implements RunBoardStateStore, BoardServerStore
-{
+export class FirestoreStorageProvider implements RunBoardStateStore {
   #database;
 
   constructor(storeName: string) {
@@ -99,6 +96,8 @@ export class FirestoreStorageProvider
     return data.data() as ServerInfo | undefined;
   }
 
+  // TODO Rename this
+  // It's confusing that we're referring to a string user ID as "user store"
   async getUserStore(userKey: string | null): Promise<GetUserStoreResult> {
     if (!userKey) {
       return { success: false, error: "No user key supplied" };

--- a/packages/board-server/src/server/storage-providers/sqlite.ts
+++ b/packages/board-server/src/server/storage-providers/sqlite.ts
@@ -4,7 +4,6 @@ import type {
   CreateUserResult,
   ListInviteResult,
   RunBoardStateStore,
-  BoardServerStore,
 } from "../types.js";
 import type {
   BoardListEntry,
@@ -25,9 +24,7 @@ import type {
 } from "@google-labs/breadboard";
 import { v4 as uuidv4 } from "uuid";
 
-export class SQLiteStorageProvider
-  implements RunBoardStateStore, BoardServerStore
-{
+export class SQLiteStorageProvider implements RunBoardStateStore {
   private db: Database.Database;
 
   constructor(dbPath: string) {

--- a/packages/board-server/src/server/store.ts
+++ b/packages/board-server/src/server/store.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { SQLiteStorageProvider } from "./storage-providers/sqlite.js";
 import { FirestoreStorageProvider } from "./storage-providers/firestore.js";
 
 export const EXPIRATION_TIME_MS = 1000 * 60 * 60 * 24 * 2; // 2 days
@@ -18,24 +17,10 @@ export type OperationResult =
   | { success: true }
   | { success: false; error: string };
 
-// Use factories here, so that the providers are only instantiated
-// when chosen.
-const providers = {
-  sqlite: () =>
-    new SQLiteStorageProvider(
-      process.env["SQLITE_DB_PATH"] || "board-server.db"
-    ),
-  firestore: () =>
-    new FirestoreStorageProvider(
-      process.env["FIRESTORE_DB_NAME"] || "board-server"
-    ),
-};
-
-export const getStore = () => {
-  const backend = process.env["STORAGE_BACKEND"];
-  const provider = providers[backend === "sqlite" ? "sqlite" : "firestore"];
-  return provider();
-};
+export function getStore(): FirestoreStorageProvider {
+  const db = process.env["FIRESTORE_DB_NAME"] || "board-server";
+  return new FirestoreStorageProvider(db);
+}
 
 const createAPIKey = async () => {
   const uuid = crypto.randomUUID();

--- a/packages/board-server/src/server/types.ts
+++ b/packages/board-server/src/server/types.ts
@@ -14,16 +14,12 @@ import type {
 import type { RunDiagnosticsLevel } from "@google-labs/breadboard/harness";
 import type { RemoteMessageWriter } from "@google-labs/breadboard/remote";
 import type {
-  BoardListEntry,
-  GetUserStoreResult,
-  OperationResult,
-  ServerInfo,
-} from "./store.js";
-import type {
   InlineDataCapabilityPart,
   LLMContent,
   StoredDataCapabilityPart,
 } from "@breadboard-ai/types";
+
+import type { FirestoreStorageProvider } from "./storage-providers/firestore.js";
 
 export type BoardId = {
   user: string;
@@ -88,31 +84,7 @@ export type RunBoardStateStore = {
   saveReanimationState(user: string, state: ReanimationState): Promise<string>;
 };
 
-export type BoardServerStore = {
-  getServerInfo(): Promise<ServerInfo | undefined>;
-  createUser(username: string, apiKey: string): Promise<CreateUserResult>;
-  list(userKey: string | null): Promise<BoardListEntry[]>;
-  getUserStore(userKey: string | null): Promise<GetUserStoreResult>;
-  get(userStore: string, boardName: string): Promise<string>;
-  update(
-    userStore: string,
-    path: string,
-    graph: GraphDescriptor
-  ): Promise<OperationResult>;
-  create(
-    userKey: string,
-    name: string,
-    dryRun: boolean
-  ): Promise<CreateBoardResult>;
-  delete(userStore: string, path: string): Promise<OperationResult>;
-  listInvites(userStore: string, path: string): Promise<ListInviteResult>;
-  deleteInvite(
-    userStore: string,
-    path: string,
-    invite: string
-  ): Promise<OperationResult>;
-  createInvite(userStore: string, path: string): Promise<CreateInviteResult>;
-};
+export type BoardServerStore = FirestoreStorageProvider;
 
 export type BlobStore = {
   saveData(


### PR DESCRIPTION
Gets rid of the generic BoardServerStore interface and replaces it explicitly with the Firestore version. This allows us to change the Firestore version without breaking the build or updating the SQLite version.

This is hopefully a temporary change. Have filed #4781 to get this hooked back up. But the whole storage layer will have changed in the meantime, so there will likely be some manual work to do to get it working again.