### PR TITLE
mcp integrations

### DIFF
--- a/.changeset/bright-buttons-tie.md
+++ b/.changeset/bright-buttons-tie.md
@@ -1,0 +1,10 @@
+---
+"@breadboard-ai/visual-editor": minor
+"@google-labs/breadboard": minor
+"@breadboard-ai/shared-ui": minor
+"@google-labs/breadboard-schema": minor
+"@breadboard-ai/types": minor
+"@breadboard-ai/mcp": minor
+---
+
+Refactor MCP machinery to be tool-centric.

--- a/packages/breadboard/src/editor/events.ts
+++ b/packages/breadboard/src/editor/events.ts
@@ -30,6 +30,7 @@ export class ChangeEvent extends Event implements GraphChangeEvent {
     public readonly affectedModules: NodeIdentifier[],
     public readonly affectedGraphs: GraphIdentifier[],
     public readonly topologyChange: boolean,
+    public readonly integrationsChange: boolean,
     public readonly label: string | null
   ) {
     super(ChangeEvent.eventName, {

--- a/packages/breadboard/src/editor/operations/remove-integration.ts
+++ b/packages/breadboard/src/editor/operations/remove-integration.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  EditOperation,
+  EditOperationContext,
+  EditSpec,
+  SingleEditResult,
+} from "@breadboard-ai/types";
+
+export { RemoveIntegration };
+
+class RemoveIntegration implements EditOperation {
+  async do(
+    spec: EditSpec,
+    context: EditOperationContext
+  ): Promise<SingleEditResult> {
+    if (spec.type !== "removeintegration") {
+      throw new Error(
+        `Editor API integrity error: expected type "removeintegration", received "${spec.type}" instead.`
+      );
+    }
+
+    const { id } = spec;
+
+    const {
+      graph: { integrations },
+    } = context;
+
+    let noChange = false;
+
+    if (integrations?.[id]) {
+      delete integrations[id];
+      if (Object.keys(integrations).length === 0) {
+        delete context.graph.integrations;
+      }
+    } else {
+      noChange = true;
+    }
+
+    return {
+      success: true,
+      affectedGraphs: [],
+      affectedModules: [],
+      affectedNodes: [],
+      integrationsChange: true,
+      noChange,
+    };
+  }
+}

--- a/packages/breadboard/src/editor/operations/upsert-integration.ts
+++ b/packages/breadboard/src/editor/operations/upsert-integration.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  EditOperation,
+  EditOperationContext,
+  EditSpec,
+  SingleEditResult,
+} from "@breadboard-ai/types";
+
+export { UpsertInteration };
+
+class UpsertInteration implements EditOperation {
+  async do(
+    spec: EditSpec,
+    context: EditOperationContext
+  ): Promise<SingleEditResult> {
+    if (spec.type !== "upsertintegration") {
+      throw new Error(
+        `Editor API integrity error: expected type "upsertintegration", received "${spec.type}" instead.`
+      );
+    }
+
+    const { id, integration } = spec;
+
+    const { graph } = context;
+
+    graph.integrations ??= {};
+    graph.integrations[id] = integration;
+
+    return {
+      success: true,
+      affectedGraphs: [],
+      affectedModules: [],
+      affectedNodes: [],
+      integrationsChange: true,
+    };
+  }
+}

--- a/packages/mcp/src/client-factory.ts
+++ b/packages/mcp/src/client-factory.ts
@@ -1,0 +1,123 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { Implementation } from "@modelcontextprotocol/sdk/types.js";
+import {
+  JsonSerializableRequestInit,
+  McpClient,
+  McpProxyRequest,
+} from "./types.js";
+import { McpBuiltInServerStore } from "./server-store.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { Outcome, TokenGetter } from "@breadboard-ai/types";
+import { err, ok } from "@breadboard-ai/utils";
+import { ProxyBackedClient } from "./proxy-backed-client.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
+
+export { McpClientFactory };
+
+const BUILTIN_SERVER_PREFIX = "builtin:";
+
+export type CreateClientOptions = {
+  proxyUrl: string;
+};
+
+class McpClientFactory {
+  constructor(
+    private readonly tokenGetter: TokenGetter,
+    private readonly proxyUrl?: string
+  ) {}
+
+  #fetch(): FetchLike {
+    const proxyURL = new URL("/api/mcp-proxy", window.location.href);
+    return async (url: string | URL, init?: RequestInit) => {
+      const accessToken = await this.tokenGetter();
+      if (!ok(accessToken)) {
+        throw new Error(accessToken.$error);
+      }
+
+      const { signal, headers, ...noSignalInit } = init || {};
+      let headersObj: Record<string, string> = {};
+      if (headers) {
+        if (headers instanceof Headers) {
+          headers.forEach((value, key) => {
+            headersObj[key] = value;
+          });
+        } else if (Array.isArray(headers)) {
+          headers.forEach(([value, key]) => {
+            headersObj[key] = value;
+          });
+        } else {
+          headersObj = headers;
+        }
+      }
+      // TODO: Check request for being serializable
+      const request: McpProxyRequest = {
+        url: typeof url === "string" ? url : url.href,
+        init: {
+          ...noSignalInit,
+          headers: headersObj,
+        } as JsonSerializableRequestInit,
+      };
+      return fetch(proxyURL, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+        },
+        signal,
+        body: JSON.stringify(request),
+      });
+    };
+  }
+
+  async createClient(
+    url: string,
+    info: Implementation
+  ): Promise<Outcome<McpClient>> {
+    const isBuiltIn = url.startsWith(BUILTIN_SERVER_PREFIX);
+
+    try {
+      if (isBuiltIn) {
+        const client = new Client(info) as McpClient;
+        const builtInServerName = url.slice(BUILTIN_SERVER_PREFIX.length);
+        const server = McpBuiltInServerStore.instance.get(builtInServerName);
+        if (!ok(server)) return server;
+        const [clientTransport, serverTransport] =
+          InMemoryTransport.createLinkedPair();
+        await server.connect(serverTransport);
+        const transport = clientTransport;
+
+        await client.connect(transport);
+        return client;
+      } else if (this.proxyUrl) {
+        const accessToken = await this.tokenGetter();
+        if (!ok(accessToken)) return accessToken;
+
+        return new ProxyBackedClient({
+          name: "MCP Proxy Backend",
+          url: url,
+          proxyToken: accessToken,
+          proxyUrl: this.proxyUrl,
+        });
+      } else {
+        const client = new Client(info) as McpClient;
+
+        const transport = new StreamableHTTPClientTransport(new URL(url), {
+          fetch: this.#fetch(),
+        });
+
+        // TODO: Implement error handling and retry.
+        await client.connect(transport);
+        return client;
+      }
+    } catch (e) {
+      return err((e as Error).message);
+    }
+  }
+}

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -6,4 +6,5 @@
 
 export { McpFileSystemBackend } from "./mcp-fs-backend.js";
 export { listBuiltInMcpServers } from "./server-store.js";
