### PR TITLE
[unified-server] Move ServerDeploymentConfiguration out of common types

### DIFF
--- a/packages/types/src/deployment-configuration.ts
+++ b/packages/types/src/deployment-configuration.ts
@@ -36,20 +36,3 @@ export interface DomainConfiguration {
    */
   disallowPublicPublishing?: boolean;
 }
-
-export type ServerDeploymentConfiguration = {
-  BACKEND_API_ENDPOINT?: string;
-  /**
-   * The URL of the deployed server.
-   */
-  SERVER_URL?: string;
-  /**
-   * The Drive Id of a folder containing featured gallery items
-   */
-  GOOGLE_DRIVE_FEATURED_GALLERY_FOLDER_ID?: string;
-  /**
-   * The list of all MCP Servers allowed by the mcp proxy. Glob patterns
-   * accepted.
-   */
-  MCP_SERVER_ALLOW_LIST?: string[];
-};

--- a/packages/unified-server/src/server/csp.ts
+++ b/packages/unified-server/src/server/csp.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ServerDeploymentConfiguration } from "@breadboard-ai/types/deployment-configuration.js";
+import type { ServerDeploymentConfiguration } from "./provide-config.js";
 import type { Handler, NextFunction, Request, Response } from "express";
 
 const CSP_CONFIG = {

--- a/packages/unified-server/src/server/provide-config.ts
+++ b/packages/unified-server/src/server/provide-config.ts
@@ -8,13 +8,29 @@ import { readFile } from "node:fs/promises";
 
 import {
   type ClientDeploymentConfiguration,
-  type ServerDeploymentConfiguration,
   type DomainConfiguration,
 } from "@breadboard-ai/types/deployment-configuration.js";
 
 export type DeploymentConfiguration = {
   client: ClientDeploymentConfiguration;
   server: ServerDeploymentConfiguration;
+};
+
+export type ServerDeploymentConfiguration = {
+  BACKEND_API_ENDPOINT?: string;
+  /**
+   * The URL of the deployed server.
+   */
+  SERVER_URL?: string;
+  /**
+   * The Drive Id of a folder containing featured gallery items
+   */
+  GOOGLE_DRIVE_FEATURED_GALLERY_FOLDER_ID?: string;
+  /**
+   * The list of all MCP Servers allowed by the mcp proxy. Glob patterns
+   * accepted.
+   */
+  MCP_SERVER_ALLOW_LIST?: string[];
 };
 
 export async function getConfig(): Promise<DeploymentConfiguration> {


### PR DESCRIPTION
It's only used in unified-server. There's no need for it to be in common
types. This is a precursor to removing the type entirely.
