### PR TITLE
[board-server] Allow specifying storage provider

### DIFF
--- a/packages/board-server/scripts/accounts.ts
+++ b/packages/board-server/scripts/accounts.ts
@@ -1,4 +1,4 @@
-import { getStore } from "../src/server/store.js";
+import { FirestoreStorageProvider } from "../src/server/storage-providers/firestore.js";
 
 async function createApiKey(): Promise<string> {
   const uuid = crypto.randomUUID();
@@ -13,7 +13,8 @@ export async function createAccount(username: string, apiKey?: string) {
   if (!apiKey) {
     apiKey = await createApiKey();
   }
-  await getStore().createUser(username, apiKey);
+  const firestore = new FirestoreStorageProvider();
+  await firestore.createUser(username, apiKey);
 
   console.log(`Created account for ${username} with API key:\n${apiKey}`);
 }

--- a/packages/board-server/src/index.ts
+++ b/packages/board-server/src/index.ts
@@ -6,7 +6,7 @@
 
 import { createServer, createServerConfig } from "./server.js";
 
-const config = createServerConfig();
+const config = createServerConfig({ storageProvider: "firestore" });
 const server = createServer(config);
 
 server.listen(config.port);

--- a/packages/board-server/src/server.test.ts
+++ b/packages/board-server/src/server.test.ts
@@ -3,19 +3,19 @@ import assert from "node:assert";
 import { afterEach, before, suite, test } from "node:test";
 import request from "supertest";
 
-import { createServer, createServerConfig } from "../../src/server.js";
-import { getStore } from "../../src/server/store.js";
-import type { BoardServerStore } from "../../src/server/store.js";
+import { createServer, createServerConfig } from "./server.js";
+import type { BoardServerStore } from "./server/store.js";
 
 suite("Board Server integration test", () => {
-  const store: BoardServerStore = getStore();
   const user = { username: "test-user", apiKey: "test-api-key" };
 
   let server: Express;
+  let store: BoardServerStore;
 
   before(async () => {
     process.env.STORAGE_BUCKET = "test-bucket";
-    server = createServer(createServerConfig());
+    server = createServer(createServerConfig({ storageProvider: "in-memory" }));
+    store = server.locals.store;
     await store.createUser(user.username, user.apiKey);
   });
 
@@ -136,7 +136,7 @@ suite("Board Server integration test", () => {
     test("POST /boards/@:user/:name/invoke", async () => {
       await store.createBoard(user.username, "test-board");
       await store.updateBoard({
-        name: "test-board.json",
+        name: "test-board",
         owner: user.username,
         displayName: "",
         description: "",

--- a/packages/board-server/src/server/boards/utils/board-server-provider.ts
+++ b/packages/board-server/src/server/boards/utils/board-server-provider.ts
@@ -17,7 +17,7 @@ import {
   type User,
 } from "@google-labs/breadboard";
 
-import { asInfo, getStore } from "../../store.js";
+import { asInfo } from "../../store.js";
 import type { BoardServerStore } from "../../store.js";
 import type { BoardServerLoadFunction } from "../../types.js";
 
@@ -72,18 +72,10 @@ export class BoardServerProvider implements BoardServer {
     this.#loader = loader;
   }
 
+  // TODO this doesn't do anything now that we're passing in server URL
   async #initialize(): Promise<void> {
     if (this.#initialized) {
       return;
-    }
-    try {
-      const store = getStore();
-      const info = await store.getServerInfo();
-      if (info) {
-        this.#serverUrl = info.url;
-      }
-    } catch (e) {
-      // Ignore errors.
     }
     this.#initialized = true;
   }

--- a/packages/board-server/src/server/config.ts
+++ b/packages/board-server/src/server/config.ts
@@ -4,9 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+export type StorageProvider = "firestore" | "in-memory";
+
 export interface ServerConfig {
   hostname: string;
   port: number;
+  storageProvider: StorageProvider;
   /**
    * The public-facing URL of the server, which
    * will be different from the `hostname` when the

--- a/packages/board-server/src/server/storage-providers/inmemory.test.ts
+++ b/packages/board-server/src/server/storage-providers/inmemory.test.ts
@@ -41,6 +41,13 @@ suite("In-memory storage provider", () => {
       description: "",
       tags: [],
       thumbnail: "",
+      graph: {
+        description: "",
+        edges: [],
+        nodes: [],
+        title: "Untitled Flow",
+        version: "0.0.1",
+      },
     });
   });
 

--- a/packages/board-server/src/server/storage-providers/inmemory.ts
+++ b/packages/board-server/src/server/storage-providers/inmemory.ts
@@ -1,4 +1,4 @@
-import type { ReanimationState } from "@google-labs/breadboard";
+import { blank, type ReanimationState } from "@google-labs/breadboard";
 import type { BoardServerStore, ServerInfo, StorageBoard } from "../store.js";
 
 export const IN_MEMORY_SERVER_INFO: ServerInfo = {
@@ -47,6 +47,7 @@ export class InMemoryStorageProvider implements BoardServerStore {
       description: "",
       tags: [],
       thumbnail: "",
+      graph: blank(),
     };
   }
 

--- a/packages/board-server/src/server/store.ts
+++ b/packages/board-server/src/server/store.ts
@@ -8,13 +8,8 @@ import type {
   GraphDescriptor,
   ReanimationState,
 } from "@google-labs/breadboard";
-import { FirestoreStorageProvider } from "./storage-providers/firestore.js";
 
 export const EXPIRATION_TIME_MS = 1000 * 60 * 60 * 24 * 2; // 2 days
-
-export function getStore(): FirestoreStorageProvider {
-  return new FirestoreStorageProvider();
-}
 
 /** A type representing a board as it is stored in a DB. */
 export type StorageBoard = {

--- a/packages/unified-server/src/server/main.ts
+++ b/packages/unified-server/src/server/main.ts
@@ -6,10 +6,12 @@ import * as boardServer from "@breadboard-ai/board-server";
 
 const server = express();
 
-const boardServerConfig = boardServer.createServerConfig();
+const boardServerConfig = boardServer.createServerConfig({
+  storageProvider: "firestore",
+});
 const connectionServerConfig = await connectionServer.createServerConfig();
 
-boardServer.addMiddleware(server);
+boardServer.addMiddleware(server, boardServerConfig);
 server.use("/board", boardServer.createRouter(boardServerConfig));
 
 server.use(
@@ -26,7 +28,6 @@ ViteExpress.config({
     return html.replace("{{displayName}}", escape(displayName));
   },
 });
-
 
 ViteExpress.static({
   enableBrotli: true,


### PR DESCRIPTION
- Update integration test to use in-memory provider
- Board and unified server start scripts use firestore provider
- Provider must always be explicitly given. No default.

Part of #4933
