### PR TITLE
files api endpoint

### DIFF
--- a/.changeset/cool-lies-dance.md
+++ b/.changeset/cool-lies-dance.md
@@ -1,0 +1,6 @@
+---
+"@breadboard-ai/unified-server": patch
+"@breadboard-ai/types": patch
+---
+
+Introduce `/files` endpoint for storing/caching gallery results.

--- a/packages/types/src/deployment-configuration.ts
+++ b/packages/types/src/deployment-configuration.ts
@@ -41,4 +41,13 @@ export interface DomainConfiguration {
 export type ServerDeploymentConfiguration = {
   BACKEND_API_ENDPOINT?: string;
   ENABLE_GOOGLE_DRIVE_PROXY?: boolean;
+  /**
+   * The public API key (no extra privileges) that is used to access
+   * Drive files.
+   */
+  GOOGLE_DRIVE_PUBLIC_API_KEY?: string;
+  /**
+   * The URL of the deployed server.
+   */
+  SERVER_URL?: string;
 };

--- a/packages/unified-server/src/server/drive-proxy.ts
+++ b/packages/unified-server/src/server/drive-proxy.ts
@@ -6,13 +6,20 @@
 
 import cors from "cors";
 import { Router, type Request, type Response } from "express";
-import { GoogleAuth } from "google-auth-library";
 import { Readable } from "node:stream";
 import { type ReadableStream } from "node:stream/web";
 
 const PRODUCTION_DRIVE_BASE_URL = "https://www.googleapis.com";
 
-export function makeDriveProxyMiddleware() {
+export type DriveProxyConfig = {
+  publicApiKey: string;
+  serverUrl: string;
+};
+
+export function makeDriveProxyMiddleware({
+  publicApiKey,
+  serverUrl,
+}: DriveProxyConfig) {
   const router = Router();
   router.use(
     cors({
@@ -21,59 +28,28 @@ export function makeDriveProxyMiddleware() {
       maxAge: 24 * 60 * 60,
     })
   );
-  router.all("*", handler);
-  return router;
-}
+  router.get("/:id", async (req: Request, res: Response) => {
+    const productionDriveUrl = new URL(
+      `/drive/v3/files${req.path}`,
+      PRODUCTION_DRIVE_BASE_URL
+    );
+    productionDriveUrl.search = new URL(
+      req.originalUrl,
+      // This is just to parse as a valid URL (since originalUrl doesn't have a
+      // protocol or origin) so we can read search params.
+      "https://placeholder.invalid"
+    ).search;
 
-async function handler(req: Request, res: Response) {
-  if (
-    !(req.path === "/drive/v3/files" || req.path.startsWith("/drive/v3/files/"))
-  ) {
-    res.sendStatus(403);
-    return;
-  }
+    // Now, append the Public API key
+    productionDriveUrl.searchParams.set("key", publicApiKey);
 
-  const userAuthHeader = req.headers.authorization;
-  if (!userAuthHeader) {
-    res.sendStatus(401);
-    return;
-  }
-
-  const productionDriveUrl = new URL(req.path, PRODUCTION_DRIVE_BASE_URL);
-  productionDriveUrl.search = new URL(
-    req.originalUrl,
-    // This is just to parse as a valid URL (since originalUrl doesn't have a
-    // protocol or origin) so we can read search params.
-    "https://placeholder.invalid"
-  ).search;
-
-  // First try with user credentials.
-  const userResponse = await fetch(productionDriveUrl, {
-    method: req.method,
-    headers: { authorization: userAuthHeader },
-  });
-  // TODO(aomarks) Checking for 404 won't suffice for a listing query, since
-  // that will just return empty/partial results when a public file is missing.
-  if (userResponse.status !== 404) {
+    const userResponse = await fetch(productionDriveUrl, {
+      headers: {
+        referer: serverUrl,
+      },
+    });
     res.status(userResponse.status);
     Readable.fromWeb(userResponse.body as ReadableStream).pipe(res);
-    return;
-  }
-
-  // Failing that, try reading it as a public file using our service account
-  // credentials.
-  //
-  // TODO(aomarks) We should probably explicitly check permissions and only
-  // return files that are definitely public, since otherwise any file shared
-  // only with our service account would be readable by anyone.
-  const serviceAuth = new GoogleAuth({
-    scopes: ["https://www.googleapis.com/auth/drive.readonly"],
   });
-  const serviceAuthClient = await serviceAuth.getClient();
-  const serviceToken = await serviceAuthClient.getAccessToken();
-  const serviceResponse = await fetch(productionDriveUrl, {
-    headers: { authorization: `Bearer ${serviceToken}` },
-  });
-  res.status(serviceResponse.status);
-  Readable.fromWeb(serviceResponse.body as ReadableStream).pipe(res);
+  return router;
 }

--- a/packages/unified-server/src/server/main.ts
+++ b/packages/unified-server/src/server/main.ts
@@ -61,7 +61,26 @@ server.use(
 
 server.use("/app/@:user/:name", boardServer.middlewares.loadBoard());
 
-server.use("/drive-proxy", makeDriveProxyMiddleware());
+if (serverConfig.GOOGLE_DRIVE_PUBLIC_API_KEY && serverConfig.SERVER_URL) {
+  server.use(
+    "/files",
+    makeDriveProxyMiddleware({
+      publicApiKey: serverConfig.GOOGLE_DRIVE_PUBLIC_API_KEY,
+      serverUrl: serverConfig.SERVER_URL,
+    })
+  );
+} else {
+  if (!serverConfig.GOOGLE_DRIVE_PUBLIC_API_KEY) {
+    console.warn(
+      "GOOGLE_DRIVE_PUBLIC_API_KEY was not supplied, `files` API endpoint will not be available"
+    );
+  }
+  if (!serverConfig.SERVER_URL) {
+    console.warn(
+      "SERVER_URL was not supplied, `files` API endpoint will not be available"
+    );
+  }
+}
 
 server.use("/app", (req, res) => {
   // Redirect the old standalone app view to the new unified view with the app


### PR DESCRIPTION
- **Repurpose old drive proxy code to implement `/files` API endpoint.**
- **A very simple cache.**
- **docs(changeset): Introduce `/files` endpoint for storing/caching gallery results.**
