### PR TITLE
[revision history] Initial revision history panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23027,7 +23027,6 @@
       "version": "0.21.1",
       "resolved": "https://registry.npmjs.org/signal-utils/-/signal-utils-0.21.1.tgz",
       "integrity": "sha512-i9cdLSvVH4j8ql8mz2lyrA93xL499P8wEbIev3ldSriXeUwqh+wM4Q5VPhIZ19gPtIS4BOopJuKB8l1+wH9LCg==",
-      "license": "MIT",
       "peerDependencies": {
         "signal-polyfill": "^0.2.0"
       }
@@ -26875,7 +26874,8 @@
         "@breadboard-ai/jsandbox": "0.5.0",
         "@breadboard-ai/types": "0.6.0",
         "@google-labs/breadboard-schema": "^1.13.0",
-        "json-schema": "^0.4.0"
+        "json-schema": "^0.4.0",
+        "signal-utils": "^0.21.1"
       },
       "devDependencies": {
         "@ava/typescript": "^4.0.0",

--- a/packages/breadboard/package.json
+++ b/packages/breadboard/package.json
@@ -180,6 +180,7 @@
     "@breadboard-ai/jsandbox": "0.5.0",
     "@breadboard-ai/types": "0.6.0",
     "@google-labs/breadboard-schema": "^1.13.0",
-    "json-schema": "^0.4.0"
+    "json-schema": "^0.4.0",
+    "signal-utils": "^0.21.1"
   }
 }

