### PR TITLE
[urls] Consolidate URL creation and parsing

### DIFF
--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -66,7 +66,8 @@
     "prepack": "npm run build",
     "build": "wireit",
     "build:tsc": "wireit",
-    "update-sideboards": "wireit"
+    "update-sideboards": "wireit",
+    "test": "wireit"
   },
   "wireit": {
     "build": {
@@ -103,6 +104,14 @@
     },
     "update-sideboards": {
       "command": "cp -f src/sideboards/sideboards-bgl/*.bgl.json dist/sideboards/sideboards-bgl"
+    },
+    "test": {
+      "command": "node --test --enable-source-maps --test-reporter spec dist/tests/",
+      "files": [],
+      "output": [],
+      "dependencies": [
+        "build:tsc"
+      ]
     }
   },
   "repository": {

--- a/packages/shared-ui/src/elements/share-panel/share-panel.ts
+++ b/packages/shared-ui/src/elements/share-panel/share-panel.ts
@@ -49,6 +49,7 @@ import {
   type SigninAdapter,
 } from "../../utils/signin-adapter.js";
 import { type GoogleDriveSharePanel } from "../elements.js";
+import { makeUrl } from "../../utils/urls.js";
 
 const APP_NAME = StringsHelper.forSection("Global").from("APP_NAME");
 const Strings = StringsHelper.forSection("UIController");
@@ -922,17 +923,13 @@ export class SharePanel extends LitElement {
         state.status === "readonly") &&
       state.shareableFile
     ) {
-      const url = new URL(window.location.href);
-      url.searchParams.set("flow", `drive:/${state.shareableFile.id}`);
-      if (state.shareableFile.resourceKey) {
-        url.searchParams.set("resourcekey", state.shareableFile.resourceKey);
-      }
-      url.searchParams.set("mode", "app");
-      url.searchParams.set("shared", "true");
-      // Undo some of the automatic URL parameter escaping so that our URLs
-      // aren't quite so ugly since browsers will parse this case OK. But,
-      // really our URL file handles should not have ":" and "/" in them at all.
-      return url.href.replace("flow=drive%3A%2F", "flow=drive:/");
+      return makeUrl({
+        page: "graph",
+        mode: "app",
+        flow: `drive:/${state.shareableFile.id}`,
+        resourceKey: state.shareableFile.resourceKey,
+        shared: true,
+      });
     }
     return undefined;
   }

