### PR TITLE
[unified-server] Move drive permissions to a literal flag

### DIFF
--- a/packages/unified-server/src/server/config.ts
+++ b/packages/unified-server/src/server/config.ts
@@ -9,7 +9,6 @@ import * as flags from "./flags.js";
 import type {
   ClientDeploymentConfiguration,
   DomainConfiguration,
-  GoogleDrivePermission,
 } from "@breadboard-ai/types/deployment-configuration.js";
 
 /**
@@ -24,7 +23,7 @@ export async function createClientConfig(): Promise<ClientDeploymentConfiguratio
     FEEDBACK_LINK: flags.FEEDBACK_LINK,
     ENABLE_GOOGLE_FEEDBACK: flags.ENABLE_GOOGLE_FEEDBACK,
     ENVIRONMENT_NAME: flags.ENVIRONMENT_NAME,
-    GOOGLE_DRIVE_PUBLISH_PERMISSIONS: await loadGoogleDrivePublishPermissions(),
+    GOOGLE_DRIVE_PUBLISH_PERMISSIONS: flags.GOOGLE_DRIVE_PUBLISH_PERMISSIONS,
     GOOGLE_DRIVE_USER_FOLDER_NAME: flags.GOOGLE_DRIVE_USER_FOLDER_NAME,
     GOOGLE_FEEDBACK_PRODUCT_ID: flags.GOOGLE_FEEDBACK_PRODUCT_ID,
     GOOGLE_FEEDBACK_BUCKET: flags.GOOGLE_FEEDBACK_BUCKET,
@@ -52,19 +51,4 @@ async function loadDomainConfig(): Promise<
   console.log(`[unified-server startup] Loading domain config from ${path}`);
   const contents = await readFile(path, "utf8");
   return JSON.parse(contents) as Record<string, DomainConfiguration>;
-}
-
-async function loadGoogleDrivePublishPermissions(): Promise<
-  GoogleDrivePermission[]
-> {
-  const path = flags.GOOGLE_DRIVE_PUBLISH_PERMISSIONS_CONFIG_FILE;
-  if (!path) {
-    return [];
-  }
-
-  console.log(
-    `[unified-server startup] Loading Drive publish config from ${path}`
-  );
-  const contents = await readFile(path, "utf8");
-  return JSON.parse(contents) as GoogleDrivePermission[];
 }

--- a/packages/unified-server/src/server/flags.ts
+++ b/packages/unified-server/src/server/flags.ts
@@ -6,6 +6,8 @@
 
 import "dotenv/config";
 
+import type { GoogleDrivePermission } from "@breadboard-ai/types/deployment-configuration.js";
+
 export const ALLOW_3P_MODULES: boolean = getBoolean("ALLOW_3P_MODULES");
 
 export const ALLOWED_REDIRECT_ORIGINS: string[] = getStringList(
@@ -44,9 +46,8 @@ export const GOOGLE_DRIVE_FEATURED_GALLERY_FOLDER_ID: string = getString(
   "GOOGLE_DRIVE_FEATURED_GALLERY_FOLDER_ID"
 );
 
-export const GOOGLE_DRIVE_PUBLISH_PERMISSIONS_CONFIG_FILE: string = getString(
-  "GOOGLE_DRIVE_PUBLISH_PERMISSIONS_CONFIG_FILE"
-);
+export const GOOGLE_DRIVE_PUBLISH_PERMISSIONS: GoogleDrivePermission[] =
+  getDrivePermissions("GOOGLE_DRIVE_PUBLISH_PERMISSIONS");
 
 export const GOOGLE_DRIVE_USER_FOLDER_NAME: string = getString(
   "GOOGLE_DRIVE_USER_FOLDER_NAME"
@@ -91,4 +92,16 @@ function getStringList(flagName: string): string[] {
  */
 function getBoolean(flagName: string): boolean {
   return getString(flagName).toLowerCase() === "true";
+}
+
+function getDrivePermissions(flagName: string): GoogleDrivePermission[] {
+  const permissions = getString(flagName);
+  if (!permissions) {
+    return [];
+  }
+
+  console.log(
+    `[unified-server startup] Parsing Drive permissions from ${flagName}`
+  );
+  return JSON.parse(permissions) as GoogleDrivePermission[];
 }


### PR DESCRIPTION
Get rid of the GOOGLE_DRIVE_PUBLISH_PERMISSIONS_CONFIG environment variable, and parse the value directly from the environment variable (which contains JSON) instead of reading a file.