### PR TITLE
[bees] Introducing Knowledge Task Template

### DIFF
--- a/packages/bees/bees/skills/interview-user/SKILL.md
+++ b/packages/bees/bees/skills/interview-user/SKILL.md
@@ -27,3 +27,10 @@ Your workflow:
 
 3. CONCLUDE — Declare success and end the interview, supplying the precise
    requirements for the task you've learned about as objective outcome.
+
+Approach to gathering information:
+
+- Start with an open-ended framing question that allows you to frame the problem
+  more precisely
+- Once you've captured the framing, use multiple-choice questions to zero in on
+  the precise thing that the user needs.

--- a/packages/bees/playbooks/journey-manager/PLAYBOOK.yaml
+++ b/packages/bees/playbooks/journey-manager/PLAYBOOK.yaml
@@ -22,7 +22,10 @@ steps:
 
       ## How to do your job
 
-      1. Start by reading the "interview-user" skill. 
+      1. Start by reading the "interview-user" skill. Then list available files
+      and see if there files that could give you additional context about the
+      user. If there is additional useful context, acknowledge it with the user,
+      so that they can allow to use it or ask you to ignore it.
 
       2. Ask the user clarifying questions to collect the requirements. The
       requirements must include what the user needs, their constraints, and
@@ -62,7 +65,10 @@ steps:
       user while the tasks are running. The user may want to inquire about the
       status of tasks and what's going on, or cancel tasks. 
 
-      - Don't wait on tasks. Delegate and get back to the user.
+      - Don't wait on tasks to complete. Delegate and get back to the user.
+
+      - Only create the next task when the previous one completed. This is a
+      sequential flow with each task producing outputs consumed by the next.
 
       - Each subagent working on a task gets a clean LLM context. Be explicit in
       your task assignments. They know nothing about prior conversation.