--- a/packages/shared-ui/src/tests/urls.test.ts
+++ b/packages/shared-ui/src/tests/urls.test.ts
@@ -1,0 +1,164 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from "node:assert";
+import { suite, test } from "node:test";
+import { makeUrl, type MakeUrlInit, parseUrl } from "../utils/urls.js";
+
+const BASE_URL = "https://example.com";
+
+function testSymmetrical(url: string, init: MakeUrlInit): void {
+  test(url, () => {
+    assert.deepEqual(makeUrl(init, BASE_URL), url);
+    assert.deepEqual(parseUrl(url), init);
+  });
+}
+
+suite("home", () => {
+  testSymmetrical(`${BASE_URL}/?mode=canvas`, {
+    page: "home",
+    mode: "canvas",
+  });
+
+  testSymmetrical(`${BASE_URL}/?mode=app`, {
+    page: "home",
+    mode: "app",
+  });
+
+  test("default to home w/ canvas", () => {
+    assert.deepEqual(parseUrl(`${BASE_URL}/`), {
+      page: "home",
+      mode: "canvas",
+    });
+  });
+});
+
+suite("app", () => {
+  testSymmetrical(`${BASE_URL}/?flow=drive:/abc123&mode=app`, {
+    page: "graph",
+    mode: "app",
+    flow: "drive:/abc123",
+    resourceKey: undefined,
+  });
+
+  testSymmetrical(
+    `${BASE_URL}/?flow=drive:/abc123&resourcekey=ghi789&mode=app`,
+    {
+      page: "graph",
+      mode: "app",
+      flow: "drive:/abc123",
+      resourceKey: "ghi789",
+    }
+  );
+
+  testSymmetrical(
+    `${BASE_URL}/?flow=drive:/abc123&shared&results=def456&mode=app`,
+    {
+      page: "graph",
+      mode: "app",
+      flow: "drive:/abc123",
+      resourceKey: undefined,
+      results: "def456",
+      shared: true,
+    }
+  );
+
+  test("old tab0 parameter", () => {
+    assert.deepEqual(parseUrl(`${BASE_URL}/?tab0=drive:/abc123`), {
+      page: "graph",
+      mode: "canvas",
+      flow: "drive:/abc123",
+      resourceKey: undefined,
+    } satisfies MakeUrlInit);
+  });
+
+  test("invalid mode", () => {
+    assert.deepEqual(parseUrl(`${BASE_URL}/?flow=drive:/abc123&mode=invalid`), {
+      page: "graph",
+      mode: "canvas",
+      flow: "drive:/abc123",
+      resourceKey: undefined,
+    } satisfies MakeUrlInit);
+  });
+});
+
+suite("canvas", () => {
+  testSymmetrical(`${BASE_URL}/?flow=drive:/abc123&mode=canvas`, {
+    page: "graph",
+    mode: "canvas",
+    flow: "drive:/abc123",
+    resourceKey: undefined,
+  });
+});
+
+suite("landing", () => {
+  testSymmetrical(`${BASE_URL}/landing/`, {
+    page: "landing",
+    redirect: { page: "home", mode: "canvas", redirectFromLanding: true },
+  });
+
+  testSymmetrical(
+    `${BASE_URL}/landing/?geo-restriction=true&missing-scopes=true`,
+    {
+      page: "landing",
+      redirect: { page: "home", mode: "canvas", redirectFromLanding: true },
+      geoRestriction: true,
+      missingScopes: true,
+    }
+  );
+
+  testSymmetrical(`${BASE_URL}/landing/?flow=drive:/abc123&mode=app`, {
+    page: "landing",
+    redirect: {
+      page: "graph",
+      mode: "app",
+      redirectFromLanding: true,
+      flow: "drive:/abc123",
+      resourceKey: undefined,
+    },
+  });
+
+  testSymmetrical(
+    `${BASE_URL}/landing/?flow=drive:/abc123&resourcekey=ghi789&shared&results=def456&mode=app`,
+    {
+      page: "landing",
+      redirect: {
+        page: "graph",
+        mode: "app",
+        redirectFromLanding: true,
+        flow: "drive:/abc123",
+        resourceKey: "ghi789",
+        results: "def456",
+        shared: true,
+      },
+    }
+  );
+
+  testSymmetrical(
+    `${BASE_URL}/landing/?flow=drive:/abc123&mode=app&oauth_redirect=foo`,
+    {
+      page: "landing",
+      redirect: {
+        page: "graph",
+        mode: "app",
+        redirectFromLanding: true,
+        flow: "drive:/abc123",
+        resourceKey: undefined,
+      },
+      oauthRedirect: "foo",
+    }
+  );
+});
+
+suite("parse errors", () => {
+  test("parseUrl(<empty>)", () => {
+    assert.throws(() => parseUrl(""));
+  });
+
+  test("parseUrl(<invalid>)", () => {
+    assert.throws(() => parseUrl("not a url"));
+  });
+});

--- a/packages/shared-ui/src/utils/urls.ts
+++ b/packages/shared-ui/src/utils/urls.ts
@@ -43,7 +43,7 @@ const SHARED = "shared";
 const GEO_RESTRICTION = "geo-restriction";
 const MISSING_SCOPES = "missing-scopes";
 const RESOURCE_KEY = "resourcekey";
