### PR TITLE
Fix the size of icons to 1em

### DIFF
--- a/packages/shared-ui/src/styles/icons.ts
+++ b/packages/shared-ui/src/styles/icons.ts
@@ -29,6 +29,8 @@ export const icons = css`
     font-style: normal;
     font-display: optional;
     font-size: 20px;
+    width: 1em;
+    height: 1em;
     user-select: none;
     line-height: 1;
     letter-spacing: normal;


### PR DESCRIPTION
This way they will have a consistent intrinsic size even before the font has loaded.