### PR TITLE
Show a message if the user should be on a different deployment

### DIFF
--- a/packages/shared-ui/src/elements/toast/snackbar.ts
+++ b/packages/shared-ui/src/elements/toast/snackbar.ts
@@ -82,6 +82,15 @@ export class Snackbar extends LitElement {
         color: var(--text-color);
         flex: 1 1 auto;
         margin-right: var(--bb-grid-size-11);
+        a,
+        a:visited {
+          color: var(--bb-ui-600);
+          text-decoration: none;
+          &:hover {
+            color: var(--bb-ui-500);
+            text-decoration: underline;
+          }
+        }
       }
 
       #actions {

--- a/packages/shared-ui/src/types/types.ts
+++ b/packages/shared-ui/src/types/types.ts
@@ -43,7 +43,7 @@ import type {
   tsSync,
 } from "@valtown/codemirror-ts";
 import { SigninAdapterState } from "../utils/signin-adapter";
-import { LitElement } from "lit";
+import { HTMLTemplateResult, LitElement } from "lit";
 
 export const enum HistoryEventType {
   DONE = "done",
@@ -632,7 +632,7 @@ export type SnackbarMessage = {
   id: SnackbarUUID;
   type: SnackType;
   persistent: boolean;
-  message: string;
+  message: string | HTMLTemplateResult;
   actions?: SnackbarAction[];
 };
 

--- a/packages/types/src/deployment-configuration.ts
+++ b/packages/types/src/deployment-configuration.ts
@@ -14,8 +14,17 @@ export type ClientDeploymentConfiguration = {
   ENABLE_GOOGLE_FEEDBACK?: boolean;
   GOOGLE_FEEDBACK_PRODUCT_ID?: string;
   GOOGLE_FEEDBACK_BUCKET?: string;
+  domains?: Record<string, DomainConfiguration>;
   flags: RuntimeFlags;
 };
+
+export interface DomainConfiguration {
+  /**
+   * A URL that users from this domain should usually use instead of the current
+   * one.
+   */
+  preferredUrl?: string;
+}
 
 export type ServerDeploymentConfiguration = {
   BACKEND_API_ENDPOINT?: string;

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -1097,7 +1097,7 @@ export class Main extends SignalWatcher(LitElement) {
     replaceAll = false
   ) {
     if (!this.#snackbarRef.value) {
-      console.error(`snackbar was not ready yet`);
+      console.error(`snackbar was not ready yet`, message);
       return;
     }
 

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -17,7 +17,7 @@ import type {
 import { createRef, ref, type Ref } from "lit/directives/ref.js";
 import { map } from "lit/directives/map.js";
 import { customElement, state } from "lit/decorators.js";
-import { LitElement, html, nothing } from "lit";
+import { HTMLTemplateResult, LitElement, html, nothing } from "lit";
 import {
   createRunObserver,
   GraphDescriptor,
@@ -1050,7 +1050,7 @@ export class Main extends SignalWatcher(LitElement) {
   }
 
   snackbar(
-    message: string,
+    message: string | HTMLTemplateResult,
     type: BreadboardUI.Types.SnackType,
     actions: BreadboardUI.Types.SnackbarAction[] = [],
     persistent = false,
@@ -1058,6 +1058,7 @@ export class Main extends SignalWatcher(LitElement) {
     replaceAll = false
   ) {
     if (!this.#snackbarRef.value) {
+      console.error(`snackbar was not ready yet`);
       return;
     }
 

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -17,13 +17,7 @@ import type {
 import { createRef, ref, type Ref } from "lit/directives/ref.js";
 import { map } from "lit/directives/map.js";
 import { customElement, state } from "lit/decorators.js";
-import {
-  HTMLTemplateResult,
-  LitElement,
-  PropertyValues,
-  html,
-  nothing,
-} from "lit";
+import { HTMLTemplateResult, LitElement, html, nothing } from "lit";
 import {
   createRunObserver,
   GraphDescriptor,

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -17,7 +17,13 @@ import type {
 import { createRef, ref, type Ref } from "lit/directives/ref.js";
 import { map } from "lit/directives/map.js";
 import { customElement, state } from "lit/decorators.js";
-import { HTMLTemplateResult, LitElement, html, nothing } from "lit";
+import {
+  HTMLTemplateResult,
+  LitElement,
+  PropertyValues,
+  html,
+  nothing,
+} from "lit";
 import {
   createRunObserver,
   GraphDescriptor,
@@ -466,6 +472,35 @@ export class Main extends SignalWatcher(LitElement) {
         console.log(`Connected to server`);
       }
     }
+
+    this.#maybeNotifyAboutPreferredUrlForDomain();
+  }
+
+  async #maybeNotifyAboutPreferredUrlForDomain() {
+    const domain = this.signinAdapter.domain;
+    if (!domain) {
+      return;
+    }
+    const url =
+      this.clientDeploymentConfiguration.domains?.[domain].preferredUrl;
+    if (!url) {
+      return;
+    }
+    for (let i = 0; !this.#snackbarRef.value && i < 5; i++) {
+      // It's tricky to know when the snackbar is going to be available.
+      // Possibly the snackbar should be a service that is always available, so
+      // that messages can be queued independent of rendering.
+      await this.updateComplete;
+    }
+    this.snackbar(
+      html`
+        Users from ${domain} should prefer
+        <a href="${url}">${new URL(url).hostname}</a>
+      `,
+      BreadboardUI.Types.SnackType.WARNING,
+      [],
+      true
+    );
   }
 
   #addRuntimeEventHandlers() {
@@ -798,6 +833,7 @@ export class Main extends SignalWatcher(LitElement) {
           }
 
           if (urlWithoutMode) {
+            let timeoutExpired = false;
             const loadingTimeout = setTimeout(() => {
               this.snackbar(
                 Strings.from("STATUS_GENERIC_LOADING"),
@@ -807,6 +843,7 @@ export class Main extends SignalWatcher(LitElement) {
                 evt.id,
                 true
               );
+              timeoutExpired = true;
             }, LOADING_TIMEOUT);
 
             this.#uiState.loadState = "Loading";
@@ -822,7 +859,9 @@ export class Main extends SignalWatcher(LitElement) {
               evt.resultsFileId
             );
             clearTimeout(loadingTimeout);
-            this.unsnackbar();
+            if (timeoutExpired) {
+              this.unsnackbar();
+            }
           }
         }
       }


### PR DESCRIPTION
- Adds domains[].preferredUrl to ClientDeploymentConfiguration
- When present, show a message to users from the given domain telling them to go to the other url
- Also allows the snackbar to render HTML templates