### PR TITLE
[sharing] Prompt to share asset when added to shared graph

### DIFF
--- a/packages/shared-ui/src/elements/elements.ts
+++ b/packages/shared-ui/src/elements/elements.ts
@@ -50,6 +50,7 @@ export { GoogleDrivePicker } from "./google-drive/google-drive-picker.js";
 export { GoogleDriveQuery } from "./google-drive/google-drive-query.js";
 export { GoogleDriveServerPicker } from "./google-drive/google-drive-server-picker.js";
 export { GoogleDriveSharePanel } from "./google-drive/google-drive-share-panel.js";
+export { GoogleDriveAssetShareDialog } from "./google-drive/google-drive-asset-share-dialog.js";
 export { Header } from "./output/header/header.js";
 export { HomepageSearchButton } from "./welcome-panel/homepage-search-button.js";
 export { ItemSelect } from "./input/item-select/item-select.js";

--- a/packages/shared-ui/src/elements/google-drive/find-google-drive-assets-in-graph.ts
+++ b/packages/shared-ui/src/elements/google-drive/find-google-drive-assets-in-graph.ts
@@ -48,6 +48,6 @@ export function findGoogleDriveAssetsInGraph(graph: GraphDescriptor): string[] {
   return [...fileIds];
 }
 
-function extractDriveFileId(str: string): string | null {
+export function extractDriveFileId(str: string): string | null {
   return str.match(/^drive:\/?(.+)/)?.[1] ?? null;
 }

--- a/packages/shared-ui/src/elements/google-drive/google-drive-asset-share-dialog.ts
+++ b/packages/shared-ui/src/elements/google-drive/google-drive-asset-share-dialog.ts
@@ -1,0 +1,243 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  onlyWritablePermissionFields,
+  type GoogleDriveClient,
+} from "@breadboard-ai/google-drive-kit/google-drive-client.js";
+import * as BreadboardUI from "@breadboard-ai/shared-ui";
+import { consume } from "@lit/context";
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import { createRef, ref } from "lit/directives/ref.js";
+import { googleDriveClientContext } from "../../contexts/google-drive-client-context.js";
+import { buttonStyles } from "../../styles/button.js";
+import { Task } from "@lit/task";
+
+const Strings = BreadboardUI.Strings.forSection("Global");
+
+type State =
+  | { status: "closed" }
+  | {
+      status: "open";
+      permissions: Array<[string, gapi.client.drive.Permission[]]>;
+    }
+  | {
+      status: "applying";
+      permissions: Array<[string, gapi.client.drive.Permission[]]>;
+    };
+
+@customElement("bb-google-drive-asset-share-dialog")
+export class GoogleDriveAssetShareDialog extends LitElement {
+  static styles = [
+    buttonStyles,
+    css`
+      :host {
+        display: contents;
+        font: 400 var(--bb-body-medium) / var(--bb-body-line-height-medium)
+          var(--bb-font-family);
+      }
+
+      dialog {
+        border-radius: var(--bb-grid-size-2);
+        border: none;
+        box-shadow:
+          0px 4px 8px 3px rgba(0, 0, 0, 0.15),
+          0px 1px 3px 0px rgba(0, 0, 0, 0.3);
+        font-family: var(--bb-font-family);
+        padding: var(--bb-grid-size-5);
+      }
+
+      h3 {
+        font: 500 var(--bb-title-medium) / var(--bb-title-line-height-medium)
+          var(--bb-font-family);
+        margin-top: 0;
+      }
+
+      #buttons {
+        margin-top: var(--bb-grid-size-4);
+        display: flex;
+        justify-content: flex-end;
+        align-items: center;
+        button {
+          margin-left: var(--bb-grid-size-2);
+          &[disabled] {
+            cursor: wait;
+          }
+        }
+        #share-button {
+          color: var(--bb-ui-700);
+        }
+      }
+    `,
+  ];
+
+  @consume({ context: googleDriveClientContext })
+  accessor googleDriveClient!: GoogleDriveClient | undefined;
+
+  @state()
+  accessor #state: State = { status: "closed" };
+
+  readonly #dialog = createRef<HTMLDialogElement>();
+
+  readonly #readFileNames = new Task(this, {
+    task: async ([googleDriveClient, permissions], { signal }) => {
+      if (!googleDriveClient || !permissions) {
+        return [];
+      }
+      let files;
+      try {
+        files = await Promise.all(
+          permissions.map(([fileId]) =>
+            googleDriveClient.getFile(fileId, {
+              fields: ["id", "name"],
+              signal,
+            })
+          )
+        );
+      } catch (e) {
+        console.error(e);
+        throw e;
+      }
+      return files.map((file) => [file.id!, file.name!] as const);
+    },
+    args: () => [
+      this.googleDriveClient,
+      this.#state.status === "closed" ? undefined : this.#state.permissions,
+    ],
+  });
+
+  override render() {
+    const state = this.#state;
+    const { status } = state;
+    if (status === "closed") {
+      return nothing;
+    } else if (status === "open" || status === "applying") {
+      const appName = Strings.from("APP_NAME");
+      const applying = status === "applying";
+      return html`
+        <dialog ${ref(this.#dialog)} @close=${this.close}>
+          <h3>Users of this ${appName} need access to an asset</h3>
+
+          <p>
+            Click <em>Share</em> to allow everyone who can access this
+            ${appName} to access:
+          </p>
+
+          <ul>
+            ${this.#readFileNames.render({
+              pending: () =>
+                state.permissions.map(
+                  ([fileId]) => html`
+                    <li>
+                      <a
+                        href="https://drive.google.com/open?id=${encodeURIComponent(
+                          fileId
+                        )}"
+                        target="_blank"
+                        >Loading ...</a
+                      >
+                    </li>
+                  `
+                ),
+              complete: (names) =>
+                names.map(
+                  ([fileId, fileName]) => html`
+                    <li>
+                      <a
+                        href="https://drive.google.com/open?id=${encodeURIComponent(
+                          fileId
+                        )}"
+                        target="_blank"
+                        >${fileName}</a
+                      >
+                    </li>
+                  `
+                ),
+            })}
+          </ul>
+
+          <div id="buttons">
+            ${applying
+              ? html`<span id="applying-message">Applying ...</span>`
+              : nothing}
+
+            <button
+              id="cancel-button"
+              class="bb-button-text"
+              .disabled=${applying}
+              @click=${this.close}
+            >
+              Cancel
+            </button>
+
+            <button
+              id="share-button"
+              class="bb-button-text"
+              .disabled=${applying}
+              @click=${this.#onClickShare}
+            >
+              Share
+            </button>
+          </div>
+        </dialog>
+      `;
+    }
+    console.error(`Unknown status ${JSON.stringify(status satisfies never)}`);
+    return nothing;
+  }
+
+  override updated() {
+    if (this.#state.status === "open") {
+      this.#dialog.value?.showModal();
+    }
+  }
+
+  open(permissions: Iterable<[string, gapi.client.drive.Permission[]]>) {
+    this.#state = { status: "open", permissions: [...permissions] };
+  }
+
+  close() {
+    this.#state = { status: "closed" };
+  }
+
+  async #onClickShare() {
+    if (this.#state.status !== "open") {
+      return;
+    }
+    if (!this.googleDriveClient) {
+      console.error("Google Drive Client was not provided");
+      return;
+    }
+    const { permissions } = this.#state;
+    this.#state = { status: "applying", permissions };
+    const writePromises = [];
+    for (const [fileId, filePermissions] of permissions) {
+      for (const permission of filePermissions) {
+        writePromises.push(
+          this.googleDriveClient.writePermission(
+            fileId,
+            onlyWritablePermissionFields(permission),
+            {
+              sendNotificationEmail: false,
+            }
+          )
+        );
+      }
+    }
+    try {
+      await Promise.all(writePromises);
+    } finally {
+      this.close();
+    }
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "bb-google-drive-asset-share-dialog": GoogleDriveAssetShareDialog;
+  }
+}

