### PR TITLE
Revert "[shared-ui] Contain the height of html-view"

### DIFF
--- a/.changeset/smart-wolves-hope.md
+++ b/.changeset/smart-wolves-hope.md
@@ -1,5 +1,0 @@
----
-"@breadboard-ai/shared-ui": patch
----
-
-Contain the height of html-view

--- a/packages/shared-ui/src/app-templates/basic/index.ts
+++ b/packages/shared-ui/src/app-templates/basic/index.ts
@@ -421,7 +421,7 @@ export class Template extends LitElement implements AppTemplate {
           & #activity {
             flex: 1;
             overflow: auto;
-            container-type: size;
+
             display: flex;
             flex-direction: column;
             padding: var(--bb-grid-size-3);

--- a/packages/shared-ui/src/elements/output/llm-output/llm-output.ts
+++ b/packages/shared-ui/src/elements/output/llm-output/llm-output.ts
@@ -307,7 +307,7 @@ export class LLMOutput extends LitElement {
       border: none;
       width: 100%;
       overflow-x: auto;
-      max-height: calc(100cqh - var(--bb-grid-size-11));
+      height: 600px;
     }
 
     :host([lite]) .value {


### PR DESCRIPTION
Reverts breadboard-ai/breadboard#5680, because it made HTML views short.

![image](https://github.com/user-attachments/assets/043ea02d-81f0-45c1-83e4-8926591897b0)