-const OAUTH_REDIRECT = "oauth_redirect";
+export const OAUTH_REDIRECT = "oauth_redirect";
 
 /**
  * Generate a URL for a page on the Breadboard Visual Editor.

--- a/packages/shared-ui/src/utils/urls.ts
+++ b/packages/shared-ui/src/utils/urls.ts
@@ -1,0 +1,164 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { type VisualEditorMode } from "../types/types.js";
+
+export type MakeUrlInit = HomeUrlInit | GraphInit | LandingUrlInit;
+
+export interface HomeUrlInit {
+  page: "home";
+  mode?: VisualEditorMode;
+  redirectFromLanding?: boolean;
+}
+
+export interface GraphInit {
+  page: "graph";
+  mode: VisualEditorMode;
+  flow: string;
+  resourceKey: string | undefined;
+  results?: string;
+  shared?: boolean;
+  redirectFromLanding?: boolean;
+}
+
+export interface LandingUrlInit {
+  page: "landing";
+  redirect: MakeUrlInit;
+  oauthRedirect?: string;
+  missingScopes?: boolean;
+  geoRestriction?: boolean;
+}
+
+const FLOW = "flow";
+const TAB0 = "tab0";
+const MODE = "mode";
+const MODE_APP = "app" as const;
+const MODE_CANVAS = "canvas" as const;
+type MODE_VALUES = typeof MODE_APP | typeof MODE_CANVAS;
+const RESULTS = "results";
+const SHARED = "shared";
+const GEO_RESTRICTION = "geo-restriction";
+const MISSING_SCOPES = "missing-scopes";
+const RESOURCE_KEY = "resourcekey";
+const OAUTH_REDIRECT = "oauth_redirect";
+
+/**
+ * Generate a URL for a page on the Breadboard Visual Editor.
+ */
+export function makeUrl(
+  init: MakeUrlInit,
+  base: string | URL = window.location.href
+): string {
+  const baseOrigin =
+    typeof base === "string" ? new URL(base).origin : base.origin;
+  const url = new URL(baseOrigin);
+  const { page } = init;
+  if (page === "home") {
+    url.pathname = "/";
+    url.searchParams.set(MODE, init.mode ?? MODE_CANVAS);
+  } else if (page === "graph") {
+    url.searchParams.set(FLOW, init.flow);
+    if (init.resourceKey) {
+      url.searchParams.set(RESOURCE_KEY, init.resourceKey);
+    }
+    if (init.shared) {
+      url.searchParams.set(SHARED, "");
+    }
+    if (init.results) {
+      url.searchParams.set(RESULTS, init.results);
+    }
+    url.searchParams.set(MODE, init.mode);
+  } else if (page === "landing") {
+    url.pathname = "landing/";
+    if (init.geoRestriction) {
+      url.searchParams.set(GEO_RESTRICTION, "true");
+    }
+    if (init.missingScopes) {
+      url.searchParams.set(MISSING_SCOPES, "true");
+    }
+    if (init.redirect.page === "graph") {
+      // To encode the redirect URL, we just copy all the search params directly
+      // onto the landing page URL, and then pick them off later. Note this
+      // could be a little brittle if we add more pages, since we aren't
+      // explicitly representing which page we're redirecting to.
+      const redirectUrl = new URL(makeUrl(init.redirect, base));
+      for (const [redirectParam, redirectValue] of redirectUrl.searchParams) {
+        url.searchParams.set(redirectParam, redirectValue);
+      }
+    }
+    if (init.oauthRedirect) {
+      url.searchParams.set(OAUTH_REDIRECT, init.oauthRedirect);
+    }
+  } else {
+    page satisfies never;
+    throw new Error(
+      `unhandled page ${JSON.stringify(page)} from ${JSON.stringify(init)}`
+    );
+  }
+  return (
+    url.href
+      // A little extra cleanup. The URL class escapes search params very
+      // strictly, and does not allow bare search params.
+      .replace("drive%3A%2F", "drive:/")
+      .replace(/[?&]shared=/, "&shared")
+  );
+}
+
+/**
+ * Parse a Breadboard Visual Editor URL into a strongly-typed object.
+ */
+export function parseUrl(url: string | URL): MakeUrlInit {
+  if (typeof url === "string") {
+    url = new URL(url);
+  }
+  if (url.pathname === "/landing/") {
+    // See note in `makeUrl` above about redirect URLs.
+    const redirectUrl = new URL(url);
+    redirectUrl.pathname = "/";
+    const redirectParsed = parseUrl(redirectUrl);
+    const landing: LandingUrlInit = {
+      page: "landing",
+      redirect:
+        redirectParsed.page === "landing"
+          ? { page: "home", redirectFromLanding: true }
+          : { ...redirectParsed, redirectFromLanding: true },
+    };
+    if (url.searchParams.has(GEO_RESTRICTION)) {
+      landing.geoRestriction = true;
+    }
+    if (url.searchParams.has(MISSING_SCOPES)) {
+      landing.missingScopes = true;
+    }
+    const oauthRedirect = url.searchParams.get(OAUTH_REDIRECT);
+    if (oauthRedirect) {
+      landing.oauthRedirect = oauthRedirect;
+    }
+    return landing;
+  } else {
+    const flow = url.searchParams.get(FLOW) || url.searchParams.get(TAB0);
+    if (!flow) {
+      return {
+        page: "home",
+        mode:
+          url.searchParams.get("mode") === MODE_APP ? MODE_APP : MODE_CANVAS,
+      };
+    }
+    const graph: GraphInit = {
+      page: "graph",
+      mode: url.searchParams.get(MODE) === "app" ? "app" : "canvas",
+      flow: flow,
+      resourceKey: url.searchParams.get(RESOURCE_KEY) ?? undefined,
+    };
+    const results = url.searchParams.get(RESULTS);
+    if (results) {
+      graph.results = results;
+    }
+    if (url.searchParams.has(SHARED)) {
+      graph.shared = true;
+    }
+    return graph;
+  }
+}

