### PR TITLE
[bees] Rename `state/` → `hive/` with env-configurable directory name

### DIFF
--- a/packages/bees/.gitignore
+++ b/packages/bees/.gitignore
@@ -2,6 +2,7 @@
 .pytype/
 __pycache__/
 *.egg-info/
+hive/
 state/
 .env
 web/node_modules/

--- a/packages/bees/README.md
+++ b/packages/bees/README.md
@@ -17,7 +17,11 @@ Create a `.env` file in `packages/bees/`:
 
 ```
 GEMINI_KEY=your-gemini-api-key
+BEES_HIVE_DIR=hive
 ```
+
+`BEES_HIVE_DIR` controls the name of the directory where Bees stores
+runtime data (tickets, logs). It defaults to `hive`.
 
 ## Running a Single Session
 
@@ -39,7 +43,7 @@ npm run ticket:add -w packages/bees -- "Tell me a joke"
 npm run ticket:add -w packages/bees -- "Write a haiku about the sea"
 ```
 
-Each ticket becomes a directory under `state/tickets/{uuid}/` containing
+Each ticket becomes a directory under `hive/tickets/{uuid}/` containing
 `objective.md` and `metadata.json`.
 
 ### Draining the Queue
@@ -321,6 +325,6 @@ CLI and web UI.
 
 ## Output
 
-All session log files land in `packages/bees/state/logs/` in the eval
+All session log files land in `packages/bees/hive/logs/` in the eval
 viewer's `EvalFileData` format (`bees-session-{date}.log.json`), loadable
 directly by `packages/visual-editor/eval/viewer`.

--- a/packages/bees/bees/config.py
+++ b/packages/bees/bees/config.py
@@ -1,0 +1,27 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Shared configuration for the Bees package.
+
+Loads ``.env`` once at import time so that environment variables are
+available to any module that imports from here — including modules
+that compute directory paths at the module level.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+PACKAGE_DIR = Path(__file__).resolve().parent.parent
+
+# Load .env early so BEES_HIVE_DIR (and GEMINI_KEY, etc.) are available
+# before any module-level path constants are computed.
+load_dotenv(PACKAGE_DIR / ".env")
+
+# The root directory where Bees stores runtime data (tickets, logs).
+# Configurable via the BEES_HIVE_DIR environment variable; defaults to "hive".
+HIVE_DIR = PACKAGE_DIR / os.environ.get("BEES_HIVE_DIR", "hive")

--- a/packages/bees/bees/session.py
+++ b/packages/bees/bees/session.py
@@ -23,7 +23,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
-from dotenv import load_dotenv
 import httpx
 
 from opal_backend.local.backend_client_impl import HttpBackendClient
@@ -47,6 +46,7 @@ from bees.functions.chat import get_chat_function_group_factory
 from bees.functions.events import get_events_function_group_factory
 from bees.functions.tasks import get_tasks_function_group_factory
 from bees.context_updates import updates_to_context_parts
+from bees.config import HIVE_DIR, PACKAGE_DIR
 from bees.disk_file_system import DiskFileSystem
 from bees.subagent_scope import SubagentScope
 
@@ -54,8 +54,7 @@ from bees.subagent_scope import SubagentScope
 _BEES_DIR = Path(__file__).resolve().parent
 _SKILLS_LISTING, _SKILLS_FILES, _SKILLS_LIST = scan_skills(_BEES_DIR)
 
-PACKAGE_DIR = Path(__file__).resolve().parent.parent
-OUT_DIR = PACKAGE_DIR / "state" / "logs"
+OUT_DIR = HIVE_DIR / "logs"
 
 CHAT_LOG_FILENAME = "chat_log.json"
 
@@ -388,8 +387,10 @@ def extract_files(
 
 
 def load_gemini_key() -> str:
-    """Load GEMINI_KEY from .env, exit on failure."""
-    load_dotenv(PACKAGE_DIR / ".env")
+    """Load GEMINI_KEY from .env, exit on failure.
+
+    The ``.env`` file is loaded at import time by ``bees.config``.
+    """
     gemini_key = os.environ.get("GEMINI_KEY", "")
     if not gemini_key:
         print("Error: GEMINI_KEY not found in .env", file=sys.stderr)

--- a/packages/bees/bees/ticket.py
+++ b/packages/bees/bees/ticket.py
@@ -4,7 +4,7 @@
 """
 Ticket data model and persistence.
 
-A ticket is a directory under ``state/tickets/{uuid}/`` containing:
+A ticket is a directory under ``{hive}/tickets/{uuid}/`` containing:
 - ``objective.md`` — the prompt text
 - ``metadata.json`` — status, dates, metrics, error/outcome
 """
@@ -19,7 +19,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
 
-TICKETS_DIR = Path(__file__).resolve().parent.parent / "state" / "tickets"
+from bees.config import HIVE_DIR
+
+TICKETS_DIR = HIVE_DIR / "tickets"
 
 TicketStatus = Literal[
     "available", "blocked", "running", "suspended", "paused",

--- a/packages/bees/package.json
+++ b/packages/bees/package.json
@@ -11,7 +11,7 @@
     "ticket:respond": ".venv/bin/python -m bees.respond",
     "playbook:run": ".venv/bin/python -m bees.run_playbook",
     "dev": "npm run dev:server & npm run dev:web",
-    "dev:clean": "rm -rf state && npm run dev",
+    "dev:clean": "rm -rf hive && npm run dev",
     "dev:server": ".venv/bin/python -m bees.server",
     "dev:web": "cd web && npm run dev",
     "test:python": ".venv/bin/python -m pytest tests/ -v"

--- a/packages/bees/web/src/data/log-store.ts
+++ b/packages/bees/web/src/data/log-store.ts
@@ -7,7 +7,7 @@
 /**
  * Signal-backed reactive store for log files.
  *
- * Resolves the `state/logs/` subdirectory via a shared StateAccess,
+ * Resolves the `hive/logs/` subdirectory via a shared StateAccess,
  * uses FileSystemObserver for live updates, and manages session grouping.
  */
 
@@ -36,7 +36,7 @@ class LogStore {
 
   // ── Private ──
 
-  /** The ``state/logs/`` subdirectory. */
+  /** The ``hive/logs/`` subdirectory. */
   #logsHandle: FileSystemDirectoryHandle | null = null;
   #observer: { disconnect(): void } | null = null;
   #cache = new Map<string, { data: LogRunEntry; lastModified: number }>();
@@ -52,7 +52,7 @@ class LogStore {
 
     const logsHandle = await this.access.getSubdirectory("logs");
     if (!logsHandle) {
-      console.warn("Could not find logs/ subdirectory in state/");
+      console.warn("Could not find logs/ subdirectory in hive/");
       return;
     }
 

--- a/packages/bees/web/src/data/state-access.ts
+++ b/packages/bees/web/src/data/state-access.ts
@@ -5,7 +5,7 @@
  */
 
 /**
- * Shared access to the `state/` directory via File System Access API.
+ * Shared access to the `hive/` directory via File System Access API.
  *
  * Manages the directory handle, IndexedDB persistence for remembering
  * the user's choice across sessions, and the permission lifecycle.
@@ -19,16 +19,16 @@ export type { AccessState };
 
 type AccessState = "none" | "prompt" | "ready";
 
-const DB_NAME = "bees-state-handles";
+const DB_NAME = "bees-hive-handles";
 const STORE_NAME = "handles";
-const HANDLE_KEY = "state-dir";
+const HANDLE_KEY = "hive-dir";
 
 class StateAccess {
   readonly accessState = new Signal.State<AccessState>("none");
 
   #handle: FileSystemDirectoryHandle | null = null;
 
-  /** The root `state/` directory handle, available when access is "ready". */
+  /** The root `hive/` directory handle, available when access is "ready". */
   get handle(): FileSystemDirectoryHandle | null {
     return this.#handle;
   }
@@ -49,7 +49,7 @@ class StateAccess {
     this.accessState.set("ready");
   }
 
-  /** Prompt the user to pick the `state/` directory. */
+  /** Prompt the user to pick the `hive/` directory. */
   async openDirectory(): Promise<void> {
     try {
       const handle = await (
@@ -63,7 +63,7 @@ class StateAccess {
         mode: "read",
         // Browser remembers the last directory chosen for this ID,
         // so re-picks open to the right place automatically.
-        id: "bees-state-dir",
+        id: "bees-hive-dir",
       });
       await this.#saveHandle(handle);
       this.#handle = handle;
@@ -83,7 +83,7 @@ class StateAccess {
     this.accessState.set("ready");
   }
 
-  /** Resolve a subdirectory from the state handle. */
+  /** Resolve a subdirectory from the hive handle. */
   async getSubdirectory(
     name: string
   ): Promise<FileSystemDirectoryHandle | null> {

--- a/packages/bees/web/src/data/ticket-store.ts
+++ b/packages/bees/web/src/data/ticket-store.ts
@@ -7,7 +7,7 @@
 /**
  * Signal-backed reactive store for ticket directories.
  *
- * Reads ticket data from `state/tickets/{uuid}/` directories,
+ * Reads ticket data from `hive/tickets/{uuid}/` directories,
  * combining `metadata.json` and `objective.md` into TicketData objects.
  * Uses FileSystemObserver for live updates.
  */
@@ -49,7 +49,7 @@ class TicketStore {
 
     const ticketsHandle = await this.access.getSubdirectory("tickets");
     if (!ticketsHandle) {
-      console.warn("Could not find tickets/ subdirectory in state/");
+      console.warn("Could not find tickets/ subdirectory in hive/");
       return;
     }
 

--- a/packages/bees/web/src/data/types.ts
+++ b/packages/bees/web/src/data/types.ts
@@ -41,7 +41,7 @@ export interface TicketData {
 
 
 // ---------------------------------------------------------------------------
-// Log file types (from EvalCollector output in packages/bees/state/logs)
+// Log file types (from EvalCollector output in packages/bees/hive/logs)
 // ---------------------------------------------------------------------------
 
 /** Per-turn boundary recorded by the EvalCollector. */

--- a/packages/bees/web/src/ui/app.ts
+++ b/packages/bees/web/src/ui/app.ts
@@ -155,10 +155,10 @@ class BeesApp extends SignalWatcher(LitElement) {
           ${access === "none"
             ? html`
                 <button @click=${() => this.handleOpenDirectory()}>
