### PR TITLE
[signin] Check for required scopes and force signin when missing

### DIFF
--- a/packages/connection-client/src/token-vendor.ts
+++ b/packages/connection-client/src/token-vendor.ts
@@ -109,6 +109,7 @@ export class TokenVendorImpl {
       picture: expiredGrant.picture,
       name: expiredGrant.name,
       domain: expiredGrant.domain,
+      scopes: expiredGrant.scopes,
     };
     await this.#store.set(connectionId, JSON.stringify(updatedGrant));
     return { state: "valid", grant: updatedGrant };

--- a/packages/connection-client/src/types.ts
+++ b/packages/connection-client/src/types.ts
@@ -80,6 +80,7 @@ export interface TokenGrant {
   name?: string;
   id?: string;
   domain: string | undefined;
+  scopes: string[] | undefined;
 }
 
 export type RefreshResponse =

--- a/packages/unified-server/package.json
+++ b/packages/unified-server/package.json
@@ -94,7 +94,8 @@
       "command": "[ -f ./secrets/local.json ] && export CONNECTIONS_FILE=./secrets/local.json && export GOOGLE_CLOUD_PROJECT=$(gcloud config get-value project) && export FIRESTORE_DB_NAME=unified-server && export STORAGE_BUCKET=bb-blob-store SERVER_URL=http://localhost:3000/board && node --enable-source-maps .",
       "service": true,
       "files": [
-        "vite.config.ts"
+        "vite.config.ts",
+        "secrets/*.json"
       ],
       "dependencies": [
         "build:tsc:server",

--- a/packages/unified-server/src/landing/main.ts
+++ b/packages/unified-server/src/landing/main.ts
@@ -201,6 +201,8 @@ async function init() {
     url.searchParams.delete("geo-restriction");
     window.history.replaceState(null, "", url);
     showGeoRestrictionDialog();
+  } else if (url.searchParams.has("missing-scopes")) {
+    scopesErrorDialog.showModal();
   }
 }
 

--- a/packages/unified-server/src/server/csp.ts
+++ b/packages/unified-server/src/server/csp.ts
@@ -38,6 +38,7 @@ const CSP_CONFIG = {
     "https://*.google.com",
     "https://www.googleapis.com/drive/",
     "https://www.googleapis.com/upload/drive/",
+    "https://oauth2.googleapis.com/tokeninfo",
   ],
   ["frame-src"]: [
     "https://docs.google.com",


### PR DESCRIPTION
We will now check that all required OAuth scopes are granted at bootstrap, and if one is missing we redirect the user to the "Additional access required" screen on the landing page.

We also now store scopes in the local signin storage. If, during the missing scopes check, we find that we don't have any scopes in local signin (because it is a signin from before this PR), then we call the https://oauth2.googleapis.com/tokeninfo endpoint to read the scopes, and automatically upgrade the local storage for next time.