### PR TITLE
fix save results

### DIFF
--- a/.changeset/little-lizards-shake.md
+++ b/.changeset/little-lizards-shake.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/shared-ui": patch
+---
+
+Correctly wire `ProjectRun` when loading saved results.

--- a/packages/shared-ui/src/state/project-run.ts
+++ b/packages/shared-ui/src/state/project-run.ts
@@ -6,7 +6,6 @@
 
 import { SignalMap } from "signal-utils/map";
 import {
-  AppScreen,
   AppScreenOutput,
   ConsoleEntry,
   ProjectRun,
@@ -71,14 +70,11 @@ function createProjectRunStateFromFinalOutput(
     output,
     schema: {},
   };
-  const current: AppScreen = {
-    title: "",
-    status: "complete",
-    last,
-    outputs: new Map([["output", last]]),
-    type: "progress",
-  };
+  const current = new ReactiveAppScreen("", [], undefined);
+  current.outputs.set("final", last);
   run.app.screens.set("final", current);
+  run.app.current = current;
+
   return run;
 }
 


### PR DESCRIPTION
- **Correctly wire `ProjectRun` when creating from saved result.**
- **docs(changeset): Correctly wire `ProjectRun` when loading saved results.**
