### PR TITLE
[bees] Move `FileHandler` type to `sca/types.ts`

### DIFF
--- a/packages/bees/web/src/sca/services/host-communication.ts
+++ b/packages/bees/web/src/sca/services/host-communication.ts
@@ -9,8 +9,7 @@ import {
   type IframeMessage,
   type HostMessage,
 } from "../../host/message-bridge.js";
-
-export type FileHandler = (path: string) => Promise<string | null>;
+import type { FileHandler } from "../types.js";
 
 export class HostCommunicationService {
   private bridge: MessageBridge | null = null;

--- a/packages/bees/web/src/sca/types.ts
+++ b/packages/bees/web/src/sca/types.ts
@@ -56,6 +56,8 @@ export interface ToastMessage {
   timeoutMs?: number;
 }
 
+export type FileHandler = (path: string) => Promise<string | null>;
+
 import { BeesAPI } from "./services/api.js";
 import { SSEClient } from "./services/sse.js";
 import { HostCommunicationService } from "./services/host-communication.js";


### PR DESCRIPTION
## What
Moved the `FileHandler` type alias from `host-communication.ts` to the canonical `sca/types.ts` file.

## Why
SCA lint rule requires shared types to be defined in `sca/types.ts`, not inline in service files.

## Changes

### `packages/bees/web`
- **`sca/types.ts`** — added `FileHandler` type export.
- **`sca/services/host-communication.ts`** — replaced inline type definition with import from `../types.js`.

## Testing
- Build passes. No consumers import `FileHandler` directly — the type is only used internally by the service class and inferred at call sites.
