### PR TITLE
Bring back edit history under Activity tab

### DIFF
--- a/packages/shared-ui/src/elements/app-preview/app-preview.styles.ts
+++ b/packages/shared-ui/src/elements/app-preview/app-preview.styles.ts
@@ -341,4 +341,50 @@ export const styles = css`
       transform: none;
     }
   }
+
+  #edit-history-buttons {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+
+    > button {
+      align-items: center;
+      background: none;
+      border-radius: var(--bb-grid-size-2);
+      border: none;
+      color: var(--bb-neutral-700);
+      cursor: pointer;
+      display: flex;
+      font: 400 var(--bb-label-large) / var(--bb-label-line-height-large)
+        var(--bb-font-family);
+      padding: var(--bb-grid-size) var(--bb-grid-size-2);
+      transition:
+        background-color 100ms,
+        color 100ms;
+
+      > .g-icon {
+        font-size: calc(var(--bb-label-large) + 4px);
+        font-variation-settings:
+          "FILL" 0,
+          "wght" 600,
+          "GRAD" 0,
+          "opsz" 48;
+        margin-right: var(--bb-grid-size);
+      }
+
+      &#toggle-edit-history:hover {
+        background: var(--bb-neutral-100);
+      }
+      &#close-edit-history:hover {
+        color: var(--bb-neutral-900);
+      }
+    }
+  }
+
+  bb-revision-history-panel {
+    width: 100%;
+    margin-top: var(--bb-grid-size-4);
+    padding-bottom: var(--bb-grid-size-4);
+    margin-bottom: calc(var(--bb-grid-size-4) * -1);
+  }
 `;

--- a/packages/shared-ui/src/elements/app-preview/app-preview.styles.ts
+++ b/packages/shared-ui/src/elements/app-preview/app-preview.styles.ts
@@ -57,7 +57,7 @@ export const styles = css`
       }
     }
 
-    & #board-console-container {
+    & #board-activity-container {
       height: 100%;
       width: 100%;
       overflow: auto;

--- a/packages/shared-ui/src/elements/app-preview/app-preview.ts
+++ b/packages/shared-ui/src/elements/app-preview/app-preview.ts
@@ -123,7 +123,7 @@ export class AppPreview extends LitElement {
   accessor _originalTheme: AppTheme | null = null;
 
   @state()
-  accessor _outputMode: "app" | "console" = "app";
+  accessor _outputMode: "app" | "activity" = "app";
 
   static styles = appPreviewStyles;
 
@@ -447,11 +447,11 @@ export class AppPreview extends LitElement {
           </button>
 
           <button
-            id="console"
-            ?disabled=${this._outputMode === "console"}
+            id="activity"
+            ?disabled=${this._outputMode === "activity"}
             class=${classMap({ [this._outputMode]: true })}
             @click=${async () => {
-              this._outputMode = "console";
+              this._outputMode = "activity";
             }}
           >
             Activity
@@ -487,7 +487,7 @@ export class AppPreview extends LitElement {
     switch (this._outputMode) {
       case "app":
         return this.#renderApp();
-      case "console":
+      case "activity":
         return this.#renderActivity();
       default: {
         console.error(
@@ -535,7 +535,7 @@ export class AppPreview extends LitElement {
     const nextNodeId = this.topGraphResult?.currentNode?.descriptor.id ?? null;
 
     return html`
-      <div id="board-console-container">
+      <div id="board-activity-container">
         <bb-board-activity
           class=${classMap({ collapsed: this.debugEvent !== null })}
           .graphUrl=${graphUrl}

--- a/packages/shared-ui/src/elements/ui-controller/ui-controller.styles.ts
+++ b/packages/shared-ui/src/elements/ui-controller/ui-controller.styles.ts
@@ -761,14 +761,14 @@ export const styles = css`
   }
 
   #board-chat-container,
-  #board-console-container {
+  #board-activity-container {
     height: 100%;
     overflow: auto;
     position: relative;
     scroll-padding-bottom: 60px;
   }
 
-  #board-console-container {
+  #board-activity-container {
     padding: var(--bb-grid-size-2);
   }
 
@@ -822,7 +822,7 @@ export const styles = css`
 
   bb-capabilities-selector,
   bb-revision-history-panel,
