### PR TITLE
Drop user-perceived latency for creating new graphs from ~5s to ~100ms

### DIFF
--- a/packages/google-drive-kit/src/board-server/operations.ts
+++ b/packages/google-drive-kit/src/board-server/operations.ts
@@ -200,7 +200,8 @@ class DriveOperations {
     parent: string,
     descriptor: GraphDescriptor
   ) {
-    const fileName = this.fileIdFromUrl(url);
+    const fileId = getFileId(url.href);
+    const fileName = crypto.randomUUID();
     const name = getFileTitle(descriptor);
 
     try {
@@ -210,9 +211,10 @@ class DriveOperations {
         descriptor
       );
 
-      const file = await this.#googleDriveClient.createFile(
+      await this.#googleDriveClient.createFile(
         new Blob([JSON.stringify(descriptor)], { type: GRAPH_MIME_TYPE }),
         {
+          id: fileId,
           name,
           mimeType: GRAPH_MIME_TYPE,
           parents: [parent],
@@ -225,10 +227,9 @@ class DriveOperations {
         },
         { fields: ["id"] }
       );
-      const updatedUrl = `${PROTOCOL}/${file.id}`;
 
-      console.log("[Google Drive] Created new board", updatedUrl);
-      return { result: true, url: updatedUrl };
+      console.log("[Google Drive] Created new board", url.href);
+      return { result: true, url: url.href };
     } catch (err) {
       console.warn(err);
       return { result: false, error: "Unable to create" };

--- a/packages/google-drive-kit/src/google-drive-client.ts
+++ b/packages/google-drive-kit/src/google-drive-client.ts
@@ -696,6 +696,24 @@ export class GoogleDriveClient {
       ? { ok: true, value: await response.json() }
       : { ok: false, error: { status: response.status } };
   }
+
+  /** https://developers.google.com/workspace/drive/api/reference/rest/v3/files/generateIds */
+  async generateIds(
+    count: number,
+    options?: BaseRequestOptions
+  ): Promise<[string, ...string[]]> {
+    const url = new URL(`drive/v3/files/generateIds`, this.#apiUrl);
+    url.searchParams.set("count", String(count));
+    const response = await this.#fetch(url, { signal: options?.signal });
+    if (!response.ok) {
+      throw new Error(
+        `Google Drive generateIds ${response.status} error: ` +
+          (await response.text())
+      );
+    }
+    const result = (await response.json()) as gapi.client.drive.GeneratedIds;
+    return result.ids as [string, ...string[]];
+  }
 }
 
 /**


### PR DESCRIPTION
This drops the user-perceived latency in creating a new graph from around 5 seconds to around 100 milliseconds.

It works like this:

- The create method now uses https://developers.google.com/workspace/drive/api/reference/rest/v3/files/generateIds to get a file ID from Drive in the quickest way possible, and returns it right away. From the caller's perspective, the graph is ready to display and edit at this time.

- Meanwhile, the rest of the create operation is backgrounded, and the initial blank graph descriptor is stored in memory. The full create operation could take up to 5 seconds, because it has to serially find the Drive folder ID, and then upload the data, and both of those calls are quite slow.

- A subsequent load() operation for that URL will return that blank graph directly from memory, and a subsequent save() or delete() will block on that initial create completing. 

- Once the background create is completed, and the first save() has finished, everything works as it did before.