### PR TITLE
Correct agent kit url

### DIFF
--- a/packages/agent-kit/src/index.ts
+++ b/packages/agent-kit/src/index.ts
@@ -18,7 +18,7 @@ const agentKit = await kit({
   title: "Agent Kit",
   description: "A collection of nodes for building Agent-like experiences.",
   version: "0.0.1",
-  url: "https://raw.githubusercontent.com/breadboard-ai/breadboard/main/packages/agent-kit/graphs/kit.json",
+  url: "https://raw.githubusercontent.com/breadboard-ai/breadboard/refs/heads/main/packages/agent-kit/agent.kit.json",
   components: {
     content,
     human,


### PR DESCRIPTION
This pull request updates the URL for the `agentKit` in the `packages/agent-kit/src/index.ts` file to point to a new JSON file location. This change ensures the correct file path is used for the `agentKit` configuration.

* **URL Update for `agentKit`:**
  * Updated the `url` property to reference `agent.kit.json` instead of `kit.json`, aligning with the new file structure. (`[packages/agent-kit/src/index.tsL21-R21](diffhunk://#diff-2d22ecbeb3542a59dd3cae09e1fb89d459731cc3736f0900c6307dfbecfcb86fL21-R21)`)