### PR TITLE
[bees] Enrich Subagent Tiles with Digest Data

### DIFF
--- a/packages/bees/playbooks/digest-tile-writer/PLAYBOOK.yaml
+++ b/packages/bees/playbooks/digest-tile-writer/PLAYBOOK.yaml
@@ -2,11 +2,12 @@ name: digest-tile-writer
 title: Digest Tile Writer
 type: task-template
 description: >
-  Generates a digest tile based on the provided context
+  Maintains a journey digest based on the provided context. This is a
+  fire-and-forget infra task that the user doesn't need to know about.
 
 steps:
   main:
-    title: Digest Tile Writer
+    title: Digest Writer
     objective: >
       Write or edit if already exists, a JSON file `digest_tile.json` in your
       assigned subdirectory of the following structure:
@@ -19,7 +20,7 @@ steps:
       goal  is to reflect the current state of the context, not list the
       updates.
 
-      Then, send a `digest_tile_ready` event with the relative path to the
+      Then, broadcast a `digest_ready` event with the relative path to the
       written file.
 
       Return "Done" as outcome.

--- a/packages/bees/playbooks/journey-manager/PLAYBOOK.yaml
+++ b/packages/bees/playbooks/journey-manager/PLAYBOOK.yaml
@@ -35,22 +35,26 @@ steps:
       The typical flow is:
 
       -> do some research to gather information on the objective
-        -> build an XState journey 
+        -> build the XState journey 
           -> build React app 
-            -> write a digest title
-            -> ask user for comments. Depending on the comments
+            -> update journey digest
+            -> ask user for comments. Depending on the comments:
               -> rebuild React app
-                 -> write a digest tile
+                 -> update journey digest
               -> rebuild the XState journey -> rebuild React app
-                 -> write a digest tile
+                 -> update journey digest
               -> do more research ...
                 -> ask user for comments ...
 
-      Rinse, repeat. When iterating, reuse the slug names and inform the
-      subagents that they can read the old information and write over it.
+      Rinse, repeat. 
 
-      Every time there's an update to the React app, send an event to parent
-      with a brief summary of what changed. 
+      When iterating, reuse the slug names and inform the subagents that they
+      can read the old information and write over it. Use these slugs for each
+      task type for consistency:
+        - `research` for the research
+        - `journey` for the XState journey
+        - `app` for the React app
+        - `digest` for the digest
 
       ## Rules
 
@@ -62,10 +66,6 @@ steps:
 
       - Each subagent working on a task gets a clean LLM context. Be explicit in
       your task assignments. They know nothing about prior conversation.
-
-      - For the app to be picked up by the frontend, make sure to use the "app"
-      subagent slug for the React app. Otherwise, the app won't be seen by the
-      user.
 
     functions:
       - chat.*

--- a/packages/bees/playbooks/opie/PLAYBOOK.yaml
+++ b/packages/bees/playbooks/opie/PLAYBOOK.yaml
@@ -33,9 +33,8 @@ steps:
   digest_manager:
     title: Digest Manager
     objective: >
-      You are the Digest Orchestrator. 
-      Your job is to listen for completed Map stages (`digest_tile_ready`
-      signals) and trigger the synthesis and UI compilation pipeline.
+      Your job is to listen for completed stages (`digest_tile_ready` signals)
+      and trigger the synthesis and UI compilation pipeline.
 
       **Lifecycle**: Your very first action MUST be to call
       chat_await_context_update and suspend. 

--- a/packages/bees/web/src/shell/components/opal-subagent-panel.ts
+++ b/packages/bees/web/src/shell/components/opal-subagent-panel.ts
@@ -12,7 +12,16 @@ import { scaContext } from "../../sca/context/context.js";
 import { type SCA } from "../../sca/sca.js";
 import { sharedStyles } from "./shared.styles.js";
 import { deriveChildAgents } from "../../sca/utils/agent-tree.js";
+import type { TicketData } from "../../data/types.js";
 
+/** Digest tile data written by the digest-tile-writer playbook. */
+interface DigestTileData {
+  title?: string;
+  summary?: string;
+  milestone?: string;
+  actionable?: string;
+  link_id?: string;
+}
 
 const styles = css`
   :host {
@@ -176,6 +185,63 @@ const styles = css`
   .empty-icon {
     font-size: 32px;
   }
