### PR TITLE
Restore some over-zealous css cleanup

### DIFF
--- a/packages/shared-ui/src/elements/welcome-panel/project-listing.ts
+++ b/packages/shared-ui/src/elements/welcome-panel/project-listing.ts
@@ -263,6 +263,22 @@ export class ProjectListing extends LitElement {
           justify-content: center;
         }
 
+        & #location-selector-container {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+
+          & #location-selector-outer {
+            display: flex;
+            align-items: center;
+
+            & #location-selector {
+              padding: 0;
+              border: none;
+            }
+          }
+        }
+
         & #content {
           display: flex;
           flex-direction: column;


### PR DESCRIPTION
One css block from https://github.com/breadboard-ai/breadboard/pull/6651 actually was used, oops.