### PR TITLE
chiclet default

### DIFF
--- a/.changeset/olive-kings-wish.md
+++ b/.changeset/olive-kings-wish.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/shared-ui": minor
+---
+
+Switch to "chiclet" as the default at-wire behavior.

--- a/packages/shared-ui/src/transforms/change-edge.ts
+++ b/packages/shared-ui/src/transforms/change-edge.ts
@@ -62,19 +62,8 @@ class ChangeEdge implements EditTransform {
       return { success: false, error: `Unable to find node with id "${id}"` };
     }
 
-    let inPort = from.in;
-    let inPortFound = true;
-    if (inPort === undefined) {
-      inPortFound = false;
-      const destinationPorts = await destination.ports();
-      const destinationMainPort = destinationPorts.inputs.ports.find((port) =>
-        port.schema.behavior?.includes("main-port")
-      );
-      if (destinationMainPort) {
-        inPort = destinationMainPort.name;
-        inPortFound = true;
-      }
-    }
+    const inPort = from.in;
+    const inPortFound = inPort !== undefined;
 
     const defaultEdit: [spec: EditSpec[], message: string] = [
       [


### PR DESCRIPTION
- **Switch to "chiclet" as a default at-wire behavior.**
- **docs(changeset): Switch to "chiclet" as the default at-wire behavior.**
