### PR TITLE
save board server safely

### DIFF
--- a/.changeset/famous-hands-serve.md
+++ b/.changeset/famous-hands-serve.md
@@ -1,0 +1,10 @@
+---
+"@breadboard-ai/filesystem-board-server": minor
+"@breadboard-ai/embedded-board-server": minor
+"@breadboard-ai/remote-board-server": minor
+"@breadboard-ai/google-drive-kit": minor
+"@google-labs/breadboard": minor
+"@breadboard-ai/shared-ui": minor
+---
+
+Separate out `DriveOperations` in Drive Board Server.

--- a/package-lock.json
+++ b/package-lock.json
@@ -24512,6 +24512,7 @@
       "dependencies": {
         "@breadboard-ai/build": "0.12.2",
         "@breadboard-ai/connection-client": "0.2.0",
+        "@breadboard-ai/types": "0.7.0",
         "@google-labs/core-kit": "^0.19.0",
         "@google-labs/template-kit": "^0.3.19"
       },

--- a/packages/board-server/src/server/boards/utils/board-server-provider.ts
+++ b/packages/board-server/src/server/boards/utils/board-server-provider.ts
@@ -7,6 +7,7 @@
 import {
   type BoardServer,
   type BoardServerCapabilities,
+  type BoardServerEventTarget,
   type BoardServerProject,
   type ChangeNotificationCallback,
   type GraphDescriptor,
@@ -46,7 +47,10 @@ function parsePath(path: string) {
   return { userStore: userStore.slice(1), boardName };
 }
 
-export class BoardServerProvider implements BoardServer {
+export class BoardServerProvider
+  extends (EventTarget as BoardServerEventTarget)
+  implements BoardServer
+{
   #initialized = false;
   #serverUrl: string | undefined;
   #path: string;
@@ -79,6 +83,7 @@ export class BoardServerProvider implements BoardServer {
     path: string,
     loader: BoardServerLoadFunction
   ) {
+    super();
     this.#serverUrl = serverUrl;
     this.#path = path;
     this.#loader = loader;

--- a/packages/breadboard/src/loader/default.ts
+++ b/packages/breadboard/src/loader/default.ts
@@ -8,6 +8,7 @@ import { GraphDescriptor } from "@breadboard-ai/types";
 import {
   BoardServer,
   BoardServerCapabilities,
+  BoardServerEventTarget,
   BoardServerProject,
   GraphProviderCapabilities,
   GraphProviderExtendedCapabilities,
@@ -55,7 +56,10 @@ export const loadWithFetch = async (url: string | URL) => {
   return await response?.json();
 };
 
-export class DefaultBoardServer implements BoardServer {
+export class DefaultBoardServer
+  extends (EventTarget as BoardServerEventTarget)
+  implements BoardServer
+{
   url: URL = new URL(
     typeof window !== "undefined"
       ? window.location.href

--- a/packages/breadboard/src/loader/types.ts
+++ b/packages/breadboard/src/loader/types.ts
@@ -12,6 +12,10 @@ import {
 } from "@breadboard-ai/types";
 import { GraphToRun, Kit } from "../types.js";
 import { DataPartTransformer } from "../data/types.js";
+import {
+  TypedEventTarget,
+  TypedEventTargetType,
+} from "../utils/typed-event-target.js";
 
 export type GraphProviderItem = {
   url: string;
@@ -318,7 +322,18 @@ export interface BoardServerConfiguration {
   capabilities: BoardServerCapabilities;
 }
 
-export interface BoardServer extends GraphProvider, BoardServerConfiguration {
+export type BoardServerUpdateEvent = Event;
+
+export type BoardServerEventMap = {
+  update: BoardServerUpdateEvent;
+};
+
+export type BoardServerEventTarget = TypedEventTarget<BoardServerEventMap>;
+
+export interface BoardServer
+  extends GraphProvider,
+    BoardServerConfiguration,
+    TypedEventTargetType<BoardServerEventMap> {
   user: User;
   getAccess(url: URL, user: User): Promise<Permission>;
 }

--- a/packages/embedded-board-server/src/index.ts
+++ b/packages/embedded-board-server/src/index.ts
@@ -7,6 +7,7 @@
 import {
   BoardServer,
   BoardServerCapabilities,
+  BoardServerEventTarget,
   BoardServerExtension,
   BoardServerProject,
   ChangeNotificationCallback,
@@ -38,7 +39,10 @@ function isFromEmbeddedServer(
   return urlString.startsWith(prefix);
 }
 
-class EmbeddedBoardServer implements BoardServer {
+class EmbeddedBoardServer
+  extends (EventTarget as BoardServerEventTarget)
+  implements BoardServer
+{
   user: User = {
     username: "",
     apiKey: "",
@@ -65,6 +69,7 @@ class EmbeddedBoardServer implements BoardServer {
     public readonly urlPrefix: string,
     public readonly bgls: Map<string, GraphDescriptor>
   ) {
+    super();
     this.#items = new Map([
       [
         "default",

--- a/packages/filesystem-board-server/src/filesystem-board-server.ts
+++ b/packages/filesystem-board-server/src/filesystem-board-server.ts
@@ -6,6 +6,7 @@
 
 import {
   blank,
+  BoardServerEventTarget,
   DataPartTransformer,
   err,
   GraphProviderPreloadHandler,
@@ -85,7 +86,10 @@ type Config = {
   writeTypeScriptSources?: boolean;
 };
 
-export class FileSystemBoardServer extends EventTarget implements BoardServer {
+export class FileSystemBoardServer
+  extends (EventTarget as BoardServerEventTarget)
+  implements BoardServer
+{
   public readonly url: URL;
   public readonly kits: Kit[];
   public readonly users: User[];

--- a/packages/google-drive-kit/package.json
+++ b/packages/google-drive-kit/package.json
@@ -150,6 +150,7 @@
   "dependencies": {
     "@breadboard-ai/build": "0.12.2",
     "@breadboard-ai/connection-client": "0.2.0",
+    "@breadboard-ai/types": "0.7.0",
     "@google-labs/core-kit": "^0.19.0",
     "@google-labs/template-kit": "^0.3.19"
   },

--- a/packages/google-drive-kit/src/board-server/api.ts
+++ b/packages/google-drive-kit/src/board-server/api.ts
@@ -6,6 +6,27 @@
 
 export { Files };
 
+export type DriveFile = {
+  id: string;
+  kind: string;
+  mimeType: string;
+  name: string;
+  resourceKey: string;
+  appProperties: Record<string, string>;
+};
+
+export type DriveFileQuery = {
+  files: DriveFile[];
+};
+
+export type AppProperties = {
+  appProperties: {
+    title: string;
+    description: string;
+    tags: string;
+  };
+};
+
 class Files {
   #accessToken: string;
 

--- a/packages/google-drive-kit/src/board-server/operations.ts
+++ b/packages/google-drive-kit/src/board-server/operations.ts
@@ -1,0 +1,307 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  err,
+  type BoardServerProject,
+  type GraphDescriptor,
+  type Outcome,
+  type User,
+} from "@google-labs/breadboard";
+import { getAccessToken } from "./access.js";
+import type { TokenVendor } from "@breadboard-ai/connection-client";
+import {
+  Files,
+  type AppProperties,
+  type DriveFile,
+  type DriveFileQuery,
+} from "./api.js";
+
+export { DriveOperations, PROTOCOL };
+
+const PROTOCOL = "drive:";
+
+// TODO(aomarks) Make this configurable via a VITE_ env variable.
+const GOOGLE_DRIVE_FOLDER_NAME = "Breadboard";
+const GOOGLE_DRIVE_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder";
+const GRAPH_MIME_TYPE = "application/vnd.breadboard.graph+json";
+const DEPRECATED_GRAPH_MIME_TYPE = "application/json";
+
+class DriveOperations {
+  constructor(
+    public readonly vendor: TokenVendor,
+    public readonly user: User,
+    public readonly url: URL
+  ) {}
+
+  static async readFolder(folderId: string, vendor: TokenVendor) {
+    const accessToken = await getAccessToken(vendor);
+
+    try {
+      const api = new Files(accessToken!);
+      const response = await fetch(api.makeGetRequest(folderId));
+
+      const folder: DriveFile = await response.json();
+      if (!folder) {
+        return null;
+      }
+
+      return folder;
+    } catch (err) {
+      console.warn(err);
+      return null;
+    }
+  }
+
+  async readGraphList(): Promise<BoardServerProject[]> {
+    const folderId = await this.findOrCreateFolder();
+    const accessToken = await getAccessToken(this.vendor);
+    const query =
+      `"${folderId}" in parents` +
+      ` and (mimeType="${GRAPH_MIME_TYPE}"` +
+      `      or mimeType="${DEPRECATED_GRAPH_MIME_TYPE}")` +
+      ` and trashed=false`;
+
+    if (!folderId || !accessToken) {
+      throw new Error("No folder ID or access token");
+    }
+
+    try {
+      const api = new Files(accessToken);
+      const fileRequest = await fetch(api.makeQueryRequest(query));
+      const response: DriveFileQuery = await fileRequest.json();
+      const canAccess = true;
+      const access = new Map([
+        [
+          this.user.username,
+          {
+            create: canAccess,
+            retrieve: canAccess,
+            update: canAccess,
+            delete: canAccess,
+          },
+        ],
+      ]);
+
+      // TODO: This is likely due to an auth error.
+      if (!("files" in response)) {
+        console.warn(response);
+      }
+
+      const projects = response.files.map((file) => {
+        const { title, tags } = readAppProperties(file);
+        return {
+          url: new URL(`${this.url}/${file.id}`),
+          metadata: {
+            owner: "board-builder",
+            tags,
+            title,
+            access,
+          },
+        };
+      });
+
+      return projects;
+    } catch (err) {
+      console.warn(err);
+      return [];
+    }
+  }
+
+  async readSharedGraphList(): Promise<string[]> {
+    const accessToken = await getAccessToken(this.vendor);
+    if (!accessToken) {
+      throw new Error("No folder ID or access token");
+    }
+    const query =
+      ` (mimeType="${GRAPH_MIME_TYPE}"` +
+      `  or mimeType="${DEPRECATED_GRAPH_MIME_TYPE}")` +
+      ` and sharedWithMe=true` +
+      ` and trashed=false`;
+    const api = new Files(accessToken);
+    const fileRequest = await fetch(api.makeQueryRequest(query));
+    const response: DriveFileQuery = await fileRequest.json();
+    return response.files.map((file) => file.id);
+  }
+
+  async writeGraphToDrive(
+    url: URL,
+    descriptor: GraphDescriptor
+  ): Promise<{ result: boolean; error?: string }> {
+    const file = url.href.replace(`${this.url.href}/`, "");
+    const accessToken = await getAccessToken(this.vendor);
+    try {
+      const api = new Files(accessToken!);
+
+      await fetch(
+        api.makePatchRequest(
+          file,
+          {
+            ...createAppProperties(file, descriptor),
+            mimeType: GRAPH_MIME_TYPE,
+          },
+          descriptor
+        )
+      );
+
+      return { result: true };
+    } catch (err) {
+      console.warn(err);
+      return { result: false, error: "Unable to save" };
+    }
+  }
+
+  async writeNewGraphToDrive(url: URL, descriptor: GraphDescriptor) {
+    const fileName = url.href.replace(`${this.url.href}/`, "");
+    const accessToken = await getAccessToken(this.vendor);
+
+    try {
+      const api = new Files(accessToken!);
+      const response = await fetch(
+        api.makeMultipartCreateRequest(
+          {
+            name: fileName,
+            mimeType: GRAPH_MIME_TYPE,
+            parents: [parent],
+            ...createAppProperties(fileName, descriptor),
+          },
+          descriptor
+        )
+      );
+
+      const file: DriveFile = await response.json();
+      const updatedUrl = `${PROTOCOL}/${file.id}`;
+
+      console.log("Google Drive: Created new board", updatedUrl);
+      return { result: true, url: updatedUrl };
+    } catch (err) {
+      console.warn(err);
+      return { result: false, error: "Unable to create" };
+    }
+  }
+
+  async listAssets(): Promise<string[]> {
+    const accessToken = await getAccessToken(this.vendor);
+    if (!accessToken) {
+      throw new Error("No folder ID or access token");
+    }
+    const query = `(mimeType contains 'image/')` + ` and trashed=false`;
+    const api = new Files(accessToken);
+    const fileRequest = await fetch(api.makeQueryRequest(query));
+    const response: DriveFileQuery = await fileRequest.json();
+    return response.files.map((file) => file.id);
+  }
+
+  async readGraphFromDrive(url: URL): Promise<GraphDescriptor | null> {
+    const file = url.href.replace(`${this.url.href}/`, "");
+    const accessToken = await getAccessToken(this.vendor);
+
+    try {
+      const api = new Files(accessToken!);
+      const response = await fetch(api.makeLoadRequest(file));
+
+      const graph: GraphDescriptor = await response.json();
+      if (!graph || "error" in graph) {
+        return null;
+      }
+
+      return graph;
+    } catch (err) {
+      console.warn(err);
+      return null;
+    }
+  }
+
+  async findOrCreateFolder(): Promise<Outcome<string>> {
+    const accessToken = await getAccessToken(this.vendor);
+    if (!accessToken) {
+      return err("No access token");
+    }
+    const api = new Files(accessToken);
+
+    const findRequest = api.makeQueryRequest(
+      `name="${GOOGLE_DRIVE_FOLDER_NAME}"` +
+        ` and mimeType="${GOOGLE_DRIVE_FOLDER_MIME_TYPE}"` +
+        ` and trashed=false`
+    );
+    try {
+      const { files } = (await (
+        await fetch(findRequest)
+      ).json()) as DriveFileQuery;
+      if (files.length > 0) {
+        if (files.length > 1) {
+          console.warn(
+            "Google Drive: Multiple candidate root folders found," +
+              " picking the first one arbitrarily:",
+            files
+          );
+        }
+        const id = files[0]!.id;
+        console.log("Google Drive: Found existing root folder", id);
+        return id;
+      }
+
+      const createRequest = api.makeCreateRequest({
+        name: GOOGLE_DRIVE_FOLDER_NAME,
+        mimeType: GOOGLE_DRIVE_FOLDER_MIME_TYPE,
+      });
+      const { id } = (await (await fetch(createRequest)).json()) as {
+        id: string;
+      };
+      console.log("Google Drive: Created new root folder", id);
+      return id;
+    } catch (e) {
+      return err((e as Error).message);
+    }
+  }
+
+  async deleteGraph(url: URL): Promise<Outcome<void>> {
+    const file = url.href.replace(`${this.url.href}/`, "");
+    const accessToken = await getAccessToken(this.vendor);
+    try {
+      const api = new Files(accessToken!);
+      await fetch(api.makeDeleteRequest(file));
+      return;
+    } catch (e) {
+      console.warn(e);
+      return err("Unable to delete");
+    }
+  }
+}
+
+function createAppProperties(
+  filename: string,
+  descriptor: GraphDescriptor
+): AppProperties {
+  const {
+    title = filename,
+    description = "",
+    metadata: { tags = [] } = {},
+  } = descriptor;
+  return {
+    appProperties: {
+      title,
+      description,
+      tags: JSON.stringify(tags),
+    },
+  };
+}
+
+function readAppProperties(file: DriveFile) {
+  const { name, appProperties: { title, description = "", tags } = {} } = file;
+  let parsedTags = [];
+  try {
+    parsedTags = tags ? JSON.parse(tags) : [];
+    if (!Array.isArray(parsedTags)) parsedTags = [];
+  } catch {
+    // do nothing.
+  }
+  return {
+    title: title || name,
+    description,
+    tags: parsedTags,
+  };
+}

--- a/packages/google-drive-kit/src/board-server/server.ts
+++ b/packages/google-drive-kit/src/board-server/server.ts
@@ -9,6 +9,7 @@ import type {
   BoardServer,
   BoardServerCapabilities,
   BoardServerConfiguration,
+  BoardServerEventTarget,
   BoardServerExtension,
   BoardServerProject,
   ChangeNotificationCallback,
@@ -49,7 +50,10 @@ const DEPRECATED_GRAPH_MIME_TYPE = "application/json";
 // "@breadboard-ai/google-drive-board-server".
 // But it's good that we have both components and the board server here:
 // Good use case.
-class GoogleDriveBoardServer extends EventTarget implements BoardServer {
+class GoogleDriveBoardServer
+  extends (EventTarget as BoardServerEventTarget)
+  implements BoardServer
+{
   static PROTOCOL = "drive:";
 
   static async connect(folderId: string, vendor: TokenVendor) {

--- a/packages/remote-board-server/src/remote-board-server.ts
+++ b/packages/remote-board-server/src/remote-board-server.ts
@@ -6,6 +6,7 @@
 
 import {
   blank,
+  BoardServerEventTarget,
   DataPartTransformer,
   NodeIdentifier,
   type BoardServer,
@@ -30,7 +31,10 @@ import { RemotePartTransformer } from "./remote-part-transformer";
 
 const USER_REGEX = /\/@[^/]+\//;
 
-export class RemoteBoardServer implements BoardServer, RemoteConnector {
+export class RemoteBoardServer
+  extends (EventTarget as BoardServerEventTarget)
+  implements BoardServer, RemoteConnector
+{
   public readonly url: URL;
   public readonly users: User[];
   public readonly secrets = new Map<string, string>();
@@ -113,6 +117,7 @@ export class RemoteBoardServer implements BoardServer, RemoteConnector {
     public readonly tokenVendor?: TokenVendor,
     autoLoadProjects = true
   ) {
+    super();
     this.url = configuration.url;
     this.projects = autoLoadProjects
       ? this.#refreshProjects()

--- a/packages/shared-ui/src/elements/google-drive/google-drive-debug-panel.ts
+++ b/packages/shared-ui/src/elements/google-drive/google-drive-debug-panel.ts
@@ -183,7 +183,7 @@ export class GoogleDriveDebugPanel extends LitElement {
     if (!server) {
       return nothing;
     }
-    const projects = await server.ops.readGraphList();
+    const projects = await server.refreshProjects();
     return projects.map((project) => {
       const fileId = project.url.href.replace(/^drive:\//, "");
       return html` <li>${this.#renderFileLink(fileId)}</li> `;


### PR DESCRIPTION
- **Make `BoardServer` an `EventTarget`.**
- **Factor out Drive operations.**
- **Introduce `DriveOperations` class that holds all drive operations.**
- **Narrow down the scope of `DriveOperations`.**
- **docs(changeset): Separate out `DriveOperations` in Drive Board Server.**
