### PR TITLE
[shared-ui] Refine icons in text editor

### DIFF
--- a/.changeset/khaki-places-lay.md
+++ b/.changeset/khaki-places-lay.md
@@ -1,0 +1,5 @@
+---
+"@breadboard-ai/shared-ui": patch
+---
+
+Refine icons in text editor

--- a/packages/shared-ui/src/state/project.ts
+++ b/packages/shared-ui/src/state/project.ts
@@ -9,6 +9,7 @@ import {
   AssetPath,
   GraphIdentifier,
   HarnessRunner,
+  InspectableNodePorts,
   LLMContent,
   NodeIdentifier,
   ParameterMetadata,
@@ -275,6 +276,21 @@ class ReactiveProject implements ProjectInternal {
       return err(`Unable to find metadata for node with id "${nodeId}"`);
     }
     return metadata;
+  }
+
+  getPortsForNode(
+    nodeId: NodeIdentifier,
+    graphId: GraphIdentifier
+  ): Outcome<InspectableNodePorts> {
+    const inspectable = this.#store.inspect(this.#mainGraphId, graphId);
+    if (!inspectable) {
+      return err(`Unable to inspect graph with "${this.#mainGraphId}"`);
+    }
+    const node = inspectable.nodeById(nodeId);
+    if (!node) {
+      return err(`Unable to find node with id "${nodeId}`);
+    }
+    return node.currentPorts();
   }
 
   findOutputPortId(

--- a/packages/shared-ui/src/state/types.ts
+++ b/packages/shared-ui/src/state/types.ts
@@ -580,6 +580,11 @@ export type Project = {
     graphId: GraphIdentifier
   ): Outcome<NodeHandlerMetadata>;
 
+  getPortsForNode(
+    nodeId: NodeIdentifier,
+    graphId: GraphIdentifier
+  ): Outcome<InspectableNodePorts>;
+
   persistDataParts(contents: LLMContent[]): Promise<LLMContent[]>;
   connectHarnessRunner(
     runner: HarnessRunner,

--- a/packages/shared-ui/src/utils/expand-chiclet.ts
+++ b/packages/shared-ui/src/utils/expand-chiclet.ts
@@ -7,6 +7,7 @@
 import { ok, TemplatePart } from "@google-labs/breadboard";
 import { Project } from "../state";
 import { iconSubstitute } from "./icon-substitute";
+import { getStepIcon } from "./get-step-icon";
 
 export function expandChiclet(
   part: TemplatePart,
@@ -24,14 +25,19 @@ export function expandChiclet(
 
   switch (type) {
     case "in": {
-      const outcome = projectState.getMetadataForNode(
+      const metadata = projectState.getMetadataForNode(
         path,
         subGraphId ? subGraphId : ""
       );
 
-      if (ok(outcome)) {
-        icon = iconSubstitute(outcome.icon);
-        tags = outcome.tags ?? [];
+      const ports = projectState.getPortsForNode(
+        path,
+        subGraphId ? subGraphId : ""
+      );
+
+      if (ok(metadata) && ok(ports)) {
+        icon = getStepIcon(metadata.icon, ports);
+        tags = metadata.tags ?? [];
       }
       break;
     }


### PR DESCRIPTION
This PR ensures that we use the subtype icon for steps and assets, so that they don't show a generic generative icon when they are – say – a generative audio step.