### PR TITLE
Add temporary drive debug panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24981,6 +24981,7 @@
         "@breadboard-ai/connection-client": "0.2.0",
         "@breadboard-ai/data-store": "0.3.2",
         "@breadboard-ai/embedded-board-server": "0.0.1",
+        "@breadboard-ai/google-drive-kit": "0.5.1",
         "@breadboard-ai/jsandbox": "0.5.0",
         "@breadboard-ai/types": "0.6.0",
         "@codemirror/autocomplete": "^6.18.6",

--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -135,6 +135,7 @@
     "@breadboard-ai/connection-client": "0.2.0",
     "@breadboard-ai/data-store": "0.3.2",
     "@breadboard-ai/embedded-board-server": "0.0.1",
+    "@breadboard-ai/google-drive-kit": "0.5.1",
     "@breadboard-ai/jsandbox": "0.5.0",
     "@breadboard-ai/types": "0.6.0",
     "@codemirror/autocomplete": "^6.18.6",

--- a/packages/shared-ui/src/elements/google-drive/google-drive-debug-panel.ts
+++ b/packages/shared-ui/src/elements/google-drive/google-drive-debug-panel.ts
@@ -1,0 +1,291 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { type TokenVendor } from "@breadboard-ai/connection-client";
+import { GoogleDriveBoardServer } from "@breadboard-ai/google-drive-kit";
+import { consume } from "@lit/context";
+import { css, html, LitElement, nothing, PropertyValues } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import { until } from "lit/directives/until.js";
+import { tokenVendorContext } from "../../contexts/token-vendor.js";
+import {
+  type SigninAdapter,
+  signinAdapterContext,
+} from "../../utils/signin-adapter.js";
+import { loadDrivePicker } from "./google-apis.js";
+import { createRef, ref } from "lit/directives/ref.js";
+
+const ASSET_MIME_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "image/svg+xml",
+].join(",");
+
+@customElement("bb-google-drive-debug-panel")
+export class GoogleDriveDebugPanel extends LitElement {
+  static styles = [
+    css`
+      :host {
+        width: 250px;
+        height: calc(100vh - 30px - 60px);
+        background: #ffffffeb;
+        border: 1px solid red;
+        position: fixed;
+        top: 60px;
+        right: 30px;
+        padding: 10px;
+        font-size: 12px;
+        overflow-y: auto;
+      }
+      * {
+        word-break: break-all;
+      }
+    `,
+  ];
+
+  @consume({ context: signinAdapterContext })
+  @property({ attribute: false })
+  accessor signinAdapter: SigninAdapter | undefined = undefined;
+
+  @consume({ context: tokenVendorContext })
+  @property({ attribute: false })
+  accessor tokenVendor!: TokenVendor;
+
+  @state()
+  accessor #googleDriveBoardServer: Promise<GoogleDriveBoardServer | null> | null =
+    null;
+
+  accessor #fileIdInput = createRef<HTMLInputElement>();
+
+  override update(changes: PropertyValues<this>) {
+    super.update(changes);
+    if (changes.has("tokenVendor")) {
+      if (this.tokenVendor) {
+        this.#googleDriveBoardServer = GoogleDriveBoardServer.from(
+          "drive:",
+          "Google Drive",
+          { username: "", apiKey: "", secrets: new Map() },
+          this.tokenVendor
+        );
+      } else {
+        this.#googleDriveBoardServer = null;
+      }
+    }
+  }
+
+  override render() {
+    return html`
+      <h2>Google Drive Debug</h2>
+
+      <p>Name: ${this.signinAdapter?.name}</p>
+
+      <p>User ID: ${this.signinAdapter?.id}</p>
+
+      <p>
+        Pic:
+        <img
+          crossorigin="anonymous"
+          src=${this.signinAdapter?.picture ?? ""}
+          width="20px"
+          height="20px"
+        />
+      </p>
+
+      <p>Parent folder: ${until(this.#renderFolderId(), "Loading...")}</p>
+
+      <button @click=${this.#openPickerForAnyFile}>Pick any file</button>
+
+      <br /><br />
+
+      <button @click=${this.#openPickerToUploadAsset}>
+        Upload image asset
+      </button>
+
+      <br /><br />
+
+      <textarea
+        ${ref(this.#fileIdInput)}
+        placeholder="Comma-delimited Drive file ids"
+      ></textarea>
+      <button @click=${this.#openPickerForSpecificFile}>
+        Force pick specific files
+      </button>
+
+      <br /><br />
+
+      <p>My projects</p>
+      <ul>
+        ${until(this.#renderUserBoards(), "Loading...")}
+      </ul>
+
+      <p>Projects shared with me</p>
+      <ul>
+        ${until(this.#renderSharedBoards(), "Loading...")}
+      </ul>
+
+      <p>Accessible image assets</p>
+      <ul>
+        ${until(this.#renderAssets(), "Loading...")}
+      </ul>
+    `;
+  }
+
+  async #renderFolderId() {
+    const server = await this.#googleDriveBoardServer;
+    if (!server) {
+      return nothing;
+    }
+    const folderId = await server?.findOrCreateFolder();
+    return html`
+      <a
+        href="https://drive.google.com/corp/drive/folders/${folderId}"
+        target="_blank"
+      >
+        ${folderId}
+      </a>
+    `;
+  }
+
+  async #renderUserBoards() {
+    const server = await this.#googleDriveBoardServer;
+    if (!server) {
+      return nothing;
+    }
+    const projects = await server.refreshProjects();
+    return projects.map((project) => {
+      const fileId = project.url.href.replace(/^drive:\//, "");
+      return html` <li>${this.#renderFileLink(fileId)}</li> `;
+    });
+  }
+
+  async #renderSharedBoards() {
+    const server = await this.#googleDriveBoardServer;
+    if (!server) {
+      return nothing;
+    }
+    const fileIds = await server.listSharedBoards();
+    return fileIds.map(
+      (fileId) => html`<li>${this.#renderFileLink(fileId)}</li>`
+    );
+  }
+
+  async #renderAssets() {
+    const server = await this.#googleDriveBoardServer;
+    if (!server) {
+      return nothing;
+    }
+    const assets = await server.listAssets();
+    return assets.map((fileId) => {
+      return html`<li>${this.#renderFileLink(fileId)}</li>`;
+    });
+  }
+
+  #renderFileLink(fileId: string) {
+    return html`
+      <a href="https://drive.google.com/file/d/${fileId}/view" target="_blank">
+        ${fileId}
+      </a>
+    `;
+  }
+
+  async #openPickerForAnyFile() {
+    const auth = await this.signinAdapter?.refresh();
+    if (auth?.state !== "valid") {
+      return;
+    }
+    const pickerLib = await loadDrivePicker();
+    const view = new pickerLib.DocsView(google.picker.ViewId.DOCS);
+    view.setMimeTypes("application/json");
+    view.setMode(google.picker.DocsViewMode.LIST);
+    // See https://developers.google.com/drive/picker/reference
+    const picker = new pickerLib.PickerBuilder()
+      .addView(view)
+      .setAppId(auth.grant.client_id)
+      .setOAuthToken(auth.grant.access_token)
+      .setCallback((result: google.picker.ResponseObject) => {
+        console.log(
+          `Google Drive file is now readable: ${JSON.stringify(result)}`
+        );
+        this.requestUpdate();
+      })
+      .build();
+    picker.setVisible(true);
+  }
+
+  async #openPickerForSpecificFile() {
+    const fileId = this.#fileIdInput.value?.value;
+    if (!fileId) {
+      return;
+    }
+    const auth = await this.signinAdapter?.refresh();
+    if (auth?.state !== "valid") {
+      return;
+    }
+    const pickerLib = await loadDrivePicker();
+    const view = new pickerLib.DocsView(google.picker.ViewId.DOCS);
+    view.setMimeTypes("application/json");
+    view.setFileIds(fileId);
+    view.setMode(google.picker.DocsViewMode.LIST);
+
+    // https://developers.google.com/drive/picker/reference
+    const picker = new pickerLib.PickerBuilder()
+      .addView(view)
+      .setAppId(auth.grant.client_id)
+      .setOAuthToken(auth.grant.access_token)
+      .enableFeature(google.picker.Feature.NAV_HIDDEN)
+      .setSize(1200, 480)
+      .setCallback((result: google.picker.ResponseObject) => {
+        console.log(
+          `Google Drive file is now readable: ${JSON.stringify(result)}`
+        );
+        this.requestUpdate();
+      })
+      .build();
+    picker.setVisible(true);
+  }
+
+  async #openPickerToUploadAsset() {
+    const auth = await this.signinAdapter?.refresh();
+    if (auth?.state !== "valid") {
+      return;
+    }
+    const server = await this.#googleDriveBoardServer;
+    if (!server) {
+      return nothing;
+    }
+    const folderId = await server?.findOrCreateFolder();
+    const pickerLib = await loadDrivePicker();
+
+    // https://developers.google.com/workspace/drive/picker/reference/picker.docsuploadview.md
+    const view = new pickerLib.DocsUploadView();
+    view.setParent(folderId);
+
+    // https://developers.google.com/drive/picker/reference
+    const picker = new pickerLib.PickerBuilder()
+      .addView(view)
+      .setAppId(auth.grant.client_id)
+      .setSelectableMimeTypes(ASSET_MIME_TYPES)
+      .setOAuthToken(auth.grant.access_token)
+      .enableFeature(google.picker.Feature.NAV_HIDDEN)
+      .setSize(1200, 480)
+      .setCallback((result: google.picker.ResponseObject) => {
+        console.log(
+          `Google Drive file is now readable: ${JSON.stringify(result)}`
+        );
+        this.requestUpdate();
+      })
+      .build();
+    picker.setVisible(true);
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "bb-google-drive-debug-panel": GoogleDriveDebugPanel;
+  }
+}

