### PR TITLE
[various] Track opened versions for shared apps

### DIFF
--- a/.changeset/lucky-eels-happen.md
+++ b/.changeset/lucky-eels-happen.md
@@ -1,0 +1,8 @@
+---
+"@breadboard-ai/google-drive-kit": patch
+"@breadboard-ai/visual-editor": patch
+"@breadboard-ai/shared-ui": patch
+"@breadboard-ai/types": patch
+---
+
+Track opened versions for shared apps

--- a/packages/google-drive-kit/src/board-server/operations.ts
+++ b/packages/google-drive-kit/src/board-server/operations.ts
@@ -85,6 +85,7 @@ export type GraphInfo = {
   tags: GraphTag[];
   thumbnail: string | undefined;
   description: string;
+  latestSharedVersion?: string;
 };
 
 /** Defines api.ts:AppProperties as stored in the drive file */
@@ -93,6 +94,7 @@ export type StoredProperties = {
   description?: string;
   tags?: string;
   thumbnailUrl?: string;
+  latestSharedVersion?: string;
 };
 
 export type DriveChange = {
@@ -753,6 +755,7 @@ export function createProperties(properties: AppProperties): StoredProperties {
     description: properties.description,
     tags: JSON.stringify(properties.tags),
     thumbnailUrl: properties.thumbnailUrl, // undefined here means "do not update".
+    latestSharedVersion: properties.latestSharedVersion,
   };
 
   // Drive has limit of how long key+value can be in bytes in UTF8 wo we are truncating the values.

--- a/packages/google-drive-kit/src/board-server/server.ts
+++ b/packages/google-drive-kit/src/board-server/server.ts
@@ -40,7 +40,6 @@ import { RefreshEvent, SaveEvent } from "./events.js";
 import {
   type DriveFileId,
   type GoogleDriveClient,
-  type ListFilesResponse,
   type NarrowedDriveFile,
 } from "../google-drive-client.js";
 import { GoogleDriveDataPartTransformer } from "./data-part-transformer.js";
@@ -243,6 +242,7 @@ class GoogleDriveBoardServer
         access,
         thumbnail: graphInfo.thumbnail,
         description: graphInfo.description,
+        latestSharedVersion: graphInfo.latestSharedVersion,
       } satisfies EntityMetadata,
     };
   }
@@ -301,6 +301,29 @@ class GoogleDriveBoardServer
       watch: false,
       preview: false,
     };
+  }
+
+  getLatestSharedVersion(url: URL): number {
+    const maybeProject = this.#projects.find(
+      (project) => project.url.href === url.href
+    );
+    if (!maybeProject) {
+      return -1;
+    }
+
+    if (!maybeProject.metadata.latestSharedVersion) {
+      return -1;
+    }
+
+    const currentVersion = Number.parseInt(
+      maybeProject.metadata.latestSharedVersion,
+      10
+    );
+    if (Number.isNaN(currentVersion)) {
+      return -1;
+    }
+
+    return currentVersion;
   }
 
   async load(url: URL): Promise<GraphDescriptor | null> {

--- a/packages/google-drive-kit/src/board-server/utils.ts
+++ b/packages/google-drive-kit/src/board-server/utils.ts
@@ -139,6 +139,9 @@ export function readProperties(
     tags: file.properties?.tags || file.appProperties?.tags,
     thumbnailUrl:
       file.properties?.thumbnailUrl || file.appProperties?.thumbnailUrl,
+    latestSharedVersion:
+      file.properties?.latestSharedVersion ||
+      file.appProperties?.latestSharedVersion,
   };
 
   let tags: Array<GraphTag> = [];
@@ -155,6 +158,7 @@ export function readProperties(
     description: storedProperties.description ?? "",
     tags,
     thumbnailUrl: storedProperties.thumbnailUrl,
+    latestSharedVersion: storedProperties.latestSharedVersion,
   };
 }
 
@@ -164,6 +168,7 @@ export type AppProperties = {
   description: string;
   tags: GraphTag[];
   thumbnailUrl?: string;
+  latestSharedVersion?: string;
 };
 
 export type GoogleDriveAsset = {
@@ -298,5 +303,6 @@ export function driveFileToGraphInfo(
     tags: properties.tags,
     thumbnail: properties.thumbnailUrl,
     description: properties.description,
+    latestSharedVersion: properties.latestSharedVersion,
   };
 }