--- a/packages/visual-editor/src/bootstrap.ts
+++ b/packages/visual-editor/src/bootstrap.ts
@@ -15,6 +15,12 @@ import type { GoogleDrivePermission } from "@breadboard-ai/shared-ui/contexts/gl
 import { SigninAdapter } from "@breadboard-ai/shared-ui/utils/signin-adapter";
 import { SettingsHelperImpl } from "@breadboard-ai/shared-ui/data/settings-helper.js";
 import { createTokenVendor } from "@breadboard-ai/connection-client";
+import {
+  type LandingUrlInit,
+  makeUrl,
+  OAUTH_REDIRECT,
+  parseUrl,
+} from "@breadboard-ai/shared-ui/utils/urls.js";
 
 export { bootstrap };
 
@@ -164,41 +170,22 @@ async function bootstrap(bootstrapArgs: BootstrapArguments) {
     }
 
     // Redirect to the landing page.
-    const landingRedirectUrl = new URL("/landing/", window.location.href);
-    const currentUrl = new URL(window.location.href);
-    if (currentUrl.searchParams.has("flow")) {
-      landingRedirectUrl.searchParams.set(
-        "flow",
-        currentUrl.searchParams.get("flow")!
-      );
-    }
-    if (currentUrl.searchParams.has("mode")) {
-      landingRedirectUrl.searchParams.set(
-        "mode",
-        currentUrl.searchParams.get("mode")!
-      );
-    }
-    if (currentUrl.searchParams.has("shared")) {
-      landingRedirectUrl.searchParams.set(
-        "shared",
-        currentUrl.searchParams.get("shared")!
-      );
-    }
-    if (currentUrl.searchParams.has("oauth_redirect")) {
-      landingRedirectUrl.searchParams.set(
-        "oauth_redirect",
-        currentUrl.searchParams.get("oauth_redirect")!
-      );
-    }
+    const landing: LandingUrlInit = {
+      page: "landing",
+      redirect: parseUrl(window.location.href),
+      oauthRedirect:
+        new URL(window.location.href).searchParams.get(OAUTH_REDIRECT) ??
+        undefined,
+    };
     if (signinAdapter.state === "signedin" && !scopeValidation.ok) {
       console.log(
         "[signin] oauth scopes were missing or unavailable, forcing signin.",
         scopeValidation.error
       );
       await signinAdapter.signOut();
-      landingRedirectUrl.searchParams.set("missing-scopes", "true");
+      landing.missingScopes = true;
     }
-    window.location.href = decodeURIComponent(landingRedirectUrl.href);
+    window.location.href = makeUrl(landing);
     return;
   }
 }

--- a/packages/visual-editor/src/event-routing/board/board.ts
+++ b/packages/visual-editor/src/event-routing/board/board.ts
@@ -72,13 +72,13 @@ export const LoadRoute: EventRoute<"board.load"> = {
   event: "board.load",
 
   async do({ runtime, originalEvent, uiState }) {
-    runtime.router.go(
-      originalEvent.detail.url,
-      uiState.mode,
-      undefined,
-      undefined,
-      originalEvent.detail.shared
-    );
+    runtime.router.go({
+      page: "graph",
+      mode: uiState.mode,
+      flow: originalEvent.detail.url,
+      resourceKey: undefined,
+      shared: originalEvent.detail.shared,
+    });
     return false;
   },
 };
