### PR TITLE
even more fixes

### DIFF
--- a/.changeset/fifty-fans-change.md
+++ b/.changeset/fifty-fans-change.md
@@ -1,0 +1,7 @@
+---
+"@breadboard-ai/google-drive-kit": patch
+"@breadboard-ai/shared-ui": patch
+---
+
+Various Fixes including GAPI client instantiation, default connection id change,
+and edge comparison.

--- a/packages/google-drive-kit/src/board-server/access.ts
+++ b/packages/google-drive-kit/src/board-server/access.ts
@@ -9,7 +9,7 @@ import type { TokenVendor } from "@breadboard-ai/connection-client";
 export { getAccessToken };
 
 async function getAccessToken(vendor: TokenVendor): Promise<string | null> {
-  const token = vendor.getToken("google-drive-limited");
+  const token = vendor.getToken("$sign-in");
   if (token.state === "expired") {
     const refreshed = await token.refresh();
     return refreshed.grant.access_token;

--- a/packages/shared-ui/src/elements/google-drive/google-drive-directory-picker.ts
+++ b/packages/shared-ui/src/elements/google-drive/google-drive-directory-picker.ts
@@ -77,7 +77,7 @@ export class GoogleDriveDirectoryPicker extends LitElement {
     if (this._authorization === undefined) {
       return html`<bb-connection-input
         @bbinputenter=${this.#onToken}
-        connectionId="google-drive-limited"
+        connectionId="$sign-in"
       ></bb-connection-input>`;
     }
     if (this._pickerLib === undefined) {

--- a/packages/shared-ui/src/elements/google-drive/google-drive-file-id.ts
+++ b/packages/shared-ui/src/elements/google-drive/google-drive-file-id.ts
@@ -106,7 +106,7 @@ export class GoogleDriveFileId extends LitElement {
   accessor value: PickedValue | null = null;
 
   @property()
-  accessor connectionName = "google-drive-limited";
+  accessor connectionName = "$sign-in";
 
   #picker?: google.picker.Picker;
 

--- a/packages/shared-ui/src/elements/google-drive/google-drive-file-viewer.ts
+++ b/packages/shared-ui/src/elements/google-drive/google-drive-file-viewer.ts
@@ -8,7 +8,7 @@ import { LitElement, css, html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { type InputEnterEvent } from "../../events/events.js";
 import "../connection/connection-input.js";
-import { loadDriveApi, loadGapi } from "./google-apis.js";
+import { loadDriveApi, loadGapiClient } from "./google-apis.js";
 import { until } from "lit/directives/until.js";
 
 @customElement("bb-google-drive-file-viewer")
@@ -68,8 +68,8 @@ export class GoogleDriveFileViewer extends LitElement {
       return html`No file set`;
     }
 
-    const driveFile = loadGapi()
-      .then((gapi) => {
+    const driveFile = loadGapiClient()
+      .then(() => {
         if (!this._authorization) {
           return;
         }

--- a/packages/shared-ui/src/elements/google-drive/google-drive-file-viewer.ts
+++ b/packages/shared-ui/src/elements/google-drive/google-drive-file-viewer.ts
@@ -48,7 +48,7 @@ export class GoogleDriveFileViewer extends LitElement {
   accessor mimeType: string | null = null;
 
   @property()
-  accessor connectionName = "google-drive-limited";
+  accessor connectionName = "$sign-in";
 
   #picker?: google.picker.Picker;
 

--- a/packages/shared-ui/src/elements/google-drive/google-drive-query.ts
+++ b/packages/shared-ui/src/elements/google-drive/google-drive-query.ts
@@ -98,7 +98,7 @@ export class GoogleDriveQuery extends LitElement {
     if (this._authorization === undefined) {
       return html`<bb-connection-input
         @bbinputenter=${this.#onToken}
-        connectionId="google-drive-limited"
+        connectionId="$sign-in"
       ></bb-connection-input>`;
     }
     if (this._pickerLib === undefined) {

--- a/packages/shared-ui/src/elements/google-drive/google-drive-server-picker.ts
+++ b/packages/shared-ui/src/elements/google-drive/google-drive-server-picker.ts
@@ -12,7 +12,7 @@ import {
 } from "../../events/events";
 import { Task } from "@lit/task";
 
-const DRIVE_CONNECTION_ID = "google-drive-limited";
+const DRIVE_CONNECTION_ID = "$sign-in";
 const ALL_BOARD_SERVER_FOLDERS_QUERY =
   "appProperties has { key = 'breadboard' and value = 'root' } and trashed = false";
 

--- a/packages/shared-ui/src/transforms/autowire-in-ports.ts
+++ b/packages/shared-ui/src/transforms/autowire-in-ports.ts
@@ -147,8 +147,8 @@ function computeEdgeDiff(current: Edge[], incoming: Edge[]) {
   return { toInsert, toDelete };
 }
 
-function edgeKey(edge: Edge) {
-  return JSON.stringify(edge);
+function edgeKey({ metadata: _m, ...rest }: Edge) {
+  return JSON.stringify(rest);
 }
 
 function getDefaultOutputPort(from: InspectableNode | undefined) {


### PR DESCRIPTION
- **Don't use edge metadata for edge comparison.**
- **Make sure to load the GAPI client (which brings in `gapi.auth`) in file viewer.**
- **Switch to use `$sign-in` as the default connection id.**
- **docs(changeset): Various Fixes including GAPI client instantiation, default connection id change, and edge comparison.**
