### PR TITLE
[gallery] Update gallery queries

### DIFF
--- a/packages/a2/scripts/update-props.ts
+++ b/packages/a2/scripts/update-props.ts
@@ -12,7 +12,6 @@ import { readFile } from "fs/promises";
 import { GraphDescriptor } from "@breadboard-ai/types";
 
 const GRAPH_MIME_TYPE = "application/vnd.breadboard.graph+json";
-const DEPRECATED_GRAPH_MIME_TYPE = "application/json";
 const MODULE_DIR = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = join(MODULE_DIR, "..");
 const OUT_DIR = join(ROOT_DIR, "out");
@@ -24,8 +23,7 @@ async function getIds(folderId: string, apiKey: string) {
 
   const query =
     `"${folderId}" in parents` +
-    ` and (mimeType="${GRAPH_MIME_TYPE}"` +
-    `      or mimeType="${DEPRECATED_GRAPH_MIME_TYPE}")` +
+    ` and mimeType="${GRAPH_MIME_TYPE}"` +
     ` and trashed=false`;
 
   const response = await fetch(api.makeQueryRequest(query));

--- a/packages/google-drive-kit/src/board-server/operations.ts
+++ b/packages/google-drive-kit/src/board-server/operations.ts
@@ -37,7 +37,6 @@ const PROTOCOL = "drive:";
 
 const GOOGLE_DRIVE_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder";
 export const GRAPH_MIME_TYPE = "application/vnd.breadboard.graph+json";
-export const DEPRECATED_GRAPH_MIME_TYPE = "application/json";
 const RUN_RESULTS_MIME_TYPE = "application/vnd.breadboard.run-results+json";
 const RUN_RESULTS_GRAPH_URL_APP_PROPERTY = "graphUrl";
 
@@ -47,9 +46,9 @@ export const LATEST_SHARED_VERSION_PROPERTY = "latestSharedVersion";
 export const MAIN_TO_SHAREABLE_COPY_PROPERTY = "mainToShareableCopy";
 export const SHAREABLE_COPY_TO_MAIN_PROPERTY = "shareableCopyToMain";
 
-const MIME_TYPE_QUERY = `(mimeType="${GRAPH_MIME_TYPE}" or mimeType="${DEPRECATED_GRAPH_MIME_TYPE}")`;
-const BASE_QUERY = `
-  ${MIME_TYPE_QUERY}
+const BASE_USER_QUERY = `
+  mimeType="${GRAPH_MIME_TYPE}"
+  and 'me' in owners
   and trashed=false
   and not properties has {
     key = ${quote(IS_SHAREABLE_COPY_PROPERTY)}
@@ -62,7 +61,7 @@ const BASE_QUERY = `
 // TODO: Once all gallery items all have shareable copy metadata, switch to
 // only show items that are shareable copies.
 const BASE_FEATURED_QUERY = `
-  ${MIME_TYPE_QUERY}
+  mimeType="${GRAPH_MIME_TYPE}"
   and trashed=false
 `;
 
@@ -163,7 +162,7 @@ class DriveOperations {
 
     this.#userGraphsList = new DriveListCache(
       "user",
-      BASE_QUERY,
+      BASE_USER_QUERY,
       this.#googleDriveClient,
       "user"
     );
@@ -171,7 +170,7 @@ class DriveOperations {
     if (featuredGalleryFolderId) {
       this.#featuredGraphsList = new DriveListCache(
         "featured",
-        `"${featuredGalleryFolderId}" in parents and ${BASE_FEATURED_QUERY}`,
+        `${BASE_FEATURED_QUERY} and "${featuredGalleryFolderId}" in parents`,
         this.#googleDriveClient,
         "public"
       );

--- a/packages/shared-ui/src/elements/google-drive/google-drive-debug-panel.ts
+++ b/packages/shared-ui/src/elements/google-drive/google-drive-debug-panel.ts
@@ -22,10 +22,7 @@ import * as BreadboardUI from "@breadboard-ai/shared-ui";
 import { ok } from "@google-labs/breadboard";
 import { googleDriveClientContext } from "../../contexts/google-drive-client-context.js";
 import { getTopLevelOrigin } from "../../utils/embed-helpers.js";
-import {
-  DEPRECATED_GRAPH_MIME_TYPE,
-  GRAPH_MIME_TYPE,
-} from "@breadboard-ai/google-drive-kit/board-server/operations.js";
+import { GRAPH_MIME_TYPE } from "@breadboard-ai/google-drive-kit/board-server/operations.js";
 
 const Strings = BreadboardUI.Strings.forSection("Global");
 
@@ -472,8 +469,7 @@ export class GoogleDriveDebugPanel extends LitElement {
 
   async readSharedGraphList(): Promise<string[]> {
     const query =
-      ` (mimeType="${GRAPH_MIME_TYPE}"` +
-      `  or mimeType="${DEPRECATED_GRAPH_MIME_TYPE}")` +
+      ` mimeType="${GRAPH_MIME_TYPE}"` +
       ` and sharedWithMe=true` +
       ` and trashed=false`;
     const response = await this.googleDriveClient!.listFiles(query, {

--- a/packages/unified-server/src/server/drive-proxy.ts
+++ b/packages/unified-server/src/server/drive-proxy.ts
@@ -25,8 +25,7 @@ const PRODUCTION_DRIVE_BASE_URL = "https://www.googleapis.com";
 // These are copied from
 // packages/google-drive-kit/src/board-server/operations.ts
 // const GRAPH_MIME_TYPE = "application/vnd.breadboard.graph+json";
-// const DEPRECATED_GRAPH_MIME_TYPE = "application/json";
-// const MIME_TYPE_QUERY = `(mimeType="${GRAPH_MIME_TYPE}" or mimeType="${DEPRECATED_GRAPH_MIME_TYPE}")`;
+// const MIME_TYPE_QUERY = `mimeType="${GRAPH_MIME_TYPE}"`;
 // const BASE_FEATURED_QUERY = `
 //   ${MIME_TYPE_QUERY}
 //   and trashed=false


### PR DESCRIPTION
Only graphs with the application/vnd.breadboard.graph+json MIME type will now be listed in the galleries. Only graphs owned by the current user will now be listed in the list of the user's graphs.