### PR TITLE
[bees] Remove dead playbook endpoints and signal emission

### DIFF
--- a/packages/bees/bees/scheduler.py
+++ b/packages/bees/bees/scheduler.py
@@ -106,8 +106,7 @@ class SchedulerHooks:
     on_events_broadcast: Callable[[Ticket], None] | None = None
     """Called when an agent broadcasts an event mid-session."""
 
-    on_playbook_complete: Callable[[str, list[Ticket], Ticket], Awaitable[None]] | None = None
-    """Called when all tickets in a playbook run are complete. (run_id, siblings, triggering_ticket)"""
+
 
     on_cycle_complete: Callable[[int], Awaitable[None]] | None = None
     """Called when there is no more work (total_cycles)."""
@@ -188,26 +187,6 @@ def _find_dep_id(ref: str, dep_ids: list[str]) -> str | None:
 # ---------------------------------------------------------------------------
 
 
-def _format_playbook_complete(playbook_id: str, siblings: list[Ticket]) -> str:
-    """Format a playbook-completion event as a context_update string."""
-    summaries: list[str] = []
-    succeeded = 0
-    failed = 0
-    for t in siblings:
-        title = t.metadata.title or t.id[:8]
-        outcome = t.metadata.outcome or "(no outcome)"
-        summaries.append(f"- **{title}**: {outcome}")
-        if t.metadata.status == "completed":
-            succeeded += 1
-        elif t.metadata.status == "failed":
-            failed += 1
-
-    summary_text = "\n".join(summaries)
-    return (
-        f'[Playbook Completed] "{playbook_id}"\n'
-        f"Results ({succeeded} succeeded, {failed} failed):\n"
-        f"{summary_text}"
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -852,40 +831,6 @@ class Scheduler:
 
         return on_event
 
-    async def _check_playbook_completion_internal(self, ticket: Ticket) -> None:
-        """Check if all tickets in a playbook run are done, and fire hook if so."""
-        run_id = ticket.metadata.playbook_run_id
-        if not run_id:
-            return
-
-        siblings = [
-            t for t in list_tickets()
-            if t.metadata.playbook_run_id == run_id
-        ]
-        if not siblings:
-            return
-
-        terminal = {"completed", "failed"}
-        all_done = all(t.metadata.status in terminal for t in siblings)
-        if not all_done:
-            return
-
-        if self._hooks.on_playbook_complete:
-            await self._hooks.on_playbook_complete(run_id, siblings, ticket)
-
-        # Emit a durable coordination signal for playbook completion.
-        # This flows through _route_coordination_ticket on the next cycle,
-        # which handles tag filtering, durable delivery, and retry.
-        playbook_id = ticket.metadata.playbook_id or "(unknown)"
-        notification = _format_playbook_complete(playbook_id, siblings)
-        create_ticket(
-            "",
-            kind="coordination",
-            signal_type="playbook_complete",
-            context=notification,
-            tags=list(ticket.metadata.tags or []),
-        )
-        self.trigger()
 
     async def _route_coordination_ticket(self, ticket: Ticket) -> None:
         """Route a coordination ticket's signal to matching subscribers.
@@ -1058,7 +1003,7 @@ class Scheduler:
                             await self._hooks.on_ticket_done(enriched)
                         if self._hooks.on_ticket_done:
                             await self._hooks.on_ticket_done(updated)
-                        await self._check_playbook_completion_internal(updated)
+
                         self.trigger()
 
                 task = asyncio.create_task(wrap_run())
@@ -1088,7 +1033,7 @@ class Scheduler:
                             await self._hooks.on_ticket_done(enriched)
                         if self._hooks.on_ticket_done:
                             await self._hooks.on_ticket_done(updated)
-                        await self._check_playbook_completion_internal(updated)
+
                         self.trigger()
 
                 task = asyncio.create_task(wrap_resume())

--- a/packages/bees/bees/server.py
+++ b/packages/bees/bees/server.py
@@ -31,7 +31,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from sse_starlette.sse import EventSourceResponse
 
-from bees.playbook import PlaybookAborted, list_playbooks, load_playbook, run_playbook, run_startup_hooks
+from bees.playbook import run_startup_hooks
 from bees.scheduler import Scheduler, SchedulerHooks
 from bees.session import load_gemini_key
 from bees.ticket import (
@@ -135,30 +135,6 @@ def _on_events_broadcast(ticket: Ticket) -> None:
     }))
 
 
-async def _on_playbook_complete(run_id: str, siblings: list[Ticket], triggering_ticket: Ticket) -> None:
-    """Broadcast playbook completion via SSE.
-
-    Watcher delivery (notifying interested tickets) is handled by the
-    scheduler's ``_deliver_to_watchers`` — this hook is only for the
-    SSE event stream so the frontend can react to completion.
-    """
-    playbook_name = triggering_ticket.metadata.playbook_id or "(unknown)"
-    succeeded = sum(1 for t in siblings if t.metadata.status == "completed")
-    failed = sum(1 for t in siblings if t.metadata.status == "failed")
-
-    logger.info(
-        "Playbook run %s (%s) complete: %d succeeded, %d failed",
-        run_id, playbook_name, succeeded, failed,
-    )
-
-    await broadcaster.broadcast({
-        "type": "playbook_complete",
-        "playbook_run_id": run_id,
-        "playbook_id": playbook_name,
-        "succeeded": succeeded,
-        "failed": failed,
-    })
-
 
 # ---------------------------------------------------------------------------
 # Request/response models
@@ -207,7 +183,6 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         on_ticket_start=_on_ticket_start,
         on_ticket_done=_on_ticket_done,
         on_events_broadcast=_on_events_broadcast,
-        on_playbook_complete=_on_playbook_complete,
         on_cycle_complete=_on_cycle_complete,
     )
     scheduler = Scheduler(http=http_client, backend=backend, hooks=hooks)
@@ -433,56 +408,6 @@ async def retry_ticket(ticket_id: str) -> dict[str, Any]:
         scheduler.trigger()
     return _ticket_to_dict(ticket)
 
-
-# ---------------------------------------------------------------------------
-# Playbook endpoints
-# ---------------------------------------------------------------------------
-
-
-@app.get("/playbooks")
-async def get_playbooks() -> list[dict[str, str]]:
-    """List available playbooks."""
-    playbooks = []
-    for name in list_playbooks():
-        try:
-            data = load_playbook(name)
-            if data.get("hidden"):
-                continue
-            playbooks.append({
-                "name": data.get("name", name),
-                "title": data.get("title", name),
-                "description": data.get("description", ""),
-            })
-        except Exception:
-            continue
-    return playbooks
-
-
-@app.post("/playbooks/{name}/run")
-async def run_playbook_endpoint(name: str) -> dict[str, Any]:
-    """Run a playbook, creating tickets for each step."""
-    try:
-        tickets = run_playbook(name)
-    except FileNotFoundError:
-        raise HTTPException(404, f"Playbook '{name}' not found")
-    except PlaybookAborted as exc:
-        return {"playbook": name, "status": "skipped", "message": str(exc)}
-    except ValueError as exc:
-        raise HTTPException(400, str(exc))
-
-    for ticket in tickets:
-        await broadcaster.broadcast({
-            "type": "ticket_added",
-            "ticket": _ticket_to_dict(ticket),
-        })
-
-    if scheduler:
-        scheduler.trigger()
-
-    return {
-        "playbook": name,
-        "tickets": [_ticket_to_dict(t) for t in tickets],
-    }
 
 
 

--- a/packages/bees/playbooks/GUIDE.md
+++ b/packages/bees/playbooks/GUIDE.md
@@ -390,9 +390,7 @@ steps:
   undelivered signals are retried on the next scheduler cycle.
 - **Busy subscribers are retried**: If the receiving agent is currently running
   (not suspended), the signal is queued and delivered when it next suspends.
-- **Playbook completion**: When all tickets in a playbook run reach a terminal
-  state, the scheduler automatically emits a `playbook_complete` signal with a
-  summary, routed via the same event mechanism.
+
 
 ### Context Updates on Chat Functions
 
@@ -812,8 +810,6 @@ The server runs on port 3200 with auto-reload for `.py`, `.md`, `.json`, and
 run without restarting the server.
 
 **API endpoints**:
-- `GET /playbooks` — list available playbooks
-- `POST /playbooks/{name}/run` — run a playbook
 - `GET /tickets` — list all tickets (optionally filter by `?tag=chat`)
 - `GET /tickets/{id}` — get a single ticket with metadata
 - `POST /tickets/{id}/respond` — submit a response to a suspended ticket
@@ -871,5 +867,4 @@ session to deliver to.
 **`chat_await_context_update` without `watch_events`**: Calling
 `chat_await_context_update` suspends the session, but without `watch_events`,
 no events will be routed to the ticket. The agent will hang
-indefinitely. The only exception is playbook-completion signals, which are routed
-by tag matching.
+indefinitely.

--- a/packages/bees/web/src/data/router.ts
+++ b/packages/bees/web/src/data/router.ts
@@ -19,7 +19,6 @@ export { parseRoute, writeRoute, type Route };
 type RoutableTab =
   | "jobs"
   | "daemons"
-  | "playbooks"
   | "logs"
   | "tickets"
   | "events";
@@ -32,7 +31,6 @@ interface Route {
 const VALID_TABS = new Set<string>([
   "jobs",
   "daemons",
-  "playbooks",
   "logs",
   "tickets",
   "events",

--- a/packages/bees/web/src/data/types.ts
+++ b/packages/bees/web/src/data/types.ts
@@ -38,11 +38,7 @@ export interface TicketData {
   files?: Array<{ path: string; mimeType: string; localPath: string }>;
 }
 
-export interface PlaybookData {
-  name: string;
-  title: string;
-  description: string;
-}
+
 
 // ---------------------------------------------------------------------------
 // Log file types (from EvalCollector output in packages/bees/state/logs)

--- a/packages/bees/web/src/sca/services/api.ts
+++ b/packages/bees/web/src/sca/services/api.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { PlaybookData } from "../../data/types.js";
+
 
 export { BeesAPI };
 
@@ -63,16 +63,7 @@ class BeesAPI {
     });
   }
 
-  async listPlaybooks(): Promise<PlaybookData[]> {
-    const resp = await fetch("/playbooks");
-    if (!resp.ok) return [];
-    return resp.json();
-  }
 
-  async runPlaybook(name: string): Promise<boolean> {
-    const resp = await fetch(`/playbooks/${name}/run`, { method: "POST" });
-    return resp.ok;
-  }
 
   async getFile(ticketId: string, path: string): Promise<string | null> {
     try {


### PR DESCRIPTION
## What
Removes the `/playbooks` REST endpoints, the `playbook_complete` signal emission machinery, and all associated dead frontend code.

## Why
The `/playbooks` endpoints were never called by the shell frontend. The `playbook_complete` coordination signal had zero subscribers — no playbook YAML ever declared `watch_events: [{type: playbook_complete}]`. Both were vestigial from an earlier design.

## Changes

### Backend (`packages/bees/bees/server.py`)
- Remove `GET /playbooks` and `POST /playbooks/{name}/run` endpoints
- Remove `_on_playbook_complete` SSE hook and its wiring
- Trim `bees.playbook` import to only `run_startup_hooks`

### Scheduler (`packages/bees/bees/scheduler.py`)
- Remove `on_playbook_complete` from `SchedulerHooks`
- Remove `_check_playbook_completion_internal` and `_format_playbook_complete`
- Remove both call sites in `wrap_run` / `wrap_resume`

### Frontend (`packages/bees/web/src/`)
- Remove `listPlaybooks()` and `runPlaybook()` from `sca/services/api.ts`
- Remove `PlaybookData` interface from `data/types.ts`
- Remove `"playbooks"` tab from `data/router.ts`

### Documentation (`packages/bees/playbooks/GUIDE.md`)
- Remove `/playbooks` API endpoints from the reference
- Remove `playbook_complete` auto-emission from Delivery Semantics
- Remove stale playbook-completion exception from Common Pitfalls

## Testing
- Verify the dev server starts cleanly (`npm run dev -w packages/bees`)
- Verify the shell loads and operates normally (ticket listing, chat, SSE events)
- Coordination ticket routing for other signal types (e.g., `digest_ready`) is untouched
