### PR TITLE
[styles] Tweak styles for icon classes

### DIFF
--- a/packages/shared-ui/src/styles/icons.ts
+++ b/packages/shared-ui/src/styles/icons.ts
@@ -19,39 +19,17 @@ import { css } from "lit";
 export const icons = css`
   .m-icon {
     font-family: "Material Symbols Outlined";
-    font-weight: normal;
-    font-style: normal;
-    font-size: 20px;
-    line-height: 1;
-    letter-spacing: normal;
-    text-transform: none;
-    display: inline-block;
-    white-space: nowrap;
-    word-wrap: normal;
-    direction: ltr;
-    -webkit-font-feature-settings: "liga";
-    -webkit-font-smoothing: antialiased;
-
-    font-variation-settings:
-      "FILL" 0,
-      "wght" 300,
-      "GRAD" 0,
-      "opsz" 48;
-
-    &.filled {
-      font-variation-settings:
-        "FILL" 1,
-        "wght" 300,
-        "GRAD" 0,
-        "opsz" 48;
-    }
   }
-
   .g-icon {
     font-family: "Google Symbols";
+  }
+  .m-icon,
+  .g-icon {
     font-weight: normal;
     font-style: normal;
+    font-display: optional;
     font-size: 20px;
+    user-select: none;
     line-height: 1;
     letter-spacing: normal;
     text-transform: none;


### PR DESCRIPTION
- Add `user-select: none` so that the text name of the symbol doesn't get selected
- Add `font-display: optional` so that while the icon font is still loading, it renders nothing instead of the name of the symbol in a fallback font
- Simplify the CSS by combining the two blocks that are almost identical