### PR TITLE
[unified-server] Remove redundant visual-editor vite build step

### DIFF
--- a/packages/unified-server/package.json
+++ b/packages/unified-server/package.json
@@ -38,7 +38,8 @@
       "command": "vite build",
       "dependencies": [
         "copy-assets",
-        "../visual-editor#build"
+        "../shared-ui#build:tsc",
+        "../visual-editor#build:tsc"
       ],
       "output": [
         "dist/client"


### PR DESCRIPTION
We were running visual editor's vite build step before the unified server one, even though its output was not used. Shaves about 9 seconds off the build:

```
Before: 🏁 [metrics] Executed 43 script(s) in 63.32 seconds
After:  🏁 [metrics] Executed 42 script(s) in 54.61 seconds
```