### PR TITLE
Automatically find or create a root folder in user's Google Drive

### DIFF
--- a/packages/google-drive-kit/src/board-server/server.ts
+++ b/packages/google-drive-kit/src/board-server/server.ts
@@ -320,6 +320,7 @@ class GoogleDriveBoardServer extends EventTarget implements BoardServer {
 
       this.projects = this.#refreshProjects();
 
+      console.log("Google Drive: Created new board", updatedUrl);
       return { result: true, url: updatedUrl };
     } catch (err) {
       console.warn(err);

--- a/packages/google-drive-kit/src/board-server/server.ts
+++ b/packages/google-drive-kit/src/board-server/server.ts
@@ -313,7 +313,7 @@ class GoogleDriveBoardServer extends EventTarget implements BoardServer {
       );
 
       const file: DriveFile = await response.json();
-      const updatedUrl = `${GoogleDriveBoardServer.PROTOCOL}//${parent}/${file.id}`;
+      const updatedUrl = `${GoogleDriveBoardServer.PROTOCOL}/${file.id}`;
 
       this.projects = this.#refreshProjects();
 

--- a/packages/google-drive-kit/src/board-server/server.ts
+++ b/packages/google-drive-kit/src/board-server/server.ts
@@ -144,7 +144,10 @@ class GoogleDriveBoardServer extends EventTarget implements BoardServer {
   async #refreshProjects(): Promise<BoardServerProject[]> {
     const folderId = await this.#findOrCreateUserRootFolder();
     const accessToken = await getAccessToken(this.vendor);
-    const query = `"${folderId}" in parents and mimeType = "application/json"`;
+    const query =
+      `"${folderId}" in parents` +
+      ` and mimeType = "application/json"` +
+      ` and trashed=false`;
 
     if (!folderId || !accessToken) {
       throw new Error("No folder ID or access token");
@@ -424,7 +427,8 @@ class GoogleDriveBoardServer extends EventTarget implements BoardServer {
 
     const findRequest = api.makeQueryRequest(
       `name="${GOOGLE_DRIVE_FOLDER_NAME}"` +
-        ` and mimeType="${GOOGLE_DRIVE_FOLDER_MIME_TYPE}"`
+        ` and mimeType="${GOOGLE_DRIVE_FOLDER_MIME_TYPE}"` +
+        ` and trashed=false`
     );
     const { files } = (await (
       await fetch(findRequest)


### PR DESCRIPTION
We now find or create a top-level Google Drive folder called "Breadboard" at initialization. We'll make that a VITE_ configurable env var later.

Other fixes:

- Don't list files or folders that are in the trash.
- Fix the board URL we return when creating a board in Drive; it only have the file ID, not the parent folder ID.