-                  📂 Open State Directory
+                  📂 Open Hive Directory
                 </button>
                 <div style="font-size:0.75rem;color:#64748b">
-                  Select the <code>packages/bees/state</code> directory
+                  Select the <code>packages/bees/hive</code> directory
                 </div>
               `
             : html`


### PR DESCRIPTION
## What
The Bees runtime data directory is renamed from `state/` to `hive/` and made configurable via `BEES_HIVE_DIR` in `.env`.

## Why
Better naming for the concept ("the hive" where bees store their work), plus env configurability so developers can point to a custom directory without code changes.

## Changes

### Python backend
- **New `bees/config.py`** — single source of truth for `HIVE_DIR`, loads `.env` at import time so env vars are available before module-level constants are computed
- **`bees/ticket.py`** — `TICKETS_DIR` derived from `HIVE_DIR` instead of hardcoded `"state"`
- **`bees/session.py`** — `OUT_DIR` derived from `HIVE_DIR`; removed redundant `load_dotenv` from `load_gemini_key()` since `config.py` handles it

### Config & docs
- **`.env`** — added `BEES_HIVE_DIR=hive`
- **`.gitignore`** — added `hive/`, kept `state/` to protect colleagues still on the old name
- **`package.json`** — `dev:clean` now removes `hive/`
- **`README.md`** — updated directory references and documented `BEES_HIVE_DIR`

### Frontend (DevTools viewer)
- **`state-access.ts`** — updated JSDoc, IDB keys, and picker ID to reference `hive/`
- **`app.ts`** — UI text: "Open Hive Directory", `packages/bees/hive`
- **`log-store.ts`**, **`ticket-store.ts`**, **`types.ts`** — updated comments

## Testing
- 161 Python tests pass (`npm run test:python -w packages/bees`)
- Verified `npm run dev` starts cleanly after `mv state hive`
