### PR TITLE
[gdrive] Give names for uploaded assets

### DIFF
--- a/packages/google-drive-kit/src/board-server/operations.ts
+++ b/packages/google-drive-kit/src/board-server/operations.ts
@@ -584,6 +584,7 @@ class DriveOperations {
     let fileId: string | undefined;
     let data: string | undefined;
     let mimeType: string;
+    let name: string | undefined;
     if ("storedData" in part) {
       fileId = part.storedData?.handle;
       // TODO(volodya): Add a check if data actually needs to be updated.
@@ -603,6 +604,7 @@ class DriveOperations {
       fileId = undefined;
       data = part.inlineData.data;
       mimeType = part.inlineData.mimeType;
+      name = part.inlineData.title;
     }
     const blob = b64toBlob(data, mimeType);
     const filePromise = fileId
@@ -615,7 +617,9 @@ class DriveOperations {
     }
     this.#googleDriveClient.updateFileMetadata(
       file.id,
-      {},
+      {
+        name,
+      },
       { addParents: [parent as string] }
     );
     const handle = `${PROTOCOL}/${file.id}`;

--- a/packages/schema/breadboard.schema.json
+++ b/packages/schema/breadboard.schema.json
@@ -535,6 +535,9 @@
 						},
 						"data": {
 							"type": "string"
+						},
+						"title": {
+							"type": "string"
 						}
 					},
 					"required": [

--- a/packages/shared-ui/src/state/organizer.ts
+++ b/packages/shared-ui/src/state/organizer.ts
@@ -11,7 +11,7 @@ import {
   NodeValue,
   ParameterMetadata,
 } from "@breadboard-ai/types";
-import { Outcome } from "@google-labs/breadboard";
+import { isInlineData, Outcome } from "@google-labs/breadboard";
 import {
   ConnectorState,
   GraphAsset,
@@ -42,6 +42,13 @@ class ReactiveOrganizer implements Organizer {
 
   async addGraphAsset(asset: GraphAssetDescriptor): Promise<Outcome<void>> {
     const { data: assetData, metadata, path } = asset;
+    for (const data of assetData) {
+      for (const part of data.parts) {
+        if (isInlineData(part)) {
+          part.inlineData.title = metadata?.title;
+        }
+      }
+    }
     const data = (await this.#project.persistDataParts(assetData)) as NodeValue;
     return this.#project.edit(
       [{ type: "addasset", path, data, metadata }],

--- a/packages/types/src/llm-content.ts
+++ b/packages/types/src/llm-content.ts
@@ -124,5 +124,6 @@ export type InlineDataCapabilityPart = {
   inlineData: {
     mimeType: string;
     data: string;
+    title?: string;
   };
 };


### PR DESCRIPTION
Current abstractions and data-transfomer layer are pretty inflexible and cannot be easily extended to pass supplemental information to drive layer. The best solution IMO is to extend InlineDataPart interface to include the title and use it in gdrive layer.