### PR TITLE
[board-server] Propagate store through board server

### DIFF
--- a/packages/board-server/src/server/blobs/create.ts
+++ b/packages/board-server/src/server/blobs/create.ts
@@ -4,22 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { IncomingMessage, ServerResponse } from "http";
-import { getBody } from "../common.js";
-import { badRequest, serverError } from "../errors.js";
+import type { Request, Response } from "express";
+
 import { isLLMContent, ok } from "@google-labs/breadboard";
 import type { LLMContent } from "@breadboard-ai/types";
+
 import { GoogleStorageBlobStore } from "../blob-store.js";
-import { getStore } from "../store.js";
+import { getBody } from "../common.js";
 import type { ServerConfig } from "../config.js";
+import { badRequest, serverError } from "../errors.js";
+import type { BoardServerStore } from "../types.js";
 
 export { createBlob };
 
-async function createBlob(
-  config: ServerConfig,
-  req: IncomingMessage,
-  res: ServerResponse
-) {
+async function createBlob(config: ServerConfig, req: Request, res: Response) {
+  const store: BoardServerStore = req.app.locals.store;
+
   const body = await getBody(req);
   const { serverUrl, storageBucket } = config;
   if (!body) {
@@ -42,7 +42,6 @@ async function createBlob(
     return;
   }
 
-  const store = getStore();
   let url = serverUrl;
   if (!url) {
     const serverInfo = await store.getServerInfo();

--- a/packages/board-server/src/server/boards/invoke.ts
+++ b/packages/board-server/src/server/boards/invoke.ts
@@ -10,10 +10,10 @@ import { getBody } from "../common.js";
 import type { ServerConfig } from "../config.js";
 import { secretsKit } from "../proxy/secrets.js";
 
-import { loadFromStore } from "./utils/board-server-provider.js";
+import { createBoardLoader } from "./utils/board-server-provider.js";
 import { invokeBoard } from "./utils/invoke-board.js";
 import { verifyKey } from "./utils/verify-key.js";
-import type { BoardId } from "../types.js";
+import type { BoardId, BoardServerStore } from "../types.js";
 import { asPath } from "../store.js";
 
 async function invokeHandler(
@@ -21,7 +21,12 @@ async function invokeHandler(
   req: Request,
   res: Response
 ): Promise<void> {
+  const store: BoardServerStore = req.app.locals.store;
+
   const boardId: BoardId = res.locals.boardId;
+
+  const serverUrl = (await store.getServerInfo())?.url ?? "";
+
   const url = new URL(req.url, config.hostname);
   const path = asPath(boardId.user, boardId.name);
   url.pathname = `boards/${path}`;
@@ -30,7 +35,7 @@ async function invokeHandler(
   const body = (await getBody(req)) as Record<string, any> | undefined;
   const inputs = body ?? {};
 
-  if (!(await verifyKey(inputs))) {
+  if (!(await verifyKey(inputs, store))) {
     // TODO Consider sending 404 instead to prevent leaking the existence of
     // the board
     res.sendStatus(403);
@@ -38,10 +43,11 @@ async function invokeHandler(
   }
 
   const result = await invokeBoard({
+    serverUrl,
     url: url.href,
     path,
     inputs,
-    loader: loadFromStore,
+    loader: createBoardLoader(store),
     kitOverrides: [secretsKit],
   });
   res.json(result);

--- a/packages/board-server/src/server/boards/utils/board-server-provider.ts
+++ b/packages/board-server/src/server/boards/utils/board-server-provider.ts
@@ -18,19 +18,20 @@ import {
 } from "@google-labs/breadboard";
 
 import { asInfo, getStore } from "../../store.js";
-import type { BoardServerLoadFunction } from "../../types.js";
+import type { BoardServerLoadFunction, BoardServerStore } from "../../types.js";
 
-export const loadFromStore = async (
-  path: string
-): Promise<GraphDescriptor | null> => {
-  const store = getStore();
-  const { userStore, boardName } = asInfo(path);
-  if (!userStore || !boardName) {
-    return null;
-  }
-  const board = await store.loadBoard(userStore, boardName);
-  return board?.graph ?? null;
-};
+export function createBoardLoader(
+  store: BoardServerStore
+): BoardServerLoadFunction {
+  return async (path: string): Promise<GraphDescriptor | null> => {
+    const { userStore, boardName } = asInfo(path);
+    if (!userStore || !boardName) {
+      return null;
+    }
+    const board = await store.loadBoard(userStore, boardName);
+    return board?.graph ?? null;
+  };
+}
 
 export class BoardServerProvider implements BoardServer {
   #initialized = false;
@@ -60,7 +61,12 @@ export class BoardServerProvider implements BoardServer {
   users = [this.user];
   name = "Board Server Provider";
 
-  constructor(path: string, loader: BoardServerLoadFunction) {
+  constructor(
+    serverUrl: string,
+    path: string,
+    loader: BoardServerLoadFunction
+  ) {
+    this.#serverUrl = serverUrl;
     this.#path = path;
     this.#loader = loader;
   }

--- a/packages/board-server/src/server/boards/utils/invoke-board.ts
+++ b/packages/board-server/src/server/boards/utils/invoke-board.ts
@@ -23,6 +23,7 @@ export const invokeBoard = async ({
   inputs,
   loader,
   kitOverrides,
+  serverUrl,
 }: InvokeBoardArguments) => {
   const store = getDataStore();
   if (!store) {
@@ -32,7 +33,7 @@ export const invokeBoard = async ({
   store.createGroup("run-board");
 
   const invokeKits = createKits(kitOverrides);
-  const boardServerProvider = new BoardServerProvider(path, loader);
+  const boardServerProvider = new BoardServerProvider(serverUrl, path, loader);
   await boardServerProvider.ready();
 
   const invokeLoader = createLoader([boardServerProvider]);

--- a/packages/board-server/src/server/boards/utils/run-board.ts
+++ b/packages/board-server/src/server/boards/utils/run-board.ts
@@ -19,6 +19,7 @@ import { NodeSandbox } from "@breadboard-ai/jsandbox/node";
 export const timestamp = () => globalThis.performance.now();
 
 export const runBoard = async ({
+  serverUrl,
   url,
   path,
   user,
@@ -41,7 +42,7 @@ export const runBoard = async ({
   // TODO: Figure out if this is the right thing to do here.
   store.createGroup("run-board");
 
-  const boardServerProvider = new BoardServerProvider(path, loader);
+  const boardServerProvider = new BoardServerProvider(serverUrl, path, loader);
   await boardServerProvider.ready();
 
   const runLoader = createLoader([boardServerProvider]);

--- a/packages/board-server/src/server/boards/utils/verify-key.ts
+++ b/packages/board-server/src/server/boards/utils/verify-key.ts
@@ -1,4 +1,4 @@
-import { getStore } from "../../store.js";
+import type { BoardServerStore } from "../../types.js";
 
 // TODO Allow invocation with an access token
 // TODO Convert to Express middleware
@@ -8,13 +8,14 @@ import { getStore } from "../../store.js";
  *
  * Returns the ID of the owner of the API key, or empty string
  */
-export async function verifyKey(inputs: Record<string, any>): Promise<string> {
+export async function verifyKey(
+  inputs: Record<string, any>,
+  store: BoardServerStore
+): Promise<string> {
   const key: string | undefined = inputs["$key"];
   delete inputs["$key"];
   if (!key) {
     return "";
   }
-
-  const store = getStore();
   return store.findUserIdByApiKey(key);
 }

--- a/packages/board-server/src/server/home/index.ts
+++ b/packages/board-server/src/server/home/index.ts
@@ -7,10 +7,10 @@
 import type { Request, Response } from "express";
 
 import packageInfo from "../../../package.json" with { type: "json" };
-import { getStore } from "../store.js";
+import type { BoardServerStore } from "../types.js";
 
-export const serveHome = async (_req: Request, res: Response) => {
-  const store = getStore();
+export const serveHome = async (req: Request, res: Response) => {
+  const store: BoardServerStore = req.app.locals.store;
   const info = await store.getServerInfo();
 
   const title = info?.title ?? "Board Server";

--- a/packages/board-server/src/server/info/index.ts
+++ b/packages/board-server/src/server/info/index.ts
@@ -6,8 +6,10 @@
 
 import { type Request, type Response, Router } from "express";
 
-import { getStore, type ServerInfo } from "../store.js";
 import packageInfo from "../../../package.json" with { type: "json" };
+
+import type { ServerInfo } from "../store.js";
+import type { BoardServerStore } from "../types.js";
 
 const DEFAULT_SERVER_INFO: ServerInfo = {
   title: "Board Server",
@@ -29,8 +31,8 @@ export function serveInfoAPI(): Router {
   return router;
 }
 
-async function get(_req: Request, res: Response): Promise<void> {
-  const store = getStore();
+async function get(req: Request, res: Response): Promise<void> {
+  const store: BoardServerStore = req.app.locals.store;
   const info = (await store.getServerInfo()) || DEFAULT_SERVER_INFO;
   const version = packageInfo.version;
 

--- a/packages/board-server/src/server/storage-providers/firestore.ts
+++ b/packages/board-server/src/server/storage-providers/firestore.ts
@@ -18,10 +18,9 @@ const REANIMATION_COLLECTION_ID = "resume";
 export class FirestoreStorageProvider implements RunBoardStateStore {
   #database;
 
-  constructor(storeName: string) {
-    this.#database = new Firestore({
-      databaseId: storeName,
-    });
+  constructor() {
+    const databaseId = process.env["FIRESTORE_DB_NAME"] || "board-server";
+    this.#database = new Firestore({ databaseId });
   }
 
   async createUser(username: string, apiKey: string): Promise<void> {

--- a/packages/board-server/src/server/store.ts
+++ b/packages/board-server/src/server/store.ts
@@ -10,8 +10,7 @@ import { FirestoreStorageProvider } from "./storage-providers/firestore.js";
 export const EXPIRATION_TIME_MS = 1000 * 60 * 60 * 24 * 2; // 2 days
 
 export function getStore(): FirestoreStorageProvider {
-  const db = process.env["FIRESTORE_DB_NAME"] || "board-server";
-  return new FirestoreStorageProvider(db);
+  return new FirestoreStorageProvider();
 }
 
 /** A type representing a board as it is stored in a DB. */

--- a/packages/board-server/src/server/types.ts
+++ b/packages/board-server/src/server/types.ts
@@ -41,9 +41,11 @@ export type InvokeBoardArguments = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   inputs: Record<string, any>;
   kitOverrides?: Kit[];
+  serverUrl: string;
 };
 
 export type RunBoardArguments = {
+  serverUrl: string;
   /**
    * The full URL or the requested board, like
    * `https://board.server/boards/@user/board.bgl.json`.

--- a/packages/board-server/tests/invoke-board.ts
+++ b/packages/board-server/tests/invoke-board.ts
@@ -25,6 +25,7 @@ describe("Board Server Invokes Boards", () => {
     const path = "/path/to/board";
     const inputs = { text: "bar" };
     const result = await invokeBoard({
+      serverUrl: "https://example.com",
       path,
       url: `https://example.com${path}`,
       inputs,

--- a/packages/board-server/tests/invoke-board.ts
+++ b/packages/board-server/tests/invoke-board.ts
@@ -22,7 +22,7 @@ const mockSecretsKit: Kit = {
 
 describe("Board Server Invokes Boards", () => {
   test("can invoke a simple board", async () => {
-    const path = "/path/to/board";
+    const path = "/boards/user/name";
     const inputs = { text: "bar" };
     const result = await invokeBoard({
       serverUrl: "https://example.com",

--- a/packages/board-server/tests/run-board.ts
+++ b/packages/board-server/tests/run-board.ts
@@ -158,6 +158,7 @@ const scriptedRun = async (
     }).getWriter();
 
     await runBoard({
+      serverUrl: "https://example.com",
       user: "test",
       path,
       url: `https://example.com${path}`,
@@ -183,6 +184,7 @@ describe("Board Server Runs Boards", () => {
       },
     }).getWriter();
     await runBoard({
+      serverUrl: "https://example.com",
       user: "test",
       path,
       url: `https://example.com${path}`,
@@ -213,6 +215,7 @@ describe("Board Server Runs Boards", () => {
       },
     }).getWriter();
     await runBoard({
+      serverUrl: "https://example.com",
       user: "test",
       path,
       url: `https://example.com${path}`,
@@ -241,6 +244,7 @@ describe("Board Server Runs Boards", () => {
       },
     }).getWriter();
     await runBoard({
+      serverUrl: "https://example.com",
       user: "test",
       path,
       url: `https://example.com${path}`,

--- a/packages/board-server/tests/run-board.ts
+++ b/packages/board-server/tests/run-board.ts
@@ -148,7 +148,7 @@ const scriptedRun = async (
   diagnostics: RunDiagnosticsLevel = false
 ) => {
   let next;
-  const path = "/path/to/board";
+  const path = "/boards/user/name";
   for (const [index, { inputs, expected }] of script.entries()) {
     const results: RemoteMessage[] = [];
     const writer = new WritableStream<RemoteMessage>({
@@ -176,7 +176,7 @@ const scriptedRun = async (
 
 describe("Board Server Runs Boards", () => {
   test("can start a simple board", async () => {
-    const path = "/path/to/board";
+    const path = "/board/user/name";
     const results: RemoteMessage[] = [];
     const writer = new WritableStream<RemoteMessage>({
       async write(chunk) {
@@ -206,7 +206,7 @@ describe("Board Server Runs Boards", () => {
   });
 
   test("can start a simple board with inputs", async () => {
-    const path = "/path/to/board";
+    const path = "/board/user/name";
     const inputs = { text: "bar" };
     const results: RemoteMessage[] = [];
     const writer = new WritableStream<RemoteMessage>({
@@ -235,7 +235,7 @@ describe("Board Server Runs Boards", () => {
   });
 
   test("can start a board with multiple inputs", async () => {
-    const path = "/path/to/board";
+    const path = "/board/user/name";
     const inputs = { text: "bar", number: 42 };
     const results: RemoteMessage[] = [];
     const writer = new WritableStream<RemoteMessage>({

--- a/packages/board-server/tests/run-board.ts
+++ b/packages/board-server/tests/run-board.ts
@@ -176,7 +176,7 @@ const scriptedRun = async (
 
 describe("Board Server Runs Boards", () => {
   test("can start a simple board", async () => {
-    const path = "/board/user/name";
+    const path = "/boards/user/name";
     const results: RemoteMessage[] = [];
     const writer = new WritableStream<RemoteMessage>({
       async write(chunk) {
@@ -206,7 +206,7 @@ describe("Board Server Runs Boards", () => {
   });
 
   test("can start a simple board with inputs", async () => {
-    const path = "/board/user/name";
+    const path = "/boards/user/name";
     const inputs = { text: "bar" };
     const results: RemoteMessage[] = [];
     const writer = new WritableStream<RemoteMessage>({
@@ -235,7 +235,7 @@ describe("Board Server Runs Boards", () => {
   });
 
   test("can start a board with multiple inputs", async () => {
-    const path = "/board/user/name";
+    const path = "/boards/user/name";
     const inputs = { text: "bar", number: 42 };
     const results: RemoteMessage[] = [];
     const writer = new WritableStream<RemoteMessage>({


### PR DESCRIPTION
Gets rid of almost all calls to `getStore` within the board server implementation. Store is created at server init and propagated downward as needed.

This doesn't matter when the store is stateless, but stateful providers -- like an in-memory provider for testing -- will break if the same object is not used everywhere.

Part of #4933
