### PR TITLE
Revert "[shared-ui] Make Entity a SignalWatcher"

### DIFF
--- a/.changeset/thick-hairs-own.md
+++ b/.changeset/thick-hairs-own.md
@@ -1,5 +1,0 @@
----
-"@breadboard-ai/shared-ui": patch
----
-
-Make Entity a SignalWatcher

--- a/packages/shared-ui/src/elements/step-editor/entity.ts
+++ b/packages/shared-ui/src/elements/step-editor/entity.ts
@@ -10,10 +10,9 @@ import { styleMap } from "lit/directives/style-map.js";
 import { toCSSMatrix } from "./utils/to-css-matrix";
 import { intersects } from "./utils/rect-intersection";
 import { Project } from "../../state";
-import { SignalWatcher } from "@lit-labs/signals";
 
 @customElement("bb-graph-entity")
-export class Entity extends SignalWatcher(LitElement) {
+export class Entity extends LitElement {
   boundsLabel = "";
   entities = new Map<string, Entity>();
 


### PR DESCRIPTION
Reverts breadboard-ai/breadboard#6521

This starts throwing cycle as detected in signal machinery. Let's remove it for now.