### PR TITLE
[sharing] Be more lenient with detecting share permissions errors

### DIFF
--- a/packages/shared-ui/src/elements/share-panel/share-panel.ts
+++ b/packages/shared-ui/src/elements/share-panel/share-panel.ts
@@ -488,7 +488,9 @@ export class SharePanel extends LitElement {
         typeof error === "object" &&
         error !== null &&
         "status" in error &&
-        error.status === 404
+        typeof error.status === "number" &&
+        error.status >= 400 &&
+        error.status <= 499
       ) {
         // We can't access permissions. This must mean we don't have write
         // access to the file. But, we got this far, so the graph must at least


### PR DESCRIPTION
Should make the "Copy link" button in the sharing dialog work more consistently.