### PR TITLE
theming cleanups

### DIFF
--- a/.changeset/eight-bobcats-enter.md
+++ b/.changeset/eight-bobcats-enter.md
@@ -1,0 +1,6 @@
+---
+"@breadboard-ai/visual-editor": patch
+"@breadboard-ai/shared-ui": patch
+---
+
+Clean up theme-creation code.

--- a/packages/shared-ui/src/state/graph-asset.ts
+++ b/packages/shared-ui/src/state/graph-asset.ts
@@ -68,7 +68,7 @@ class GraphAssetImpl implements GraphAsset {
       await update;
 
       // Now persist blobs and update the asset data.
-      const persistedData = await this.project.persistBlobs(data);
+      const persistedData = await this.project.persistDataParts(data);
       update = this.project.apply(
         new UpdateAssetData(this.path, metadata, persistedData)
       );

--- a/packages/shared-ui/src/state/organizer.ts
+++ b/packages/shared-ui/src/state/organizer.ts
@@ -42,7 +42,7 @@ class ReactiveOrganizer implements Organizer {
 
   async addGraphAsset(asset: GraphAssetDescriptor): Promise<Outcome<void>> {
     const { data: assetData, metadata, path } = asset;
-    const data = (await this.#project.persistBlobs(assetData)) as NodeValue;
+    const data = (await this.#project.persistDataParts(assetData)) as NodeValue;
     return this.#project.edit(
       [{ type: "addasset", path, data, metadata }],
       `Adding asset at path "${path}"`
@@ -66,7 +66,7 @@ class ReactiveOrganizer implements Organizer {
   ): Promise<Outcome<void>> {
     // TODO: Make work for subgraphs.
     const { sample: ephemeralSample } = metadata;
-    const sample = (await this.#project.persistBlobs(
+    const sample = (await this.#project.persistDataParts(
       ephemeralSample as LLMContent[]
     )) as NodeValue;
     const persistedMetadata: ParameterMetadata = { ...metadata, sample };

--- a/packages/shared-ui/src/state/project.ts
+++ b/packages/shared-ui/src/state/project.ts
@@ -194,9 +194,16 @@ class ReactiveProject implements ProjectInternal {
     }
 
     const server = this.#boardServerFinder(new URL(urlString));
-    if (!server || !server.dataPartTransformer) {
+    if (!server) {
       console.warn(
         `Failed to persist blob: no server found for url "${urlString}"`
+      );
+      return contents;
+    }
+
+    if (!server.dataPartTransformer) {
+      console.warn(
+        `Failed to persist blob: the server for url "${urlString} does not support dataPartTransformer`
       );
       return contents;
     }

--- a/packages/shared-ui/src/state/project.ts
+++ b/packages/shared-ui/src/state/project.ts
@@ -186,7 +186,7 @@ class ReactiveProject implements ProjectInternal {
     }
   }
 
-  async persistBlobs(contents: LLMContent[]): Promise<LLMContent[]> {
+  async persistDataParts(contents: LLMContent[]): Promise<LLMContent[]> {
     const urlString = this.#store.get(this.#mainGraphId)?.graph.url;
     if (!urlString) {
       console.warn("Can't persist blob without graph URL");

--- a/packages/shared-ui/src/state/types.ts
+++ b/packages/shared-ui/src/state/types.ts
@@ -207,7 +207,7 @@ export type Project = {
   fastAccess: FastAccess;
   renderer: RendererState;
 
-  persistBlobs(contents: LLMContent[]): Promise<LLMContent[]>;
+  persistDataParts(contents: LLMContent[]): Promise<LLMContent[]>;
 };
 
 export type ProjectInternal = Project & {

--- a/packages/shared-ui/src/state/types.ts
+++ b/packages/shared-ui/src/state/types.ts
@@ -206,6 +206,8 @@ export type Project = {
   organizer: Organizer;
   fastAccess: FastAccess;
   renderer: RendererState;
+
+  persistBlobs(contents: LLMContent[]): Promise<LLMContent[]>;
 };
 
 export type ProjectInternal = Project & {
@@ -213,7 +215,6 @@ export type ProjectInternal = Project & {
   runtime(): SideBoardRuntime;
   apply(transform: EditTransform): Promise<Outcome<void>>;
   edit(spec: EditSpec[], label: string): Promise<Outcome<void>>;
-  persistBlobs(contents: LLMContent[]): Promise<LLMContent[]>;
   findOutputPortId(
     graphId: GraphIdentifier,
     id: NodeIdentifier

--- a/packages/shared-ui/src/utils/image.ts
+++ b/packages/shared-ui/src/utils/image.ts
@@ -82,16 +82,21 @@ export async function loadImage(
     const imageData = await resolveImage(googleDriveClient, url);
     return imageData ?? "";
   } else if (url) {
-    const response = await fetch(url);
-    const data = await response.blob();
-    return new Promise<string>((resolve) => {
-      const reader = new FileReader();
-      reader.addEventListener("loadend", () => {
-        const result = reader.result as string;
+    try {
+      const response = await fetch(url);
+      const data = await response.blob();
+      return new Promise<string>((resolve) => {
+        const reader = new FileReader();
+        reader.addEventListener("loadend", () => {
+          const result = reader.result as string;
 
-        resolve(result);
+          resolve(result);
+        });
+        reader.readAsDataURL(data);
       });
-      reader.readAsDataURL(data);
-    });
+    } catch (e) {
+      console.warn("Unable to fetch image", e);
+      return "";
+    }
   }
 }

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -22,7 +22,6 @@ import { map } from "lit/directives/map.js";
 import { customElement, property, state } from "lit/decorators.js";
 import { LitElement, html, HTMLTemplateResult, nothing } from "lit";
 import {
-  asBase64,
   createRunObserver,
   GraphDescriptor,
   BoardServer,
@@ -36,8 +35,6 @@ import {
   createEphemeralBlobStore,
   assetsFromGraphDescriptor,
   blank as breadboardBlank,
-  isInlineData,
-  isStoredData,
   EditHistoryCreator,
   envFromGraphDescriptor,
   FileSystem,
@@ -77,9 +74,7 @@ import { sandbox } from "./sandbox";
 import {
   AssetMetadata,
   GraphIdentifier,
-  GraphTheme,
   InputValues,
-  LLMContent,
   Module,
   ModuleIdentifier,
 } from "@breadboard-ai/types";
@@ -3937,80 +3932,15 @@ export class Main extends LitElement {
                   this.tab?.mainGraphId,
                   this.#runtime.edit.getEditor(this.tab)
                 );
-
-                const {
-                  primary,
-                  secondary,
-                  tertiary,
-                  error,
-                  neutral,
-                  neutralVariant,
-                } = evt.theme;
-
-                const graphTheme: GraphTheme = {
-                  template: "basic",
-                  templateAdditionalOptions: {},
-                  palette: {
-                    primary,
-                    secondary,
-                    tertiary,
-                    error,
-                    neutral,
-                    neutralVariant,
-                  },
-                  themeColors: {
-                    primaryColor: evt.theme.primaryColor,
-                    secondaryColor: evt.theme.secondaryColor,
-                    backgroundColor: evt.theme.backgroundColor,
-                    primaryTextColor: evt.theme.primaryTextColor,
-                    textColor: evt.theme.textColor,
-                  },
-                };
-
-                // TODO: Show some status.
-                if (evt.theme.splashScreen) {
-                  if (isStoredData(evt.theme.splashScreen)) {
-                    // Fetch the stored data so that we can add to the graph.
-                    const response = await fetch(
-                      evt.theme.splashScreen.storedData.handle
-                    );
-                    const imgBlob = await response.blob();
-                    const data = await asBase64(imgBlob);
-                    const mimeType = imgBlob.type;
-                    evt.theme.splashScreen = { inlineData: { data, mimeType } };
-                  }
-                  const data: LLMContent[] = [
-                    {
-                      role: "user",
-                      parts: [evt.theme.splashScreen],
-                    },
-                  ];
-
-                  // Convert inline data to stored asset.
-                  if (isInlineData(evt.theme.splashScreen)) {
-                    await projectState?.organizer.addGraphAsset({
-                      path: "@@splash",
-                      metadata: { title: "Splash", type: "file" },
-                      data,
-                    });
-
-                    const splashScreen =
-                      projectState?.graphAssets.get("@@splash")?.data[0]
-                        ?.parts[0];
-                    if (isStoredData(splashScreen)) {
-                      graphTheme.splashScreen = splashScreen;
-                    } else {
-                      console.warn(
-                        "Unable to save splash screen",
-                        splashScreen
-                      );
-                    }
-
-                    await projectState?.organizer.removeGraphAsset("@@splash");
-                  }
+                if (!projectState) {
+                  console.warn("Failed to create theme: no project state");
+                  return;
                 }
-
-                await this.#runtime.edit.createTheme(this.tab, graphTheme);
+                await this.#runtime.edit.createTheme(
+                  this.tab,
+                  evt.theme,
+                  projectState
+                );
               }}
               @bbnoderunrequest=${async (
                 evt: BreadboardUI.Events.NodeRunRequestEvent

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -3925,22 +3925,8 @@ export class Main extends LitElement {
               ) => {
                 await this.#runtime.edit.deleteTheme(this.tab, evt.themeId);
               }}
-              @bbthemecreate=${async (
-                evt: BreadboardUI.Events.ThemeCreateEvent
-              ) => {
-                const projectState = this.#runtime.state.getOrCreate(
-                  this.tab?.mainGraphId,
-                  this.#runtime.edit.getEditor(this.tab)
-                );
-                if (!projectState) {
-                  console.warn("Failed to create theme: no project state");
-                  return;
-                }
-                await this.#runtime.edit.createTheme(
-                  this.tab,
-                  evt.theme,
-                  projectState
-                );
+              @bbthemecreate=${(evt: BreadboardUI.Events.ThemeCreateEvent) => {
+                this.#runtime.edit.createTheme(this.tab, evt.theme);
               }}
               @bbnoderunrequest=${async (
                 evt: BreadboardUI.Events.NodeRunRequestEvent

--- a/packages/visual-editor/src/runtime/edit.ts
+++ b/packages/visual-editor/src/runtime/edit.ts
@@ -5,7 +5,6 @@
  */
 
 import {
-  asBase64,
   blankLLMContent,
   defaultModuleContent,
   EditableGraph,
@@ -13,7 +12,6 @@ import {
   EditSpec,
   GraphDescriptor,
   GraphLoader,
-  isInlineData,
   isStoredData,
   Kit,
   MoveToGraphTransform,
@@ -47,7 +45,6 @@ import {
   GraphMetadata,
   GraphTag,
   GraphTheme,
-  LLMContent,
   Module,
   ModuleCode,
   ModuleIdentifier,
@@ -386,30 +383,14 @@ export class Edit extends EventTarget {
 
     // TODO: Show some status.
     if (appTheme.splashScreen) {
-      if (isStoredData(appTheme.splashScreen)) {
-        // Fetch the stored data so that we can add to the graph.
-        const response = await fetch(appTheme.splashScreen.storedData.handle);
-        const imgBlob = await response.blob();
-        const data = await asBase64(imgBlob);
-        const mimeType = imgBlob.type;
-        appTheme.splashScreen = { inlineData: { data, mimeType } };
-      }
-      const data: LLMContent[] = [
-        {
-          role: "user",
-          parts: [appTheme.splashScreen],
-        },
-      ];
-
-      // Convert inline data to stored asset.
-      if (isInlineData(appTheme.splashScreen)) {
-        const persisted = await project.persistBlobs(data);
-        const splashScreen = persisted?.[0].parts[0];
-        if (isStoredData(splashScreen)) {
-          graphTheme.splashScreen = splashScreen;
-        } else {
-          console.warn("Unable to save splash screen", splashScreen);
-        }
+      const persisted = await project.persistBlobs([
+        { parts: [appTheme.splashScreen] },
+      ]);
+      const splashScreen = persisted?.[0].parts[0];
+      if (isStoredData(splashScreen)) {
+        graphTheme.splashScreen = splashScreen;
+      } else {
+        console.warn("Unable to save splash screen", splashScreen);
       }
     }
 

--- a/packages/visual-editor/src/runtime/edit.ts
+++ b/packages/visual-editor/src/runtime/edit.ts
@@ -383,7 +383,7 @@ export class Edit extends EventTarget {
 
     // TODO: Show some status.
     if (appTheme.splashScreen) {
-      const persisted = await project.persistBlobs([
+      const persisted = await project.persistDataParts([
         { parts: [appTheme.splashScreen] },
       ]);
       const splashScreen = persisted?.[0].parts[0];

--- a/packages/visual-editor/src/runtime/runtime.ts
+++ b/packages/visual-editor/src/runtime/runtime.ts
@@ -110,6 +110,8 @@ export async function create(config: RuntimeConfig): Promise<{
     config.proxy
   ).createSideboardRuntime();
 
+  const state = new StateManager(graphStore, sideboards, servers);
+
   const runtime = {
     board: new Board(
       [],
@@ -120,7 +122,7 @@ export async function create(config: RuntimeConfig): Promise<{
       config.googleDriveClient
     ),
     edit: new Edit(
-      [],
+      state,
       loader,
       kits,
       config.sandbox,
@@ -129,7 +131,7 @@ export async function create(config: RuntimeConfig): Promise<{
       config.settings
     ),
     run: new Run(graphStore, dataStore, config.runStore),
-    state: new StateManager(graphStore, sideboards, servers),
+    state,
     sideboards,
     select: new Select(),
     util: Util,


### PR DESCRIPTION
- **Fold theming code into Edit where it belongs.**
- **Move managing of `Project` state to runtime.**
- **Remove unnecessary stored/inline data conversions.**
- **Rename `persistBlobs` to `persistDataParts`.**
- **Better error messages.**
- **Add try/catch around iamge fetching.**
- **docs(changeset): Clean up theme-creation code.**
