### PR TITLE
Allow for copying generated jpeg to clipboard

### DIFF
--- a/packages/shared-ui/src/elements/output/multi-output/multi-output.ts
+++ b/packages/shared-ui/src/elements/output/multi-output/multi-output.ts
@@ -186,6 +186,8 @@ export class MultiOutput extends LitElement {
     switch (mime) {
       case "image/png":
       case "image/jpg":
+      case "image/jpeg":
+      case "image/wepb":
       case "image/gif": {
         return html`<img src=${data} />`;
       }


### PR DESCRIPTION
Previously copy-to-clipboard was only available on PNG whereas Imagen produces JPEG.

