### PR TITLE
[gdrive] Maybe we should refresh the UI immediately when a gallery item gets deleted?

### DIFF
--- a/packages/google-drive-kit/src/board-server/operations.ts
+++ b/packages/google-drive-kit/src/board-server/operations.ts
@@ -471,6 +471,8 @@ class DriveOperations {
             if (this.#featuredGraphsList) {
               await this.#featuredGraphsList!.forceRefresh();
             }
+            // Forcefully refreshed the caches - give the heads up to the UI layer.
+            await this.refreshProjectListCallback();
             // #imageCache relies solely on the drive.changes, no invalidation here needed.
           }
           return; // All refreshed.
@@ -509,8 +511,11 @@ class DriveOperations {
           (accumulator, value) => accumulator.concat(value),
           []
         );
+        if (affectedFileIds.length > 0) {
+          await this.refreshProjectListCallback();
+        }
         console.info(
-          `Drive Cache: Received ${changes.length} changes affecting ${affectedFileIds.length} file` +
+          `Drive Cache: Received ${changes.length} changes affecting ${affectedFileIds.length} files. ` +
             `${nextRefreshMsg}. Affected files:`,
           affectedFileIDLists
         );


### PR DESCRIPTION
So far we were only refreshing if the item changed because of the actions of the user themselves. 

IMO there is a drawback of what I'm doing here since an item can disappear from under the users cursor or UI can refresh and jump without user doing anyting.

Also IMO a more proper way to implement this is to gray out the [deleted] element and make it unclickable while the UI remaining stable, with a snack bar saying "list changed, click here to refresh". However this is too much effort for the moment so I'm just sending refresh event in this PR.