### PR TITLE
[sharing] Include splash images when sharing files

### DIFF
--- a/packages/shared-ui/src/elements/google-drive/find-google-drive-assets-in-graph.ts
+++ b/packages/shared-ui/src/elements/google-drive/find-google-drive-assets-in-graph.ts
@@ -7,22 +7,35 @@
 import type { GraphDescriptor, LLMContent } from "@breadboard-ai/types";
 
 export function findGoogleDriveAssetsInGraph(graph: GraphDescriptor): string[] {
-  if (!graph.assets) {
-    return [];
-  }
   // Use a set because there can be duplicates.
   const fileIds = new Set<string>();
-  for (const asset of Object.values(graph.assets)) {
-    if (asset.metadata?.subType === "gdrive") {
-      // Cast needed because `data` is very broadly typed as `NodeValue`.
-      const firstPart = (asset.data as LLMContent[])[0]?.parts[0];
-      if (firstPart && "fileData" in firstPart) {
-        const fileId = firstPart.fileData?.fileUri;
-        if (fileId) {
-          fileIds.add(fileId);
+
+  if (graph.assets) {
+    for (const asset of Object.values(graph.assets)) {
+      if (asset.metadata?.subType === "gdrive") {
+        // Cast needed because `data` is very broadly typed as `NodeValue`.
+        const firstPart = (asset.data as LLMContent[])[0]?.parts[0];
+        if (firstPart && "fileData" in firstPart) {
+          const fileId = firstPart.fileData?.fileUri;
+          if (fileId) {
+            fileIds.add(fileId);
+          }
         }
       }
     }
   }
+
+  // Theme splash images are not listed in assets.
+  const themes = graph.metadata?.visual?.presentation?.themes;
+  if (themes) {
+    for (const theme of Object.values(themes)) {
+      const splashHandle = theme.splashScreen?.storedData?.handle;
+      const fileIdMatch = splashHandle?.match(/^drive:\/?(.+)/);
+      if (fileIdMatch?.[1]) {
+        fileIds.add(fileIdMatch[1]);
+      }
+    }
+  }
+
   return [...fileIds];
 }


### PR DESCRIPTION
Splash images are not listed under assets, but they too need to be shared when sharing a graph.