### PR TITLE
describer once 2

### DIFF
--- a/.changeset/six-fans-tell.md
+++ b/.changeset/six-fans-tell.md
@@ -1,0 +1,6 @@
+---
+"@google-labs/breadboard": patch
+"@breadboard-ai/shared-ui": patch
+---
+
+Reduce the number of times describers are called during the run.

--- a/packages/breadboard/src/graph-based-node-handler.ts
+++ b/packages/breadboard/src/graph-based-node-handler.ts
@@ -81,6 +81,7 @@ class GraphBasedNodeHandler implements NodeHandlerObject {
       }
       mutable = graphStore.get(adding.result)!;
     }
+    mutable = await graphStore.getLatest(mutable);
     if (this.#graph.moduleId) {
       const moduleId = this.#graph.moduleId;
       const graph = this.#graph.graph;

--- a/packages/breadboard/src/inspector/graph-store.ts
+++ b/packages/breadboard/src/inspector/graph-store.ts
@@ -47,7 +47,7 @@ import {
 import { filterEmptyValues } from "./utils.js";
 import { FileSystem, FileSystemEntry } from "../data/types.js";
 import { DescribeResultTypeCache } from "./graph/describe-type-cache.js";
-import { NodeTypeDescriberManager } from "./graph/describer-manager.js";
+import { NodeTypeDescriberManager } from "./graph/node-type-describer-manager.js";
 
 export {
   contextFromMutableGraph,

--- a/packages/breadboard/src/inspector/graph/bubbled-node.ts
+++ b/packages/breadboard/src/inspector/graph/bubbled-node.ts
@@ -86,13 +86,11 @@ export class BubbledInspectableNode implements InspectableNode {
     return this.#actual.metadata();
   }
 
-  async describe(
-    inputs?: InputValues | undefined
-  ): Promise<NodeDescriberResult> {
+  async describe(): Promise<NodeDescriberResult> {
     if (this.descriptor.type === "input") {
-      return describeInput({ inputs });
+      return describeInput({ inputs: this.#actual.configuration() });
     }
-    return this.#actual.describe(inputs);
+    return this.#actual.describe();
   }
 
   #portsForInput(inputValues?: InputValues, outputValues?: OutputValues) {

--- a/packages/breadboard/src/inspector/graph/describe-cache.ts
+++ b/packages/breadboard/src/inspector/graph/describe-cache.ts
@@ -4,11 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type {
-  GraphIdentifier,
-  InputValues,
-  NodeIdentifier,
-} from "@breadboard-ai/types";
+import type { GraphIdentifier, NodeIdentifier } from "@breadboard-ai/types";
 import {
   DescribeResultCacheArgs,
   InspectableDescriberResultCache,
@@ -31,14 +27,10 @@ class DescribeResultCache implements InspectableDescriberResultCache {
 
   constructor(public readonly args: DescribeResultCacheArgs) {}
 
-  #createSnapshotArgs(
-    graphId: GraphIdentifier,
-    nodeId: NodeIdentifier,
-    inputs?: InputValues
-  ) {
+  #createSnapshotArgs(graphId: GraphIdentifier, nodeId: NodeIdentifier) {
     return {
       initial: () => this.args.initial(graphId, nodeId),
-      latest: () => this.args.latest(graphId, nodeId, inputs),
+      latest: () => this.args.latest(graphId, nodeId),
       willUpdate: (previous, current) =>
         this.args.willUpdate(previous, current),
       updated: () => {
@@ -47,30 +39,10 @@ class DescribeResultCache implements InspectableDescriberResultCache {
     } as SnapshotUpdaterArgs<NodeDescriberResult>;
   }
 
-  #createInertSnapshotArgs(
-    graphId: GraphIdentifier,
-    nodeId: NodeIdentifier,
-    inputs?: InputValues
-  ) {
-    return {
-      initial: () => this.args.initial(graphId, nodeId),
-      latest: () => this.args.latest(graphId, nodeId, inputs),
-      willUpdate() {},
-    } as SnapshotUpdaterArgs<NodeDescriberResult>;
-  }
-
   get(
     id: NodeIdentifier,
-    graphId: GraphIdentifier,
-    inputs?: InputValues
+    graphId: GraphIdentifier
   ): InspectableDescriberResultCacheEntry {
-    if (inputs && Object.keys(inputs).length > 0) {
-      // bypass cache when there are inputs. We can't cache these
-      // describer results ... yet.
-      return new SnapshotUpdater(
-        this.#createInertSnapshotArgs(graphId, id, inputs)
-      ).snapshot();
-    }
     const hash = computeHash({ id, graphId });
     let result = this.#map.get(hash);
     if (result) {

--- a/packages/breadboard/src/inspector/graph/describer-manager.ts
+++ b/packages/breadboard/src/inspector/graph/describer-manager.ts
@@ -7,7 +7,6 @@
 import {
   GraphDescriptor,
   GraphIdentifier,
-  InputValues,
   NodeIdentifier,
   NodeTypeIdentifier,
 } from "@breadboard-ai/types";
@@ -158,8 +157,7 @@ class NodeDescriberManager implements DescribeResultCacheArgs {
 
   async latest(
     graphId: GraphIdentifier,
-    nodeId: NodeIdentifier,
-    inputs?: InputValues
+    nodeId: NodeIdentifier
   ): Promise<NodeDescriberResult> {
     const node = this.mutable.nodes.get(nodeId, graphId);
     if (!node) {
@@ -171,7 +169,7 @@ class NodeDescriberManager implements DescribeResultCacheArgs {
       {
         incoming: node.incoming(),
         outgoing: node.outgoing(),
-        inputs: { ...node.configuration(), ...inputs },
+        inputs: { ...node.configuration() },
       }
     );
     return result;

--- a/packages/breadboard/src/inspector/graph/mutable-graph.ts
+++ b/packages/breadboard/src/inspector/graph/mutable-graph.ts
@@ -37,7 +37,7 @@ import { ModuleCache } from "./module.js";
 import { NodeCache } from "./node-cache.js";
 import { Node } from "./node.js";
 import { PortCache } from "./port-cache.js";
-import { NodeDescriberManager } from "./describer-manager.js";
+import { NodeDescriberManager } from "./node-describer-manager.js";
 import { UpdateEvent } from "./event.js";
 import { GraphRepresentation } from "../../traversal/representation.js";
 

--- a/packages/breadboard/src/inspector/graph/node-describer-manager.ts
+++ b/packages/breadboard/src/inspector/graph/node-describer-manager.ts
@@ -5,140 +5,45 @@
  */
 
 import {
-  GraphDescriptor,
   GraphIdentifier,
   NodeIdentifier,
   NodeTypeIdentifier,
 } from "@breadboard-ai/types";
-import {
-  DescribeResultCacheArgs,
-  DescribeResultTypeCacheArgs,
-  InspectableEdge,
-  MutableGraph,
-  MutableGraphStore,
-  NodeTypeDescriberOptions,
-} from "../types.js";
+import { envFromGraphDescriptor } from "../../data/file-system/assets.js";
+import { assetsFromGraphDescriptor } from "../../data/index.js";
+import { getHandler } from "../../handler.js";
+import { createLoader } from "../../loader/index.js";
+import { invokeMainDescriber } from "../../sandbox/invoke-describer.js";
 import {
   NodeDescriberContext,
   NodeDescriberFunction,
   NodeDescriberResult,
   NodeHandler,
 } from "../../types.js";
+import { SchemaDiffer } from "../../utils/schema-differ.js";
+import { contextFromMutableGraph } from "../graph-store.js";
+import {
+  DescribeResultCacheArgs,
+  InspectableEdge,
+  MutableGraph,
+  NodeTypeDescriberOptions,
+} from "../types.js";
+import { UpdateEvent } from "./event.js";
+import { GraphDescriptorHandle } from "./graph-descriptor-handle.js";
 import {
   describeInput,
   describeOutput,
   edgesToSchema,
   EdgeType,
 } from "./schemas.js";
-import { createLoader, SENTINEL_BASE_URL } from "../../loader/index.js";
-import { getHandler } from "../../handler.js";
-import { GraphDescriptorHandle } from "./graph-descriptor-handle.js";
-import {
-  contextFromMutableGraph,
-  contextFromMutableGraphStore,
-} from "../graph-store.js";
-import { SchemaDiffer } from "../../utils/schema-differ.js";
-import { UpdateEvent } from "./event.js";
-import { invokeMainDescriber } from "../../sandbox/invoke-describer.js";
-import { assetsFromGraphDescriptor } from "../../data/index.js";
-import { envFromGraphDescriptor } from "../../data/file-system/assets.js";
 
-export { NodeDescriberManager, NodeTypeDescriberManager };
-
-const PLACEHOLDER_ID = crypto.randomUUID();
-
-const TYPE_DESCRIPTOR_GRAPH_URL = SENTINEL_BASE_URL.href;
+export { NodeDescriberManager, emptyResult };
 
 function emptyResult(): NodeDescriberResult {
   return {
     inputSchema: { type: "object" },
     outputSchema: { type: "object" },
   };
-}
-
-class NodeTypeDescriberManager implements DescribeResultTypeCacheArgs {
-  constructor(public readonly store: MutableGraphStore) {}
-
-  initial(): NodeDescriberResult {
-    return emptyResult();
-  }
-
-  updated(): void {
-    this.store.dispatchEvent(new UpdateEvent(PLACEHOLDER_ID, "", "", []));
-  }
-
-  latest(type: NodeTypeIdentifier): Promise<NodeDescriberResult> {
-    return this.getLatestDescription(type);
-  }
-
-  async getLatestDescription(type: NodeTypeIdentifier) {
-    // The schema of an input or an output is defined by their
-    // configuration schema or their incoming/outgoing edges.
-    if (type === "input") {
-      return describeInput({});
-    }
-    if (type === "output") {
-      return describeOutput({});
-    }
-
-    const kits = [...this.store.kits];
-    const describer = await this.#getDescriber(type);
-    const asWired = NodeDescriberManager.asWired();
-    if (!describer) {
-      return asWired;
-    }
-    const loader = this.store.loader || createLoader();
-    // When describing types, we provide a weird empty graph with a special URL
-    // because we're not actually inside of any graph, and that is ok.
-    const outerGraph: GraphDescriptor = {
-      nodes: [],
-      edges: [],
-      url: TYPE_DESCRIPTOR_GRAPH_URL,
-    };
-    const context: NodeDescriberContext = {
-      outerGraph,
-      loader,
-      kits,
-      sandbox: this.store.sandbox,
-      graphStore: this.store,
-      fileSystem: this.store.fileSystem.createRunFileSystem({
-        graphUrl: TYPE_DESCRIPTOR_GRAPH_URL,
-        env: envFromGraphDescriptor(this.store.fileSystem.env()),
-        assets: assetsFromGraphDescriptor(),
-      }),
-      wires: { incoming: {}, outgoing: {} },
-      asType: true,
-    };
-    try {
-      return describer(
-        undefined,
-        asWired.inputSchema,
-        asWired.outputSchema,
-        context
-      );
-    } catch (e) {
-      console.warn(`Error describing node type ${type}`, e);
-      return asWired;
-    }
-  }
-
-  async #getDescriber(
-    type: NodeTypeIdentifier
-  ): Promise<NodeDescriberFunction | undefined> {
-    let handler: NodeHandler | undefined;
-    try {
-      handler = await getHandler(
-        type,
-        contextFromMutableGraphStore(this.store)
-      );
-    } catch (e) {
-      console.warn(`Error getting describer for node type ${type}`, e);
-    }
-    if (!handler || !("describe" in handler) || !handler.describe) {
-      return undefined;
-    }
-    return handler.describe;
-  }
 }
 
 class NodeDescriberManager implements DescribeResultCacheArgs {

--- a/packages/breadboard/src/inspector/graph/node-type-describer-manager.ts
+++ b/packages/breadboard/src/inspector/graph/node-type-describer-manager.ts
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GraphDescriptor, NodeTypeIdentifier } from "@breadboard-ai/types";
+import { envFromGraphDescriptor } from "../../data/file-system/assets.js";
+import { assetsFromGraphDescriptor } from "../../data/index.js";
+import { getHandler } from "../../handler.js";
+import { createLoader, SENTINEL_BASE_URL } from "../../loader/index.js";
+import {
+  NodeDescriberContext,
+  NodeDescriberFunction,
+  NodeDescriberResult,
+  NodeHandler,
+} from "../../types.js";
+import { contextFromMutableGraphStore } from "../graph-store.js";
+import { DescribeResultTypeCacheArgs, MutableGraphStore } from "../types.js";
+import { UpdateEvent } from "./event.js";
+import { describeInput, describeOutput } from "./schemas.js";
+import { emptyResult, NodeDescriberManager } from "./node-describer-manager.js";
+
+export { NodeTypeDescriberManager };
+
+const PLACEHOLDER_ID = crypto.randomUUID();
+
+const TYPE_DESCRIPTOR_GRAPH_URL = SENTINEL_BASE_URL.href;
+
+class NodeTypeDescriberManager implements DescribeResultTypeCacheArgs {
+  constructor(public readonly store: MutableGraphStore) {}
+
+  initial(): NodeDescriberResult {
+    return emptyResult();
+  }
+
+  updated(): void {
+    this.store.dispatchEvent(new UpdateEvent(PLACEHOLDER_ID, "", "", []));
+  }
+
+  latest(type: NodeTypeIdentifier): Promise<NodeDescriberResult> {
+    return this.getLatestDescription(type);
+  }
+
+  async getLatestDescription(type: NodeTypeIdentifier) {
+    // The schema of an input or an output is defined by their
+    // configuration schema or their incoming/outgoing edges.
+    if (type === "input") {
+      return describeInput({});
+    }
+    if (type === "output") {
+      return describeOutput({});
+    }
+
+    const kits = [...this.store.kits];
+    const describer = await this.#getDescriber(type);
+    const asWired = NodeDescriberManager.asWired();
+    if (!describer) {
+      return asWired;
+    }
+    const loader = this.store.loader || createLoader();
+    // When describing types, we provide a weird empty graph with a special URL
+    // because we're not actually inside of any graph, and that is ok.
+    const outerGraph: GraphDescriptor = {
+      nodes: [],
+      edges: [],
+      url: TYPE_DESCRIPTOR_GRAPH_URL,
+    };
+    const context: NodeDescriberContext = {
+      outerGraph,
+      loader,
+      kits,
+      sandbox: this.store.sandbox,
+      graphStore: this.store,
+      fileSystem: this.store.fileSystem.createRunFileSystem({
+        graphUrl: TYPE_DESCRIPTOR_GRAPH_URL,
+        env: envFromGraphDescriptor(this.store.fileSystem.env()),
+        assets: assetsFromGraphDescriptor(),
+      }),
+      wires: { incoming: {}, outgoing: {} },
+      asType: true,
+    };
+    try {
+      return describer(
+        undefined,
+        asWired.inputSchema,
+        asWired.outputSchema,
+        context
+      );
+    } catch (e) {
+      console.warn(`Error describing node type ${type}`, e);
+      return asWired;
+    }
+  }
+
+  async #getDescriber(
+    type: NodeTypeIdentifier
+  ): Promise<NodeDescriberFunction | undefined> {
+    let handler: NodeHandler | undefined;
+    try {
+      handler = await getHandler(
+        type,
+        contextFromMutableGraphStore(this.store)
+      );
+    } catch (e) {
+      console.warn(`Error getting describer for node type ${type}`, e);
+    }
+    if (!handler || !("describe" in handler) || !handler.describe) {
+      return undefined;
+    }
+    return handler.describe;
+  }
+}

--- a/packages/breadboard/src/inspector/graph/node.ts
+++ b/packages/breadboard/src/inspector/graph/node.ts
@@ -92,11 +92,10 @@ export class Node implements InspectableNode {
     return this.descriptor.metadata || {};
   }
 
-  async describe(inputs?: InputValues): Promise<NodeDescriberResult> {
+  async describe(): Promise<NodeDescriberResult> {
     const describeEntry = this.#graph.describe.get(
       this.descriptor.id,
-      this.#graphId,
-      inputs
+      this.#graphId
     );
     return describeEntry.latest;
   }
@@ -122,7 +121,7 @@ export class Node implements InspectableNode {
     inputValues?: InputValues,
     outputValues?: OutputValues
   ): Promise<InspectableNodePorts> {
-    const described = await this.describe(inputValues);
+    const described = await this.describe();
     return describerResultToPorts(
       this,
       described,

--- a/packages/breadboard/src/inspector/types.ts
+++ b/packages/breadboard/src/inspector/types.ts
@@ -125,7 +125,7 @@ export type InspectableNode = {
    * This function is designed to match the output of the
    * `NodeDescriberFunction`.
    */
-  describe(inputs?: InputValues): Promise<NodeDescriberResult>;
+  describe(): Promise<NodeDescriberResult>;
   /**
    * Returns configuration of the node.
    * TODO: Use a friendlier to inspection return type.
@@ -445,8 +445,7 @@ export type DescribeResultCacheArgs = {
   ): NodeDescriberResult;
   latest(
     graphId: GraphIdentifier,
-    nodeId: NodeIdentifier,
-    inputs?: InputValues
+    nodeId: NodeIdentifier
   ): Promise<NodeDescriberResult>;
   willUpdate(previous: NodeDescriberResult, current: NodeDescriberResult): void;
   updated(graphId: GraphIdentifier, nodeId: NodeIdentifier): void;
@@ -763,8 +762,7 @@ export type InspectableDescriberResultTypeCache = {
 export type InspectableDescriberResultCache = {
   get(
     id: NodeIdentifier,
-    graphId: GraphIdentifier,
-    inputs?: InputValues
+    graphId: GraphIdentifier
   ): InspectableDescriberResultCacheEntry;
   update(affectedNodes: AffectedNode[]): void;
   clear(visualOnly: boolean, affectedNodes: AffectedNode[]): void;

--- a/packages/breadboard/src/loader/loader.ts
+++ b/packages/breadboard/src/loader/loader.ts
@@ -16,7 +16,12 @@ import type {
 export const SENTINEL_BASE_URL = new URL("sentinel://sentinel/sentinel");
 const MODULE_PREFIX = "module:";
 
-export { resolveGraph, getGraphUrl, getGraphUrlComponents };
+export {
+  resolveGraph,
+  getGraphUrl,
+  getGraphUrlComponents,
+  urlComponentsFromString,
+};
 
 function getGraphUrl(path: string, context: GraphLoaderContext): URL {
   const base = baseURLFromContext(context);
@@ -91,6 +96,26 @@ export const baseURLFromContext = (context: GraphLoaderContext) => {
   if (context.base) return context.base;
   return SENTINEL_BASE_URL;
 };
+
+function urlComponentsFromString(
+  urlString: string,
+  context: GraphLoaderContext = {}
+): {
+  mainGraphUrl: string;
+  graphId: string;
+  moduleId?: string;
+} {
+  if (urlString.startsWith(MODULE_PREFIX)) {
+    const parts = urlString.split(":");
+    const moduleId = parts[1];
+    return {
+      graphId: "",
+      moduleId,
+      mainGraphUrl: parts.slice(2).join(":"),
+    };
+  }
+  return getGraphUrlComponents(getGraphUrl(urlString, context));
+}
 
 export class Loader implements GraphLoader {
   #graphProviders: GraphProvider[];

--- a/packages/breadboard/tests/inspector/observer-load.ts
+++ b/packages/breadboard/tests/inspector/observer-load.ts
@@ -183,7 +183,7 @@ test("run load/save: serialization produces consistent size", async (t) => {
   }
   const serializedRun = await run.serialize();
   const s = JSON.stringify(serializedRun);
-  t.is(s.length, 1175273);
+  t.is(s.length, 1199121);
   t.true(
     (
       await observer.load(serializedRun, {

--- a/packages/shared-ui/src/elements/board-activity/board-activity.ts
+++ b/packages/shared-ui/src/elements/board-activity/board-activity.ts
@@ -359,7 +359,7 @@ export class BoardActivity extends LitElement {
 
   async #renderPendingInput(idx: number, event: InspectableRunNodeEvent) {
     const { inputs, node } = event;
-    const nodeSchema = await node.describe(inputs);
+    const nodeSchema = await node.describe();
     const descriptor = node.descriptor;
     let schema = nodeSchema?.outputSchema;
     if (!schema || Object.keys(schema).length === 0) {


### PR DESCRIPTION
- **Ensure latest MutableGraph in GrpahBasedNodeHandler.**
- **Stop passing `InputValue` to describers.**
- **Move classes out of `describer-manager` into their own files.**
- **Remove `sameCheck` and stop mutating graphs when adding them. Also, use `urlComponentsFromString` to correctly parse `module:` prefixed paths.**
- **docs(changeset): Reduce the number of times describers are called during the run.**