--- a/packages/shared-ui/src/elements/welcome-panel/project-listing.ts
+++ b/packages/shared-ui/src/elements/welcome-panel/project-listing.ts
@@ -43,7 +43,13 @@ import { Task, TaskStatus } from "@lit/task";
 
 const MODE_KEY = "bb-project-listing-mode";
 const OVERFLOW_MENU_CLEARANCE = 4;
-const FORCE_NO_BOARDS = new URL(document.URL).searchParams.has("forceNoBoards");
+
+const URL_PARAMS = new URL(document.URL).searchParams;
+const FORCE_NO_BOARDS = URL_PARAMS.has("forceNoBoards");
+const SHOW_GOOGLE_DRIVE_DEBUG_PANEL = URL_PARAMS.has("driveDebug");
+if (SHOW_GOOGLE_DRIVE_DEBUG_PANEL) {
+  import("../google-drive/google-drive-debug-panel.js");
+}
 
 @customElement("bb-project-listing")
 export class ProjectListing extends LitElement {
@@ -712,7 +718,8 @@ export class ProjectListing extends LitElement {
       this.selectedLocation
     );
 
-    return html` <div id="wrapper" ${ref(this.#wrapperRef)}>
+    return html`
+      <div id="wrapper" ${ref(this.#wrapperRef)}>
         <section id="hero">
           <h1>
             <span class="gradient"
@@ -1054,7 +1061,11 @@ export class ProjectListing extends LitElement {
           </div>`
         : nothing}
 
-      <div id="app-version">${this.version} (${this.gitCommitHash})</div>`;
+      <div id="app-version">${this.version} (${this.gitCommitHash})</div>
+      ${SHOW_GOOGLE_DRIVE_DEBUG_PANEL
+        ? html`<bb-google-drive-debug-panel></bb-google-drive-debug-panel>`
+        : nothing}
+    `;
   }
 
   #renderCreateNewButton() {


### PR DESCRIPTION
On the homepage, you can now add the driveDebug URL parameter to show a debug panel that displays a bunch of internal data about Google Drive. Useful for understanding capability/debugging. Will probably remove eventually.