### PR TITLE
[devx] Fix double reload for most edits by moving ClientDeploymentConfiguration to types package

### DIFF
--- a/packages/shared-ui/src/config/client-deployment-configuration.ts
+++ b/packages/shared-ui/src/config/client-deployment-configuration.ts
@@ -4,19 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { RuntimeFlags } from "@breadboard-ai/types";
+import { type RuntimeFlags } from "@breadboard-ai/types";
+import { type ClientDeploymentConfiguration } from "@breadboard-ai/types/deployment-configuration.js";
 import { createContext } from "@lit/context";
-
-export type ClientDeploymentConfiguration = {
-  MEASUREMENT_ID?: string;
-  BACKEND_API_ENDPOINT?: string;
-  ENABLE_GOOGLE_DRIVE_PROXY?: boolean;
-  FEEDBACK_LINK?: string;
-  ENABLE_GOOGLE_FEEDBACK?: boolean;
-  GOOGLE_FEEDBACK_PRODUCT_ID?: string;
-  GOOGLE_FEEDBACK_BUCKET?: string;
-  flags: RuntimeFlags;
-};
 
 /**
  * These are the default values for runtime flags, necessary

--- a/packages/shared-ui/src/elements/feedback/feedback-panel.ts
+++ b/packages/shared-ui/src/elements/feedback/feedback-panel.ts
@@ -4,14 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { type ClientDeploymentConfiguration } from "@breadboard-ai/types/deployment-configuration.js";
 import { consume } from "@lit/context";
 import { css, html, LitElement, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { createRef, ref, type Ref } from "lit/directives/ref.js";
-import {
-  type ClientDeploymentConfiguration,
-  clientDeploymentConfigurationContext,
-} from "../../config/client-deployment-configuration.js";
+import { clientDeploymentConfigurationContext } from "../../config/client-deployment-configuration.js";
 import { type BuildInfo, buildInfoContext } from "../../contexts/build-info.js";
 import { icons } from "../../styles/icons.js";
 import { spinAnimationStyles } from "../../styles/spin-animation.js";

--- a/packages/types/src/deployment-configuration.ts
+++ b/packages/types/src/deployment-configuration.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { type RuntimeFlags } from "./flags.js";
+
+export type ClientDeploymentConfiguration = {
+  MEASUREMENT_ID?: string;
+  BACKEND_API_ENDPOINT?: string;
+  ENABLE_GOOGLE_DRIVE_PROXY?: boolean;
+  FEEDBACK_LINK?: string;
+  ENABLE_GOOGLE_FEEDBACK?: boolean;
+  GOOGLE_FEEDBACK_PRODUCT_ID?: string;
+  GOOGLE_FEEDBACK_BUCKET?: string;
+  flags: RuntimeFlags;
+};
+
+export type ServerDeploymentConfiguration = {
+  BACKEND_API_ENDPOINT?: string;
+  ENABLE_GOOGLE_DRIVE_PROXY?: boolean;
+};

--- a/packages/unified-server/package.json
+++ b/packages/unified-server/package.json
@@ -87,7 +87,7 @@
       "dependencies": [
         "../board-server#build:tsc",
         "../connection-server#build:tsc",
-        "../shared-ui#build:tsc"
+        "../types#build:tsc"
       ]
     },
     "serve": {

--- a/packages/unified-server/src/server/provide-config.ts
+++ b/packages/unified-server/src/server/provide-config.ts
@@ -5,20 +5,12 @@
  */
 
 import { SecretsProvider } from "@breadboard-ai/board-server";
-import { type ClientDeploymentConfiguration } from "@breadboard-ai/shared-ui/config/client-deployment-configuration.js";
+import {
+  type ClientDeploymentConfiguration,
+  type ServerDeploymentConfiguration,
+} from "@breadboard-ai/types/deployment-configuration.js";
 
 export { getConfigFromSecretManager };
-
-/**
- * Server-specific variables of deployment configuration. These values
- * are only available to the server. To add a new value:
- * 1. Add it here
- * 2. Consume it in `./main.ts`
- */
-export type ServerDeploymentConfiguration = {
-  BACKEND_API_ENDPOINT?: string;
-  ENABLE_GOOGLE_DRIVE_PROXY?: boolean;
-};
 
 export type SecretValueFormat = {
   client: ClientDeploymentConfiguration;

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -96,10 +96,9 @@ import { stringifyPermission } from "@breadboard-ai/shared-ui/elements/share-pan
 import { type GoogleDriveAssetShareDialog } from "@breadboard-ai/shared-ui/elements/elements.js";
 import { boardServerContext } from "@breadboard-ai/shared-ui/contexts/board-server.js";
 import { extractGoogleDriveFileId } from "@breadboard-ai/google-drive-kit/board-server/utils.js";
-import {
-  type ClientDeploymentConfiguration,
-  clientDeploymentConfigurationContext,
-} from "@breadboard-ai/shared-ui/config/client-deployment-configuration.js";
+import { clientDeploymentConfigurationContext } from "@breadboard-ai/shared-ui/config/client-deployment-configuration.js";
+import { type ClientDeploymentConfiguration } from "@breadboard-ai/types/deployment-configuration.js";
+
 import { Admin } from "./admin";
 import { MainArguments, TosStatus } from "./types/types";
 import {

--- a/packages/visual-editor/src/types/types.ts
+++ b/packages/visual-editor/src/types/types.ts
@@ -6,7 +6,7 @@
 
 import { EmbedHandler } from "@breadboard-ai/embed";
 import type * as BreadboardUI from "@breadboard-ai/shared-ui";
-import { ClientDeploymentConfiguration } from "@breadboard-ai/shared-ui/config/client-deployment-configuration.js";
+import { type ClientDeploymentConfiguration } from "@breadboard-ai/types/deployment-configuration.js";
 import { type BuildInfo } from "@breadboard-ai/shared-ui/contexts/build-info.js";
 import { SettingsStore } from "@breadboard-ai/shared-ui/data/settings-store.js";
 import {


### PR DESCRIPTION
The double reload was happening because the unified server itself (the node code) was depending on shared-ui, in order to import the ClientDeploymentConfiguration type.

That caused the server to restart for any shared-ui change, which was almost always unnecessary, and which caused the double reload (once when the client code changed and the first instance of the server noticed, and then again as the second instance of the server replaced the first one).

So, I moved ClientDeploymentConfiguration to the types package, and removed the wireit dependency between the server and shared-ui. The double reload will now only happen when modifying something in the types package, which should be much less frequent than shared-ui.