--- a/packages/shared-ui/src/styles/button.ts
+++ b/packages/shared-ui/src/styles/button.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { css } from "lit";
+
+export const buttonStyles = css`
+  .bb-button-filled,
+  .bb-button-outlined,
+  .bb-button-text {
+    color: var(--bb-neutral-700);
+    border-radius: 100px;
+    padding: var(--bb-grid-size-2) var(--bb-grid-size-4);
+    font-size: var(--bb-label-large);
+    cursor: pointer;
+    transition:
+      background 0.2s cubic-bezier(0, 0, 0.3, 1),
+      color 0.2s cubic-bezier(0, 0, 0.3, 1);
+    &[disabled] {
+      opacity: 80%;
+    }
+  }
+
+  .bb-button-filled {
+    border: none;
+    background: var(--bb-neutral-300);
+
+    &:not([disabled]) {
+      &:focus,
+      &:hover {
+        background: var(--bb-button-hover-background, var(--bb-neutral-100));
+      }
+    }
+  }
+
+  .bb-button-outlined {
+    border: 1px solid currentColor;
+    background: transparent;
+
+    &:not([disabled]) {
+      &:focus,
+      &:hover {
+        background: var(
+          --bb-button-hover-background,
+          color-mix(in srgb, currentColor 10%, transparent)
+        );
+      }
+    }
+  }
+
+  .bb-button-text {
+    border: none;
+    background: transparent;
+
+    &:not([disabled]) {
+      &:focus,
+      &:hover {
+        background: var(
+          --bb-button-hover-background,
+          color-mix(in srgb, currentColor 10%, transparent)
+        );
+      }
+    }
+  }
+`;


### PR DESCRIPTION
If the graph is shared (either published or shared granularly), adding an asset from Drive will now display a dialog like this:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/bb83ebe0-4856-490f-9128-c7db99248744" />

Clicking share will update the permissions of that asset to match the main graph.