### PR TITLE
[bees] Hivetool hierarchical ticket view

### DIFF
--- a/packages/bees/hivetool/src/data/ticket-tree.ts
+++ b/packages/bees/hivetool/src/data/ticket-tree.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Derives a parent–child tree from a flat ticket list using
+ * `creator_ticket_id`. Hivetool-specific copy — no filtering beyond
+ * what the caller provides (devtools should show everything).
+ */
+
+import type { TicketData } from "../../../common/types.js";
+
+export { deriveTicketTree };
+export type { TicketTreeNode };
+
+/** A node in the ticket tree. */
+interface TicketTreeNode {
+  ticket: TicketData;
+  children: TicketTreeNode[];
+}
+
+/**
+ * Build a forest of ticket trees from a flat list.
+ *
+ * Root nodes are tickets with no `creator_ticket_id`.
+ * Children are sorted by `created_at` ascending (oldest first) so the
+ * tree reads in chronological order.
+ */
+function deriveTicketTree(tickets: TicketData[]): TicketTreeNode[] {
+  const childrenOf = new Map<string, TicketData[]>();
+  const roots: TicketData[] = [];
+
+  for (const t of tickets) {
+    if (t.creator_ticket_id) {
+      const siblings = childrenOf.get(t.creator_ticket_id) ?? [];
+      siblings.push(t);
+      childrenOf.set(t.creator_ticket_id, siblings);
+    } else {
+      roots.push(t);
+    }
+  }
+
+  function buildNode(ticket: TicketData): TicketTreeNode {
+    const children = (childrenOf.get(ticket.id) ?? [])
+      .sort((a, b) => (a.created_at ?? "").localeCompare(b.created_at ?? ""))
+      .map(buildNode);
+    return { ticket, children };
+  }
+
+  // Roots sorted newest-first to match the flat list convention.
+  return roots
+    .sort((a, b) => (b.created_at ?? "").localeCompare(a.created_at ?? ""))
+    .map(buildNode);
+}

--- a/packages/bees/hivetool/src/ui/app.styles.ts
+++ b/packages/bees/hivetool/src/ui/app.styles.ts
@@ -24,6 +24,26 @@ export const styles = css`
 
   * {
     box-sizing: border-box;
+    scrollbar-width: thin;
+    scrollbar-color: #334155 transparent;
+  }
+
+  *::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  *::-webkit-scrollbar-thumb {
+    background: #334155;
+    border-radius: 3px;
+  }
+
+  *::-webkit-scrollbar-thumb:hover {
+    background: #475569;
   }
 
   .mono {
@@ -145,6 +165,42 @@ export const styles = css`
     line-height: 1;
   }
 
