### PR TITLE
[publishing] Allow disabling publishing for specific domains with notice

### DIFF
--- a/packages/types/src/deployment-configuration.ts
+++ b/packages/types/src/deployment-configuration.ts
@@ -20,10 +20,17 @@ export type ClientDeploymentConfiguration = {
 
 export interface DomainConfiguration {
   /**
-   * A URL that users from this domain should usually use instead of the current
-   * one.
+   * If set, a notification will appear telling users from this domain to visit
+   * this other deployment instead of the current one.
    */
   preferredUrl?: string;
+
+  /**
+   * If true, the simple publishing flow will be disabled for users from this
+   * domain. Granular sharing with specific people and groups will still be
+   * available.
+   */
+  disallowPublicPublishing?: boolean;
 }
 
 export type ServerDeploymentConfiguration = {


### PR DESCRIPTION
Adds `disallowPublicPublishing` domain config, and if set disables publishing (granular sharing is still allowed) and shows a notice in the sharing panel.