### PR TITLE
[shared-ui] Prioritize visible floating inputs

### DIFF
--- a/.changeset/eight-snakes-boil.md
+++ b/.changeset/eight-snakes-boil.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/shared-ui": patch
+---
+
+Prioritize visible floating inputs

--- a/packages/shared-ui/src/app-templates/basic/index.ts
+++ b/packages/shared-ui/src/app-templates/basic/index.ts
@@ -12,6 +12,7 @@ import { customElement, property, state } from "lit/decorators.js";
 import {
   AppTemplate,
   AppTemplateOptions,
+  FloatingInputFocusState,
   SnackbarUUID,
   SnackType,
 } from "../../types/types";
@@ -101,6 +102,9 @@ export class Template extends SignalWatcher(LitElement) implements AppTemplate {
 
   @consume({ context: projectRunContext, subscribe: true })
   accessor run: ProjectRun | null = null;
+
+  @property()
+  accessor focusWhenIn: FloatingInputFocusState = ["app"];
 
   @property()
   accessor graph: GraphDescriptor | null = null;
@@ -557,6 +561,7 @@ export class Template extends SignalWatcher(LitElement) implements AppTemplate {
     return html`<bb-floating-input
       .schema=${input.schema}
       .showDisclaimer=${this.showDisclaimer}
+      .focusWhenIn=${this.focusWhenIn}
       @bbresize=${(evt: ResizeEvent) => {
         this.style.setProperty(
           "--input-clearance",

--- a/packages/shared-ui/src/contexts/ui-state.ts
+++ b/packages/shared-ui/src/contexts/ui-state.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createContext } from "@lit/context";
+import { UI } from "../state/types";
+
+/** The current global UI state. */
+export const uiStateContext = createContext<UI>("bb-ui-state");

--- a/packages/shared-ui/src/elements/app-controller/app-controller.ts
+++ b/packages/shared-ui/src/elements/app-controller/app-controller.ts
@@ -17,6 +17,7 @@ import {
   AppTemplate,
   AppTemplateOptions,
   AppTheme,
+  FloatingInputFocusState,
   SettingsStore,
   STATUS,
 } from "../../types/types.js";
@@ -71,6 +72,9 @@ export class AppController extends SignalWatcher(LitElement) {
 
   @property()
   accessor graphTopologyUpdateId = 0;
+
+  @property()
+  accessor focusWhenIn: FloatingInputFocusState = ["app"];
 
   @property()
   accessor isMine = false;
@@ -343,6 +347,7 @@ export class AppController extends SignalWatcher(LitElement) {
       this.#appTemplate.showShareButton = false;
       this.#appTemplate.showContentWarning = !this.isMine;
       this.#appTemplate.isEmpty = this.graphIsEmpty;
+      this.#appTemplate.focusWhenIn = this.focusWhenIn;
     }
 
     return html`

--- a/packages/shared-ui/src/elements/canvas-controller/canvas-controller.ts
+++ b/packages/shared-ui/src/elements/canvas-controller/canvas-controller.ts
@@ -51,7 +51,7 @@ import {
   MAIN_BOARD_ID,
 } from "../../constants/constants.js";
 import { classMap } from "lit/directives/class-map.js";
-import { Project } from "../../state/types.js";
+import { Project, UI } from "../../state/types.js";
 import "../../edit-history/edit-history-panel.js";
 import "../../edit-history/edit-history-overlay.js";
 import {
@@ -79,9 +79,13 @@ const SIDE_ITEM_KEY = "bb-canvas-controller-side-nav-item";
 import "./empty-state.js";
 import { findGoogleDriveAssetsInGraph } from "@breadboard-ai/google-drive-kit/board-server/utils.js";
 import { isEmpty } from "../../utils/utils.js";
+import { uiStateContext } from "../../contexts/ui-state.js";
 
 @customElement("bb-canvas-controller")
 export class CanvasController extends LitElement {
+  @consume({ context: uiStateContext })
+  accessor #uiState!: UI;
+
   @property()
   accessor boardServerKits: Kit[] = [];
 
@@ -168,6 +172,12 @@ export class CanvasController extends LitElement {
       globalThis.localStorage.setItem(SIDE_ITEM_KEY, item);
     } else {
       globalThis.localStorage.removeItem(SIDE_ITEM_KEY);
+    }
+
+    if (item === "app-view") {
+      this.#uiState.editorSection = "preview";
+    } else if (item === "activity") {
+      this.#uiState.editorSection = "console";
     }
   }
   get sideNavItem() {
@@ -504,6 +514,7 @@ export class CanvasController extends LitElement {
             class=${classMap({
               active: this.sideNavItem === "app-view",
             })}
+            .focusWhenIn=${["canvas", "preview"]}
             .graph=${this.graph}
             .graphIsEmpty=${graphIsEmpty}
             .graphTopologyUpdateId=${this.graphTopologyUpdateId}

--- a/packages/shared-ui/src/elements/input/floating-input/floating-input.ts
+++ b/packages/shared-ui/src/elements/input/floating-input/floating-input.ts
@@ -30,6 +30,10 @@ import { LLMContent } from "@breadboard-ai/types";
 import { icons } from "../../../styles/icons";
 import { type } from "../../../styles/host/type";
 import { classMap } from "lit/directives/class-map.js";
+import { consume } from "@lit/context";
+import { uiStateContext } from "../../../contexts/ui-state";
+import { UI } from "../../../state/types";
+import { FloatingInputFocusState } from "../../../types/types";
 
 interface SupportedActions {
   allowAddAssets: boolean;
@@ -50,6 +54,9 @@ export class FloatingInput extends LitElement {
   @property()
   accessor schema: Schema | null = null;
 
+  @property()
+  accessor focusWhenIn: FloatingInputFocusState = ["app"];
+
   @query("#asset-shelf")
   accessor assetShelf: AssetShelf | null = null;
 
@@ -61,6 +68,9 @@ export class FloatingInput extends LitElement {
 
   @state()
   accessor showAddAssetModal = false;
+
+  @consume({ context: uiStateContext })
+  accessor #uiState!: UI;
 
   static styles = [
     icons,
@@ -355,7 +365,24 @@ export class FloatingInput extends LitElement {
   }
 
   protected firstUpdated(): void {
+    // Ensure we only attempt to focus a visible text input.
     if (!this.textInput) {
+      return;
+    }
+
+    let attemptFocus = false;
+    if (this.focusWhenIn[0] === this.#uiState.mode) {
+      if (
+        this.focusWhenIn[1] !== undefined &&
+        this.#uiState.editorSection === this.focusWhenIn[1]
+      ) {
+        attemptFocus = true;
+      } else if (this.focusWhenIn[1] === undefined) {
+        attemptFocus = true;
+      }
+    }
+
+    if (!attemptFocus) {
       return;
     }
 

--- a/packages/shared-ui/src/elements/output/console-view/console-view.ts
+++ b/packages/shared-ui/src/elements/output/console-view/console-view.ts
@@ -290,6 +290,7 @@ export class ConsoleView extends SignalWatcher(LitElement) {
     const PADDING = 24;
     return html`<bb-floating-input
       .schema=${input.schema}
+      .focusWhenIn=${["canvas", "console"]}
       @bbresize=${(evt: ResizeEvent) => {
         this.style.setProperty(
           "--input-clearance",

--- a/packages/shared-ui/src/state/types.ts
+++ b/packages/shared-ui/src/state/types.ts
@@ -366,6 +366,7 @@ export type UI = {
   mode: VisualEditorMode;
   boardServer: string;
   boardLocation: string;
+  editorSection: "console" | "preview";
 
   /**
    * Indicates whether or not the UI can currently run a flow or not.

--- a/packages/shared-ui/src/state/ui.ts
+++ b/packages/shared-ui/src/state/ui.ts
@@ -49,6 +49,9 @@ class ReactiveUIState implements UI {
   @signal
   accessor projectFilter: string | null = null;
 
+  @signal
+  accessor editorSection: "preview" | "console" = "preview";
+
   accessor show = new SignalSet<UIOverlays>();
 
   accessor toasts = new SignalMap<

--- a/packages/shared-ui/src/types/types.ts
+++ b/packages/shared-ui/src/types/types.ts
@@ -578,6 +578,7 @@ export interface AppTemplate extends LitElement {
   showContentWarning: boolean;
   showDisclaimer: boolean;
   isEmpty: boolean;
+  focusWhenIn: ["canvas", "preview" | "console"] | ["app"];
 }
 
 export interface Utterance {
@@ -695,3 +696,7 @@ export type ColorPalettes = {
 };
 
 export type VisualEditorMode = "app" | "canvas";
+
+export type FloatingInputFocusState =
+  | ["canvas", "preview" | "console"]
+  | ["app"];

--- a/packages/visual-editor/src/index.styles.ts
+++ b/packages/visual-editor/src/index.styles.ts
@@ -583,12 +583,10 @@ export const styles = [
       left: 0;
       top: 0;
       overflow: hidden;
-      pointer-events: none;
-      opacity: 0;
+      display: none;
 
       &.active {
-        opacity: 1;
-        pointer-events: auto;
+        display: block;
       }
     }
 

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -63,6 +63,7 @@ import {
   globalConfigContext,
 } from "@breadboard-ai/shared-ui/contexts";
 import { boardServerContext } from "@breadboard-ai/shared-ui/contexts/board-server.js";
+import { uiStateContext } from "@breadboard-ai/shared-ui/contexts/ui-state.js";
 import { googleDriveClientContext } from "@breadboard-ai/shared-ui/contexts/google-drive-client-context.js";
 import { sideBoardRuntime } from "@breadboard-ai/shared-ui/contexts/side-board-runtime.js";
 import { IterateOnPromptEvent } from "@breadboard-ai/shared-ui/events/events.js";
@@ -140,6 +141,10 @@ export class Main extends SignalWatcher(LitElement) {
   @provide({ context: boardServerContext })
   accessor boardServer: BoardServer | undefined;
 
+  @provide({ context: uiStateContext })
+  @state()
+  accessor #uiState!: BreadboardUI.State.UI;
+
   @state()
   accessor #tab: Runtime.Types.Tab | null = null;
 
@@ -211,7 +216,6 @@ export class Main extends SignalWatcher(LitElement) {
   readonly #runStore = getRunStore();
   readonly #lastPointerPosition = { x: 0, y: 0 };
   readonly #embedHandler?: EmbedHandler;
-  accessor #uiState!: BreadboardUI.State.UI;
   readonly #apiClient: AppCatalystApiClient;
   readonly #secretsHelper: SecretsHelper;
   readonly #settings: SettingsStore;


### PR DESCRIPTION
I noticed that we don't reliably focus the floating input. This is because we aren't differentiating between the three instances we have: the console view, the preview view, and the app view. This PR distributes the current UI state so that the floating input can compare the in-focus view with its own configuration to decide whether or not it should attempt to focus the `textarea` it contains.