### PR TITLE
default board service

### DIFF
--- a/.changeset/grumpy-falcons-dress.md
+++ b/.changeset/grumpy-falcons-dress.md
@@ -1,0 +1,7 @@
+---
+"@breadboard-ai/unified-server": minor
+"@breadboard-ai/visual-editor": minor
+---
+
+Add `defaultBoardService` to remove the need for always specifying the
+BOARD_SERVICE.

--- a/packages/unified-server/.env.development
+++ b/packages/unified-server/.env.development
@@ -3,6 +3,5 @@ VITE_LANGUAGE_PACK=@breadboard-ai/shared-ui/strings/en_US
 VITE_ASSET_PACK=/icons/
 VITE_FONT_FACE_MONO="Courier New", Courier, monospace
 VITE_FONT_FACE="Helvetica Neue", Helvetica, Arial, sans-serif
-VITE_BOARD_SERVICE="/board/"
 VITE_ENABLE_TOS=false
 VITE_TOS_HTML_PATH=""

--- a/packages/unified-server/.env.production
+++ b/packages/unified-server/.env.production
@@ -5,7 +5,6 @@ VITE_LANGUAGE_PACK=@breadboard-ai/shared-ui/strings/en_US
 VITE_ASSET_PACK=/icons/
 VITE_FONT_FACE_MONO="Courier New", Courier, monospace
 VITE_FONT_FACE="Helvetica Neue", Helvetica, Arial, sans-serif
-VITE_BOARD_SERVICE="/board/"
 VITE_ENABLE_TOS=false
 VITE_TOS_HTML_PATH=""
 # Uncomment when ready to disable all non-A2 module invocations.

--- a/packages/unified-server/src/init.ts
+++ b/packages/unified-server/src/init.ts
@@ -16,6 +16,7 @@ bootstrap({
   connectionServerUrl: new URL("/connection/", window.location.href),
   requiresSignin: true,
   kits: [asRuntimeKit(Core)],
+  defaultBoardService: "/board/",
   moduleInvocationFilter: (context) => {
     if (!import.meta.env.VITE_NO_3P_MODULES) return;
     if (!isA2(baseURLFromContext(context))) {

--- a/packages/visual-editor/src/bootstrap.ts
+++ b/packages/visual-editor/src/bootstrap.ts
@@ -21,6 +21,7 @@ export { bootstrap };
 export type BootstrapArguments = {
   connectionServerUrl?: URL;
   requiresSignin?: boolean;
+  defaultBoardService?: string;
   kits?: Kit[];
   graphStorePreloader?: (graphStore: MutableGraphStore) => void;
   moduleInvocationFilter?: (context: NodeHandlerContext) => Outcome<void>;
@@ -101,7 +102,9 @@ function bootstrap(args: BootstrapArguments = {}) {
       settings: SettingsStore.instance(),
       version: pkg.version,
       gitCommitHash: GIT_HASH,
-      boardServerUrl: getUrlFromBoardServiceFlag(BOARD_SERVICE),
+      boardServerUrl: getUrlFromBoardServiceFlag(
+        BOARD_SERVICE || args.defaultBoardService
+      ),
       connectionServerUrl: args?.connectionServerUrl,
       requiresSignin: args?.requiresSignin,
       enableTos: ENABLE_TOS,


### PR DESCRIPTION
- **Add `defaultBoardService`, so that we don't have to specify VITE_BOARD_SERVICE for default configuration.**
- **docs(changeset): Add `defaultBoardService` to remove the need for always specifying the BOARD_SERVICE.**
