### PR TITLE
Stop showing the original intent in the edit box

### DIFF
--- a/packages/shared-ui/src/flow-gen/flowgen-editor-input.ts
+++ b/packages/shared-ui/src/flow-gen/flowgen-editor-input.ts
@@ -200,9 +200,7 @@ export class FlowgenEditorInput extends LitElement {
         <bb-expanding-textarea
           ${ref(this.#descriptionInput)}
           .disabled=${isGenerating}
-          .placeholder=${this.#originalIntent ||
-          Strings.from("COMMAND_DESCRIBE_EDIT_FLOW")}
-          .tabCompletesPlaceholder=${!!this.#originalIntent}
+          .placeholder=${Strings.from("COMMAND_DESCRIBE_EDIT_FLOW")}
           @change=${this.#onInputChange}
           @focus=${this.#onInputFocus}
           @blur=${this.#onInputBlur}

--- a/packages/shared-ui/src/strings/en_US/editor.ts
+++ b/packages/shared-ui/src/strings/en_US/editor.ts
@@ -42,7 +42,7 @@ export default {
     str: "Describe an edit",
   },
   COMMAND_DESCRIBE_EDIT_FLOW: {
-    str: "Describe an edit",
+    str: "Suggest an edit",
   },
   COMMAND_DESCRIBE_EDIT_STEP: {
     str: "Describe an edit to this prompt",


### PR DESCRIPTION
It was confusing and weird and UX has a new idea.
