### PR TITLE
[assets] Separate tabs for mine vs shared files in asset picker

### DIFF
--- a/packages/shared-ui/src/elements/google-drive/google-drive-file-id.ts
+++ b/packages/shared-ui/src/elements/google-drive/google-drive-file-id.ts
@@ -129,9 +129,6 @@ export class GoogleDriveFileId extends LitElement {
   accessor connectionName = "$sign-in";
 
   @property()
-  accessor ownedByMeOnly = false;
-
-  @property()
   accessor autoTrigger = false;
 
   #picker?: google.picker.Picker;
@@ -262,24 +259,29 @@ export class GoogleDriveFileId extends LitElement {
     }
     this.#destroyPicker();
 
-    const view = new this._pickerLib.DocsView();
-    view.setMimeTypes(MIME_TYPES);
-    view.setIncludeFolders(true);
-    view.setSelectFolderEnabled(false);
+    const myFilesView = new this._pickerLib.DocsView();
+    myFilesView.setMimeTypes(MIME_TYPES);
+    myFilesView.setIncludeFolders(true);
+    myFilesView.setSelectFolderEnabled(false);
+    myFilesView.setOwnedByMe(true);
+    myFilesView.setMode(google.picker.DocsViewMode.GRID);
 
-    if (this.ownedByMeOnly) {
-      view.setOwnedByMe(true);
-    }
-    view.setMode(google.picker.DocsViewMode.LIST);
+    const sharedFilesView = new this._pickerLib.DocsView();
+    sharedFilesView.setMimeTypes(MIME_TYPES);
+    sharedFilesView.setIncludeFolders(true);
+    sharedFilesView.setSelectFolderEnabled(false);
+    sharedFilesView.setOwnedByMe(false);
+    sharedFilesView.setMode(google.picker.DocsViewMode.GRID);
 
     // See https://developers.google.com/drive/picker/reference
     this.#picker = new this._pickerLib.PickerBuilder()
       .setOrigin(getTopLevelOrigin())
-      .addView(view)
+      .addView(myFilesView)
+      .addView(sharedFilesView)
       .setAppId(this._authorization.clientId)
       .setOAuthToken(this._authorization.secret)
       .setCallback(this.#pickerCallback.bind(this))
-      .enableFeature(google.picker.Feature.NAV_HIDDEN)
+      // .enableFeature(google.picker.Feature.NAV_HIDDEN)
       .build();
     this.#picker.setVisible(true);
   }

--- a/packages/shared-ui/src/elements/input/add-asset/add-asset-modal.ts
+++ b/packages/shared-ui/src/elements/input/add-asset/add-asset-modal.ts
@@ -448,7 +448,6 @@ export class AddAssetModal extends LitElement {
             ${ref(this.#addDriveInputRef)}
             .connectionName=${SIGN_IN_CONNECTION_ID}
             .autoTrigger=${true}
-            .ownedByMeOnly=${true}
             @bbinputcancel=${() => {
               this.dispatchEvent(new OverlayDismissedEvent());
             }}

--- a/packages/shared-ui/src/elements/step-editor/editor-controls.ts
+++ b/packages/shared-ui/src/elements/step-editor/editor-controls.ts
@@ -1018,7 +1018,6 @@ export class EditorControls extends LitElement {
               id="add-drive-proxy"
               ${ref(this.#addDriveInputRef)}
               .connectionName=${SIGN_IN_CONNECTION_ID}
-              .ownedByMeOnly=${false}
               @bb-input-change=${(evt: InputChangeEvent) => {
                 const driveFile = evt.value as {
                   preview: string;


### PR DESCRIPTION
Previously, when opening the asset picker you would see both my files and all shared files. This would usually take a very long time to load.

Now, there are instead 2 tabs: my files, and shared files. Only when clicking shared files do things slow down as all the docs are loaded.