### PR TITLE
[bees] Hive switching for Hivetool

### DIFF
--- a/packages/bees/hivetool/src/data/log-store.ts
+++ b/packages/bees/hivetool/src/data/log-store.ts
@@ -230,6 +230,19 @@ class LogStore {
     };
   }
 
+  /** Tear down all state so the store can be re-activated against a new hive. */
+  reset(): void {
+    this.#observer?.disconnect();
+    this.#observer = null;
+    this.#logsHandle = null;
+    this.#cache.clear();
+    this.#activated = false;
+    this.sessions.set([]);
+    this.selectedSessionId.set(null);
+    this.selectedView.set(null);
+    this.recentlyUpdatedSession.set(null);
+  }
+
   /** Clean up the observer. */
   destroy(): void {
     this.#observer?.disconnect();

--- a/packages/bees/hivetool/src/data/state-access.ts
+++ b/packages/bees/hivetool/src/data/state-access.ts
@@ -25,6 +25,7 @@ const HANDLE_KEY = "hive-dir";
 
 class StateAccess {
   readonly accessState = new Signal.State<AccessState>("none");
+  readonly hiveName = new Signal.State<string | null>(null);
 
   #handle: FileSystemDirectoryHandle | null = null;
 
@@ -46,6 +47,7 @@ class StateAccess {
       return;
     }
     this.#handle = handle;
+    this.hiveName.set(handle.name);
     this.accessState.set("ready");
   }
 
@@ -67,6 +69,7 @@ class StateAccess {
       });
       await this.#saveHandle(handle);
       this.#handle = handle;
+      this.hiveName.set(handle.name);
       this.accessState.set("ready");
     } catch {
       // User cancelled the picker.
@@ -80,6 +83,7 @@ class StateAccess {
     const granted = await this.#checkPermission(handle);
     if (!granted) return;
     this.#handle = handle;
+    this.hiveName.set(handle.name);
     this.accessState.set("ready");
   }
 

--- a/packages/bees/hivetool/src/data/ticket-store.ts
+++ b/packages/bees/hivetool/src/data/ticket-store.ts
@@ -101,6 +101,17 @@ class TicketStore {
     this.selectedTicketId.set(id);
   }
 
+  /** Tear down all state so the store can be re-activated against a new hive. */
+  reset(): void {
+    this.#observer?.disconnect();
+    this.#observer = null;
+    this.#ticketsHandle = null;
+    this.#activated = false;
+    this.tickets.set([]);
+    this.selectedTicketId.set(null);
+    this.recentlyUpdatedTicket.set(null);
+  }
+
   /** Clean up the observer. */
   destroy(): void {
     this.#observer?.disconnect();

--- a/packages/bees/hivetool/src/ui/app.styles.ts
+++ b/packages/bees/hivetool/src/ui/app.styles.ts
@@ -55,6 +55,36 @@ export const styles = css`
     gap: 8px;
   }
 
+  .hive-switcher {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .hive-name {
+    font-size: 0.75rem;
+    color: #94a3b8;
+    font-family: "Google Mono", "Roboto Mono", monospace;
+  }
+
+  .switch-hive-btn {
+    padding: 4px 10px;
+    font-size: 0.7rem;
+    background: transparent;
+    color: #94a3b8;
+    border: 1px solid #334155;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.15s;
+  }
+
+  .switch-hive-btn:hover {
+    color: #e2e8f0;
+    border-color: #3b82f6;
+    background: #1e293b;
+  }
+
   .top-bar-tabs {
     display: flex;
     padding: 0 20px;

--- a/packages/bees/hivetool/src/ui/app.ts
+++ b/packages/bees/hivetool/src/ui/app.ts
@@ -83,6 +83,19 @@ class BeesApp extends SignalWatcher(LitElement) {
     }
   }
 
+  private async handleSwitchHive(): Promise<void> {
+    this.logStore.reset();
+    this.ticketStore.reset();
+    this.ticketFileTree = [];
+    this.ticketFileContents = {};
+    this.selectedEventId = null;
+    await this.stateAccess.openDirectory();
+    if (this.stateAccess.accessState.get() === "ready") {
+      await this.activateStores();
+      this.restoreRoute();
+    }
+  }
+
   // --- Routing ---
 
   /** Write current tab + selection to the URL hash. */
@@ -146,7 +159,7 @@ class BeesApp extends SignalWatcher(LitElement) {
       return html`
         <div class="top-bar">
           <div class="top-bar-header">
-            <h1>${APP_ICON} ${APP_NAME} DevTools</h1>
+            <h1>${APP_ICON} ${APP_NAME} Hivetool</h1>
           </div>
         </div>
         <div
@@ -176,7 +189,18 @@ class BeesApp extends SignalWatcher(LitElement) {
     return html`
       <div class="top-bar">
         <div class="top-bar-header">
-          <h1>${APP_ICON} ${APP_NAME} DevTools</h1>
+          <h1>${APP_ICON} ${APP_NAME} Hivetool</h1>
+          <div class="hive-switcher">
+            <span class="hive-name" title="Current hive directory">
+              📂 ${this.stateAccess.hiveName.get() ?? ""}
+            </span>
+            <button
+              class="switch-hive-btn"
+              @click=${() => this.handleSwitchHive()}
+            >
+              Switch Hive
+            </button>
+          </div>
         </div>
         <div class="top-bar-tabs">
           <div
@@ -204,7 +228,7 @@ class BeesApp extends SignalWatcher(LitElement) {
               this.syncHash();
             }}
           >
-            Logs
+            Sessions
           </div>
         </div>
       </div>


### PR DESCRIPTION
## What
Adds the ability to switch to a different hive directory at runtime without reloading the page, and renames the tool to "Bees Hivetool".

## Why
The FileSystem API initialization and hive root selection was a one-time process — once a hive was opened, the only way to point at a different one was to reload the page and re-pick. This makes it easy to quickly compare hives or switch between environments.

## Changes

### `packages/bees/hivetool`

- **`state-access.ts`** — Added `hiveName` signal exposing the active directory handle's name
- **`log-store.ts`** — Added `reset()` to tear down observer, clear cache/signals, and re-enable `activate()`
- **`ticket-store.ts`** — Same `reset()` pattern for clean teardown and re-activation
- **`app.ts`** — Added `handleSwitchHive()` method, "Switch Hive" button + hive name in top bar; renamed title to "Bees Hivetool" and "Logs" tab to "Sessions"
- **`app.styles.ts`** — Styles for the hive switcher (ghost button + monospace directory name)

## Testing
Open hivetool, pick a hive directory, verify the directory name appears in the top bar. Click "Switch Hive", pick a different directory, verify all data refreshes to reflect the new hive.
