### PR TITLE
[gemini asset upload] Fix get vs export bug when google workspace mime type is provided

### DIFF
--- a/packages/board-server/src/server/boards/assets-drive.ts
+++ b/packages/board-server/src/server/boards/assets-drive.ts
@@ -126,7 +126,7 @@ export function makeHandleAssetsDriveRequest({
     try {
       let arrayBuffer: ArrayBuffer;
 
-      if (mimeType) {
+      if (mimeType && !mimeType.startsWith("application/vnd.google-apps.")) {
         const gettingMedia = await googleDriveClient.getFileMedia(driveId);
         if (!gettingMedia.ok) {
           serverError(


### PR DESCRIPTION
We weren't passing the mime type of google workspace docs prior to  https://github.com/breadboard-ai/breadboard/pull/6368, and the gemini file upload server was using the absence of a mime type to decide when a file needed to be exported vs downloaded directly.