### PR TITLE
Use EmbedHandler to support iterate-on-prompt button, homepage loaded, and creating a new board message.

### DIFF
--- a/packages/embed/src/index.ts
+++ b/packages/embed/src/index.ts
@@ -6,6 +6,7 @@
 
 import {
   BreadboardMessage,
+  EmbedderMessage,
   EmbedHandler,
   EmbedState,
   MessageCallback,
@@ -47,7 +48,7 @@ export class Handler implements EmbedHandler {
   async #onMessage(evt: MessageEvent) {
     this.#log(`[Embed handler received]: `, evt.data);
 
-    const message = evt.data as BreadboardMessage;
+    const message = evt.data as EmbedderMessage;
     const subscribers = this.#subscribers.get(message.type);
     if (!subscribers) {
       return;
@@ -76,8 +77,8 @@ export class Handler implements EmbedHandler {
   async subscribe<T extends MessageType>(
     type: T,
     callback: (
-      message: Extract<BreadboardMessage, { type: T }>
-    ) => Promise<BreadboardMessage | void>
+      message: Extract<EmbedderMessage, { type: T }>
+    ) => Promise<EmbedderMessage | void>
   ): Promise<void> {
     let subscribers = this.#subscribers.get(type);
     if (!subscribers) {
@@ -95,8 +96,8 @@ export class Handler implements EmbedHandler {
   async unsubscribe<T extends MessageType>(
     type: T,
     callback: (
-      message: Extract<BreadboardMessage, { type: T }>
-    ) => Promise<BreadboardMessage | void>
+      message: Extract<EmbedderMessage, { type: T }>
+    ) => Promise<EmbedderMessage | void>
   ) {
     const subscribers = this.#subscribers.get(type);
     if (!subscribers) {

--- a/packages/embed/src/types/types.ts
+++ b/packages/embed/src/types/types.ts
@@ -12,7 +12,6 @@
 /** A Message from Breadboard to parent iframe, sent via window.parent.postMessage */
 export type BreadboardMessage =
   | DebugMessage
-  | ToggleIterateOnPromptMessage
   | HandshakeReadyMessage
   | OauthRedirectMessage
   | BackClickedMessage
@@ -23,11 +22,6 @@ export type BreadboardMessage =
 /** Event for enabling debug. */
 export interface DebugMessage {
   type: "debug";
-  on: boolean;
-}
-
-export interface ToggleIterateOnPromptMessage {
-  type: "toggle_iterate_on_prompt";
   on: boolean;
 }
 
@@ -93,7 +87,13 @@ export interface IterateOnPromptMessage {
 }
 
 /** A message from parent iframe to Breadboard, sent via iframe.contentWindow.postMessage */
-export type IframeMessage = CreateNewBoardMessage | HandshakeCompleteMessage;
+export type EmbedderMessage = ToggleIterateOnPromptMessage | CreateNewBoardMessage | HandshakeCompleteMessage;
+
+/** Message to determine whether to display Iterate-on-prompt button. */
+export interface ToggleIterateOnPromptMessage {
+  type: "toggle_iterate_on_prompt";
+  on: boolean;
+}
 
 /** Message that creates a new Breadboard board. */
 export interface CreateNewBoardMessage {
@@ -114,15 +114,15 @@ export interface HandshakeCompleteMessage {
 
 /** Checks if a message is of type HandshakeCompleteMessage. */
 export function isHandshakeCompleteMessage(
-  message: IframeMessage
+  message: EmbedderMessage
 ): message is HandshakeCompleteMessage {
   return message.type === "handshake_complete";
 }
 
-export type MessageType = BreadboardMessage["type"];
+export type MessageType = EmbedderMessage["type"];
 export type MessageCallback = (
-  message: BreadboardMessage
-) => Promise<BreadboardMessage | undefined>;
+  message: EmbedderMessage
+) => Promise<EmbedderMessage | undefined>;
 
 export interface EmbedState {
   showIterateOnPrompt: boolean;
@@ -136,13 +136,13 @@ export interface EmbedHandler {
   subscribe<T extends MessageType>(
     type: T,
     callback: (
-      message: Extract<BreadboardMessage, { type: T }>
-    ) => Promise<BreadboardMessage | void>
+      message: Extract<EmbedderMessage, { type: T }>
+    ) => Promise<EmbedderMessage | void>
   ): Promise<void>;
   unsubscribe<T extends MessageType>(
     type: T,
     callback: (
-      message: Extract<BreadboardMessage, { type: T }>
-    ) => Promise<BreadboardMessage | void>
+      message: Extract<EmbedderMessage, { type: T }>
+    ) => Promise<EmbedderMessage | void>
   ): Promise<void>;
 }

--- a/packages/shared-ui/src/events/events.ts
+++ b/packages/shared-ui/src/events/events.ts
@@ -1573,3 +1573,18 @@ export class SnackbarActionEvent extends Event {
     super(SnackbarActionEvent.eventName, { ...eventInit });
   }
 }
+
+/** Events */
+
+export class IterateOnPromptEvent extends Event {
+  static eventName = "bbiterateonprompt";
+
+  constructor(
+    public readonly title: string,
+    public readonly promptTemplate: string,
+    public readonly boardId: string,
+    public readonly nodeId: string,
+  ) {
+    super(IterateOnPromptEvent.eventName, { ...eventInit });
+  }
+}

--- a/packages/shared-ui/src/utils/board-id.ts
+++ b/packages/shared-ui/src/utils/board-id.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const ARG_NAME = 'tab0';
+
+/** 
+ * Extract the board ID from a breadboard URL.
+ */
+export function getBoardIdFromUrl(url: URL): string | null {
+    const params = new URLSearchParams(url.search);
+    return params.get(ARG_NAME);
+}

--- a/packages/shared-ui/src/utils/utils.ts
+++ b/packages/shared-ui/src/utils/utils.ts
@@ -5,6 +5,7 @@
  */
 
 export { formatError } from "./format-error";
+export { getBoardIdFromUrl } from "./board-id";
 export { TopGraphObserver } from "./top-graph-observer/index";
 // export { getIsolatedNodeGraphDescriptor } from "./isolated-node-board.js";
 export { getModuleId } from "./module-id.js";

--- a/packages/unified-server/package.json
+++ b/packages/unified-server/package.json
@@ -131,7 +131,7 @@
   "repository": {
     "directory": "packages/unified-serer",
     "type": "git",
-    "url": "https://github.com/breadboard-ai/breadboard.git"
+    "url": "git+https://github.com/breadboard-ai/breadboard.git"
   },
   "files": [
     "dist/src"
@@ -185,5 +185,8 @@
     "google-auth-library": "^9.15.1",
     "vite": "^6.2.7",
     "vite-express": "^0.21.1"
+  },
+  "directories": {
+    "test": "tests"
   }
 }

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -94,6 +94,7 @@ import {
   ToggleExperimentalComponentsCommand,
   UngroupCommand,
 } from "./commands/commands";
+import { getBoardIdFromUrl } from "@breadboard-ai/shared-ui/utils/board-id.js";
 import {
   SIGN_IN_CONNECTION_ID,
   SigninAdapter,
@@ -112,11 +113,16 @@ import { GoogleDriveClient } from "@breadboard-ai/google-drive-kit/google-drive-
 
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import {
+  CreateNewBoardMessage,
   EmbedHandler,
   embedState,
   EmbedState,
-  ToggleIterateOnPromptMessage,
+  IterateOnPromptMessage,
+  ToggleIterateOnPromptMessage
 } from "@breadboard-ai/embed";
+import { IterateOnPromptEvent } from "@breadboard-ai/shared-ui/events/events.js";
+import { AppCatalystApiClient } from "@breadboard-ai/shared-ui/flow-gen/app-catalyst.js";
+import { FlowGenerator } from "@breadboard-ai/shared-ui/flow-gen/flow-generator.js";
 
 const STORAGE_PREFIX = "bb-main";
 const LOADING_TIMEOUT = 1250;
@@ -937,6 +943,10 @@ export class Main extends LitElement {
           this.environment,
           this.settingsHelper
         );
+        // Once we've determined the sign-in status, relay it to an embedder.
+        this.#embedHandler?.sendToEmbedder(
+          {type: "home_loaded", isSignedIn: signInAdapter.state === "valid"}
+        )
         if (signInAdapter.state === "signedout") {
           return;
         }
@@ -991,6 +1001,52 @@ export class Main extends LitElement {
         this.embedState.showIterateOnPrompt = message.on;
       }
     );
+    this.#embedHandler?.subscribe(
+      "create_new_board",
+      async (message: CreateNewBoardMessage) => {
+        void this.#generateBoard(message.prompt)
+          .then((graph) =>  this.#generateBoardSuccess(graph))
+          .catch((error) => console.error("Error generating board", error));
+      }
+    );
+    this.#embedHandler?.sendToEmbedder(
+      {type: "handshake_ready"});
+  }
+
+  async #generateBoard(intent: string): Promise<GraphDescriptor> {
+    const generator = new FlowGenerator(
+      new AppCatalystApiClient(this.signinAdapter)
+    );
+    const { flow } = await generator.oneShot({ intent });
+    return flow;
+  }
+
+  async #generateBoardSuccess(graph: GraphDescriptor) {
+    const boardServerName = this.selectedBoardServer;
+    const location = this.selectedLocation;
+    const fileName = `${globalThis.crypto.randomUUID()}.bgl.json`;
+
+    const boardData = await this.#attemptBoardSaveAs(
+      boardServerName,
+      location,
+      fileName,
+      graph,
+      true,
+      {
+        start: Strings.from("STATUS_CREATING_PROJECT"),
+        end: Strings.from("STATUS_PROJECT_CREATED"),
+        error: Strings.from("ERROR_UNABLE_TO_CREATE_PROJECT"),
+      },
+    );
+    if (!boardData) return;
+    const {url} = boardData;
+    const boardId = getBoardIdFromUrl(url);
+    if (boardId) {
+      this.#embedHandler?.sendToEmbedder({
+        type: 'board_id_created', 
+        id: boardId,
+      });
+    }
   }
 
   disconnectedCallback(): void {
@@ -1568,7 +1624,8 @@ export class Main extends LitElement {
     }
   }
 
