### PR TITLE
reactive app view 3

### DIFF
--- a/.changeset/mean-seas-learn.md
+++ b/.changeset/mean-seas-learn.md
@@ -1,0 +1,7 @@
+---
+"@breadboard-ai/unified-server": patch
+"@breadboard-ai/visual-editor": patch
+"@breadboard-ai/shared-ui": patch
+---
+
+Wean <app-basic> off `TopGraphResult`.

--- a/packages/shared-ui/src/app-templates/basic/index.ts
+++ b/packages/shared-ui/src/app-templates/basic/index.ts
@@ -1480,11 +1480,8 @@ export class Template extends SignalWatcher(LitElement) implements AppTemplate {
     `;
 
     let content: NonNullable<unknown>;
-    if (
-      (this.topGraphResult.status === "stopped" &&
-        this.topGraphResult.log.length === 0) ||
-      this.#totalNodeCount === 0
-    ) {
+    const appState = this.run?.app.state || "splash";
+    if (appState === "splash") {
       content = splashScreen;
     } else {
       content = [

--- a/packages/shared-ui/src/app-templates/basic/index.ts
+++ b/packages/shared-ui/src/app-templates/basic/index.ts
@@ -12,7 +12,6 @@ import { customElement, property, state } from "lit/decorators.js";
 import {
   AppTemplate,
   AppTemplateOptions,
-  EdgeLogEntry,
   TopGraphRunResult,
 } from "../../types/types";
 import Mode from "../shared/styles/icons.js";
@@ -38,9 +37,7 @@ import {
   ToastEvent,
   ToastType,
 } from "../../events/events";
-import { repeat } from "lit/directives/repeat.js";
 import { createRef, Ref } from "lit/directives/ref.js";
-import { extractError } from "../shared/utils/utils";
 import { AssetShelf } from "../../elements/elements";
 import { SigninState } from "../../utils/signin-adapter";
 
@@ -58,7 +55,6 @@ import "../../elements/output/llm-output/llm-output-array.js";
 import "../../elements/output/llm-output/export-toolbar.js";
 import "../../elements/output/llm-output/llm-output.js";
 import "../../elements/output/multi-output/multi-output.js";
-import { markdown } from "../../directives/markdown";
 import { createThemeStyles } from "@breadboard-ai/theme";
 import { icons } from "../../styles/icons";
 import { ActionTracker } from "../../utils/action-tracker.js";
@@ -1003,143 +999,6 @@ export class Template extends SignalWatcher(LitElement) implements AppTemplate {
     return html`<div id="activity">${[activityContents, status]}</div>`;
   }
 
-  #renderActivityOld(topGraphResult: TopGraphRunResult) {
-    let activityContents:
-      | HTMLTemplateResult
-      | Array<HTMLTemplateResult | symbol>
-      | symbol = nothing;
-
-    const currentItem = topGraphResult.log.at(-1);
-    if (currentItem?.type === "error") {
-      activityContents = html`
-        <details class="error">
-          <summary>
-            <h1>We are sorry, but there was a problem with this flow.</h1>
-            <p>Tap for more details</p>
-          </summary>
-          <div>
-            <p>${extractError(currentItem.error)}</p>
-          </div>
-        </details>
-      `;
-    } else if (
-      currentItem?.type === "edge" &&
-      topGraphResult.status === "paused"
-    ) {
-      // Attempt to find the most recent output. If there is one, show it
-      // otherwise show any message that's coming from the edge.
-      let lastOutput = null;
-      let showAsStatus = false;
-      for (let i = topGraphResult.log.length - 1; i >= 0; i--) {
-        const result = topGraphResult.log[i];
-        if (result.type === "edge" && result.descriptor?.type === "output") {
-          const newest = topGraphResult.log.at(-1);
-          if (newest?.type === "edge" && newest.descriptor?.type === "input") {
-            const props = Object.values(newest.schema?.properties ?? {});
-            for (const prop of props) {
-              // TODO: Use a better way to determine that this is a User Input
-              // requiring a status flag.
-              if ("format" in prop) {
-                showAsStatus = true;
-                break;
-              }
-            }
-          }
-
-          lastOutput = result;
-          break;
-        }
-      }
-
-      // Render the output.
-      if (lastOutput !== null) {
-        activityContents = html`<bb-multi-output
-          .showAsStatus=${showAsStatus}
-          .outputs=${lastOutput.value ?? null}
-        ></bb-multi-output>`;
-      }
-    } else if (topGraphResult.status === "running") {
-      let status: HTMLTemplateResult | symbol = nothing;
-      let bubbledValue: HTMLTemplateResult | symbol = nothing;
-
-      if (topGraphResult.currentNode?.descriptor.metadata?.title) {
-        status = html`<div id="status">
-          <span class="g-icon"></span>
-          ${topGraphResult.currentNode.descriptor.metadata.title}
-        </div>`;
-      }
-
-      let idx = 0;
-      let lastOutput: EdgeLogEntry | null = null;
-      for (let i = topGraphResult.log.length - 1; i >= 0; i--) {
-        const result = topGraphResult.log[i];
-        if (result.type === "edge" && result.value && result.schema) {
-          lastOutput = result;
-          idx = i;
-          break;
-        }
-      }
-
-      if (lastOutput !== null && lastOutput.schema && lastOutput.value) {
-        bubbledValue = html`${repeat(
-          Object.entries(lastOutput.schema.properties ?? {}),
-          () => idx,
-          ([name, property]) => {
-            if (!lastOutput.value) {
-              return nothing;
-            }
-
-            if (property.type !== "string" && property.format !== "markdown") {
-              return nothing;
-            }
-
-            const value = lastOutput.value[name];
-            if (typeof value !== "string") {
-              return nothing;
-            }
-
-            const classes: Record<string, boolean> = {};
-            if (property.title) {
-              classes[
-                property.title.toLocaleLowerCase().replace(/\W/gim, "-")
-              ] = true;
-            }
-
-            if (property.icon) {
-              classes[property.icon.toLocaleLowerCase().replace(/\W/gim, "-")] =
-                true;
-            }
-
-            return html`<div class=${classMap(classes)}>
-              <h1>${property.title}</h1>
-              ${markdown(value)}
-            </div> `;
-          }
-        )}`;
-      }
-
-      activityContents = [bubbledValue, status];
-    } else {
-      // Find the last item.
-      let lastOutput = null;
-      for (let i = topGraphResult.log.length - 1; i >= 0; i--) {
-        const result = topGraphResult.log[i];
-        if (result.type === "edge" && result.value) {
-          lastOutput = result;
-          break;
-        }
-      }
-
-      if (lastOutput !== null) {
-        activityContents = html`<bb-multi-output
-          .outputs=${lastOutput.value ?? null}
-        ></bb-multi-output>`;
-      }
-    }
-
-    return html`<div id="activity">${activityContents}</div>`;
-  }
-
   #renderSaveResultsButton() {
     if (
       this.topGraphResult?.status !== "stopped" ||
@@ -1304,7 +1163,7 @@ export class Template extends SignalWatcher(LitElement) implements AppTemplate {
       [this.options.mode]: true,
     };
 
-    if (!this.topGraphResult) {
+    if (!this.run) {
       return nothing;
     }
 
@@ -1340,7 +1199,7 @@ export class Template extends SignalWatcher(LitElement) implements AppTemplate {
       typeof this.options.splashImage === "boolean" &&
       this.options.splashImage
     ) {
-      if (!this.topGraphResult || this.topGraphResult.status === "stopped") {
+      if (!this.run || this.run.status === "stopped") {
         return html`<section
           class=${classMap(classes)}
           style=${styleMap(styles)}
@@ -1420,7 +1279,7 @@ export class Template extends SignalWatcher(LitElement) implements AppTemplate {
               ${this.state === "anonymous" || this.state === "valid"
                 ? html`<button
                     id="run"
-                    ?disabled=${!this.run?.runnable}
+                    ?disabled=${!this.run.runnable}
                     @click=${() => {
                       ActionTracker.runApp(this.graph?.url, "app_preview");
                       this.dispatchEvent(new RunEvent());
@@ -1430,7 +1289,7 @@ export class Template extends SignalWatcher(LitElement) implements AppTemplate {
                   </button>`
                 : html`<button
                     id="sign-in"
-                    ?disabled=${!this.run?.runnable}
+                    ?disabled=${!this.run.runnable}
                     @click=${() => {
                       this.dispatchEvent(new SignInRequestedEvent());
                     }}
@@ -1444,8 +1303,7 @@ export class Template extends SignalWatcher(LitElement) implements AppTemplate {
     `;
 
     let content: NonNullable<unknown>;
-    const appState = this.run?.app.state || "splash";
-    if (appState === "splash") {
+    if (this.run.app.state === "splash") {
       content = splashScreen;
     } else {
       content = [

--- a/packages/shared-ui/src/app-templates/basic/index.ts
+++ b/packages/shared-ui/src/app-templates/basic/index.ts
@@ -9,11 +9,7 @@ const Strings = StringsHelper.forSection("Global");
 
 import { LitElement, html, css, nothing, HTMLTemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import {
-  AppTemplate,
-  AppTemplateOptions,
-  TopGraphRunResult,
-} from "../../types/types";
+import { AppTemplate, AppTemplateOptions } from "../../types/types";
 import Mode from "../shared/styles/icons.js";
 import Animations from "../shared/styles/animations.js";
 
@@ -85,9 +81,6 @@ export class Template extends SignalWatcher(LitElement) implements AppTemplate {
 
   @property()
   accessor graph: GraphDescriptor | null = null;
-
-  @property()
-  accessor topGraphResult: TopGraphRunResult | null = null;
 
   @property()
   accessor showGDrive = false;
@@ -1018,12 +1011,12 @@ export class Template extends SignalWatcher(LitElement) implements AppTemplate {
   }
 
   async #onClickSaveResults() {
-    if (!this.topGraphResult) {
-      console.error(`No top graph result`);
+    if (!this.run) {
+      console.error(`No project run`);
       return;
     }
     // Clone because we are going to inline content below.
-    const finalOutputValues = structuredClone(this.run?.finalOutput);
+    const finalOutputValues = structuredClone(this.run.finalOutput);
     if (!finalOutputValues) {
       return;
     }

--- a/packages/shared-ui/src/app-templates/basic/index.ts
+++ b/packages/shared-ui/src/app-templates/basic/index.ts
@@ -59,7 +59,6 @@ import { createThemeStyles } from "@breadboard-ai/theme";
 import { icons } from "../../styles/icons";
 import { ActionTracker } from "../../utils/action-tracker.js";
 import { buttonStyles } from "../../styles/button.js";
-import { findFinalOutputValues } from "../../utils/save-results.js";
 import { consume } from "@lit/context";
 import { boardServerContext } from "../../contexts/board-server.js";
 import { GoogleDriveBoardServer } from "@breadboard-ai/google-drive-kit";
@@ -1000,10 +999,7 @@ export class Template extends SignalWatcher(LitElement) implements AppTemplate {
   }
 
   #renderSaveResultsButton() {
-    if (
-      this.topGraphResult?.status !== "stopped" ||
-      !findFinalOutputValues(this.topGraphResult)
-    ) {
+    if (!this.run?.finalOutput) {
       return nothing;
     }
     // TODO(aomarks) Add share button.
@@ -1027,9 +1023,7 @@ export class Template extends SignalWatcher(LitElement) implements AppTemplate {
       return;
     }
     // Clone because we are going to inline content below.
-    const finalOutputValues = structuredClone(
-      findFinalOutputValues(this.topGraphResult)
-    );
+    const finalOutputValues = structuredClone(this.run?.finalOutput);
     if (!finalOutputValues) {
       return;
     }

--- a/packages/shared-ui/src/app-templates/basic/index.ts
+++ b/packages/shared-ui/src/app-templates/basic/index.ts
@@ -1456,7 +1456,7 @@ export class Template extends SignalWatcher(LitElement) implements AppTemplate {
               ${this.state === "anonymous" || this.state === "valid"
                 ? html`<button
                     id="run"
-                    ?disabled=${this.#totalNodeCount === 0}
+                    ?disabled=${!this.run?.runnable}
                     @click=${() => {
                       ActionTracker.runApp(this.graph?.url, "app_preview");
                       this.dispatchEvent(new RunEvent());
@@ -1466,7 +1466,7 @@ export class Template extends SignalWatcher(LitElement) implements AppTemplate {
                   </button>`
                 : html`<button
                     id="sign-in"
-                    ?disabled=${this.#totalNodeCount === 0}
+                    ?disabled=${!this.run?.runnable}
                     @click=${() => {
                       this.dispatchEvent(new SignInRequestedEvent());
                     }}

--- a/packages/shared-ui/src/app-templates/basic/index.ts
+++ b/packages/shared-ui/src/app-templates/basic/index.ts
@@ -108,9 +108,6 @@ export class Template extends SignalWatcher(LitElement) implements AppTemplate {
   accessor showDisclaimer = false;
 
   @property()
-  accessor isInSelectionState = false;
-
-  @property()
   accessor state: SigninState = "anonymous";
 
   @property({ reflect: true, type: Boolean })
@@ -1483,12 +1480,7 @@ export class Template extends SignalWatcher(LitElement) implements AppTemplate {
     `;
 
     let content: NonNullable<unknown>;
-    if (this.isInSelectionState && this.topGraphResult.log.length === 0) {
-      content = html`<div id="preview-step-not-run">
-        <h1>No data available</h1>
-        <p>This step has yet to run</p>
-      </div>`;
-    } else if (
+    if (
       (this.topGraphResult.status === "stopped" &&
         this.topGraphResult.log.length === 0) ||
       this.#totalNodeCount === 0

--- a/packages/shared-ui/src/app-templates/basic/index.ts
+++ b/packages/shared-ui/src/app-templates/basic/index.ts
@@ -7,14 +7,7 @@
 import * as StringsHelper from "../../strings/helper.js";
 const Strings = StringsHelper.forSection("Global");
 
-import {
-  LitElement,
-  html,
-  css,
-  PropertyValues,
-  nothing,
-  HTMLTemplateResult,
-} from "lit";
+import { LitElement, html, css, nothing, HTMLTemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import {
   AppTemplate,
@@ -955,10 +948,7 @@ export class Template extends SignalWatcher(LitElement) implements AppTemplate {
   #splashRef: Ref<HTMLDivElement> = createRef();
   #assetShelfRef: Ref<AssetShelf> = createRef();
 
-  #renderControls(topGraphResult: TopGraphRunResult) {
-    if (topGraphResult.currentNode?.descriptor.id) {
-      this.#nodesLeftToVisit.delete(topGraphResult.currentNode?.descriptor.id);
-    }
+  #renderControls() {
     return html`<bb-header
       .progress=${this.run?.progress}
       .replayActive=${true}
@@ -1308,32 +1298,6 @@ export class Template extends SignalWatcher(LitElement) implements AppTemplate {
     ></bb-floating-input>`;
   }
 
-  #totalNodeCount = 0;
-  #nodesLeftToVisit = new Set<string>();
-  protected willUpdate(changedProperties: PropertyValues): void {
-    if (changedProperties.has("topGraphResult")) {
-      if (
-        this.graph &&
-        this.topGraphResult &&
-        (this.topGraphResult.log.length === 0 || this.#totalNodeCount === 0)
-      ) {
-        this.#nodesLeftToVisit = new Set(
-          this.graph.nodes.map((node) => node.id)
-        );
-
-        this.#totalNodeCount = this.#nodesLeftToVisit.size;
-
-        for (const item of this.topGraphResult.log) {
-          if (item.type !== "node") {
-            continue;
-          }
-
-          this.#nodesLeftToVisit.delete(item.descriptor.id);
-        }
-      }
-    }
-  }
-
   render() {
     const classes: Record<string, boolean> = {
       "app-template": true,
@@ -1485,7 +1449,7 @@ export class Template extends SignalWatcher(LitElement) implements AppTemplate {
       content = splashScreen;
     } else {
       content = [
-        this.#renderControls(this.topGraphResult),
+        this.#renderControls(),
         this.#renderActivity(),
         this.#renderSaveResultsButton(),
         this.#renderInput(),

--- a/packages/shared-ui/src/elements/app-preview/app-preview.ts
+++ b/packages/shared-ui/src/elements/app-preview/app-preview.ts
@@ -92,9 +92,6 @@ export class AppPreview extends LitElement {
   accessor isMine = false;
 
   @property()
-  accessor isInSelectionState = false;
-
-  @property()
   accessor topGraphResult: TopGraphRunResult | null = null;
 
   @property()
@@ -380,7 +377,6 @@ export class AppPreview extends LitElement {
       this.#appTemplate.graph = this.graph;
       this.#appTemplate.topGraphResult = this.topGraphResult;
       this.#appTemplate.showGDrive = this.showGDrive;
-      this.#appTemplate.isInSelectionState = this.isInSelectionState;
       this.#appTemplate.readOnly = false;
       this.#appTemplate.showShareButton = false;
       this.#appTemplate.showContentWarning = !this.isMine;

--- a/packages/shared-ui/src/elements/app-preview/app-preview.ts
+++ b/packages/shared-ui/src/elements/app-preview/app-preview.ts
@@ -375,7 +375,6 @@ export class AppPreview extends LitElement {
   render() {
     if (this.#appTemplate) {
       this.#appTemplate.graph = this.graph;
-      this.#appTemplate.topGraphResult = this.topGraphResult;
       this.#appTemplate.showGDrive = this.showGDrive;
       this.#appTemplate.readOnly = false;
       this.#appTemplate.showShareButton = false;

--- a/packages/shared-ui/src/elements/output/console-view/console-view.ts
+++ b/packages/shared-ui/src/elements/output/console-view/console-view.ts
@@ -522,7 +522,9 @@ export class ConsoleView extends SignalWatcher(LitElement) {
         .replayActive=${this.run !== null}
         .progress=${this.run?.progress}
       ></bb-header>`,
-      this.run ? this.#renderRun() : this.#renderRunButton(),
+      this.run?.status !== "stopped"
+        ? this.#renderRun()
+        : this.#renderRunButton(),
       this.#renderInput(),
     ];
   }

--- a/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
+++ b/packages/shared-ui/src/elements/ui-controller/ui-controller.ts
@@ -610,7 +610,6 @@ export class UI extends LitElement {
             .projectRun=${this.projectState?.run}
             .topGraphResult=${this.topGraphResult}
             .showGDrive=${this.signedIn}
-            .isInSelectionState=${false}
             .settings=${this.settings}
             .boardServers=${this.boardServers}
             .status=${this.status}

--- a/packages/shared-ui/src/state/app.ts
+++ b/packages/shared-ui/src/state/app.ts
@@ -12,6 +12,11 @@ import { ReactiveAppScreen } from "./app-screen";
 export { ReactiveApp };
 
 class ReactiveApp implements App {
+  @signal
+  get state() {
+    return this.screens.size > 0 ? "screen" : "splash";
+  }
+
   screens: Map<string, AppScreen> = new SignalMap();
 
   @signal

--- a/packages/shared-ui/src/state/console-entry.ts
+++ b/packages/shared-ui/src/state/console-entry.ts
@@ -52,7 +52,7 @@ class ReactiveConsoleEntry implements ConsoleEntry {
   #outputSchema: Schema | undefined;
 
   constructor(
-    private readonly fileSystem: FileSystem,
+    private readonly fileSystem: FileSystem | undefined,
     { title, icon, tags }: NodeMetadata,
     path: number[],
     outputSchema: Schema | undefined

--- a/packages/shared-ui/src/state/project-run.ts
+++ b/packages/shared-ui/src/state/project-run.ts
@@ -26,6 +26,7 @@ import {
   FileSystem,
   InspectableGraph,
   Outcome,
+  OutputValues,
 } from "@google-labs/breadboard";
 import { getStepIcon } from "../utils/get-step-icon";
 import { ReactiveApp } from "./app";
@@ -111,6 +112,13 @@ class ReactiveProjectRun implements ProjectRun {
 
   @signal
   accessor input: UserInput | null = null;
+
+  @signal
+  get finalOutput(): OutputValues | null {
+    if (this.status !== "stopped") return null;
+
+    return this.app.current?.last?.output || null;
+  }
 
   private constructor(
     private readonly inspectable: InspectableGraph | undefined,

--- a/packages/shared-ui/src/state/project.ts
+++ b/packages/shared-ui/src/state/project.ts
@@ -164,6 +164,10 @@ class ReactiveProject implements ProjectInternal {
     this.run = ReactiveProjectRun.createInert(this.#inspectable());
   }
 
+  resetRun(): void {
+    this.run = ReactiveProjectRun.createInert(this.#inspectable());
+  }
+
   #inspectable() {
     return this.#store.inspect(this.#mainGraphId, "");
   }

--- a/packages/shared-ui/src/state/project.ts
+++ b/packages/shared-ui/src/state/project.ts
@@ -100,7 +100,7 @@ class ReactiveProject implements ProjectInternal {
   #connectorMap: SignalMap<string, ConnectorType>;
 
   @signal
-  accessor run: ProjectRun | null = null;
+  accessor run: ProjectRun;
 
   readonly graphUrl: URL | null;
   readonly graphAssets: SignalMap<AssetPath, GraphAsset>;
@@ -161,6 +161,11 @@ class ReactiveProject implements ProjectInternal {
     this.#updateTools();
     this.#updateMyTools();
     this.#updateParameters();
+    this.run = ReactiveProjectRun.createInert(this.#inspectable());
+  }
+
+  #inspectable() {
+    return this.#store.inspect(this.#mainGraphId, "");
   }
 
   connectHarnessRunner(
@@ -169,8 +174,8 @@ class ReactiveProject implements ProjectInternal {
     signal?: AbortSignal
   ): Outcome<void> {
     // Intentionally reset this property with a new instance.
-    this.run = new ReactiveProjectRun(
-      this.#store.inspect(this.#mainGraphId, ""),
+    this.run = ReactiveProjectRun.create(
+      this.#inspectable(),
       fileSystem,
       runner,
       signal

--- a/packages/shared-ui/src/state/types.ts
+++ b/packages/shared-ui/src/state/types.ts
@@ -49,6 +49,10 @@ export type ProjectRun = {
    */
   progress: number;
   /**
+   * Answers whether the project is runnable in its current state.
+   */
+  runnable: boolean;
+  /**
    * Console (fka Activity View)
    */
   console: Map<string, ConsoleEntry>;
@@ -329,7 +333,7 @@ export type ConnectorState = {
  * Contains all the state for the project.
  */
 export type Project = {
-  run: ProjectRun | null;
+  run: ProjectRun;
   graphAssets: Map<AssetPath, GraphAsset>;
   parameters: Map<string, ParameterMetadata>;
   connectors: ConnectorState;

--- a/packages/shared-ui/src/state/types.ts
+++ b/packages/shared-ui/src/state/types.ts
@@ -73,6 +73,10 @@ export type ProjectRun = {
    * the run is not currently waiting on user input.
    */
   input: UserInput | null;
+  /**
+   * Final output values. When the run is still ongoing, will be `null`.
+   */
+  finalOutput: OutputValues | null;
 };
 
 /**

--- a/packages/shared-ui/src/state/types.ts
+++ b/packages/shared-ui/src/state/types.ts
@@ -81,6 +81,12 @@ export type ProjectRun = {
  */
 export type App = {
   /**
+   * Current state of the app. Can be one of the following:
+   * - "splash" -- the app is showing a splash screen
+   * - "screen" -- the app is showing a screen
+   */
+  state: "splash" | "screen";
+  /**
    * A sequences of screens that is produced during the run.
    */
   screens: Map<string, AppScreen>;
@@ -340,6 +346,11 @@ export type Project = {
   organizer: Organizer;
   fastAccess: FastAccess;
   renderer: RendererState;
+
+  /**
+   * Resets the current run.
+   */
+  resetRun(): void;
 
   /**
    * Returns metadata for a given node. This function is sync, and it

--- a/packages/shared-ui/src/state/work-item.ts
+++ b/packages/shared-ui/src/state/work-item.ts
@@ -66,7 +66,7 @@ class ReactiveWorkItem implements WorkItem {
   }
 
   static fromOutput(
-    fileSystem: FileSystem,
+    fileSystem: FileSystem | undefined,
     data: OutputResponse,
     start: number
   ): [string, ReactiveWorkItem] {
@@ -84,21 +84,27 @@ class ReactiveWorkItem implements WorkItem {
     );
     let item: ReactiveWorkItem;
     if (particleMode) {
-      const part = Object.values(products).at(0)!.parts.at(0) as FileDataPart;
-      item = new ParticleWorkItem(
-        type,
-        title,
-        icon,
-        start,
-        chat,
-        fileSystem,
-        part
-      );
-    } else {
-      item = new ReactiveWorkItem(type, title, icon, start, chat);
-      for (const [name, product] of Object.entries(products)) {
-        item.product.set(name, product);
+      if (!fileSystem) {
+        console.warn(
+          "Particle emitted, but no file system was provided, ignoring"
+        );
+      } else {
+        const part = Object.values(products).at(0)!.parts.at(0) as FileDataPart;
+        item = new ParticleWorkItem(
+          type,
+          title,
+          icon,
+          start,
+          chat,
+          fileSystem,
+          part
+        );
+        return [id, item];
       }
+    }
+    item = new ReactiveWorkItem(type, title, icon, start, chat);
+    for (const [name, product] of Object.entries(products)) {
+      item.product.set(name, product);
     }
     return [id, item];
   }

--- a/packages/shared-ui/src/types/types.ts
+++ b/packages/shared-ui/src/types/types.ts
@@ -570,7 +570,6 @@ export interface AppTemplate extends LitElement {
   state: SigninState | null;
   options: AppTemplateOptions;
   graph: GraphDescriptor | null;
-  topGraphResult: TopGraphRunResult | null;
   additionalOptions: AppTemplateAdditionalOptionsAvailable;
   showGDrive: boolean;
   readOnly: boolean;

--- a/packages/shared-ui/src/types/types.ts
+++ b/packages/shared-ui/src/types/types.ts
@@ -573,7 +573,6 @@ export interface AppTemplate extends LitElement {
   topGraphResult: TopGraphRunResult | null;
   additionalOptions: AppTemplateAdditionalOptionsAvailable;
   showGDrive: boolean;
-  isInSelectionState: boolean;
   readOnly: boolean;
   showShareButton: boolean;
   showContentWarning: boolean;

--- a/packages/unified-server/src/client/app/elements/app-view/app-view.ts
+++ b/packages/unified-server/src/client/app/elements/app-view/app-view.ts
@@ -30,10 +30,8 @@ import {
   AppTemplate,
   AppTemplateOptions,
   SnackType,
-  TopGraphRunResult,
 } from "@breadboard-ai/shared-ui/types/types.js";
 import { getThemeModeFromBackground } from "../../utils/color.js";
-import { TopGraphObserver } from "@breadboard-ai/shared-ui/utils/top-graph-observer";
 import { InputEnterEvent } from "../../events/events.js";
 import {
   RunEndEvent,
@@ -101,7 +99,6 @@ export class AppView extends LitElement {
   readonly flow: GraphDescriptor;
   #runner: Runner | null;
   #signInAdapter: SigninAdapter;
-  #overrideTopGraphRunResult: TopGraphRunResult | null;
   #snackbarRef: Ref<BreadboardUI.Elements.Snackbar> = createRef();
 
   constructor(
@@ -120,29 +117,6 @@ export class AppView extends LitElement {
     this.googleDriveClient = config.googleDriveClient;
     this.boardServer = config.boardServer;
     this.projectRun = config.projectRun;
-    this.#overrideTopGraphRunResult = config.runResults
-      ? {
-          status: "stopped",
-          log: [
-            {
-              type: "edge",
-              value: config.runResults.finalOutputValues,
-              end: null,
-            },
-          ],
-          graph: null,
-          currentNode: null,
-          edgeValues: {
-            get: () => undefined,
-            current: null,
-          },
-          nodeInformation: {
-            getActivity: () => undefined,
-            canRunNode: () => false,
-          },
-        }
-      : null;
-
     this.#setDocumentTitle();
     this.#applyThemeToTemplate();
     this.#initializeListeners();
@@ -465,10 +439,6 @@ export class AppView extends LitElement {
       error: () => `An unexpected error occured`,
       complete: (appTemplate) => {
         appTemplate.state = this.#signInAdapter.state;
-        appTemplate.topGraphResult =
-          this.#overrideTopGraphRunResult ??
-          this.#runner?.topGraphObserver.current() ??
-          TopGraphObserver.entryResult(this.flow);
         appTemplate.showGDrive = this.#signInAdapter.state === "valid";
         return appTemplate;
       },

--- a/packages/unified-server/src/client/app/types/types.ts
+++ b/packages/unified-server/src/client/app/types/types.ts
@@ -22,7 +22,6 @@ import {
 } from "@google-labs/breadboard";
 import { type SigninAdapter } from "@breadboard-ai/shared-ui/utils/signin-adapter";
 import { type GoogleDriveClient } from "@breadboard-ai/google-drive-kit/google-drive-client.js";
-import { type RunResults } from "@breadboard-ai/google-drive-kit/board-server/operations.js";
 import { ClientDeploymentConfiguration } from "@breadboard-ai/shared-ui/config/client-deployment-configuration.js";
 import { ProjectRun } from "@breadboard-ai/shared-ui/state/types.js";
 
@@ -51,7 +50,6 @@ export interface AppViewConfig {
   googleDriveClient: GoogleDriveClient;
   projectRun: ProjectRun;
   boardServer: BoardServer;
-  runResults: RunResults | null;
   clientDeploymentConfiguration: ClientDeploymentConfiguration;
 }
 

--- a/packages/visual-editor/src/runtime/run.ts
+++ b/packages/visual-editor/src/runtime/run.ts
@@ -87,7 +87,7 @@ export class Run extends EventTarget {
     if (run) {
       const project = this.state.getOrCreate(run.mainGraphId);
       if (project) {
-        project.run = null;
+        project.resetRun();
       }
     } else {
       console.warn(


### PR DESCRIPTION
- **Remove unused code path around `isInSelectionState`.**
- **Introduce `runnable` flag on `ProjectRun`.**
- **Introduce `App.state` and start using it.**
- **Get rid of node counting in basic app template.**
- **Remove the use of `TopGraphResult` from `render` in basic app template.**
- **Teach `ConsoleView` that run is always present.**
- **Introduce `ProjectRun.finalOutput` and use it.**
- **Make saved result work without TGR.**
- **docs(changeset): Wean <app-basic> off `TopGraphResult`.**