+export { McpClientFactory } from "./client-factory.js";
 export type * from "./types.js";

--- a/packages/mcp/src/mcp-fs-backend.ts
+++ b/packages/mcp/src/mcp-fs-backend.ts
@@ -14,25 +14,15 @@ import {
   PersistentBackend,
 } from "@breadboard-ai/types";
 import { err, fromJson, ok, toJson } from "@breadboard-ai/utils";
-import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import type { FetchLike } from "@modelcontextprotocol/sdk/shared/transport.js";
 import {
   CallToolRequest,
   Implementation,
 } from "@modelcontextprotocol/sdk/types.js";
-import { ProxyBackedClient } from "./proxy-backed-client.js";
-import { McpBuiltInServerStore } from "./server-store.js";
-import type {
-  JsonSerializableRequestInit,
-  McpClient,
-  McpProxyRequest,
-} from "./types.js";
+import type { McpClient } from "./types.js";
+import { McpClientFactory } from "./client-factory.js";
 
 export { McpFileSystemBackend, parsePath };
 
-const BUILTIN_SERVER_PREFIX = "builtin:";
 const COMMON_PREFIX: FileSystemPath = `/mnt/mcp/session`;
 const SUPPORTED_METHODS = ["connect", "listTools", "callTool"] as const;
 
