### PR TITLE
[flowgen] Bugfix: skip our own messages correctly when parsing response

### DIFF
--- a/packages/shared-ui/src/flow-gen/flow-generator.ts
+++ b/packages/shared-ui/src/flow-gen/flow-generator.ts
@@ -59,7 +59,7 @@ export class FlowGenerator {
     const responseFlows: GraphDescriptor[] = [];
     const responseMessages: string[] = [];
     for (
-      let i = /* Assume the first 2 messages are our own. */ 2;
+      let i = /* Skip our own messages */ request.messages.length;
       i < messages.length;
       i++
     ) {


### PR DESCRIPTION
Bug in https://github.com/breadboard-ai/breadboard/pull/4908