+
+  /* ── Enriched card (with digest tile) ── */
+
+  .agent-card.enriched {
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--cg-sp-2, 8px);
+  }
+
+  .agent-card-header {
+    display: flex;
+    align-items: center;
+    gap: var(--cg-sp-4, 16px);
+  }
+
+  .digest-meta {
+    display: flex;
+    align-items: center;
+    gap: var(--cg-sp-2, 8px);
+    flex-wrap: wrap;
+    padding-left: 48px;
+  }
+
+  .milestone-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 10px;
+    border-radius: var(--cg-radius-full, 999px);
+    font-size: 11px;
+    font-weight: 500;
+    background: var(--cg-color-tertiary-container, #f3e8f9);
+    color: var(--cg-color-on-tertiary-container, #4a2260);
+  }
+
+  .actionable-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 10px;
+    border-radius: var(--cg-radius-full, 999px);
+    font-size: 11px;
+    font-weight: 600;
+    background: #ff980022;
+    color: #e65100;
+  }
+
+  .digest-summary {
+    font-size: var(--cg-text-body-sm-size, 12px);
+    color: var(--cg-color-on-surface-muted, #79757f);
+    line-height: 1.5;
+    padding-left: 48px;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
 `;
 
 @customElement("opal-subagent-panel")
@@ -187,6 +253,10 @@ export class OpalSubagentPanel extends SignalWatcher(LitElement) {
   accessor parentTicketId: string = "";
 
   static styles = [sharedStyles, styles];
+
+  #digestTiles = new Map<string, DigestTileData>();
+  #lastFetchKey = "";
+  #fetching = false;
 
   render() {
     if (!this.parentTicketId) {
@@ -208,52 +278,141 @@ export class OpalSubagentPanel extends SignalWatcher(LitElement) {
       </div>`;
     }
 
+    // Detect digest_ready signals to know when to re-fetch tiles.
+    const digestReadyCount = tickets.filter(
+      (t) => t.kind === "coordination" && t.signal_type === "digest_ready"
+    ).length;
+    const fetchKey = `${this.parentTicketId}:${digestReadyCount}`;
+    if (fetchKey !== this.#lastFetchKey) {
+      this.#lastFetchKey = fetchKey;
+      this.#fetchDigestTiles(children);
+    }
+
     return html`
       <div class="panel-container">
         <div class="panel-title">Subagents</div>
-        ${children.map((child) => {
-          const isRunning = child.status === "running";
-
-          const icon =
-            child.status === "completed"
-              ? "✅"
-              : child.status === "failed"
-                ? "❌"
-                : child.status === "paused"
-                  ? "⏸"
-                  : isRunning
-                    ? "⏳"
-                    : "📝";
-
-          const title =
-            child.title ||
-            child.playbook_id?.replace(/-/g, " ") ||
-            child.id.slice(0, 8);
-
-          const detailText = isRunning
-            ? "Working..."
-            : child.status;
-
-          return html`
-            <button
-              class="agent-card"
-              @click=${() =>
-                this.sca.controller.agentTree.selectedAgentId = child.id
-              }
-            >
-              <div class="agent-status-icon ${child.status}">${icon}</div>
-              <div class="agent-info">
-                <div class="agent-name">${title}</div>
-                <div class="agent-detail">
-                  ${detailText}
-                  ${isRunning ? html`<span class="dot-flashing"></span>` : ""}
-                </div>
-              </div>
-              <span class="agent-arrow">→</span>
-            </button>
-          `;
-        })}
+        ${children.map((child) => this.#renderCard(child))}
       </div>
     `;
+  }
+
+  #renderCard(child: TicketData) {
+    const isRunning = child.status === "running";
+
+    const icon =
+      child.status === "completed"
+        ? "✅"
+        : child.status === "failed"
+          ? "❌"
+          : child.status === "paused"
+            ? "⏸"
+            : isRunning
+              ? "⏳"
+              : "📝";
+
+    const digest = child.slug ? this.#digestTiles.get(child.slug) : undefined;
+
+    const title =
+      digest?.title ||
+      child.title ||
+      child.playbook_id?.replace(/-/g, " ") ||
+      child.id.slice(0, 8);
+
+    const detailText = isRunning
+      ? "Working..."
+      : child.status === "suspended"
+        ? "Ready for your input"
+        : child.status;
+
+    const navigate = () => {
+      this.sca.controller.agentTree.selectedAgentId = child.id;
+    };
+
+    if (digest) {
+      return html`
+        <button class="agent-card enriched" @click=${navigate}>
+          <div class="agent-card-header">
+            <div class="agent-status-icon ${child.status}">${icon}</div>
+            <div class="agent-info">
+              <div class="agent-name">${title}</div>
+              <div class="agent-detail">
+                ${detailText}
+                ${isRunning ? html`<span class="dot-flashing"></span>` : ""}
+              </div>
+            </div>
+            <span class="agent-arrow">→</span>
+          </div>
+          <div class="digest-meta">
+            ${digest.milestone
+              ? html`<span class="milestone-chip">📍 ${digest.milestone}</span>`
+              : ""}
+          </div>
+          ${digest.summary
+            ? html`<div class="digest-summary">${digest.summary}</div>`
+            : ""}
+        </button>
+      `;
+    }
+
+    return html`
+      <button class="agent-card" @click=${navigate}>
+        <div class="agent-status-icon ${child.status}">${icon}</div>
+        <div class="agent-info">
+          <div class="agent-name">${title}</div>
+          <div class="agent-detail">
+            ${detailText}
+            ${isRunning ? html`<span class="dot-flashing"></span>` : ""}
+          </div>
+        </div>
+        <span class="agent-arrow">→</span>
+      </button>
+    `;
+  }
+
+  async #fetchDigestTiles(children: TicketData[]) {
+    if (this.#fetching || !this.parentTicketId) return;
+    this.#fetching = true;
+    try {
+      const api = this.sca.services.api;
+      const allFiles = await api.listFiles(this.parentTicketId);
+      const digestFiles = allFiles.filter((f) =>
+        f.endsWith("digest_tile.json")
+      );
+
+      if (digestFiles.length === 0) {
+        if (this.#digestTiles.size > 0) {
+          this.#digestTiles = new Map();
+          this.requestUpdate();
+        }
+        return;
+      }
+
+      const newTiles = new Map<string, DigestTileData>();
+
+      for (const child of children) {
+        if (!child.slug) continue;
+
+        // Find the shallowest digest_tile.json under this child's slug.
+        const matches = digestFiles
+          .filter((f) => f.startsWith(child.slug + "/"))
+          .sort((a, b) => a.split("/").length - b.split("/").length);
+
+        if (matches.length === 0) continue;
+
+        const content = await api.getFile(this.parentTicketId, matches[0]);
+        if (content) {
+          try {
+            newTiles.set(child.slug!, JSON.parse(content));
+          } catch {
+            // Invalid JSON — skip.
+          }
+        }
+      }
+
+      this.#digestTiles = newTiles;
+      this.requestUpdate();
+    } finally {
+      this.#fetching = false;
+    }
   }
 }


### PR DESCRIPTION
## What
Enriched the "Subagent" tab in the Bees shell to display additional information from `digest_tile.json` files when available, and improved the labeling of suspended tasks.

## Why
To provide users with a richer, more informative overview of subagent progress directly in the subagent list, making it easier to see current milestones and summaries without diving into each agent.

## Changes
### packages/bees/web
- **opal-subagent-panel.ts**
  - Added logic to scan and fetch `digest_tile.json` files from the parent ticket's filesystem.
  - Implemented shallowest-path-wins resolution for nested digest tiles.
  - Added reactive re-fetching triggered by `digest_ready` coordination signals.
  - Enriched the UI card layout to show title, milestone, and summary from the digest.
  - Remapped "suspended" status to "Ready for your input" and dropped the redundant status badge.

## Testing
- Verified clean compilation with `tsc`.
- Manual verification in the browser to check that tiles render correctly when `digest_tile.json` is present and that clicking them still navigates correctly.