@@ -80,11 +70,11 @@ type TokenGetter = () => Promise<Outcome<string>>;
  */
 class McpFileSystemBackend implements PersistentBackend {
   #sessions: Map<string, SessionInfo> = new Map();
+  #clientFactory: McpClientFactory;
 
-  constructor(
-    private readonly tokenGetter: TokenGetter,
-    private readonly proxyUrl?: string
-  ) {}
+  constructor(tokenGetter: TokenGetter, proxyUrl?: string) {
+    this.#clientFactory = new McpClientFactory(tokenGetter, proxyUrl);
+  }
 
   async query(
     _graphUrl: string,
@@ -135,97 +125,14 @@ class McpFileSystemBackend implements PersistentBackend {
     }
   }
 
-  #fetch(): FetchLike {
-    const proxyURL = new URL("/api/mcp-proxy", window.location.href);
-    return async (url: string | URL, init?: RequestInit) => {
-      const accessToken = await this.tokenGetter();
-      if (!ok(accessToken)) {
-        throw new Error(accessToken.$error);
-      }
-
-      const { signal, headers, ...noSignalInit } = init || {};
-      let headersObj: Record<string, string> = {};
-      if (headers) {
-        if (headers instanceof Headers) {
-          headers.forEach((value, key) => {
-            headersObj[key] = value;
-          });
-        } else if (Array.isArray(headers)) {
-          headers.forEach(([value, key]) => {
-            headersObj[key] = value;
-          });
-        } else {
-          headersObj = headers;
-        }
-      }
-      // TODO: Check request for being serializable
-      const request: McpProxyRequest = {
-        url: typeof url === "string" ? url : url.href,
-        init: {
-          ...noSignalInit,
-          headers: headersObj,
-        } as JsonSerializableRequestInit,
-      };
-      return fetch(proxyURL, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${accessToken}`,
-          "Content-Type": "application/json",
-        },
-        signal,
-        body: JSON.stringify(request),
-      });
-    };
-  }
-
   async #initializeClient(data: LLMContent[]): Promise<Outcome<McpClient>> {
     const initialization = toJson<InitializeSessionWrite>(data);
     if (!initialization) {
       return err(`MCP Backend: invalid session initialization payload`);
     }
+    const { url, info } = initialization;
 
-    const isBuiltIn = initialization.url.startsWith(BUILTIN_SERVER_PREFIX);
-
-    try {
-      if (isBuiltIn) {
-        const client = new Client(initialization.info) as McpClient;
-        const builtInServerName = initialization.url.slice(
-          BUILTIN_SERVER_PREFIX.length
-        );
-        const server = McpBuiltInServerStore.instance.get(builtInServerName);
-        if (!ok(server)) return server;
-        const [clientTransport, serverTransport] =
-          InMemoryTransport.createLinkedPair();
-        await server.connect(serverTransport);
-        const transport = clientTransport;
-
-        await client.connect(transport);
-        return client;
-      } else if (this.proxyUrl) {
-        const accessToken = await this.tokenGetter();
-        if (!ok(accessToken)) return accessToken;
-
-        return new ProxyBackedClient({
-          name: "MCP Proxy Backend",
-          url: initialization.url,
-          proxyToken: accessToken,
-          proxyUrl: this.proxyUrl,
-        });
-      } else {
-        const client = new Client(initialization.info) as McpClient;
-
-        const url = new URL(initialization.url);
-        const transport = new StreamableHTTPClientTransport(url, {
-          fetch: this.#fetch(),
-        });
-
-        // TODO: Implement error handling and retry.
-        await client.connect(transport);
-        return client;
-      }
-    } catch (e) {
-      return err((e as Error).message);
-    }
+    return this.#clientFactory.createClient(url, info);
   }
 
   async #closeSession(id: string): Promise<FileSystemWriteResult> {

--- a/packages/mcp/src/server-store.ts
+++ b/packages/mcp/src/server-store.ts
@@ -32,6 +32,7 @@ const BUILTIN_SERVERS: Map<string, McpStoreEntry> = new Map([
           url: `builtin:memory`,
         },
         removable: false,
+        registered: false,
       },
       factory: createSimpleMemoryMcpServer,
     },

--- a/packages/schema/breadboard.schema.json
+++ b/packages/schema/breadboard.schema.json
@@ -138,6 +138,16 @@
 					},
 					"description": "An optional collection of imports, or known GraphDescriptors that this GraphDescriptor uses. Imports are spiritually similar to `dependencies` in npm or import maps in Web Platform. In addition to specifying the depenency, they provide a short identifier that can be used to refer to the import."
 				},
+				"integrations": {
+					"type": "object",
+					"additionalProperties": {
+						"$ref": "#/definitions/Integration"
+					},
+					"propertyNames": {
+						"description": "Unique identifier of the integration. Usually, the URL of the server"
+					},
+					"description": "An optional collection of integrations: MCP servers that are used by this graph. If the integration is not in this list then it can not be used by the graph."
+				},
 				"main": {
 					"$ref": "#/definitions/ModuleIdentifier",
 					"description": "The id of the Module that is used as an entry point for this graph. If this value is set, the graph is a \"module graph\": it is backed by code rather than by nodes and edges."
@@ -967,6 +977,25 @@
 			],
 			"additionalProperties": false,
 			"description": "A declaration of an import."
+		},
+		"Integration": {
+			"type": "object",
+			"properties": {
+				"title": {
+					"type": "string",
+					"description": "Friendly title of the Integration."
+				},
+				"url": {
+					"type": "string",
+					"description": "URL of the MCP Server."
+				}
+			},
+			"required": [
+				"title",
+				"url"
+			],
+			"additionalProperties": false,
+			"description": "Details of the integration"
 		},
 		"Edge": {
 			"type": "object",

--- a/packages/shared-ui/src/elements/fast-access-menu/fast-access-menu.ts
+++ b/packages/shared-ui/src/elements/fast-access-menu/fast-access-menu.ts
@@ -36,6 +36,7 @@ import { icons } from "../../styles/icons";
 import { colorsLight } from "../../styles/host/colors-light";
 import { type } from "../../styles/host/type";
 import { iconSubstitute } from "../../utils/icon-substitute";
+import { repeat } from "lit/directives/repeat.js";
 
 @customElement("bb-fast-access-menu")
 export class FastAccessMenu extends SignalWatcher(LitElement) {
@@ -123,7 +124,8 @@ export class FastAccessMenu extends SignalWatcher(LitElement) {
       #assets,
       #tools,
       #outputs,
-      #parameters {
+      #parameters,
+      section.integration {
         & h3 {
           font-size: 12px;
           color: var(--n-40);
@@ -749,6 +751,40 @@ export class FastAccessMenu extends SignalWatcher(LitElement) {
             ? html`<div class="no-items">No components</div>`
             : nothing}
       </section>
+
+      ${this.state
+        ? repeat(
+            this.state.integrations,
+            ([url]) => url,
+            ([_url, integration]) => {
+              return html`<section class="integration">
+                <h3 class="sans-flex w-400 round">${integration.title}</h3>
+                <menu>${menu()}</menu>
+              </section>`;
+
+              function menu() {
+                switch (integration.status) {
+                  case "loading":
+                    return html`<li>Loading...</li>`;
+                  case "complete":
+                    return html`
+                      ${repeat(
+                        integration.tools,
+                        ([id]) => id,
+                        ([_id, tool]) => {
+                          return html`<li>
+                            <button>${tool.title}</button>
+                          </li>`;
+                        }
+                      )}
+                    `;
+                  case "error":
+                    return html`<li>${integration.message}</li>`;
+                }
+              }
+            }
+          )
+        : nothing}
     </div>`;
   }
 }

--- a/packages/shared-ui/src/elements/fast-access-menu/fast-access-menu.ts
+++ b/packages/shared-ui/src/elements/fast-access-menu/fast-access-menu.ts
@@ -601,6 +601,9 @@ export class FastAccessMenu extends SignalWatcher(LitElement) {
             }
 
             this.filter = evt.target.value;
+            if (this.state) {
+              this.state.integrations.filter = this.filter;
+            }
           }}
         />
       </header>
