### PR TITLE
[particles-ui/shared-ui] Handle non-LLMContent conversions

### DIFF
--- a/.changeset/rich-cases-obey.md
+++ b/.changeset/rich-cases-obey.md
@@ -1,0 +1,6 @@
+---
+"@breadboard-ai/particles-ui": patch
+"@breadboard-ai/shared-ui": patch
+---
+
+Handle non-LLMContent conversions

--- a/packages/particles-ui/src/elements/groups/particle-ui-list.ts
+++ b/packages/particles-ui/src/elements/groups/particle-ui-list.ts
@@ -112,9 +112,6 @@ export class ParticleUIList extends SignalWatcher(LitElement) {
 
     const particleGroup = this.group;
     const theme = this.theme;
-    if (particleGroup.group.size === 0) {
-      return nothing;
-    }
 
     return html`<section id="list" class=${classMap(theme.groups.list)}>
       ${this.group.presentation.behaviors.includes("editable")

--- a/packages/shared-ui/src/app-templates/shared/utils/app-screen-to-particles.ts
+++ b/packages/shared-ui/src/app-templates/shared/utils/app-screen-to-particles.ts
@@ -232,10 +232,18 @@ export function appScreenToParticles(
     const behaviors =
       appScreenOutput.schema?.properties?.[name]?.behavior ?? [];
 
-    if (isLLMContent(outputData)) {
-      appendToItems(outputData, group, behaviors);
-    } else if (isLLMContentArray(outputData)) {
-      for (const llmContent of outputData) {
+    let toAppend = outputData;
+    if (typeof outputData === "string") {
+      toAppend = {
+        role: "model",
+        parts: [{ text: outputData }],
+      } satisfies LLMContent;
+    }
+
+    if (isLLMContent(toAppend)) {
+      appendToItems(toAppend, group, behaviors);
+    } else if (isLLMContentArray(toAppend)) {
+      for (const llmContent of toAppend) {
         appendToItems(llmContent, group, behaviors);
       }
     }


### PR DESCRIPTION
It turns out there are times where the run output isn't an LLMContent but is, in fact, text. So we need to wrap that into an LLMContent with a text part so it can be converted to a Particle.