### PR TITLE
unified server race fix

### DIFF
--- a/.changeset/old-walls-own.md
+++ b/.changeset/old-walls-own.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/unified-server": patch
+---
+
+Make deps that write to `dist/client` more explicit in unified-server

--- a/packages/unified-server/package.json
+++ b/packages/unified-server/package.json
@@ -40,7 +40,8 @@
       "dependencies": [
         "copy-assets",
         "../shared-ui#build:tsc",
-        "../visual-editor#build:tsc"
+        "../visual-editor#build:tsc",
+        "build:tsc:client"
       ],
       "output": [
         "dist/client"


### PR DESCRIPTION
- **Make `build:view` depend on `build:tsc:client`.**
- **docs(changeset): Make deps that write to `dist/client` more explicit in unified-server**
