### PR TITLE
[gdrive] Ignore the url config saved in idb

### DIFF
--- a/packages/board-server-management/src/index.ts
+++ b/packages/board-server-management/src/index.ts
@@ -42,7 +42,6 @@ interface BoardServerListing extends idb.DBSchema {
 }
 
 export async function createGoogleDriveBoardServer(
-  url: string,
   title: string,
   user: User,
   tokenVendor?: TokenVendor,
@@ -82,7 +81,6 @@ export async function createGoogleDriveBoardServer(
   const userFolderName =
     import.meta.env.VITE_GOOGLE_DRIVE_USER_FOLDER_NAME || "Breadboard";
   return GoogleDriveBoardServer.from(
-    url,
     title,
     user,
     tokenVendor,
@@ -118,7 +116,6 @@ export async function getBoardServers(
 
       if (url.startsWith(GoogleDriveBoardServer.PROTOCOL)) {
         return createGoogleDriveBoardServer(
-          url,
           title,
           user,
           tokenVendor,

--- a/packages/google-drive-kit/src/board-server/operations.ts
+++ b/packages/google-drive-kit/src/board-server/operations.ts
@@ -300,7 +300,6 @@ class DriveOperations {
   constructor(
     public readonly vendor: TokenVendor,
     public readonly username: string,
-    public readonly url: URL,
     private readonly refreshProjectListCallback: () => Promise<void>,
     userFolderName: string,
     publicApiKey?: string,
@@ -833,11 +832,8 @@ class DriveOperations {
     }
   }
 
-  fileIdFromUrl(url: URL) {
-    return url.href.replace(
-      `${this.url.href}${this.url.pathname ? "" : "/"}`,
-      ""
-    );
+  fileIdFromUrl(url: URL): string {
+    return url.href.split("/").at(-1)!;
   }
 }
 

--- a/packages/google-drive-kit/src/board-server/server.ts
+++ b/packages/google-drive-kit/src/board-server/server.ts
@@ -53,7 +53,6 @@ class GoogleDriveBoardServer
   static PROTOCOL = PROTOCOL;
 
   static async from(
-    url: string,
     title: string,
     user: User,
     vendor: TokenVendor,
@@ -64,7 +63,7 @@ class GoogleDriveBoardServer
   ) {
     try {
       const configuration = {
-        url: new URL(url),
+        url: new URL(`${PROTOCOL}/`),
         projects: Promise.resolve([]),
         kits: [],
         users: [],
@@ -97,7 +96,7 @@ class GoogleDriveBoardServer
     }
   }
 
-  public readonly url: URL;
+  public readonly url = new URL(PROTOCOL);
   public readonly users: User[];
   public readonly secrets = new Map<string, string>();
   public readonly extensions: BoardServerExtension[] = [];
@@ -122,7 +121,6 @@ class GoogleDriveBoardServer
     this.ops = new DriveOperations(
       vendor,
       user.username,
-      configuration.url,
       async () => {
         await this.refreshProjectList();
         this.dispatchEvent(new RefreshEvent());
@@ -132,7 +130,6 @@ class GoogleDriveBoardServer
       featuredGalleryFolderId
     );
 
-    this.url = configuration.url;
     this.kits = configuration.kits;
     this.users = configuration.users;
     this.secrets = configuration.secrets;
@@ -233,12 +230,13 @@ class GoogleDriveBoardServer
   }
 
   canProvide(url: URL): false | GraphProviderCapabilities {
-    if (!url.href.startsWith(this.url.href)) {
+    if (!url.href.startsWith(PROTOCOL)) {
       return false;
     }
 
+    const fileId = getFileId(url.href);
     const project = this.#projects.find((project) => {
-      return url.pathname.startsWith(project.url.pathname);
+      return fileId === getFileId(project.url.href);
     });
 
     // We recognize it as something that can be loaded from this Board Server,

--- a/packages/unified-server/src/client/app/utils/run-config.ts
+++ b/packages/unified-server/src/client/app/utils/run-config.ts
@@ -55,7 +55,6 @@ export async function createRunConfig(
       secrets: new Map(),
     };
     const googleDriveBoardserver = await createGoogleDriveBoardServer(
-      "drive:/",
       "Google Drive Board Server",
       user,
       tokenVendor,


### PR DESCRIPTION
It's not used and might produce invalid behavior given that a lot of code checks if URL.startswith(server.url) which it shouldn't do.

That logic also leaked into UI code, but I'm not brave enough to touch that right now.