### PR TITLE
[signin] Support incremental oauth scopes

### DIFF
--- a/packages/connection-client/package.json
+++ b/packages/connection-client/package.json
@@ -3,7 +3,16 @@
   "version": "0.3.0",
   "description": "Breadboard Connection Client",
   "main": "./dist/src/index.js",
-  "exports": "./dist/src/index.js",
+  "exports": {
+    ".": {
+      "default": "./dist/src/index.js",
+      "types": "./dist/src/index.d.ts"
+    },
+    "./*.js": {
+      "types": "./dist/src/*.d.ts",
+      "default": "./dist/src/*.js"
+    }
+  },
   "types": "dist/src/index.d.ts",
   "type": "module",
   "scripts": {

--- a/packages/connection-client/src/oauth-scopes.ts
+++ b/packages/connection-client/src/oauth-scopes.ts
@@ -8,6 +8,8 @@ export const OAUTH_SCOPES = {
   // https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
   openid: {
     category: "Google Account",
+    // Always required according to the OpenID Connect Core spec.
+    required: true,
   },
 
   // https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
@@ -20,6 +22,8 @@ export const OAUTH_SCOPES = {
   email: {
     aliases: ["https://www.googleapis.com/auth/userinfo.email"],
     category: "Google Account",
+    // Required for checking geo-location.
+    required: true,
   },
 
   // https://developers.google.com/workspace/drive/api/guides/api-specific-auth#drive-scopes
@@ -39,6 +43,12 @@ export const OAUTH_SCOPES = {
 } as const satisfies Record<string, OAuthScopeInfo>;
 
 type OAuthScopeInfo = {
+  /**
+   * If true, this scope will always be requested, regardless of which specific
+   * scopes are being requested at the time.
+   */
+  required?: boolean;
+
   /**
    * Some scopes have multiple valid values that mean the same exact thing.
    */

--- a/packages/connection-client/src/oauth-scopes.ts
+++ b/packages/connection-client/src/oauth-scopes.ts
@@ -4,56 +4,41 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/**
- * Note the keys here are short names that are only valid within this codebase,
- * for convenience.
- */
-const OAUTH_SCOPE_INFO = {
+export const OAUTH_SCOPES = {
   // https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
   openid: {
-    canonical: "openid",
     category: "Google Account",
   },
 
   // https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
   profile: {
-    canonical: "profile",
     aliases: ["https://www.googleapis.com/auth/userinfo.profile"],
     category: "Google Account",
   } satisfies OAuthScopeInfo,
 
   // https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
   email: {
-    canonical: "email",
     aliases: ["https://www.googleapis.com/auth/userinfo.email"],
     category: "Google Account",
   },
 
   // https://developers.google.com/workspace/drive/api/guides/api-specific-auth#drive-scopes
-  "drive.readonly": {
-    canonical: "https://www.googleapis.com/auth/drive.readonly",
+  "https://www.googleapis.com/auth/drive.readonly": {
     category: "Google Drive",
   },
 
   // https://developers.google.com/workspace/drive/api/guides/api-specific-auth#drive-scopes
-  "drive.file": {
-    canonical: "https://www.googleapis.com/auth/drive.file",
+  "https://www.googleapis.com/auth/drive.file": {
     category: "Google Drive",
   },
 
   // https://ai.google.dev/gemini-api/docs/oauth
-  "generative-language.retriever": {
-    canonical: "https://www.googleapis.com/auth/generative-language.retriever",
+  "https://www.googleapis.com/auth/generative-language.retriever": {
     category: "Gemini",
   },
 } as const satisfies Record<string, OAuthScopeInfo>;
 
 type OAuthScopeInfo = {
-  /**
-   * The actual canonical OAuth scope value that we will request.
-   */
-  canonical: string;
-
   /**
    * Some scopes have multiple valid values that mean the same exact thing.
    */
@@ -71,16 +56,7 @@ type OAuthScopeInfo = {
   category: string;
 };
 
-export type OAuthScopeShortName = keyof typeof OAUTH_SCOPE_INFO;
-
-type OAuthScopeCanonical =
-  (typeof OAUTH_SCOPE_INFO)[OAuthScopeShortName]["canonical"];
-
-export function expandOAuthScopeShortNames(
-  shortNames: Array<OAuthScopeShortName>
-): OAuthScopeCanonical[] {
-  return shortNames.map((shortName) => OAUTH_SCOPE_INFO[shortName].canonical);
-}
+export type OAuthScope = keyof typeof OAUTH_SCOPES;
 
 const OAUTH_SCOPE_ALIAS_TO_CANONICAL = new Map<string, string>();
 for (const { value, aliases } of Object.values(

--- a/packages/connection-client/src/oauth-scopes.ts
+++ b/packages/connection-client/src/oauth-scopes.ts
@@ -1,0 +1,98 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Note the keys here are short names that are only valid within this codebase,
+ * for convenience.
+ */
+const OAUTH_SCOPE_INFO = {
+  // https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
+  openid: {
+    canonical: "openid",
+    category: "Google Account",
+  },
+
+  // https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+  profile: {
+    canonical: "profile",
+    aliases: ["https://www.googleapis.com/auth/userinfo.profile"],
+    category: "Google Account",
+  } satisfies OAuthScopeInfo,
+
+  // https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+  email: {
+    canonical: "email",
+    aliases: ["https://www.googleapis.com/auth/userinfo.email"],
+    category: "Google Account",
+  },
+
+  // https://developers.google.com/workspace/drive/api/guides/api-specific-auth#drive-scopes
+  "drive.readonly": {
+    canonical: "https://www.googleapis.com/auth/drive.readonly",
+    category: "Google Drive",
+  },
+
+  // https://developers.google.com/workspace/drive/api/guides/api-specific-auth#drive-scopes
+  "drive.file": {
+    canonical: "https://www.googleapis.com/auth/drive.file",
+    category: "Google Drive",
+  },
+
+  // https://ai.google.dev/gemini-api/docs/oauth
+  "generative-language.retriever": {
+    canonical: "https://www.googleapis.com/auth/generative-language.retriever",
+    category: "Gemini",
+  },
+} as const satisfies Record<string, OAuthScopeInfo>;
+
+type OAuthScopeInfo = {
+  /**
+   * The actual canonical OAuth scope value that we will request.
+   */
+  canonical: string;
+
+  /**
+   * Some scopes have multiple valid values that mean the same exact thing.
+   */
+  aliases?: string[];
+
+  /**
+   * A short human-readable category label that may be shown to the user when
+   * requesting scopes.
+   *
+   * Note we don't want to provide specific detail about each individual scope,
+   * because there is an official description that will be shown to the user
+   * when they are in the OAuth flow, and it would be confusing if we describe
+   * it in a different way.
+   */
+  category: string;
+};
+
+export type OAuthScopeShortName = keyof typeof OAUTH_SCOPE_INFO;
+
+type OAuthScopeCanonical =
+  (typeof OAUTH_SCOPE_INFO)[OAuthScopeShortName]["canonical"];
+
+export function expandOAuthScopeShortNames(
+  shortNames: Array<OAuthScopeShortName>
+): OAuthScopeCanonical[] {
+  return shortNames.map((shortName) => OAUTH_SCOPE_INFO[shortName].canonical);
+}
+
+const OAUTH_SCOPE_ALIAS_TO_CANONICAL = new Map<string, string>();
+for (const { value, aliases } of Object.values(
+  OAUTH_SCOPE_ALIAS_TO_CANONICAL
+)) {
+  if (aliases) {
+    for (const alias of aliases) {
+      OAUTH_SCOPE_ALIAS_TO_CANONICAL.set(alias, value);
+    }
+  }
+}
+
+export function canonicalizeOAuthScope(scope: string): string {
+  return OAUTH_SCOPE_ALIAS_TO_CANONICAL.get(scope) ?? scope;
+}

--- a/packages/connection-client/src/oauth-scopes.ts
+++ b/packages/connection-client/src/oauth-scopes.ts
@@ -68,13 +68,15 @@ type OAuthScopeInfo = {
 
 export type OAuthScope = keyof typeof OAUTH_SCOPES;
 
+export const REQUIRED_OAUTH_SCOPES = Object.entries(OAUTH_SCOPES)
+  .filter(([, info]) => "required" in info && info.required)
+  .map(([scope]) => scope);
+
 const OAUTH_SCOPE_ALIAS_TO_CANONICAL = new Map<string, string>();
-for (const { value, aliases } of Object.values(
-  OAUTH_SCOPE_ALIAS_TO_CANONICAL
-)) {
-  if (aliases) {
-    for (const alias of aliases) {
-      OAUTH_SCOPE_ALIAS_TO_CANONICAL.set(alias, value);
+for (const [canonical, info] of Object.entries(OAUTH_SCOPES)) {
+  if ("aliases" in info) {
+    for (const alias of info.aliases) {
+      OAUTH_SCOPE_ALIAS_TO_CANONICAL.set(alias, canonical);
     }
   }
 }

--- a/packages/connection-client/src/oauth-scopes.ts
+++ b/packages/connection-client/src/oauth-scopes.ts
@@ -68,7 +68,7 @@ type OAuthScopeInfo = {
 
 export type OAuthScope = keyof typeof OAUTH_SCOPES;
 
-export const REQUIRED_OAUTH_SCOPES = Object.entries(OAUTH_SCOPES)
+export const ALWAYS_REQUIRED_OAUTH_SCOPES = Object.entries(OAUTH_SCOPES)
   .filter(([, info]) => "required" in info && info.required)
   .map(([scope]) => scope);
 

--- a/packages/connection-client/src/token-vendor.ts
+++ b/packages/connection-client/src/token-vendor.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { OAuthScopeShortName } from "./oauth-scopes.js";
+import type { OAuthScope } from "./oauth-scopes.js";
 import type {
   ConnectionEnvironment,
   GrantStore,
@@ -40,7 +40,7 @@ export class TokenVendorImpl implements TokenVendor {
     this.#environment = environment;
   }
 
-  getToken(connectionId: string, scopes?: OAuthScopeShortName[]): TokenResult {
+  getToken(connectionId: string, scopes?: OAuthScope[]): TokenResult {
     if (scopes?.length) {
       console.debug("token requested with scopes", scopes);
     }

--- a/packages/connection-client/src/token-vendor.ts
+++ b/packages/connection-client/src/token-vendor.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
+import type { OAuthScopeShortName } from "./oauth-scopes.js";
+import type {
   ConnectionEnvironment,
   GrantStore,
   ListConnectionsResponse,
@@ -39,7 +40,10 @@ export class TokenVendorImpl implements TokenVendor {
     this.#environment = environment;
   }
 
-  getToken(connectionId: string): TokenResult {
+  getToken(connectionId: string, scopes?: OAuthScopeShortName[]): TokenResult {
+    if (scopes?.length) {
+      console.debug("token requested with scopes", scopes);
+    }
     const grantJsonString = this.#store.get(connectionId);
     if (grantJsonString === undefined) {
       return { state: "signedout" };

--- a/packages/connection-client/src/token-vendor.ts
+++ b/packages/connection-client/src/token-vendor.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { OAuthScope } from "./oauth-scopes.js";
 import type {
   ConnectionEnvironment,
   GrantStore,
@@ -40,10 +39,7 @@ export class TokenVendorImpl implements TokenVendor {
     this.#environment = environment;
   }
 
-  getToken(connectionId: string, scopes?: OAuthScope[]): TokenResult {
-    if (scopes?.length) {
-      console.debug("token requested with scopes", scopes);
-    }
+  getToken(connectionId: string): TokenResult {
     const grantJsonString = this.#store.get(connectionId);
     if (grantJsonString === undefined) {
       return { state: "signedout" };

--- a/packages/connection-client/src/types.ts
+++ b/packages/connection-client/src/types.ts
@@ -4,8 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { OAuthScopeShortName } from "./oauth-scopes.js";
+
 export type TokenVendor = {
-  getToken(connectionId: string): TokenResult;
+  getToken(connectionId: string, scopes?: OAuthScopeShortName[]): TokenResult;
   isSignedIn(connectionId: string): boolean;
 };
 

--- a/packages/connection-client/src/types.ts
+++ b/packages/connection-client/src/types.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { OAuthScopeShortName } from "./oauth-scopes.js";
+import type { OAuthScope } from "./oauth-scopes.js";
 
 export type TokenVendor = {
-  getToken(connectionId: string, scopes?: OAuthScopeShortName[]): TokenResult;
+  getToken(connectionId: string, scopes?: OAuthScope[]): TokenResult;
   isSignedIn(connectionId: string): boolean;
 };
 

--- a/packages/connection-server/src/api/list.ts
+++ b/packages/connection-server/src/api/list.ts
@@ -63,6 +63,7 @@ function makeAuthorizationEndpointUrl(config: ConnectionConfig): string {
   const url = new URL(config.oauth.auth_uri);
   const params = url.searchParams;
   params.set("client_id", config.oauth.client_id);
+  // TODO(aomarks) Remove this once scopes are fully handled by the client.
   params.set("scope", config.oauth.scopes.join(" "));
   params.set("response_type", "code");
   params.set("access_type", "offline");

--- a/packages/google-drive-kit/src/google-drive-client.ts
+++ b/packages/google-drive-kit/src/google-drive-client.ts
@@ -499,9 +499,9 @@ export class GoogleDriveClient {
       undefined,
       {
         kind: "bearer",
-        token: await this.#getUserAccessToken([
-          "https://www.googleapis.com/auth/drive.file",
-        ]),
+        // TODO(aomarks) Set the drive.file scope here, and either that or
+        // drive.readonly for every other method.
+        token: await this.#getUserAccessToken(),
       }
     );
     if (!response.ok) {

--- a/packages/google-drive-kit/src/google-drive-client.ts
+++ b/packages/google-drive-kit/src/google-drive-client.ts
@@ -6,7 +6,7 @@
 
 /// <reference types="@types/gapi.client.drive-v3" />
 
-import type { OAuthScopeShortName } from "@breadboard-ai/connection-client/oauth-scopes.js";
+import type { OAuthScope } from "@breadboard-ai/connection-client/oauth-scopes.js";
 import { retryableFetch } from "./board-server/utils.js";
 
 type File = gapi.client.drive.File;
@@ -184,9 +184,7 @@ export class GoogleDriveClient {
         marked: Set<string>;
       }
     | undefined;
-  readonly #getUserAccessToken: (
-    scopes?: OAuthScopeShortName[]
-  ) => Promise<string>;
+  readonly #getUserAccessToken: (scopes?: OAuthScope[]) => Promise<string>;
 
   constructor(options: GoogleDriveClientOptions) {
     this.apiUrl = options.apiBaseUrl || "https://www.googleapis.com";
@@ -201,7 +199,7 @@ export class GoogleDriveClient {
 
   // TODO(aomarks) Remove. Anything that needs an access token should get it
   // itself.
-  async accessToken(scopes?: OAuthScopeShortName[]): Promise<string> {
+  async accessToken(scopes?: OAuthScope[]): Promise<string> {
     return this.#getUserAccessToken(scopes);
   }
 
@@ -501,7 +499,9 @@ export class GoogleDriveClient {
       undefined,
       {
         kind: "bearer",
-        token: await this.#getUserAccessToken(["drive.file"]),
+        token: await this.#getUserAccessToken([
+          "https://www.googleapis.com/auth/drive.file",
+        ]),
       }
     );
     if (!response.ok) {

--- a/packages/shared-ui/src/elements/shell/sign-in-modal.ts
+++ b/packages/shared-ui/src/elements/shell/sign-in-modal.ts
@@ -26,6 +26,7 @@ export class VESignInModal extends LitElement {
     | { status: "closed" }
     | {
         status: "open";
+        reason: "sign-in" | "add-scope";
         scopes: OAuthScope[] | undefined;
         outcomePromise: Promise<boolean>;
         outcomeResolve: (outcome: boolean) => void;
@@ -78,19 +79,27 @@ export class VESignInModal extends LitElement {
     if (this.#state.status !== "open") {
       return nothing;
     }
-    // TODO(aomarks) Differentiate between fresh sign-in vs adding scopes.
+    const { reason } = this.#state;
     return html`
       <bb-modal
         icon="login"
-        modalTitle="Sign In"
+        .modalTitle=${reason === "sign-in"
+          ? "Sign In"
+          : "Requesting additional permissions"}
         showCloseButton
         @bbmodaldismissed=${this.#onDismiss}
       >
         <section>
-          <p>To continue, you'll need to sign in with your Google account.</p>
+          <p>
+            ${reason === "sign-in"
+              ? html`To continue, you'll need to sign in with your Google
+                account.`
+              : html`This action requires additional permissions. Please click
+                  <em>Continue</em> to view permissions and allow access.`}
+          </p>
           <aside>
             <button id="sign-in" class="sans" @click=${this.#onClickSignIn}>
-              Sign In
+              ${reason === "sign-in" ? "Sign In" : "Continue"}
             </button>
           </aside>
         </section>
@@ -103,6 +112,8 @@ export class VESignInModal extends LitElement {
       let resolve: (outcome: boolean) => void;
       this.#state = {
         status: "open",
+        reason:
+          this.signinAdapter?.state === "signedin" ? "add-scope" : "sign-in",
         outcomePromise: new Promise<boolean>((r) => (resolve = r)),
         outcomeResolve: resolve!,
         scopes,

--- a/packages/shared-ui/src/elements/shell/sign-in-modal.ts
+++ b/packages/shared-ui/src/elements/shell/sign-in-modal.ts
@@ -47,6 +47,10 @@ export class VESignInModal extends LitElement {
         z-index: 1;
       }
 
+      section {
+        max-width: 500px;
+      }
+
       p,
       li {
         margin: 0 0 var(--bb-grid-size-2) 0;

--- a/packages/shared-ui/src/utils/signin-adapter.ts
+++ b/packages/shared-ui/src/utils/signin-adapter.ts
@@ -21,7 +21,7 @@ import {
 import { SETTINGS_TYPE, SettingsHelper } from "../types/types";
 import { createContext } from "@lit/context";
 import { getEmbedderRedirectUri } from "./embed-helpers";
-import { type OAuthScopeShortName } from "@breadboard-ai/connection-client/oauth-scopes.js";
+import { type OAuthScope } from "@breadboard-ai/connection-client/oauth-scopes.js";
 
 export { SigninAdapter };
 
@@ -128,7 +128,7 @@ class SigninAdapter {
    * signed out.
    */
   async token(
-    scopes?: OAuthScopeShortName[]
+    scopes?: OAuthScope[]
   ): Promise<ValidTokenResult | SignedOutTokenResult> {
     if (this.#state.status === "anonymous") {
       await this.#handleSignInRequest?.();

--- a/packages/shared-ui/src/utils/signin-adapter.ts
+++ b/packages/shared-ui/src/utils/signin-adapter.ts
@@ -21,6 +21,7 @@ import {
 import { SETTINGS_TYPE, SettingsHelper } from "../types/types";
 import { createContext } from "@lit/context";
 import { getEmbedderRedirectUri } from "./embed-helpers";
+import { type OAuthScopeShortName } from "@breadboard-ai/connection-client/oauth-scopes.js";
 
 export { SigninAdapter };
 
@@ -126,7 +127,9 @@ class SigninAdapter {
    * Gets you a token, refreshing automatically if needed, unless the user is
    * signed out.
    */
-  async token(): Promise<ValidTokenResult | SignedOutTokenResult> {
+  async token(
+    scopes?: OAuthScopeShortName[]
+  ): Promise<ValidTokenResult | SignedOutTokenResult> {
     if (this.#state.status === "anonymous") {
       await this.#handleSignInRequest?.();
       if (
@@ -137,12 +140,12 @@ class SigninAdapter {
         return { state: "signedout" };
       }
     }
-    let token = this.#tokenVendor.getToken(SIGN_IN_CONNECTION_ID);
+    let token = this.#tokenVendor.getToken(SIGN_IN_CONNECTION_ID, scopes);
     if (token.state === "expired") {
       token = await token.refresh();
       if (token.state === "signedout") {
         if ((await this.signIn()).ok) {
-          token = this.#tokenVendor.getToken(SIGN_IN_CONNECTION_ID);
+          token = this.#tokenVendor.getToken(SIGN_IN_CONNECTION_ID, scopes);
         }
       }
     }

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -106,6 +106,7 @@ import { envFromFlags } from "./utils/env-from-flags";
 import { envFromSettings } from "./utils/env-from-settings";
 import { makeUrl, parseUrl } from "@breadboard-ai/shared-ui/utils/urls.js";
 import { VESignInModal } from "@breadboard-ai/shared-ui/elements/elements.js";
+import { type OAuthScopeShortName } from "@breadboard-ai/connection-client/oauth-scopes.js";
 
 type RenderValues = {
   canSave: boolean;
@@ -364,8 +365,8 @@ export class Main extends SignalWatcher(LitElement) {
     this.googleDriveClient = new GoogleDriveClient({
       apiBaseUrl,
       proxyApiBaseUrl,
-      getUserAccessToken: async () => {
-        const token = await this.signinAdapter.token();
+      getUserAccessToken: async (scopes?: OAuthScopeShortName[]) => {
+        const token = await this.signinAdapter.token(scopes);
         if (token.state === "valid") {
           return token.grant.access_token;
         }

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -309,7 +309,7 @@ export class Main extends SignalWatcher(LitElement) {
       this.tokenVendor,
       this.globalConfig,
       this.settingsHelper,
-      () => this.#askUserToSignIn()
+      (scopes?: OAuthScope[]) => this.#askUserToSignIn(scopes)
     );
 
     // Asyncronously check if the user has a geo-restriction and sign out if so.
@@ -2206,7 +2206,7 @@ export class Main extends SignalWatcher(LitElement) {
     </bb-ve-header>`;
   }
 
-  async #askUserToSignIn(): Promise<boolean> {
+  async #askUserToSignIn(scopes?: OAuthScope[]): Promise<boolean> {
     this.#uiState.show.add("SignInModal");
     await this.updateComplete;
     const signInModal = this.#signInModalRef.value;
@@ -2214,7 +2214,7 @@ export class Main extends SignalWatcher(LitElement) {
       console.warn(`Could not find sign-in modal.`);
       return false;
     }
-    return signInModal.openAndWaitForSignIn();
+    return signInModal.openAndWaitForSignIn(scopes);
   }
 
   readonly #signInModalRef = createRef<VESignInModal>();

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -106,7 +106,7 @@ import { envFromFlags } from "./utils/env-from-flags";
 import { envFromSettings } from "./utils/env-from-settings";
 import { makeUrl, parseUrl } from "@breadboard-ai/shared-ui/utils/urls.js";
 import { VESignInModal } from "@breadboard-ai/shared-ui/elements/elements.js";
-import { type OAuthScopeShortName } from "@breadboard-ai/connection-client/oauth-scopes.js";
+import { type OAuthScope } from "@breadboard-ai/connection-client/oauth-scopes.js";
 
 type RenderValues = {
   canSave: boolean;
@@ -365,7 +365,7 @@ export class Main extends SignalWatcher(LitElement) {
     this.googleDriveClient = new GoogleDriveClient({
       apiBaseUrl,
       proxyApiBaseUrl,
-      getUserAccessToken: async (scopes?: OAuthScopeShortName[]) => {
+      getUserAccessToken: async (scopes?: OAuthScope[]) => {
         const token = await this.signinAdapter.token(scopes);
         if (token.state === "valid") {
           return token.grant.access_token;


### PR DESCRIPTION
`SigninAdapter.token()` now takes an optional `scopes` argument, which is an array of scopes defined in the new `connection-client/src/oauth-scopes.ts` module. If `scopes` is set, and one or more of those scopes have not been granted by the user, a new dialog will popup asking the user to add that permission by going through the OAuth flow.