-  #board-console-container,
+  #board-activity-container,
   bb-app-preview,
   bb-entity-editor {
     display: none;

--- a/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
@@ -595,6 +595,7 @@ export class UI extends LitElement {
             .settings=${this.settings}
             .boardServers=${this.boardServers}
             .status=${this.status}
+            .history=${this.history}
             @bbthemeeditrequest=${(evt: ThemeEditRequestEvent) => {
               this.showThemeDesigner = true;
               this.#themeOptions = evt.themeOptions;

--- a/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
@@ -207,9 +207,6 @@ export class UI extends LitElement {
   @state()
   accessor autoFocusEditor = false;
 
-  @state()
-  accessor outputMode: "app" | "console" = "app";
-
   #autoFocusEditorOnRender = false;
   #sideNavItem: "console" | "capabilities" | "revision-history" | "editor" =
     "editor";

--- a/packages/shared-ui/src/revision-history/revision-history-overlay.ts
+++ b/packages/shared-ui/src/revision-history/revision-history-overlay.ts
@@ -34,15 +34,14 @@ export class RevisionHistoryOverlay extends SignalWatcher(LitElement) {
           "opsz" 48;
       }
       #banner {
-        padding: 10px;
+        width: 100%;
+        padding: var(--bb-grid-size-3);
         font: 500 var(--bb-title-medium) / var(--bb-title-line-height-medium)
           var(--bb-font-family);
         display: inline-flex;
         flex-direction: column;
         cursor: initial;
         background: var(--bb-neutral-0);
-        margin: 20px;
-        border-radius: 12px;
         box-shadow: 0 2px 5px 0px rgb(0 0 0 / 10%);
         transition: box-shadow 1s ease-out;
       }
@@ -75,8 +74,12 @@ export class RevisionHistoryOverlay extends SignalWatcher(LitElement) {
         padding: 10px;
         border: none;
         cursor: pointer;
+        transition: color 100ms;
         & > .g-icon {
           font-size: 24px;
+        }
+        &:hover {
+          color: var(--bb-neutral-600);
         }
       }
       #restore-button {
@@ -95,7 +98,9 @@ export class RevisionHistoryOverlay extends SignalWatcher(LitElement) {
         & > .g-icon {
           margin-right: 8px;
         }
-        transition: box-shadow filter 0.15s cubic-bezier(0.4, 0, 0.2, 1);
+        transition:
+          box-shadow 0.15s,
+          filter 0.15s;
         &:hover {
           filter: brightness(105%);
           box-shadow:

--- a/packages/shared-ui/src/revision-history/revision-history-panel.ts
+++ b/packages/shared-ui/src/revision-history/revision-history-panel.ts
@@ -40,17 +40,6 @@ export class RevisionHistoryPanel extends SignalWatcher(LitElement) {
           var(--bb-font-family);
         height: 100%;
         overflow-y: auto;
-        padding: 16px;
-      }
-
-      #wip-msg {
-        text-align: center;
-        background: #ffb61554;
-        border-radius: 12px;
-        padding: 12px 16px;
-        margin: 0;
-        font-size: 14px;
-        line-height: 1.5em;
       }
 
       #no-history-msg {
@@ -168,9 +157,6 @@ export class RevisionHistoryPanel extends SignalWatcher(LitElement) {
       );
     }
     return html`
-      <p id="wip-msg">
-        Revision history is a work in progress with known bugs.
-      </p>
       <ul id="revisions">
         ${listItems}
       </ul>


### PR DESCRIPTION
Restores the edit history, but this time under the activity tab.

Also updates the edit history overlay to be a full width banner instead of floating. Probably not the final design, but looks less odd (previously it sat partially on top of the standard toolbar).