### PR TITLE
[bees] Hivetool Templates & Skills tabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2359,6 +2359,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "license": "MIT"
+    },
     "node_modules/@types/jsdom": {
       "version": "27.0.0",
       "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-27.0.0.tgz",
@@ -6411,7 +6417,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -10285,7 +10290,9 @@
       "name": "bees-hivetool",
       "dependencies": {
         "@lit-labs/signals": "^0.1.3",
+        "@types/js-yaml": "^4.0.9",
         "@types/markdown-it": "^14.1.2",
+        "js-yaml": "^4.1.1",
         "lit": "^3.3.2",
         "markdown-it": "^14.1.1",
         "signal-polyfill": "^0.2.2"

--- a/packages/bees/hivetool/package.json
+++ b/packages/bees/hivetool/package.json
@@ -10,9 +10,9 @@
   },
   "dependencies": {
     "@lit-labs/signals": "^0.1.3",
-    "@types/markdown-it": "^14.1.2",
+    "@types/js-yaml": "^4.0.9",
+    "js-yaml": "^4.1.1",
     "lit": "^3.3.2",
-    "markdown-it": "^14.1.1",
     "signal-polyfill": "^0.2.2"
   },
   "devDependencies": {

--- a/packages/bees/hivetool/src/data/router.ts
+++ b/packages/bees/hivetool/src/data/router.ts
@@ -21,7 +21,9 @@ type RoutableTab =
   | "daemons"
   | "logs"
   | "tickets"
-  | "events";
+  | "events"
+  | "templates"
+  | "skills";
 
 interface Route {
   tab: RoutableTab;
@@ -34,6 +36,8 @@ const VALID_TABS = new Set<string>([
   "logs",
   "tickets",
   "events",
+  "templates",
+  "skills",
 ]);
 
 function parseRoute(hash = location.hash): Route {

--- a/packages/bees/hivetool/src/data/skill-store.ts
+++ b/packages/bees/hivetool/src/data/skill-store.ts
@@ -1,0 +1,148 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Signal-backed reactive store for skills.
+ *
+ * Reads `hive/skills/{name}/SKILL.md` files via the shared `StateAccess`
+ * handle. Parses YAML frontmatter for metadata and exposes the full
+ * markdown body for detail rendering.
+ */
+
+import { Signal } from "signal-polyfill";
+import type { StateAccess } from "./state-access.js";
+
+export { SkillStore };
+export type { SkillData };
+
+/** Parsed skill metadata + body from a SKILL.md file. */
+interface SkillData {
+  /** Directory name (used as the key). */
+  dirName: string;
+  /** Frontmatter `name` field, falling back to dirName. */
+  name: string;
+  /** Frontmatter `title` field. */
+  title?: string;
+  /** Frontmatter `description` field. */
+  description?: string;
+  /** Full markdown body (everything after the frontmatter). */
+  body: string;
+}
+
+/** Matches YAML frontmatter delimited by --- lines. */
+const FRONTMATTER_RE = /\A---\s*\n(.*?)\n---\s*\n/s;
+
+/**
+ * Minimal frontmatter parser — extracts key: value pairs from a
+ * `---`-delimited YAML block at the start of a markdown file.
+ * Avoids pulling in js-yaml for this simple structure.
+ */
+function parseFrontmatter(text: string): {
+  meta: Record<string, string>;
+  body: string;
+} {
+  const match = text.match(FRONTMATTER_RE);
+  if (!match) return { meta: {}, body: text };
+
+  const yamlBlock = match[1];
+  const meta: Record<string, string> = {};
+  // Simple line-by-line key: value extraction. Handles multi-line
+  // values that are indented continuations.
+  let currentKey = "";
+  let currentValue = "";
+  for (const line of yamlBlock.split("\n")) {
+    const kvMatch = line.match(/^(\w[\w-]*):\s*(.*)/);
+    if (kvMatch) {
+      if (currentKey) meta[currentKey] = currentValue.trim();
+      currentKey = kvMatch[1];
+      currentValue = kvMatch[2];
+    } else if (currentKey && /^\s+/.test(line)) {
+      // Continuation line.
+      currentValue += " " + line.trim();
+    }
+  }
+  if (currentKey) meta[currentKey] = currentValue.trim();
+
+  const body = text.slice(match[0].length);
+  return { meta, body };
+}
+
+class SkillStore {
+  constructor(private access: StateAccess) {}
+
+  readonly skills = new Signal.State<SkillData[]>([]);
+  readonly selectedSkillDir = new Signal.State<string | null>(null);
+  readonly selectedSkill = new Signal.Computed(() => {
+    const dir = this.selectedSkillDir.get();
+    if (!dir) return null;
+    return this.skills.get().find((s) => s.dirName === dir) ?? null;
+  });
+
+  #activated = false;
+
+  /** Activate the store — resolve skills/ subdir and scan. */
+  async activate(): Promise<void> {
+    if (this.#activated) return;
+    if (this.access.accessState.get() !== "ready") return;
+    this.#activated = true;
+    await this.scan();
+  }
+
+  /** Scan the skills/ directory and parse each SKILL.md. */
+  async scan(): Promise<void> {
+    const handle = this.access.handle;
+    if (!handle) return;
+
+    try {
+      const skillsDir = await handle.getDirectoryHandle("skills");
+      const entries: SkillData[] = [];
+
+      for await (const [name, entry] of (
+        skillsDir as FileSystemDirectoryHandle & {
+          entries(): AsyncIterable<[string, FileSystemHandle]>;
+        }
+      ).entries()) {
+        if (entry.kind !== "directory") continue;
+
+        try {
+          const skillDir = await skillsDir.getDirectoryHandle(name);
+          const fileHandle = await skillDir.getFileHandle("SKILL.md");
+          const file = await fileHandle.getFile();
+          const text = await file.text();
+          const { meta, body } = parseFrontmatter(text);
+
+          entries.push({
+            dirName: name,
+            name: meta.name || name,
+            title: meta.title,
+            description: meta.description,
+            body,
+          });
+        } catch {
+          // Skip directories without SKILL.md.
+        }
+      }
+
+      // Sort alphabetically by name.
+      entries.sort((a, b) => a.name.localeCompare(b.name));
+      this.skills.set(entries);
+    } catch (e) {
+      console.warn("Could not read skills/ directory:", e);
+      this.skills.set([]);
+    }
+  }
+
+  selectSkill(dirName: string): void {
+    this.selectedSkillDir.set(dirName);
+  }
+
+  /** Tear down state so the store can be re-activated against a new hive. */
+  reset(): void {
+    this.#activated = false;
+    this.skills.set([]);
+    this.selectedSkillDir.set(null);
+  }
+}

--- a/packages/bees/hivetool/src/data/template-store.ts
+++ b/packages/bees/hivetool/src/data/template-store.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Signal-backed reactive store for ticket templates.
+ *
+ * Reads `hive/config/TEMPLATES.yaml` via the shared `StateAccess` handle
+ * and exposes the parsed template list as a reactive signal.
+ */
+
+import { Signal } from "signal-polyfill";
+import yaml from "js-yaml";
+
+import type { StateAccess } from "./state-access.js";
+
+export { TemplateStore };
+export type { TemplateData };
+
+/** A single template entry from TEMPLATES.yaml. */
+interface TemplateData {
+  name: string;
+  title?: string;
+  description?: string;
+  objective?: string;
+  functions?: string[];
+  skills?: string[];
+  tags?: string[];
+  model?: string;
+  watch_events?: Array<{ type: string }>;
+  tasks?: string[];
+  assignee?: string;
+}
+
+class TemplateStore {
+  constructor(private access: StateAccess) {}
+
+  readonly templates = new Signal.State<TemplateData[]>([]);
+  readonly selectedTemplateName = new Signal.State<string | null>(null);
+  readonly selectedTemplate = new Signal.Computed(() => {
+    const name = this.selectedTemplateName.get();
+    if (!name) return null;
+    return this.templates.get().find((t) => t.name === name) ?? null;
+  });
+
+  #activated = false;
+
+  /** Activate the store — resolve config dir, parse TEMPLATES.yaml. */
+  async activate(): Promise<void> {
+    if (this.#activated) return;
+    if (this.access.accessState.get() !== "ready") return;
+    this.#activated = true;
+    await this.scan();
+  }
+
+  /** Read and parse TEMPLATES.yaml from the hive handle. */
+  async scan(): Promise<void> {
+    const handle = this.access.handle;
+    if (!handle) return;
+
+    try {
+      const configDir = await handle.getDirectoryHandle("config");
+      const fileHandle = await configDir.getFileHandle("TEMPLATES.yaml");
+      const file = await fileHandle.getFile();
+      const text = await file.text();
+      const data = yaml.load(text);
+
+      if (!Array.isArray(data)) {
+        console.warn("TEMPLATES.yaml must be a list; got", typeof data);
+        this.templates.set([]);
+        return;
+      }
+
+      this.templates.set(data as TemplateData[]);
+    } catch (e) {
+      console.warn("Could not read TEMPLATES.yaml:", e);
+      this.templates.set([]);
+    }
+  }
+
+  selectTemplate(name: string): void {
+    this.selectedTemplateName.set(name);
+  }
+
+  /** Tear down state so the store can be re-activated against a new hive. */
+  reset(): void {
+    this.#activated = false;
+    this.templates.set([]);
+    this.selectedTemplateName.set(null);
+  }
+}

--- a/packages/bees/hivetool/src/ui/app.styles.ts
+++ b/packages/bees/hivetool/src/ui/app.styles.ts
@@ -1002,4 +1002,69 @@ export const styles = css`
   .lightning-flash {
     animation: lightning-flash 15s ease-out !important;
   }
+
+  /* ── Template badge ── */
+  .template-badge {
+    font-size: 0.65rem;
+    font-weight: 700;
+    padding: 3px 10px;
+    border-radius: 999px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    background: #134e4a33;
+    color: #5eead4;
+    border: 1px solid #134e4a;
+  }
+
+  /* ── Template sidebar hints ── */
+  .template-model-hint {
+    font-size: 0.65rem;
+    color: #c4b5fd;
+    font-family: "Google Mono", "Roboto Mono", monospace;
+  }
+
+  /* ── Template task delegation chips ── */
+  .template-tasks-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+  }
+
+  .template-task-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 10px;
+    border-radius: 6px;
+    font-size: 0.75rem;
+    font-family: "Google Mono", "Roboto Mono", monospace;
+    background: #111d1f;
+    color: #5eead4;
+    border: 1px solid #1a3338;
+    transition: background 0.15s, border-color 0.15s, color 0.15s;
+  }
+
+  .template-task-chip.linkable {
+    cursor: pointer;
+  }
+
+  .template-task-chip.linkable:hover {
+    background: #1a3338;
+    border-color: #2dd4bf;
+    color: #99f6e4;
+  }
+
+  /* ── Skill badge ── */
+  .skill-badge {
+    font-size: 0.65rem;
+    font-weight: 700;
+    padding: 3px 10px;
+    border-radius: 999px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    background: #1e3a8a22;
+    color: #93c5fd;
+    border: 1px solid #1e3a5c;
+  }
 `;
+

--- a/packages/bees/hivetool/src/ui/app.ts
+++ b/packages/bees/hivetool/src/ui/app.ts
@@ -12,9 +12,14 @@ import { APP_ICON, APP_NAME } from "../constants.js";
 import { LogStore } from "../data/log-store.js";
 import { parseRoute, writeRoute } from "../data/router.js";
 import { StateAccess } from "../data/state-access.js";
+import { SkillStore } from "../data/skill-store.js";
 import type { FileTreeNode } from "../data/ticket-store.js";
 import type { TicketData } from "../data/types.js";
 import { TicketStore } from "../data/ticket-store.js";
+import {
+  TemplateStore,
+  type TemplateData,
+} from "../data/template-store.js";
 import { deriveTicketTree, type TicketTreeNode } from "../data/ticket-tree.js";
 import { getRelativeTime } from "../utils.js";
 import { styles } from "./app.styles.js";
@@ -25,7 +30,7 @@ import "./truncated-text.js";
 
 export { BeesApp };
 
-type TabId = "logs" | "tickets" | "events";
+type TabId = "logs" | "tickets" | "events" | "templates" | "skills";
 type TicketViewMode = "flat" | "tree";
 
 const VIEW_MODE_KEY = "bees-hivetool-ticket-view-mode";
@@ -42,6 +47,8 @@ class BeesApp extends SignalWatcher(LitElement) {
   private stateAccess = new StateAccess();
   private logStore = new LogStore(this.stateAccess);
   private ticketStore = new TicketStore(this.stateAccess);
+  private templateStore = new TemplateStore(this.stateAccess);
+  private skillStore = new SkillStore(this.stateAccess);
   private currentFlashTicketId: string | null = null;
   private currentFlashLogId: string | null = null;
 
@@ -68,10 +75,16 @@ class BeesApp extends SignalWatcher(LitElement) {
     await this.stateAccess.init();
     if (this.stateAccess.accessState.get() !== "ready") return;
     await this.activateStores();
+    this.restoreRoute();
   }
 
   private async activateStores(): Promise<void> {
-    await Promise.all([this.logStore.activate(), this.ticketStore.activate()]);
+    await Promise.all([
+      this.logStore.activate(),
+      this.ticketStore.activate(),
+      this.templateStore.activate(),
+      this.skillStore.activate(),
+    ]);
   }
 
   private async handleOpenDirectory(): Promise<void> {
@@ -93,6 +106,8 @@ class BeesApp extends SignalWatcher(LitElement) {
   private async handleSwitchHive(): Promise<void> {
     this.logStore.reset();
     this.ticketStore.reset();
+    this.templateStore.reset();
+    this.skillStore.reset();
     this.ticketFileTree = [];
     this.ticketFileContents = {};
     this.selectedEventId = null;
@@ -118,6 +133,12 @@ class BeesApp extends SignalWatcher(LitElement) {
       case "events":
         id = this.selectedEventId;
         break;
+      case "templates":
+        id = this.templateStore.selectedTemplateName.get();
+        break;
+      case "skills":
+        id = this.skillStore.selectedSkillDir.get();
+        break;
     }
     writeRoute(this.activeTab, id);
   }
@@ -125,7 +146,7 @@ class BeesApp extends SignalWatcher(LitElement) {
   /** Restore tab and selection from the URL hash on load. */
   private async restoreRoute(): Promise<void> {
     const route = parseRoute();
-    const validTabs: TabId[] = ["logs", "tickets", "events"];
+    const validTabs: TabId[] = ["logs", "tickets", "events", "templates", "skills"];
     const tab = validTabs.includes(route.tab as TabId)
       ? (route.tab as TabId)
       : "tickets";
@@ -146,6 +167,12 @@ class BeesApp extends SignalWatcher(LitElement) {
         break;
       case "events":
         if (route.id) this.selectedEventId = route.id;
+        break;
+      case "templates":
+        if (route.id) this.templateStore.selectTemplate(route.id);
+        break;
+      case "skills":
+        if (route.id) this.skillStore.selectSkill(route.id);
         break;
     }
   }
@@ -237,6 +264,24 @@ class BeesApp extends SignalWatcher(LitElement) {
           >
             Sessions
           </div>
+          <div
+            class="sidebar-tab ${this.activeTab === "templates" ? "active" : ""}"
+            @click=${() => {
+              this.activeTab = "templates";
+              this.syncHash();
+            }}
+          >
+            Templates
+          </div>
+          <div
+            class="sidebar-tab ${this.activeTab === "skills" ? "active" : ""}"
+            @click=${() => {
+              this.activeTab = "skills";
+              this.syncHash();
+            }}
+          >
+            Skills
+          </div>
         </div>
       </div>
 
@@ -246,7 +291,11 @@ class BeesApp extends SignalWatcher(LitElement) {
             ? this.renderTicketsList()
             : this.activeTab === "events"
               ? this.renderEventsList()
-              : this.renderLogsList()}
+              : this.activeTab === "templates"
+                ? this.renderTemplatesList()
+                : this.activeTab === "skills"
+                  ? this.renderSkillsList()
+                  : this.renderLogsList()}
         </div>
 
         <div class="main">
@@ -254,7 +303,11 @@ class BeesApp extends SignalWatcher(LitElement) {
             ? this.renderTicketDetail()
             : this.activeTab === "events"
               ? this.renderEventDetail()
-              : this.renderLogDetail()}
+              : this.activeTab === "templates"
+                ? this.renderTemplateDetail()
+                : this.activeTab === "skills"
+                  ? this.renderSkillDetail()
+                  : this.renderLogDetail()}
         </div>
       </div>
     `;
@@ -793,6 +846,315 @@ class BeesApp extends SignalWatcher(LitElement) {
                 </div>
               `
             : nothing}
+        </div>
+      </div>
+    `;
+  }
+
+  // --- Templates ---
+
+  private renderTemplatesList() {
+    const templates = this.templateStore.templates.get();
+    const selectedName = this.templateStore.selectedTemplateName.get();
+
+    if (templates.length === 0) {
+      return html`<div class="empty-state">No templates found.</div>`;
+    }
+
+    return html`
+      <div class="jobs-list">
+        ${templates.map(
+          (t) => html`
+            <div
+              class="job-item ${selectedName === t.name ? "selected" : ""}"
+              @click=${() => {
+                this.templateStore.selectTemplate(t.name);
+                this.syncHash();
+              }}
+            >
+              <div class="job-header">
+                <div class="job-title">${t.title || t.name}</div>
+              </div>
+              <div class="job-meta">
+                <span class="mono">${t.name}</span>
+                ${t.model
+                  ? html`<span class="template-model-hint">${t.model}</span>`
+                  : nothing}
+              </div>
+              ${t.description
+                ? html`<div class="job-meta" style="margin-top:2px">
+                    <span
+                      style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:260px"
+                      >${t.description}</span
+                    >
+                  </div>`
+                : nothing}
+            </div>
+          `
+        )}
+      </div>
+    `;
+  }
+
+  private renderTemplateDetail() {
+    const template = this.templateStore.selectedTemplate.get();
+    if (!template)
+      return this.renderEmptyMain("Select a template to view details");
+
+    // Build identity chips.
+    const chips: Array<{
+      label: string;
+      value: string;
+      cls?: string;
+      onclick?: () => void;
+    }> = [];
+    chips.push({ label: "name", value: template.name, cls: "playbook" });
+    if (template.model)
+      chips.push({ label: "model", value: template.model, cls: "model" });
+    if (template.assignee)
+      chips.push({ label: "assignee", value: template.assignee });
+
+    // Resolve delegation targets — check which names exist as templates.
+    const allTemplates = this.templateStore.templates.get();
+    const templateNames = new Set(allTemplates.map((t) => t.name));
+
+    return html`
+      <div class="job-detail">
+        <div class="job-detail-header">
+          <div class="job-detail-header-top">
+            <h2 class="job-detail-title">${template.title || template.name}</h2>
+            <div class="template-badge">TEMPLATE</div>
+          </div>
+          ${template.description
+            ? html`<div class="job-detail-meta">
+                <span>${template.description}</span>
+              </div>`
+            : nothing}
+        </div>
+
+        <div class="timeline">
+          ${chips.length > 0
+            ? html`
+                <div class="identity-row">
+                  ${chips.map(
+                    (c) => html`
+                      <span
+                        class="identity-chip ${c.cls ?? ""} ${c.onclick
+                          ? "linkable"
+                          : ""}"
+                        @click=${c.onclick ?? nothing}
+                      >
+                        <span class="identity-label">${c.label}</span>
+                        ${c.value}
+                      </span>
+                    `
+                  )}
+                </div>
+              `
+            : nothing}
+          ${template.objective
+            ? html`
+                <div class="block">
+                  <div class="block-header">Objective</div>
+                  <div class="block-content">
+                    <bees-truncated-text
+                      threshold="500"
+                      max-height="300"
+                      fadeBg="#0f1115"
+                      >${template.objective}</bees-truncated-text
+                    >
+                  </div>
+                </div>
+              `
+            : nothing}
+          ${template.tasks && template.tasks.length > 0
+            ? html`
+                <div class="block">
+                  <div class="block-header">Subtask Templates</div>
+                  <div class="block-content">
+                    <div class="template-tasks-list">
+                      ${template.tasks.map((taskName) => {
+                        const exists = templateNames.has(taskName);
+                        return html`<span
+                          class="template-task-chip ${exists ? "linkable" : ""}"
+                          @click=${exists
+                            ? () => {
+                                this.templateStore.selectTemplate(taskName);
+                                this.syncHash();
+                              }
+                            : nothing}
+                          >${taskName}</span
+                        >`;
+                      })}
+                    </div>
+                  </div>
+                </div>
+              `
+            : nothing}
+          ${template.tags && template.tags.length > 0
+            ? html`
+                <div class="block">
+                  <div class="block-header">Tags</div>
+                  <div class="block-content">
+                    ${template.tags.map(
+                      (tag) =>
+                        html`<span class="tool-badge" style="margin-right:6px"
+                          >${tag}</span
+                        >`
+                    )}
+                  </div>
+                </div>
+              `
+            : nothing}
+          ${template.skills && template.skills.length > 0
+            ? html`
+                <div class="block">
+                  <div class="block-header">Skills</div>
+                  <div class="block-content">
+                    ${template.skills.map(
+                      (s) => html`
+                        <span class="identity-chip skill" style="margin-right:6px"
+                          >${s}</span
+                        >
+                      `
+                    )}
+                  </div>
+                </div>
+              `
+            : nothing}
+          ${template.functions && template.functions.length > 0
+            ? html`
+                <div class="block">
+                  <div class="block-header">Functions</div>
+                  <div class="block-content">
+                    ${template.functions.map(
+                      (fn) =>
+                        html`<span class="tool-badge" style="margin-right:6px"
+                          >${fn}</span
+                        >`
+                    )}
+                  </div>
+                </div>
+              `
+            : nothing}
+          ${template.watch_events && template.watch_events.length > 0
+            ? html`
+                <div class="block">
+                  <div class="block-header">Listening For</div>
+                  <div class="block-content">
+                    ${template.watch_events.map(
+                      (ev) =>
+                        html`<span class="signal-chip" style="margin-right:6px"
+                          >${ev.type}</span
+                        >`
+                    )}
+                  </div>
+                </div>
+              `
+            : nothing}
+        </div>
+      </div>
+    `;
+  }
+
+  // --- Skills ---
+
+  private renderSkillsList() {
+    const skills = this.skillStore.skills.get();
+    const selectedDir = this.skillStore.selectedSkillDir.get();
+
+    if (skills.length === 0) {
+      return html`<div class="empty-state">No skills found.</div>`;
+    }
+
+    return html`
+      <div class="jobs-list">
+        ${skills.map(
+          (s) => html`
+            <div
+              class="job-item ${selectedDir === s.dirName ? "selected" : ""}"
+              @click=${() => {
+                this.skillStore.selectSkill(s.dirName);
+                this.syncHash();
+              }}
+            >
+              <div class="job-header">
+                <div class="job-title">${s.title || s.name}</div>
+              </div>
+              <div class="job-meta">
+                <span class="mono">${s.dirName}</span>
+              </div>
+              ${s.description
+                ? html`<div class="job-meta" style="margin-top:2px">
+                    <span
+                      style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:260px"
+                      >${s.description}</span
+                    >
+                  </div>`
+                : nothing}
+            </div>
+          `
+        )}
+      </div>
+    `;
+  }
+
+  private renderSkillDetail() {
+    const skill = this.skillStore.selectedSkill.get();
+    if (!skill)
+      return this.renderEmptyMain("Select a skill to view details");
+
+    // Build identity chips.
+    const chips: Array<{
+      label: string;
+      value: string;
+      cls?: string;
+    }> = [];
+    chips.push({ label: "name", value: skill.name, cls: "skill" });
+    if (skill.dirName !== skill.name)
+      chips.push({ label: "dir", value: skill.dirName });
+
+
+    return html`
+      <div class="job-detail">
+        <div class="job-detail-header">
+          <div class="job-detail-header-top">
+            <h2 class="job-detail-title">${skill.title || skill.name}</h2>
+            <div class="skill-badge">SKILL</div>
+          </div>
+          ${skill.description
+            ? html`<div class="job-detail-meta">
+                <span>${skill.description}</span>
+              </div>`
+            : nothing}
+        </div>
+
+        <div class="timeline">
+          ${chips.length > 0
+            ? html`
+                <div class="identity-row">
+                  ${chips.map(
+                    (c) => html`
+                      <span class="identity-chip ${c.cls ?? ""}">
+                        <span class="identity-label">${c.label}</span>
+                        ${c.value}
+                      </span>
+                    `
+                  )}
+                </div>
+              `
+            : nothing}
+          <div class="block">
+            <div class="block-header">Content</div>
+            <div class="block-content">
+              <bees-truncated-text
+                threshold="800"
+                max-height="500"
+                fadeBg="#0f1115"
+                >${skill.body}</bees-truncated-text
+              >
+            </div>
+          </div>
         </div>
       </div>
     `;

--- a/packages/bees/hivetool/src/ui/truncated-text.ts
+++ b/packages/bees/hivetool/src/ui/truncated-text.ts
@@ -43,6 +43,10 @@ class BeesTruncatedText extends LitElement {
       overflow: hidden;
     }
 
+    .text {
+      white-space: pre-wrap;
+    }
+
     .body.clamped::after {
       content: "";
       position: absolute;
@@ -99,7 +103,7 @@ class BeesTruncatedText extends LitElement {
         class="body ${isLong && !this.expanded ? "clamped" : ""}"
         style="${bodyStyle}"
       >
-        <slot></slot>
+        <div class="text"><slot></slot></div>
         ${isLong && !this.expanded
           ? html`<button class="toggle" @click=${this.handleExpand}>»</button>`
           : nothing}


### PR DESCRIPTION
## What
Adds two new read-only tabs to Hivetool — **Templates** (reads `hive/config/TEMPLATES.yaml`) and **Skills** (reads `hive/skills/*/SKILL.md`) — so the hive's configuration is browsable alongside tickets, events, and sessions.

## Why
Templates and skills are the core building blocks of a hive, but until now they were only visible as raw YAML/markdown files on disk. Surfacing them in Hivetool makes the agent configuration inspectable and lays the groundwork for future in-browser editing.

## Changes

### New files
- **`template-store.ts`** — Reactive store that reads and parses `TEMPLATES.yaml` via the File System Access API handle using `js-yaml`.
- **`skill-store.ts`** — Reactive store that scans `skills/` directories, parses YAML frontmatter from each `SKILL.md`, and exposes the markdown body.

### Modified files
- **`router.ts`** — Added `"templates"` and `"skills"` to routable tabs for deep-linking (`#/templates/opie`, `#/skills/persona`).
- **`app.ts`** — Wired both stores into the app lifecycle (activate, reset, routing). Added sidebar lists and structured detail views for templates (identity chips, objective, subtask template navigation, tags, skills, functions, watch events) and skills (identity chips, plain-text body with truncation).
- **`app.styles.ts`** — Template badge, model hint, task delegation chips, and skill badge styles.
- **`truncated-text.ts`** — Wrapped `<slot>` in a `.text` div with `white-space: pre-wrap` so slotted content preserves whitespace without affecting sibling elements (toggle button).
- **`package.json`** — Added `js-yaml` dependency.

### Bug fix
- **Selection persistence on reload** — `initStores()` now calls `restoreRoute()` after stores are activated, fixing a race where the tab was restored but the selected item wasn't (affected all tabs, not just the new ones).

## Testing
1. Run `npm run dev:hivetool -w packages/bees` and open Hivetool
2. Open a hive directory, switch to the **Templates** tab — verify all 7 templates appear, selecting one shows structured detail, task chips navigate between templates
3. Switch to the **Skills** tab — verify all 5 skills appear with frontmatter metadata and plain-text body
4. Deep-link test: navigate to `#/templates/opie`, reload — should restore both tab and selection
5. Verify existing Tickets/Events/Sessions tabs still work correctly
