### PR TITLE
Remove now unnecessary levels of cajoling

### DIFF
--- a/packages/shared-ui/src/flow-gen/flow-generator.ts
+++ b/packages/shared-ui/src/flow-gen/flow-generator.ts
@@ -156,11 +156,8 @@ export class FlowGenerator {
               ` with ID ${JSON.stringify(constraint.stepId)}.`
           );
         }
-        return (
-          `IMPORTANT: You MUST edit the configuration ONLY for Step "${title}". ` +
-          ` You MUST NOT change the step name or output name in any way.` +
-          ` Do not change any other steps or metadata in the app.`
-        );
+        // Note: this string is a magic contract with the backend planner.
+        return `IMPORTANT: You MUST edit the configuration ONLY for Step "${title}".`;
       }
       default: {
         constraint.kind satisfies never;


### PR DESCRIPTION
The backend always treats this step-constrained
edit case specially so there's no need to be
so adamant about not changing other aspects.
