### PR TITLE
Fix bug connecting to Google Drive from embedded page.

### DIFF
--- a/packages/shared-ui/src/elements/connection/connection-broker.ts
+++ b/packages/shared-ui/src/elements/connection/connection-broker.ts
@@ -10,7 +10,7 @@ import {
   oauthTokenBroadcastChannelName,
   type OAuthStateParameter,
 } from "./connection-common.js";
-import { getEmbedderRedirectUri } from "../../utils/oauth-redirect.js";
+import { getEmbedderRedirectUri } from "../../utils/embed-helpers.js";
 
 export class ConnectionBroker extends HTMLElement {
   #embedHandler?: EmbedHandler;

--- a/packages/shared-ui/src/elements/google-drive/google-drive-debug-panel.ts
+++ b/packages/shared-ui/src/elements/google-drive/google-drive-debug-panel.ts
@@ -26,6 +26,7 @@ import { type GoogleDriveClient } from "@breadboard-ai/google-drive-kit/google-d
 import * as BreadboardUI from "@breadboard-ai/shared-ui";
 import { ok } from "@google-labs/breadboard";
 import { googleDriveClientContext } from "../../contexts/google-drive-client-context.js";
+import { getTopLevelOrigin } from "../../utils/embed-helpers.js";
 
 const Strings = BreadboardUI.Strings.forSection("Global");
 
@@ -242,6 +243,7 @@ export class GoogleDriveDebugPanel extends LitElement {
     view.setSelectFolderEnabled(true);
     // See https://developers.google.com/drive/picker/reference
     const picker = new pickerLib.PickerBuilder()
+      .setOrigin(getTopLevelOrigin())
       .addView(view)
       .setAppId(auth.grant.client_id)
       .setOAuthToken(auth.grant.access_token)
@@ -280,6 +282,7 @@ export class GoogleDriveDebugPanel extends LitElement {
 
     // https://developers.google.com/drive/picker/reference
     const picker = new pickerLib.PickerBuilder()
+      .setOrigin(getTopLevelOrigin())
       .addView(view)
       .setAppId(auth.grant.client_id)
       .setOAuthToken(auth.grant.access_token)
@@ -412,6 +415,7 @@ export class GoogleDriveDebugPanel extends LitElement {
 
     // https://developers.google.com/drive/picker/reference
     const picker = new pickerLib.PickerBuilder()
+      .setOrigin(getTopLevelOrigin())
       .addView(view)
       .setAppId(auth.grant.client_id)
       .setSelectableMimeTypes(ASSET_MIME_TYPES)

--- a/packages/shared-ui/src/elements/google-drive/google-drive-directory-picker.ts
+++ b/packages/shared-ui/src/elements/google-drive/google-drive-directory-picker.ts
@@ -12,6 +12,7 @@ import {
 } from "../../events/events.js";
 import "../connection/connection-input.js";
 import { loadDrivePicker } from "./google-apis.js";
+import { getTopLevelOrigin } from "../../utils/embed-helpers.js";
 
 @customElement("bb-google-drive-directory-picker")
 export class GoogleDriveDirectoryPicker extends LitElement {
@@ -114,6 +115,7 @@ export class GoogleDriveDirectoryPicker extends LitElement {
     this.#destroyPicker();
     // See https://developers.google.com/drive/picker/reference
     this.#picker = new this._pickerLib.PickerBuilder()
+      .setOrigin(getTopLevelOrigin())
       .setAppId(this._authorization.clientId)
       .setOAuthToken(this._authorization.secret)
       .setCallback(this.#pickerCallback.bind(this))

--- a/packages/shared-ui/src/elements/google-drive/google-drive-file-id.ts
+++ b/packages/shared-ui/src/elements/google-drive/google-drive-file-id.ts
@@ -19,6 +19,7 @@ import {
   loadGapiClient,
 } from "./google-apis.js";
 import { createRef, ref, Ref } from "lit/directives/ref.js";
+import { getTopLevelOrigin } from "../../utils/embed-helpers.js";
 
 type PickedValue = {
   // A special value recognized by the "GraphPortLabel": if present in an
@@ -269,6 +270,7 @@ export class GoogleDriveFileId extends LitElement {
 
     // See https://developers.google.com/drive/picker/reference
     this.#picker = new this._pickerLib.PickerBuilder()
+      .setOrigin(getTopLevelOrigin())
       .addView(view)
       .setAppId(this._authorization.clientId)
       .setOAuthToken(this._authorization.secret)

--- a/packages/shared-ui/src/elements/google-drive/google-drive-picker.ts
+++ b/packages/shared-ui/src/elements/google-drive/google-drive-picker.ts
@@ -14,6 +14,7 @@ import {
 } from "../../utils/signin-adapter.js";
 import { loadDrivePicker } from "./google-apis.js";
 import { GoogleDrivePickerCloseEvent } from "../../events/events.js";
+import { getTopLevelOrigin } from "../../utils/embed-helpers.js";
 
 const Strings = BreadboardUI.Strings.forSection("Global");
 
@@ -97,6 +98,7 @@ export class GoogleDrivePicker extends LitElement {
 
     // https://developers.google.com/drive/picker/reference
     const picker = new pickerLib.PickerBuilder()
+      .setOrigin(getTopLevelOrigin())
       .addView(view)
       .setAppId(auth.grant.client_id)
       .setOAuthToken(auth.grant.access_token)
@@ -185,6 +187,7 @@ export class GoogleDrivePicker extends LitElement {
     underlay.mode = overlay.mode = "pick-shared-assets";
 
     const picker = new pickerLib.PickerBuilder()
+      .setOrigin(getTopLevelOrigin())
       .addView(view)
       .setAppId(auth.grant.client_id)
       .setOAuthToken(auth.grant.access_token)

--- a/packages/shared-ui/src/elements/google-drive/google-drive-query.ts
+++ b/packages/shared-ui/src/elements/google-drive/google-drive-query.ts
@@ -10,6 +10,7 @@ import type { InputPlugin } from "../../plugins/input-plugin.js";
 import { type InputEnterEvent } from "../../events/events.js";
 import "../connection/connection-input.js";
 import { loadDrivePicker } from "./google-apis.js";
+import { getTopLevelOrigin } from "../../utils/embed-helpers.js";
 
 export const googleDriveQueryInputPlugin: InputPlugin = {
   instantiate: {
@@ -153,6 +154,7 @@ export class GoogleDriveQuery extends LitElement {
     this.#destroyPicker();
     // See https://developers.google.com/drive/picker/reference
     this.#picker = new this._pickerLib.PickerBuilder()
+      .setOrigin(getTopLevelOrigin())
       .setAppId(this._authorization.clientId)
       .setOAuthToken(this._authorization.secret)
       .setCallback(this.#pickerCallback.bind(this))

--- a/packages/shared-ui/src/utils/embed-helpers.ts
+++ b/packages/shared-ui/src/utils/embed-helpers.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const REDIRECT_PARAM = "oauth_redirect";
+export const REDIRECT_PARAM = "oauth_redirect";
 
 /**
  * Returns embedder-provided redirect URI if valid.
@@ -15,6 +15,26 @@ const REDIRECT_PARAM = "oauth_redirect";
  * on the list, returns null.
  */
 export function getEmbedderRedirectUri(): string | null {
+  const embedderRedirectUrl = getEmbedderRedirectUrl();
+  return embedderRedirectUrl ? embedderRedirectUrl.href : null;
+}
+
+/**
+ * Returns embedder-provided origin if valid; otherwise returns window origin.
+ *
+ * Retrieves redirect origin as provided in search params and validates
+ * against the build-time provided list of valid redirect origins.
+ * If there is no provided redirect URI, or the one provided is not
+ * on the allowlist, return the window origin.
+ */
+export function getTopLevelOrigin(): string {
+  const embedderRedirectUrl = getEmbedderRedirectUrl();
+  return embedderRedirectUrl
+    ? embedderRedirectUrl.origin
+    : window.location.origin;
+}
+
+function getEmbedderRedirectUrl(): URL | null {
   const params = new URLSearchParams(window.location.search);
   if (!params.has(REDIRECT_PARAM)) {
     return null;
@@ -24,6 +44,6 @@ export function getEmbedderRedirectUri(): string | null {
     import.meta.env.VITE_VALID_REDIRECT_URI_ORIGINS || `[]`
   );
   return validRedirectOrigins.includes(embeddedRedirectUri.origin)
-    ? embeddedRedirectUri.href
+    ? embeddedRedirectUri
     : null;
 }

--- a/packages/shared-ui/src/utils/signin-adapter.ts
+++ b/packages/shared-ui/src/utils/signin-adapter.ts
@@ -18,7 +18,7 @@ import {
 } from "../elements/connection/connection-common";
 import { SETTINGS_TYPE, SettingsHelper } from "../types/types";
 import { createContext } from "@lit/context";
-import { getEmbedderRedirectUri } from "./oauth-redirect";
+import { getEmbedderRedirectUri } from "./embed-helpers";
 
 export { SigninAdapter };
 

--- a/packages/shared-ui/src/utils/utils.ts
+++ b/packages/shared-ui/src/utils/utils.ts
@@ -6,7 +6,7 @@
 
 export { formatError } from "./format-error";
 export { getBoardUrlFromCurrentWindow } from "./board-id";
-export { getEmbedderRedirectUri } from "./oauth-redirect";
+export { getEmbedderRedirectUri } from "./embed-helpers";
 export { TopGraphObserver } from "./top-graph-observer/index";
 // export { getIsolatedNodeGraphDescriptor } from "./isolated-node-board.js";
 export { getModuleId } from "./module-id.js";

--- a/packages/visual-editor/src/runtime/board.ts
+++ b/packages/visual-editor/src/runtime/board.ts
@@ -51,6 +51,7 @@ import * as idb from "idb";
 import { BOARD_SAVE_STATUS } from "@breadboard-ai/shared-ui/types/types.js";
 import { GoogleDriveClient } from "@breadboard-ai/google-drive-kit/google-drive-client.js";
 import { loadImage } from "@breadboard-ai/shared-ui/utils/image";
+import { REDIRECT_PARAM } from "@breadboard-ai/shared-ui/utils/embed-helpers.js";
 
 const documentStyles = getComputedStyle(document.documentElement);
 
@@ -260,6 +261,14 @@ export class Board extends EventTarget {
     const params = new URLSearchParams();
     let t = 0;
     let activeTab = 0;
+
+    // To identify the top-level origin when embedded, we persist the
+    // redirect URI param into the new board URL.
+    const previousParams = new URLSearchParams(window.location.search);
+    if (previousParams.has(REDIRECT_PARAM)) {
+      params.set(REDIRECT_PARAM, previousParams.get(REDIRECT_PARAM)!);
+    }
+
     for (const tab of this.#tabs.values()) {
       if (tab.type !== TabType.URL || !tab.graph.url) {
         continue;


### PR DESCRIPTION
Allows users to upload Drive assets when Breadboard embedded in another page.

The  `PickerBuilder` requires the origin to be set to the top-most origin when the application is running in an iframe. (See [docs](https://developers.google.com/workspace/drive/picker/reference/picker.pickerbuilder.setorigin.md).) Hence, we retrieve the origin from the query param already provided by the embedder, and as usual vet it against the list of valid embedder origins. If valid, we use it to set the `PickerBuilder` origin; otherwise we use the standard window origin.
