### PR TITLE
[drive] Require immediate login in app view for Drive graphs

### DIFF
--- a/packages/shared-ui/src/elements/connection/connection-entry-signin.ts
+++ b/packages/shared-ui/src/elements/connection/connection-entry-signin.ts
@@ -122,3 +122,9 @@ export class ConnectionEntrySignin extends LitElement {
     </div>`;
   }
 }
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "bb-connection-entry-signin": ConnectionEntrySignin;
+  }
+}

--- a/packages/unified-server/src/client/app/elements/app-view/app-view.ts
+++ b/packages/unified-server/src/client/app/elements/app-view/app-view.ts
@@ -38,10 +38,6 @@ import {
 } from "@google-labs/breadboard/harness";
 import { blobHandleToUrl } from "@breadboard-ai/shared-ui/elements/app-preview/app-preview.js";
 
-const usingGoogleDrive = new URL(window.location.href).pathname.startsWith(
-  "/app/drive"
-);
-
 @customElement("app-view")
 export class AppView extends LitElement {
   static styles = css`
@@ -234,26 +230,6 @@ export class AppView extends LitElement {
   }
 
   render() {
-    if (usingGoogleDrive && this.#signInAdapter.state !== "valid") {
-      // With Google Drive, if a graph has been shared with specific people or a
-      // domain, we are not able to know anything about it until the user has
-      // signed in.
-      //
-      // If a graph has been shared fully publicy, we could in theory do the
-      // nicer thing and show the splash image etc. before sign-in (because we
-      // have an API key that lets us read those files without user
-      // credentials). But, for now we are keeping it simple and always
-      // requiring sign-in first.
-      return html`
-        <bb-connection-entry-signin
-          .adapter=${this.#signInAdapter}
-          @bbsignin=${() => {
-            window.location.reload();
-          }}
-        ></bb-connection-entry-signin>
-      `;
-    }
-
     if (!this.flow || !this.#runner) {
       return html`404 not found`;
     }


### PR DESCRIPTION
Also includes a fix to the share panel to allow it to display the app link for graphs not owned by the current user.

Note there are still some issues where the graph seems to have trouble executing, like an OAuth issue, but the same thing is happening with our Firebase-backed version too, so I'm treating that as a separate issue.