### PR TITLE
metadata for node

### DIFF
--- a/.changeset/great-ghosts-itch.md
+++ b/.changeset/great-ghosts-itch.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/shared-ui": patch
+---
+
+Plumb `getMetadataForNode` on `Project`.

--- a/packages/shared-ui/src/state/project.ts
+++ b/packages/shared-ui/src/state/project.ts
@@ -21,6 +21,7 @@ import {
   GraphStoreEntry,
   MainGraphIdentifier,
   MutableGraphStore,
+  NodeHandlerMetadata,
   ok,
   Outcome,
   PortIdentifier,
@@ -244,6 +245,25 @@ class ReactiveProject implements ProjectInternal {
     }
 
     return transformed;
+  }
+
+  getMetadataForNode(
+    nodeId: NodeIdentifier,
+    graphId: GraphIdentifier
+  ): Outcome<NodeHandlerMetadata> {
+    const inspectable = this.#store.inspect(this.#mainGraphId, graphId);
+    if (!inspectable) {
+      return err(`Unable to inspect graph with "${this.#mainGraphId}"`);
+    }
+    const node = inspectable.nodeById(nodeId);
+    if (!node) {
+      return err(`Unable to find node with id "${nodeId}`);
+    }
+    const metadata = node.currentDescribe().metadata;
+    if (!metadata) {
+      return err(`Unable to find metadata for node with id "${nodeId}"`);
+    }
+    return metadata;
   }
 
   findOutputPortId(

--- a/packages/shared-ui/src/state/types.ts
+++ b/packages/shared-ui/src/state/types.ts
@@ -18,6 +18,7 @@ import {
   EditSpec,
   EditTransform,
   FileSystem,
+  NodeHandlerMetadata,
   Outcome,
   PortIdentifier,
   Schema,
@@ -327,6 +328,16 @@ export type Project = {
   organizer: Organizer;
   fastAccess: FastAccess;
   renderer: RendererState;
+
+  /**
+   * Returns metadata for a given node. This function is sync, and it
+   * will return the current result, not the latest -- which is fine in most
+   * cases.
+   */
+  getMetadataForNode(
+    nodeId: NodeIdentifier,
+    graphId: GraphIdentifier
+  ): Outcome<NodeHandlerMetadata>;
 
   persistDataParts(contents: LLMContent[]): Promise<LLMContent[]>;
   connectHarnessRunner(


### PR DESCRIPTION
- **Plumb `getMetadataForNode`.**
- **docs(changeset): Plumb `getMetadataForNode` on `Project`.**
