### PR TITLE
Highlight state

### DIFF
--- a/.changeset/gold-clubs-talk.md
+++ b/.changeset/gold-clubs-talk.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/shared-ui": patch
+---
+
+Teach DOM Renderer about highlights

--- a/packages/shared-ui/src/elements/step-editor/graph-edge.ts
+++ b/packages/shared-ui/src/elements/step-editor/graph-edge.ts
@@ -38,6 +38,10 @@ const EDGE_CONSUMED = getGlobalColor("--bb-input-600");
 // Value is on the wire, but hasn't been consumed by receiving component yet.
 const EDGE_STORED = getGlobalColor("--bb-human-600");
 
+// Value is on the wire, but hasn't been consumed by receiving component yet.
+const EDGE_USER = getGlobalColor("--bb-joiner-600");
+const EDGE_MODEL = getGlobalColor("--bb-generative-600");
+
 const HALF_HEADER_HEIGHT = 18;
 const LINE_CLEARANCE = 8;
 const ARROW_SIZE = 8;
@@ -62,6 +66,12 @@ export class GraphEdge extends Box {
 
   @property({ reflect: true, type: Boolean })
   accessor showEdgePointSelectors = false;
+
+  @property({ reflect: true, type: String })
+  accessor highlightType: "user" | "model" = "user";
+
+  @property({ reflect: true, type: Boolean })
+  accessor highlighted = false;
 
   static styles = [
     Box.styles,
@@ -615,6 +625,20 @@ export class GraphEdge extends Box {
       default: {
         edgeColor = EDGE_STANDARD;
         break;
+      }
+    }
+
+    if (this.highlighted) {
+      switch (this.highlightType) {
+        case "user": {
+          edgeColor = EDGE_USER;
+          break;
+        }
+
+        case "model": {
+          edgeColor = EDGE_MODEL;
+          break;
+        }
       }
     }
 

--- a/packages/shared-ui/src/elements/step-editor/graph-node.ts
+++ b/packages/shared-ui/src/elements/step-editor/graph-node.ts
@@ -80,6 +80,9 @@ export class GraphNode extends Box implements DragConnectorReceiver {
   @property()
   accessor hasMainPort = false;
 
+  @property({ reflect: true, type: String })
+  accessor highlightType: "user" | "model" = "model";
+
   @property({ reflect: true, type: Boolean })
   accessor highlighted = false;
 
@@ -295,8 +298,12 @@ export class GraphNode extends Box implements DragConnectorReceiver {
         outline: 2px solid var(--border);
       }
 
-      :host([highlighted]) #container {
-        outline: 3px solid var(--border);
+      :host(:not([updating])[highlighted][highlighttype="model"]) #container {
+        outline: 6px solid oklch(from var(--bb-generative-700) l c h / 0.4);
+      }
+
+      :host(:not([updating])[highlighted][highlighttype="user"]) #container {
+        outline: 6px solid oklch(from var(--bb-joiner-700) l c h / 0.4);
       }
 
       :host([moving]) #container header {

--- a/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
@@ -35,6 +35,7 @@ import { customElement, property, state } from "lit/decorators.js";
 import { guard } from "lit/directives/guard.js";
 import {
   AppTemplateAdditionalOptionsAvailable,
+  HighlightStateWithChangeId,
   RecentBoard,
   SETTINGS_TYPE,
   STATUS,
@@ -61,6 +62,10 @@ import { Sandbox } from "@breadboard-ai/jsandbox";
 import { ChatController } from "../../state/chat-controller.js";
 import { Organizer } from "../../state/types.js";
 import "../../revision-history/revision-history-panel.js";
+import {
+  createEmptyHighlightState,
+  createHighlightId,
+} from "../../utils/workspace.js";
 
 const SIDE_ITEM_KEY = "bb-ui-controller-side-nav-item";
 
@@ -106,7 +111,7 @@ export class UI extends LitElement {
   accessor failedToLoad = false;
 
   @property()
-  accessor readOnly = false;
+  accessor readOnly = true;
 
   @property()
   accessor version = "dev";
@@ -150,6 +155,9 @@ export class UI extends LitElement {
 
   @property()
   accessor selectionState: WorkspaceSelectionStateWithChangeId | null = null;
+
+  @property()
+  accessor highlightState: HighlightStateWithChangeId | null = null;
 
   @property()
   accessor visualChangeId: WorkspaceVisualChangeId | null = null;
@@ -413,7 +421,9 @@ export class UI extends LitElement {
           .graphStore=${this.graphStore}
           .graphStoreUpdateId=${this.graphStoreUpdateId}
           .selectionState=${this.selectionState}
+          .highlightState=${this.highlightState}
           .mainGraphId=${this.mainGraphId}
+          .readOnly=${this.readOnly}
           .showExperimentalComponents=${showExperimentalComponents}
           .topGraphResult=${this.topGraphResult}
           @bbshowassetorganizer=${() => {

--- a/packages/shared-ui/src/types/types.ts
+++ b/packages/shared-ui/src/types/types.ts
@@ -476,6 +476,21 @@ export interface WorkspaceSelectionStateWithChangeId {
   moveToSelection: "immediate" | "animated" | false;
 }
 
+export interface GraphHighlightState {
+  nodes: Set<NodeIdentifier>;
+  comments: Set<string>;
+  edges: Set<string>;
+}
+export type HighlightChangeId = ReturnType<typeof crypto.randomUUID>;
+export type HighlightState = {
+  graphs: Map<GraphIdentifier, GraphHighlightState>;
+};
+export interface HighlightStateWithChangeId {
+  highlightChangeId: HighlightChangeId;
+  highlightState: HighlightState;
+  highlightType: "user" | "model";
+}
+
 export interface DragConnectorReceiver extends HTMLElement {
   isOnDragConnectorTarget(): boolean;
   highlight(): void;

--- a/packages/shared-ui/src/utils/workspace.ts
+++ b/packages/shared-ui/src/utils/workspace.ts
@@ -12,7 +12,9 @@ import {
   NodeIdentifier,
 } from "@google-labs/breadboard";
 import {
+  GraphHighlightState,
   GraphSelectionState,
+  HighlightState,
   WorkspaceSelectionChangeId,
   WorkspaceSelectionState,
 } from "../types/types";
@@ -47,12 +49,32 @@ export function createEmptyWorkspaceSelectionState(): WorkspaceSelectionState {
   };
 }
 
+export function createHighlightId(): ReturnType<
+  typeof globalThis.crypto.randomUUID
+> {
+  return globalThis.crypto.randomUUID();
+}
+
+export function createEmptyHighlightState(): HighlightState {
+  return {
+    graphs: new Map(),
+  };
+}
+
 export function createEmptyGraphSelectionState(): GraphSelectionState {
   return {
     nodes: new Set(),
     comments: new Set(),
     edges: new Set(),
     references: new Set(),
+  };
+}
+
+export function createEmptyGraphHighlightState(): GraphHighlightState {
+  return {
+    nodes: new Set(),
+    comments: new Set(),
+    edges: new Set(),
   };
 }
 


### PR DESCRIPTION
Allows the creation of a highlight state independent of the current selection. To make a highlight state it goes something like this:

```typescript
const highlightState: HighlightStateWithChangeId = {
  highlightState: createEmptyHighlightState(),
  highlightChangeId: createHighlightId(),
  /** "user" or "model" */
  highlightType: "user",
};

highlightState.highlightState.graphs.set(MAIN_BOARD_ID, {
  /** A set of node IDs to highlight */
  nodes: new Set(["44e570f0-4535-437b-af65-c22c6c84205e"]),
  /** Same for comments */
  comments: new Set(),
  /** The ID for the edge generated by `inspectableEdgeToString`, which is in the format below */
  edges: new Set([
    "907489d2-c4c3-41e0-833f-149fe8313197:context->771ea370-6147-4510-a8be-d32ce7189279:context",
  ]),
});
```