### PR TITLE
stop loading legacy kits

### DIFF
--- a/.changeset/violet-weeks-shine.md
+++ b/.changeset/violet-weeks-shine.md
@@ -1,0 +1,6 @@
+---
+"@breadboard-ai/unified-server": minor
+"@breadboard-ai/visual-editor": minor
+---
+
+Stop loading legacy kits in unified server.

--- a/packages/unified-server/src/init.ts
+++ b/packages/unified-server/src/init.ts
@@ -5,8 +5,11 @@
  */
 
 import { bootstrap } from "@breadboard-ai/visual-editor/bootstrap";
+import { asRuntimeKit } from "@google-labs/breadboard";
+import Core from "@google-labs/core-kit";
 
 bootstrap({
   connectionServerUrl: new URL("/connection/", window.location.href),
   requiresSignin: true,
+  kits: [asRuntimeKit(Core)],
 });

--- a/packages/visual-editor/package.json
+++ b/packages/visual-editor/package.json
@@ -8,10 +8,6 @@
       "types": "./build/src/index.d.ts",
       "default": "./build/src/index.js"
     },
-    "./preview.js": {
-      "types": "./build/preview.d.ts",
-      "default": "./build/preview.js"
-    },
     "./config.js": {
       "types": "./build/src/config.d.ts",
       "default": "./build/src/config.js"
@@ -19,14 +15,6 @@
     "./public": "./public",
     "./index.html": "./index.html",
     "./preview.html": "./preview.html",
-    "./embed.js": "./build/embed.js",
-    "./core-kit.js": "./build/core-kit.js",
-    "./json-kit.js": "./build/json-kit.js",
-    "./template-kit.js": "./build/template-kit.js",
-    "./providers": {
-      "types": "./build/providers/types.d.ts",
-      "default": "./build/providers/types.js"
-    },
     "./vite": "./build/src/configure-assets.js",
     "./build-info": "./build/src/build-info.js",
     "./bootstrap": "./build/src/bootstrap.js"

--- a/packages/visual-editor/src/bootstrap.ts
+++ b/packages/visual-editor/src/bootstrap.ts
@@ -9,12 +9,15 @@ import * as StringsHelper from "@breadboard-ai/shared-ui/strings";
 import { MainArguments } from "./index.js";
 import { LanguagePack } from "@breadboard-ai/shared-ui/types/types.js";
 import { GoogleDriveBoardServer } from "@breadboard-ai/google-drive-kit";
+import { Kit, MutableGraphStore } from "@google-labs/breadboard";
 
 export { bootstrap };
 
 export type BootstrapArguments = {
   connectionServerUrl?: URL;
   requiresSignin?: boolean;
+  kits?: Kit[];
+  graphStorePreloader?: (graphStore: MutableGraphStore) => void;
 };
 
 function getUrlFromBoardServiceFlag(
@@ -82,6 +85,8 @@ function bootstrap(args: BootstrapArguments = {}) {
       boardServerUrl: getUrlFromBoardServiceFlag(BOARD_SERVICE),
       connectionServerUrl: args?.connectionServerUrl,
       requiresSignin: args?.requiresSignin,
+      kits: args?.kits,
+      graphStorePreloader: args?.graphStorePreloader,
     };
 
     window.oncontextmenu = (evt) => evt.preventDefault();

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -41,6 +41,8 @@ import {
   EditHistoryCreator,
   envFromGraphDescriptor,
   FileSystem,
+  Kit,
+  addSandboxedRunModule,
 } from "@google-labs/breadboard";
 import {
   createFileSystemBackend,
@@ -128,6 +130,8 @@ export type MainArguments = {
    * Whether or not this instance of requires sign in.
    */
   requiresSignin?: boolean;
+  kits?: Kit[];
+  graphStorePreloader?: (graphStore: MutableGraphStore) => void;
 };
 
 type BoardOverlowMenuConfiguration = {
@@ -539,6 +543,7 @@ export class Main extends LitElement {
           proxy: this.#proxy,
           fileSystem: this.#fileSystem,
           builtInBoardServers: [createA2Server()],
+          kits: addSandboxedRunModule(sandbox, config.kits || []),
         });
       })
       .then((runtime) => {
@@ -547,6 +552,10 @@ export class Main extends LitElement {
         this.#boardServers = runtime.board.getBoardServers() || [];
 
         this.sideBoardRuntime = runtime.sideboards;
+
+        // This is currently used only for legacy graph kits (Agent,
+        // Google Drive).
+        config.graphStorePreloader?.(this.#graphStore);
 
         this.sideBoardRuntime.addEventListener("empty", () => {
           this.canRun = true;

--- a/packages/visual-editor/src/init.ts
+++ b/packages/visual-editor/src/init.ts
@@ -5,5 +5,9 @@
  */
 
 import { bootstrap } from "./bootstrap";
+import { loadKits, registerLegacyKits } from "./utils/kit-loader";
 
-bootstrap();
+bootstrap({
+  kits: loadKits(),
+  graphStorePreloader: registerLegacyKits,
+});

--- a/packages/visual-editor/src/runtime/runtime.ts
+++ b/packages/visual-editor/src/runtime/runtime.ts
@@ -4,12 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  addSandboxedRunModule,
-  createGraphStore,
-  createLoader,
-  Kit,
-} from "@google-labs/breadboard";
+import { createGraphStore, createLoader, Kit } from "@google-labs/breadboard";
 import { Board } from "./board.js";
 import { Run } from "./run.js";
 import { Edit } from "./edit.js";
@@ -26,21 +21,14 @@ import {
   BoardServerAwareDataStore,
 } from "@breadboard-ai/board-server-management";
 
-import { loadKits, registerLegacyKits } from "../utils/kit-loader";
-
 export * as Events from "./events.js";
 export * as Types from "./types.js";
 
-import { sandbox } from "../sandbox";
 import { Select } from "./select.js";
 import { StateManager } from "./state.js";
 import { getDataStore } from "@breadboard-ai/data-store";
 import { createSideboardRuntimeProvider } from "./sideboard-runtime.js";
 import { SideBoardRuntime } from "@breadboard-ai/shared-ui/sideboards/types.js";
-
-function withRunModule(kits: Kit[]): Kit[] {
-  return addSandboxedRunModule(sandbox, kits);
-}
 
 export async function create(config: RuntimeConfig): Promise<{
   board: Board;
@@ -52,8 +40,7 @@ export async function create(config: RuntimeConfig): Promise<{
   state: StateManager;
   util: typeof Util;
 }> {
-  const kits = withRunModule(loadKits());
-
+  const kits = config.kits;
   let servers = await getBoardServers(config.tokenVendor);
 
   // First run - set everything up.
@@ -82,7 +69,6 @@ export async function create(config: RuntimeConfig): Promise<{
     fileSystem: config.fileSystem,
   };
   const graphStore = createGraphStore(graphStoreArgs);
-  registerLegacyKits(graphStore);
 
   servers.forEach((server) => {
     server.ready().then(() => {

--- a/packages/visual-editor/src/runtime/types.ts
+++ b/packages/visual-editor/src/runtime/types.ts
@@ -71,6 +71,7 @@ export interface RuntimeConfig {
   // The board servers that are built in: initialized separately and come
   // as part of the environment.
   builtInBoardServers: BoardServer[];
+  kits: Kit[];
 }
 
 export interface RuntimeConfigBoardServers {


### PR DESCRIPTION
- **Move loading kits into the init module.**
- **Load Core kit only for unified server.**
- **Remove spurious exports.**
- **docs(changeset): Stop loading legacy kits in unified server.**
