### PR TITLE
[shared-ui] Enable experimental 2D matrix rendering of graph

### DIFF
--- a/.changeset/giant-clubs-try.md
+++ b/.changeset/giant-clubs-try.md
@@ -1,0 +1,6 @@
+---
+"@breadboard-ai/shared-ui": patch
+"@breadboard-ai/types": patch
+---
+
+Enable experimental 2D matrix rendering of graph

--- a/packages/shared-ui/src/config/client-deployment-configuration.ts
+++ b/packages/shared-ui/src/config/client-deployment-configuration.ts
@@ -19,6 +19,7 @@ const DEFAULT_FLAG_VALUES: RuntimeFlags = {
   saveAsCode: false,
   generateForEach: false,
   mcp: false,
+  force2DGraph: false,
 };
 
 export function populateFlags(

--- a/packages/shared-ui/src/elements/canvas-controller/canvas-controller.ts
+++ b/packages/shared-ui/src/elements/canvas-controller/canvas-controller.ts
@@ -82,9 +82,10 @@ import "./empty-state.js";
 import { findGoogleDriveAssetsInGraph } from "@breadboard-ai/google-drive-kit/board-server/utils.js";
 import { isEmpty } from "../../utils/utils.js";
 import { uiStateContext } from "../../contexts/ui-state.js";
+import { SignalWatcher } from "@lit-labs/signals";
 
 @customElement("bb-canvas-controller")
-export class CanvasController extends LitElement {
+export class CanvasController extends SignalWatcher(LitElement) {
   @consume({ context: uiStateContext })
   accessor #uiState!: UI;
 
@@ -384,6 +385,7 @@ export class CanvasController extends LitElement {
         this.highlightState,
         this.visualChangeId,
         this.graphTopologyUpdateId,
+        this.#uiState.flags,
         collapseNodesByDefault,
         hideSubboardSelectorWhenEmpty,
         showNodeShortcuts,
@@ -399,6 +401,7 @@ export class CanvasController extends LitElement {
         return html`<bb-renderer
           .boardServerKits=${this.boardServerKits}
           .projectState=${this.projectState}
+          .runtimeFlags=${this.#uiState.flags}
           .graph=${graph}
           .graphIsMine=${this.graphIsMine}
           .graphTopologyUpdateId=${this.graphTopologyUpdateId}

--- a/packages/shared-ui/src/elements/step-editor/entity.ts
+++ b/packages/shared-ui/src/elements/step-editor/entity.ts
@@ -43,6 +43,18 @@ export class Entity extends LitElement {
   @property()
   accessor cullable = false;
 
+  @property({ reflect: true, type: Boolean })
+  set force2D(force2D: boolean) {
+    this.#force2D = force2D;
+    for (const entity of this.entities.values()) {
+      entity.force2D = force2D;
+    }
+  }
+  get force2D() {
+    return this.#force2D;
+  }
+  #force2D = false;
+
   @property()
   set readOnly(readOnly: boolean) {
     this.#readOnly = readOnly;
@@ -126,7 +138,7 @@ export class Entity extends LitElement {
     }
 
     const styles: Record<string, string> = {
-      transform: `${toCSSMatrix(this.worldTransform)}`,
+      transform: `${toCSSMatrix(this.worldTransform, this.force2D)}`,
       width: `${this.bounds.width}px`,
       height: `${this.bounds.height}px`,
     };

--- a/packages/shared-ui/src/elements/step-editor/graph-asset.ts
+++ b/packages/shared-ui/src/elements/step-editor/graph-asset.ts
@@ -376,7 +376,7 @@ export class GraphAsset
 
   protected renderSelf() {
     const styles: Record<string, string> = {
-      transform: toCSSMatrix(this.worldTransform),
+      transform: toCSSMatrix(this.worldTransform, this.force2D),
     };
 
     let defaultAdd: HTMLTemplateResult | symbol = nothing;

--- a/packages/shared-ui/src/elements/step-editor/graph-edge.ts
+++ b/packages/shared-ui/src/elements/step-editor/graph-edge.ts
@@ -115,7 +115,12 @@ export class GraphEdge extends Box {
 
       svg {
         pointer-events: none;
-        will-change: transform;
+      }
+
+      :host(:not([force2d])) {
+        svg {
+          will-change: transform;
+        }
       }
 
       svg > * {
@@ -697,7 +702,7 @@ export class GraphEdge extends Box {
 
   protected renderSelf() {
     const styles: Record<string, string> = {
-      transform: toCSSMatrix(this.worldTransform),
+      transform: toCSSMatrix(this.worldTransform, this.force2D),
     };
 
     const nodeBoundPoints = this.#getNodeBoundPoints();

--- a/packages/shared-ui/src/elements/step-editor/graph-node.ts
+++ b/packages/shared-ui/src/elements/step-editor/graph-node.ts
@@ -38,7 +38,6 @@ import {
   isPreviewBehavior,
 } from "../../utils/behaviors";
 import { createTruncatedValue } from "./utils/create-truncated-value";
-import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { styles as ChicletStyles } from "../../styles/chiclet.js";
 import { toGridSize } from "./utils/to-grid-size";
 import { DragConnectorReceiver } from "../../types/types";
@@ -782,7 +781,7 @@ export class GraphNode extends Box implements DragConnectorReceiver {
 
   protected renderSelf() {
     const styles: Record<string, string> = {
-      transform: toCSSMatrix(this.worldTransform),
+      transform: toCSSMatrix(this.worldTransform, this.force2D),
     };
 
     let chatAdornment: HTMLTemplateResult[] | symbol = nothing;

--- a/packages/shared-ui/src/elements/step-editor/graph.ts
+++ b/packages/shared-ui/src/elements/step-editor/graph.ts
@@ -639,7 +639,7 @@ export class Graph extends Box {
     if (renderBoundary) {
       const boundaryTransform = this.worldTransform.translate(-20, -20);
       const styles: Record<string, string> = {
-        transform: `${toCSSMatrix(boundaryTransform)}`,
+        transform: `${toCSSMatrix(boundaryTransform, this.force2D)}`,
         width: `${this.bounds.width + 40}px`,
         height: `${this.bounds.height + 40}px`,
       };

--- a/packages/shared-ui/src/elements/step-editor/utils/to-css-matrix.ts
+++ b/packages/shared-ui/src/elements/step-editor/utils/to-css-matrix.ts
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export function toCSSMatrix(m: DOMMatrix): string {
+export function toCSSMatrix(m: DOMMatrix, force2D = false): string {
+  if (force2D) {
+    return `matrix(${m.a},${m.b},${m.c},${m.d},${m.e},${m.f})`;
+  }
+
   return `matrix3d(${m.m11}, ${m.m12}, ${m.m13}, ${m.m14},
       ${m.m21}, ${m.m22}, ${m.m23}, ${m.m24},
       ${m.m31}, ${m.m32}, ${m.m33}, ${m.m34},

--- a/packages/types/src/flags.ts
+++ b/packages/types/src/flags.ts
@@ -37,6 +37,10 @@ export type RuntimeFlags = {
    * Enable MCP support
    */
   mcp: boolean;
+  /**
+   * Use 2D matrices for graph rendering.
+   */
+  force2DGraph: boolean;
 };
 
 /**


### PR DESCRIPTION
By default we use 3D matrices for rendering nodes & edges which creates compositor layers in Chromium-based browsers. For larger graphs particularly this can create memory pressure where the tab needs more memory than it can access, which in turn causes rendering bugs.

This PR enables an experimental flag for using 2D matrices (and bypassing `will-change`) on edges and nodes. The trade-off is this:

1. With this flag off (the default) everything is given its own compositor layer. This means we avoid re-rasterizing but for larger graphs we can see memory pressure/exhaustion.
2. With this flag on everything is drawn into the same compositor layer. This means that every pan & zoom action will cause re-rasterizing, but on the upside everything is on a single compositor layer so there's less to manage at that level.