### PR TITLE
[bees] Add `readFile` to OpalSDK

### DIFF
--- a/packages/bees/hive/skills/ui-generator/SKILL.md
+++ b/packages/bees/hive/skills/ui-generator/SKILL.md
@@ -293,7 +293,7 @@ Each state gets its own component file named after the state:
 **boundary** (the segment's final view), use `window.opalSDK.emit` to send data
 back to the orchestrator.
 
-The **SDK** is available as `window.opalSDK`. It has exactly three methods:
+The **SDK** is available as `window.opalSDK`. It has three methods:
 
 ```jsx
 // Navigate to another view WITHIN this segment.
@@ -303,14 +303,53 @@ window.opalSDK.navigateTo("select_models", { teamProfile });
 // Use on the final view's CTA — this is what connects segments.
 window.opalSDK.emit("journey:result", { decision, comparisonSet });
 
-// Get an asset URL by reference name.
-window.opalSDK.asset("logo"); // → "blob:..."
+// Read a file from the shared workspace (async, returns text or null).
+const data = await window.opalSDK.readFile("groceries.json");
 ```
 
 **Do not call any other methods on `window.opalSDK`.** There is no
 `onNavigation`, `subscribe`, or event listener API. Navigation state is managed
 internally by your App component (e.g. `useState` + switch statement), not by
 the SDK.
+
+### Data Loading with `readFile`
+
+Use `readFile` to load data files from the shared workspace at runtime instead
+of hardcoding data into your component. Paths are relative to the workspace
+root. You can read files written by any agent in the workspace — for example, a
+menu planner can read files produced by a diet researcher.
+
+```jsx
+import React, { useState, useEffect } from "react";
+
+export default function GroceryList() {
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    window.opalSDK.readFile("groceries.json").then((text) => {
+      if (text) {
+        setItems(JSON.parse(text));
+      }
+      setLoading(false);
+    });
+  }, []);
+
+  if (loading) return <div>Loading…</div>;
+  return (
+    <ul>
+      {items.map((item, i) => <li key={i}>{item}</li>)}
+    </ul>
+  );
+}
+```
+
+**Rules for `readFile`:**
+- Returns `Promise<string | null>`. `null` means the file was not found.
+- Paths are workspace-relative (e.g. `"analysis/results.json"`,
+  `"diet_research/notes.md"`).
+- Always handle the `null` case gracefully — the file may not exist yet.
+- Show a loading state while data is being fetched.
 
 ### View Contract
 
@@ -339,7 +378,7 @@ export default function SelectModels({ data = {}, onTransition }) {
 3. **Shared components go in `components/`.** Headers, cards, buttons used
    across multiple views should be extracted.
 4. **Context flows forward.** Each transition carries the data the next view
-   needs. Views never fetch — they receive.
+   needs. Views may also use `readFile` to load shared workspace data.
 5. **Final view emits.** The last view must include a CTA that calls
    `window.opalSDK.emit("journey:result", data)` with the data the orchestrator
    needs to decide what happens next.

--- a/packages/bees/web/src/iframe/entry.ts
+++ b/packages/bees/web/src/iframe/entry.ts
@@ -25,22 +25,28 @@ export type HostMessage =
       code: string;
       css?: string;
       props: Record<string, unknown>;
-      assets: Record<string, string>;
     }
   | { type: "update-props"; props: Record<string, unknown> }
-  | { type: "host.chat.switch"; payload: { ticket_id: string; role: string } };
+  | { type: "host.chat.switch"; payload: { ticket_id: string; role: string } }
+  | {
+      type: "readFile.response";
+      requestId: string;
+      data: string | null;
+      error?: string;
+    };
 
 /** Messages the iframe sends TO the host. */
 export type IframeMessage =
   | { type: "ready" }
   | { type: "navigate"; viewId: string; params?: Record<string, unknown> }
   | { type: "emit"; event: string; payload?: unknown }
-  | { type: "error"; message: string; stack?: string };
+  | { type: "error"; message: string; stack?: string }
+  | { type: "readFile"; requestId: string; path: string };
 
 export interface OpalSDK {
   navigateTo(viewId: string, params?: Record<string, unknown>): void;
   emit(event: string, payload?: unknown): void;
-  asset(name: string): string | undefined;
+  readFile(path: string): Promise<string | null>;
 }
 
 // ─── Globals ─────────────────────────────────────────────────────────────────
@@ -61,7 +67,11 @@ function requireShim(id: string): unknown {
 // ─── Opal SDK ─────────────────────────────────────────────────────────────────
 // The ONLY way components talk to the host. No raw postMessage access.
 
-let currentAssets: Record<string, string> = {};
+/** Pending readFile requests awaiting host responses. */
+const pendingReads = new Map<
+  string,
+  { resolve: (v: string | null) => void; reject: (e: Error) => void }
+>();
 
 const opalSDK: OpalSDK = {
   navigateTo(viewId: string, params?: Record<string, unknown>) {
@@ -72,8 +82,12 @@ const opalSDK: OpalSDK = {
     window.parent.postMessage({ type: "emit", event, payload }, "*");
   },
 
-  asset(name: string): string | undefined {
-    return currentAssets[name];
+  readFile(path: string): Promise<string | null> {
+    const requestId = crypto.randomUUID();
+    return new Promise((resolve, reject) => {
+      pendingReads.set(requestId, { resolve, reject });
+      window.parent.postMessage({ type: "readFile", requestId, path }, "*");
+    });
   },
 };
 
@@ -85,7 +99,7 @@ const safeOpalSDK = new Proxy(opalSDK, {
     }
     console.warn(
       `[opal-sdk] Unknown method "${String(prop)}" — ` +
-        `available: navigateTo, emit, asset`
+        `available: navigateTo, emit, readFile`
     );
     return () => {};
   },
@@ -165,13 +179,23 @@ function handleMessage(event: MessageEvent<HostMessage>) {
       currentProps = data.props;
       rerender();
       break;
+    case "readFile.response": {
+      const pending = pendingReads.get(data.requestId);
+      if (pending) {
+        pendingReads.delete(data.requestId);
+        if (data.error) {
+          pending.reject(new Error(data.error));
+        } else {
+          pending.resolve(data.data);
+        }
+      }
+      break;
+    }
   }
 }
 
 function handleRender(msg: HostMessage & { type: "render" }) {
-  const { code, css, props, assets } = msg;
-
-  currentAssets = assets;
+  const { code, css, props } = msg;
 
   try {
     // Inject CSS if provided.

--- a/packages/bees/web/src/sca/services/host-communication.ts
+++ b/packages/bees/web/src/sca/services/host-communication.ts
@@ -10,15 +10,28 @@ import {
   type HostMessage,
 } from "../../host/message-bridge.js";
 
+export type FileHandler = (path: string) => Promise<string | null>;
+
 export class HostCommunicationService {
   private bridge: MessageBridge | null = null;
   private eventBus: EventTarget;
+  private fileHandler: FileHandler | null = null;
 
   constructor(eventBus: EventTarget) {
     this.eventBus = eventBus;
   }
 
   private currentIframe: HTMLIFrameElement | null = null;
+
+  /**
+   * Install a handler for `readFile` requests from the iframe.
+   *
+   * Called by `loadBundleAsync` after rendering a bundle so that the
+   * handler closure captures the correct ticket context.
+   */
+  setFileHandler(handler: FileHandler | null) {
+    this.fileHandler = handler;
+  }
 
   connect(iframe: HTMLIFrameElement) {
     // Same iframe element — keep the existing bridge (its readyPromise
@@ -33,8 +46,14 @@ export class HostCommunicationService {
     this.bridge = new MessageBridge(iframe);
 
     this.bridge.onMessage((msg: IframeMessage) => {
-      // Map all iframe events directly into the global event bus.
-      // E.g 'render_complete' -> 'iframe.render_complete'
+      // Handle readFile requests inline — they need a response, not
+      // a fire-and-forget event dispatch.
+      if (msg.type === "readFile") {
+        this.#handleReadFile(msg.requestId, msg.path);
+        return;
+      }
+
+      // Map all other iframe events directly into the global event bus.
       this.eventBus.dispatchEvent(
         new CustomEvent(`iframe.${msg.type}`, { detail: msg })
       );
@@ -49,5 +68,35 @@ export class HostCommunicationService {
     this.bridge?.dispose();
     this.bridge = null;
     this.currentIframe = null;
+    this.fileHandler = null;
+  }
+
+  async #handleReadFile(requestId: string, path: string) {
+    if (!this.fileHandler) {
+      await this.bridge?.send({
+        type: "readFile.response",
+        requestId,
+        data: null,
+        error: "No file handler installed",
+      });
+      return;
+    }
+
+    try {
+      const data = await this.fileHandler(path);
+      await this.bridge?.send({
+        type: "readFile.response",
+        requestId,
+        data,
+      });
+    } catch (e) {
+      await this.bridge?.send({
+        type: "readFile.response",
+        requestId,
+        data: null,
+        error: (e as Error).message,
+      });
+    }
   }
 }
+

--- a/packages/bees/web/src/sca/utils/load-bundle.ts
+++ b/packages/bees/web/src/sca/utils/load-bundle.ts
@@ -15,6 +15,10 @@ export { loadBundleAsync };
  * When `slug` is provided (subagent), only files under the slug
  * subdirectory are considered. This prevents loading a sibling
  * agent's bundle from the shared workspace.
+ *
+ * After rendering, installs a file handler so the iframe can read
+ * arbitrary files from the ticket's shared filesystem via
+ * `window.opalSDK.readFile(path)`.
  */
 async function loadBundleAsync(
   ticketId: string,
@@ -50,6 +54,13 @@ async function loadBundleAsync(
     code,
     css: css || undefined,
     props: {},
-    assets: {},
   });
+
+  // Install file handler so the iframe can read files from the
+  // ticket's shared filesystem. Paths are NOT scoped by slug —
+  // the component can reach any file in the workspace.
+  services.hostCommunication.setFileHandler((path) =>
+    services.api.getFile(ticketId, path)
+  );
 }
+


### PR DESCRIPTION
## What
Adds `window.opalSDK.readFile(path)` so generated React apps running in the sandboxed iframe can load files from the ticket's shared hive filesystem at runtime. Also removes the unused `asset` method from the SDK.

## Why
Generated UIs had to bake all data into component source code. A shopping list organizer, for example, couldn't load the latest groceries — they had to be hardcoded. `readFile` lets components fetch workspace files on demand, including files produced by sibling agents (e.g., a menu planner reading a diet researcher's output).

## Changes

### iframe / host messaging (`web/src/iframe/entry.ts`)
- Added `readFile` to `OpalSDK` interface and implementation
- Request-response correlation via `crypto.randomUUID()` + pending-request map
- New message types: `readFile` (iframe→host), `readFile.response` (host→iframe)
- Removed dead `asset` method and `currentAssets` state

### Host communication (`web/src/sca/services/host-communication.ts`)
- Added `FileHandler` type and `setFileHandler()` method
- Intercepts `readFile` iframe messages, calls handler, sends response back

### Bundle loading (`web/src/sca/utils/load-bundle.ts`)
- Installs file handler after rendering: `(path) => api.getFile(ticketId, path)`
- Paths resolve against the full shared filesystem (no slug scoping)
- Removed `assets: {}` from render message

### Skill docs (`hive/skills/ui-generator/SKILL.md`)
- Documented `readFile` with usage example and rules
- Removed `asset` reference, updated method count to three

## Testing
- `npx tsc --noEmit` passes in `packages/bees/web`
- Manual: run a ui-generator agent that writes a data file, then generates a component calling `readFile()` to render it
