### PR TITLE
[unified-server] Make ServerDeploymentConfiguration props non-optional

### DIFF
--- a/packages/unified-server/src/server/provide-config.ts
+++ b/packages/unified-server/src/server/provide-config.ts
@@ -17,20 +17,20 @@ export type DeploymentConfiguration = {
 };
 
 export type ServerDeploymentConfiguration = {
-  BACKEND_API_ENDPOINT?: string;
+  BACKEND_API_ENDPOINT: string;
   /**
    * The URL of the deployed server.
    */
-  SERVER_URL?: string;
+  SERVER_URL: string;
   /**
    * The Drive Id of a folder containing featured gallery items
    */
-  GOOGLE_DRIVE_FEATURED_GALLERY_FOLDER_ID?: string;
+  GOOGLE_DRIVE_FEATURED_GALLERY_FOLDER_ID: string;
   /**
    * The list of all MCP Servers allowed by the mcp proxy. Glob patterns
    * accepted.
    */
-  MCP_SERVER_ALLOW_LIST?: string[];
+  MCP_SERVER_ALLOW_LIST: string[];
 };
 
 export async function getConfig(): Promise<DeploymentConfiguration> {


### PR DESCRIPTION
They are always provided with fallbacks to default values
