### PR TITLE
[ve/su] Allow pasting in text editor

### DIFF
--- a/.changeset/wild-rats-accept.md
+++ b/.changeset/wild-rats-accept.md
@@ -1,0 +1,6 @@
+---
+"@breadboard-ai/visual-editor": patch
+"@breadboard-ai/shared-ui": patch
+---
+
+Allow pasting in text editor

--- a/packages/shared-ui/src/elements/input/text-editor/text-editor.ts
+++ b/packages/shared-ui/src/elements/input/text-editor/text-editor.ts
@@ -159,11 +159,15 @@ export class TextEditor extends LitElement {
   #startTrackingSelectionsBound = this.#startTrackingSelections.bind(this);
   #stopTrackingSelectionsBound = this.#stopTrackingSelections.bind(this);
   #checkSelectionsBound = this.#checkChicletSelections.bind(this);
+  #onContextMenuBound = this.#onContextMenu.bind(this);
   #shouldCheckSelections = false;
 
   connectedCallback(): void {
     super.connectedCallback();
 
+    window.addEventListener("contextmenu", this.#onContextMenuBound, {
+      capture: true,
+    });
     window.addEventListener("selectionchange", this.#checkSelectionsBound, {
       capture: true,
     });
@@ -186,6 +190,9 @@ export class TextEditor extends LitElement {
   disconnectedCallback(): void {
     super.disconnectedCallback();
 
+    window.removeEventListener("contextmenu", this.#onContextMenuBound, {
+      capture: true,
+    });
     window.removeEventListener("selectionchange", this.#checkSelectionsBound, {
       capture: true,
     });
@@ -201,6 +208,15 @@ export class TextEditor extends LitElement {
     window.removeEventListener("pointerup", this.#stopTrackingSelectionsBound, {
       capture: true,
     });
+  }
+
+  #onContextMenu(evt: Event) {
+    const isOnSelf = evt.composedPath().find((el) => el === this);
+    if (!isOnSelf) {
+      return;
+    }
+
+    evt.stopImmediatePropagation();
   }
 
   #onGlobalPointerDown() {

--- a/packages/visual-editor/src/commands/types.ts
+++ b/packages/visual-editor/src/commands/types.ts
@@ -8,10 +8,12 @@ import { SettingsStore } from "@breadboard-ai/shared-ui/data/settings-store.js";
 import { Runtime } from "../runtime/runtime";
 import { Tab, WorkspaceSelectionStateWithChangeId } from "../runtime/types";
 import type * as BreadboardUI from "@breadboard-ai/shared-ui";
+import { MutableGraphStore } from "@breadboard-ai/types";
 
 export interface KeyboardCommandDeps {
   runtime: Runtime;
   selectionState: WorkspaceSelectionStateWithChangeId | null;
+  graphStore: MutableGraphStore;
   tab: Tab | null;
   originalEvent: KeyboardEvent;
   pointerLocation: { x: number; y: number };

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -1099,6 +1099,7 @@ export class Main extends SignalWatcher(LitElement) {
       originalEvent: evt,
       pointerLocation: this.#lastPointerPosition,
       settings: this.#settings,
+      graphStore: this.#graphStore,
       strings: Strings,
     } as const;
 
@@ -1126,7 +1127,7 @@ export class Main extends SignalWatcher(LitElement) {
         } else {
           notifyUserOnTimeout = setTimeout(
             notifyUser,
-            command.messageTimeout ?? 100
+            command.messageTimeout ?? 500
           );
         }
 
@@ -1158,9 +1159,11 @@ export class Main extends SignalWatcher(LitElement) {
           if (notifyUserOnTimeout) {
             clearTimeout(notifyUserOnTimeout);
           }
+          this.#uiState.blockingAction = false;
         }
 
         this.#handlingShortcut = false;
+        break;
       }
     }
   }


### PR DESCRIPTION
To this point we have intercepted all context menu requests and prevented the default behavior. However, that prevents people from doing things like right-click and paste of – say – a prompt into the text area. This PR contains a quality-of-life improvement where the context menu is shown for right clicks on the Text Editor thereby allowing them to paste content (or access any other menu items they may wish).