### PR TITLE
[bees] Declarative `autostart` for templates

### DIFF
--- a/packages/bees/bees/functions/tasks.py
+++ b/packages/bees/bees/functions/tasks.py
@@ -81,53 +81,27 @@ def _make_handlers(
         if status_cb:
             status_cb(f"Creating task of type: {task_type}")
             
-        from bees.playbook import load_playbook
+        from bees.playbook import load_playbook, stamp_child_ticket
         try:
             load_playbook(task_type)
         except FileNotFoundError:
             return {"error": f"Task type not found: {task_type}"}
 
 
-        # Compose child scope from parent scope + new slug.
-        if scope:
-            child_scope = scope.child(slug)
-        else:
-            # Fallback: no parent scope (shouldn't happen in practice).
-            child_scope = SubagentScope(
-                workspace_root_id=caller_ticket_id or "",
-                slug_path=slug,
-            )
-
-        from bees.playbook import run_playbook
         try:
-            ticket = run_playbook(
+            from bees.ticket import load_ticket as _load
+            parent = _load(caller_ticket_id) if caller_ticket_id else None
+            if not parent:
+                return {"error": "Parent ticket not found"}
+
+            ticket = stamp_child_ticket(
                 task_type,
+                parent_ticket=parent,
+                slug=slug,
                 context=objective,
-                parent_ticket_id=child_scope.workspace_root_id,
-                slug=child_scope.slug_path,
+                title=title or summary,
+                scope=scope,
             )
-            
-            if child_scope.slug_path:
-                sandbox_block = child_scope.sandbox_instructions()
-                ticket.objective = (
-                    f"{ticket.objective}\n\n"
-                    f"<subagent_context>\n"
-                    f"Your parent id is: {caller_ticket_id}\n"
-                    f"</subagent_context>\n"
-                    f"{sandbox_block}"
-                )
-                ticket.save()
-                child_scope.writable_dir(ticket.fs_dir).mkdir(
-                    parents=True, exist_ok=True,
-                )
-                
-            if title:
-                ticket.metadata.title = title
-            elif summary:
-                ticket.metadata.title = summary
-                
-            ticket.metadata.creator_ticket_id = caller_ticket_id
-            ticket.save_metadata()
             
         except Exception as e:
             logger.exception("tasks_create_task failed")

--- a/packages/bees/bees/playbook.py
+++ b/packages/bees/bees/playbook.py
@@ -7,7 +7,8 @@ Template loader and runner.
 A template is an entry in ``hive/config/TEMPLATES.yaml`` that defines a
 single agent ticket: an objective, tools, skills, and metadata.
 
-Running a template creates one ticket and returns it.
+Running a template creates one ticket and returns it.  If the template
+declares ``autostart``, child tickets are stamped automatically.
 """
 
 from __future__ import annotations
@@ -22,6 +23,7 @@ from typing import Any
 import yaml
 
 from bees.config import HIVE_DIR
+from bees.subagent_scope import SubagentScope
 from bees.ticket import Ticket, create_ticket
 
 logger = logging.getLogger(__name__)
@@ -146,7 +148,72 @@ def run_playbook(
         slug=slug,
     )
 
+    # Autostart: stamp child tickets declared in the template.
+    for child_name in data.get("autostart", []):
+        try:
+            stamp_child_ticket(
+                child_name,
+                parent_ticket=ticket,
+                slug=child_name,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Autostart of '%s' for '%s' failed: %s",
+                child_name, name, exc,
+            )
+
     return ticket
+
+
+def stamp_child_ticket(
+    template_name: str,
+    *,
+    parent_ticket: Ticket,
+    slug: str,
+    context: str | None = None,
+    title: str | None = None,
+    scope: SubagentScope | None = None,
+) -> Ticket:
+    """Create a child ticket from a template under a parent.
+
+    Handles SubagentScope composition, sandbox instructions, writable
+    directory creation, and ``creator_ticket_id`` assignment — the
+    shared logic for both ``autostart`` and ``tasks_create_task``.
+
+    If *scope* is not provided, one is derived from the parent ticket.
+    """
+    if scope is None:
+        scope = SubagentScope.for_ticket(parent_ticket)
+    child_scope = scope.child(slug)
+
+    child = run_playbook(
+        template_name,
+        context=context,
+        parent_ticket_id=child_scope.workspace_root_id,
+        slug=child_scope.slug_path,
+    )
+
+    if child_scope.slug_path:
+        sandbox_block = child_scope.sandbox_instructions()
+        child.objective = (
+            f"{child.objective}\n\n"
+            f"<subagent_context>\n"
+            f"Your parent id is: {parent_ticket.id}\n"
+            f"</subagent_context>\n"
+            f"{sandbox_block}"
+        )
+        child.save()
+        child_scope.writable_dir(child.fs_dir).mkdir(
+            parents=True, exist_ok=True,
+        )
+
+    if title:
+        child.metadata.title = title
+
+    child.metadata.creator_ticket_id = parent_ticket.id
+    child.save_metadata()
+
+    return child
 
 
 def load_system_config() -> dict[str, Any]:

--- a/packages/bees/hive/config/TEMPLATES.yaml
+++ b/packages/bees/hive/config/TEMPLATES.yaml
@@ -18,6 +18,9 @@
 #   watch_events  — Subscribe to inter-agent events.
 #   tasks         — Allowlist of template names this agent can delegate to.
 #   assignee      — Initial assignee ("user" or "agent"). Rarely needed.
+#   autostart     — List of template names to stamp as child tickets
+#                   automatically when this template is run. Each entry
+#                   creates a subagent ticket with the template name as slug.
 
 - name: opie
   title: Opie
@@ -26,13 +29,13 @@
     You are Opie, an executive assistant. Use the "persona" skill to learn how
     to behave.
 
-    Start the knowledge task first with the "knowledge" slug. Then, await user
-    requests and act on them. Use tasks for delegating work. Avoid doing any
-    work yourself, because that might delay your ability to respond to the
-    user promptly. Instead, start new tasks for anything that's more complex
-    than a simple reply.
+    Await user requests and act on them. Use tasks for delegating work. Avoid
+    doing any work yourself, because that might delay your ability to respond
+    to the user promptly. Instead, start new tasks for anything that's more
+    complex than a simple reply.
 
   skills: ["persona"]
+  autostart: ["knowledge"]
   # "opie" — hooks on_startup checks for this tag to avoid double-booting.
   # "chat" — enables persistent chat history across page reloads.
   tags: ["opie", "chat"]

--- a/packages/bees/tests/test_playbook.py
+++ b/packages/bees/tests/test_playbook.py
@@ -17,6 +17,7 @@ from bees.playbook import (
     load_system_config,
     run_playbook,
     run_event_hooks,
+    stamp_child_ticket,
 )
 from bees.ticket import TICKETS_DIR, _DEP_PATTERN
 
@@ -362,3 +363,145 @@ class TestLoadSystemConfig:
     def test_returns_empty_when_missing(self):
         config = load_system_config()
         assert config == {}
+
+
+# --- stamp_child_ticket ---
+
+
+class TestStampChildTicket:
+
+    def test_creates_child_with_correct_hierarchy(self, write_template):
+        write_template(
+            {"name": "parent", "objective": "Manage."},
+            {"name": "worker", "objective": "Do work."},
+        )
+
+        parent = run_playbook("parent")
+        child = stamp_child_ticket(
+            "worker", parent_ticket=parent, slug="my-worker",
+        )
+
+        assert child.metadata.creator_ticket_id == parent.id
+        assert child.metadata.parent_ticket_id == parent.id
+        assert child.metadata.slug == "my-worker"
+        assert child.metadata.playbook_id == "worker"
+
+    def test_sandbox_instructions_appended(self, write_template):
+        write_template(
+            {"name": "parent", "objective": "Manage."},
+            {"name": "worker", "objective": "Do work."},
+        )
+
+        parent = run_playbook("parent")
+        child = stamp_child_ticket(
+            "worker", parent_ticket=parent, slug="my-worker",
+        )
+
+        assert "<sandbox_environment>" in child.objective
+        assert "my-worker" in child.objective
+        assert "<subagent_context>" in child.objective
+
+    def test_writable_dir_created(self, write_template):
+        write_template(
+            {"name": "parent", "objective": "Manage."},
+            {"name": "worker", "objective": "Do work."},
+        )
+
+        parent = run_playbook("parent")
+        child = stamp_child_ticket(
+            "worker", parent_ticket=parent, slug="my-worker",
+        )
+
+        writable = child.fs_dir / "my-worker"
+        assert writable.is_dir()
+
+    def test_context_propagates(self, write_template):
+        write_template(
+            {"name": "parent", "objective": "Manage."},
+            {"name": "worker", "objective": "Do {{system.context}}"},
+        )
+
+        parent = run_playbook("parent")
+        child = stamp_child_ticket(
+            "worker", parent_ticket=parent, slug="w",
+            context="the important thing",
+        )
+
+        assert child.metadata.context == "the important thing"
+
+    def test_title_override(self, write_template):
+        write_template(
+            {"name": "parent", "objective": "Manage."},
+            {"name": "worker", "title": "Default Title", "objective": "Do work."},
+        )
+
+        parent = run_playbook("parent")
+        child = stamp_child_ticket(
+            "worker", parent_ticket=parent, slug="w",
+            title="Custom Title",
+        )
+
+        assert child.metadata.title == "Custom Title"
+
+
+# --- autostart ---
+
+
+class TestAutostart:
+
+    def test_autostart_creates_child_tickets(self, write_template):
+        write_template(
+            {"name": "boss", "objective": "Manage.", "autostart": ["helper"]},
+            {"name": "helper", "objective": "Help."},
+        )
+
+        parent = run_playbook("boss")
+
+        from bees.ticket import list_tickets
+        all_tickets = list_tickets()
+        children = [t for t in all_tickets if t.metadata.creator_ticket_id == parent.id]
+
+        assert len(children) == 1
+        child = children[0]
+        assert child.metadata.playbook_id == "helper"
+        assert child.metadata.slug == "helper"
+        assert child.metadata.parent_ticket_id == parent.id
+
+    def test_autostart_empty_creates_no_children(self, write_template):
+        write_template(
+            {"name": "solo", "objective": "Work alone."},
+        )
+
+        parent = run_playbook("solo")
+
+        from bees.ticket import list_tickets
+        all_tickets = list_tickets()
+        children = [t for t in all_tickets if t.metadata.creator_ticket_id == parent.id]
+
+        assert len(children) == 0
+
+    def test_autostart_failed_child_does_not_block_parent(self, write_template):
+        write_template(
+            {"name": "boss", "objective": "Manage.", "autostart": ["nonexistent"]},
+        )
+
+        # Should not raise — the failed autostart is logged and skipped.
+        parent = run_playbook("boss")
+        assert parent.metadata.status == "available"
+
+    def test_autostart_multiple_children(self, write_template):
+        write_template(
+            {"name": "boss", "objective": "Manage.", "autostart": ["a", "b"]},
+            {"name": "a", "objective": "Do A."},
+            {"name": "b", "objective": "Do B."},
+        )
+
+        parent = run_playbook("boss")
+
+        from bees.ticket import list_tickets
+        all_tickets = list_tickets()
+        children = [t for t in all_tickets if t.metadata.creator_ticket_id == parent.id]
+
+        assert len(children) == 2
+        slugs = {c.metadata.slug for c in children}
+        assert slugs == {"a", "b"}

--- a/packages/bees/tests/test_tasks.py
+++ b/packages/bees/tests/test_tasks.py
@@ -160,8 +160,9 @@ async def test_tasks_create_task_async(write_template):
         "objective": "Do it.",
     })
 
-    scope = SubagentScope(workspace_root_id="caller-id")
-    handlers = _make_handlers(scope=scope, caller_ticket_id="caller-id")
+    caller = create_ticket("I'm the caller")
+    scope = SubagentScope(workspace_root_id=caller.id)
+    handlers = _make_handlers(scope=scope, caller_ticket_id=caller.id)
 
     args = {
         "type": "my-task",
@@ -178,7 +179,7 @@ async def test_tasks_create_task_async(write_template):
     ticket = load_ticket(result["task_id"])
     assert ticket is not None
 
-    assert ticket.metadata.creator_ticket_id == "caller-id"
+    assert ticket.metadata.creator_ticket_id == caller.id
     assert ticket.metadata.slug == "my-slug"
     assert ticket.metadata.title == "Testing create"
     assert "You are assigned to work in the subdirectory: ./my-slug" in ticket.objective
@@ -197,8 +198,9 @@ async def test_tasks_create_task_sync_wait_timeout(write_template, monkeypatch):
     mock_scheduler = MagicMock()
     mock_scheduler.wait_for_ticket = AsyncMock(return_value="running")
 
-    scope = SubagentScope(workspace_root_id="caller-id")
-    handlers = _make_handlers(scope=scope, caller_ticket_id="caller-id", scheduler=mock_scheduler)
+    caller = create_ticket("I'm the caller")
+    scope = SubagentScope(workspace_root_id=caller.id)
+    handlers = _make_handlers(scope=scope, caller_ticket_id=caller.id, scheduler=mock_scheduler)
 
     args = {
         "type": "my-task",
@@ -256,13 +258,14 @@ async def test_tasks_create_task_nested_slug(write_template):
         "objective": "Do it.",
     })
 
+    caller = create_ticket("I'm the caller")
     parent_scope = SubagentScope(
-        workspace_root_id="root-id",
+        workspace_root_id=caller.id,
         slug_path="research",
     )
     handlers = _make_handlers(
         scope=parent_scope,
-        caller_ticket_id="parent-id",
+        caller_ticket_id=caller.id,
     )
 
     args = {
@@ -280,6 +283,6 @@ async def test_tasks_create_task_nested_slug(write_template):
     assert ticket is not None
 
     assert ticket.metadata.slug == "research/deep-dive"
-    assert ticket.metadata.creator_ticket_id == "parent-id"
+    assert ticket.metadata.creator_ticket_id == caller.id
     assert "./research/deep-dive" in ticket.objective
     assert (ticket.fs_dir / "research" / "deep-dive").exists()


### PR DESCRIPTION
## What
Added an `autostart` field to `TEMPLATES.yaml` that automatically stamps child tickets when a parent ticket is created, replacing the natural-language instruction that told agents to do it manually.

## Why
Telling the agent "start the knowledge task first" via prompt is fragile — it may not happen, may happen late, or use the wrong slug. Declarative autostart makes it engine-level and deterministic.

## Changes

### Playbook (`bees/playbook.py`)
- New `stamp_child_ticket()` — shared helper for creating a child ticket with scope, sandbox, writable dir, and `creator_ticket_id`
- `run_playbook()` now iterates `autostart` entries after creating the parent ticket

### Tasks (`bees/functions/tasks.py`)
- Refactored `_tasks_create_task` to use `stamp_child_ticket()`, deduplicating ~30 lines of inline scope/sandbox logic

### Config (`hive/config/TEMPLATES.yaml`)
- Added `autostart: ["knowledge"]` to the `opie` template
- Removed the manual "start the knowledge task first" instruction from Opie's objective
- Added `autostart` to the field documentation

### Tests
- 9 new tests for `stamp_child_ticket()` and autostart behavior
- Updated 3 existing task tests to use real parent tickets on disk

## Testing
```bash
cd packages/bees && .venv/bin/python -m pytest tests/test_playbook.py tests/test_tasks.py -v
# 45 passed
```

Also verified end-to-end with `npm run dev:clean` — knowledge agent auto-starts alongside Opie without any prompt instruction.
