### PR TITLE
Update embedder logic to work with new landing page.

### DIFF
--- a/packages/unified-server/src/landing/main.ts
+++ b/packages/unified-server/src/landing/main.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Handler } from "@breadboard-ai/embed";
 import {
   type LanguagePack,
   SETTINGS_TYPE,
@@ -53,6 +54,7 @@ async function init() {
     connectionRedirectUrl: "/oauth/",
     requiresSignin: true,
   } as GlobalConfig;
+  const embedHandler = window.self !== window.top ? new Handler() : undefined;
 
   const { SettingsStore } = await import(
     "@breadboard-ai/shared-ui/data/settings-store.js"
@@ -88,6 +90,11 @@ async function init() {
     redirect();
     return;
   }
+  // Inform embedder if not signed in.
+  embedHandler?.sendToEmbedder({
+    type: "home_loaded",
+    isSignedIn: false,
+  });
 
   const StringsHelper = await import("@breadboard-ai/shared-ui/strings");
   await StringsHelper.initFrom(LANGUAGE_PACK as LanguagePack);

--- a/packages/visual-editor/src/bootstrap.ts
+++ b/packages/visual-editor/src/bootstrap.ts
@@ -183,6 +183,12 @@ async function bootstrap(bootstrapArgs: BootstrapArguments) {
         currentUrl.searchParams.get("shared")!
       );
     }
+    if (currentUrl.searchParams.has("oauth_redirect")) {
+      landingRedirectUrl.searchParams.set(
+        "oauth_redirect",
+        currentUrl.searchParams.get("oauth_redirect")!
+      );
+    }
     window.location.href = decodeURIComponent(landingRedirectUrl.href);
     return;
   }


### PR DESCRIPTION
Ensures embedder-breadboard communication works by:
- Persisting `oauth_redirect` search param to new landing page
- Sending `home_loaded` message when not signed in