### PR TITLE
reactive app view

### DIFF
--- a/.changeset/quiet-coins-shop.md
+++ b/.changeset/quiet-coins-shop.md
@@ -1,0 +1,6 @@
+---
+"@breadboard-ai/unified-server": minor
+"@breadboard-ai/shared-ui": minor
+---
+
+Plumb `ProjectRun` to `<app-basic>` and start using it.

--- a/packages/shared-ui/src/app-templates/basic/index.ts
+++ b/packages/shared-ui/src/app-templates/basic/index.ts
@@ -78,13 +78,14 @@ import { GoogleDriveBoardServer } from "@breadboard-ai/google-drive-kit";
 import { NodeValue } from "@breadboard-ai/types";
 import { projectRunContext } from "../../contexts/project-run.js";
 import { ProjectRun } from "../../state/types.js";
+import { SignalWatcher } from "@lit-labs/signals";
 
 function keyFromGraphUrl(url: string) {
   return `cw-${url.replace(/\W/gi, "-")}`;
 }
 
 @customElement("app-basic")
-export class Template extends LitElement implements AppTemplate {
+export class Template extends SignalWatcher(LitElement) implements AppTemplate {
   @property({ type: Object })
   accessor options: AppTemplateOptions = {
     title: "Untitled App",
@@ -1265,13 +1266,9 @@ export class Template extends LitElement implements AppTemplate {
     );
   }
 
-  #renderInput(topGraphResult: TopGraphRunResult) {
-    const currentItem = topGraphResult.log.at(-1);
-    if (
-      topGraphResult.status !== "paused" ||
-      currentItem?.type !== "edge" ||
-      !currentItem.schema
-    ) {
+  #renderInput() {
+    const input = this.projectRun?.input;
+    if (!input) {
       this.style.setProperty("--input-clearance", `0px`);
 
       return nothing;
@@ -1279,7 +1276,7 @@ export class Template extends LitElement implements AppTemplate {
 
     const PADDING = 24;
     return html`<bb-floating-input
-      .schema=${currentItem.schema}
+      .schema=${input.schema}
       .showDisclaimer=${this.showDisclaimer}
       @bbresize=${(evt: ResizeEvent) => {
         this.style.setProperty(
@@ -1480,7 +1477,7 @@ export class Template extends LitElement implements AppTemplate {
         this.#renderControls(this.topGraphResult),
         this.#renderActivity(this.topGraphResult),
         this.#renderSaveResultsButton(),
-        this.#renderInput(this.topGraphResult),
+        this.#renderInput(),
         this.showDisclaimer
           ? html`<p id="disclaimer">${Strings.from("LABEL_DISCLAIMER")}</p>`
           : nothing,

--- a/packages/shared-ui/src/app-templates/basic/index.ts
+++ b/packages/shared-ui/src/app-templates/basic/index.ts
@@ -30,7 +30,6 @@ import {
   asBase64,
   BoardServer,
   GraphDescriptor,
-  InspectableRun,
   isLLMContentArray,
   ok,
   transformDataParts,
@@ -92,9 +91,6 @@ export class Template extends SignalWatcher(LitElement) implements AppTemplate {
     mode: "light",
     splashImage: false,
   };
-
-  @property({ reflect: false })
-  accessor run: InspectableRun | null = null;
 
   @consume({ context: projectRunContext, subscribe: true })
   accessor projectRun: ProjectRun | null = null;

--- a/packages/shared-ui/src/app-templates/basic/index.ts
+++ b/packages/shared-ui/src/app-templates/basic/index.ts
@@ -102,15 +102,6 @@ export class Template extends SignalWatcher(LitElement) implements AppTemplate {
   accessor topGraphResult: TopGraphRunResult | null = null;
 
   @property()
-  accessor appURL: string | null = null;
-
-  @property()
-  accessor eventPosition = 0;
-
-  @property()
-  accessor pendingSplashScreen = false;
-
-  @property()
   accessor showGDrive = false;
 
   @property()
@@ -118,9 +109,6 @@ export class Template extends SignalWatcher(LitElement) implements AppTemplate {
 
   @property()
   accessor isInSelectionState = false;
-
-  @property()
-  accessor showingOlderResult = false;
 
   @property()
   accessor state: SigninState = "anonymous";

--- a/packages/shared-ui/src/app-templates/basic/index.ts
+++ b/packages/shared-ui/src/app-templates/basic/index.ts
@@ -76,6 +76,8 @@ import { consume } from "@lit/context";
 import { boardServerContext } from "../../contexts/board-server.js";
 import { GoogleDriveBoardServer } from "@breadboard-ai/google-drive-kit";
 import { NodeValue } from "@breadboard-ai/types";
+import { projectRunContext } from "../../contexts/project-run.js";
+import { ProjectRun } from "../../state/types.js";
 
 function keyFromGraphUrl(url: string) {
   return `cw-${url.replace(/\W/gi, "-")}`;
@@ -92,6 +94,9 @@ export class Template extends LitElement implements AppTemplate {
 
   @property({ reflect: false })
   accessor run: InspectableRun | null = null;
+
+  @consume({ context: projectRunContext, subscribe: true })
+  accessor projectRun: ProjectRun | null = null;
 
   @property()
   accessor graph: GraphDescriptor | null = null;

--- a/packages/shared-ui/src/app-templates/basic/index.ts
+++ b/packages/shared-ui/src/app-templates/basic/index.ts
@@ -93,7 +93,7 @@ export class Template extends SignalWatcher(LitElement) implements AppTemplate {
   };
 
   @consume({ context: projectRunContext, subscribe: true })
-  accessor projectRun: ProjectRun | null = null;
+  accessor run: ProjectRun | null = null;
 
   @property()
   accessor graph: GraphDescriptor | null = null;
@@ -1251,7 +1251,7 @@ export class Template extends SignalWatcher(LitElement) implements AppTemplate {
   }
 
   #renderInput() {
-    const input = this.projectRun?.input;
+    const input = this.run?.input;
     if (!input) {
       this.style.setProperty("--input-clearance", `0px`);
 

--- a/packages/shared-ui/src/elements/app-preview/app-preview.ts
+++ b/packages/shared-ui/src/elements/app-preview/app-preview.ts
@@ -412,7 +412,6 @@ export class AppPreview extends LitElement {
   render() {
     if (this.#appTemplate) {
       this.#appTemplate.graph = this.graph;
-      this.#appTemplate.run = this.run;
       this.#appTemplate.topGraphResult = this.topGraphResult;
       this.#appTemplate.eventPosition = this.eventPosition;
       this.#appTemplate.showGDrive = this.showGDrive;

--- a/packages/shared-ui/src/elements/app-preview/app-preview.ts
+++ b/packages/shared-ui/src/elements/app-preview/app-preview.ts
@@ -32,11 +32,13 @@ import {
   TopGraphRunResult,
 } from "../../types/types.js";
 import { classMap } from "lit/directives/class-map.js";
-import { consume } from "@lit/context";
+import { consume, provide } from "@lit/context";
 import { googleDriveClientContext } from "../../contexts/google-drive-client-context.js";
 import { GoogleDriveClient } from "@breadboard-ai/google-drive-kit/google-drive-client.js";
 import { generatePaletteFromColor } from "@breadboard-ai/theme";
 import { loadPart } from "../../utils/data-parts.js";
+import { projectRunContext } from "../../contexts/project-run.js";
+import { ProjectRun } from "../../state/types.js";
 
 const primaryColor = "#ffffff";
 const secondaryColor = "#7a7a7a";
@@ -64,7 +66,7 @@ function getThemeModeFromBackground(hexColor: string): "light" | "dark" {
 
     const luma = r * 0.299 + g * 0.587 + b * 0.114;
     return luma > 128 ? "light" : "dark";
-  } catch (err) {
+  } catch {
     return "light";
   }
 }
@@ -85,6 +87,10 @@ export class AppPreview extends LitElement {
 
   @property({ reflect: false })
   accessor run: InspectableRun | null = null;
+
+  @property({ reflect: false })
+  @provide({ context: projectRunContext })
+  accessor projectRun: ProjectRun | null = null;
 
   @property()
   accessor eventPosition = 0;

--- a/packages/shared-ui/src/elements/output/console-view/console-view.ts
+++ b/packages/shared-ui/src/elements/output/console-view/console-view.ts
@@ -21,8 +21,6 @@ import { classMap } from "lit/directives/class-map.js";
 import { ResizeEvent, RunEvent } from "../../../events/events";
 import { icons } from "../../../styles/icons";
 import { SignalWatcher } from "@lit-labs/signals";
-import { provide } from "@lit/context";
-import { projectRunContext } from "../../../contexts/project-run.js";
 import { isParticle } from "@breadboard-ai/particles";
 import { sharedStyles } from "./shared-styles.js";
 import { colorsLight } from "../../../styles/host/colors-light.js";
@@ -32,7 +30,6 @@ import { iconSubstitute } from "../../../utils/icon-substitute.js";
 @customElement("bb-console-view")
 export class ConsoleView extends SignalWatcher(LitElement) {
   @property()
-  @provide({ context: projectRunContext })
   accessor run: ProjectRun | null = null;
 
   static styles = [

--- a/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
@@ -607,13 +607,10 @@ export class UI extends LitElement {
             })}
             .graph=${this.graph}
             .themeHash=${themeHash}
-            .run=${run}
             .projectRun=${this.projectState?.run}
-            .eventPosition=${eventPosition}
             .topGraphResult=${this.topGraphResult}
             .showGDrive=${this.signedIn}
             .isInSelectionState=${false}
-            .showingOlderResult=${false}
             .settings=${this.settings}
             .boardServers=${this.boardServers}
             .status=${this.status}

--- a/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
@@ -608,6 +608,7 @@ export class UI extends LitElement {
             .graph=${this.graph}
             .themeHash=${themeHash}
             .run=${run}
+            .projectRun=${this.projectState?.run}
             .eventPosition=${eventPosition}
             .topGraphResult=${this.topGraphResult}
             .showGDrive=${this.signedIn}

--- a/packages/shared-ui/src/state/app-screen.ts
+++ b/packages/shared-ui/src/state/app-screen.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { LLMContent, NodeEndResponse } from "@breadboard-ai/types";
+import { AppScreen } from "./types";
+import { SignalMap } from "signal-utils/map";
+import { Schema } from "@google-labs/breadboard";
+import { idFromPath, toLLMContentArray } from "./common";
+import { signal } from "signal-utils";
+
+export { ReactiveAppScreen };
+
+class ReactiveAppScreen implements AppScreen {
+  id: string;
+
+  @signal
+  accessor status: "interactive" | "complete" = "interactive";
+
+  output: Map<string, LLMContent> = new SignalMap();
+
+  #outputSchema: Schema | undefined;
+
+  constructor(path: number[], outputSchema: Schema | undefined) {
+    this.#outputSchema = outputSchema;
+    this.id = idFromPath(path);
+  }
+
+  finalize(data: NodeEndResponse) {
+    const { outputs } = data;
+    const { products } = toLLMContentArray(this.#outputSchema || {}, outputs);
+    for (const [name, product] of Object.entries(products)) {
+      this.output.set(name, product);
+    }
+    this.status = "complete";
+  }
+}

--- a/packages/shared-ui/src/state/app-screen.ts
+++ b/packages/shared-ui/src/state/app-screen.ts
@@ -19,6 +19,9 @@ class ReactiveAppScreen implements AppScreen {
   @signal
   accessor status: "interactive" | "complete" = "interactive";
 
+  @signal
+  accessor type: "progress" | "input" = "progress";
+
   output: Map<string, LLMContent> = new SignalMap();
 
   #outputSchema: Schema | undefined;
@@ -26,6 +29,13 @@ class ReactiveAppScreen implements AppScreen {
   constructor(path: number[], outputSchema: Schema | undefined) {
     this.#outputSchema = outputSchema;
     this.id = idFromPath(path);
+  }
+
+  /**
+   * Marks this screen as "input" screen.
+   */
+  markAsInput(): void {
+    this.type = "input";
   }
 
   finalize(data: NodeEndResponse) {

--- a/packages/shared-ui/src/state/app.ts
+++ b/packages/shared-ui/src/state/app.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { signal } from "signal-utils";
+import { App, AppScreen } from "./types";
+import { SignalMap } from "signal-utils/map";
+import { ReactiveAppScreen } from "./app-screen";
+
+export { ReactiveApp };
+
+class ReactiveApp implements App {
+  screens: Map<string, AppScreen> = new SignalMap();
+
+  @signal
+  accessor current: ReactiveAppScreen | null = null;
+}

--- a/packages/shared-ui/src/state/index.ts
+++ b/packages/shared-ui/src/state/index.ts
@@ -6,4 +6,5 @@
 
 export * from "./types.js";
 export { createProjectState } from "./project.js";
+export { createProjectRunState } from "./project-run.js";
 export type * from "./organizer.js";

--- a/packages/shared-ui/src/state/project-run.ts
+++ b/packages/shared-ui/src/state/project-run.ts
@@ -183,6 +183,7 @@ class ReactiveProjectRun implements ProjectRun {
     }
     this.current.addInput(event.data, {
       itemCreated: (item) => {
+        this.app.current?.markAsInput();
         if (!item.schema) {
           console.warn(`Schema unavailable for input, skipping`, event.data);
           return;

--- a/packages/shared-ui/src/state/project-run.ts
+++ b/packages/shared-ui/src/state/project-run.ts
@@ -8,6 +8,7 @@ import { SignalMap } from "signal-utils/map";
 import { ConsoleEntry, ProjectRun, RunError, UserInput } from "./types";
 import {
   HarnessRunner,
+  RunConfig,
   RunErrorEvent,
   RunGraphEndEvent,
   RunGraphStartEvent,
@@ -20,12 +21,50 @@ import { signal } from "signal-utils";
 import { formatError } from "../utils/format-error";
 import { ReactiveConsoleEntry } from "./console-entry";
 import { idFromPath } from "./common";
-import { FileSystem, InspectableGraph } from "@google-labs/breadboard";
+import {
+  err,
+  FileSystem,
+  InspectableGraph,
+  Outcome,
+} from "@google-labs/breadboard";
 import { getStepIcon } from "../utils/get-step-icon";
 import { ReactiveApp } from "./app";
 import { ReactiveAppScreen } from "./app-screen";
 
-export { ReactiveProjectRun };
+export { ReactiveProjectRun, createProjectRunState };
+
+function createProjectRunState(
+  runConfig: RunConfig,
+  harnessRunner: HarnessRunner
+): Outcome<ProjectRun> {
+  const { fileSystem, graphStore, runner: graph, signal } = runConfig;
+  if (!fileSystem) {
+    return error(`File system wasn't initialized`);
+  }
+  if (!graph) {
+    return error(`Graph wasn't specified`);
+  }
+  if (!graphStore) {
+    return error(`Graph store wasn't supplied`);
+  }
+
+  const gettingMainGraph = graphStore.getByDescriptor(graph);
+  if (!gettingMainGraph?.success) {
+    return error(`Can't to find graph in graph store`);
+  }
+  const inspectable = graphStore.inspect(gettingMainGraph.result, "");
+  if (!inspectable) {
+    return error(`Can't instantiate inspectable graph`);
+  }
+
+  return new ReactiveProjectRun(inspectable, fileSystem, harnessRunner, signal);
+
+  function error(msg: string) {
+    const full = `Unable to create project run state: ${msg}`;
+    console.error(full);
+    return err(full);
+  }
+}
 
 class ReactiveProjectRun implements ProjectRun {
   app: ReactiveApp = new ReactiveApp();

--- a/packages/shared-ui/src/state/types.ts
+++ b/packages/shared-ui/src/state/types.ts
@@ -33,6 +33,10 @@ import { SideBoardRuntime } from "../sideboards/types";
  */
 export type ProjectRun = {
   /**
+   * Represents the App state during the run.
+   */
+  app: App;
+  /**
    * Provides an estimate of entries that will be in console for this run.
    * The estimate is updated when the run goes over it.
    */
@@ -54,10 +58,42 @@ export type ProjectRun = {
    */
   current: ConsoleEntry | null;
   /**
-   * The input (if any) that the user is waiting on. If `null`,
-   * the user is not currently waiting on input.
+   * The user input (if any) that the run is waiting on. If `null`,
+   * the run is not currently waiting on user input.
    */
   input: UserInput | null;
+};
+
+/**
+ * Represents the App state during the run.
+ * Designed so that the App View can be built from this state
+ */
+export type App = {
+  /**
+   * A sequences of screens that is produced during the run.
+   */
+  screens: Map<string, AppScreen>;
+  /**
+   * The current screen.
+   */
+  current: AppScreen | null;
+};
+
+/**
+ * Represents the state of a single App Screen
+ */
+export type AppScreen = {
+  /**
+   * When "interactive", indicates that this screen is still being created
+   * or is asking user for input.
+   * When "complete", indicates that this screen is finalized and is now
+   * a historical artifact of the run.
+   */
+  status: "interactive" | "complete";
+  /**
+   * The output for this screen
+   */
+  output: Map<string, LLMContent /* Particle */>;
 };
 
 /**

--- a/packages/shared-ui/src/state/types.ts
+++ b/packages/shared-ui/src/state/types.ts
@@ -91,6 +91,14 @@ export type AppScreen = {
    */
   status: "interactive" | "complete";
   /**
+   * The "progress" screen only shows the output to the user, either final
+   * or intermediate results.
+   * The "input" screen shows the output to the user and requests input
+   * from the user.
+   * See https://github.com/breadboard-ai/breadboard/wiki/Screens for details.
+   */
+  type: "progress" | "input";
+  /**
    * The output for this screen
    */
   output: Map<string, LLMContent /* Particle */>;

--- a/packages/shared-ui/src/types/types.ts
+++ b/packages/shared-ui/src/types/types.ts
@@ -571,12 +571,9 @@ export interface AppTemplate extends LitElement {
   options: AppTemplateOptions;
   graph: GraphDescriptor | null;
   topGraphResult: TopGraphRunResult | null;
-  eventPosition: number;
   additionalOptions: AppTemplateAdditionalOptionsAvailable;
   showGDrive: boolean;
   isInSelectionState: boolean;
-  showingOlderResult: boolean;
-  appURL: string | null;
   readOnly: boolean;
   showShareButton: boolean;
   showContentWarning: boolean;

--- a/packages/shared-ui/src/types/types.ts
+++ b/packages/shared-ui/src/types/types.ts
@@ -19,7 +19,6 @@ import {
   InspectableNodePorts,
   PortIdentifier,
   NodeHandlerMetadata,
-  InspectableRun,
   InspectableAssetEdgeDirection,
 } from "@google-labs/breadboard";
 import {
@@ -570,7 +569,6 @@ export interface AppTemplateOptions {
 export interface AppTemplate extends LitElement {
   state: SigninState | null;
   options: AppTemplateOptions;
-  run: InspectableRun | null;
   graph: GraphDescriptor | null;
   topGraphResult: TopGraphRunResult | null;
   eventPosition: number;

--- a/packages/unified-server/src/client/app/elements/app-view/app-view.ts
+++ b/packages/unified-server/src/client/app/elements/app-view/app-view.ts
@@ -60,6 +60,8 @@ import {
   clientDeploymentConfigurationContext,
 } from "@breadboard-ai/shared-ui/config/client-deployment-configuration.js";
 import { createRef, ref, Ref } from "lit/directives/ref.js";
+import { projectRunContext } from "@breadboard-ai/shared-ui/contexts";
+import { ProjectRun } from "@breadboard-ai/shared-ui/state/types.js";
 
 @customElement("app-view")
 export class AppView extends LitElement {
@@ -93,6 +95,9 @@ export class AppView extends LitElement {
   @provide({ context: boardServerContext })
   accessor boardServer: BoardServer | undefined;
 
+  @provide({ context: projectRunContext })
+  accessor projectRun: ProjectRun | null = null;
+
   readonly flow: GraphDescriptor;
   #runner: Runner | null;
   #signInAdapter: SigninAdapter;
@@ -114,6 +119,7 @@ export class AppView extends LitElement {
     this.flow = earlyLoadedFlow ?? config.flow;
     this.googleDriveClient = config.googleDriveClient;
     this.boardServer = config.boardServer;
+    this.projectRun = config.projectRun;
     this.#overrideTopGraphRunResult = config.runResults
       ? {
           status: "stopped",

--- a/packages/unified-server/src/client/app/elements/app-view/app-view.ts
+++ b/packages/unified-server/src/client/app/elements/app-view/app-view.ts
@@ -366,13 +366,8 @@ export class AppView extends LitElement {
   readonly #initializeAppTemplate = new Task(this, {
     args: () => [this.config.template],
     task: async ([appTemplate]): Promise<AppTemplate> => {
-      const run = this.#runner
-        ? (await this.#runner.runObserver.runs())[0]
-        : null;
-
       appTemplate.showDisclaimer = true;
       appTemplate.graph = this.flow;
-      appTemplate.run = run;
 
       appTemplate.addEventListener("bbsigninrequested", async () => {
         const url = await this.#signInAdapter.getSigninUrl();
@@ -474,7 +469,6 @@ export class AppView extends LitElement {
           this.#overrideTopGraphRunResult ??
           this.#runner?.topGraphObserver.current() ??
           TopGraphObserver.entryResult(this.flow);
-        appTemplate.eventPosition = appTemplate.run?.events.length ?? 0;
         appTemplate.showGDrive = this.#signInAdapter.state === "valid";
         return appTemplate;
       },

--- a/packages/unified-server/src/client/app/types/types.ts
+++ b/packages/unified-server/src/client/app/types/types.ts
@@ -24,6 +24,7 @@ import { type SigninAdapter } from "@breadboard-ai/shared-ui/utils/signin-adapte
 import { type GoogleDriveClient } from "@breadboard-ai/google-drive-kit/google-drive-client.js";
 import { type RunResults } from "@breadboard-ai/google-drive-kit/board-server/operations.js";
 import { ClientDeploymentConfiguration } from "@breadboard-ai/shared-ui/config/client-deployment-configuration.js";
+import { ProjectRun } from "@breadboard-ai/shared-ui/state/types.js";
 
 export type Runner = {
   harnessRunner: HarnessRunner;
@@ -48,6 +49,7 @@ export interface AppViewConfig {
   description: string | null;
   templateAdditionalOptions: Record<string, string> | null;
   googleDriveClient: GoogleDriveClient;
+  projectRun: ProjectRun;
   boardServer: BoardServer;
   runResults: RunResults | null;
   clientDeploymentConfiguration: ClientDeploymentConfiguration;


### PR DESCRIPTION
- **Sketch out `App` and `AppScreen`.**
- **Differentiate between "input" and "progress" screens.**
- **Provide ProjectRun as Lit context**
- **Wire up app view to start using ProjectRun state.**
- **Remove `<app-basic>.run` property**
- **Remove a bunch of unused properties.**
- **Rename `projectRun` to just `run` in `<app-basic>`**
- **docs(changeset): Plumb `ProjectRun` to `<app-basic>` and start using it.**
