### PR TITLE
[drive] Custom share modal with publish toggle

### DIFF
--- a/packages/bbrt/src/bootstrap.ts
+++ b/packages/bbrt/src/bootstrap.ts
@@ -15,5 +15,8 @@ document.body.appendChild(
     plugins: {
       input: [],
     },
+    googleDrive: {
+      publishPermissions: [],
+    },
   })
 );

--- a/packages/bbrt/src/test/playwright/main_test.ts
+++ b/packages/bbrt/src/test/playwright/main_test.ts
@@ -13,6 +13,7 @@ describe("bbrt-main", () => {
       connectionRedirectUrl: "",
       connectionServerUrl: "",
       plugins: { input: [] },
+      googleDrive: { publishPermissions: [] },
     });
     expect(c).instanceOf(HTMLElement);
   });

--- a/packages/shared-ui/src/contexts/environment.ts
+++ b/packages/shared-ui/src/contexts/environment.ts
@@ -7,12 +7,19 @@
 import { createContext } from "@lit/context";
 import { InputPlugin } from "../plugins/input-plugin.js";
 
+export type GoogleDrivePermission =
+  | { id: string; type: "user"; emailAddress: string }
+  | { id: string; type: "domain"; domain: string };
+
 export interface Environment {
   connectionServerUrl: string | undefined;
   connectionRedirectUrl: string;
   requiresSignin?: boolean;
   plugins: {
     input: InputPlugin[];
+  };
+  googleDrive: {
+    publishPermissions: GoogleDrivePermission[];
   };
 }
 

--- a/packages/shared-ui/src/elements/elements.ts
+++ b/packages/shared-ui/src/elements/elements.ts
@@ -72,6 +72,7 @@ export { Renderer } from "./step-editor/renderer.js";
 export { SaveAsOverlay } from "./overlay/save-as.js";
 export { SchemaEditor } from "./input/schema-editor/schema-editor.js";
 export { SettingsEditOverlay } from "./overlay/settings-edit.js";
+export { SharePanel } from "./share-panel/share-panel.js";
 export { SlideBoardSelector } from "./input/board-selector/slide-board-selector.js";
 export { SpeechToText } from "./input/speech-to-text/speech-to-text.js";
 export { Splitter } from "./splitter/splitter.js";

--- a/packages/shared-ui/src/elements/google-drive/google-drive-share-panel.ts
+++ b/packages/shared-ui/src/elements/google-drive/google-drive-share-panel.ts
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { FileDataPart } from "@breadboard-ai/types";
-import { type GraphDescriptor, type LLMContent } from "@breadboard-ai/types";
+import { type GraphDescriptor } from "@breadboard-ai/types";
 import { consume } from "@lit/context";
 import { css, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
@@ -13,6 +12,7 @@ import {
   type SigninAdapter,
   signinAdapterContext,
 } from "../../utils/signin-adapter.js";
+import { findGoogleDriveAssetsInGraph } from "./find-google-drive-assets-in-graph.js";
 import { loadDriveShare } from "./google-apis.js";
 
 // Silly dynamic type expression because "gapi.drive.share.ShareClient" doesn't
@@ -122,22 +122,4 @@ declare global {
   interface HTMLElementTagNameMap {
     "bb-google-drive-share-panel": GoogleDriveSharePanel;
   }
-}
-
-function findGoogleDriveAssetsInGraph(graph: GraphDescriptor): string[] {
-  // Use a set because there can be duplicates.
-  const fileIds = new Set<string>();
-  for (const asset of Object.values(graph?.assets ?? {})) {
-    if (asset.metadata?.subType === "gdrive") {
-      // Cast needed because `data` is very broadly typed as `NodeValue`.
-      const firstPart = (asset.data as LLMContent[])[0]?.parts[0];
-      if (firstPart && "fileData" in firstPart) {
-        const fileId = firstPart.fileData?.fileUri;
-        if (fileId) {
-          fileIds.add(fileId);
-        }
-      }
-    }
-  }
-  return [...fileIds];
 }

--- a/packages/shared-ui/src/elements/google-drive/google-drive-share-panel.ts
+++ b/packages/shared-ui/src/elements/google-drive/google-drive-share-panel.ts
@@ -105,6 +105,7 @@ export class GoogleDriveSharePanel extends LitElement {
           this.#status = "closed";
           globalShareClientLocked = false;
           observer.disconnect();
+          this.dispatchEvent(new Event("close"));
         }
       }
     });

