### PR TITLE
Wait for graph create to finish before opening share panel

### DIFF
--- a/packages/google-drive-kit/src/board-server/server.ts
+++ b/packages/google-drive-kit/src/board-server/server.ts
@@ -299,6 +299,10 @@ class GoogleDriveBoardServer
   }
 
   async flushSaveQueue(url: string): Promise<void> {
+    const create = this.#pendingCreates.get(url);
+    if (create) {
+      await create.createDone;
+    }
     const debouncer = this.#saving.get(url);
     if (!debouncer) {
       return;


### PR DESCRIPTION
Fixes a race condition where sharing quickly after creating might fail.