### PR TITLE
[unified-server] Provide endpoint URL to CSP handler instead of whole config

### DIFF
--- a/packages/unified-server/src/server/csp.ts
+++ b/packages/unified-server/src/server/csp.ts
@@ -58,12 +58,10 @@ const CSP_CONFIG = {
 const CSP_HEADER_NAME = "Content-Security-Policy";
 
 /** https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP */
-export function makeCspHandler(
-  serverConfig: ServerDeploymentConfiguration
-): Handler {
+export function makeCspHandler(backendApiEndpoint: string): Handler {
   const cspConfig = structuredClone(CSP_CONFIG);
-  if (serverConfig.BACKEND_API_ENDPOINT) {
-    cspConfig["connect-src"].push(serverConfig.BACKEND_API_ENDPOINT);
+  if (backendApiEndpoint) {
+    cspConfig["connect-src"].push(backendApiEndpoint);
   }
   const cspHeaderValue = Object.entries(cspConfig)
     .map(([key, vals]) => `${key} ${vals.join(" ")}`)

--- a/packages/unified-server/src/server/main.ts
+++ b/packages/unified-server/src/server/main.ts
@@ -33,7 +33,7 @@ const server = express();
 
 const { client: clientConfig, server: serverConfig } = await getConfig();
 
-server.use(makeCspHandler(serverConfig));
+server.use(makeCspHandler(serverConfig.BACKEND_API_ENDPOINT));
 
 const boardServerConfig = boardServer.createServerConfig({
   storageProvider: "firestore",

--- a/packages/unified-server/src/server/provide-config.ts
+++ b/packages/unified-server/src/server/provide-config.ts
@@ -17,20 +17,20 @@ export type DeploymentConfiguration = {
 };
 
 export type ServerDeploymentConfiguration = {
-  BACKEND_API_ENDPOINT?: string;
+  BACKEND_API_ENDPOINT: string;
   /**
    * The URL of the deployed server.
    */
-  SERVER_URL?: string;
+  SERVER_URL: string;
   /**
    * The Drive Id of a folder containing featured gallery items
    */
-  GOOGLE_DRIVE_FEATURED_GALLERY_FOLDER_ID?: string;
+  GOOGLE_DRIVE_FEATURED_GALLERY_FOLDER_ID: string;
   /**
    * The list of all MCP Servers allowed by the mcp proxy. Glob patterns
    * accepted.
    */
-  MCP_SERVER_ALLOW_LIST?: string[];
+  MCP_SERVER_ALLOW_LIST: string[];
 };
 
 export async function getConfig(): Promise<DeploymentConfiguration> {


### PR DESCRIPTION
It only uses the endpoint URL. It doesn't need the whole config.
