### PR TITLE
[gdrive] force refresh the project list when one changes

### DIFF
--- a/packages/google-drive-kit/src/board-server/operations.ts
+++ b/packages/google-drive-kit/src/board-server/operations.ts
@@ -5,11 +5,7 @@
  */
 
 import type { TokenVendor } from "@breadboard-ai/connection-client";
-import type {
-  Asset,
-  GraphTag,
-  InlineDataCapabilityPart,
-} from "@breadboard-ai/types";
+import type { Asset, GraphTag } from "@breadboard-ai/types";
 import {
   err,
   type GraphDescriptor,
@@ -90,10 +86,14 @@ class DriveOperations {
   readonly #publicApiKey?: string;
   readonly #featuredGalleryFolderId?: string;
 
+  /**
+   * @param refreshProjectListCallback will be called when project list may have to be updated.
+   */
   constructor(
     public readonly vendor: TokenVendor,
     public readonly username: string,
     public readonly url: URL,
+    private readonly refreshProjectListCallback: () => Promise<void>,
     userFolderName: string,
     publicApiKey?: string,
     featuredGalleryFolderId?: string
@@ -268,6 +268,9 @@ class DriveOperations {
     } catch (err) {
       console.warn(err);
       return { result: false, error: "Unable to save" };
+    } finally {
+      // The above update is a non-atomic operation so refresh after both success or fail.
+      await this.refreshProjectListCallback();
     }
   }
 
@@ -319,6 +322,9 @@ class DriveOperations {
     } catch (err) {
       console.warn(err);
       return { result: false, error: "Unable to create" };
+    } finally {
+      // The above update is a non-atomic operation so refresh after both success or fail.
+      await this.refreshProjectListCallback();
     }
   }
 
@@ -498,6 +504,8 @@ class DriveOperations {
     } catch (e) {
       console.warn(e);
       return err("Unable to delete");
+    } finally {
+      await this.refreshProjectListCallback();
     }
   }
 

--- a/packages/google-drive-kit/src/board-server/server.ts
+++ b/packages/google-drive-kit/src/board-server/server.ts
@@ -138,7 +138,9 @@ class GoogleDriveBoardServer
       vendor,
       user.username,
       configuration.url,
-      this.refreshProjectList.bind(this),
+      async () => {
+        await this.refreshProjectList();
+      },
       userFolderName,
       publicApiKey,
       featuredGalleryFolderId

--- a/packages/google-drive-kit/src/board-server/server.ts
+++ b/packages/google-drive-kit/src/board-server/server.ts
@@ -138,6 +138,7 @@ class GoogleDriveBoardServer
       vendor,
       user.username,
       configuration.url,
+      this.refreshProjectList.bind(this),
       userFolderName,
       publicApiKey,
       featuredGalleryFolderId
@@ -150,7 +151,7 @@ class GoogleDriveBoardServer
     this.extensions = configuration.extensions;
     this.capabilities = configuration.capabilities;
     this.#googleDriveClient = googleDriveClient;
-    this.projects = this.refreshProjects();
+    this.projects = this.listProjects();
   }
 
   #saving = new Map<string, SaveDebouncer>();
@@ -162,7 +163,7 @@ class GoogleDriveBoardServer
     this.#projects = await this.projects;
   }
 
-  async refreshProjects(): Promise<BoardServerProject[]> {
+  async listProjects(): Promise<BoardServerProject[]> {
     // Run two lists operations in parallel.
     const userGraphsPromise = this.ops.readGraphList();
     let featuredGraphs = await this.ops.readFeaturedGalleryGraphList();
@@ -226,6 +227,15 @@ class GoogleDriveBoardServer
     );
 
     return [...userProjects, ...galleryProjects];
+  }
+
+  /**
+   * Issues a query for the project list and resets the `projects` promise.
+   * The work is done asynchronously unless you await to its result.
+   */
+  refreshProjectList(): Promise<BoardServerProject[]> {
+    this.projects = this.listProjects();
+    return this.projects;
   }
 
   getAccess(_url: URL, _user: User): Promise<Permission> {
@@ -316,9 +326,6 @@ class GoogleDriveBoardServer
       parent,
       descriptor
     );
-    if (writing.result) {
-      this.projects = this.refreshProjects();
-    }
     return writing;
   }
 
@@ -328,8 +335,6 @@ class GoogleDriveBoardServer
     if (!ok(deleting)) {
       return { result: false, error: deleting.$error };
     }
-    this.projects = this.refreshProjects();
-
     return { result: true };
   }
 

--- a/packages/shared-ui/src/elements/google-drive/google-drive-debug-panel.ts
+++ b/packages/shared-ui/src/elements/google-drive/google-drive-debug-panel.ts
@@ -194,7 +194,7 @@ export class GoogleDriveDebugPanel extends LitElement {
     if (!server) {
       return nothing;
     }
-    const projects = await server.refreshProjects();
+    const projects = await server.listProjects();
     return projects.map((project) => {
       const fileId = project.url.href.replace(/^drive:\//, "");
       return html` <li>${this.#renderFileLink(fileId)}</li> `;


### PR DESCRIPTION
note that this solves only one half of the problem of not refreshing after updating a gdrive board - the other half is because of debounce - will follow up.