### PR TITLE
Correct board URL logic and declare interfaces for Breadboard-embedder communication

### DIFF
--- a/packages/embed/src/types/types.ts
+++ b/packages/embed/src/types/types.ts
@@ -20,37 +20,37 @@ export type BreadboardMessage =
   | IterateOnPromptMessage;
 
 /** Event for enabling debug. */
-export interface DebugMessage {
+export declare interface DebugMessage {
   type: "debug";
   on: boolean;
 }
 
 /** Event when Breadboard has begun listening for messages from parent iframe. */
-export interface HandshakeReadyMessage {
+export declare interface HandshakeReadyMessage {
   type: "handshake_ready";
 }
 
 /** Event sent from /oauth. */
-export interface OauthRedirectMessage {
+export declare interface OauthRedirectMessage {
   type: "oauth_redirect";
   /** If true, the user successfully signed in. */
   success: boolean;
 }
 
 /** Event when the user clicks the back button in the view Breadboard page. */
-export interface BackClickedMessage {
+export declare interface BackClickedMessage {
   type: "back_clicked";
 }
 
 /** Event when the Breadboard homepage is loaded. */
-export interface HomeLoadedMessage {
+export declare interface HomeLoadedMessage {
   type: "home_loaded";
   /** If true, the "Sign in" button is not shown. */
   isSignedIn: boolean;
 }
 
 /** Event when a new breadboard has been created. */
-export interface BoardIdCreatedMessage {
+export declare interface BoardIdCreatedMessage {
   type: "board_id_created";
   /**
    * The id of the newly created Breadboard.
@@ -60,7 +60,7 @@ export interface BoardIdCreatedMessage {
 }
 
 /** Event when a new breadboard has been created. */
-export interface IterateOnPromptMessage {
+export declare interface IterateOnPromptMessage {
   type: "iterate_on_prompt";
   /** The title of the node in Breadboard. */
   title: string;
@@ -95,13 +95,13 @@ export type EmbedderMessage =
   | HandshakeCompleteMessage;
 
 /** Message to determine whether to display Iterate-on-prompt button. */
-export interface ToggleIterateOnPromptMessage {
+export declare interface ToggleIterateOnPromptMessage {
   type: "toggle_iterate_on_prompt";
   on: boolean;
 }
 
 /** Message that creates a new Breadboard board. */
-export interface CreateNewBoardMessage {
+export declare interface CreateNewBoardMessage {
   type: "create_new_board";
   /**
    * Natural language prompt for the new Breadboard.
@@ -111,7 +111,7 @@ export interface CreateNewBoardMessage {
 }
 
 /** Message that relays to Breadboard that it's in an parent iframe iframe. */
-export interface HandshakeCompleteMessage {
+export declare interface HandshakeCompleteMessage {
   type: "handshake_complete";
   // The top-level origin from parent iframe.
   origin: string;

--- a/packages/shared-ui/src/elements/entity-editor/entity-editor.ts
+++ b/packages/shared-ui/src/elements/entity-editor/entity-editor.ts
@@ -77,7 +77,7 @@ import { icons } from "../../styles/icons";
 import { consume } from "@lit/context";
 import { embedderContext } from "../../contexts/embedder";
 import { EmbedState, embedState } from "@breadboard-ai/embed";
-import { getBoardIdFromUrl } from "../../utils/board-id.js";
+import { getBoardUrlFromCurrentWindow } from "../../utils/board-id.js";
 
 const Strings = StringsHelper.forSection("Editor");
 
@@ -1184,9 +1184,10 @@ export class EntityEditor extends SignalWatcher(LitElement) {
     nodeTitle: string,
     node: InspectableNode
   ) {
-    const url = new URL(this.graph?.raw().url ?? window.location.href);
-    const boardId = getBoardIdFromUrl(url);
-    if (!boardId || !isGenerativeNode(node)) {
+    // Note that the board URL here may not be a HTTP/HTTPS URL - it could
+    // be a Drive URL of the form drive:/12345.
+    const boardUrl = this.graph?.raw().url ?? getBoardUrlFromCurrentWindow();
+    if (!boardUrl || !isGenerativeNode(node)) {
       return nothing;
     }
     // If tools are contained in prompt, iterate-on-prompt will be disabled.
@@ -1209,7 +1210,7 @@ export class EntityEditor extends SignalWatcher(LitElement) {
           new IterateOnPromptEvent(
             nodeTitle,
             promptTemplate,
-            boardId!,
+            boardUrl!,
             nodeId,
             modelId
           )

--- a/packages/shared-ui/src/utils/board-id.ts
+++ b/packages/shared-ui/src/utils/board-id.ts
@@ -7,9 +7,13 @@
 const ARG_NAME = "tab0";
 
 /**
- * Extract the board ID from a breadboard URL.
+ * Extract the board URL from a current window HTTP/HTTPS URL.
+ *
+ * Note that the board URL here may not be a HTTP/HTTPS URL - it could
+ * be a Drive URL of the form drive:/12345.
  */
-export function getBoardIdFromUrl(url: URL): string | null {
+export function getBoardUrlFromCurrentWindow(): string | null {
+  const url = new URL(window.location.href);
   const params = new URLSearchParams(url.search);
   return params.get(ARG_NAME);
 }

--- a/packages/shared-ui/src/utils/utils.ts
+++ b/packages/shared-ui/src/utils/utils.ts
@@ -5,7 +5,7 @@
  */
 
 export { formatError } from "./format-error";
-export { getBoardIdFromUrl } from "./board-id";
+export { getBoardUrlFromCurrentWindow } from "./board-id";
 export { getEmbedderRedirectUri } from "./oauth-redirect";
 export { TopGraphObserver } from "./top-graph-observer/index";
 // export { getIsolatedNodeGraphDescriptor } from "./isolated-node-board.js";

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -94,7 +94,6 @@ import {
   ToggleExperimentalComponentsCommand,
   UngroupCommand,
 } from "./commands/commands";
-import { getBoardIdFromUrl } from "@breadboard-ai/shared-ui/utils/board-id.js";
 import {
   SIGN_IN_CONNECTION_ID,
   SigninAdapter,
@@ -1039,14 +1038,10 @@ export class Main extends LitElement {
       }
     );
     if (!boardData) return;
-    const { url } = boardData;
-    const boardId = getBoardIdFromUrl(url);
-    if (boardId) {
-      this.#embedHandler?.sendToEmbedder({
-        type: "board_id_created",
-        id: boardId,
-      });
-    }
+    this.#embedHandler?.sendToEmbedder({
+      type: "board_id_created",
+      id: boardData.url.href,
+    });
   }
 
   disconnectedCallback(): void {


### PR DESCRIPTION
Small fixes for breadboard-embedder integration:

- Corrects logic to extract board URL/ID. The prior code treated `graph.raw().url` as an HTTP/HTTPS URL, where the "board ID" was the `tab0` search param within that URL. In actuality, the `graph.raw().url` is the board ID (or rather, board URL). If this is not available; then we extract the `tab0` value from the current window.location.
- Add "declare" for all interfaces shared between breadboard and embedder to ensure field don't get renamed by the compiler. This is not currently a problem, but as a precaution, making it explicit.
