### PR TITLE
[unified-server] Fix z-index battle between sign-in and image on the landing page

### DIFF
--- a/.changeset/lovely-suits-make.md
+++ b/.changeset/lovely-suits-make.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/unified-server": patch
+---
+
+Fix z-index battle between sign-in and image

--- a/packages/unified-server/landing/styles/landing.css
+++ b/packages/unified-server/landing/styles/landing.css
@@ -323,6 +323,8 @@ main {
       display: flex;
       align-items: center;
       flex-direction: column;
+      z-index: 1;
+      position: relative;
 
       & h1 {
         padding: var(--bb-grid-size-8) 0;


### PR DESCRIPTION
In certain instances the new sign-in button can be obscured by the headline image on the landing page. This adjusts the z-index so that the sign-in button is always at the top.