### PR TITLE
[cleanup] Replace all usage of GAPI drive API with GoogleDriveClient

### DIFF
--- a/packages/google-drive-kit/src/board-server/operations.ts
+++ b/packages/google-drive-kit/src/board-server/operations.ts
@@ -805,7 +805,7 @@ class DriveOperations {
       return data;
     }
     const fileId = getFileId(sourceHandle);
-    let response = await this.#googleDriveClient.copy(fileId);
+    let response = await this.#googleDriveClient.copyFile(fileId);
     const result: StoredDataCapabilityPart = {
       storedData: {
         handle: "",
@@ -882,7 +882,7 @@ class DriveOperations {
   async publishFile(fileId: string): Promise<gapi.client.drive.Permission[]> {
     return await Promise.all(
       this.#publishPermissions.map((permission) =>
-        this.#googleDriveClient.writePermission(
+        this.#googleDriveClient.createPermission(
           fileId,
           { ...permission, role: "reader" },
           { sendNotificationEmail: false }

--- a/packages/google-drive-kit/src/google-drive-client.ts
+++ b/packages/google-drive-kit/src/google-drive-client.ts
@@ -424,6 +424,33 @@ export class GoogleDriveClient {
     return (await response.json()) as gapi.client.drive.Permission;
   }
 
+  async deletePermission(
+    fileId: string,
+    permissionId: string,
+    options?: BaseRequestOptions
+  ): Promise<void> {
+    const authorization = {
+      kind: "bearer",
+      token: await this.#getUserAccessToken(),
+    } as const;
+    const url = this.#makeUrl(
+      `drive/v3/files/${encodeURIComponent(fileId)}` +
+        `/permissions/${encodeURIComponent(permissionId)}`,
+      authorization
+    );
+    const response = await retryableFetch(url, {
+      method: "DELETE",
+      headers: this.#makeHeaders(authorization),
+      signal: options?.signal,
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Google Drive delete permission ${response.status} error: ` +
+          (await response.text())
+      );
+    }
+  }
+
   /** Returns one of the two types of responses - either from .copy() or from file.get() in case of a public board. */
   async copy(fileId: string): Promise<Response> {
     const authorization = {

--- a/packages/google-drive-kit/src/google-drive-client.ts
+++ b/packages/google-drive-kit/src/google-drive-client.ts
@@ -147,14 +147,14 @@ export class GoogleDriveClient {
         response = new Response(null, { status: 404 });
       } else {
         console.log(
-          `Google Drive getFile proxy ${response.status} error:`,
+          `Google Drive getFileMetadata proxy ${response.status} error:`,
           await proxyResponse.text()
         );
       }
     }
 
     throw new Error(
-      `Google Drive readFile ${response.status} error: ` +
+      `Google Drive getFileMetadata ${response.status} error: ` +
         (await response.text())
     );
   }
@@ -175,7 +175,7 @@ export class GoogleDriveClient {
     });
     if (!response.ok) {
       throw new Error(
-        `Google Drive create file metadata ${response.status} error: ` +
+        `Google Drive createFileMetadata ${response.status} error: ` +
           (await response.text())
       );
     }
@@ -202,7 +202,7 @@ export class GoogleDriveClient {
     });
     if (!response.ok) {
       throw new Error(
-        `Google Drive update metadata ${response.status} error: ` +
+        `Google Drive updateFileMetadata ${response.status} error: ` +
           (await response.text())
       );
     }
@@ -456,7 +456,7 @@ export class GoogleDriveClient {
     });
     if (!response.ok) {
       throw new Error(
-        `Google Drive write permission ${response.status} error: ` +
+        `Google Drive createPermission ${response.status} error: ` +
           (await response.text())
       );
     }
@@ -479,7 +479,7 @@ export class GoogleDriveClient {
     );
     if (!response.ok) {
       throw new Error(
-        `Google Drive delete permission ${response.status} error: ` +
+        `Google Drive deletePermission ${response.status} error: ` +
           (await response.text())
       );
     }

--- a/packages/google-drive-kit/src/google-drive-client.ts
+++ b/packages/google-drive-kit/src/google-drive-client.ts
@@ -159,6 +159,29 @@ export class GoogleDriveClient {
     );
   }
 
+  /** https://developers.google.com/workspace/drive/api/reference/rest/v3/files/create#:~:text=metadata%2Donly */
+  async createFileMetadata<const T extends ReadFileOptions>(
+    file: gapi.client.drive.File & { name: string; mimeType: string },
+    options?: T
+  ): Promise<NarrowedDriveFile<T["fields"]>> {
+    const url = new URL(`drive/v3/files`, this.#apiBaseUrl);
+    if (options?.fields?.length) {
+      url.searchParams.set("fields", options.fields.join(","));
+    }
+    const response = await this.#fetch(url, {
+      method: "POST",
+      body: JSON.stringify(file),
+      signal: options?.signal,
+    });
+    if (!response.ok) {
+      throw new Error(
+        `Google Drive create file metadata ${response.status} error: ` +
+          (await response.text())
+      );
+    }
+    return await response.json();
+  }
+
   /** https://developers.google.com/workspace/drive/api/reference/rest/v3/files/update */
   async updateFileMetadata<const T extends ReadFileOptions>(
     fileId: string,

--- a/packages/google-drive-kit/src/google-drive-client.ts
+++ b/packages/google-drive-kit/src/google-drive-client.ts
@@ -467,34 +467,14 @@ export class GoogleDriveClient {
       kind: "bearer",
       token: await this.#getUserAccessToken(),
     } as const;
-    const response = await this.#copy(fileId, authorization);
-    if (response.status === 404) {
-      // Note it is not possible to suppress the 404 error that will appear in
-      // the console, so this log statement and the similar ones throughout this
-      // file are here to hopefully make this look less concerning.
-      console.log(
-        `Received 404 response for Google Drive file "${fileId}"` +
-          ` using user credentials, trying public fallback.`
-      );
-
-      return this.#getFileMedia(fileId, undefined, {
-        kind: "key",
-        key: this.#publicApiKey,
-      });
-    }
-    return response;
-  }
-
-  async #copy(fileId: string, authorization: GoogleApiAuthorization) {
     const url = this.#makeUrl(
       `drive/v3/files/${encodeURIComponent(fileId)}/copy`,
       authorization
     );
-    const response = await retryableFetch(url, {
+    return retryableFetch(url, {
       method: "POST",
       headers: this.#makeHeaders(authorization),
     });
-    return response;
   }
 
   #makeUrl(path: string, authorization: GoogleApiAuthorization): URL {

--- a/packages/google-drive-kit/src/google-drive-client.ts
+++ b/packages/google-drive-kit/src/google-drive-client.ts
@@ -78,11 +78,12 @@ export class GoogleDriveClient {
     return this.#getUserAccessToken();
   }
 
+  /** https://developers.google.com/workspace/drive/api/reference/rest/v3/files/get#:~:text=metadata */
   async getFileMetadata<const T extends ReadFileOptions>(
     fileId: string,
     options?: T
   ): Promise<NarrowedDriveFile<T["fields"]>> {
-    let response = await this.#getFile(fileId, options, {
+    let response = await this.#getFileMetadata(fileId, options, {
       kind: "bearer",
       token: await this.#getUserAccessToken(),
     });
@@ -91,7 +92,7 @@ export class GoogleDriveClient {
         `Received 404 response for Google Drive file "${fileId}"` +
           ` using user credentials, trying public fallback.`
       );
-      response = await this.#getFile(fileId, options, {
+      response = await this.#getFileMetadata(fileId, options, {
         kind: "key",
         key: this.#publicApiKey,
       });
@@ -148,6 +149,7 @@ export class GoogleDriveClient {
     );
   }
 
+  /** https://developers.google.com/workspace/drive/api/reference/rest/v3/files/update */
   async updateFileMetadata<const T extends ReadFileOptions>(
     fileId: string,
     metadata: gapi.client.drive.File,
@@ -179,7 +181,7 @@ export class GoogleDriveClient {
     return await response.json();
   }
 
-  #getFile(
+  #getFileMetadata(
     fileId: string,
     options: ReadFileOptions | undefined,
     authorization: GoogleApiAuthorization
@@ -197,6 +199,7 @@ export class GoogleDriveClient {
     });
   }
 
+  /** https://developers.google.com/workspace/drive/api/reference/rest/v3/files/get#:~:text=media */
   async getFileMedia(
     fileId: string,
     options?: BaseRequestOptions
@@ -290,6 +293,7 @@ export class GoogleDriveClient {
     });
   }
 
+  /** https://developers.google.com/workspace/drive/api/reference/rest/v3/files/export */
   async exportFile(
     fileId: string,
     options: ExportFileOptions
@@ -378,7 +382,11 @@ export class GoogleDriveClient {
     }
   }
 
-  async readPermissions(
+  /**
+   * Convenience: exactly the same as calling `getFileMetadata` and asking for
+   * only permissions.
+   */
+  async getFilePermissions(
     fileId: string,
     options?: BaseRequestOptions
   ): Promise<gapi.client.drive.Permission[]> {
@@ -392,7 +400,8 @@ export class GoogleDriveClient {
     );
   }
 
-  async writePermission(
+  /** https://developers.google.com/workspace/drive/api/reference/rest/v3/permissions/create */
+  async createPermission(
     fileId: string,
     permission: gapi.client.drive.Permission,
     options: WritePermissionOptions
@@ -424,6 +433,7 @@ export class GoogleDriveClient {
     return (await response.json()) as gapi.client.drive.Permission;
   }
 
+  /** https://developers.google.com/workspace/drive/api/reference/rest/v3/permissions/delete */
   async deletePermission(
     fileId: string,
     permissionId: string,
@@ -451,8 +461,8 @@ export class GoogleDriveClient {
     }
   }
 
-  /** Returns one of the two types of responses - either from .copy() or from file.get() in case of a public board. */
-  async copy(fileId: string): Promise<Response> {
+  /** https://developers.google.com/workspace/drive/api/reference/rest/v3/files/copy */
+  async copyFile(fileId: string): Promise<Response> {
     const authorization = {
       kind: "bearer",
       token: await this.#getUserAccessToken(),

--- a/packages/shared-ui/src/elements/google-drive/google-apis.ts
+++ b/packages/shared-ui/src/elements/google-drive/google-apis.ts
@@ -14,42 +14,10 @@ let gapiPromise: Promise<typeof globalThis.gapi>;
  *
  * See https://github.com/google/google-api-javascript-client/blob/master/docs/reference.md
  */
-export async function loadGapi(): Promise<typeof globalThis.gapi> {
+async function loadGapi(): Promise<typeof globalThis.gapi> {
   return (gapiPromise ??= (async () => {
     await loadNonModuleWithHeadScriptTag("https://apis.google.com/js/api.js");
     return globalThis.gapi;
-  })());
-}
-
-let gapiClientPromise: Promise<typeof globalThis.gapi.client>;
-/**
- * Load the GAPI (Google API) Client library.
- *
- * See https://github.com/google/google-api-javascript-client/blob/master/docs/reference.md
- */
-export async function loadGapiClient(): Promise<typeof globalThis.gapi.client> {
-  return (gapiClientPromise ??= (async () => {
-    const gapi = await loadGapi();
-    await new Promise<void>((resolve) => gapi.load("client", () => resolve()));
-    return globalThis.gapi.client;
-  })());
-}
-
-let driveApiPromise: Promise<typeof globalThis.gapi.client.drive>;
-/**
- * Load the the GAPI (Google API) Drive API.
- *
- * See https://developers.google.com/drive/api/reference/rest/v3
- */
-export async function loadDriveApi(): Promise<
-  typeof globalThis.gapi.client.drive
-> {
-  return (driveApiPromise ??= (async () => {
-    const gapiClient = await loadGapiClient();
-    await gapiClient.load(
-      "https://www.googleapis.com/discovery/v1/apis/drive/v3/rest"
-    );
-    return globalThis.gapi.client.drive;
   })());
 }
 
@@ -63,41 +31,33 @@ export async function loadDrivePicker(): Promise<
   typeof globalThis.google.picker
 > {
   return (drivePickerPromise ??= (async () => {
-    await Promise.all([
-      loadDriveApi(),
-      (async () => {
-        const gapi = await loadGapi();
-        await new Promise((resolve) => gapi.load("picker", resolve));
-      })(),
-    ]);
+    const gapi = await loadGapi();
+    await new Promise((resolve) => gapi.load("picker", resolve));
     return globalThis.google.picker;
   })());
 }
 
-// eslint-disable-next-line @typescript-eslint/no-namespace
-declare namespace gapi.drive.share {
-  class ShareClient {
-    setOAuthToken: (oauthToken: string) => void;
-    setItemIds: (itemIds: string[]) => void;
-    showSettingsDialog: () => void;
-  }
+export interface ShareClient {
+  setOAuthToken: (oauthToken: string) => void;
+  setItemIds: (itemIds: string[]) => void;
+  showSettingsDialog: () => void;
 }
 
-let sharingDialogPromise: Promise<typeof gapi.drive.share>;
+let shareClientPromise: Promise<new () => ShareClient>;
 /**
  * Load the the GAPI (Google API) Drive Sharing Dialog API.
  *
  * See https://developers.google.com/workspace/drive/api/guides/share-button
  */
-export async function loadDriveShare(): Promise<typeof gapi.drive.share> {
-  return (sharingDialogPromise ??= (async () => {
-    await Promise.all([
-      (async () => {
-        const gapi = await loadGapi();
-        await new Promise((resolve) => gapi.load("drive-share", resolve));
-      })(),
-    ]);
-    return gapi.drive.share;
+export async function loadDriveShareClient(): Promise<new () => ShareClient> {
+  return (shareClientPromise ??= (async () => {
+    const gapi = await loadGapi();
+    await new Promise((resolve) => gapi.load("drive-share", resolve));
+    return (
+      gapi as object as {
+        drive: { share: { ShareClient: new () => ShareClient } };
+      }
+    ).drive.share.ShareClient;
   })());
 }
 

--- a/packages/shared-ui/src/elements/google-drive/google-drive-asset-share-dialog.ts
+++ b/packages/shared-ui/src/elements/google-drive/google-drive-asset-share-dialog.ts
@@ -218,7 +218,7 @@ export class GoogleDriveAssetShareDialog extends LitElement {
     for (const [fileId, filePermissions] of permissions) {
       for (const permission of filePermissions) {
         writePromises.push(
-          this.googleDriveClient.writePermission(fileId, permission, {
+          this.googleDriveClient.createPermission(fileId, permission, {
             sendNotificationEmail: false,
           })
         );

--- a/packages/shared-ui/src/elements/google-drive/google-drive-debug-panel.ts
+++ b/packages/shared-ui/src/elements/google-drive/google-drive-debug-panel.ts
@@ -16,11 +16,7 @@ import {
   type SigninAdapter,
   signinAdapterContext,
 } from "../../utils/signin-adapter.js";
-import {
-  loadDriveApi,
-  loadDrivePicker,
-  loadDriveShare,
-} from "./google-apis.js";
+import { loadDrivePicker, loadDriveShare } from "./google-apis.js";
 import { Files } from "@breadboard-ai/google-drive-kit/board-server/api.js";
 import { type GoogleDriveClient } from "@breadboard-ai/google-drive-kit/google-drive-client.js";
 import * as BreadboardUI from "@breadboard-ai/shared-ui";
@@ -438,21 +434,13 @@ export class GoogleDriveDebugPanel extends LitElement {
 
   async #listFolderContentsInConsole() {
     const folderId = this.#fileIdInput.value?.value;
-    if (!folderId) {
+    if (!folderId || !this.googleDriveClient) {
       return;
     }
 
-    const drive = await loadDriveApi();
-    const auth = await this.signinAdapter?.token();
-    if (auth?.state !== "valid") {
-      return;
-    }
-    const { access_token } = auth.grant;
-    const response = await drive.files.list({
-      access_token,
-      q: `"${folderId}" in parents`,
-    });
-    const result = JSON.parse(response.body);
+    const result = await this.googleDriveClient.listFiles(
+      `"${folderId}" in parents`
+    );
     console.log({ result });
   }
 

--- a/packages/shared-ui/src/elements/google-drive/google-drive-debug-panel.ts
+++ b/packages/shared-ui/src/elements/google-drive/google-drive-debug-panel.ts
@@ -16,7 +16,7 @@ import {
   type SigninAdapter,
   signinAdapterContext,
 } from "../../utils/signin-adapter.js";
-import { loadDrivePicker, loadDriveShare } from "./google-apis.js";
+import { loadDrivePicker, loadDriveShareClient } from "./google-apis.js";
 import { Files } from "@breadboard-ai/google-drive-kit/board-server/api.js";
 import { type GoogleDriveClient } from "@breadboard-ai/google-drive-kit/google-drive-client.js";
 import * as BreadboardUI from "@breadboard-ai/shared-ui";
@@ -420,12 +420,12 @@ export class GoogleDriveDebugPanel extends LitElement {
     if (!fileIds) {
       return;
     }
-    const driveShare = await loadDriveShare();
+    const ShareClient = await loadDriveShareClient();
     const auth = await this.signinAdapter?.token();
     if (auth?.state !== "valid") {
       return;
     }
-    const client = new driveShare.ShareClient();
+    const client = new ShareClient();
     client.setOAuthToken(auth.grant.access_token);
     const itemIds = fileIds.split(",");
     client.setItemIds(itemIds);

--- a/packages/shared-ui/src/elements/google-drive/google-drive-share-panel.ts
+++ b/packages/shared-ui/src/elements/google-drive/google-drive-share-panel.ts
@@ -11,14 +11,7 @@ import {
   type SigninAdapter,
   signinAdapterContext,
 } from "../../utils/signin-adapter.js";
-import { loadDriveShare } from "./google-apis.js";
-
-// Silly dynamic type expression because "gapi.drive.share.ShareClient" doesn't
-// resolve for some reason, even though it's declared in a namespace statement
-// in "./google-apis.js".
-type ShareClient = InstanceType<
-  Awaited<ReturnType<typeof loadDriveShare>>["ShareClient"]
->;
+import { type ShareClient, loadDriveShareClient } from "./google-apis.js";
 
 // We want only one ShareClient to ever exist globally, and only one user of it
 // at a time, because it is stateful. Each instance of ShareClient dumps a bunch
@@ -72,8 +65,8 @@ export class GoogleDriveSharePanel extends LitElement {
     this.#status = "opening";
     globalShareClientLocked = true;
     if (!globalShareClient) {
-      const shareLib = await loadDriveShare();
-      globalShareClient = new shareLib.ShareClient();
+      const ShareClient = await loadDriveShareClient();
+      globalShareClient = new ShareClient();
     }
 
     globalShareClient.setItemIds(fileIds);

--- a/packages/shared-ui/src/elements/share-panel/share-panel.ts
+++ b/packages/shared-ui/src/elements/share-panel/share-panel.ts
@@ -875,7 +875,7 @@ export class SharePanel extends LitElement {
 
     const graphPublishResponsesPromise = Promise.all(
       publishPermissions.map((permission) =>
-        googleDriveClient.writePermission(
+        googleDriveClient.createPermission(
           shareableFile.id,
           { ...permission, role: "reader" },
           { sendNotificationEmail: false }
@@ -920,7 +920,7 @@ export class SharePanel extends LitElement {
         if (metadata.capabilities.canShare) {
           await Promise.all(
             permissions.map((permission) =>
-              googleDriveClient.writePermission(
+              googleDriveClient.createPermission(
                 assetFileId,
                 { ...permission, role: "reader" },
                 { sendNotificationEmail: false }

--- a/packages/shared-ui/src/elements/share-panel/share-panel.ts
+++ b/packages/shared-ui/src/elements/share-panel/share-panel.ts
@@ -449,6 +449,9 @@ export class SharePanel extends LitElement {
     if (oldState.status !== "writable" || !oldState.shareableFile) {
       return;
     }
+    if (!this.googleDriveClient) {
+      throw new Error(`No google drive client provided`);
+    }
     if (!this.boardServer) {
       throw new Error(`No board server provided`);
     }
@@ -470,11 +473,6 @@ export class SharePanel extends LitElement {
     const updatedShareableGraph = structuredClone(this.graph);
     delete updatedShareableGraph["url"];
 
-    const [driveApi, token] = await Promise.all([
-      loadDriveApi(),
-      this.#getAccessToken(),
-    ]);
-
     await Promise.all([
       // Update the contents of the shareable copy.
       this.boardServer.ops.writeGraphToDrive(
@@ -482,14 +480,9 @@ export class SharePanel extends LitElement {
         updatedShareableGraph
       ),
       // Update the latest version property on the main file.
-      // TODO(aomarks) Add GoogleDriveClient.updateFileMetadata
-      driveApi.files.update({
-        access_token: token,
-        fileId: oldState.shareableFile.id,
-        resource: {
-          properties: {
-            [LATEST_SHARED_VERSION_PROPERTY]: oldState.latestVersion,
-          },
+      this.googleDriveClient.updateFileMetadata(oldState.shareableFile.id, {
+        properties: {
+          [LATEST_SHARED_VERSION_PROPERTY]: oldState.latestVersion,
         },
       }),
       // Ensure all assets have the same permissions as the shareable file,
@@ -1031,6 +1024,9 @@ export class SharePanel extends LitElement {
     shareableCopyFileId: string;
     newMainVersion: string;
   }> {
+    if (!this.googleDriveClient) {
+      throw new Error(`No google drive client provided`);
+    }
     if (!this.boardServer) {
       throw new Error(`No board server provided`);
     }
@@ -1072,36 +1068,21 @@ export class SharePanel extends LitElement {
       throw new Error(`Error creating shareable file`);
     }
 
-    const [driveApi, token] = await Promise.all([
-      loadDriveApi(),
-      this.#getAccessToken(),
-    ]);
-
-    // TODO(aomarks) Add GoogleDriveClient.updateFileMetadata
-    const updateMainResponse = await driveApi.files.update({
-      access_token: token,
-      fileId: mainFileId,
-      resource: {
+    // Update the latest version property on the main file.
+    const updateMainResult = await this.googleDriveClient.updateFileMetadata(
+      mainFileId,
+      {
         properties: {
           [MAIN_TO_SHAREABLE_COPY_PROPERTY]: shareableCopyFileId,
         },
       },
-      fields: "version",
-    });
-    const updateMainResult = JSON.parse(updateMainResponse.body) as Required<
-      Pick<gapi.client.drive.File, "version">
-    >;
-
-    // TODO(aomarks) Add GoogleDriveClient.updateFileMetadata
-    await driveApi.files.update({
-      access_token: token,
-      fileId: shareableCopyFileId,
-      resource: {
-        properties: {
-          [SHAREABLE_COPY_TO_MAIN_PROPERTY]: mainFileId,
-          [LATEST_SHARED_VERSION_PROPERTY]: updateMainResult.version,
-          [IS_SHAREABLE_COPY_PROPERTY]: "true",
-        },
+      { fields: ["version"] }
+    );
+    await this.googleDriveClient.updateFileMetadata(shareableCopyFileId, {
+      properties: {
+        [SHAREABLE_COPY_TO_MAIN_PROPERTY]: mainFileId,
+        [LATEST_SHARED_VERSION_PROPERTY]: updateMainResult.version,
+        [IS_SHAREABLE_COPY_PROPERTY]: "true",
       },
     });
 

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -2197,12 +2197,12 @@ export class Main extends SignalWatcher(LitElement) {
         async (assetFileId) =>
           [
             assetFileId,
-            await googleDriveClient.readPermissions(assetFileId),
+            await googleDriveClient.getFilePermissions(assetFileId),
           ] as const
       )
     );
     const processedGraphPermissions = (
-      await googleDriveClient.readPermissions(graphFileId)
+      await googleDriveClient.getFilePermissions(graphFileId)
     )
       .filter(
         (permission) =>


### PR DESCRIPTION
- New GoogleDriveClient methods: updateFileMetadata, deletePermission, listFiles
- Some renaming/cleanup/refactoring/documenting of GoogleDriveClient
- This should slightly improve reliability of publishing, since this gives us retry logic in some places we didn't have it before
- Completely removes usage of the GAPI drive API in favor of our own better API