### PR TITLE
[shared-ui] Couple of small UI tweaks

### DIFF
--- a/.changeset/fast-gifts-add.md
+++ b/.changeset/fast-gifts-add.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/shared-ui": patch
+---
+
+Couple of small UI tweaks

--- a/packages/shared-ui/src/flow-gen/flowgen-editor-input.ts
+++ b/packages/shared-ui/src/flow-gen/flowgen-editor-input.ts
@@ -66,7 +66,7 @@ export class FlowgenEditorInput extends LitElement {
       }
 
       p {
-        word-break: break-all;
+        word-break: auto-phrase;
       }
 
       #feedback {
@@ -78,7 +78,7 @@ export class FlowgenEditorInput extends LitElement {
         border-radius: var(--bb-grid-size-2);
         padding-left: var(--bb-grid-size-5);
         padding-right: var(--bb-grid-size-5);
-        word-break: break-all;
+        word-break: auto-phrase;
         display: flex;
         align-items: center;
         justify-content: space-between;

--- a/packages/shared-ui/src/state/utils/decode-error.ts
+++ b/packages/shared-ui/src/state/utils/decode-error.ts
@@ -145,7 +145,7 @@ function decodeError(event: RunErrorEvent): RunError {
       } else {
         return {
           message: `${preamble}.`,
-          details: `${preamble} for the following reasons:\n\n ${reasonDescriptions.map((reason) => `- ${reason}\n`)}`,
+          details: `${preamble} for the following reasons:\n\n ${reasonDescriptions.map((reason) => `- ${reason}`).join("\n")}`,
         };
       }
     }


### PR DESCRIPTION
This PR:

1. Formats error messages from the NL flow so that they don't break mid-word
2. Tweaks the snackbar error messages so that they are joined with "\n" rather than "\n," (which breaks markdown formatting).