--- a/packages/shared-ui/src/elements/share-panel/share-panel.ts
+++ b/packages/shared-ui/src/elements/share-panel/share-panel.ts
@@ -1,0 +1,429 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { type GraphDescriptor } from "@breadboard-ai/types";
+import { consume } from "@lit/context";
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import { createRef, ref } from "lit/directives/ref.js";
+import {
+  environmentContext,
+  type GoogleDrivePermission,
+  type Environment,
+} from "../../contexts/environment.js";
+import { icons } from "../../styles/icons.js";
+import {
+  signinAdapterContext,
+  type SigninAdapter,
+} from "../../utils/signin-adapter.js";
+import { type GoogleDriveSharePanel } from "../elements.js";
+import { loadDriveApi } from "../google-drive/google-apis.js";
+
+@customElement("bb-share-panel")
+export class SharePanel extends LitElement {
+  static styles = [
+    icons,
+    css`
+      :host {
+        display: contents;
+      }
+
+      dialog {
+        border-radius: var(--bb-grid-size-2);
+        border: none;
+        box-shadow:
+          0px 4px 8px 3px rgba(0, 0, 0, 0.15),
+          0px 1px 3px 0px rgba(0, 0, 0, 0.3);
+        font-family: var(--bb-font-family);
+        padding: var(--bb-grid-size-5);
+
+        /* Match the width and backdrop of the Google Drive sharing panel, whose
+           style we don't control, and which will replace our own dialog if the
+           user clicks "View permissions". */
+        width: 512px;
+        box-sizing: border-box;
+        &::backdrop {
+          background-color: #fff;
+          opacity: 50%;
+        }
+      }
+
+      header {
+        display: flex;
+        justify-content: space-between;
+        margin-bottom: var(--bb-grid-size-4);
+      }
+      h2 {
+        font: 500 var(--bb-title-medium) / var(--bb-title-line-height-medium)
+          var(--bb-font-family);
+        margin-top: 0;
+      }
+      #closeButton {
+        background: none;
+        border: none;
+        cursor: pointer;
+        padding: 0;
+        font-size: 24px;
+        /* Our default icon weight is too thin. */
+        font-variation-settings:
+          "FILL" 0,
+          "wght" 600,
+          "GRAD" 0,
+          "opsz" 48;
+      }
+
+      #permissions {
+        display: flex;
+        justify-content: space-between;
+        margin-top: var(--bb-grid-size-4);
+      }
+      #viewPermissionsButton {
+        text-decoration: none;
+        color: inherit;
+        &:hover {
+          text-decoration: underline;
+        }
+      }
+      #publishedToggle {
+        input,
+        label {
+          cursor: pointer;
+        }
+      }
+    `,
+  ];
+
+  @consume({ context: environmentContext })
+  @property({ attribute: false })
+  accessor environment!: Environment;
+
+  @consume({ context: signinAdapterContext })
+  @property({ attribute: false })
+  accessor signinAdapter: SigninAdapter | undefined = undefined;
+
+  @property({ attribute: false })
+  accessor graph: GraphDescriptor | undefined;
+
+  @state()
+  accessor #status: "closed" | "open" | "drive-share" = "closed";
+
+  @state()
+  accessor #publishState:
+    | { status: "initial" }
+    | { status: "reading" }
+    | {
+        status: "written";
+        published: true;
+        relevantPermissions: GoogleDrivePermission[];
+      }
+    | {
+        status: "written";
+        published: false;
+      }
+    | {
+        status: "writing";
+        published: boolean;
+      } = { status: "initial" };
+
+  #dialog = createRef<HTMLDialogElement>();
+  #publishedToggleInput = createRef<HTMLInputElement>();
+  #googleDriveSharePanel = createRef<GoogleDriveSharePanel>();
+
+  override render() {
+    if (this.#status === "closed") {
+      return nothing;
+    } else if (this.#status === "open") {
+      return this.#renderOpen();
+    } else if (this.#status === "drive-share") {
+      return this.#renderDriveShare();
+    }
+    console.error(
+      `Unknown status ${JSON.stringify(this.#status satisfies never)}`
+    );
+    return nothing;
+  }
+
+  override updated() {
+    if (this.#status === "open") {
+      this.#dialog.value?.showModal();
+      if (this.#publishState.status === "initial") {
+        this.#readPublishedState();
+      }
+    } else if (this.#status === "drive-share") {
+      this.#googleDriveSharePanel.value?.open();
+    }
+  }
+
+  open(): void {
+    this.#status = "open";
+  }
+
+  close(): void {
+    this.#status = "closed";
+  }
+
+  #renderOpen() {
+    return html`
+      <dialog ${ref(this.#dialog)} @close=${this.close}>
+        <header>
+          <h2>Share</h2>
+          <button
+            id="closeButton"
+            class="g-icon"
+            aria-label="Close"
+            @click=${this.close}
+          >
+            close
+          </button>
+        </header>
+
+        <div id="permissions">
+          <a
+            id="viewPermissionsButton"
+            href=""
+            @click=${this.#onClickViewPermissions}
+          >
+            View permissions
+          </a>
+          ${this.#renderPublishedToggle()}
+        </div>
+      </dialog>
+    `;
+  }
+
+  #renderPublishedToggle() {
+    const status = this.#publishState.status;
+    if (status === "initial" || status === "reading") {
+      return html`<p>Checking ...</p>`;
+    }
+
+    status satisfies "written" | "writing";
+    const published = this.#publishState.published;
+    return html`
+      <div id="publishedToggle">
+        <input
+          ${ref(this.#publishedToggleInput)}
+          id="publishedToggleInput"
+          type="checkbox"
+          ?checked=${published}
+          ?disabled=${status === "writing"}
+          @change=${this.#onPublishedToggleChange}
+        />
+        <label for="publishedToggleInput">
+          ${status === "written"
+            ? published
+              ? "Published"
+              : "Private"
+            : published
+              ? "Publishing ..."
+              : "Unpublishing ..."}
+        </label>
+      </div>
+    `;
+  }
+
+  #renderDriveShare() {
+    return html`
+      <bb-google-drive-share-panel
+        ${ref(this.#googleDriveSharePanel)}
+        .graph=${this.graph}
+        @close=${this.#onGoogleDriveSharePanelClose}
+      ></bb-google-drive-share-panel>
+    `;
+  }
+
+  #onClickViewPermissions(event: MouseEvent) {
+    event.preventDefault();
+    this.#status = "drive-share";
+  }
+
+  #onPublishedToggleChange() {
+    const input = this.#publishedToggleInput.value;
+    if (!input) {
+      console.error("Expected input element to be rendered");
+      return;
+    }
+    const checked = input.checked;
+    if (checked) {
+      this.#publish();
+    } else {
+      this.#unpublish();
+    }
+  }
+
+  #onGoogleDriveSharePanelClose() {
+    // The user might have changed something that would affect the published
+    // state while they were in the Drive sharing modal, so we should reset.
+    this.#publishState = { status: "initial" };
+    this.open();
+  }
+
+  async #readPublishedState(): Promise<boolean | undefined> {
+    const publishPermissions = this.#getPublishPermissions();
+    if (publishPermissions.length === 0) {
+      return undefined;
+    }
+    const fileId = this.#getFileId();
+    if (!fileId) {
+      return undefined;
+    }
+
+    this.#publishState = { status: "reading" };
+
+    const drive = await loadDriveApi();
+    const response = await drive.permissions.list({ fileId, fields: "*" });
+    const result = JSON.parse(response.body) as {
+      permissions: GoogleDrivePermission[];
+    };
+
+    const missingRequiredPermissions = new Set(
+      publishPermissions.map(stringifyPermission)
+    );
+    const relevantPermissions = [];
+    for (const permission of result.permissions) {
+      if (missingRequiredPermissions.delete(stringifyPermission(permission))) {
+        relevantPermissions.push(permission);
+      }
+    }
+    const published = missingRequiredPermissions.size === 0;
+    this.#publishState = {
+      status: "written",
+      published,
+      relevantPermissions,
+    };
+  }
+
+  async #publish() {
+    const publishPermissions = this.#getPublishPermissions();
+    if (publishPermissions.length === 0) {
+      return undefined;
+    }
+    if (this.#publishState.status !== "written") {
+      console.error('Expected published status to be "written"');
+      return;
+    }
+    if (this.#publishState.published === true) {
+      return;
+    }
+    const fileId = this.#getFileId();
+    if (!fileId) {
+      return;
+    }
+    const oldPublished = this.#publishState;
+    this.#publishState = { status: "writing", published: true };
+    const auth = await this.signinAdapter?.refresh();
+    if (auth?.state !== "valid") {
+      console.error(`Expected valid auth, got "${auth?.state}"`);
+      this.#publishState = oldPublished;
+      return;
+    }
+    const drive = await loadDriveApi();
+    const responses = await Promise.all(
+      publishPermissions.map((permission) =>
+        drive.permissions.create({
+          access_token: auth.grant.access_token,
+          fileId,
+          resource: { ...permission, role: "reader" },
+          sendNotificationEmail: false,
+        })
+      )
+    );
+    const relevantPermissions = responses.map(
+      (response) => JSON.parse(response.body) as GoogleDrivePermission
+    );
+    this.#publishState = {
+      status: "written",
+      published: true,
+      relevantPermissions,
+    };
+  }
+
+  async #unpublish() {
+    if (this.#publishState.status !== "written") {
+      console.error('Expected published status to be "written"');
+      return;
+    }
+    if (this.#publishState.published === false) {
+      return;
+    }
+    const fileId = this.#getFileId();
+    if (!fileId) {
+      return;
+    }
+    const oldPublished = this.#publishState;
+    this.#publishState = { status: "writing", published: false };
+    const auth = await this.signinAdapter?.refresh();
+    if (auth?.state !== "valid") {
+      console.error(`Expected valid auth, got "${auth?.state}"`);
+      this.#publishState = oldPublished;
+      return;
+    }
+    const drive = await loadDriveApi();
+    await Promise.all(
+      oldPublished.relevantPermissions.map((permission) =>
+        drive.permissions.delete({
+          access_token: auth.grant.access_token,
+          fileId,
+          permissionId: permission.id,
+        })
+      )
+    );
+    this.#publishState = { status: "written", published: false };
+  }
+
+  #getFileId(): string | undefined {
+    const graphUrl = this.graph?.url;
+    if (!graphUrl) {
+      console.error("No graph URL");
+      return undefined;
+    }
+    if (!graphUrl.startsWith("drive:")) {
+      console.error(
+        `Expected "drive:" prefixed graph URL, got ${JSON.stringify(graphUrl)}`
+      );
+      return undefined;
+    }
+    const fileId = graphUrl.replace(/^drive:\/+/, "");
+    if (!fileId) {
+      console.error(`File id was empty`);
+    }
+    return fileId;
+  }
+
+  #getPublishPermissions(): GoogleDrivePermission[] {
+    if (!this.environment) {
+      console.error(`No environment was provided`);
+      return [];
+    }
+    const permissions = this.environment.googleDrive.publishPermissions;
+    if (permissions.length === 0) {
+      console.error(`Environment contained no googleDrive.publishPermissions`);
+    }
+    return permissions;
+  }
+}
+
+/**
+ * Make a string from a permission object that can be used for Set membership.
+ */
+function stringifyPermission(permission: GoogleDrivePermission) {
+  if (permission.type === "domain") {
+    return `domain:${permission.domain}`;
+  }
+  if (permission.type === "user") {
+    return `user:${permission.emailAddress}`;
+  }
+  permission satisfies never;
+  throw new Error(
+    `Unexpected permission type "${(permission as GoogleDrivePermission).type}"`
+  );
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "bb-share-panel": SharePanel;
+  }
+}

