### PR TITLE
[perf] Shrink Google Symbols font from 9MB to 141KB

### DIFF
--- a/packages/visual-editor/index.html
+++ b/packages/visual-editor/index.html
@@ -9,7 +9,7 @@
   />
   <link
     rel="stylesheet"
-    href="https://fonts.googleapis.com/css2?family=Google+Symbols:opsz,wght,FILL,GRAD,ROND@20..48,100..700,0..1,-50..200,0..100&display=block"
+    href="https://fonts.googleapis.com/css2?family=Google+Symbols:opsz,wght,FILL,GRAD,ROND@20..48,100..700,0..1,-50..200,0..100&display=block&icon_names=3p,add,add_circle,alternate_email,arrow_back,arrow_circle_right,arrow_drop_down,audio_magic_eraser,call_split,chat,check,check_box,close,code_blocks,collapse_content,content_copy,csv,data_array,data_info_alert,delete,developer_board,docs,download,draw,drive,drive_pdf,edit,error,expand_content,extension,fit_screen,flag,flowchart,frame_source,globe_book,history,history_2,human,input,keyboard_arrow_down,keyboard_arrow_up,language,laps,link,logout,mail,map_search,merge_type,more_vert,movie,pen_spark,person,photo_spark,preview,progress_activity,redo,replay,save,search,search_spark,settings,share,smart_toy,spark,step,summarize,sunny,tab_inactive,text_analysis,text_fields,undo,upload,video_youtube,videocam_auto,voice_selection"
   />
 
   <link rel="stylesheet" href="/styles/global.css" />


### PR DESCRIPTION
Reduces the size of the Google Symbols woff2 file from 9MB to 141KB by enumerating the symbols we are actually using.

There's a chance I missed some, but poked around the app a bunch and don't see anything missing. I looked at these 3 declaration styles:

- Static names inside g-icon elements
- ::before content on g-icon elements
- "icon" properties in the A2 BGL files