--- a/packages/google-drive-kit/tests/board-server/operations.ts
+++ b/packages/google-drive-kit/tests/board-server/operations.ts
@@ -22,6 +22,7 @@ describe("create/readProperties", () => {
       description: "test desc",
       tags: `["a","b"]`,
       thumbnailUrl: "abc",
+      latestSharedVersion: "1",
     };
 
     file = {
@@ -42,6 +43,7 @@ describe("create/readProperties", () => {
       thumbnailUrl: "abc",
       title: "test title",
       tags: ["a", "b"],
+      latestSharedVersion: "1",
     });
     const savedProps = createProperties(props);
     deepEqual(savedProps, properties);
@@ -55,6 +57,7 @@ describe("create/readProperties", () => {
       thumbnailUrl: "abc",
       title: "overridden",
       tags: ["a", "b"],
+      latestSharedVersion: "1",
     });
     const savedProps = createProperties(props);
     deepEqual(savedProps, { ...properties, title: "overridden" });
@@ -69,6 +72,7 @@ describe("create/readProperties", () => {
       description: "from props",
       tags: [],
       thumbnailUrl: undefined,
+      latestSharedVersion: undefined,
     });
     const savedProps = createProperties(props);
     deepEqual(savedProps, {
@@ -76,6 +80,7 @@ describe("create/readProperties", () => {
       description: "from props",
       tags: "[]",
       thumbnailUrl: undefined,
+      latestSharedVersion: undefined,
     });
   });
 
@@ -88,6 +93,7 @@ describe("create/readProperties", () => {
       description: "",
       tags: [],
       thumbnailUrl: undefined,
+      latestSharedVersion: undefined,
     });
   });
 });

--- a/packages/shared-ui/src/strings/en_US/global.ts
+++ b/packages/shared-ui/src/strings/en_US/global.ts
@@ -202,6 +202,9 @@ export default {
   STATUS_LOGGED_OUT: {
     str: "Successfully signed out",
   },
+  STATUS_NEWER_VERSION: {
+    str: "This app has been updated by the owner with new published changes",
+  },
 
   // Errors.
   ERROR_UNABLE_TO_CREATE_PROJECT: {

--- a/packages/types/src/loader.ts
+++ b/packages/types/src/loader.ts
@@ -359,6 +359,7 @@ export interface BoardServer
     TypedEventTargetType<BoardServerEventMap> {
   user: User;
   getAccess(url: URL, user: User): Promise<Permission>;
+  getLatestSharedVersion?(url: URL): number;
 }
 
 export interface EntityMetadata {
@@ -369,6 +370,7 @@ export interface EntityMetadata {
   icon?: string;
   thumbnail?: string;
   tags?: GraphTag[];
+  latestSharedVersion?: string;
 }
 
 export interface Entity {

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -728,6 +728,20 @@ export class Main extends SignalWatcher(LitElement) {
     );
 
     this.#runtime.board.addEventListener(
+      Runtime.Events.RuntimeNewerSharedVersionEvent.eventName,
+      () => {
+        this.snackbar(
+          Strings.from("STATUS_NEWER_VERSION"),
+          BreadboardUI.Types.SnackType.INFORMATION,
+          [],
+          true,
+          globalThis.crypto.randomUUID(),
+          true
+        );
+      }
+    );
+
+    this.#runtime.board.addEventListener(
       Runtime.Events.RuntimeTabChangeEvent.eventName,
       async (evt: Runtime.Events.RuntimeTabChangeEvent) => {
         this.#tab = this.#runtime.board.currentTab;

--- a/packages/visual-editor/src/runtime/events.ts
+++ b/packages/visual-editor/src/runtime/events.ts
@@ -165,6 +165,14 @@ export class RuntimeBoardServerChangeEvent extends Event {
   }
 }
 
+export class RuntimeNewerSharedVersionEvent extends Event {
+  static eventName = "runtimenewersharedversion" as const;
+
+  constructor() {
+    super(RuntimeNewerSharedVersionEvent.eventName, { ...eventInit });
+  }
+}
+
 export class RuntimeTabChangeEvent extends Event {
   static eventName = "runtimetabchange" as const;
 

--- a/packages/visual-editor/src/runtime/types.ts
+++ b/packages/visual-editor/src/runtime/types.ts
@@ -58,6 +58,7 @@ export interface Tab {
   subGraphId: string | null;
   moduleId: ModuleIdentifier | null;
   version: number;
+  lastLoadedVersion: number;
   readOnly: boolean;
   type: TabType;
   /**


### PR DESCRIPTION
To this point a user doesn't know if an app they've opened has been updated by the author. This PR includes a quality-of-life improvement whereby the version of an opened app is retained in browser storage. If and when that same app is opened in future the version number is checked and, should the app have been updated, the user is shown a snackbar telling them as much.