+  /* ── Sidebar toolbar ── */
+  .sidebar-toolbar {
+    display: flex;
+    justify-content: flex-end;
+    padding: 8px 12px 0;
+    flex-shrink: 0;
+  }
+
+  .view-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    font-size: 0.8rem;
+    background: transparent;
+    color: #64748b;
+    border: 1px solid #334155;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: all 0.15s;
+  }
+
+  .view-toggle:hover {
+    color: #e2e8f0;
+    border-color: #3b82f6;
+    background: #1e293b;
+  }
+
+  .view-toggle.active {
+    color: #60a5fa;
+    border-color: #3b82f6;
+    background: #1e293b33;
+  }
+
   .jobs-list {
     flex: 1;
     overflow-y: auto;
@@ -152,6 +208,27 @@ export const styles = css`
     display: flex;
     flex-direction: column;
     gap: 4px;
+  }
+
+  /* ── Ticket tree (hierarchical view) ── */
+  .ticket-tree-branch {
+    border: none;
+    margin: 0;
+  }
+
+  .ticket-tree-branch > summary {
+    list-style: none;
+    cursor: default;
+  }
+
+  .ticket-tree-branch > summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .ticket-tree-children {
+    margin-left: 16px;
+    border-left: 1px solid #1e293b;
+    padding-left: 4px;
   }
 
   .job-item {

--- a/packages/bees/hivetool/src/ui/app.ts
+++ b/packages/bees/hivetool/src/ui/app.ts
@@ -13,7 +13,9 @@ import { LogStore } from "../data/log-store.js";
 import { parseRoute, writeRoute } from "../data/router.js";
 import { StateAccess } from "../data/state-access.js";
 import type { FileTreeNode } from "../data/ticket-store.js";
+import type { TicketData } from "../data/types.js";
 import { TicketStore } from "../data/ticket-store.js";
+import { deriveTicketTree, type TicketTreeNode } from "../data/ticket-tree.js";
 import { getRelativeTime } from "../utils.js";
 import { styles } from "./app.styles.js";
 import { renderJson } from "./json-tree.js";
@@ -24,10 +26,15 @@ import "./truncated-text.js";
 export { BeesApp };
 
 type TabId = "logs" | "tickets" | "events";
+type TicketViewMode = "flat" | "tree";
+
+const VIEW_MODE_KEY = "bees-hivetool-ticket-view-mode";
 
 @customElement("bees-app")
 class BeesApp extends SignalWatcher(LitElement) {
   @state() accessor activeTab: TabId = "tickets";
+  @state() accessor ticketViewMode: TicketViewMode =
+    (localStorage.getItem(VIEW_MODE_KEY) as TicketViewMode) || "flat";
   @state() accessor selectedEventId: string | null = null;
   @state() accessor ticketFileTree: FileTreeNode[] = [];
   @state() accessor ticketFileContents: Record<string, string | null> = {};
@@ -341,6 +348,11 @@ class BeesApp extends SignalWatcher(LitElement) {
     this.syncHash();
   }
 
+  private toggleTicketViewMode() {
+    this.ticketViewMode = this.ticketViewMode === "flat" ? "tree" : "flat";
+    localStorage.setItem(VIEW_MODE_KEY, this.ticketViewMode);
+  }
+
   private renderTicketsList() {
     const allTickets = this.ticketStore.tickets.get();
     const tickets = allTickets.filter((t) => t.kind !== "coordination");
@@ -350,45 +362,93 @@ class BeesApp extends SignalWatcher(LitElement) {
       return html`<div class="empty-state">No tickets found.</div>`;
     }
 
+    const isTree = this.ticketViewMode === "tree";
+
     return html`
-      <div class="jobs-list">
-        ${tickets.map(
-          (t) => html`
-            <div
-              class="job-item ${selectedId === t.id ? "selected" : ""} ${this.currentFlashTicketId === t.id ? "lightning-flash" : ""}"
-              @click=${() => {
-                this.ticketFileTree = [];
-                this.ticketFileContents = {};
-                this.ticketStore.selectTicket(t.id);
-                this.syncHash();
-              }}
-            >
-              <div class="job-header">
-                <div class="job-title">${t.title || t.id.slice(0, 8)}</div>
-                <div class="job-status ${t.status}"></div>
-              </div>
-              <div class="job-meta">
-                <span>${t.playbook_id ?? "ad-hoc"}</span>
-                <span>${getRelativeTime(t.created_at)}</span>
-              </div>
-              ${t.tags && t.tags.length > 0
-                ? html`
-                    <div class="job-meta">
-                      ${t.tags.map(
-                        (tag) =>
-                          html`<span
-                            class="tool-badge"
-                            style="font-size:0.65rem;padding:1px 5px"
-                            >${tag}</span
-                          >`
-                      )}
-                    </div>
-                  `
-                : nothing}
-            </div>
-          `
-        )}
+      <div class="sidebar-toolbar">
+        <button
+          class="view-toggle ${isTree ? "active" : ""}"
+          @click=${() => this.toggleTicketViewMode()}
+          title="${isTree ? "Switch to flat list" : "Switch to tree view"}"
+        >
+          ${isTree ? "🌳" : "☰"}
+        </button>
       </div>
+      <div class="jobs-list">
+        ${isTree
+          ? this.renderTicketsTree(tickets, selectedId)
+          : tickets.map((t) => this.renderTicketItem(t, selectedId))}
+      </div>
+    `;
+  }
+
+  private renderTicketItem(
+    t: TicketData,
+    selectedId: string | null
+  ) {
+    return html`
+      <div
+        class="job-item ${selectedId === t.id ? "selected" : ""} ${this.currentFlashTicketId === t.id ? "lightning-flash" : ""}"
+        @click=${() => {
+          this.ticketFileTree = [];
+          this.ticketFileContents = {};
+          this.ticketStore.selectTicket(t.id);
+          this.syncHash();
+        }}
+      >
+        <div class="job-header">
+          <div class="job-title">${t.title || t.id.slice(0, 8)}</div>
+          <div class="job-status ${t.status}"></div>
+        </div>
+        <div class="job-meta">
+          <span>${t.playbook_id ?? "ad-hoc"}</span>
+          <span>${getRelativeTime(t.created_at)}</span>
+        </div>
+        ${t.tags && t.tags.length > 0
+          ? html`
+              <div class="job-meta">
+                ${t.tags.map(
+                  (tag) =>
+                    html`<span
+                      class="tool-badge"
+                      style="font-size:0.65rem;padding:1px 5px"
+                      >${tag}</span
+                    >`
+                )}
+              </div>
+            `
+          : nothing}
+      </div>
+    `;
+  }
+
+  private renderTicketsTree(
+    tickets: TicketData[],
+    selectedId: string | null
+  ) {
+    const tree = deriveTicketTree(tickets);
+    return tree.map((node) => this.renderTreeNode(node, selectedId));
+  }
+
+  private renderTreeNode(
+    node: TicketTreeNode,
+    selectedId: string | null
+  ): unknown {
+    const t = node.ticket;
+    const hasChildren = node.children.length > 0;
+    const item = this.renderTicketItem(t, selectedId);
+
+    if (!hasChildren) return item;
+
+    return html`
+      <details class="ticket-tree-branch" open>
+        <summary>${item}</summary>
+        <div class="ticket-tree-children">
+          ${node.children.map((child) =>
+            this.renderTreeNode(child, selectedId)
+          )}
+        </div>
+      </details>
     `;
   }
 


### PR DESCRIPTION
## What
Adds a flat/tree toggle to the Hivetool ticket sidebar, letting users switch between a flat list and a hierarchical view based on `creator_ticket_id` parent-child relationships. Also styles scrollbars to match the dark theme.

## Why
Flat lists lose the parent→subagent structure, making it hard to trace agent delegation chains. The toggle persists to `localStorage` so users keep their preferred view across sessions.

## Changes

### `packages/bees/hivetool`
- **New `src/data/ticket-tree.ts`** — `deriveTicketTree()` builds a forest of `TicketTreeNode` from flat tickets using `creator_ticket_id`. Hivetool-local copy (no filtering — devtools shows all tickets).
- **`src/ui/app.ts`** — Adds `ticketViewMode` state (flat/tree) initialized from `localStorage`. Extracts shared `renderTicketItem()`, adds `renderTicketsTree()` + `renderTreeNode()` for recursive `<details>`/`<summary>` rendering. Toggle button (☰/🌳) in new sidebar toolbar.
- **`src/ui/app.styles.ts`** — Sidebar toolbar and toggle button styles. Tree indentation with left border guide. Dark-themed thin scrollbars (6px, transparent track) so desktop matches laptop overlay behavior.

## Testing
1. Open Hivetool, verify the toggle button appears top-right of the ticket sidebar
2. Click toggle — sidebar switches between flat list and indented tree
3. Refresh the page — view mode persists
4. Verify scrollbars are thin and dark-themed on both laptop and desktop displays