-  async #attemptBoardSaveAs(
+
+  async #attemptBoardSaveAsAndNavigate(
     boardServerName: string,
     location: string,
     fileName: string,
@@ -1581,8 +1638,37 @@ export class Main extends LitElement {
     },
     creator: EditHistoryCreator
   ) {
-    if (this.#isSaving) {
+    const boardData = await this.#attemptBoardSaveAs(
+      boardServerName, 
+      location, 
+      fileName, 
+      graph,
+      ackUser,
+      ackUserMessage)
+    if (!boardData) {
       return;
+    }
+    const {id, url} = boardData;
+    this.#attemptBoardLoad(
+      new BreadboardUI.Events.StartEvent(url.href, undefined, creator),
+      id
+    );
+  }
+
+  async #attemptBoardSaveAs(
+    boardServerName: string,
+    location: string,
+    fileName: string,
+    graph: GraphDescriptor,
+    ackUser = true,
+    ackUserMessage = {
+      start: Strings.from("STATUS_SAVING_PROJECT"),
+      end: Strings.from("STATUS_PROJECT_SAVED"),
+      error: Strings.from("ERROR_UNABLE_TO_CREATE_PROJECT"),
+    },
+  ): Promise<{id: BreadboardUI.Types.SnackbarUUID | undefined, url: URL} | null> {
+    if (this.#isSaving) {
+      return null;
     }
 
     let id: BreadboardUI.Types.SnackbarUUID | undefined;
@@ -1615,16 +1701,12 @@ export class Main extends LitElement {
         );
       }
 