@@ -754,7 +757,7 @@ export class FastAccessMenu extends SignalWatcher(LitElement) {
 
       ${this.state
         ? repeat(
-            this.state.integrations,
+            this.state.integrations.results,
             ([url]) => url,
             ([_url, integration]) => {
               return html`<section class="integration">

--- a/packages/shared-ui/src/elements/shell/mcp-server-modal.ts
+++ b/packages/shared-ui/src/elements/shell/mcp-server-modal.ts
@@ -381,7 +381,7 @@ export class VEMCPServersModal extends SignalWatcher(LitElement) {
                   <input
                     type="checkbox"
                     id=${id}
-                    .checked=${!!server.instanceId}
+                    .checked=${!!server.registered}
                     @change=${(evt: Event) => {
                       if (
                         !(evt.target instanceof HTMLInputElement) ||

--- a/packages/shared-ui/src/elements/shell/mcp-server-modal.ts
+++ b/packages/shared-ui/src/elements/shell/mcp-server-modal.ts
@@ -261,7 +261,7 @@ export class VEMCPServersModal extends SignalWatcher(LitElement) {
     try {
       this.#loading = true;
 
-      const outcome = await this.project.mcp.add(url, title);
+      const outcome = await this.project.integrations.add(url, title);
       if (!ok(outcome)) {
         this.#status = html`<span class="error">${outcome.$error}</span>`;
       } else {
@@ -331,7 +331,7 @@ export class VEMCPServersModal extends SignalWatcher(LitElement) {
       return html`MCP Server configuration unavailable`;
     }
 
-    const servers = this.project.mcp.servers;
+    const servers = this.project.integrations.servers;
     if (!servers.value) {
       if (servers.status === "error") {
         return html`<p>Error loading MCP server list</p>`;
@@ -365,7 +365,8 @@ export class VEMCPServersModal extends SignalWatcher(LitElement) {
                         ) {
                           return;
                         }
-                        const removing = await this.project?.mcp.remove(id);
+                        const removing =
+                          await this.project?.integrations.remove(id);
                         if (!ok(removing)) {
                           // TODO: Expose this in UI somehow.
                           console.error(
@@ -391,9 +392,9 @@ export class VEMCPServersModal extends SignalWatcher(LitElement) {
                       }
 
                       if (evt.target.checked) {
-                        this.project.mcp.register(id);
+                        this.project.integrations.register(id);
                       } else {
-                        this.project.mcp.unregister(id);
+                        this.project.integrations.unregister(id);
                       }
                     }}
                   />

--- a/packages/shared-ui/src/state/fast-access.ts
+++ b/packages/shared-ui/src/state/fast-access.ts
@@ -12,8 +12,8 @@ import {
 import {
   Components,
   FastAccess,
+  FilteredIntegrations,
   GraphAsset,
-  IntegrationState,
   ProjectInternal,
   Tool,
 } from "./types";
@@ -30,7 +30,7 @@ class ReactiveFastAccess implements FastAccess {
     public readonly myTools: Map<string, Tool>,
     public readonly components: Map<GraphIdentifier, Components>,
     public readonly parameters: Map<string, ParameterMetadata>,
-    public readonly integrations: Map<string, IntegrationState>
+    public readonly integrations: FilteredIntegrations
   ) {
     this.#project = project;
   }

--- a/packages/shared-ui/src/state/fast-access.ts
+++ b/packages/shared-ui/src/state/fast-access.ts
@@ -13,6 +13,7 @@ import {
   Components,
   FastAccess,
   GraphAsset,
+  IntegrationState,
   ProjectInternal,
   Tool,
 } from "./types";
@@ -28,7 +29,8 @@ class ReactiveFastAccess implements FastAccess {
     public readonly tools: Map<string, Tool>,
     public readonly myTools: Map<string, Tool>,
     public readonly components: Map<GraphIdentifier, Components>,
-    public readonly parameters: Map<string, ParameterMetadata>
+    public readonly parameters: Map<string, ParameterMetadata>,
+    public readonly integrations: Map<string, IntegrationState>
   ) {
     this.#project = project;
   }

--- a/packages/shared-ui/src/state/filtered-integrations.ts
+++ b/packages/shared-ui/src/state/filtered-integrations.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { signal } from "signal-utils";
+import { FilteredIntegrations, IntegrationState, Tool } from "./types";
+
+export { FilteredIntegrationsImpl };
+
+class FilteredIntegrationsImpl implements FilteredIntegrations {
+  @signal
+  accessor filter: string = "";
+
+  @signal
+  get results(): Map<string, IntegrationState> {
+    if (!this.filter) return this.integrations;
+    const filter = new RegExp(this.filter, "gim");
+    const filtered = new Map<string, IntegrationState>();
+    this.integrations.forEach((integration, url) => {
+      const tools = new Map<string, Tool>();
+      if (integration.status !== "complete") return;
+      integration.tools.forEach((tool, key) => {
+        const { title } = tool;
+        if (!title || filter.test(title)) {
+          tools.set(key, tool);
+        }
+      });
+      if (tools.size === 0) return;
+      filtered.set(url, {
+        title: integration.title,
+        url: integration.url,
+        status: integration.status,
+        message: integration.message,
+        tools,
+      });
+    });
+    return filtered;
+  }
+
+  constructor(private readonly integrations: Map<string, IntegrationState>) {}
+}

--- a/packages/shared-ui/src/state/integrations.ts
+++ b/packages/shared-ui/src/state/integrations.ts
@@ -18,7 +18,7 @@ import {
 import {
   AsyncComputedResult,
   Integrations,
-  IntegrationsToolList,
+  IntegrationState,
   Tool,
 } from "./types";
 import { err, ok } from "@breadboard-ai/utils";
@@ -39,7 +39,7 @@ export { IntegrationsImpl };
 function fromMcpTool(url: string, tool: McpListToolResult["tools"][0]): Tool {
   return {
     url,
-    title: tool.title,
+    title: tool.title || tool.name,
     description: tool.description,
     icon: "tool",
     connectorInstance: tool.name,
@@ -48,8 +48,18 @@ function fromMcpTool(url: string, tool: McpListToolResult["tools"][0]): Tool {
   };
 }
 
-class IntegrationManager implements IntegrationsToolList {
+class IntegrationManager implements IntegrationState {
   #client: Promise<Outcome<McpClient>>;
+
+  @signal
+  get title() {
+    return this.integration.title;
+  }
+
+  @signal
+  get url() {
+    return this.integration.url;
+  }
 
   @signal
   accessor integration: Integration;
@@ -122,7 +132,7 @@ class IntegrationsImpl implements Integrations {
    * A grouped list of all tools available.
    */
   @signal
-  get all(): Map<McpServerIdentifier, IntegrationsToolList> {
+  get all(): Map<McpServerIdentifier, IntegrationState> {
     // TODO: Expand this to include built-ins.
     return this.#integrations;
   }

--- a/packages/shared-ui/src/state/integrations.ts
+++ b/packages/shared-ui/src/state/integrations.ts
@@ -14,7 +14,7 @@ import {
   Outcome,
   UUID,
 } from "@breadboard-ai/types";
-import { AsyncComputedResult, Mcp, ProjectInternal } from "./types";
+import { AsyncComputedResult, Integrations, ProjectInternal } from "./types";
 import { err, ok } from "@breadboard-ai/utils";
 import { SignalMap } from "signal-utils/map";
 import { McpServerStore } from "./utils/mcp-server-store";
@@ -22,9 +22,9 @@ import { AsyncComputed } from "signal-utils/async-computed";
 import { listBuiltInMcpServers } from "@breadboard-ai/mcp";
 import { signal } from "signal-utils";
 
-export { McpImpl };
+export { IntegrationsImpl };
 
-class McpImpl implements Mcp {
+class IntegrationsImpl implements Integrations {
   @signal
   accessor #integrations: Map<string, Integration> = new Map();
 

--- a/packages/shared-ui/src/state/integrations.ts
+++ b/packages/shared-ui/src/state/integrations.ts
@@ -50,7 +50,7 @@ class IntegrationsImpl implements Integrations {
 
   #reload(graph: GraphDescriptor) {
     const { integrations = {} } = graph;
-    this.#integrations = new SignalMap(Object.entries(integrations));
+    this.#integrations = new Map(Object.entries(integrations));
   }
 
   get servers(): AsyncComputedResult<

--- a/packages/shared-ui/src/state/integrations.ts
+++ b/packages/shared-ui/src/state/integrations.ts
@@ -14,7 +14,7 @@ import {
   Outcome,
   UUID,
 } from "@breadboard-ai/types";
-import { AsyncComputedResult, Integrations, ProjectInternal } from "./types";
+import { AsyncComputedResult, Integrations } from "./types";
 import { err, ok } from "@breadboard-ai/utils";
 import { SignalMap } from "signal-utils/map";
 import { McpServerStore } from "./utils/mcp-server-store";
@@ -30,10 +30,7 @@ class IntegrationsImpl implements Integrations {
 
   #serverList = new McpServerStore();
 
-  constructor(
-    private readonly project: ProjectInternal,
-    private readonly editable?: EditableGraph
-  ) {
+  constructor(private readonly editable?: EditableGraph) {
     if (!editable) {
       console.warn(
         `Integration Initialization will fail: No editable supplied`

--- a/packages/shared-ui/src/state/project.ts
+++ b/packages/shared-ui/src/state/project.ts
@@ -56,6 +56,7 @@ import {
 } from "./types";
 import { IntegrationsImpl } from "./integrations";
 import { updateMap } from "./utils/update-map";
+import { FilteredIntegrationsImpl } from "./filtered-integrations";
 
 export { createProjectState, ReactiveProject };
 
@@ -177,7 +178,7 @@ class ReactiveProject implements ProjectInternal {
       this.myTools,
       this.components,
       this.parameters,
-      this.integrations.all
+      new FilteredIntegrationsImpl(this.integrations.all)
     );
     this.#updateGraphAssets();
     this.renderer = new RendererStateImpl(this.graphAssets);

--- a/packages/shared-ui/src/state/project.ts
+++ b/packages/shared-ui/src/state/project.ts
@@ -165,13 +165,19 @@ class ReactiveProject implements ProjectInternal {
     this.#updateConnectors();
     this.connectors = new ConnectorStateImpl(this, this.#connectorMap);
     this.organizer = new ReactiveOrganizer(this);
+    this.integrations = new IntegrationsImpl(
+      tokenGetter,
+      mcpProxyUrl,
+      editable
+    );
     this.fastAccess = new ReactiveFastAccess(
       this,
       this.graphAssets,
       this.tools,
       this.myTools,
       this.components,
-      this.parameters
+      this.parameters,
+      this.integrations.all
     );
     this.#updateGraphAssets();
     this.renderer = new RendererStateImpl(this.graphAssets);
@@ -180,11 +186,6 @@ class ReactiveProject implements ProjectInternal {
     this.#updateMyTools();
     this.#updateParameters();
     this.run = ReactiveProjectRun.createInert(this.#mainGraphId, this.#store);
-    this.integrations = new IntegrationsImpl(
-      tokenGetter,
-      mcpProxyUrl,
-      editable
-    );
   }
 
   resetRun(): void {

--- a/packages/shared-ui/src/state/project.ts
+++ b/packages/shared-ui/src/state/project.ts
@@ -140,7 +140,13 @@ class ReactiveProject implements ProjectInternal {
       this.#updateConnectors();
       this.#updateTools();
     });
-    const graphUrlString = this.#store.get(mainGraphId)?.graph.url;
+    const graph = this.#store.get(mainGraphId)?.graph;
+    if (!graph) {
+      console.warn(
+        `No graph when initializing Project state: most things will likely not work`
+      );
+    }
+    const graphUrlString = graph?.url;
     this.graphUrl = graphUrlString ? new URL(graphUrlString) : null;
     this.graphAssets = new SignalMap();
     this.tools = new SignalMap();
@@ -166,7 +172,7 @@ class ReactiveProject implements ProjectInternal {
     this.#updateMyTools();
     this.#updateParameters();
     this.run = ReactiveProjectRun.createInert(this.#mainGraphId, this.#store);
-    this.mcp = new McpImpl(this);
+    this.mcp = new McpImpl(this, editable);
   }
 
   resetRun(): void {

--- a/packages/shared-ui/src/state/project.ts
+++ b/packages/shared-ui/src/state/project.ts
@@ -45,7 +45,7 @@ import {
   ConnectorState,
   FastAccess,
   GraphAsset,
-  Mcp,
+  Integrations,
   Organizer,
   Project,
   ProjectInternal,
@@ -53,7 +53,7 @@ import {
   RendererState,
   Tool,
 } from "./types";
-import { McpImpl } from "./mcp";
+import { IntegrationsImpl } from "./integrations";
 
 export { createProjectState, ReactiveProject };
 
@@ -116,7 +116,7 @@ class ReactiveProject implements ProjectInternal {
   readonly parameters: SignalMap<string, ParameterMetadata>;
   readonly connectors: ConnectorState;
   readonly renderer: RendererState;
-  readonly mcp: Mcp;
+  readonly integrations: Integrations;
 
   constructor(
     mainGraphId: MainGraphIdentifier,
@@ -172,7 +172,7 @@ class ReactiveProject implements ProjectInternal {
     this.#updateMyTools();
     this.#updateParameters();
     this.run = ReactiveProjectRun.createInert(this.#mainGraphId, this.#store);
-    this.mcp = new McpImpl(this, editable);
+    this.integrations = new IntegrationsImpl(this, editable);
   }
 
   resetRun(): void {

--- a/packages/shared-ui/src/state/project.ts
+++ b/packages/shared-ui/src/state/project.ts
@@ -172,7 +172,7 @@ class ReactiveProject implements ProjectInternal {
     this.#updateMyTools();
     this.#updateParameters();
     this.run = ReactiveProjectRun.createInert(this.#mainGraphId, this.#store);
-    this.integrations = new IntegrationsImpl(this, editable);
+    this.integrations = new IntegrationsImpl(editable);
   }
 
   resetRun(): void {

--- a/packages/shared-ui/src/state/types.ts
+++ b/packages/shared-ui/src/state/types.ts
@@ -506,11 +506,18 @@ export type UI = {
   flags: RuntimeFlags | null;
 };
 
+export type IntegrationsToolList = {
+  status: "loading" | "complete" | "error";
+
+  tools: Map<string, Tool>;
+};
+
 /**
  * Represents the Model+Controller for of the project's Integrations
  * configuration.
  */
 export type Integrations = {
+  all: Map<McpServerIdentifier, IntegrationsToolList>;
   /**
    * List of currently all known MCP servers.
    */

--- a/packages/shared-ui/src/state/types.ts
+++ b/packages/shared-ui/src/state/types.ts
@@ -431,7 +431,7 @@ export type FastAccess = {
   myTools: Map<string, Tool>;
   components: Map<GraphIdentifier, Components>;
   parameters: Map<string, ParameterMetadata>;
-  integrations: Map<string, IntegrationState>;
+  integrations: FilteredIntegrations;
 };
 
 /**
@@ -516,6 +516,12 @@ export type IntegrationState = {
   tools: Map<string, Tool>;
 
   message: string | null;
+};
+
+export type FilteredIntegrations = {
+  filter: string;
+
+  results: Map<McpServerIdentifier, IntegrationState>;
 };
 
 /**

--- a/packages/shared-ui/src/state/types.ts
+++ b/packages/shared-ui/src/state/types.ts
@@ -507,10 +507,10 @@ export type UI = {
 };
 
 /**
- * Represents the Model+Controller for of the project's MCP
+ * Represents the Model+Controller for of the project's Integrations
  * configuration.
  */
-export type Mcp = {
+export type Integrations = {
   /**
    * List of currently all known MCP servers.
    */
@@ -561,7 +561,7 @@ export type Project = {
   graphAssets: Map<AssetPath, GraphAsset>;
   parameters: Map<string, ParameterMetadata>;
   connectors: ConnectorState;
-  mcp: Mcp;
+  integrations: Integrations;
   organizer: Organizer;
   fastAccess: FastAccess;
   renderer: RendererState;

--- a/packages/shared-ui/src/state/types.ts
+++ b/packages/shared-ui/src/state/types.ts
@@ -431,6 +431,7 @@ export type FastAccess = {
   myTools: Map<string, Tool>;
   components: Map<GraphIdentifier, Components>;
   parameters: Map<string, ParameterMetadata>;
+  integrations: Map<string, IntegrationState>;
 };
 
 /**
@@ -506,10 +507,15 @@ export type UI = {
   flags: RuntimeFlags | null;
 };
 
-export type IntegrationsToolList = {
+export type IntegrationState = {
+  title: string;
+  url: string;
+
   status: "loading" | "complete" | "error";
 
   tools: Map<string, Tool>;
+
+  message: string | null;
 };
 
 /**
@@ -517,7 +523,7 @@ export type IntegrationsToolList = {
  * configuration.
  */
 export type Integrations = {
-  all: Map<McpServerIdentifier, IntegrationsToolList>;
+  all: Map<McpServerIdentifier, IntegrationState>;
   /**
    * List of currently all known MCP servers.
    */

--- a/packages/shared-ui/src/state/utils/update-map.ts
+++ b/packages/shared-ui/src/state/utils/update-map.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { updateMap, updateMapDynamic };
+
+/**
+ * Incrementally updates a map, given updated values.
+ * Updates the values in `updated`, deletes the ones that aren't in it.
+ */
+function updateMap<T extends Map<K, V>, K = string, V = unknown>(
+  map: T,
+  updated: [K, V][]
+): void {
+  const toDelete = new Set(map.keys());
+
+  updated.forEach(([key, value]) => {
+    map.set(key, value);
+    toDelete.delete(key);
+  });
+
+  [...toDelete.values()].forEach((key) => {
+    map.delete(key);
+  });
+}
+
+type MapEntryUpdater<I = unknown, V = unknown> = {
+  create(from: I): V;
+  update(from: I, existing: V): V;
+};
+
+function updateMapDynamic<K = string, I = unknown, V = unknown>(
+  map: Map<K, V>,
+  updated: [K, I][],
+  updater: MapEntryUpdater<I, V>
+): void {
+  const toDelete = new Set(map.keys());
+
+  updated.forEach(([key, initial]) => {
+    const existing = map.get(key);
+    if (!existing) {
+      const value = updater.create(initial);
+      map.set(key, value);
+    } else {
+      const value = updater.update(initial, existing);
+      if (value !== existing) {
+        map.set(key, value);
+      }
+    }
+    toDelete.delete(key);
+  });
+
+  [...toDelete.values()].forEach((key) => {
+    map.delete(key);
+  });
+}

--- a/packages/types/src/edit.ts
+++ b/packages/types/src/edit.ts
@@ -12,6 +12,7 @@ import {
   GraphDescriptor,
   GraphIdentifier,
   GraphMetadata,
+  Integration,
   Module,
   ModuleIdentifier,
   NodeConfiguration,
@@ -35,6 +36,7 @@ export type GraphChangeEvent = Event & {
   affectedNodes: AffectedNode[];
   affectedGraphs: GraphIdentifier[];
   topologyChange: boolean;
+  integrationsChange: boolean;
   label: string | null;
 };
 
@@ -201,6 +203,17 @@ export type ReplaceGraphSpec = {
   creator: EditHistoryCreator;
 };
 
+export type UpsertIntegrationSpec = {
+  type: "upsertintegration";
+  id: string;
+  integration: Integration;
+};
+
+export type RemoveIntegrationSpec = {
+  type: "removeintegration";
+  id: string;
+};
+
 export type EditOperationConductor = (
   edits: EditSpec[],
   editLabel: string
@@ -235,7 +248,9 @@ export type EditSpec =
   | AddAssetSpec
   | RemoveAssetSpec
   | ChangeAssetMetadataSpec
-  | ReplaceGraphSpec;
+  | ReplaceGraphSpec
+  | UpsertIntegrationSpec
+  | RemoveIntegrationSpec;
 
 export type EditableGraph = {
   addEventListener<Key extends keyof EditableGraphEventMap>(
@@ -364,6 +379,10 @@ export type SingleEditResult =
       affectedNodes: AffectedNode[];
       affectedModules: ModuleIdentifier[];
       affectedGraphs: GraphIdentifier[];
+      /**
+       * Indicates that the change updated integrations.
+       */
+      integrationsChange?: boolean;
       /**
        * Indicates that the change resulted in topology change:
        * - node added or removed

--- a/packages/types/src/graph-descriptor.ts
+++ b/packages/types/src/graph-descriptor.ts
@@ -729,6 +729,32 @@ export type GraphCommonProperties = GraphInlineMetadata & {
    * used to refer to the import.
    */
   imports?: Record<ImportIdentifier, Import>;
+
+  /**
+   * An optional collection of integrations: MCP servers that are used by this
+   * graph. If the integration is not in this list then it can not be used by
+   * the graph.
+   */
+  integrations?: Record<IntegrationIdentifier, Integration>;
+};
+
+/**
+ * Unique identifier of the integration. Usually, the URL of the server
+ */
+export type IntegrationIdentifier = string;
+
+/**
+ * Details of the integration
+ */
+export type Integration = {
+  /**
+   * Friendly title of the Integration.
+   */
+  title: string;
+  /**
+   * URL of the MCP Server.
+   */
+  url: string;
 };
 
 /**

--- a/packages/types/src/mcp.ts
+++ b/packages/types/src/mcp.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { UUID } from "./uuid.js";
-
 export type McpServerDetails = {
   /**
    * Name of the server. Part of the technical details, though when title is
@@ -24,7 +22,7 @@ export type McpServerDetails = {
 
 export type McpServerIdentifier = string;
 
-export type McpServerInstanceIdentifier = `connectors/${UUID}`;
+export type McpServerInstanceIdentifier = string;
 
 export type McpServerDescriptor = {
   /**
@@ -43,7 +41,7 @@ export type McpServerDescriptor = {
   /**
    * Whether or not the server is currently registered in this project.
    */
-  instanceId?: McpServerInstanceIdentifier;
+  readonly registered: boolean;
   /**
    * Whether or not the server is removable. We will have some servers that are
    * built-in, so they aren't removable.

--- a/packages/types/src/mcp.ts
+++ b/packages/types/src/mcp.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Outcome } from "./data.js";
+
 export type McpServerDetails = {
   /**
    * Name of the server. Part of the technical details, though when title is
@@ -48,3 +50,5 @@ export type McpServerDescriptor = {
    */
   readonly removable: boolean;
 };
+
+export type TokenGetter = () => Promise<Outcome<string>>;

--- a/packages/visual-editor/src/runtime/state.ts
+++ b/packages/visual-editor/src/runtime/state.ts
@@ -6,7 +6,11 @@
 
 import { State } from "@breadboard-ai/shared-ui";
 import { SideBoardRuntime } from "@breadboard-ai/shared-ui/sideboards/types.js";
-import { BoardServer, RuntimeFlagManager } from "@breadboard-ai/types";
+import {
+  BoardServer,
+  RuntimeFlagManager,
+  TokenGetter,
+} from "@breadboard-ai/types";
 import {
   EditableGraph,
   MainGraphIdentifier,
@@ -25,17 +29,23 @@ class StateManager {
   #runtime: SideBoardRuntime;
   #servers: BoardServer[];
   #flagManager: RuntimeFlagManager;
+  #tokenGetter: TokenGetter;
+  #mcpProxyUrl?: string;
 
   constructor(
     store: MutableGraphStore,
     runtime: SideBoardRuntime,
     boardServers: BoardServer[],
-    flagManager: RuntimeFlagManager
+    flagManager: RuntimeFlagManager,
+    tokenGetter: TokenGetter,
+    mcpProxyUrl?: string
   ) {
     this.#store = store;
     this.#runtime = runtime;
     this.#servers = boardServers;
     this.#flagManager = flagManager;
+    this.#tokenGetter = tokenGetter;
+    this.#mcpProxyUrl = mcpProxyUrl;
   }
 
   #findServer(url: URL): BoardServer | null {
@@ -83,6 +93,8 @@ class StateManager {
       this.#store,
       this.#runtime,
       this.#findServer.bind(this),
+      this.#tokenGetter,
+      this.#mcpProxyUrl,
       editable || undefined
     );
     this.#map.set(mainGraphId, state);


### PR DESCRIPTION
- **Move MCP server storage to "integrations" in BGL.**
- **Rename 'Mcp` to `Integrations`.**
- **No need to use `SignalMap`.**
- **Don't pass Project into IntegrationsImpl.**
- **Start compiling the list of tools at design-time.**
- **Plumb integrations to the menu.**
- **Add search/filtering.**
- **docs(changeset): Refactor MCP machinery to be tool-centric.**
