### PR TITLE
[board-server] Require current user to get board

### DIFF
--- a/packages/board-server/src/server/boards/create.ts
+++ b/packages/board-server/src/server/boards/create.ts
@@ -25,7 +25,7 @@ async function create(req: Request, res: Response): Promise<void> {
   }
 
   // If a board by this name already exists, return 400
-  if (await store.loadBoardByUser(userId, name)) {
+  if (await store.loadBoardByUser(userId, name, userId)) {
     res.sendStatus(400);
     return;
   }

--- a/packages/board-server/src/server/boards/get.ts
+++ b/packages/board-server/src/server/boards/get.ts
@@ -8,21 +8,12 @@ import type { Request, Response } from "express";
 import * as errors from "../errors.js";
 import type { StorageBoard } from "../store.js";
 
-async function get(req: Request, res: Response) {
+async function get(_req: Request, res: Response) {
   try {
     const board: StorageBoard | null = res.locals.loadedBoard;
     if (!board) {
       res.sendStatus(404);
       return;
-    }
-
-    // TODO Fail closed, not open
-    // TODO Return 404 or 403, not 401
-    if (board.graph?.metadata?.tags?.includes("private")) {
-      if (res.locals.userId != req.params["user"]) {
-        errors.unauthorized(res);
-        return;
-      }
     }
     res.json(board.graph);
   } catch (e) {

--- a/packages/board-server/src/server/boards/invoke.ts
+++ b/packages/board-server/src/server/boards/invoke.ts
@@ -36,7 +36,8 @@ async function invokeHandler(
   const body = (await getBody(req)) as Record<string, any> | undefined;
   const inputs = body ?? {};
 
-  if (!(await verifyKey(inputs, store))) {
+  const userId = await verifyKey(inputs, store);
+  if (!userId) {
     // TODO Consider sending 404 instead to prevent leaking the existence of
     // the board
     res.sendStatus(403);
@@ -48,7 +49,7 @@ async function invokeHandler(
     url: url.href,
     path,
     inputs,
-    loader: createBoardLoader(store),
+    loader: createBoardLoader(store, userId),
     kitOverrides: [secretsKit],
   });
   res.json(result);

--- a/packages/board-server/src/server/boards/loader.ts
+++ b/packages/board-server/src/server/boards/loader.ts
@@ -35,7 +35,8 @@ export function loadBoard(opts?: { addJsonSuffix?: boolean }): RequestHandler {
       }
 
       const store: BoardServerStore = res.app.locals.store;
-      const board = await store.loadBoardByUser(user, name);
+      const currentUser = res.locals.userId ?? "";
+      const board = await store.loadBoardByUser(user, name, currentUser);
       if (board) {
         res.locals.loadedBoard = board;
       }

--- a/packages/board-server/src/server/boards/run.ts
+++ b/packages/board-server/src/server/boards/run.ts
@@ -82,7 +82,7 @@ async function runHandler(
     path,
     user: userId,
     inputs,
-    loader: createBoardLoader(store),
+    loader: createBoardLoader(store, userId),
     kitOverrides: [secretsKit],
     writer,
     next,

--- a/packages/board-server/src/server/boards/utils/board-server-provider.ts
+++ b/packages/board-server/src/server/boards/utils/board-server-provider.ts
@@ -17,21 +17,29 @@ import {
   type User,
 } from "@google-labs/breadboard";
 
-import { asInfo } from "../../store.js";
 import type { BoardServerStore } from "../../store.js";
 import type { BoardServerLoadFunction } from "../../types.js";
 
 export function createBoardLoader(
-  store: BoardServerStore
+  store: BoardServerStore,
+  userId: string
 ): BoardServerLoadFunction {
   return async (path: string): Promise<GraphDescriptor | null> => {
-    const { userStore, boardName } = asInfo(path);
+    const { userStore, boardName } = parsePath(path);
     if (!userStore || !boardName) {
       return null;
     }
-    const board = await store.loadBoardByUser(userStore, boardName);
+    const board = await store.loadBoardByUser(userStore, boardName, userId);
     return board?.graph ?? null;
   };
+}
+
+function parsePath(path: string) {
+  const [userStore, boardName] = path.split("/");
+  if (!userStore || userStore[0] !== "@") {
+    return {};
+  }
+  return { userStore: userStore.slice(1), boardName };
 }
 
 export class BoardServerProvider implements BoardServer {

--- a/packages/board-server/src/server/storage-providers/inmemory.test.ts
+++ b/packages/board-server/src/server/storage-providers/inmemory.test.ts
@@ -30,29 +30,38 @@ suite("In-memory storage provider", () => {
   });
 
   test("create board", async () => {
-    assert.equal(await provider.loadBoardByUser("user", "test-board"), null);
+    assert.equal(
+      await provider.loadBoardByUser("user", "test-board", "user"),
+      null
+    );
 
     provider.createBoard("user", "test-board");
 
-    assert.deepEqual(await provider.loadBoardByUser("user", "test-board"), {
-      name: "test-board",
-      owner: "user",
-      displayName: "test-board",
-      description: "",
-      tags: [],
-      thumbnail: "",
-      graph: {
+    assert.deepEqual(
+      await provider.loadBoardByUser("user", "test-board", "user"),
+      {
+        name: "test-board",
+        owner: "user",
+        displayName: "test-board",
         description: "",
-        edges: [],
-        nodes: [],
-        title: "Untitled Flow",
-        version: "0.0.1",
-      },
-    });
+        tags: [],
+        thumbnail: "",
+        graph: {
+          description: "",
+          edges: [],
+          nodes: [],
+          title: "Untitled Flow",
+          version: "0.0.1",
+        },
+      }
+    );
   });
 
   test("update board", async () => {
-    assert.equal(await provider.loadBoardByUser("user", "test-board"), null);
+    assert.equal(
+      await provider.loadBoardByUser("user", "test-board", "user"),
+      null
+    );
 
     const updatedBoard: StorageBoard = {
       name: "test-board",
@@ -68,7 +77,7 @@ suite("In-memory storage provider", () => {
     provider.updateBoard(updatedBoard);
 
     assert.deepEqual(
-      await provider.loadBoardByUser("user", "test-board"),
+      await provider.loadBoardByUser("user", "test-board", "user"),
       updatedBoard
     );
   });

--- a/packages/board-server/src/server/storage-providers/inmemory.ts
+++ b/packages/board-server/src/server/storage-providers/inmemory.ts
@@ -31,7 +31,8 @@ export class InMemoryStorageProvider implements BoardServerStore {
 
   async loadBoardByUser(
     _userId: string,
-    name: string
+    name: string,
+    _currentUser: string
   ): Promise<StorageBoard | null> {
     return this.#boards[name] ?? null;
   }

--- a/packages/board-server/src/server/storage-providers/sqlite.ts
+++ b/packages/board-server/src/server/storage-providers/sqlite.ts
@@ -11,7 +11,7 @@
 import Database from "better-sqlite3";
 import type { RunBoardStateStore } from "../types.js";
 import type { ServerInfo } from "../store.js";
-import { asInfo, asPath, EXPIRATION_TIME_MS } from "../store.js";
+import { asPath, EXPIRATION_TIME_MS } from "../store.js";
 import type {
   GraphDescriptor,
   ReanimationState,
@@ -503,4 +503,12 @@ const sanitize = (name: string) => {
   }
   name = name.replace(/[^a-zA-Z0-9]/g, "-");
   return name;
+};
+
+const asInfo = (path: string) => {
+  const [userStore, boardName] = path.split("/");
+  if (!userStore || userStore[0] !== "@") {
+    return {};
+  }
+  return { userStore: userStore.slice(1), boardName };
 };

--- a/packages/board-server/src/server/store.ts
+++ b/packages/board-server/src/server/store.ts
@@ -40,8 +40,12 @@ export interface BoardServerStore {
    */
   findUserIdByApiKey(apiKey: string): Promise<string>;
 
-  /** Load a given user's board by name */
-  loadBoardByUser(userId: string, name: string): Promise<StorageBoard | null>;
+  /** Load a given user's board by name. */
+  loadBoardByUser(
+    userId: string,
+    name: string,
+    currentUser: string
+  ): Promise<StorageBoard | null>;
 
   /**
    * Load a board by name, if viewable by the current user. This method assumes
@@ -99,12 +103,4 @@ export type ServerInfo = {
 
 export const asPath = (userStore: string, boardName: string) => {
   return `@${userStore}/${boardName}`;
-};
-
-export const asInfo = (path: string) => {
-  const [userStore, boardName] = path.split("/");
-  if (!userStore || userStore[0] !== "@") {
-    return {};
-  }
-  return { userStore: userStore.slice(1), boardName };
 };


### PR DESCRIPTION
Previously we were only checking for board permissions in the `GET` handler(s) for the boards API. This change pushes that auth check down into the storage layer.

Prior to this change, the invoke handler could actually be used as a workaround for auth checks. Since it would load any board by name that was embedded in the owned board. As long as the initial board could be loaded, all others would succeed without checking permissions. This would allow private boards to be invoked via the invoked handler without permission.

Overall, we *need* to push the auth logic down into the storage layer, since a lot of our auth logic is specific to the storage mechanism. Different storage providers will have different ways to do auth.

Part of #4960
