### PR TITLE
Don't block loading graphs on all user graphs being listed

### DIFF
--- a/packages/types/src/loader.ts
+++ b/packages/types/src/loader.ts
@@ -120,6 +120,15 @@ export type GraphProvider = {
    */
   canProvide(url: URL): false | GraphProviderCapabilities;
   /**
+   * IMPORTANT: This method **assumes that the given graph has been successfully
+   * loaded at some point in the lifetime of this instance**, and will always
+   * return `undefined` otherwise.
+   *
+   * @returns Whether the currently signed-in user owns the given graph, or
+   * `undefined` if we don't know because the graph hasn't been loaded yet.
+   */
+  isMine?: (url: URL) => boolean | undefined;
+  /**
    * Expresses the `GraphProviderExtendedCapabilities` of the provider.
    */
   extendedCapabilities(): GraphProviderExtendedCapabilities;

--- a/packages/visual-editor/src/runtime/board.ts
+++ b/packages/visual-editor/src/runtime/board.ts
@@ -600,11 +600,6 @@ export class Board extends EventTarget {
       let graph: GraphDescriptor | null = null;
       if (this.#canParse(url, base.href)) {
         boardServer = this.getBoardServerForURL(new URL(url, base));
-        if (boardServer) {
-          // Ensure the the provider has actually loaded fully before
-          // requesting the graph file from it.
-          await boardServer.ready();
-        }
         if (boardServer && this.boardServers) {
           kits = (boardServer as BoardServer).kits ?? this.boardServerKits;
           const resourceKey = urlAtTimeOfCall
@@ -870,6 +865,10 @@ export class Board extends EventTarget {
     const boardServer = this.getBoardServerForURL(boardUrl);
     if (!boardServer) {
       return false;
+    }
+    const isMineAccordingToBoardServer = boardServer.isMine?.(boardUrl);
+    if (isMineAccordingToBoardServer !== undefined) {
+      return isMineAccordingToBoardServer;
     }
 
     const capabilities = boardServer.canProvide(boardUrl);


### PR DESCRIPTION
This should improve latency on loading every graph. Previously, we could never load a graph until we had listed all of the user's graphs. But, really that's only needed for the homepage, and since it can be slow, we don't want to do that. We previously needed the list of graphs because that's how we tracked ownership and versioning, so now we get that data on a per-graph basis instead, when we load it.