### PR TITLE
[sharing] Invalidate user list cache so that shareable copies don't appear in the gallery

### DIFF
--- a/packages/google-drive-kit/src/board-server/operations.ts
+++ b/packages/google-drive-kit/src/board-server/operations.ts
@@ -238,8 +238,8 @@ class DriveListCache {
     return await this.#list();
   }
 
-  async refresh() {
-    await this.#list();
+  async refresh(forceInvalidate = false) {
+    await this.#list(forceInvalidate);
   }
 
   /**
@@ -624,7 +624,7 @@ class DriveOperations {
       return { result: false, error: "Unable to save" };
     } finally {
       // The above update is a non-atomic operation so refresh after both success or fail.
-      await this.#refreshUserList();
+      await this.refreshUserList();
     }
   }
 
@@ -679,7 +679,7 @@ class DriveOperations {
       return { result: false, error: "Unable to create" };
     } finally {
       // The above update is a non-atomic operation so refresh after both success or fail.
-      await this.#refreshUserList();
+      await this.refreshUserList();
     }
   }
 
@@ -826,9 +826,9 @@ class DriveOperations {
     return result;
   }
 
-  async #refreshUserList() {
+  async refreshUserList(forceInvalidate = false) {
     // In that order, awating.
-    await this.#userGraphsList.refresh();
+    await this.#userGraphsList.refresh(forceInvalidate);
     await this.refreshProjectListCallback();
   }
 
@@ -991,7 +991,7 @@ class DriveOperations {
       console.warn(e);
       return err("Unable to delete");
     } finally {
-      await this.#refreshUserList();
+      await this.refreshUserList();
     }
   }
 

--- a/packages/shared-ui/src/elements/share-panel/share-panel.ts
+++ b/packages/shared-ui/src/elements/share-panel/share-panel.ts
@@ -1087,6 +1087,13 @@ export class SharePanel extends LitElement {
       },
     });
 
+    // TODO(aomarks) This shouldn't be necessary, but if we don't do this, the
+    // copy will appear on the user's gallery page until the browser's site data
+    // is cleared because of our Drive caching infrastructure. This is a quick
+    // hack in lieu of understanding how to make the caching infrastructure
+    // handle this case better.
+    await this.boardServer.ops.refreshUserList(true);
+
     console.debug(
       `[Sharing] Made a new shareable graph copy "${shareableCopyFileId}"` +
         ` at version "${updateMainResult.version}".`


### PR DESCRIPTION
This shouldn't be necessary, but if we don't do this, the copy will appear on the user's gallery page until the browser's site data is cleared because of our Drive caching infrastructure. This is a quick hack in lieu of understanding how to make the caching infrastructure handle this case better.