### PR TITLE
Default to .7 and .3 split instead of .75 and .25

### DIFF
--- a/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
@@ -815,7 +815,7 @@ export class UI extends LitElement {
       <bb-splitter
         direction=${"horizontal"}
         name="layout-main"
-        split="[0.75, 0.25]"
+        split="[0.70, 0.30]"
         @pointerdown=${() => {
           this.showThemeDesigner = false;
         }}


### PR DESCRIPTION
This is a hotfix that addresses the cutoff prompt
box in advance of more elegant solution. IMO it's
also nice to give the side nav a bit more default
real estate.