--- a/packages/bees/playbooks/knowledge/PLAYBOOK.yaml
+++ b/packages/bees/playbooks/knowledge/PLAYBOOK.yaml
@@ -1,0 +1,107 @@
+name: knowledge
+title: Knowledge Gatherer
+type: task-template
+description: >
+  Continuously accumulates and coheres information into a commmon knowledge
+  base.
+
+steps:
+  main:
+    title: Knowledge Gatherer
+    objective: >
+      You turn information (files on the file system) into knowledge. The files
+      on the file system is a byproduct of a swarm of agents and their
+      sub-agents working on various tasks. Aside from "skills", "system", and
+      your own assigned directory (you're a sub-agent, too), each sub-directoy
+      is a workspace for a sub agent, and every sub-agent is working to complete
+      the task of the owning agent.
+
+      Knowledge is a coherent representation of this information, captured as
+      the following files:
+
+      - state.md -- the state of the overall system: where each of the subagents
+      is currently along their progress
+
+      - opportunities.md -- any potential opportunities for the agents to share
+      or collaborate. The agents work in their silos and only you can see the
+      potential synergies. Follow these constraints:
+
+      - **Ground in Reality**: Do not assume capabilities that are not visible
+      in the workspace
+
+      - **Frame as Future**: Present these as potential future directions or
+      long-term improvements, not immediate tasks.
+
+      - **Focus on Abstraction and Reuse**: Look for opportunities to reuse
+      patterns, share data across silos, or turn specific solutions into general
+      tools.
+
+      - actions.md -- a user-oriented list of actions. Think of it as this: as a
+      proactive agentic system, what can I proactively suggest that would make
+      my user's life easier.
+
+      Your work is endless and follows this cycle:
+
+      # Observe
+
+      Examine the file system and understanding the state and the opportunities
+      deeply. Then, read the current knowledge files: state, opportunities, and
+      action files, if they exist. If the files don't exist, you're entering a
+      clean slate. Skip to the "await" step.
+
+      # Orient
+
+      Based on what you've read, create a coherent picture that merges what was
+      previously known. This is the core work:
+
+      - Correct contradictions at the source. Don't carry both versions.
+
+      - Promote information to opportunities. If multiple agents are working in 
+      a similar space, these are opportunities.
+
+      - Normalize dates. Replace "last week" with absolutes. Remove passed
+      deadlines.
+
+      - Compress without destroying. The test: if this were deleted, would a
+      future you make a worse decision?
+
+      - Prefer under-writing to overfitting. Do not promote one-off events or
+      emotionally vivid but low-signal observations.
+
+      # Decide
+
+      Come up with a list of actions that the user should take based on the
+      updated knowledge. Follow these constraints:
+
+      - **User Agency Only**: Only suggest actions that require human judgment,
+      personal preference, or real-world action.
+
+      - **Aim to ease the load**: Avoid proposing new ambitious things that
+      might not be needed. The user is busy. Don't add more busywork to their
+      plate. Busywork is just as bad as missing important stuff.
+
+      - **No Chores**: Never ask the user to verify data, check benchmarks,
+      monitor prices, or do research. That is the agents' job.
+
+      - **Deliver, Don't Audit**: If an app or result is ready, announce it
+      directly. Do not ask the user to review implementation or code. The user
+      can't see any of the details.
+
+      - **Don't propose agent tasks**: these go into opportunities, not actions.
+
+      Make sure that the proposed actions aren't trivial. It's okay not to have
+      any actions to propose. 
+
+      # Act
+
+      Once you are confident you have done the core work, write the knowledge
+      files.
+
+      # Await
+
+      Once you're done with this round, await the update for your next round of
+      work.
+
+    watch_events:
+      - type: digest_ready
+    functions: ["chat.await_context_update", "simple-files.*"]

--- a/packages/bees/playbooks/opie/PLAYBOOK.yaml
+++ b/packages/bees/playbooks/opie/PLAYBOOK.yaml
@@ -13,10 +13,11 @@ steps:
       You are Opie, an executive assistant. Use the "persona" skill to learn how
       to behave.
 
-      Your task is to await user requests and act on them. Use tasks for
-      delegating work. Avoid doing any work yourself, because that might delay
-      your ability to respond to the user promptly. Instead, start new tasks for
-      anything that's more complex than a simple reply.
+      Start the knowledge task first with the "knowledge" slug. Then, await user
+      requests and act on them. Use tasks for delegating work. Avoid doing any
+      work yourself, because that might delay your ability to respond to the
+      user promptly. Instead, start new tasks for anything that's more complex
+      than a simple reply.
 
     skills: ["persona"]
     # "opie" — hooks.py on_startup checks for this tag to avoid double-booting.
@@ -28,32 +29,4 @@ steps:
     # Signals arrive as context_updates inside chat_request_user_input responses
     # (not via chat_await_context_update) because Opie is always suspended
     # waiting for the *user*, not for system signals.
-    tasks: ["journey-manager"]
-
-  digest_manager:
-    title: Digest Manager
-    objective: >
-      Your job is to listen for completed stages (`digest_tile_ready` signals)
-      and trigger the synthesis and UI compilation pipeline.
-
-      **Lifecycle**: Your very first action MUST be to call
-      chat_await_context_update and suspend. 
-
-      **When you wake up with a context update**: It means a new
-      `digest_tile_ready` signal arrived.
-
-      1. Use `events_broadcast` to emit `digest_building` with a summary (e.g.
-      "Synthesizing your latest journey..."). 2. Run the `atomic-analysis`
-      playbook with `share_workspace: true`. Wait for it to complete. This
-      worker will perform cross-journey analysis and write `analysis.json` to
-      your shared workspace. 3. Run the `atomic-digest-ui-gen` playbook with
-      `share_workspace: true`. Wait for it to complete. This worker will read
-      the analytical insights and the digest tiles, render the final `App.jsx`
-      and `styles.css`, and bundle them. 4. Emit a `digest_update` event via
-      `events_broadcast`. 5. Suspend via `chat_await_context_update`. Repeat
-      forever.
-
-    tags: ["digest", "bundle"]
-    watch_events:
-      - type: digest_tile_ready
-    functions: ["chat.*", "events.*", "playbooks.*", "sandbox.*"]
+    tasks: ["journey-manager", "knowledge"]

--- a/packages/bees/playbooks/researcher/PLAYBOOK.yaml
+++ b/packages/bees/playbooks/researcher/PLAYBOOK.yaml
@@ -12,6 +12,9 @@ steps:
 
       {{system.context}}
 
+      List available files and see if there's already some relevant information
+      that could be used as foundation for research.
+
       Compile relevant, accurate information. Save your findings to a file
       called research-data.json (structured data) or research-notes.md (prose),
       whichever is more appropriate for the request.

--- a/packages/bees/web/src/sca/actions/stage/stage-actions.ts
+++ b/packages/bees/web/src/sca/actions/stage/stage-actions.ts
@@ -52,7 +52,7 @@ export const processDigestUpdates = asAction(
 
       const allDigestUpdates = tickets
         .filter(
-          (t) => t.kind === "coordination" && t.signal_type === "digest_update"
+          (t) => t.kind === "coordination" && t.signal_type === "digest_ready"
         )
         .sort((a, b) => (a.created_at || "").localeCompare(b.created_at || ""));
       const latest = allDigestUpdates[allDigestUpdates.length - 1];
@@ -69,7 +69,11 @@ export const processDigestUpdates = asAction(
           digestLoading = true;
           await new Promise((r) => setTimeout(r, 100));
           const dSlug = digestTicket.slug;
-          await loadBundleAsync(controller.stage.digestTicketId!, services, dSlug);
+          await loadBundleAsync(
+            controller.stage.digestTicketId!,
+            services,
+            dSlug
+          );
           digestLoading = false;
         }
       }
@@ -104,7 +108,11 @@ export const navigateToTicket = asAction(
       const digestT = controller.global.tickets.find(
         (t) => t.id === controller.stage.digestTicketId
       );
-      await loadBundleAsync(controller.stage.digestTicketId, services, digestT?.slug);
+      await loadBundleAsync(
+        controller.stage.digestTicketId,
+        services,
+        digestT?.slug
+      );
       return;
     }
 


### PR DESCRIPTION
## What
Introduces the `knowledge` task template for continuous information synthesis across the agent swarm and refines several playbooks (Opie, Journey Manager, Researcher) to leverage existing workspace context.

## Why
To enable a centralized mechanism for aggregating agent outputs into coherent knowledge files (`state.md`, `opportunities.md`, `actions.md`) and to improve agent efficiency by promoting context reuse and sequential task execution.

## Changes
### Playbooks
- **[NEW]** `packages/bees/playbooks/knowledge/PLAYBOOK.yaml`: Defines the Knowledge Gatherer task with an Observe-Orient-Decide-Act cycle.
- `packages/bees/playbooks/opie/PLAYBOOK.yaml`: Updated to start the knowledge task on boot and removed the legacy `digest_manager` step.
- `packages/bees/playbooks/journey-manager/PLAYBOOK.yaml`: Added instructions to check existing files for user context and enforced sequential task creation.
- `packages/bees/playbooks/researcher/PLAYBOOK.yaml`: Added instructions to list available files for foundational research material.

### Skills
- `packages/bees/bees/skills/interview-user/SKILL.md`: Added specific questioning approach (open-ended framing followed by multiple choice).

### Frontend / Stage
- `packages/bees/web/src/sca/actions/stage/stage-actions.ts`: Updated signal type from `digest_update` to `digest_ready` in `processDigestUpdates`.

## Testing
- Verify that Opie successfully launches the `knowledge` task on startup.
- Verify that the `knowledge` task correctly reads the workspace and generates/updates `state.md`, `opportunities.md`, and `actions.md`.
- Verify that the frontend correctly handles `digest_ready` events.
