### PR TITLE
[flowgen] Fix expanding textarea height bugs

### DIFF
--- a/packages/shared-ui/src/elements/input/expanding-textarea.ts
+++ b/packages/shared-ui/src/elements/input/expanding-textarea.ts
@@ -109,6 +109,7 @@ export class ExpandingTextarea extends LitElement {
         /* Not sure why, but we need this small adjustment to make the #measure
            div consistently align with the textarea. */
         margin-right: 2px;
+        white-space: pre-wrap;
       }
       #measure::after {
         /* Unlike our <textarea>, our measurement <div> won't claim height for

--- a/packages/shared-ui/src/elements/input/expanding-textarea.ts
+++ b/packages/shared-ui/src/elements/input/expanding-textarea.ts
@@ -146,7 +146,7 @@ export class ExpandingTextarea extends LitElement {
   }
 
   override updated(changes: PropertyValues<this>) {
-    if (changes.has("value")) {
+    if (changes.has("value") || changes.has("placeholder")) {
       this.updateComplete.then(() => this.#recomputeHeight());
     }
   }


### PR DESCRIPTION
1. The measurement div needed `whitespace: pre-wrap` so that it doesn't collapse whitespace (this caused blank lines not to be accounted for in the height).
2. When the placeholder changes (which it now does on a rotation every few seconds), we also need to re-measure height.