### PR TITLE
[shared-ui/visual-editor] Add shortcuts for duplicating content

### DIFF
--- a/.changeset/pink-cameras-punch.md
+++ b/.changeset/pink-cameras-punch.md
@@ -1,0 +1,6 @@
+---
+"@breadboard-ai/visual-editor": patch
+"@breadboard-ai/shared-ui": patch
+---
+
+Add shortcuts for duplicating content

--- a/packages/shared-ui/src/elements/step-editor/renderer.ts
+++ b/packages/shared-ui/src/elements/step-editor/renderer.ts
@@ -77,7 +77,7 @@ import { EditorControls } from "./editor-controls";
 import { createRef, ref, Ref } from "lit/directives/ref.js";
 import { DATA_TYPE, MOVE_GRAPH_ID } from "./constants";
 import { AssetMetadata } from "@breadboard-ai/types";
-import { isCtrlCommand } from "../../utils/is-ctrl-command";
+import { isCtrlCommand, isMacPlatform } from "../../utils/is-ctrl-command";
 import { Project, RendererState } from "../../state";
 import { colorsLight } from "../../styles/host/colors-light.js";
 import { ItemSelect } from "../elements.js";
@@ -1503,6 +1503,11 @@ export class Renderer extends LitElement {
           title: "Delete selection",
           icon: "delete",
         },
+        {
+          id: "duplicate",
+          title: "Duplicate selection",
+          icon: "file_copy",
+        },
       ]}
       @close=${() => {
         this.#selectionOverflowMenu = null;
@@ -1517,11 +1522,28 @@ export class Renderer extends LitElement {
         switch (select.value) {
           case "delete": {
             // There is already a keyboard shortcut for handling deletions so
-            // rather than duplicating it we redirect this action to the same
-            // endpoint in the Visual Editor root.
+            // we redirect this action to the same endpoint in the Visual Editor
+            // root.
             this.dispatchEvent(
               new KeyboardEvent("keydown", {
                 key: "Delete",
+                bubbles: true,
+                cancelable: true,
+                composed: true,
+              })
+            );
+            break;
+          }
+
+          case "duplicate": {
+            // There is already a keyboard shortcut for handling duplications so
+            // we redirect this action to the same endpoint in the Visual Editor
+            // root.
+            this.dispatchEvent(
+              new KeyboardEvent("keydown", {
+                key: "d",
+                ctrlKey: !isMacPlatform(),
+                metaKey: isMacPlatform(),
                 bubbles: true,
                 cancelable: true,
                 composed: true,

--- a/packages/shared-ui/src/utils/is-ctrl-command.ts
+++ b/packages/shared-ui/src/utils/is-ctrl-command.ts
@@ -5,6 +5,10 @@
  */
 
 export function isCtrlCommand(evt: PointerEvent | KeyboardEvent | WheelEvent) {
-  const isMac = navigator.platform.indexOf("Mac") === 0;
+  const isMac = isMacPlatform();
   return isMac ? evt.metaKey : evt.ctrlKey;
+}
+
+export function isMacPlatform() {
+  return navigator.platform.indexOf("Mac") === 0;
 }


### PR DESCRIPTION
This change adds both a keyboard shortcut (Ctrl/Cmd+d) to duplicate the current selection, as well as adding it to the right-click menu within the graph renderer.