--- a/packages/breadboard/src/editor/history.ts
+++ b/packages/breadboard/src/editor/history.ts
@@ -96,7 +96,11 @@ export class EditHistoryManager {
     // Chop off the history at #index.
     this.history.splice(this.#index + 1);
     // Insert new entry.
-    this.history.push({ graph: structuredClone(graph), label });
+    this.history.push({
+      graph: structuredClone(graph),
+      label,
+      timestamp: Date.now(),
+    });
     // Point #index the new entry.
     this.#index = this.history.length - 1;
   }

--- a/packages/breadboard/src/editor/history.ts
+++ b/packages/breadboard/src/editor/history.ts
@@ -10,6 +10,8 @@ import {
   EditHistoryController,
   EditHistoryEntry,
 } from "./types.js";
+import { SignalArray } from "signal-utils/array";
+import { signal } from "signal-utils";
 
 export class GraphEditHistory implements EditHistory {
   #controller: EditHistoryController;
@@ -56,6 +58,13 @@ export class GraphEditHistory implements EditHistory {
     this.#controller.setGraph(graph);
   }
 
+  jump(index: number): void {
+    this.#history.resume(this.#controller.graph(), this.#controller.version());
+    const graph = this.#history.jump(index);
+    if (!graph) return;
+    this.#controller.setGraph(graph);
+  }
+
   entries(): EditHistoryEntry[] {
     return this.#history.history;
   }
@@ -66,8 +75,9 @@ export class GraphEditHistory implements EditHistory {
 }
 
 export class EditHistoryManager {
-  history: EditHistoryEntry[] = [];
-  #index: number = 0;
+  readonly history = new SignalArray<EditHistoryEntry>();
+  @signal
+  accessor #index = 0;
   pauseLabel: string | null = null;
   #version: number = 0;
 
@@ -100,16 +110,18 @@ export class EditHistoryManager {
   }
 
   back(): GraphDescriptor | null {
-    if (this.paused()) return null;
-    this.#index && this.#index--;
-    return this.current();
+    return this.jump(this.#index - 1);
   }
 
   forth(): GraphDescriptor | null {
-    if (this.paused()) return null;
-    const newIndex = this.#index + 1;
-    const maxIndex = this.history.length - 1;
-    if (newIndex <= maxIndex) {
+    return this.jump(this.#index + 1);
+  }
+
+  jump(newIndex: number) {
+    if (this.paused()) {
+      return null;
+    }
+    if (newIndex >= 0 && newIndex < this.history.length) {
       this.#index = newIndex;
     }
     return this.current();

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -320,7 +320,11 @@ export type EditHistory = {
   index(): number;
 };
 
-export type EditHistoryEntry = { graph: GraphDescriptor; label: string };
+export type EditHistoryEntry = {
+  graph: GraphDescriptor;
+  label: string;
+  timestamp: number;
+};
 
 export type EditableGraphOptions = InspectableGraphOptions & {
   /**

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -305,6 +305,11 @@ export type EditHistory = {
   redo(): void;
 
   /**
+   * Jumps to the entry with the given index.
+   */
+  jump(index: number): void;
+
+  /**
    * Returns a list of all entries in the history.
    */
   entries(): EditHistoryEntry[];

--- a/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
@@ -60,6 +60,7 @@ import { classMap } from "lit/directives/class-map.js";
 import { Sandbox } from "@breadboard-ai/jsandbox";
 import { ChatController } from "../../state/chat-controller.js";
 import { Organizer } from "../../state/types.js";
+import "../../revision-history/revision-history-panel.js";
 
 @customElement("bb-ui-controller")
 export class UI extends LitElement {
@@ -127,8 +128,12 @@ export class UI extends LitElement {
   accessor mode = "tree" as const;
 
   @property()
-  accessor sideNavItem: "app-view" | "console" | "capabilities" | null =
-    "app-view";
+  accessor sideNavItem:
+    | "app-view"
+    | "console"
+    | "capabilities"
+    | "revision-history"
+    | null = "revision-history";
 
   @property()
   accessor selectionState: WorkspaceSelectionStateWithChangeId | null = null;
@@ -608,6 +613,28 @@ export class UI extends LitElement {
         )}`;
         break;
       }
+
+      case "revision-history": {
+        sideNavItem = html`
+          <bb-revision-history-panel
+            .history=${this.history}
+          ></bb-revision-history-panel>
+        `;
+        break;
+      }
+
+      case null: {
+        sideNavItem = nothing;
+        break;
+      }
+
+      default: {
+        console.error(
+          `Internal error: Unexpected sideNavItem:`,
+          this.sideNavItem satisfies never
+        );
+        break;
+      }
     }
 
     let assetOrganizer: HTMLTemplateResult | symbol = nothing;
@@ -657,6 +684,9 @@ export class UI extends LitElement {
         <button ?disabled=${this.sideNavItem === "console"} @click=${() => {
           this.sideNavItem = "console";
         }}>Console</button>
+        <button ?disabled=${this.sideNavItem === "revision-history"} @click=${() => {
+          this.sideNavItem = "revision-history";
+        }}>Revision history</button>
         </div>
         <div id="side-nav-content">
         ${sideNavItem}

--- a/packages/shared-ui/src/flow-gen/flow-diff.ts
+++ b/packages/shared-ui/src/flow-gen/flow-diff.ts
@@ -64,34 +64,22 @@ function jsonEqual(a: JsonSerializable, b: JsonSerializable): boolean {
   }
 
   if (typeof a === "object") {
-    if (typeof b !== "object") {
+    if (b === null || typeof b !== "object") {
       return false;
     }
-    const doneInFirstPass = new Set<string>();
-    for (const keyA of Object.getOwnPropertyNames(a)) {
-      if (
-        !jsonEqual(
-          (a as Record<string, JsonSerializable>)[keyA],
-          (b as Record<string, JsonSerializable>)[keyA]
-        )
-      ) {
+    for (const [key, valA] of Object.entries(a)) {
+      const valB = (b as Record<string, JsonSerializable | undefined>)[key];
+      if (valB === undefined || !jsonEqual(valA, valB)) {
         return false;
       }
-      doneInFirstPass.add(keyA);
     }
-    for (const keyB of Object.getOwnPropertyNames(b)) {
-      if (
-        !doneInFirstPass.has(keyB) &&
-        !jsonEqual(
-          (a as Record<string, JsonSerializable>)[keyB],
-          (b as Record<string, JsonSerializable>)[keyB]
-        )
-      ) {
+    for (const key of Object.keys(b)) {
+      if (!Object.hasOwn(a, key)) {
         return false;
       }
     }
     return true;
   }
 
-  throw new Error(`"Not a valid JSON object: <${typeof a}>`, a);
+  throw new Error(`"Not a valid JSON value: <${typeof a}>`, a satisfies never);
 }

--- a/packages/shared-ui/src/revision-history/revision-history-panel.ts
+++ b/packages/shared-ui/src/revision-history/revision-history-panel.ts
@@ -1,0 +1,195 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { LitElement, html, css, nothing } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { icons } from "../styles/icons.js";
+import { classMap } from "lit/directives/class-map.js";
+import { SignalWatcher } from "@lit-labs/signals";
+import { EditHistory, EditHistoryEntry } from "@google-labs/breadboard";
+import { consume } from "@lit/context";
+import {
+  SigninAdapter,
+  signinAdapterContext,
+} from "../utils/signin-adapter.js";
+
+@customElement("bb-revision-history-panel")
+export class RevisionHistoryPanel extends SignalWatcher(LitElement) {
+  static styles = [
+    icons,
+    css`
+      :host {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        font-family: "Google Sans", sans-serif;
+        height: 100%;
+        overflow-y: auto;
+        padding: 16px;
+      }
+
+      #wip-msg {
+        text-align: center;
+        background: #ffb61554;
+        border-radius: 12px;
+        padding: 12px 16px;
+        margin: 0;
+        font-size: 14px;
+        line-height: 1.5em;
+      }
+
+      #no-history-msg {
+        margin: auto;
+        margin-top: 24px;
+        color: var(--bb-neutral-500, currentColor);
+        display: flex;
+        & > .g-icon {
+          margin-right: 8px;
+          animation: spin 1.5s linear infinite;
+        }
+      }
+      @keyframes spin {
+        from {
+          transform: rotate(0deg);
+        }
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      #revisions {
+        margin: 0;
+        padding: 0;
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .revision {
+        cursor: pointer;
+        list-style-type: none;
+        display: flex;
+        flex-direction: column;
+        padding: 12px 16px;
+        border-radius: 12px;
+        gap: 8px;
+        &.displayed {
+          background: var(--bb-neutral-50);
+        }
+      }
+      .date {
+        font-size: 14px;
+        font-weight: 500;
+      }
+      .current {
+        font-size: 12px;
+        font-style: italic;
+      }
+      .label {
+        font-size: 12px;
+      }
+      .creator {
+        display: flex;
+        align-items: center;
+        font-size: 12px;
+        & > .icon {
+          &.placeholder {
+            margin: 0 4px 0 -3px;
+          }
+          &.signedin {
+            width: 16px;
+            aspect-ratio: 1;
+            border-radius: 50%;
+            margin-right: 8px;
+          }
+        }
+      }
+    `,
+  ];
+
+  @consume({ context: signinAdapterContext })
+  accessor signinAdapter: SigninAdapter | undefined = undefined;
+
+  @property({ attribute: false })
+  accessor history: EditHistory | undefined | null = undefined;
+
+  override render() {
+    if (!this.history) {
+      return html`
+        <p id="no-history-msg">
+          <span class="g-icon">progress_activity</span>
+          Waiting for history ...
+        </p>
+      `;
+    }
+    const rows = [];
+    const revisions = this.history.entries();
+    for (let i = revisions.length - 1; i >= 0; i--) {
+      rows.push(this.#renderRevision(revisions, i));
+    }
+    return html`
+      <p id="wip-msg">
+        Revision history is a work in progress with known bugs.
+      </p>
+      <ul id="revisions">
+        ${rows}
+      </ul>
+    `;
+  }
+
+  #renderRevision(revisions: EditHistoryEntry[], index: number) {
+    const revision = revisions[index];
+    const isCurrent = index === revisions.length - 1;
+    const isDisplayed = index === this.history?.index();
+    const formattedDate = new Date(revision.timestamp)
+      .toLocaleString("en-US", {
+        month: "long",
+        day: "numeric",
+        hour: "numeric",
+        minute: "numeric",
+        hour12: true,
+      })
+      .replace(" at ", ", ");
+    return html`
+      <li
+        class=${classMap({ revision: true, displayed: isDisplayed })}
+        @click=${() => this.#onClickRevision(index)}
+      >
+        <span class="date">${formattedDate}</span>
+        ${isCurrent
+          ? html`<span class="current">Current version</span>`
+          : nothing}
+        <span class="label">${revision.label}</span>
+        <span class="creator">
+          ${this.signinAdapter?.picture
+            ? html`
+                <img
+                  class="icon signedin"
+                  crossorigin="anonymous"
+                  src=${this.signinAdapter.picture}
+                />
+              `
+            : html`
+                <span class="icon placeholder g-icon filled">person</span>
+              `}
+          <span class="name"
+            >${this.signinAdapter?.name ?? "Unknown User"}</span
+          >
+        </span>
+      </li>
+    `;
+  }
+
+  #onClickRevision(index: number) {
+    this.history?.jump(index);
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "bb-revision-history-panel": RevisionHistoryPanel;
+  }
+}

--- a/packages/shared-ui/src/utils/signin-adapter.ts
+++ b/packages/shared-ui/src/utils/signin-adapter.ts
@@ -17,6 +17,7 @@ import {
   oauthTokenBroadcastChannelName,
 } from "../elements/connection/connection-common";
 import { SETTINGS_TYPE, SettingsHelper } from "../types/types";
+import { createContext } from "@lit/context";
 
 export { SigninAdapter };
 
@@ -33,6 +34,10 @@ export const SIGN_IN_CONNECTION_ID = "$sign-in";
  *                function properly.
  */
 export type SigninState = "signedout" | "valid" | "anonymous" | "invalid";
+
+export const signinAdapterContext = createContext<SigninAdapter | undefined>(
+  "SigninAdapter"
+);
 
 /**
  * A specialized adapter to handle sign in using the connection server

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -81,7 +81,10 @@ import {
   SelectAllCommand,
   UngroupCommand,
 } from "./commands/commands";
-import { SigninAdapter } from "@breadboard-ai/shared-ui/utils/signin-adapter.js";
+import {
+  SigninAdapter,
+  signinAdapterContext,
+} from "@breadboard-ai/shared-ui/utils/signin-adapter.js";
 import { sideBoardRuntime } from "@breadboard-ai/shared-ui/contexts/side-board-runtime.js";
 import { SideBoardRuntime } from "@breadboard-ai/shared-ui/sideboards/types.js";
 import { OverflowAction } from "@breadboard-ai/shared-ui/types/types.js";
@@ -260,6 +263,9 @@ export class Main extends LitElement {
 
   @provide({ context: sideBoardRuntime })
   accessor sideBoardRuntime!: SideBoardRuntime;
+
+  @provide({ context: signinAdapterContext })
+  accessor signinAdapter!: SigninAdapter;
 
   @state()
   accessor selectedBoardServer = "Browser Storage";
@@ -553,6 +559,12 @@ export class Main extends LitElement {
         this.sideBoardRuntime.addEventListener("running", () => {
           this.canRun = false;
         });
+
+        this.signinAdapter = new BreadboardUI.Utils.SigninAdapter(
+          this.tokenVendor,
+          this.environment,
+          this.settingsHelper
+        );
 
         this.#graphStore.addEventListener("update", (evt) => {
           const { mainGraphId } = evt;


### PR DESCRIPTION
Adds a "Revision history" panel to the right-hand-side of the editor. Visually modeled after the Google Docs history view. To support this, the existing graph history data structure is now signal-aware. Also, a timestamp has been added to history entries.  Also threw in a bug fix for jsonEqual. Major known issues:

- History is not preserved across reloads.
- Some operations don't update the backing graph history in a timely way, appearing only after some additional change is made.
- No visual distinction between human and AI edits.
- Many operations have labels that are UUIDs instead of something human-readable.
- We very likely want a treatment over the whole editor when anything other than the current revision is displayed, so that it is clear the user is viewing an older revision, and also so that the user knows that making an edit is equivalent to a rollback that will destroy subsequent history.