--- a/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
@@ -83,6 +83,7 @@ import {
 } from "../../utils/signin-adapter.js";
 import { findGoogleDriveAssetsInGraph } from "../google-drive/find-google-drive-assets-in-graph.js";
 import { loadDriveApi } from "../google-drive/google-apis.js";
+import { SharePanel } from "../share-panel/share-panel.js";
 
 const SIDE_ITEM_KEY = "bb-ui-controller-side-nav-item";
 
@@ -237,7 +238,7 @@ export class UI extends LitElement {
     | "app-view" = "editor";
   #entityEditorRef: Ref<EntityEditor> = createRef();
   #moduleEditorRef: Ref<ModuleEditor> = createRef();
-  #googleDriveSharePanelRef: Ref<GoogleDriveSharePanel> = createRef();
+  #sharePanelRef: Ref<SharePanel> = createRef();
   #googleDriveAssetAccessPickerRef: Ref<GoogleDrivePicker> = createRef();
 
   static styles = [icons, uiControllerStyles];
@@ -815,11 +816,8 @@ export class UI extends LitElement {
           </section>`
         : html`<section id="content" class="welcome">${graphEditor}</section>`,
       html`
-        <bb-google-drive-share-panel
-          .graph=${this.graph}
-          ${ref(this.#googleDriveSharePanelRef)}
-        >
-        </bb-google-drive-share-panel>
+        <bb-share-panel .graph=${this.graph} ${ref(this.#sharePanelRef)}>
+        </bb-share-panel>
         <bb-google-drive-picker
           ${ref(this.#googleDriveAssetAccessPickerRef)},
           mode="pick-shared-assets"
@@ -886,7 +884,7 @@ export class UI extends LitElement {
   }
 
   openSharePanel() {
-    this.#googleDriveSharePanelRef?.value?.open();
+    this.#sharePanelRef?.value?.open();
   }
 
   async #checkGoogleDriveAssetsAreReadable() {

--- a/packages/unified-server/src/client/app/init.ts
+++ b/packages/unified-server/src/client/app/init.ts
@@ -117,6 +117,9 @@ async function createEnvironment(
     plugins: {
       input: [],
     },
+    googleDrive: {
+      publishPermissions: [],
+    },
   };
 }
 

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -106,6 +106,7 @@ import { MAIN_BOARD_ID } from "@breadboard-ai/shared-ui/constants/constants.js";
 import { createA2Server } from "@breadboard-ai/a2";
 import { envFromSettings } from "./utils/env-from-settings";
 import { getGoogleDriveBoardService } from "@breadboard-ai/board-server-management";
+import { type GoogleDrivePermission } from "@breadboard-ai/shared-ui/contexts/environment.js";
 
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 
@@ -185,7 +186,19 @@ const ENVIRONMENT: BreadboardUI.Contexts.Environment = {
       BreadboardUI.Elements.googleDriveQueryInputPlugin,
     ],
   },
+  googleDrive: {
+    publishPermissions: JSON.parse(
+      import.meta.env.VITE_GOOGLE_DRIVE_PUBLISH_PERMISSIONS || `[]`
+    ) as GoogleDrivePermission[],
+  },
 };
+
+if (ENVIRONMENT.googleDrive.publishPermissions.length === 0) {
+  console.warn(
+    "No googleDrive.publishPermissions were configured." +
+      " Publishing with Google Drive will not be supported."
+  );
+}
 
 const BOARD_AUTO_SAVE_TIMEOUT = 1_500;
 


### PR DESCRIPTION
Clicking share now opens a modal with a simple publish toggle. Enabling/disabling the toggle adds/removes a fixed set of permissions configured per deployment via the `VITE_GOOGLE_DRIVE_PUBLISH_PERMISSIONS` variable.