### PR TITLE
[unified-server] Create server-side flags for client-side env vars

### DIFF
--- a/packages/shared-ui/src/contexts/global-config.ts
+++ b/packages/shared-ui/src/contexts/global-config.ts
@@ -7,6 +7,7 @@
 import type { ClientDeploymentConfiguration } from "@breadboard-ai/types/deployment-configuration.js";
 import { createContext } from "@lit/context";
 
+// TODO Replace this with the version in the types package
 export type GoogleDrivePermission =
   | { id: string; type: "user"; emailAddress: string }
   | { id: string; type: "group"; emailAddress: string }

--- a/packages/types/src/deployment-configuration.ts
+++ b/packages/types/src/deployment-configuration.ts
@@ -7,10 +7,14 @@
 import { type RuntimeFlags } from "./flags.js";
 
 export type ClientDeploymentConfiguration = {
+  ALLOWED_REDIRECT_ORIGINS?: string[];
   MEASUREMENT_ID?: string;
   BACKEND_API_ENDPOINT?: string;
   FEEDBACK_LINK?: string;
   ENABLE_GOOGLE_FEEDBACK?: boolean;
+  ENVIRONMENT_NAME?: string;
+  GOOGLE_DRIVE_PUBLISH_PERMISSIONS?: GoogleDrivePermission[];
+  GOOGLE_DRIVE_USER_FOLDER_NAME?: string;
   GOOGLE_FEEDBACK_PRODUCT_ID?: string;
   GOOGLE_FEEDBACK_BUCKET?: string;
   /**
@@ -36,3 +40,9 @@ export interface DomainConfiguration {
    */
   disallowPublicPublishing?: boolean;
 }
+
+export type GoogleDrivePermission =
+  | { id: string; type: "user"; emailAddress: string }
+  | { id: string; type: "group"; emailAddress: string }
+  | { id: string; type: "domain"; domain: string }
+  | { id: string; type: "anyone" };

--- a/packages/unified-server/src/server/config.ts
+++ b/packages/unified-server/src/server/config.ts
@@ -6,9 +6,10 @@
 
 import { readFile } from "node:fs/promises";
 import * as flags from "./flags.js";
-import {
-  type ClientDeploymentConfiguration,
-  type DomainConfiguration,
+import type {
+  ClientDeploymentConfiguration,
+  DomainConfiguration,
+  GoogleDrivePermission,
 } from "@breadboard-ai/types/deployment-configuration.js";
 
 /**
@@ -16,16 +17,19 @@ import {
  * passed to the client.
  */
 export async function createClientConfig(): Promise<ClientDeploymentConfiguration> {
-  const domainConfig = await loadDomainConfig();
   return {
+    ALLOWED_REDIRECT_ORIGINS: flags.ALLOWED_REDIRECT_ORIGINS,
     MEASUREMENT_ID: flags.MEASUREMENT_ID,
     BACKEND_API_ENDPOINT: flags.BACKEND_API_ENDPOINT,
     FEEDBACK_LINK: flags.FEEDBACK_LINK,
     ENABLE_GOOGLE_FEEDBACK: flags.ENABLE_GOOGLE_FEEDBACK,
+    ENVIRONMENT_NAME: flags.ENVIRONMENT_NAME,
+    GOOGLE_DRIVE_PUBLISH_PERMISSIONS: await loadGoogleDrivePublishPermissions(),
+    GOOGLE_DRIVE_USER_FOLDER_NAME: flags.GOOGLE_DRIVE_USER_FOLDER_NAME,
     GOOGLE_FEEDBACK_PRODUCT_ID: flags.GOOGLE_FEEDBACK_PRODUCT_ID,
     GOOGLE_FEEDBACK_BUCKET: flags.GOOGLE_FEEDBACK_BUCKET,
     ALLOW_3P_MODULES: flags.ALLOW_3P_MODULES,
-    domains: domainConfig,
+    domains: await loadDomainConfig(),
     flags: {
       usePlanRunner: flags.ENABLE_PLAN_RUNNER,
       saveAsCode: flags.ENABLE_SAVE_AS_CODE,
@@ -45,7 +49,22 @@ async function loadDomainConfig(): Promise<
     return {};
   }
 
-  console.log(`Loading domain config from ${path}`);
+  console.log(`[unified-server startup] Loading domain config from ${path}`);
   const contents = await readFile(path, "utf8");
   return JSON.parse(contents) as Record<string, DomainConfiguration>;
+}
+
+async function loadGoogleDrivePublishPermissions(): Promise<
+  GoogleDrivePermission[]
+> {
+  const path = flags.GOOGLE_DRIVE_PUBLISH_PERMISSIONS_CONFIG_FILE;
+  if (!path) {
+    return [];
+  }
+
+  console.log(
+    `[unified-server startup] Loading Drive publish config from ${path}`
+  );
+  const contents = await readFile(path, "utf8");
+  return JSON.parse(contents) as GoogleDrivePermission[];
 }

--- a/packages/unified-server/src/server/flags.ts
+++ b/packages/unified-server/src/server/flags.ts
@@ -8,6 +8,10 @@ import "dotenv/config";
 
 export const ALLOW_3P_MODULES: boolean = getBoolean("ALLOW_3P_MODULES");
 
+export const ALLOWED_REDIRECT_ORIGINS: string[] = getStringList(
+  "ALLOWED_REDIRECT_ORIGINS"
+);
+
 export const BACKEND_API_ENDPOINT: string = getString("BACKEND_API_ENDPOINT");
 
 export const DOMAIN_CONFIG_FILE: string = getString("DOMAIN_CONFIG_FILE");
@@ -32,10 +36,20 @@ export const ENABLE_PLAN_RUNNER: boolean = getBoolean("ENABLE_PLAN_RUNNER");
 
 export const ENABLE_SAVE_AS_CODE: boolean = getBoolean("ENABLE_SAVE_AS_CODE");
 
+export const ENVIRONMENT_NAME: string = getString("ENVIRONMENT_NAME");
+
 export const FEEDBACK_LINK: string = getString("FEEDBACK_LINK");
 
 export const GOOGLE_DRIVE_FEATURED_GALLERY_FOLDER_ID: string = getString(
   "GOOGLE_DRIVE_FEATURED_GALLERY_FOLDER_ID"
+);
+
+export const GOOGLE_DRIVE_PUBLISH_PERMISSIONS_CONFIG_FILE: string = getString(
+  "GOOGLE_DRIVE_PUBLISH_PERMISSIONS_CONFIG_FILE"
+);
+
+export const GOOGLE_DRIVE_USER_FOLDER_NAME: string = getString(
+  "GOOGLE_DRIVE_USER_FOLDER_NAME"
 );
 
 export const GOOGLE_FEEDBACK_BUCKET: string = getString(


### PR DESCRIPTION
Set them in the client deployment config.

This doesn't do anything on its own, but sets up further work to replace the VITE_ environment variables with their runtime counterparts. The goal is to get rid of all build-time variables, so that the same image can be deployed to multiple environments.
