### PR TITLE
[revision history] Overlay with restore button

### DIFF
--- a/packages/breadboard/src/editor/history.ts
+++ b/packages/breadboard/src/editor/history.ts
@@ -44,6 +44,13 @@ export class GraphEditHistory implements EditHistory {
     this.#controller.onHistoryChanged?.(this.#historyIncludingPending);
   }
 
+  revert(index: number) {
+    const revision = this.#history.revert(index);
+    this.#controller.setGraph(revision.graph);
+    this.#controller.onHistoryChanged?.(this.#historyIncludingPending);
+    return revision;
+  }
+
   canUndo(): boolean {
     return this.#history.canGoBack();
   }
@@ -116,6 +123,14 @@ export class EditHistoryManager {
 
   index() {
     return this.#index;
+  }
+
+  revert(index: number) {
+    this.history.splice(index + 1);
+    this.#index = index;
+    this.pending = undefined;
+    this.pauseLabel = null;
+    return this.history[index];
   }
 
   add(

--- a/packages/breadboard/src/editor/history.ts
+++ b/packages/breadboard/src/editor/history.ts
@@ -44,8 +44,8 @@ export class GraphEditHistory implements EditHistory {
     this.#controller.onHistoryChanged?.(this.#historyIncludingPending);
   }
 
-  revert(index: number) {
-    const revision = this.#history.revert(index);
+  revertTo(index: number) {
+    const revision = this.#history.revertTo(index);
     this.#controller.setGraph(revision.graph);
     this.#controller.onHistoryChanged?.(this.#historyIncludingPending);
     return revision;
@@ -125,7 +125,7 @@ export class EditHistoryManager {
     return this.#index;
   }
 
-  revert(index: number) {
+  revertTo(index: number) {
     this.history.splice(index + 1);
     this.#index = index;
     this.pending = undefined;

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -329,6 +329,8 @@ export type EditHistory = {
    * Current index in the history.
    */
   index(): number;
+
+  revert(index: number): EditHistoryEntry;
 };
 
 export type EditHistoryEntry = {

--- a/packages/breadboard/src/editor/types.ts
+++ b/packages/breadboard/src/editor/types.ts
@@ -330,7 +330,7 @@ export type EditHistory = {
    */
   index(): number;
 
-  revert(index: number): EditHistoryEntry;
+  revertTo(index: number): EditHistoryEntry;
 };
 
 export type EditHistoryEntry = {

--- a/packages/shared-ui/src/elements/step-editor/graph-node.ts
+++ b/packages/shared-ui/src/elements/step-editor/graph-node.ts
@@ -299,11 +299,11 @@ export class GraphNode extends Box implements DragConnectorReceiver {
       }
 
       :host(:not([updating])[highlighted][highlighttype="model"]) #container {
-        outline: 6px solid oklch(from var(--bb-generative-700) l c h / 0.4);
+        outline: 7px solid oklch(from var(--bb-generative-700) l c h / 0.6);
       }
 
       :host(:not([updating])[highlighted][highlighttype="user"]) #container {
-        outline: 6px solid oklch(from var(--bb-joiner-700) l c h / 0.4);
+        outline: 7px solid oklch(from var(--bb-ui-600) l c h / 0.6);
       }
 
       :host([moving]) #container header {

--- a/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
@@ -62,6 +62,7 @@ import { Sandbox } from "@breadboard-ai/jsandbox";
 import { ChatController } from "../../state/chat-controller.js";
 import { Organizer } from "../../state/types.js";
 import "../../revision-history/revision-history-panel.js";
+import "../../revision-history/revision-history-overlay.js";
 import type { HighlightEvent } from "../step-editor/events/events.js";
 
 const SIDE_ITEM_KEY = "bb-ui-controller-side-nav-item";
@@ -711,6 +712,8 @@ export class UI extends LitElement {
         }}
       >
       <div id="graph-container" slot="slot-0">
+        <bb-revision-history-overlay .history=${this.history}>
+        </bb-revision-history-overlay>
         ${graphEditor}
         ${themeEditor}
       </div>

--- a/packages/shared-ui/src/revision-history/revision-history-overlay.ts
+++ b/packages/shared-ui/src/revision-history/revision-history-overlay.ts
@@ -1,0 +1,186 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { LitElement, html, css, nothing } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { icons } from "../styles/icons.js";
+import { SignalWatcher } from "@lit-labs/signals";
+import type { EditHistory } from "@google-labs/breadboard";
+import { HighlightEvent } from "../elements/step-editor/events/events.js";
+import { createRef, ref } from "lit/directives/ref.js";
+
+@customElement("bb-revision-history-overlay")
+export class RevisionHistoryOverlay extends SignalWatcher(LitElement) {
+  static styles = [
+    icons,
+    css`
+      #overlay {
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 100%;
+        width: 100%;
+        z-index: 1;
+        cursor: not-allowed;
+      }
+      .g-icon {
+        font-variation-settings:
+          "FILL" 0,
+          "wght" 600,
+          "GRAD" 0,
+          "opsz" 48;
+      }
+      #banner {
+        padding: 10px;
+        font-family: "Google Sans", sans-serif;
+        display: inline-flex;
+        flex-direction: column;
+        cursor: initial;
+        background: var(--bb-neutral-0);
+        margin: 20px;
+        border-radius: 12px;
+        box-shadow: 0 2px 5px 0px rgb(0 0 0 / 10%);
+        transition: box-shadow 1s ease-out;
+      }
+      :host([highlighted]) #banner {
+        transition: box-shadow 200ms ease-in;
+        box-shadow: 0 0 10px 4px rgb(0 150 255 / 50%);
+      }
+      #buttons {
+        display: inline-flex;
+        align-items: center;
+      }
+      #date {
+        font-family: "Google Sans", sans-serif;
+        font-weight: 500;
+        font-size: 16px;
+        /* Ensure there is enough space for the longest date so that changing
+        revisions doesn't bounce around. */
+        min-width: 10em;
+        text-align: center;
+      }
+      #message {
+        font-weight: 500;
+        font-size: 16px;
+        margin: 0 0 12px 0;
+      }
+      #back-button {
+        background: none;
+        display: inline;
+        padding: 10px;
+        border: none;
+        cursor: pointer;
+        & > .g-icon {
+          font-size: 24px;
+        }
+      }
+      #restore-button {
+        margin-left: 24px;
+        background: var(--bb-ui-500);
+        display: inline-flex;
+        align-items: center;
+        font-family: inherit;
+        border: none;
+        border-radius: 64px;
+        color: var(--bb-neutral-0);
+        padding: 10px 20px;
+        font-weight: 500;
+        font-size: 14px;
+        cursor: pointer;
+        & > .g-icon {
+          margin-right: 8px;
+        }
+        transition: box-shadow filter 0.15s cubic-bezier(0.4, 0, 0.2, 1);
+        &:hover {
+          filter: brightness(105%);
+          box-shadow:
+            0 1px 2px rgba(0, 0, 0, 0.3),
+            0 1px 3px 1px rgba(0, 0, 0, 0.15);
+        }
+      }
+    `,
+  ];
+
+  #banner = createRef<HTMLElement>();
+
+  @property({ attribute: false })
+  accessor history: EditHistory | undefined | null = undefined;
+
+  @property({ reflect: true, type: Boolean })
+  accessor highlighted = false;
+
+  render() {
+    const history = this.history;
+    if (
+      !history ||
+      history.pending ||
+      history.index() === history.entries().length - 1
+    ) {
+      return nothing;
+    }
+    const revision = history.entries()[history.index()];
+    if (!revision) {
+      return nothing;
+    }
+    const formattedDate = new Date(revision.timestamp)
+      .toLocaleString("en-US", {
+        month: "long",
+        day: "numeric",
+        hour: "numeric",
+        minute: "numeric",
+        hour12: true,
+      })
+      .replace(" at ", ", ");
+    return html`
+      <div id="overlay" @click=${this.#onClickOverlay}>
+        <div id="banner" ${ref(this.#banner)}>
+          <!-- <h2 id="message">You are viewing an older version</h2> -->
+          <div id="buttons">
+            <button id="back-button" @click=${this.#onClickBack}>
+              <span class="g-icon">arrow_back</span>
+            </button>
+            <span id="date">${formattedDate}</span>
+            <button id="restore-button" @click=${this.#onClickRestore}>
+              <span class="g-icon">history</span>
+              Restore this version
+            </button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  #onClickBack() {
+    if (!this.history) {
+      return;
+    }
+    if (this.history.entries().length > 0 && !this.history.pending) {
+      this.history.jump(this.history.entries().length - 1);
+      this.dispatchEvent(new HighlightEvent(null));
+    }
+  }
+
+  #onClickRestore() {
+    if (!this.history) {
+      return;
+    }
+    this.history.revert(this.history.index());
+  }
+
+  #onClickOverlay(event: MouseEvent & { target: Node }) {
+    if (this.highlighted || this.#banner.value?.contains(event.target)) {
+      return;
+    }
+    this.highlighted = true;
+    setTimeout(() => (this.highlighted = false), 1500);
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "bb-revision-history-overlay": RevisionHistoryOverlay;
+  }
+}

--- a/packages/shared-ui/src/revision-history/revision-history-overlay.ts
+++ b/packages/shared-ui/src/revision-history/revision-history-overlay.ts
@@ -167,7 +167,7 @@ export class RevisionHistoryOverlay extends SignalWatcher(LitElement) {
     if (!this.history) {
       return;
     }
-    this.history.revert(this.history.index());
+    this.history.revertTo(this.history.index());
   }
 
   #onClickOverlay(event: MouseEvent & { target: Node }) {


### PR DESCRIPTION
Selecting any non-current revision now prevents interaction with the graph, and displays the selected date, with back and revert buttons.

Also tweaked the color and contrast of the node highlights, and made highlights appear/disappear more consistently.