### PR TITLE
[assets] Treat picked files as storedData and add managed metadata boolean

### DIFF
--- a/packages/breadboard/src/editor/operations/change-asset-metadata.ts
+++ b/packages/breadboard/src/editor/operations/change-asset-metadata.ts
@@ -26,7 +26,8 @@ class ChangeAssetMetadata implements EditOperation {
       existing.title === incoming.title &&
       existing.description === incoming.description &&
       existing.type === incoming.type &&
-      existing.subType == incoming.subType
+      existing.subType == incoming.subType &&
+      existing.managed === incoming.managed
     );
   }
 

--- a/packages/breadboard/src/inspector/graph/inspectable-asset.ts
+++ b/packages/breadboard/src/inspector/graph/inspectable-asset.ts
@@ -21,6 +21,7 @@ class InspectableAssetImpl implements InspectableAsset {
   readonly subType: string;
   readonly data: LLMContent[];
   readonly visual: Record<string, unknown>;
+  readonly managed: boolean;
 
   constructor(path: AssetPath, asset: Asset) {
     this.title = asset.metadata?.title || path;
@@ -29,5 +30,6 @@ class InspectableAssetImpl implements InspectableAsset {
     this.subType = asset.metadata?.subType || "";
     this.data = asset.data as LLMContent[];
     this.visual = (asset?.metadata?.visual as Record<string, unknown>) || {};
+    this.managed = asset.metadata?.managed ?? false;
   }
 }

--- a/packages/schema/breadboard.schema.json
+++ b/packages/schema/breadboard.schema.json
@@ -934,6 +934,9 @@
 							}
 						}
 					]
+				},
+				"managed": {
+					"type": "boolean"
 				}
 			},
 			"required": [

--- a/packages/shared-ui/src/elements/share-panel/share-panel.ts
+++ b/packages/shared-ui/src/elements/share-panel/share-panel.ts
@@ -15,7 +15,6 @@ import {
   diffAssetReadPermissions,
   extractGoogleDriveFileId,
   findGoogleDriveAssetsInGraph,
-  isManagedAsset,
   permissionMatchesAnyOf,
   type GoogleDriveAsset,
 } from "@breadboard-ai/google-drive-kit/board-server/utils.js";
@@ -1145,7 +1144,7 @@ export class SharePanel extends LitElement {
     const managedAssets: GoogleDriveAsset[] = [];
     const unmanagedAssets: GoogleDriveAsset[] = [];
     for (const asset of this.#getAssets()) {
-      if (isManagedAsset(asset)) {
+      if (asset.managed) {
         managedAssets.push(asset);
       } else {
         unmanagedAssets.push(asset);

--- a/packages/shared-ui/src/elements/step-editor/editor-controls.ts
+++ b/packages/shared-ui/src/elements/step-editor/editor-controls.ts
@@ -912,6 +912,7 @@ export class EditorControls extends LitElement {
                           path: globalThis.crypto.randomUUID(),
                           type: "file",
                           name: file.name,
+                          managed: true,
                           data: {
                             role: "user",
                             parts: [
@@ -1018,12 +1019,13 @@ export class EditorControls extends LitElement {
                       name: driveFile.preview,
                       type: "content",
                       subType: "gdrive",
+                      managed: false,
                       data: {
                         role: "user",
                         parts: [
                           {
-                            fileData: {
-                              fileUri: driveFile.id,
+                            storedData: {
+                              handle: `drive:/${driveFile.id}`,
                               mimeType: driveFile.mimeType,
                               resourceKey: driveFile.resourceKey,
                             },

--- a/packages/shared-ui/src/elements/step-editor/renderer.ts
+++ b/packages/shared-ui/src/elements/step-editor/renderer.ts
@@ -1401,6 +1401,7 @@ export class Renderer extends LitElement {
           description: graphAsset.description,
           subType: graphAsset.subType,
           visual,
+          managed: graphAsset.managed,
         };
 
         edits.push({

--- a/packages/shared-ui/src/types/types.ts
+++ b/packages/shared-ui/src/types/types.ts
@@ -595,6 +595,7 @@ export interface NewAsset {
   data: LLMContent;
   subType?: string;
   visual?: Record<string, number>;
+  managed?: boolean;
 }
 
 export interface AssetEdge {

--- a/packages/types/src/graph-descriptor.ts
+++ b/packages/types/src/graph-descriptor.ts
@@ -637,6 +637,7 @@ export type AssetMetadata = {
   type: AssetType;
   subType?: string;
   visual?: NodeValue;
+  managed?: boolean;
 };
 
 export type Asset = {

--- a/packages/types/src/inspect.ts
+++ b/packages/types/src/inspect.ts
@@ -403,6 +403,7 @@ export type InspectableAsset = {
   readonly subType: string;
   readonly data: LLMContent[];
   readonly visual: Record<string, unknown>;
+  readonly managed: boolean;
 };
 
 /**

--- a/packages/visual-editor/src/event-routing/asset/asset.ts
+++ b/packages/visual-editor/src/event-routing/asset/asset.ts
@@ -62,6 +62,7 @@ export const AddRoute: EventRoute<"asset.add"> = {
           title: asset.name,
           type: asset.type,
           visual: asset.visual,
+          managed: asset.managed,
         };
 
         if (asset.subType) {


### PR DESCRIPTION
- Drive picked assets are now storedData, instead of fileData, making them consistent with uploaded files and themes.
- Drive picked assets can now be sent to Gemini.
- Drive picked assets will now get copied when remixing/duplicating.
- There is a new "managed" asset metadata boolean to distinguish uploaded from picked assets in sharing.