### PR TITLE
[unified-server] Add a DOMAIN_CONFIG flag

### DIFF
--- a/packages/unified-server/src/server/config.ts
+++ b/packages/unified-server/src/server/config.ts
@@ -40,10 +40,16 @@ export async function createClientConfig(): Promise<ClientDeploymentConfiguratio
   };
 }
 
-// TODO Delete this once we're loading domain config from environment vars
+// TODO Delete this once we're no longer using the DOMAIN_CONFIG_FILE flag
 async function loadDomainConfig(): Promise<
   Record<string, DomainConfiguration>
 > {
+  // Prefer the literal variable if it is set
+  if (process.env.DOMAIN_CONFIG) {
+    return flags.DOMAIN_CONFIG;
+  }
+
+  // Otherwise load from file
   const path = flags.DOMAIN_CONFIG_FILE;
   if (!path) {
     return {};

--- a/packages/unified-server/src/server/flags.ts
+++ b/packages/unified-server/src/server/flags.ts
@@ -19,6 +19,7 @@ export const ALLOWED_REDIRECT_ORIGINS: string[] = getStringList(
 
 export const BACKEND_API_ENDPOINT: string = getString("BACKEND_API_ENDPOINT");
 
+// TODO Deprecate this flag in favor of DOMAIN_CONFIG
 export const DOMAIN_CONFIG_FILE: string = getString("DOMAIN_CONFIG_FILE");
 
 export const DOMAIN_CONFIG: Record<string, DomainConfiguration> =


### PR DESCRIPTION
Allows setting the domain config as a literal JSON string instead of parsing a file. The old flag is left in place since it's currently in use in production.
