### PR TITLE
invalid chiclet fixes

### DIFF
--- a/.changeset/open-singers-crash.md
+++ b/.changeset/open-singers-crash.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/shared-ui": patch
+---
+
+A slew of fixes around port reference editing

--- a/packages/shared-ui/src/transforms/mark-in-ports-invalid-spec.ts
+++ b/packages/shared-ui/src/transforms/mark-in-ports-invalid-spec.ts
@@ -16,52 +16,61 @@ import { TransformAllNodes } from "./transform-all-nodes";
 
 export { MarkInPortsInvalidSpec };
 
+type InvalidItems = {
+  nodes: Set<NodeIdentifier>;
+  edges: Map<NodeIdentifier, NodeIdentifier>;
+};
+
+/**
+ * Despite its weird name, this is the transform that takes in an EditSpec,
+ * figures out which chiclets need to be marked as invalid, then applies the
+ * EditSpec and then applies the necessary edits to mark chiclets as invalid.
+ */
 class MarkInPortsInvalidSpec implements EditTransform {
   constructor(public readonly spec: EditSpec[]) {}
   async apply(context: EditOperationContext): Promise<EditTransformResult> {
-    const removedNodes = new Map<GraphIdentifier, Set<NodeIdentifier>>();
+    const removedItems = new Map<GraphIdentifier, InvalidItems>();
 
     for (const edit of this.spec) {
       if (edit.type === "removeedge") {
-        const {
-          graphId,
-          edge: { from, in: inPort },
-        } = edit;
-        if (!inPort?.startsWith("p-z-")) continue;
-        upsert(graphId, from);
+        const { graphId, edge } = edit;
+        if (!edge.in?.startsWith("p-z-")) continue;
+        upsert(graphId).edges.set(edge.from, edge.to);
       } else if (edit.type === "removenode") {
         const { graphId, id } = edit;
-        upsert(graphId, id);
+        upsert(graphId).nodes.add(id);
       }
     }
 
     const editing = await context.apply(this.spec, "First pass: Edits");
     if (!editing) return editing;
 
-    for (const [graphId, ids] of removedNodes.entries()) {
+    for (const [graphId, items] of removedItems.entries()) {
       const marking = await new TransformAllNodes(
         graphId,
-        (part) => {
+        (part, nodeId) => {
           const { path } = part;
-          if (ids.has(path)) return { ...part, invalid: true };
+          if (items.nodes.has(path) || nodeId === items.edges.get(path)) {
+            return { ...part, invalid: true };
+          }
           return null;
         },
         `Marking "@" in port as invalid`,
         /* nodeTransformer */ undefined,
-        /* skippedNodes */ [...ids]
+        /* skippedNodes */ [...items.nodes]
       ).apply(context);
       if (!marking.success) return marking;
     }
 
     return { success: true };
 
-    function upsert(graphId: GraphIdentifier, id: NodeIdentifier) {
-      let ids = removedNodes.get(graphId);
-      if (!ids) {
-        ids = new Set();
-        removedNodes.set(graphId, ids);
+    function upsert(graphId: GraphIdentifier) {
+      let items = removedItems.get(graphId);
+      if (!items) {
+        items = { nodes: new Set(), edges: new Map() };
+        removedItems.set(graphId, items);
       }
-      ids.add(id);
+      return items;
     }
   }
 }

--- a/packages/shared-ui/src/transforms/mark-in-ports-invalid.ts
+++ b/packages/shared-ui/src/transforms/mark-in-ports-invalid.ts
@@ -39,13 +39,17 @@ class MarkInPortsInvalid implements EditTransform {
       };
     }
 
-    const newConfig = transformConfiguration(node.configuration(), (part) => {
-      const { path } = part;
-      if (path === this.from) {
-        return { ...part, invalid: true };
+    const newConfig = transformConfiguration(
+      this.to,
+      node.configuration(),
+      (part) => {
+        const { path } = part;
+        if (path === this.from) {
+          return { ...part, invalid: true };
+        }
+        return null;
       }
-      return null;
-    });
+    );
     if (newConfig !== null) {
       return context.apply(
         [

--- a/packages/shared-ui/src/transforms/transform-all-nodes.ts
+++ b/packages/shared-ui/src/transforms/transform-all-nodes.ts
@@ -26,12 +26,14 @@ export { TransformAllNodes, transformConfiguration };
  * be replaced.
  */
 export type TemplatePartTransformer = (
-  part: TemplatePart
+  part: TemplatePart,
+  nodeId: NodeIdentifier
 ) => TemplatePart | null;
 
 export type EditTransformFactory = (id: NodeIdentifier) => EditTransform;
 
 function transformConfiguration(
+  id: NodeIdentifier,
   config: NodeConfiguration,
   templateTransformer: TemplatePartTransformer
 ): NodeConfiguration | null {
@@ -55,7 +57,7 @@ function transformConfiguration(
           const template = new Template(part.text);
           if (template.hasPlaceholders) {
             const text = template.transform((part) => {
-              const transformed = templateTransformer(part);
+              const transformed = templateTransformer(part, id);
               if (transformed === null) {
                 return part;
               } else {
@@ -109,6 +111,7 @@ class TransformAllNodes implements EditTransform {
       const id = node.descriptor.id;
       if (this.skippedNodes?.includes(id)) continue;
       const newConfig = transformConfiguration(
+        id,
         node.configuration(),
         this.templateTransformer
       );


### PR DESCRIPTION
- **Distinguish between deleted ports and edges when invalidating references.**
- **Un-invalidate port references when reconnecting.**
- **Allow adding more references to same node without adding wires.**
- **Leave invalid port refs invalid.**
- **docs(changeset): A slew of fixes around port reference editing**
