### PR TITLE
[bees] Skill-level `allowed-tools`

### DIFF
--- a/packages/bees/bees/functions/skills.py
+++ b/packages/bees/bees/functions/skills.py
@@ -48,9 +48,10 @@ class SkillInfo:
     vfs_path: str
     content: str
     dir_name: str
+    allowed_tools: list[str]
 
 
-def _parse_frontmatter(text: str) -> dict[str, str]:
+def _parse_frontmatter(text: str) -> dict[str, Any]:
     """Extract YAML frontmatter key-value pairs from markdown text."""
     match = _FRONTMATTER_RE.match(text)
     if not match:
@@ -58,7 +59,7 @@ def _parse_frontmatter(text: str) -> dict[str, str]:
     data = yaml.safe_load(match.group(1))
     if not isinstance(data, dict):
         return {}
-    return {k: str(v) for k, v in data.items()}
+    return data
 
 
 def scan_skills(
@@ -105,13 +106,23 @@ def scan_skills(
         vfs_name = f"{vfs_prefix}/{dir_name}/SKILL.md"
         vfs_path = vfs_name
 
+        # Parse allowed-tools: accepts YAML list or space-separated string.
+        raw_tools = meta.get("allowed-tools", [])
+        if isinstance(raw_tools, str):
+            allowed_tools = raw_tools.split()
+        elif isinstance(raw_tools, list):
+            allowed_tools = [str(t) for t in raw_tools]
+        else:
+            allowed_tools = []
+
         skill = SkillInfo(
-            name=meta.get("name", dir_name),
-            title=meta.get("title", dir_name),
-            description=meta.get("description", ""),
+            name=str(meta.get("name", dir_name)),
+            title=str(meta.get("title", dir_name)),
+            description=str(meta.get("description", "")),
             vfs_path=vfs_path,
             content=content,
             dir_name=dir_name,
+            allowed_tools=allowed_tools,
         )
         skills.append(skill)
 

--- a/packages/bees/bees/session.py
+++ b/packages/bees/bees/session.py
@@ -398,8 +398,15 @@ def load_gemini_key() -> str:
 
 
 
-def _filter_skills(allowed_skills: list[str] | None) -> tuple[str, dict[str, str]]:
-    """Filter skills based on allowed_skills and return listing + files."""
+def _filter_skills(allowed_skills: list[str] | None) -> tuple[str, dict[str, str], list[str]]:
+    """Filter skills based on allowed_skills and return listing, files, and tool globs.
+
+    Returns:
+        A ``(listing, files, skill_tools)`` tuple:
+        - ``listing``: Formatted markdown for ``{{available_skills}}``.
+        - ``files``: Dict of ``{vfs_name: content}`` for seeding.
+        - ``skill_tools``: Merged ``allowed-tools`` from all selected skills.
+    """
     skills_to_use = allowed_skills if allowed_skills is not None else []
 
     if "*" in skills_to_use:
@@ -408,10 +415,12 @@ def _filter_skills(allowed_skills: list[str] | None) -> tuple[str, dict[str, str
         filtered_skills = [s for s in _SKILLS_LIST if s.name in skills_to_use]
 
     lines = []
+    skill_tools: list[str] = []
     for s in filtered_skills:
         lines.append(f"- [{s.title}]({s.vfs_path})")
         if s.description:
             lines.append(f"  {s.description}")
+        skill_tools.extend(s.allowed_tools)
     session_listing = "\n".join(lines)
 
     session_files = {}
@@ -419,7 +428,7 @@ def _filter_skills(allowed_skills: list[str] | None) -> tuple[str, dict[str, str
         if any(f"skills/{s.dir_name}/" in k for s in filtered_skills):
             session_files[k] = v
 
-    return session_listing, session_files
+    return session_listing, session_files, skill_tools
 
 
 # ---------------------------------------------------------------------------
@@ -468,7 +477,14 @@ async def run_session(
     out_path = OUT_DIR / f"{log_prefix}-{date_stamp}.log.json"
 
 
-    session_listing, session_files = _filter_skills(allowed_skills)
+    session_listing, session_files, skill_tools = _filter_skills(allowed_skills)
+
+    # Union skill-declared tools into the template's function filter.
+    # Also inject skills.* automatically when any skills are selected —
+    # the agent needs it to read skill instructions.
+    if function_filter is not None and allowed_skills:
+        skill_tools.append("skills.*")
+        function_filter = list(dict.fromkeys(function_filter + skill_tools))
 
     # Create disk-backed file system.
     work_dir = fs_dir or (ticket_dir / "filesystem" if ticket_dir else Path(tempfile.mkdtemp(prefix="bees-fs-")))
@@ -652,7 +668,7 @@ async def resume_session(
         except Exception:
             pass
 
-    session_listing, _ = _filter_skills(allowed_skills)
+    session_listing, _, _ = _filter_skills(allowed_skills)
 
     # Create disk-backed file system — files are already on disk from
     # the previous run, so no seeding needed.

--- a/packages/bees/hive/config/TEMPLATES.yaml
+++ b/packages/bees/hive/config/TEMPLATES.yaml
@@ -30,9 +30,9 @@
     to behave.
 
     Await user requests and act on them. Use tasks for delegating work. Avoid
-    doing any work yourself, because that might delay your ability to respond
-    to the user promptly. Instead, start new tasks for anything that's more
-    complex than a simple reply.
+    doing any work yourself, because that might delay your ability to respond to
+    the user promptly. Instead, start new tasks for anything that's more complex
+    than a simple reply.
 
   skills: ["persona"]
   autostart: ["knowledge"]
@@ -41,7 +41,7 @@
   tags: ["opie", "chat"]
   # No system.* — Opie never terminates. It lives as an infinite chat agent,
   # suspending on chat_request_user_input between turns.
-  functions: ["chat.*", "simple-files.*", "skills.*", "tasks.*"]
+  functions: ["simple-files.*", "tasks.*"]
   # Signals arrive as context_updates inside chat_request_user_input responses
   # (not via chat_await_context_update) because Opie is always suspended
   # waiting for the *user*, not for system signals.
@@ -54,8 +54,8 @@
     journey design, and UI generation, and iterates on feedback until the
     objective is met.
   objective: >
-    You are a Journey Manager — a project manager responsible for delivering
-    an outcome to the user.
+    You are a Journey Manager — a project manager responsible for delivering an
+    outcome to the user.
 
     Here is the user's objective:
 
@@ -75,9 +75,9 @@
     requirements must include what the user needs, their constraints, and
     preferences.
 
-    3. Once you have the requirements, switch to delegation mode: read the
-    list of available task types and then create the necessary tasks that will
-    allow subagents to to build and iterate on a React app with the user.
+    3. Once you have the requirements, switch to delegation mode: read the list
+    of available task types and then create the necessary tasks that will allow
+    subagents to to build and iterate on a React app with the user.
 
     The typical flow is:
 
@@ -95,9 +95,9 @@
 
     Rinse, repeat.
 
-    When iterating, reuse the slug names and inform the subagents that they
-    can read the old information and write over it. Use these slugs for each
-    task type for consistency:
+    When iterating, reuse the slug names and inform the subagents that they can
+    read the old information and write over it. Use these slugs for each task
+    type for consistency:
       - `research` for the research
       - `journey` for the XState journey
       - `app` for the React app
@@ -105,9 +105,9 @@
 
     ## Rules
 
-    - Keep your chat responses brief, but be cordial and converse with the
-    user while the tasks are running. The user may want to inquire about the
-    status of tasks and what's going on, or cancel tasks.
+    - Keep your chat responses brief, but be cordial and converse with the user
+    while the tasks are running. The user may want to inquire about the status
+    of tasks and what's going on, or cancel tasks.
 
     - Don't wait on tasks to complete. Delegate and get back to the user.
 
@@ -118,9 +118,7 @@
     your task assignments. They know nothing about prior conversation.
 
   functions:
-    - chat.*
     - simple-files.*
-    - skills.*
     - tasks.*
   skills: ["interview-user"]
   tags: ["journey", "chat"]
@@ -136,25 +134,25 @@
     Continuously accumulates and coheres information into a common knowledge
     base.
   objective: >
-    You turn information (files on the file system) into knowledge. The files
-    on the file system is a byproduct of a swarm of agents and their
-    sub-agents working on various tasks. Aside from "skills", "system", and
-    your own assigned directory (you're a sub-agent, too), each sub-directoy
-    is a workspace for a sub agent, and every sub-agent is working to complete
-    the task of the owning agent.
+    You turn information (files on the file system) into knowledge. The files on
+    the file system is a byproduct of a swarm of agents and their sub-agents
+    working on various tasks. Aside from "skills", "system", and your own
+    assigned directory (you're a sub-agent, too), each sub-directoy is a
+    workspace for a sub agent, and every sub-agent is working to complete the
+    task of the owning agent.
 
-    Knowledge is a coherent representation of this information, captured as
-    the following files:
+    Knowledge is a coherent representation of this information, captured as the
+    following files:
 
     - state.md -- the state of the overall system: where each of the subagents
     is currently along their progress
 
-    - opportunities.md -- any potential opportunities for the agents to share
-    or collaborate. The agents work in their silos and only you can see the
+    - opportunities.md -- any potential opportunities for the agents to share or
+    collaborate. The agents work in their silos and only you can see the
     potential synergies. Follow these constraints:
 
-    - **Ground in Reality**: Do not assume capabilities that are not visible
-    in the workspace
+    - **Ground in Reality**: Do not assume capabilities that are not visible in
+    the workspace
 
     - **Frame as Future**: Present these as potential future directions or
     long-term improvements, not immediate tasks.
@@ -164,8 +162,8 @@
     tools.
 
     - actions.md -- a user-oriented list of actions. Think of it as this: as a
-    proactive agentic system, what can I proactively suggest that would make
-    my user's life easier.
+    proactive agentic system, what can I proactively suggest that would make my
+    user's life easier.
 
     Your work is endless and follows this cycle:
 
@@ -183,8 +181,8 @@
 
     - Correct contradictions at the source. Don't carry both versions.
 
-    - Promote information to opportunities. If multiple agents are working in
-    a similar space, these are opportunities.
+    - Promote information to opportunities. If multiple agents are working in a
+    similar space, these are opportunities.
 
     - Normalize dates. Replace "last week" with absolutes. Remove passed
     deadlines.
@@ -203,9 +201,9 @@
     - **User Agency Only**: Only suggest actions that require human judgment,
     personal preference, or real-world action.
 
-    - **Aim to ease the load**: Avoid proposing new ambitious things that
-    might not be needed. The user is busy. Don't add more busywork to their
-    plate. Busywork is just as bad as missing important stuff.
+    - **Aim to ease the load**: Avoid proposing new ambitious things that might
+    not be needed. The user is busy. Don't add more busywork to their plate.
+    Busywork is just as bad as missing important stuff.
 
     - **No Chores**: Never ask the user to verify data, check benchmarks,
     monitor prices, or do research. That is the agents' job.
@@ -245,9 +243,9 @@
     List available files and see if there's already some relevant information
     that could be used as foundation for research.
 
-    Compile relevant, accurate information. Save your findings to a file
-    called research-data.json (structured data) or research-notes.md (prose),
-    whichever is more appropriate for the request.
+    Compile relevant, accurate information. Save your findings to a file called
+    research-data.json (structured data) or research-notes.md (prose), whichever
+    is more appropriate for the request.
 
     Return the relative path of the file with research.
   functions: ["system.*", "sandbox.*", "simple-files.*", "generate.text"]
@@ -257,8 +255,8 @@
   description: >
     Produces an XState-backed journey.json blueprint
   objective: >
-    Your job is to produce a journey.json file describing the XState machine
-    for a UI segment.
+    Your job is to produce a journey.json file describing the XState machine for
+    a UI segment.
 
     Here is the brief:
 
@@ -273,7 +271,7 @@
     3. Save the result as journey.json.
 
     4. Return the path to the blueprint.
-  functions: ["system.*", "simple-files.*", "skills.*"]
+  functions: ["system.*"]
   skills: ["app-architect"]
 
 - name: ui-generator
@@ -290,11 +288,11 @@
     token discipline, and component architecture rules.
 
     2. List files in your assigned directory. If a journey.json file exists,
-    read it — it contains an XState machine definition that describes the
-    views and transitions for this UI segment. Follow it precisely — each
-    state becomes a view component, each transition becomes a navigation
-    action. If research data files exist (e.g. research-data.json,
-    research-notes.md), read those too for content to populate the UI.
+    read it — it contains an XState machine definition that describes the views
+    and transitions for this UI segment. Follow it precisely — each state
+    becomes a view component, each transition becomes a navigation action. If
+    research data files exist (e.g. research-data.json, research-notes.md), read
+    those too for content to populate the UI.
 
     3. Generate the React application (App.jsx, components, styles.css).
 
@@ -302,14 +300,12 @@
     $HOME/skills/ui-generator/tools/bundler.mjs` via execute_bash to produce
     bundle.js and bundle.css.
 
-    5. After a successful bundle, emit an event by calling events_broadcast
-    with type "app_update". The payload should describe what the app does, its
-    key features, and include a navigateTo link:
+    5. After a successful bundle, emit an event by calling events_broadcast with
+    type "app_update". The payload should describe what the app does, its key
+    features, and include a navigateTo link:
     `navigateTo('{{system.ticket_id}}')`.
 
     Return a brief message summarizing what was done.
-  functions:
-    ["system.*", "sandbox.*", "simple-files.*", "events.*", "skills.*"]
   skills: ["ui-generator"]
   tags: ["bundle"]
   # Use a more capable model for code generation.
@@ -324,16 +320,15 @@
     Write or edit if already exists, a JSON file `digest_tile.json` in your
     assigned subdirectory of the following structure:
 
-    {"title": "Title of Journey", "summary": "Brief summary", "milestone":
-    "The name of the milestone reached", "actionable": "Yes or No", "link_id":
-    "the parent id passed via context"}.
+    {"title": "Title of Journey", "summary": "Brief summary", "milestone": "The
+    name of the milestone reached", "actionable": "Yes or No", "link_id": "the
+    parent id passed via context"}.
 
-    Incorporate new context into the old one, providing continuity. The
-    goal  is to reflect the current state of the context, not list the
-    updates.
+    Incorporate new context into the old one, providing continuity. The goal  is
+    to reflect the current state of the context, not list the updates.
 
-    Then, broadcast a `digest_ready` event with the relative path to the
-    written file.
+    Then, broadcast a `digest_ready` event with the relative path to the written
+    file.
 
     Return "Done" as outcome.
 

--- a/packages/bees/hive/skills/app-architect/SKILL.md
+++ b/packages/bees/hive/skills/app-architect/SKILL.md
@@ -5,6 +5,8 @@ description:
   Decompose a user objective into a segmented app. Each segment is a multi-view
   mini-app. Segments are separated by LLM decision points where the orchestrator
   decides what comes next.
+allowed-tools:
+  - simple-files.*
 ---
 
 # App Architect

--- a/packages/bees/hive/skills/interview-user/SKILL.md
+++ b/packages/bees/hive/skills/interview-user/SKILL.md
@@ -3,6 +3,8 @@ name: interview-user
 title: Interview User
 description:
   Read it to understand the style and workflow for interviewing a user.
+allowed-tools:
+  - chat.*
 ---
 
 Conversation style:

--- a/packages/bees/hive/skills/persona/SKILL.md
+++ b/packages/bees/hive/skills/persona/SKILL.md
@@ -4,6 +4,8 @@ title: EA Persona
 description:
   Shapes how you behave — calming presence, discretion, no branding. Read this
   before every interaction.
+allowed-tools:
+  - chat.*
 ---
 
 # EA Persona

--- a/packages/bees/hive/skills/ui-generator/SKILL.md
+++ b/packages/bees/hive/skills/ui-generator/SKILL.md
@@ -4,6 +4,11 @@ title: UI Component Generation
 description:
   Generate multi-file React component bundles with design tokens from natural
   language descriptions.
+allowed-tools:
+  - sandbox.*
+  - simple-files.*
+  - events.*
+  - system.*
 ---
 
 # UI Component Generation Skill
@@ -25,7 +30,11 @@ component bundles from natural language descriptions.
    `IndexedDB`, or any Web Storage APIs. The iframe environment may not have
    storage access due to origin restrictions. All state lives in React component
    state or is passed via props and the SDK.
-4. **Respect the host theme.** We use a light theme. Do not set `background: black`, `background: #000`, `color: #fff`, or any dark-theme values. All backgrounds must use `var(--cg-color-surface*)` tokens and all text must use `var(--cg-color-on-surface*)` tokens. The tokens will natively map to their light theme variants.
+4. **Respect the host theme.** We use a light theme. Do not set
+   `background: black`, `background: #000`, `color: #fff`, or any dark-theme
+   values. All backgrounds must use `var(--cg-color-surface*)` tokens and all
+   text must use `var(--cg-color-on-surface*)` tokens. The tokens will natively
+   map to their light theme variants.
 
 ## Responsive Layout
 
@@ -110,9 +119,9 @@ code in your response.**
 
 ## Component Library
 
-Before generating sub-components, check `library/` for existing components
-from previous runs. Each subdirectory is a previous run, containing its
-`App.jsx` and `components/*.jsx`.
+Before generating sub-components, check `library/` for existing components from
+previous runs. Each subdirectory is a previous run, containing its `App.jsx` and
+`components/*.jsx`.
 
 **Reuse workflow:**
 
@@ -338,13 +347,16 @@ export default function GroceryList() {
   if (loading) return <div>Loading…</div>;
   return (
     <ul>
-      {items.map((item, i) => <li key={i}>{item}</li>)}
+      {items.map((item, i) => (
+        <li key={i}>{item}</li>
+      ))}
     </ul>
   );
 }
 ```
 
 **Rules for `readFile`:**
+
 - Returns `Promise<string | null>`. `null` means the file was not found.
 - Paths are workspace-relative (e.g. `"analysis/results.json"`,
   `"diet_research/notes.md"`).


### PR DESCRIPTION
## What
Skills can now declare the functions they need via `allowed-tools` in their SKILL.md frontmatter. At session setup, these are unioned into the template's function filter automatically. `skills.*` is also auto-injected whenever a template uses any skills.

## Why
Function requirements were duplicated: the skill's instructions reference specific tools (e.g., `execute_bash`, `events_broadcast`), but the template had to independently list the same globs. Adding a skill to a template could silently break if the template's `functions` didn't cover the skill's needs. Now the skill is self-describing.

## Changes

### Skill scanning (`bees/functions/skills.py`)
- Added `allowed_tools: list[str]` to `SkillInfo`
- Parse `allowed-tools` from SKILL.md frontmatter (accepts YAML list or space-separated string per agentskills.io spec)

### Session setup (`bees/session.py`)
- `_filter_skills` now returns skill-declared tool globs as a third element
- `run_session` unions skill tools into `function_filter`; auto-injects `skills.*` when any skills are selected

### SKILL.md declarations
- `ui-generator`: `sandbox.*`, `simple-files.*`, `events.*`, `system.*`
- `interview-user`: `chat.*`
- `app-architect`: `simple-files.*`
- `persona`: `chat.*`

### Template cleanup (`TEMPLATES.yaml`)
- Removed `skills.*` from all templates (now auto-injected)
- Removed tool globs that skills now bring themselves
- Removed stale `type: task-template` field
- Line-length formatting pass

## Testing
Run the system with a template that omits a skill-required tool from its `functions` list — the agent should still have access because the skill's `allowed-tools` brings it in.
