### PR TITLE
Revert back to "Type your prompt here"

### DIFF
--- a/packages/a2/bgl/src/environment.d.ts
+++ b/packages/a2/bgl/src/environment.d.ts
@@ -355,6 +355,11 @@ declare type BehaviorSchema =
    */
   | "hint-preview"
   /**
+   * Hints that the node input is not a traditional LLM prompt, rather some other
+   * kind of textual input.
+   */
+  | "hint-no-prompt"
+  /**
    * In combination with "config" and "reactive", hints that the port controls
    * the rest of the configuration and may be used as the first to be
    * displayed in the UI.

--- a/packages/agent-kit/agent.kit.json
+++ b/packages/agent-kit/agent.kit.json
@@ -10641,6 +10641,7 @@
                           "hint-controller",
                           "hint-image",
                           "hint-multimodal",
+                          "hint-no-prompt",
                           "hint-preview",
                           "hint-single-line",
                           "hint-text",

--- a/packages/agent-kit/boards/specialist.bgl.json
+++ b/packages/agent-kit/boards/specialist.bgl.json
@@ -3710,6 +3710,7 @@
                       "hint-controller",
                       "hint-image",
                       "hint-multimodal",
+                      "hint-no-prompt",
                       "hint-preview",
                       "hint-single-line",
                       "hint-text",

--- a/packages/breadboard/src/inspector/graph/ports.ts
+++ b/packages/breadboard/src/inspector/graph/ports.ts
@@ -76,6 +76,7 @@ const BEHAVIOR_AFFECTS_TYPE_CHECKING: { [K in BehaviorSchema]: boolean } = {
   "hint-preview": false,
   "hint-advanced": false,
   "hint-chat-mode": false,
+  "hint-no-prompt": false,
   "hint-controller": false,
   "hint-single-line": false,
   module: true,

--- a/packages/breadboard/src/types.ts
+++ b/packages/breadboard/src/types.ts
@@ -115,6 +115,11 @@ export type BehaviorSchema =
    */
   | "hint-chat-mode"
   /**
+   * Hints that the node input is not a traditional LLM prompt, rather some other
+   * kind of textual input.
+   */
+  | "hint-no-prompt"
+  /**
    * Hints that the text is short (e.g. a query) and needs a single line treatment.
    */
   | "hint-single-line"

--- a/packages/jsandbox/src/environment.d.ts
+++ b/packages/jsandbox/src/environment.d.ts
@@ -380,6 +380,11 @@ declare type BehaviorSchema =
    */
   | "hint-chat-mode"
   /**
+   * Hints that the node input is not a traditional LLM prompt, rather some other
+   * kind of textual input.
+   */
+  | "hint-no-prompt"
+  /**
    * Hints that the text is short (e.g. a query) and needs a single line treatment.
    */
   | "hint-single-line"

--- a/packages/jsandbox/src/type-declarations.ts
+++ b/packages/jsandbox/src/type-declarations.ts
@@ -390,6 +390,11 @@ declare type BehaviorSchema =
    */
   | "hint-chat-mode"
   /**
+   * Hints that the node input is not a traditional LLM prompt, rather some other
+   * kind of textual input.
+   */
+  | "hint-no-prompt"
+  /**
    * Hints that the text is short (e.g. a query) and needs a single line treatment.
    */
   | "hint-single-line"

--- a/packages/shared-ui/src/elements/input/text-editor/text-editor.ts
+++ b/packages/shared-ui/src/elements/input/text-editor/text-editor.ts
@@ -83,7 +83,7 @@ export class TextEditor extends LitElement {
           var(--text-editor-padding-left, var(--bb-grid-size-2));
 
         &.placeholder::before {
-          content: "Type your prompt here. You can use @ to add assets or previous step outputs.";
+          content: "Type your prompt here";
           font: normal var(--bb-body-medium) / var(--bb-body-line-height-medium)
             var(--bb-font-family);
           color: var(--bb-neutral-600);


### PR DESCRIPTION
Not all callsites of this component make sense with the new copy, so reverting for now. Also adds a
"hint-no-prompt" we can use in A2 to reference
fields that don't have traditional prompt semantics. This hint is not yet used.
