### PR TITLE
Simplify GraphBoardServerLoadRequestEvent

### DIFF
--- a/packages/shared-ui/src/elements/overlay/open-board.ts
+++ b/packages/shared-ui/src/elements/overlay/open-board.ts
@@ -718,14 +718,12 @@ export class OpenBoardOverlay extends LitElement {
       return;
     }
 
-    const { url, boardServer } = selected.dataset;
+    const { url } = selected.dataset;
     if (!url) {
       return;
     }
 
-    this.dispatchEvent(
-      new GraphBoardServerLoadRequestEvent(boardServer ?? "", url)
-    );
+    this.dispatchEvent(new GraphBoardServerLoadRequestEvent(url));
   }
 
   #onKeyDown(evt: KeyboardEvent) {
@@ -960,16 +958,9 @@ export class OpenBoardOverlay extends LitElement {
                         this.#selectedIndex = itemIdx;
                         this.#highlightSelectedBoard();
                       }}
-                      @click=${(evt: PointerEvent) => {
-                        const isMac = navigator.platform.indexOf("Mac") === 0;
-                        const isCtrlCommand = isMac ? evt.metaKey : evt.ctrlKey;
-
+                      @click=${() => {
                         this.dispatchEvent(
-                          new GraphBoardServerLoadRequestEvent(
-                            boardServer.name,
-                            url,
-                            isCtrlCommand
-                          )
+                          new GraphBoardServerLoadRequestEvent(url)
                         );
                       }}
                       data-board-server=${boardServer.name}

--- a/packages/shared-ui/src/elements/welcome-panel/gallery.ts
+++ b/packages/shared-ui/src/elements/welcome-panel/gallery.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { BoardServer, GraphProviderItem } from "@google-labs/breadboard";
+import type { GraphProviderItem } from "@google-labs/breadboard";
 import { consume } from "@lit/context";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
@@ -250,9 +250,6 @@ export class Gallery extends LitElement {
   @property({ attribute: false })
   accessor recentItems: string[] | undefined = undefined;
 
-  @property({ attribute: false })
-  accessor boardServer: BoardServer | undefined = undefined;
-
   @property({ type: Number })
   accessor page = 0;
 
@@ -391,17 +388,8 @@ export class Gallery extends LitElement {
     `;
   }
 
-  #onBoardClick(event: PointerEvent | KeyboardEvent, url: string) {
-    if (!this.boardServer) {
-      return;
-    }
-    this.dispatchEvent(
-      new GraphBoardServerLoadRequestEvent(
-        this.boardServer.name,
-        url,
-        this.#isCtrlCommand(event)
-      )
-    );
+  #onBoardClick(_event: PointerEvent | KeyboardEvent, url: string) {
+    this.dispatchEvent(new GraphBoardServerLoadRequestEvent(url));
   }
 
   #onBoardKeydown(event: KeyboardEvent, url: string) {

--- a/packages/shared-ui/src/elements/welcome-panel/project-listing.ts
+++ b/packages/shared-ui/src/elements/welcome-panel/project-listing.ts
@@ -863,7 +863,6 @@ export class ProjectListing extends LitElement {
                           <bb-gallery
                             .items=${myItems}
                             .pageSize=${8}
-                            .boardServer=${boardServer}
                           ></bb-gallery>
                         </div>
                       `
@@ -884,7 +883,6 @@ export class ProjectListing extends LitElement {
                       <bb-gallery
                         .items=${sampleItems}
                         .pageSize=${/* Unlimited */ -1}
-                        .boardServer=${boardServer}
                       ></bb-gallery>
                     </div>
                   `,

--- a/packages/shared-ui/src/events/events.ts
+++ b/packages/shared-ui/src/events/events.ts
@@ -645,11 +645,7 @@ export class GraphBoardServerRemixRequestEvent extends Event {
 export class GraphBoardServerLoadRequestEvent extends Event {
   static eventName = "bbgraphboardserverloadrequest";
 
-  constructor(
-    public readonly boardServerName: string,
-    public readonly url: string,
-    public readonly newTab = false
-  ) {
+  constructor(public readonly url: string) {
     super(GraphBoardServerLoadRequestEvent.eventName, { ...eventInit });
   }
 }


### PR DESCRIPTION
The boardServerName and isCtrlCommand parameters aren't used anymore.