### PR TITLE
[remixing/copying] Only copy managed assets when remixing

### DIFF
--- a/packages/google-drive-kit/src/board-server/utils.ts
+++ b/packages/google-drive-kit/src/board-server/utils.ts
@@ -179,6 +179,7 @@ export type GoogleDriveAsset = {
    * we will ask the user before modifying sharing ACLs.
    */
   managed: boolean;
+  part: DataPart;
 };
 
 export function findGoogleDriveAssetsInGraph(
@@ -197,6 +198,7 @@ export function findGoogleDriveAssetsInGraph(
           files.set(fileId.id, {
             fileId,
             managed: asset.metadata?.managed ?? false,
+            part: firstPart,
           });
         }
       }
@@ -210,7 +212,11 @@ export function findGoogleDriveAssetsInGraph(
       if (splashScreen) {
         const fileId = partToDriveFileId(splashScreen);
         if (fileId) {
-          files.set(fileId.id, { fileId, managed: true });
+          files.set(fileId.id, {
+            fileId,
+            managed: true,
+            part: splashScreen,
+          });
         }
       }
     }


### PR DESCRIPTION
Only copy managed assets, such as themes and directly uploaded files,
which are intrinsic to the graph. Unmanaged assets are references to
existing files that were picked from Drive. We don't want to copy
those by default, because:

1. The file might have restrictive sharing, and we don't want to make
   it too easy to expand access by copying and publishing.

2. The file might be a common source-of-truth, like a shared prompt
   guidelines doc, and we don't want to duplicate that.