### PR TITLE
Never use the public proxy when fetching metadata in the share panel

### DIFF
--- a/packages/shared-ui/src/elements/share-panel/share-panel.ts
+++ b/packages/shared-ui/src/elements/share-panel/share-panel.ts
@@ -1036,6 +1036,12 @@ export class SharePanel extends LitElement {
     const shareableCopyFileMetadata =
       await this.googleDriveClient.getFileMetadata(shareableCopyFileId, {
         fields: ["resourceKey", "properties", "permissions"],
+        // If we're working on one of the featured gallery graphs, and it's
+        // already been published, then the shared copy file ID will have been
+        // marked as one we should use the proxy for! But, the proxy won't
+        // return all the metadata we need right here, because it won't be
+        // fetched with our credentials (e.g. permissions will be missing).
+        bypassProxy: true,
       });
     const allGraphPermissions = shareableCopyFileMetadata.permissions ?? [];
     const diff = diffAssetReadPermissions({


### PR DESCRIPTION
This was causing an issue where when editing a graph that has already been published to the public gallery, the share panel would always think that the graph was not published, because the metadata fetch was not returning permissions, because it was not being fetched with user credentials.