### PR TITLE
[cleanup] SigninAdapter cleanup and simplification

### DIFF
--- a/packages/connection-client/src/types.ts
+++ b/packages/connection-client/src/types.ts
@@ -32,8 +32,6 @@ export type TokenResult =
 export interface ValidTokenResult {
   state: "valid";
   grant: TokenGrant;
-  expired?: never;
-  refresh?: never;
 }
 
 /**
@@ -42,8 +40,7 @@ export interface ValidTokenResult {
  */
 export interface ExpiredTokenResult {
   state: "expired";
-  grant?: TokenGrant;
-  expired?: never;
+  grant: TokenGrant;
   refresh: (opts?: { signal?: AbortSignal }) => Promise<ValidTokenResult>;
 }
 
@@ -54,9 +51,6 @@ export interface ExpiredTokenResult {
  */
 export interface SignedOutTokenResult {
   state: "signedout";
-  grant?: never;
-  expired?: never;
-  refresh?: never;
 }
 
 // IMPORTANT: Keep in sync with

--- a/packages/shared-ui/src/app-templates/basic/index.ts
+++ b/packages/shared-ui/src/app-templates/basic/index.ts
@@ -29,7 +29,7 @@ import {
   StateEvent,
   UnsnackbarEvent,
 } from "../../events/events";
-import { SigninState } from "../../utils/signin-adapter";
+import { SigninAdapterState } from "../../utils/signin-adapter";
 import { createThemeStyles } from "@breadboard-ai/theme";
 import { ActionTracker } from "../../utils/action-tracker.js";
 import { consume, provide } from "@lit/context";
@@ -98,7 +98,7 @@ export class Template extends SignalWatcher(LitElement) implements AppTemplate {
   accessor showDisclaimer = false;
 
   @property()
-  accessor state: SigninState = "anonymous";
+  accessor state: SigninAdapterState["status"] = "anonymous";
 
   @property({ reflect: true, type: Boolean })
   accessor hasRenderedSplash = false;

--- a/packages/shared-ui/src/app-templates/basic/index.ts
+++ b/packages/shared-ui/src/app-templates/basic/index.ts
@@ -568,7 +568,7 @@ export class Template extends SignalWatcher(LitElement) implements AppTemplate {
           ></p>
           <div id="input" class="stopped">
             <div>
-              ${this.state === "anonymous" || this.state === "valid"
+              ${this.state === "anonymous" || this.state === "signedin"
                 ? html`<button
                     id="run"
                     ?disabled=${!this.run.runnable}

--- a/packages/shared-ui/src/elements/canvas-controller/canvas-controller.ts
+++ b/packages/shared-ui/src/elements/canvas-controller/canvas-controller.ts
@@ -64,10 +64,6 @@ import {
 import { icons } from "../../styles/icons.js";
 import { type GoogleDrivePicker, EntityEditor } from "../elements.js";
 import { consume } from "@lit/context";
-import {
-  type SigninAdapter,
-  signinAdapterContext,
-} from "../../utils/signin-adapter.js";
 import { findGoogleDriveAssetsInGraph } from "../google-drive/find-google-drive-assets-in-graph.js";
 import { SharePanel } from "../share-panel/share-panel.js";
 import { type GoogleDriveClient } from "@breadboard-ai/google-drive-kit/google-drive-client.js";
@@ -187,10 +183,6 @@ export class CanvasController extends LitElement {
 
   @state()
   accessor #showEditHistory = false;
-
-  @consume({ context: signinAdapterContext })
-  @property({ attribute: false })
-  accessor signinAdapter: SigninAdapter | undefined = undefined;
 
   @consume({ context: googleDriveClientContext })
   @property({ attribute: false })

--- a/packages/shared-ui/src/elements/connection/connection-entry-signin.ts
+++ b/packages/shared-ui/src/elements/connection/connection-entry-signin.ts
@@ -120,22 +120,7 @@ export class ConnectionEntrySignin extends LitElement {
       <h1>Welcome to ${Strings.from("APP_NAME")}</h1>
       <a
         .href=${until(this.adapter.getSigninUrl())}
-        @click=${() => {
-          if (!this.adapter) {
-            return;
-          }
-
-          this.adapter.whenSignedIn(async (adapter) => {
-            // The adapter is immutable, this callback will always return a new
-            // copy with a new state, including picture and name.
-            if (adapter.state === "valid") {
-              ActionTracker.signInSuccess();
-              this.dispatchEvent(new SignInEvent());
-            } else if (adapter.errorMessage) {
-              this.errorMessage = adapter.errorMessage;
-            }
-          });
-        }}
+        @click=${this.#onClickSignin}
         target="_blank"
         title="Sign into Google"
         >Sign into Google</a
@@ -144,6 +129,19 @@ export class ConnectionEntrySignin extends LitElement {
         ? html`<p class="error-message">${this.errorMessage}</p>`
         : nothing}
     </div>`;
+  }
+
+  async #onClickSignin() {
+    if (!this.adapter) {
+      return;
+    }
+    const result = await this.adapter.signIn();
+    if (result.ok) {
+      ActionTracker.signInSuccess();
+      this.dispatchEvent(new SignInEvent());
+    } else {
+      this.errorMessage = result.error;
+    }
   }
 }
 

--- a/packages/shared-ui/src/elements/google-drive/google-drive-debug-panel.ts
+++ b/packages/shared-ui/src/elements/google-drive/google-drive-debug-panel.ts
@@ -233,7 +233,7 @@ export class GoogleDriveDebugPanel extends LitElement {
   }
 
   async #openPickerForAnyFile() {
-    const auth = await this.signinAdapter?.refresh();
+    const auth = await this.signinAdapter?.token();
     if (auth?.state !== "valid") {
       return;
     }
@@ -262,7 +262,7 @@ export class GoogleDriveDebugPanel extends LitElement {
     if (!fileId) {
       return;
     }
-    const auth = await this.signinAdapter?.refresh();
+    const auth = await this.signinAdapter?.token();
     if (auth?.state !== "valid") {
       return;
     }
@@ -360,7 +360,7 @@ export class GoogleDriveDebugPanel extends LitElement {
     if (!fileId || !emailAddress) {
       return;
     }
-    const auth = await this.signinAdapter?.refresh();
+    const auth = await this.signinAdapter?.token();
     if (auth?.state !== "valid") {
       return;
     }
@@ -395,7 +395,7 @@ export class GoogleDriveDebugPanel extends LitElement {
   }
 
   async #openPickerToUploadAsset() {
-    const auth = await this.signinAdapter?.refresh();
+    const auth = await this.signinAdapter?.token();
     if (auth?.state !== "valid") {
       return;
     }
@@ -438,7 +438,7 @@ export class GoogleDriveDebugPanel extends LitElement {
       return;
     }
     const driveShare = await loadDriveShare();
-    const auth = await this.signinAdapter?.refresh();
+    const auth = await this.signinAdapter?.token();
     if (auth?.state !== "valid") {
       return;
     }
@@ -456,7 +456,7 @@ export class GoogleDriveDebugPanel extends LitElement {
     }
 
     const drive = await loadDriveApi();
-    const auth = await this.signinAdapter?.refresh();
+    const auth = await this.signinAdapter?.token();
     if (auth?.state !== "valid") {
       return;
     }
@@ -474,7 +474,7 @@ export class GoogleDriveDebugPanel extends LitElement {
     if (!fileId) {
       return;
     }
-    const auth = await this.signinAdapter?.refresh();
+    const auth = await this.signinAdapter?.token();
     if (auth?.state !== "valid") {
       return;
     }

--- a/packages/shared-ui/src/elements/google-drive/google-drive-picker.ts
+++ b/packages/shared-ui/src/elements/google-drive/google-drive-picker.ts
@@ -81,7 +81,7 @@ export class GoogleDrivePicker extends LitElement {
       );
     }
     const pickerLib = await loadDrivePicker();
-    const auth = await this.signinAdapter?.refresh();
+    const auth = await this.signinAdapter?.token();
     if (auth?.state !== "valid") {
       console.error(`Expected "valid" auth state, got "${auth?.state}"`);
       return;
@@ -172,7 +172,7 @@ export class GoogleDrivePicker extends LitElement {
       return;
     }
     const pickerLib = await loadDrivePicker();
-    const auth = await this.signinAdapter?.refresh();
+    const auth = await this.signinAdapter?.token();
     if (auth?.state !== "valid") {
       console.error(`Expected "valid" auth state, got "${auth?.state}"`);
       return;

--- a/packages/shared-ui/src/elements/google-drive/google-drive-share-panel.ts
+++ b/packages/shared-ui/src/elements/google-drive/google-drive-share-panel.ts
@@ -63,7 +63,7 @@ export class GoogleDriveSharePanel extends LitElement {
       console.error("Global ShareClient was locked");
       return;
     }
-    const auth = await this.signinAdapter?.refresh();
+    const auth = await this.signinAdapter?.token();
     if (auth?.state !== "valid") {
       console.error(`Expected "valid" auth state, got: ${auth?.state}`);
       return;

--- a/packages/shared-ui/src/elements/output/llm-output/export-toolbar.ts
+++ b/packages/shared-ui/src/elements/output/llm-output/export-toolbar.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TokenVendor } from "@breadboard-ai/connection-client";
 import type { LLMContent } from "@breadboard-ai/types";
 import {
   isFileDataCapabilityPart,
@@ -12,13 +11,11 @@ import {
   isStoredData,
   isTextCapabilityPart,
 } from "@google-labs/breadboard";
-import { consume } from "@lit/context";
 import { LitElement, css, html, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { renderMarkdownToHtmlString } from "../../../directives/markdown.js";
 import { ToastEvent, ToastType } from "../../../events/events.js";
 import { toolbarStyles } from "../../../styles/toolbar-styles.js";
-import { tokenVendorContext } from "../../elements.js";
 import { classMap } from "lit/directives/class-map.js";
 
 const CAN_COPY = "ClipboardItem" in window;
@@ -30,9 +27,6 @@ export class ExportToolbar extends LitElement {
 
   @property({ type: Object })
   accessor value: LLMContent | null = null;
-
-  @consume({ context: tokenVendorContext })
-  accessor tokenVendor!: TokenVendor;
 
   @property({ type: Object })
   accessor supported = {

--- a/packages/shared-ui/src/elements/output/llm-output/llm-output.ts
+++ b/packages/shared-ui/src/elements/output/llm-output/llm-output.ts
@@ -31,9 +31,6 @@ import { classMap } from "lit/directives/class-map.js";
 import { map } from "lit/directives/map.js";
 import { until } from "lit/directives/until.js";
 import { markdown } from "../../../directives/markdown.js";
-import { tokenVendorContext } from "../../elements.js";
-import { consume } from "@lit/context";
-import type { TokenVendor } from "@breadboard-ai/connection-client";
 import { styleMap } from "lit/directives/style-map.js";
 import {
   convertShareUriToEmbedUri,
@@ -72,9 +69,6 @@ export class LLMOutput extends LitElement {
 
   @property()
   accessor graphUrl: URL | null = null;
-
-  @consume({ context: tokenVendorContext })
-  accessor tokenVendor!: TokenVendor;
 
   #partDataURLs = new Map<number, string>();
   #partTask = new Map<number, Task>();

--- a/packages/shared-ui/src/elements/share-panel/share-panel.ts
+++ b/packages/shared-ui/src/elements/share-panel/share-panel.ts
@@ -1015,7 +1015,7 @@ export class SharePanel extends LitElement {
       console.error(`No signinAdapter was provided`);
       return "";
     }
-    const auth = await this.signinAdapter.refresh();
+    const auth = await this.signinAdapter.token();
     if (auth?.state !== "valid") {
       console.error(`Expected valid auth, got "${auth?.state}"`);
       return "";

--- a/packages/shared-ui/src/elements/shell/header.ts
+++ b/packages/shared-ui/src/elements/shell/header.ts
@@ -630,7 +630,7 @@ export class VEHeader extends LitElement {
   #renderUser() {
     if (
       !this.signinAdapter ||
-      this.signinAdapter.state !== "valid" ||
+      this.signinAdapter.state !== "signedin" ||
       !this.signinAdapter.picture
     ) {
       return nothing;

--- a/packages/shared-ui/src/flow-gen/app-catalyst.ts
+++ b/packages/shared-ui/src/flow-gen/app-catalyst.ts
@@ -45,7 +45,7 @@ export class AppCatalystApiClient {
   async chat(
     request: AppCatalystChatRequest
   ): Promise<AppCatalystChatResponse> {
-    const token = await this.#signinAdapter.refresh();
+    const token = await this.#signinAdapter.token();
     if (token?.state !== "valid") {
       throw new Error(`Expected "valid" token, got "${token?.state}"`);
     }
@@ -63,7 +63,7 @@ export class AppCatalystApiClient {
   }
 
   async checkTos(): Promise<CheckAppAccessResponse> {
-    const token = await this.#signinAdapter.refresh();
+    const token = await this.#signinAdapter.token();
     if (token?.state !== "valid") {
       throw new Error(`Expected "valid" token, got "${token?.state}"`);
     }
@@ -88,7 +88,7 @@ export class AppCatalystApiClient {
   }
 
   async acceptTos(tosVersion: number = 1, acceptTos = false): Promise<void> {
-    const token = await this.#signinAdapter.refresh();
+    const token = await this.#signinAdapter.token();
     if (token?.state !== "valid") {
       throw new Error(`Expected "valid" token, got "${token?.state}"`);
     }

--- a/packages/shared-ui/src/types/types.ts
+++ b/packages/shared-ui/src/types/types.ts
@@ -42,7 +42,7 @@ import type {
   tsLinter,
   tsSync,
 } from "@valtown/codemirror-ts";
-import { SigninState } from "../utils/signin-adapter";
+import { SigninAdapterState } from "../utils/signin-adapter";
 import { LitElement } from "lit";
 
 export const enum HistoryEventType {
@@ -568,7 +568,7 @@ export interface AppTemplateOptions {
 }
 
 export interface AppTemplate extends LitElement {
-  state: SigninState | null;
+  state: SigninAdapterState["status"] | null;
   options: AppTemplateOptions;
   graph: GraphDescriptor | null;
   additionalOptions: AppTemplateAdditionalOptionsAvailable;

--- a/packages/shared-ui/src/utils/signin-adapter.ts
+++ b/packages/shared-ui/src/utils/signin-adapter.ts
@@ -34,7 +34,6 @@ export type SigninAdapterState =
       status: "signedin";
       id: string | undefined;
       name: string | undefined;
-      /** Picture URL */
       picture: string | undefined;
     };
 
@@ -53,7 +52,6 @@ class SigninAdapter {
   readonly #tokenVendor: TokenVendor;
   readonly #environment: Environment;
   readonly #settingsHelper: SettingsHelper;
-  #cachedPicture: string | null | undefined;
   #nonce = crypto.randomUUID();
   #state: SigninAdapterState;
 
@@ -100,37 +98,6 @@ class SigninAdapter {
 
   get picture() {
     return this.#state.status === "signedin" ? this.#state.picture : undefined;
-  }
-
-  async cachedPicture(): Promise<string | undefined> {
-    if (
-      this.#cachedPicture === undefined &&
-      this.#state.status === "signedin" &&
-      this.#state.picture
-    ) {
-      try {
-        const token = await this.token();
-        if (token.state === "signedout") {
-          this.#cachedPicture = null;
-          return;
-        }
-        const picture = await fetch(this.#state.picture, {
-          headers: {
-            Authorization: `Bearer ${token.grant.access_token}`,
-          },
-        });
-        if (!picture.ok) {
-          this.#cachedPicture = null;
-          return;
-        }
-        const blobURL = URL.createObjectURL(await picture.blob());
-        return blobURL;
-      } catch (e) {
-        console.warn(e);
-        this.#cachedPicture = null;
-      }
-    }
-    return this.#cachedPicture || undefined;
   }
 
   /**

--- a/packages/shared-ui/src/utils/signin-adapter.ts
+++ b/packages/shared-ui/src/utils/signin-adapter.ts
@@ -64,8 +64,7 @@ class SigninAdapter {
   constructor(
     tokenVendor: TokenVendor,
     environment: Environment,
-    settingsHelper: SettingsHelper,
-    public readonly errorMessage?: string
+    settingsHelper: SettingsHelper
   ) {
     this.#tokenVendor = tokenVendor;
     this.#environment = environment;

--- a/packages/shared-ui/src/utils/signin-adapter.ts
+++ b/packages/shared-ui/src/utils/signin-adapter.ts
@@ -178,18 +178,13 @@ class SigninAdapter {
 
   async signIn(): Promise<{ ok: true } | { ok: false; error: string }> {
     const now = Date.now();
-    const nonce = this.#nonce;
-    // Reset the nonce in case the user signs out and signs back in again, since
-    // we don't want to ever mix up different requests.
-    setTimeout(
-      // TODO(aomarks) This shouldn't be necessary, what's up?
-      () => (this.#nonce = crypto.randomUUID()),
-      500
-    );
     // The OAuth broker page will know to broadcast the token on this unique
     // channel because it also knows the nonce (since we pack that in the OAuth
     // "state" parameter).
-    const channelName = oauthTokenBroadcastChannelName(nonce);
+    const channelName = oauthTokenBroadcastChannelName(this.#nonce);
+    // Reset the nonce in case the user signs out and signs back in again, since
+    // we don't want to ever mix up different requests.
+    this.#nonce = crypto.randomUUID();
     const channel = new BroadcastChannel(channelName);
     const grantResponse = await new Promise<GrantResponse>((resolve) => {
       channel.addEventListener("message", (m) => resolve(m.data), {

--- a/packages/shared-ui/src/utils/signin-adapter.ts
+++ b/packages/shared-ui/src/utils/signin-adapter.ts
@@ -53,7 +53,10 @@ class SigninAdapter {
 
   #nonce = crypto.randomUUID();
 
-  readonly state: SigninState;
+  #state: SigninState;
+  get state() {
+    return this.#state;
+  }
   readonly picture?: string;
   readonly id?: string;
   readonly name?: string;
@@ -69,18 +72,18 @@ class SigninAdapter {
     this.#settingsHelper = settingsHelper;
 
     if (!environment.requiresSignin) {
-      this.state = "anonymous";
+      this.#state = "anonymous";
       return;
     }
     const token = tokenVendor.getToken(SIGN_IN_CONNECTION_ID);
     const { state } = token;
     if (state === "signedout") {
-      this.state = "signedout";
+      this.#state = "signedout";
       return;
     }
     const { grant } = token;
 
-    this.state = "signedin";
+    this.#state = "signedin";
     this.picture = grant.picture;
     this.id = grant.id;
     this.name = grant.name;
@@ -227,12 +230,12 @@ class SigninAdapter {
     return { ok: true };
   }
 
-  async signout(signoutCallback: () => void) {
+  async signOut(): Promise<void> {
     const connection = await this.#getConnection();
     if (!connection) {
       return;
     }
     await this.#settingsHelper.delete(SETTINGS_TYPE.CONNECTIONS, connection.id);
-    signoutCallback();
+    this.#state = "signedout";
   }
 }

--- a/packages/shared-ui/src/utils/signin-adapter.ts
+++ b/packages/shared-ui/src/utils/signin-adapter.ts
@@ -93,7 +93,7 @@ class SigninAdapter {
   async cachedPicture(): Promise<string | undefined> {
     if (SigninAdapter.#cachedPicture === undefined && this.picture) {
       try {
-        const token = await this.refresh();
+        const token = await this.token();
         if (token.state === "signedout") {
           SigninAdapter.#cachedPicture = null;
           return;
@@ -121,7 +121,7 @@ class SigninAdapter {
    * Gets you a token, refreshing automatically if needed, unless the user is
    * signed out.
    */
-  async refresh(): Promise<ValidTokenResult | SignedOutTokenResult> {
+  async token(): Promise<ValidTokenResult | SignedOutTokenResult> {
     const token = this.#tokenVendor.getToken(SIGN_IN_CONNECTION_ID);
     if (token.state === "expired") {
       return token.refresh();

--- a/packages/shared-ui/src/utils/signin-adapter.ts
+++ b/packages/shared-ui/src/utils/signin-adapter.ts
@@ -81,15 +81,15 @@ class SigninAdapter {
     const { grant } = token;
 
     this.state = "signedin";
-    this.picture = grant?.picture;
-    this.id = grant?.id;
-    this.name = grant?.name;
+    this.picture = grant.picture;
+    this.id = grant.id;
+    this.name = grant.name;
   }
 
   accessToken(): string | null {
     if (this.state === "signedin") {
       const token = this.#tokenVendor.getToken(SIGN_IN_CONNECTION_ID);
-      if (token?.state === "valid") {
+      if (token.state === "valid") {
         return token.grant.access_token;
       }
     }
@@ -125,7 +125,7 @@ class SigninAdapter {
 
   async refresh() {
     const token = this.#tokenVendor.getToken(SIGN_IN_CONNECTION_ID);
-    if (token?.state === "expired") {
+    if (token.state === "expired") {
       return token.refresh();
     }
     return token;
@@ -142,7 +142,7 @@ class SigninAdapter {
       return;
     }
     const list = (await httpRes.json()) as ListConnectionsResponse;
-    const connection = list.connections?.find(
+    const connection = list.connections.find(
       (connection) => connection.id == SIGN_IN_CONNECTION_ID
     );
     if (!connection) {

--- a/packages/shared-ui/src/utils/signin-adapter.ts
+++ b/packages/shared-ui/src/utils/signin-adapter.ts
@@ -48,7 +48,7 @@ export const signinAdapterContext = createContext<SigninAdapter | undefined>(
  * settingsHelper are present.
  */
 class SigninAdapter {
-  static #cachedPicture: string | null | undefined;
+  #cachedPicture: string | null | undefined;
   readonly #tokenVendor: TokenVendor;
   readonly #environment: Environment;
   readonly #settingsHelper: SettingsHelper;
@@ -91,11 +91,11 @@ class SigninAdapter {
   }
 
   async cachedPicture(): Promise<string | undefined> {
-    if (SigninAdapter.#cachedPicture === undefined && this.picture) {
+    if (this.#cachedPicture === undefined && this.picture) {
       try {
         const token = await this.token();
         if (token.state === "signedout") {
-          SigninAdapter.#cachedPicture = null;
+          this.#cachedPicture = null;
           return;
         }
         const picture = await fetch(this.picture, {
@@ -104,17 +104,17 @@ class SigninAdapter {
           },
         });
         if (!picture.ok) {
-          SigninAdapter.#cachedPicture = null;
+          this.#cachedPicture = null;
           return;
         }
         const blobURL = URL.createObjectURL(await picture.blob());
         return blobURL;
       } catch (e) {
         console.warn(e);
-        SigninAdapter.#cachedPicture = null;
+        this.#cachedPicture = null;
       }
     }
-    return SigninAdapter.#cachedPicture || undefined;
+    return this.#cachedPicture || undefined;
   }
 
   /**

--- a/packages/shared-ui/src/utils/signin-adapter.ts
+++ b/packages/shared-ui/src/utils/signin-adapter.ts
@@ -30,9 +30,9 @@ export const SIGN_IN_CONNECTION_ID = "$sign-in";
  * - "anonymous" -- the runtime is not configured to use the sign in.
  * - "signedout" -- the user is not yet signed in or has signed out, but the
  *                  runtime is configured to use sign in.
- * - "valid" -- the user is currently signed in.
+ * - "signedin" -- the user is currently signed in.
  */
-export type SigninState = "signedout" | "valid" | "anonymous";
+export type SigninState = "signedout" | "signedin" | "anonymous";
 
 export const signinAdapterContext = createContext<SigninAdapter | undefined>(
   "SigninAdapter"
@@ -80,14 +80,14 @@ class SigninAdapter {
     }
     const { grant } = token;
 
-    this.state = "valid";
+    this.state = "signedin";
     this.picture = grant?.picture;
     this.id = grant?.id;
     this.name = grant?.name;
   }
 
   accessToken(): string | null {
-    if (this.state === "valid") {
+    if (this.state === "signedin") {
       const token = this.#tokenVendor.getToken(SIGN_IN_CONNECTION_ID);
       if (token?.state === "valid") {
         return token.grant.access_token;

--- a/packages/shared-ui/src/utils/signin-adapter.ts
+++ b/packages/shared-ui/src/utils/signin-adapter.ts
@@ -88,16 +88,6 @@ class SigninAdapter {
     this.name = grant.name;
   }
 
-  accessToken(): string | null {
-    if (this.state === "signedin") {
-      const token = this.#tokenVendor.getToken(SIGN_IN_CONNECTION_ID);
-      if (token.state === "valid") {
-        return token.grant.access_token;
-      }
-    }
-    return null;
-  }
-
   async cachedPicture(): Promise<string | undefined> {
     if (SigninAdapter.#cachedPicture === undefined && this.picture) {
       try {

--- a/packages/shared-ui/src/utils/signin-adapter.ts
+++ b/packages/shared-ui/src/utils/signin-adapter.ts
@@ -8,8 +8,10 @@ import {
   Connection,
   GrantResponse,
   ListConnectionsResponse,
+  SignedOutTokenResult,
   TokenGrant,
   TokenVendor,
+  ValidTokenResult,
 } from "@breadboard-ai/connection-client";
 import { Environment } from "../contexts/environment";
 import {
@@ -92,7 +94,7 @@ class SigninAdapter {
     if (SigninAdapter.#cachedPicture === undefined && this.picture) {
       try {
         const token = await this.refresh();
-        if (!token || token.state === "signedout") {
+        if (token.state === "signedout") {
           SigninAdapter.#cachedPicture = null;
           return;
         }
@@ -115,7 +117,11 @@ class SigninAdapter {
     return SigninAdapter.#cachedPicture || undefined;
   }
 
-  async refresh() {
+  /**
+   * Gets you a token, refreshing automatically if needed, unless the user is
+   * signed out.
+   */
+  async refresh(): Promise<ValidTokenResult | SignedOutTokenResult> {
     const token = this.#tokenVendor.getToken(SIGN_IN_CONNECTION_ID);
     if (token.state === "expired") {
       return token.refresh();

--- a/packages/shared-ui/src/utils/signin-adapter.ts
+++ b/packages/shared-ui/src/utils/signin-adapter.ts
@@ -85,10 +85,6 @@ class SigninAdapter {
       return;
     }
     const { grant } = token;
-    if (!grant) {
-      this.state = "invalid";
-      return;
-    }
 
     this.state = "valid";
     this.picture = grant?.picture;
@@ -99,7 +95,9 @@ class SigninAdapter {
   accessToken(): string | null {
     if (this.state === "valid") {
       const token = this.#tokenVendor?.getToken(SIGN_IN_CONNECTION_ID);
-      return token?.grant?.access_token || null;
+      if (token?.state === "valid") {
+        return token.grant.access_token;
+      }
     }
     return null;
   }
@@ -108,7 +106,7 @@ class SigninAdapter {
     if (SigninAdapter.#cachedPicture === undefined && this.picture) {
       try {
         const token = await this.refresh();
-        if (!token?.grant) {
+        if (!token || token.state === "signedout") {
           SigninAdapter.#cachedPicture = null;
           return;
         }

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -743,21 +743,16 @@ export class Main extends SignalWatcher(LitElement) {
 
             // Check and see if we're being asked for a sign-in key
             if (keys.at(0) === signInKey) {
-              // Yay, we can handle this ourselves.
-              if (this.signinAdapter.state === "signedin") {
-                runner?.run({ [signInKey]: this.signinAdapter.accessToken() });
-              } else {
-                this.signinAdapter.refresh().then((token) => {
-                  if (!runner?.running()) {
-                    runner?.run({
-                      [signInKey]:
-                        token.state === "valid"
-                          ? token.grant.access_token
-                          : undefined,
-                    });
-                  }
-                });
-              }
+              this.signinAdapter.refresh().then((token) => {
+                if (!runner?.running()) {
+                  runner?.run({
+                    [signInKey]:
+                      token.state === "valid"
+                        ? token.grant.access_token
+                        : undefined,
+                  });
+                }
+              });
               return;
             }
 

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -1383,7 +1383,6 @@ export class Main extends SignalWatcher(LitElement) {
 
     if (this.signinAdapter.state === "signedout") {
       return html`<bb-connection-entry-signin
-        .adapter=${this.signinAdapter}
         @bbsignin=${async () => {
           window.location.reload();
         }}

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -2076,16 +2076,12 @@ export class Main extends SignalWatcher(LitElement) {
           return;
         }
 
-        await signinAdapter.signout(() => {
-          this.toast(
-            Strings.from("STATUS_LOGGED_OUT"),
-            BreadboardUI.Events.ToastType.INFORMATION
-          );
-        });
-
-        // Recreating the signin adapter here will trigger a re-render with the
-        // updated state, which will cause us to show the sign-in dialog.
-        this.signinAdapter = this.#createSigninAdapter();
+        await signinAdapter.signOut();
+        this.toast(
+          Strings.from("STATUS_LOGGED_OUT"),
+          BreadboardUI.Events.ToastType.INFORMATION
+        );
+        this.requestUpdate();
       }}
       @bbclose=${() => {
         if (!this.#tab) {

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -314,7 +314,7 @@ export class Main extends SignalWatcher(LitElement) {
       proxyUrl: googleDriveProxyUrl,
       publicApiKey: this.environment.googleDrive.publicApiKey,
       getUserAccessToken: async () => {
-        const token = await this.signinAdapter.refresh();
+        const token = await this.signinAdapter.token();
         if (token?.state === "valid") {
           return token.grant.access_token;
         }
@@ -743,7 +743,7 @@ export class Main extends SignalWatcher(LitElement) {
 
             // Check and see if we're being asked for a sign-in key
             if (keys.at(0) === signInKey) {
-              this.signinAdapter.refresh().then((token) => {
+              this.signinAdapter.token().then((token) => {
                 if (!runner?.running()) {
                   runner?.run({
                     [signInKey]:


### PR DESCRIPTION
- Much stronger types. Remove "invalid" state. Make a bunch of things not possible to be undefined. And a bunch of cleanup that this enabled.
- Improved names (e.g. refresh -> token, valid -> signedin) to prevent overlap with TokenVendor since the semantics were different.
- There is now always exactly one SigninAdapter.
- Replaced callback APIs with promises.
- Removed a bunch of unused code.