### PR TITLE
fail gracefully

### DIFF
--- a/.changeset/polite-terms-prove.md
+++ b/.changeset/polite-terms-prove.md
@@ -1,0 +1,7 @@
+---
+"@breadboard-ai/google-drive-kit": patch
+"@breadboard-ai/board-server": patch
+"@google-labs/breadboard": patch
+---
+
+Handle Drive errors a bit more gracefully.

--- a/packages/breadboard/src/data/inflate-deflate.ts
+++ b/packages/breadboard/src/data/inflate-deflate.ts
@@ -77,6 +77,8 @@ export const inflateData = async (
             if (ok(transforming)) {
               const part = transforming.at(0)?.parts.at(0);
               if (part) return part;
+            } else {
+              throw new Error(transforming.$error);
             }
           }
         }

--- a/packages/google-drive-kit/src/board-server/data-part-transformer.ts
+++ b/packages/google-drive-kit/src/board-server/data-part-transformer.ts
@@ -84,38 +84,46 @@ class GoogleDriveDataPartTransformer implements DataPartTransformer {
     if (isFileDataCapabilityPart(part)) {
       mimeType = part.fileData.mimeType;
       if (isGoogleDriveDocument(part)) {
-        const fileId = part.fileData.fileUri;
-        // TODO: Un-hardcode the path and get rid of the "@foo/bar".
-        const path = `/board/boards/@foo/bar/assets/drive/${fileId}`;
-        const converting = await fetch(
-          await this.#createRequest(path, { part })
-        );
-        if (!converting.ok) return err(await converting.text());
+        try {
+          const fileId = part.fileData.fileUri;
+          // TODO: Un-hardcode the path and get rid of the "@foo/bar".
+          const path = `/board/boards/@foo/bar/assets/drive/${fileId}`;
+          const converting = await fetch(
+            await this.#createRequest(path, { part })
+          );
+          if (!converting.ok) return err(await converting.text());
 
-        const converted =
-          (await converting.json()) as Outcome<GoogleDriveToGeminiResponse>;
-        if (!ok(converted)) return converted;
+          const converted =
+            (await converting.json()) as Outcome<GoogleDriveToGeminiResponse>;
+          if (!ok(converted)) return converted;
 
-        return converted.part;
+          return converted.part;
+        } catch (e) {
+          return err((e as Error).message);
+        }
       }
     } else {
       const url = part.storedData.handle;
       mimeType = part.storedData.mimeType;
       if (url.startsWith("drive:")) {
-        // TODO: Dedupe this code with above.
-        const fileId = url.replace(/^drive:\/+/, "");
+        try {
+          // TODO: Dedupe this code with above.
+          const fileId = url.replace(/^drive:\/+/, "");
 
-        const path = `/board/boards/@foo/bar/assets/drive/${fileId}?mimeType=${mimeType}`;
-        const converting = await fetch(
-          await this.#createRequest(path, { part })
-        );
-        if (!converting.ok) return err(await converting.text());
+          const path = `/board/boards/@foo/bar/assets/drive/${fileId}?mimeType=${mimeType}`;
+          const converting = await fetch(
+            await this.#createRequest(path, { part })
+          );
+          if (!converting.ok) return err(await converting.text());
 
-        const converted =
-          (await converting.json()) as Outcome<GoogleDriveToGeminiResponse>;
-        if (!ok(converted)) return converted;
+          const converted =
+            (await converting.json()) as Outcome<GoogleDriveToGeminiResponse>;
+          if (!ok(converted)) return converted;
 
-        return converted.part;
+          return converted.part;
+        } catch (e) {
+          return err((e as Error).message);
+        }
       }
       mimeType = part.storedData.mimeType;
     }


### PR DESCRIPTION
- **Add try/catch around fetches in `GoogleDriveDataPartTransformer`**
- **Throw an error when can't inflate.**
- **Teach server to send a more precise error message.**
- **docs(changeset): Handle Drive errors a bit more gracefully.**
