### PR TITLE
[shared-ui] Fix content warning behavior

### DIFF
--- a/.changeset/kind-breads-smile.md
+++ b/.changeset/kind-breads-smile.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/shared-ui": patch
+---
+
+Fix content warning behavior

--- a/packages/shared-ui/src/app-templates/basic/index.ts
+++ b/packages/shared-ui/src/app-templates/basic/index.ts
@@ -138,7 +138,21 @@ export class Template extends SignalWatcher(LitElement) implements AppTemplate {
   accessor readOnly = true;
 
   @property()
-  accessor showContentWarning = false;
+  set showContentWarning(value: null | boolean) {
+    // Once the content warning has been set to false, we ignore further
+    // updates. When the user goes to get a different board this component will
+    // be remounted and the original value of null will be set.
+    if (this.#showContentWarning === false) {
+      return;
+    }
+
+    this.#showContentWarning = value;
+  }
+  get showContentWarning() {
+    return this.#showContentWarning;
+  }
+
+  #showContentWarning: boolean | null = null;
 
   @consume({ context: boardServerContext, subscribe: true })
   accessor boardServer: BoardServer | undefined;

--- a/packages/shared-ui/src/types/types.ts
+++ b/packages/shared-ui/src/types/types.ts
@@ -575,7 +575,7 @@ export interface AppTemplate extends LitElement {
   showGDrive: boolean;
   readOnly: boolean;
   showShareButton: boolean;
-  showContentWarning: boolean;
+  showContentWarning: boolean | null;
   showDisclaimer: boolean;
   isEmpty: boolean;
   focusWhenIn: ["canvas", "preview" | "console"] | ["app"];


### PR DESCRIPTION
We now only allow resetting of the content warning when the app template has been unmounted and remounted, meaning that it remains dismissed rather than returning on re-render.