-      return;
+      return null;
     }
 
     this.#setBoardPendingSaveState(false);
     this.#persistBoardServerAndLocation(boardServerName, location);
-
-    this.#attemptBoardLoad(
-      new BreadboardUI.Events.StartEvent(url.href, undefined, creator),
-      id
-    );
+    return {id: id, url: url};
   }
 
   async #attemptBoardDelete(
@@ -1686,7 +1768,7 @@ export class Main extends LitElement {
     const location = this.selectedLocation;
     const fileName = `${globalThis.crypto.randomUUID()}.bgl.json`;
 
-    await this.#attemptBoardSaveAs(
+    await this.#attemptBoardSaveAsAndNavigate(
       boardServerName,
       location,
       fileName,
@@ -4161,6 +4243,16 @@ export class Main extends LitElement {
                   this.tab?.id,
                   this.#runtime.util.createWorkspaceSelectionChangeId()
                 );
+              }}
+              @bbiterateonprompt=${(iterateOnPromptEvent: IterateOnPromptEvent) => {
+                  const message: IterateOnPromptMessage = {
+                    type: 'iterate_on_prompt',
+                    title: iterateOnPromptEvent.title,
+                    promptTemplate: iterateOnPromptEvent.promptTemplate,
+                    boardId: iterateOnPromptEvent.boardId,
+                    nodeId: iterateOnPromptEvent.nodeId,
+                  };
+                  this.#embedHandler?.sendToEmbedder(message);
               }}
             ></bb-ui-controller>
         ${


### PR DESCRIPTION
Implements the following three features in communicating between an iframed breadboard page and its embedder:

1. **Iterate on prompt**. Allows the embedder to send an `toggle_iterate_on_prompt` message which enables a new button in the title of the expanded node. Pressing this button emits a `iterate_on_prompt` message to the embedder conveying information about the board and node of origin, as well as the prompt at the time of button press.

1. **Create a new board.** Allows the parent to send a `create_new_board` message. If the requested board is succesfully created, the generated board ID is sent back as a message to the embedder.

1. **Home loaded.** Sends the embedder a message notifying it that Breadboard loaded, along with the user's signed-in status.

1.  **Handshake ready.** Sends the embedder a message notifying it that Breadboard is ready to receive messages. This is necessary to prevent the embedder from sending messages before Breadboard has set up the necessary event listeners. (In this code, we do not receive the `handshake_complete` message, as there is nothing that needs to happen then.)

Also renames the class of message sent by the embedder as `EmbedderMessage` to distinguish them from `BreadboardMessage`, which denote messages sent by Breadboard.