### PR TITLE
[cleanup] Tighten up main initialization

### DIFF
--- a/packages/shared-ui/src/data/settings-store.ts
+++ b/packages/shared-ui/src/data/settings-store.ts
@@ -13,12 +13,13 @@ const SETTINGS_NAME = "settings";
 const SETTINGS_VERSION = 7;
 
 export class SettingsStore implements BreadboardUI_Types.SettingsStore {
-  static #instance: SettingsStore;
-  static instance() {
-    if (!this.#instance) {
-      this.#instance = new SettingsStore();
-    }
-    return this.#instance;
+  static #instance: Promise<SettingsStore>;
+  static restoredInstance(): Promise<SettingsStore> {
+    return (this.#instance ??= (async () => {
+      const instance = new SettingsStore();
+      await instance.restore();
+      return instance;
+    })());
   }
 
   #settings: BreadboardUI_Types.Settings = {

--- a/packages/visual-editor/src/bootstrap.ts
+++ b/packages/visual-editor/src/bootstrap.ts
@@ -58,10 +58,10 @@ async function bootstrap(bootstrapArgs: BootstrapArguments) {
 
   await StringsHelper.initFrom(LANGUAGE_PACK as LanguagePack);
 
-  const { Main } = await import("./index.js");
-  const { SettingsStore } = await import(
-    "@breadboard-ai/shared-ui/data/settings-store.js"
-  );
+  const [{ Main }, { SettingsStore }] = await Promise.all([
+    import("./index.js"),
+    import("@breadboard-ai/shared-ui/data/settings-store.js"),
+  ]);
 
   const mainArgs: MainArguments = {
     settings: await SettingsStore.restoredInstance(),

--- a/packages/visual-editor/src/bootstrap.ts
+++ b/packages/visual-editor/src/bootstrap.ts
@@ -64,7 +64,7 @@ async function bootstrap(bootstrapArgs: BootstrapArguments) {
   );
 
   const mainArgs: MainArguments = {
-    settings: SettingsStore.instance(),
+    settings: await SettingsStore.restoredInstance(),
     buildInfo: {
       packageJsonVersion: pkg.version,
       gitCommitHash: GIT_HASH,

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -361,12 +361,6 @@ export class Main extends SignalWatcher(LitElement) {
   }
 
   async #init(args: MainArguments) {
-    let settingsRestore = Promise.resolve();
-
-    settingsRestore = this.#settings.restore();
-
-    await settingsRestore;
-
     this.#fileSystem = createFileSystem({
       env: [...envFromSettings(this.#settings), ...(args.env || [])],
       local: createFileSystemBackend(createEphemeralBlobStore()),

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -182,20 +182,20 @@ export class Main extends SignalWatcher(LitElement) {
   readonly #feedbackPanelRef: Ref<BreadboardUI.Elements.FeedbackPanel> =
     createRef();
 
-  #boardRunStatus = new Map<TabId, BreadboardUI.Types.STATUS>();
-  #boardServers: BoardServer[];
-  #onShowTooltipBound = this.#onShowTooltip.bind(this);
-  #hideTooltipBound = this.#hideTooltip.bind(this);
-  #onKeyboardShortCut = this.#onKeyboardShortcut.bind(this);
-  #recentBoardStore = RecentBoardStore.instance();
+  readonly #boardRunStatus = new Map<TabId, BreadboardUI.Types.STATUS>();
+  #boardServers: BoardServer[] = [];
+  readonly #onShowTooltipBound = this.#onShowTooltip.bind(this);
+  readonly #hideTooltipBound = this.#hideTooltip.bind(this);
+  readonly #onKeyboardShortCut = this.#onKeyboardShortcut.bind(this);
+  readonly #recentBoardStore = RecentBoardStore.instance();
   #graphStore!: MutableGraphStore;
-  #runStore = getRunStore();
-  #fileSystem!: FileSystem;
+  readonly #runStore = getRunStore();
+  readonly #fileSystem: FileSystem;
   #selectionState: WorkspaceSelectionStateWithChangeId | null = null;
   #lastVisualChangeId: WorkspaceVisualChangeId | null = null;
-  #lastPointerPosition = { x: 0, y: 0 };
+  readonly #lastPointerPosition = { x: 0, y: 0 };
   #runtime!: Runtime.RuntimeInstance;
-  #embedHandler?: EmbedHandler;
+  readonly #embedHandler?: EmbedHandler;
 
   /**
    * Monotonically increases whenever the graph topology of a graph in the
@@ -308,7 +308,11 @@ export class Main extends SignalWatcher(LitElement) {
       },
     });
 
-    this.#boardServers = [];
+    this.#fileSystem = createFileSystem({
+      env: [...envFromSettings(this.#settings), ...(args.env || [])],
+      local: createFileSystemBackend(createEphemeralBlobStore()),
+    });
+
     this.#embedHandler = args.embedHandler;
 
     this.#init(args).then(() => {
@@ -361,11 +365,6 @@ export class Main extends SignalWatcher(LitElement) {
   }
 
   async #init(args: MainArguments) {
-    this.#fileSystem = createFileSystem({
-      env: [...envFromSettings(this.#settings), ...(args.env || [])],
-      local: createFileSystemBackend(createEphemeralBlobStore()),
-    });
-
     this.#runtime = await Runtime.create({
       recentBoardStore: this.#recentBoardStore,
       graphStore: this.#graphStore,

--- a/packages/visual-editor/src/types/types.ts
+++ b/packages/visual-editor/src/types/types.ts
@@ -49,7 +49,7 @@ export type BootstrapArguments = {
 };
 
 export type MainArguments = {
-  settings?: SettingsStore;
+  settings: SettingsStore;
   proxy?: HarnessProxyConfig[];
   buildInfo: BuildInfo;
   languagePack?: string;


### PR DESCRIPTION
- Make settings and some other things guaranteed to exist so that we're not unnecessarily checking for them.
- Make settings guaranteed to be initialized at all times.
- Move a bunch of initialization from `async init` into the constructor so we don't have to do any casting for them.
- Load some bootstrap modules in parallel.