### PR TITLE
[drive] Temporarily disable the /files endpoint

### DIFF
--- a/packages/google-drive-kit/src/google-drive-client.ts
+++ b/packages/google-drive-kit/src/google-drive-client.ts
@@ -438,23 +438,24 @@ export class GoogleDriveClient {
     options: BaseRequestOptions | undefined,
     authorization?: GoogleApiAuthorization
   ): Promise<Response> {
-    let url;
+    // TODO(aomarks) Temporarily disabled.
+    // let url;
     // This is a bit hacky: we detect when we're trying to use the public
     // API key and route over to the drive proxy.
     // TODO: Make this more explicit.
-    if (authorization?.kind === "key") {
-      url = new URL(
-        `/files/${encodeURIComponent(fileId.id)}`,
-        window.location.href
-      );
-      // Don't send the actual key: it will be provided by the proxy.
-      authorization = undefined;
-    } else {
-      url = new URL(
-        `drive/v3/files/${encodeURIComponent(fileId.id)}`,
-        this.#apiBaseUrl
-      );
-    }
+    // if (authorization?.kind === "key") {
+    //   url = new URL(
+    //     `/files/${encodeURIComponent(fileId.id)}`,
+    //     window.location.href
+    //   );
+    //   // Don't send the actual key: it will be provided by the proxy.
+    //   authorization = undefined;
+    // } else {
+    const url = new URL(
+      `drive/v3/files/${encodeURIComponent(fileId.id)}`,
+      this.#apiBaseUrl
+    );
+    // }
     url.searchParams.set("alt", "media");
     return this.#fetch(
       url,

--- a/packages/unified-server/src/server/main.ts
+++ b/packages/unified-server/src/server/main.ts
@@ -11,7 +11,7 @@ import * as connectionServer from "@breadboard-ai/connection-server";
 import * as boardServer from "@breadboard-ai/board-server";
 import { InputValues, NodeDescriptor } from "@breadboard-ai/types";
 
-import { makeDriveProxyMiddleware } from "./drive-proxy.js";
+// import { makeDriveProxyMiddleware } from "./drive-proxy.js";
 import { allowListChecker } from "./allow-list-checker.js";
 import { getConfigFromSecretManager } from "./provide-config.js";
 import { makeCspHandler } from "./csp.js";
@@ -62,15 +62,16 @@ server.use(
 
 server.use("/app/@:user/:name", boardServer.middlewares.loadBoard());
 
-server.use(
-  "/files",
-  makeDriveProxyMiddleware({
-    publicApiKey: serverConfig.GOOGLE_DRIVE_PUBLIC_API_KEY,
-    serverUrl: serverConfig.SERVER_URL,
-    featuredGalleryFolderId:
-      serverConfig.GOOGLE_DRIVE_FEATURED_GALLERY_FOLDER_ID,
-  })
-);
+// TODO(aomarks) Temporarily disabled.
+// server.use(
+//   "/files",
+//   makeDriveProxyMiddleware({
+//     publicApiKey: serverConfig.GOOGLE_DRIVE_PUBLIC_API_KEY,
+//     serverUrl: serverConfig.SERVER_URL,
+//     featuredGalleryFolderId:
+//       serverConfig.GOOGLE_DRIVE_FEATURED_GALLERY_FOLDER_ID,
+//   })
+// );
 
 server.use("/updates", createUpdatesHandler());
 


### PR DESCRIPTION
Disabling until we have more confidence. Right now when it starts up, it block developers from calling the drive API because of abuse detection.