@@ -197,8 +197,9 @@ export const CreateRoute: EventRoute<"board.create"> = {
 
     runtime.router.go(
       {
-      // Ensure we always go back to the canvas when a board is created.
-        page: "canvas",
+        page: "graph",
+        // Ensure we always go back to the canvas when a board is created.
+        mode: "canvas",
         flow: result.url.href,
         // Resource key not required because we know the current user created it.
         resourceKey: undefined,

--- a/packages/visual-editor/src/event-routing/board/board.ts
+++ b/packages/visual-editor/src/event-routing/board/board.ts
@@ -196,9 +196,13 @@ export const CreateRoute: EventRoute<"board.create"> = {
     }
 
     runtime.router.go(
-      result.url.href,
+      {
       // Ensure we always go back to the canvas when a board is created.
-      "canvas",
+        page: "canvas",
+        flow: result.url.href,
+        // Resource key not required because we know the current user created it.
+        resourceKey: undefined,
+      },
       tab?.id,
       originalEvent.detail.editHistoryCreator
     );

--- a/packages/visual-editor/src/event-routing/host/host.ts
+++ b/packages/visual-editor/src/event-routing/host/host.ts
@@ -4,13 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { parseUrl } from "@breadboard-ai/shared-ui/utils/urls.js";
 import { EventRoute } from "../types";
 
 export const ModeRoute: EventRoute<"host.modetoggle"> = {
   event: "host.modetoggle",
 
   async do({ runtime, originalEvent }) {
-    runtime.router.go(window.location.href, originalEvent.detail.mode);
+    const current = parseUrl(window.location.href);
+    if (current.page === "graph") {
+      const newMode = originalEvent.detail.mode;
+      if (newMode !== current.mode) {
+        runtime.router.go({ ...current, mode: newMode });
+      }
+    }
     return false;
   },
 };

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -2040,7 +2040,7 @@ export class Main extends SignalWatcher(LitElement) {
         this.#embedHandler?.sendToEmbedder({
           type: "back_clicked",
         });
-        this.#runtime.router.go(null, this.#uiState.mode);
+        this.#runtime.router.go({ page: "home", mode: this.#uiState.mode });
       }}
       @bbsharerequested=${() => {
         if (!this.#canvasControllerRef.value) {

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -103,6 +103,7 @@ import { MainArguments } from "./types/types";
 import { envFromSettings } from "./utils/env-from-settings";
 import { envFromFlags } from "./utils/env-from-flags";
 import { FileSystemPersistentBackend } from "@breadboard-ai/filesystem-board-server";
+import { makeUrl } from "@breadboard-ai/shared-ui/utils/urls.js";
 
 type RenderValues = {
   canSave: boolean;
@@ -315,7 +316,15 @@ export class Main extends SignalWatcher(LitElement) {
         ))
       ) {
         await this.signinAdapter.signOut();
-        window.history.pushState(undefined, "", "/landing/?geo-restriction");
+        window.history.pushState(
+          undefined,
+          "",
+          makeUrl({
+            page: "landing",
+            geoRestriction: true,
+            redirect: { page: "home" },
+          })
+        );
         window.location.reload();
       }
     });

--- a/packages/visual-editor/src/runtime/board.ts
+++ b/packages/visual-editor/src/runtime/board.ts
@@ -61,6 +61,7 @@ import { GoogleDriveClient } from "@breadboard-ai/google-drive-kit/google-drive-
 import { loadImage } from "@breadboard-ai/shared-ui/utils/image";
 import { RecentBoardStore } from "../data/recent-boards";
 import { type RunResults } from "@breadboard-ai/google-drive-kit/board-server/operations.js";
+import { parseUrl } from "@breadboard-ai/shared-ui/utils/urls.js";
 
 const documentStyles = getComputedStyle(document.documentElement);
 
@@ -684,8 +685,8 @@ export class Board extends EventTarget {
 
       if (!graph) {
         // Confirm that the user is using a shared URL.
-        const currentLocationHref = new URL(window.location.href);
-        if (!currentLocationHref.searchParams.has("shared")) {
+        const currentUrlParsed = parseUrl(window.location.href);
+        if (currentUrlParsed.page === "graph" && !currentUrlParsed.shared) {
           this.dispatchEvent(new RuntimeShareMissingEvent());
           return;
         }


### PR DESCRIPTION
Adds new makeUrl and parseUrl functions which understand all of the kinds of URLs in our app, and updated every place (at least those I could find; there might be a few stragglers) where we create or parse URLs to use this.

One bug this fixes is that previously if you were signed-out but clicked on a link with a results file, the results parameter got dropped.

In general this should make it easier to create valid consistent URLs, and will make it easier to change our URL scheme if we want, too.

Also adds a test script to the shared-ui package. It's a node test, but that's the simplest/fastest way to run unit tests assuming it's not depending on any web-specific apis.