### PR TITLE
[themes] Enable CORS for image requests so that we can read pixels

### DIFF
--- a/packages/shared-ui/src/elements/app-preview/app-theme-creator.ts
+++ b/packages/shared-ui/src/elements/app-preview/app-theme-creator.ts
@@ -560,6 +560,7 @@ export class AppThemeCreator extends LitElement {
         img.src = `data:${splashScreen.inlineData.mimeType};base64,${splashScreen.inlineData.data}`;
       } else {
         img.src = splashScreen.storedData.handle;
+        img.crossOrigin = "anonymous";
       }
       theme = await generatePaletteFromImage(img);
 

--- a/packages/unified-server/src/client/app/init.ts
+++ b/packages/unified-server/src/client/app/init.ts
@@ -246,6 +246,7 @@ async function extractThemeFromFlow(flow: GraphDescriptor | null): Promise<{
         if (url) {
           const img = new Image();
           img.src = url.href;
+          img.crossOrigin = "anonymous";
 
           const generatedTheme = await generatePaletteFromImage(img);
           theme = { ...theme, ...generatedTheme };

--- a/packages/visual-editor/src/runtime/board.ts
+++ b/packages/visual-editor/src/runtime/board.ts
@@ -672,6 +672,7 @@ export class Board extends EventTarget {
 
     const img = new Image();
     img.src = splashUrl.href;
+    img.crossOrigin = "anonymous";
     theme.palette = await generatePaletteFromImage(img);
   }
 


### PR DESCRIPTION
For security, to read the pixels out of an image (required for the new material theming logic), the image must be fetched with CORS enabled. Since we didn't have a cross-origin attribute, we were not sending any CORS headers. Now we do.