### PR TITLE
[board-server] Push logic out of the storage layer

### DIFF
--- a/packages/board-server/src/server/boards/delete.ts
+++ b/packages/board-server/src/server/boards/delete.ts
@@ -4,25 +4,35 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Request, Response } from "express";
+import type { NextFunction, Request, Response } from "express";
 
-import { badRequest } from "../errors.js";
+import { asPath } from "../store.js";
 import type { BoardId, BoardServerStore } from "../types.js";
 
-async function del(req: Request, res: Response): Promise<void> {
+async function del(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
   const store: BoardServerStore = req.app.locals.store;
 
   const boardId: BoardId = res.locals.boardId;
   const userId: string = res.locals.userId;
 
-  const result = await store.delete(userId, boardId.fullPath);
-  if (!result.success) {
-    badRequest(res, result.error!);
+  if (userId != boardId.user) {
+    // TODO factor this check to middleware
+    res.sendStatus(403);
     return;
   }
 
+  try {
+    await store.delete(userId, boardId.name);
+  } catch (e) {
+    next(e);
+  }
+
   // TODO don't return a response on delete. 200 OK is sufficient
-  res.json({ deleted: boardId.fullPath });
+  res.json({ deleted: asPath(boardId.user, boardId.name) });
 }
 
 export default del;

--- a/packages/board-server/src/server/boards/invite-list.ts
+++ b/packages/board-server/src/server/boards/invite-list.ts
@@ -4,26 +4,33 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Request, Response } from "express";
+import type { NextFunction, Request, Response } from "express";
 
 import type { BoardId, BoardServerStore } from "../types.js";
 
-async function inviteList(req: Request, res: Response): Promise<void> {
+async function inviteList(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
   const store: BoardServerStore = req.app.locals.store;
 
   const boardId: BoardId = res.locals.boardId;
   const userId: string = res.locals.userId;
 
-  const result = await store.listInvites(userId, boardId.fullPath);
-  let responseBody;
-  if (!result.success) {
-    // TODO: Be nice and return a proper error code
-    responseBody = { error: result.error };
-  } else {
-    responseBody = { invites: result.invites };
+  if (userId != boardId.user) {
+    // TODO factor this check to middleware
+    res.sendStatus(403);
+    return;
   }
 
-  res.json(responseBody);
+  try {
+    const invites = await store.listInvites(userId, boardId.name);
+    const responseBody = { invites };
+    res.json(responseBody);
+  } catch (e) {
+    next(e);
+  }
 }
 
 export default inviteList;

--- a/packages/board-server/src/server/boards/invite-update.ts
+++ b/packages/board-server/src/server/boards/invite-update.ts
@@ -4,49 +4,53 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Request, Response } from "express";
+import type { NextFunction, Request, Response } from "express";
 
 import { getBody } from "../common.js";
-import type { BoardId, BoardServerStore } from "../types.js";
+import { INVITE_EXPIRATION_TIME_MS } from "../store.js";
+import type { BoardId, BoardServerStore, Invite } from "../types.js";
 
-async function updateInvite(req: Request, res: Response): Promise<void> {
+async function updateInvite(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
   const store: BoardServerStore = req.app.locals.store;
   const boardId: BoardId = res.locals.boardId;
   const userId: string = res.locals.userId;
 
+  if (userId != boardId.user) {
+    // TODO factor this check to middleware
+    res.sendStatus(403);
+    return;
+  }
+
   const body = await getBody(req);
   if (!body) {
     // create new invite
-    const result = await store.createInvite(userId, boardId.fullPath);
-    let responseBody;
-    if (!result.success) {
-      responseBody = { error: result.error };
-    } else {
-      responseBody = { invite: result.invite };
+    const invite: Invite = {
+      name: Math.random().toString(36).slice(2, 10),
+      expireAt: new Date(Date.now() + INVITE_EXPIRATION_TIME_MS),
+    };
+    try {
+      await store.createInvite(userId, boardId.name, invite);
+      res.json({ invite: invite.name });
+    } catch (e) {
+      next(e);
     }
-    res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(JSON.stringify(responseBody));
-    return;
   } else {
     // delete invite
     const del = body as { delete: string };
     if (!del.delete) {
+      res.sendStatus(400);
       return;
     }
-    const result = await store.deleteInvite(
-      userId,
-      boardId.fullPath,
-      del.delete
-    );
-    let responseBody;
-    if (!result.success) {
-      // TODO: Be nice and return a proper error code
-      responseBody = { error: result.error };
-    } else {
-      responseBody = { deleted: del.delete };
+    try {
+      await store.deleteInvite(userId, boardId.name, del.delete);
+      res.json({ deleted: del.delete });
+    } catch (e) {
+      next(e);
     }
-    res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(JSON.stringify(responseBody));
   }
 }
 

--- a/packages/board-server/src/server/boards/invoke.ts
+++ b/packages/board-server/src/server/boards/invoke.ts
@@ -13,20 +13,27 @@ import { secretsKit } from "../proxy/secrets.js";
 import { loadFromStore } from "./utils/board-server-provider.js";
 import { invokeBoard } from "./utils/invoke-board.js";
 import { verifyKey } from "./utils/verify-key.js";
+import type { BoardId } from "../types.js";
+import { asPath } from "../store.js";
 
 async function invokeHandler(
   config: ServerConfig,
   req: Request,
   res: Response
 ): Promise<void> {
-  const { user, name, fullPath } = res.locals.boardId;
+  const boardId: BoardId = res.locals.boardId;
   const url = new URL(req.url, config.hostname);
-  url.pathname = `boards/${fullPath}`;
+  const path = asPath(boardId.user, boardId.name);
+  url.pathname = `boards/${path}`;
   url.search = "";
 
   const body = await getBody(req);
   const inputs = body as Record<string, any>;
-  const keyVerificationResult = await verifyKey(user, name, inputs);
+  const keyVerificationResult = await verifyKey(
+    boardId.user,
+    boardId.name,
+    inputs
+  );
   if (!keyVerificationResult.success) {
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ $error: keyVerificationResult.error }));
@@ -34,7 +41,7 @@ async function invokeHandler(
   }
   const result = await invokeBoard({
     url: url.href,
-    path: fullPath,
+    path,
     inputs,
     loader: loadFromStore,
     kitOverrides: [secretsKit],

--- a/packages/board-server/src/server/boards/loader.ts
+++ b/packages/board-server/src/server/boards/loader.ts
@@ -11,7 +11,6 @@ export function parseBoardId(opts?: { addJsonSuffix?: boolean }) {
     let boardId: BoardId = {
       user,
       name,
-      fullPath: `@${user}/${name}`,
     };
     res.locals.boardId = boardId;
     next();

--- a/packages/board-server/src/server/boards/post.ts
+++ b/packages/board-server/src/server/boards/post.ts
@@ -4,32 +4,37 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Request, Response } from "express";
+import type { NextFunction, Request, Response } from "express";
 
 import { type GraphDescriptor } from "@google-labs/breadboard";
 
-import { badRequest } from "../errors.js";
 import { getBody } from "../common.js";
 
 import del from "./delete.js";
 import type { BoardId, BoardServerStore } from "../types.js";
+import { asPath } from "../store.js";
 
-async function post(req: Request, res: Response): Promise<void> {
+async function post(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
   const body = await getBody(req);
 
   // We handle deletion by accepting a POST request with { delete: true } in the body
   // TODO Don't do this. Use HTTP DELETE instead.
   const maybeDelete = body as { delete: boolean };
   if (maybeDelete.delete === true) {
-    await del(req, res);
+    await del(req, res, next);
   } else {
-    await update(req, res, body);
+    await update(req, res, next, body);
   }
 }
 
 async function update(
   req: Request,
   res: Response,
+  next: NextFunction,
   body: unknown
 ): Promise<void> {
   const store: BoardServerStore = req.app.locals.store;
@@ -37,27 +42,32 @@ async function update(
   const boardId: BoardId = res.locals.boardId;
   const userId: string = res.locals.userId;
 
+  if (userId != boardId.user) {
+    // TODO factor this check to middleware
+    res.sendStatus(403);
+    return;
+  }
   if (!body) {
-    badRequest(res, "No body provided");
+    // TODO Error body
+    res.sendStatus(400);
     return;
   }
 
   const maybeGraph = body as GraphDescriptor;
-
   if (
     !(("nodes" in maybeGraph && "edges" in maybeGraph) || "main" in maybeGraph)
   ) {
-    badRequest(res, "Malformed body");
+    // TODO Error body
+    res.sendStatus(400);
     return;
   }
 
-  const result = await store.update(userId, boardId.fullPath, maybeGraph);
-  if (!result.success) {
-    badRequest(res, result.error);
-    return;
+  try {
+    await store.update(boardId.user, boardId.name, maybeGraph);
+    res.json({ created: asPath(boardId.user, boardId.name) });
+  } catch (e) {
+    next(e);
   }
-
-  res.json({ created: boardId.fullPath });
 }
 
 export default post;

--- a/packages/board-server/src/server/storage-providers/sqlite.ts
+++ b/packages/board-server/src/server/storage-providers/sqlite.ts
@@ -1,10 +1,15 @@
+/**
+ * Storage provider backed by a SQLite database.
+ *
+ * This module is out of sync with the rest of the board server and does not
+ * work as expected. It is maintained for archival and future purposes.
+ *
+ * TODO: #4781 - Update this to match the current storage spec and make this
+ * work again
+ */
+
 import Database from "better-sqlite3";
-import type {
-  CreateInviteResult,
-  CreateUserResult,
-  ListInviteResult,
-  RunBoardStateStore,
-} from "../types.js";
+import type { CreateUserResult, RunBoardStateStore } from "../types.js";
 import type {
   BoardListEntry,
   GetUserStoreResult,
@@ -16,13 +21,32 @@ import {
   asPath,
   EXPIRATION_TIME_MS,
   INVITE_EXPIRATION_TIME_MS,
-  sanitize,
 } from "../store.js";
 import type {
   GraphDescriptor,
   ReanimationState,
 } from "@google-labs/breadboard";
 import { v4 as uuidv4 } from "uuid";
+
+export type CreateInviteResult =
+  | {
+      success: true;
+      invite: string;
+    }
+  | {
+      success: false;
+      error: string;
+    };
+
+export type ListInviteResult =
+  | {
+      success: true;
+      invites: string[];
+    }
+  | {
+      success: false;
+      error: string;
+    };
 
 export class SQLiteStorageProvider implements RunBoardStateStore {
   private db: Database.Database;
@@ -455,3 +479,13 @@ export class SQLiteStorageProvider implements RunBoardStateStore {
     });
   }
 }
+
+const sanitize = (name: string) => {
+  if (name.endsWith(".bgl.json")) {
+    name = name.slice(0, -9);
+  } else if (name.endsWith(".json")) {
+    name = name.slice(0, -5);
+  }
+  name = name.replace(/[^a-zA-Z0-9]/g, "-");
+  return name;
+};

--- a/packages/board-server/src/server/store.ts
+++ b/packages/board-server/src/server/store.ts
@@ -6,7 +6,6 @@
 
 import type { GraphDescriptor } from "@breadboard-ai/types";
 import { FirestoreStorageProvider } from "./storage-providers/firestore.js";
-import type { BoardId } from "./types.js";
 
 export const EXPIRATION_TIME_MS = 1000 * 60 * 60 * 24 * 2; // 2 days
 export const INVITE_EXPIRATION_TIME_MS = 1000 * 60 * 60 * 24 * 4; // 4 days
@@ -86,16 +85,6 @@ export type ServerInfo = {
 
 export const asPath = (userStore: string, boardName: string) => {
   return `@${userStore}/${boardName}`;
-};
-
-export const sanitize = (name: string) => {
-  if (name.endsWith(".bgl.json")) {
-    name = name.slice(0, -9);
-  } else if (name.endsWith(".json")) {
-    name = name.slice(0, -5);
-  }
-  name = name.replace(/[^a-zA-Z0-9]/g, "-");
-  return name;
 };
 
 export const asInfo = (path: string) => {

--- a/packages/board-server/src/server/types.ts
+++ b/packages/board-server/src/server/types.ts
@@ -24,7 +24,6 @@ import type { FirestoreStorageProvider } from "./storage-providers/firestore.js"
 export type BoardId = {
   user: string;
   name: string;
-  fullPath: string;
 };
 
 export type SecretInputs = {
@@ -110,25 +109,10 @@ export type CreateUserResult =
   | { success: true; apiKey: string }
   | { success: false; message: string };
 
-export type CreateInviteResult =
-  | {
-      success: true;
-      invite: string;
-    }
-  | {
-      success: false;
-      error: string;
-    };
-
-export type ListInviteResult =
-  | {
-      success: true;
-      invites: string[];
-    }
-  | {
-      success: false;
-      error: string;
-    };
+export type Invite = {
+  name: string;
+  expireAt: Date;
+};
 
 export type PageMetadata = {
   title: string;

--- a/packages/board-server/tests/integration/board-server.test.ts
+++ b/packages/board-server/tests/integration/board-server.test.ts
@@ -1,6 +1,6 @@
 import type { Express } from "express";
 import assert from "node:assert";
-import { before, suite, test } from "node:test";
+import { afterEach, before, suite, test } from "node:test";
 import request from "supertest";
 
 import { createServer, createServerConfig } from "../../src/server.js";
@@ -40,6 +40,12 @@ suite("Board Server integration test", () => {
   });
 
   suite("Boards API", () => {
+    afterEach(async () => {
+      const store = getStore();
+      await store.delete(user.account, "test-board");
+      await store.delete(user.account, "test-board.json");
+    });
+
     test("OPTIONS /boards -> 204", async () => {
       const response = await request(server).options(`/boards`);
       assert.equal(response.status, 204);
@@ -154,7 +160,7 @@ suite("Board Server integration test", () => {
     test("POST /boards/@:user/:name/describe", async () => {
       const store = getStore();
       await store.create(user.account, "test-board");
-      const path = `@${user.account}/test-board.api`;
+      const path = `@${user.account}/test-board`;
 
       const response = await request(server)
         .post(`/boards/${path}/describe`)


### PR DESCRIPTION
Simplify the board storage logic and push logic out of the storage implementation layer and into the request haandlers. This should help reduce duplicated code between storage implementations.

In particular, security checks (i.e. user can only modify owned data) are made in the handler layer, not the storage layer.

Get rid of unneeded "result" types returned from the storage layer.

Get rid of the "fullPath" property in BoardId. This was always being immediately deconstructed into its component parts anyway.
