### PR TITLE
[unified-server] Make BACKEND_API_ENDPOINT a module-level flag

### DIFF
--- a/packages/unified-server/src/server/allow-list-checker.ts
+++ b/packages/unified-server/src/server/allow-list-checker.ts
@@ -6,21 +6,27 @@
 
 import type { GrantResponse } from "@breadboard-ai/types/oauth.js";
 
+import * as flags from "./flags.js";
+
 export { allowListChecker };
 
 type AllowListCheckResponse = {
   canAccess: boolean;
 };
 
-function allowListChecker(endpointUrl: URL | "" | undefined) {
+function allowListChecker() {
   return async (
     grant: GrantResponse
   ): Promise<{ ok: true } | { ok: false; error: string }> => {
-    // When endpointUrl isn't supplied, allow everyone.
-    if (!endpointUrl) return { ok: true };
+    // When BACKEND_API_ENDPOINT isn't supplied, allow everyone.
+    if (!flags.BACKEND_API_ENDPOINT) {
+      return { ok: true };
+    }
+    if ("error" in grant) {
+      return { ok: true };
+    }
 
-    if ("error" in grant) return { ok: true };
-
+    const endpointUrl = new URL(flags.BACKEND_API_ENDPOINT);
     try {
       const result = (await (
         await fetch(new URL(`/v1beta1/checkAppAccess`, endpointUrl), {

--- a/packages/unified-server/src/server/csp.ts
+++ b/packages/unified-server/src/server/csp.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { ServerDeploymentConfiguration } from "./provide-config.js";
+import * as flags from "./flags.js";
+
 import type { Handler, NextFunction, Request, Response } from "express";
 
 const CSP_CONFIG = {
@@ -58,10 +59,10 @@ const CSP_CONFIG = {
 const CSP_HEADER_NAME = "Content-Security-Policy";
 
 /** https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CSP */
-export function makeCspHandler(backendApiEndpoint: string): Handler {
+export function makeCspHandler(): Handler {
   const cspConfig = structuredClone(CSP_CONFIG);
-  if (backendApiEndpoint) {
-    cspConfig["connect-src"].push(backendApiEndpoint);
+  if (flags.BACKEND_API_ENDPOINT) {
+    cspConfig["connect-src"].push(flags.BACKEND_API_ENDPOINT);
   }
   const cspHeaderValue = Object.entries(cspConfig)
     .map(([key, vals]) => `${key} ${vals.join(" ")}`)

--- a/packages/unified-server/src/server/flags.ts
+++ b/packages/unified-server/src/server/flags.ts
@@ -17,7 +17,6 @@ export type DeploymentConfiguration = {
 };
 
 export type ServerDeploymentConfiguration = {
-  BACKEND_API_ENDPOINT: string;
   /**
    * The URL of the deployed server.
    */
@@ -33,6 +32,8 @@ export type ServerDeploymentConfiguration = {
   MCP_SERVER_ALLOW_LIST: string[];
 };
 
+export const BACKEND_API_ENDPOINT: string = getString("BACKEND_API_ENDPOINT");
+
 export async function getConfig(): Promise<DeploymentConfiguration> {
   console.log("Loading config from environment");
 
@@ -40,7 +41,7 @@ export async function getConfig(): Promise<DeploymentConfiguration> {
 
   const clientConfig: ClientDeploymentConfiguration = {
     MEASUREMENT_ID: getString("MEASUREMENT_ID"),
-    BACKEND_API_ENDPOINT: getString("BACKEND_API_ENDPOINT"),
+    BACKEND_API_ENDPOINT: BACKEND_API_ENDPOINT,
     FEEDBACK_LINK: getString("FEEDBACK_LINK"),
     ENABLE_GOOGLE_FEEDBACK: getBoolean("ENABLE_GOOGLE_FEEDBACK"),
     GOOGLE_FEEDBACK_PRODUCT_ID: getString("GOOGLE_FEEDBACK_PRODUCT_ID"),
@@ -57,7 +58,6 @@ export async function getConfig(): Promise<DeploymentConfiguration> {
   };
 
   const serverConfig: ServerDeploymentConfiguration = {
-    BACKEND_API_ENDPOINT: getString("BACKEND_API_ENDPOINT"),
     SERVER_URL: getString("SERVER_URL"),
     GOOGLE_DRIVE_FEATURED_GALLERY_FOLDER_ID: getString(
       "GOOGLE_DRIVE_FEATURED_GALLERY_FOLDER_ID"


### PR DESCRIPTION
Access it when necessary instead of passing it as an argument.

Also rename provide-config to flags. We are going to give this treatment
to all of the flags that we recognize, so that there's a single place to
access flag values.
