### PR TITLE
[bees] Hivetool skill frontmatter + cross-entity linking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2388,12 +2388,14 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
       "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/markdown-it": {
       "version": "14.1.2",
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/linkify-it": "^5",
@@ -2404,6 +2406,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
       "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -10291,10 +10294,8 @@
       "dependencies": {
         "@lit-labs/signals": "^0.1.3",
         "@types/js-yaml": "^4.0.9",
-        "@types/markdown-it": "^14.1.2",
         "js-yaml": "^4.1.1",
         "lit": "^3.3.2",
-        "markdown-it": "^14.1.1",
         "signal-polyfill": "^0.2.2"
       },
       "devDependencies": {

--- a/packages/bees/hivetool/src/data/skill-store.ts
+++ b/packages/bees/hivetool/src/data/skill-store.ts
@@ -12,6 +12,7 @@
  * markdown body for detail rendering.
  */
 
+import yaml from "js-yaml";
 import { Signal } from "signal-polyfill";
 import type { StateAccess } from "./state-access.js";
 
@@ -28,43 +29,28 @@ interface SkillData {
   title?: string;
   /** Frontmatter `description` field. */
   description?: string;
+  /** Frontmatter `allowed-tools` list. */
+  allowedTools: string[];
   /** Full markdown body (everything after the frontmatter). */
   body: string;
 }
 
 /** Matches YAML frontmatter delimited by --- lines. */
-const FRONTMATTER_RE = /\A---\s*\n(.*?)\n---\s*\n/s;
+const FRONTMATTER_RE = /^---\s*\n(.*?)\n---\s*\n/s;
 
-/**
- * Minimal frontmatter parser — extracts key: value pairs from a
- * `---`-delimited YAML block at the start of a markdown file.
- * Avoids pulling in js-yaml for this simple structure.
- */
+/** Parse YAML frontmatter from a markdown file using js-yaml. */
 function parseFrontmatter(text: string): {
-  meta: Record<string, string>;
+  meta: Record<string, unknown>;
   body: string;
 } {
   const match = text.match(FRONTMATTER_RE);
   if (!match) return { meta: {}, body: text };
 
-  const yamlBlock = match[1];
-  const meta: Record<string, string> = {};
-  // Simple line-by-line key: value extraction. Handles multi-line
-  // values that are indented continuations.
-  let currentKey = "";
-  let currentValue = "";
-  for (const line of yamlBlock.split("\n")) {
-    const kvMatch = line.match(/^(\w[\w-]*):\s*(.*)/);
-    if (kvMatch) {
-      if (currentKey) meta[currentKey] = currentValue.trim();
-      currentKey = kvMatch[1];
-      currentValue = kvMatch[2];
-    } else if (currentKey && /^\s+/.test(line)) {
-      // Continuation line.
-      currentValue += " " + line.trim();
-    }
-  }
-  if (currentKey) meta[currentKey] = currentValue.trim();
+  const parsed = yaml.load(match[1]);
+  const meta =
+    parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
 
   const body = text.slice(match[0].length);
   return { meta, body };
@@ -114,11 +100,22 @@ class SkillStore {
           const text = await file.text();
           const { meta, body } = parseFrontmatter(text);
 
+          // Parse allowed-tools: accepts YAML list or space-separated string.
+          const rawTools = meta["allowed-tools"];
+          let allowedTools: string[] = [];
+          if (Array.isArray(rawTools)) {
+            allowedTools = rawTools.map(String);
+          } else if (typeof rawTools === "string") {
+            allowedTools = rawTools.split(/\s+/).filter(Boolean);
+          }
+
           entries.push({
             dirName: name,
-            name: meta.name || name,
-            title: meta.title,
-            description: meta.description,
+            name: String(meta.name || name),
+            title: meta.title != null ? String(meta.title) : undefined,
+            description:
+              meta.description != null ? String(meta.description) : undefined,
+            allowedTools,
             body,
           });
         } catch {

--- a/packages/bees/hivetool/src/ui/app.styles.ts
+++ b/packages/bees/hivetool/src/ui/app.styles.ts
@@ -1066,5 +1066,35 @@ export const styles = css`
     color: #93c5fd;
     border: 1px solid #1e3a5c;
   }
+
+  /* ── Backlink chips ── */
+  .backlink-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+  }
+
+  .backlink-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 10px;
+    border-radius: 6px;
+    font-size: 0.75rem;
+    background: #1e293b;
+    color: #94a3b8;
+    border: 1px solid #334155;
+    transition: background 0.15s, border-color 0.15s, color 0.15s;
+  }
+
+  .backlink-chip.linkable {
+    cursor: pointer;
+  }
+
+  .backlink-chip.linkable:hover {
+    background: #253347;
+    border-color: #3b82f6;
+    color: #93c5fd;
+  }
 `;
 

--- a/packages/bees/hivetool/src/ui/app.ts
+++ b/packages/bees/hivetool/src/ui/app.ts
@@ -16,10 +16,7 @@ import { SkillStore } from "../data/skill-store.js";
 import type { FileTreeNode } from "../data/ticket-store.js";
 import type { TicketData } from "../data/types.js";
 import { TicketStore } from "../data/ticket-store.js";
-import {
-  TemplateStore,
-  type TemplateData,
-} from "../data/template-store.js";
+import { TemplateStore } from "../data/template-store.js";
 import { deriveTicketTree, type TicketTreeNode } from "../data/ticket-tree.js";
 import { getRelativeTime } from "../utils.js";
 import { styles } from "./app.styles.js";
@@ -146,7 +143,13 @@ class BeesApp extends SignalWatcher(LitElement) {
   /** Restore tab and selection from the URL hash on load. */
   private async restoreRoute(): Promise<void> {
     const route = parseRoute();
-    const validTabs: TabId[] = ["logs", "tickets", "events", "templates", "skills"];
+    const validTabs: TabId[] = [
+      "logs",
+      "tickets",
+      "events",
+      "templates",
+      "skills",
+    ];
     const tab = validTabs.includes(route.tab as TabId)
       ? (route.tab as TabId)
       : "tickets";
@@ -184,10 +187,16 @@ class BeesApp extends SignalWatcher(LitElement) {
   render() {
     const access = this.stateAccess.accessState.get();
     const recentUpdate = this.ticketStore.recentlyUpdatedTicket.get();
-    this.currentFlashTicketId = (recentUpdate && (Date.now() - recentUpdate.at < 15000)) ? recentUpdate.id : null;
-    
+    this.currentFlashTicketId =
+      recentUpdate && Date.now() - recentUpdate.at < 15000
+        ? recentUpdate.id
+        : null;
+
     const recentLogUpdate = this.logStore.recentlyUpdatedSession.get();
-    this.currentFlashLogId = (recentLogUpdate && (Date.now() - recentLogUpdate.at < 15000)) ? recentLogUpdate.id : null;
+    this.currentFlashLogId =
+      recentLogUpdate && Date.now() - recentLogUpdate.at < 15000
+        ? recentLogUpdate.id
+        : null;
 
     if (access !== "ready") {
       return html`
@@ -238,7 +247,9 @@ class BeesApp extends SignalWatcher(LitElement) {
         </div>
         <div class="top-bar-tabs">
           <div
-            class="sidebar-tab ${this.activeTab === "tickets" ? "active" : ""} ${this.currentFlashTicketId ? "lightning-flash" : ""}"
+            class="sidebar-tab ${this.activeTab === "tickets"
+              ? "active"
+              : ""} ${this.currentFlashTicketId ? "lightning-flash" : ""}"
             @click=${() => {
               this.activeTab = "tickets";
               this.syncHash();
@@ -256,7 +267,9 @@ class BeesApp extends SignalWatcher(LitElement) {
             Events
           </div>
           <div
-            class="sidebar-tab ${this.activeTab === "logs" ? "active" : ""} ${this.currentFlashLogId ? "lightning-flash" : ""}"
+            class="sidebar-tab ${this.activeTab === "logs"
+              ? "active"
+              : ""} ${this.currentFlashLogId ? "lightning-flash" : ""}"
             @click=${() => {
               this.activeTab = "logs";
               this.syncHash();
@@ -265,7 +278,9 @@ class BeesApp extends SignalWatcher(LitElement) {
             Sessions
           </div>
           <div
-            class="sidebar-tab ${this.activeTab === "templates" ? "active" : ""}"
+            class="sidebar-tab ${this.activeTab === "templates"
+              ? "active"
+              : ""}"
             @click=${() => {
               this.activeTab = "templates";
               this.syncHash();
@@ -326,6 +341,20 @@ class BeesApp extends SignalWatcher(LitElement) {
     this.syncHash();
   }
 
+  /** Navigate to a specific skill by switching to the Skills tab. */
+  private navigateToSkill(dirName: string) {
+    this.activeTab = "skills";
+    this.skillStore.selectSkill(dirName);
+    this.syncHash();
+  }
+
+  /** Navigate to a specific template by switching to the Templates tab. */
+  private navigateToTemplate(name: string) {
+    this.activeTab = "templates";
+    this.templateStore.selectTemplate(name);
+    this.syncHash();
+  }
+
   private renderLogsList() {
     const sessions = this.logStore.sessions.get();
     const selectedSid = this.logStore.selectedSessionId.get();
@@ -342,7 +371,9 @@ class BeesApp extends SignalWatcher(LitElement) {
               <div
                 class="job-item ${selectedSid === session.sessionId
                   ? "selected"
-                  : ""} ${this.currentFlashLogId === session.sessionId ? "lightning-flash" : ""}"
+                  : ""} ${this.currentFlashLogId === session.sessionId
+                  ? "lightning-flash"
+                  : ""}"
                 @click=${() => {
                   this.logStore.selectSession(session.sessionId);
                   this.syncHash();
@@ -435,13 +466,13 @@ class BeesApp extends SignalWatcher(LitElement) {
     `;
   }
 
-  private renderTicketItem(
-    t: TicketData,
-    selectedId: string | null
-  ) {
+  private renderTicketItem(t: TicketData, selectedId: string | null) {
     return html`
       <div
-        class="job-item ${selectedId === t.id ? "selected" : ""} ${this.currentFlashTicketId === t.id ? "lightning-flash" : ""}"
+        class="job-item ${selectedId === t.id ? "selected" : ""} ${this
+          .currentFlashTicketId === t.id
+          ? "lightning-flash"
+          : ""}"
         @click=${() => {
           this.ticketFileTree = [];
           this.ticketFileContents = {};
@@ -475,10 +506,7 @@ class BeesApp extends SignalWatcher(LitElement) {
     `;
   }
 
-  private renderTicketsTree(
-    tickets: TicketData[],
-    selectedId: string | null
-  ) {
+  private renderTicketsTree(tickets: TicketData[], selectedId: string | null) {
     const tree = deriveTicketTree(tickets);
     return tree.map((node) => this.renderTreeNode(node, selectedId));
   }
@@ -525,33 +553,54 @@ class BeesApp extends SignalWatcher(LitElement) {
     }> = [];
     if (ticket.model)
       identityChips.push({ label: "model", value: ticket.model, cls: "model" });
-    if (ticket.playbook_id)
+    if (ticket.playbook_id) {
+      const templateNames = new Set(
+        this.templateStore.templates.get().map((t) => t.name)
+      );
+      const exists = templateNames.has(ticket.playbook_id);
       identityChips.push({
-        label: "playbook",
+        label: "template",
         value: ticket.playbook_id,
         cls: "playbook",
+        onclick: exists
+          ? () => this.navigateToTemplate(ticket.playbook_id!)
+          : undefined,
       });
-    if (ticket.parent_ticket_id)
+    }
+    if (ticket.creator_ticket_id)
       identityChips.push({
         label: "parent",
-        value: ticket.parent_ticket_id.slice(0, 8),
-        onclick: () => this.navigateToTicket(ticket.parent_ticket_id!),
+        value: ticket.creator_ticket_id.slice(0, 8),
+        onclick: () => this.navigateToTicket(ticket.creator_ticket_id!),
       });
     identityChips.push({
       label: "session",
       value: ticket.id.slice(0, 8),
       onclick: () => this.navigateToLog(ticket.id),
     });
-    if (ticket.skills && ticket.skills.length > 0)
+    if (ticket.skills && ticket.skills.length > 0) {
+      const skillDirs = new Set(
+        this.skillStore.skills.get().map((sk) => sk.dirName)
+      );
       for (const s of ticket.skills)
-        identityChips.push({ label: "skill", value: s, cls: "skill" });
+        identityChips.push({
+          label: "skill",
+          value: s,
+          cls: "skill",
+          onclick: skillDirs.has(s) ? () => this.navigateToSkill(s) : undefined,
+        });
+    }
 
     const chatHistory = (ticket.chat_history ?? []).filter(
       (m) => m.text.trim() !== ""
     );
 
     return html`
-      <div class="job-detail ${this.currentFlashTicketId === ticket.id ? "lightning-flash" : ""}">
+      <div
+        class="job-detail ${this.currentFlashTicketId === ticket.id
+          ? "lightning-flash"
+          : ""}"
+      >
         <div class="job-detail-header">
           <div class="job-detail-header-top">
             <h2 class="job-detail-title">${ticket.title || "Ticket"}</h2>
@@ -1007,20 +1056,31 @@ class BeesApp extends SignalWatcher(LitElement) {
               `
             : nothing}
           ${template.skills && template.skills.length > 0
-            ? html`
-                <div class="block">
-                  <div class="block-header">Skills</div>
-                  <div class="block-content">
-                    ${template.skills.map(
-                      (s) => html`
-                        <span class="identity-chip skill" style="margin-right:6px"
+            ? (() => {
+                const skillDirs = new Set(
+                  this.skillStore.skills.get().map((sk) => sk.dirName)
+                );
+                return html`
+                  <div class="block">
+                    <div class="block-header">Skills</div>
+                    <div class="block-content">
+                      ${template.skills.map((s) => {
+                        const exists = skillDirs.has(s);
+                        return html`<span
+                          class="identity-chip skill ${exists
+                            ? "linkable"
+                            : ""}"
+                          style="margin-right:6px"
+                          @click=${exists
+                            ? () => this.navigateToSkill(s)
+                            : nothing}
                           >${s}</span
-                        >
-                      `
-                    )}
+                        >`;
+                      })}
+                    </div>
                   </div>
-                </div>
-              `
+                `;
+              })()
             : nothing}
           ${template.functions && template.functions.length > 0
             ? html`
@@ -1052,6 +1112,34 @@ class BeesApp extends SignalWatcher(LitElement) {
                 </div>
               `
             : nothing}
+          ${(() => {
+                const usingTickets = this.ticketStore.tickets
+                  .get()
+                  .filter(
+                    (t) =>
+                      t.kind !== "coordination" &&
+                      t.playbook_id === template.name
+                  );
+                if (usingTickets.length === 0) return nothing;
+                return html`
+                  <div class="block">
+                    <div class="block-header">
+                      Used by Tickets (${usingTickets.length})
+                    </div>
+                    <div class="block-content">
+                      <div class="backlink-list">
+                        ${usingTickets.map(
+                          (t) => html`<span
+                            class="backlink-chip linkable"
+                            @click=${() => this.navigateToTicket(t.id)}
+                            >${t.title || t.id.slice(0, 8)}</span
+                          >`
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                `;
+              })()}
         </div>
       </div>
     `;
@@ -1101,8 +1189,7 @@ class BeesApp extends SignalWatcher(LitElement) {
 
   private renderSkillDetail() {
     const skill = this.skillStore.selectedSkill.get();
-    if (!skill)
-      return this.renderEmptyMain("Select a skill to view details");
+    if (!skill) return this.renderEmptyMain("Select a skill to view details");
 
     // Build identity chips.
     const chips: Array<{
@@ -1113,7 +1200,6 @@ class BeesApp extends SignalWatcher(LitElement) {
     chips.push({ label: "name", value: skill.name, cls: "skill" });
     if (skill.dirName !== skill.name)
       chips.push({ label: "dir", value: skill.dirName });
-
 
     return html`
       <div class="job-detail">
@@ -1144,6 +1230,21 @@ class BeesApp extends SignalWatcher(LitElement) {
                 </div>
               `
             : nothing}
+          ${skill.allowedTools.length > 0
+            ? html`
+                <div class="block">
+                  <div class="block-header">Allowed Tools</div>
+                  <div class="block-content">
+                    ${skill.allowedTools.map(
+                      (t) =>
+                        html`<span class="tool-badge" style="margin-right:6px"
+                          >${t}</span
+                        >`
+                    )}
+                  </div>
+                </div>
+              `
+            : nothing}
           <div class="block">
             <div class="block-header">Content</div>
             <div class="block-content">
@@ -1155,6 +1256,58 @@ class BeesApp extends SignalWatcher(LitElement) {
               >
             </div>
           </div>
+          ${(() => {
+                const usingTemplates = this.templateStore.templates
+                  .get()
+                  .filter((t) => t.skills?.includes(skill.dirName));
+                if (usingTemplates.length === 0) return nothing;
+                return html`
+                  <div class="block">
+                    <div class="block-header">
+                      Used by Templates (${usingTemplates.length})
+                    </div>
+                    <div class="block-content">
+                      <div class="backlink-list">
+                        ${usingTemplates.map(
+                          (t) => html`<span
+                            class="backlink-chip linkable"
+                            @click=${() => this.navigateToTemplate(t.name)}
+                            >${t.title || t.name}</span
+                          >`
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                `;
+              })()}
+          ${(() => {
+                const usingTickets = this.ticketStore.tickets
+                  .get()
+                  .filter(
+                    (t) =>
+                      t.kind !== "coordination" &&
+                      t.skills?.includes(skill.dirName)
+                  );
+                if (usingTickets.length === 0) return nothing;
+                return html`
+                  <div class="block">
+                    <div class="block-header">
+                      Used by Tickets (${usingTickets.length})
+                    </div>
+                    <div class="block-content">
+                      <div class="backlink-list">
+                        ${usingTickets.map(
+                          (t) => html`<span
+                            class="backlink-chip linkable"
+                            @click=${() => this.navigateToTicket(t.id)}
+                            >${t.title || t.id.slice(0, 8)}</span
+                          >`
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                `;
+              })()}
         </div>
       </div>
     `;


### PR DESCRIPTION
## What
Fix skill frontmatter parsing and add cross-entity navigation (skills ↔ templates ↔ tickets) throughout hivetool.

## Why
The frontmatter regex used `\A` (a Python/Ruby anchor, not valid in JS), so skill metadata was never parsed — titles fell back to directory names and `allowed-tools` was invisible. While fixing that, added the linking and backlinks that make hivetool a navigable graph rather than isolated lists.

## Changes

### `packages/bees/hivetool/src/data/skill-store.ts`
- Fixed `FRONTMATTER_RE`: `\A` → `^` (JS start-of-string anchor)
- Replaced hand-rolled line-by-line YAML parser with `js-yaml` (already a dependency)
- Added `allowedTools: string[]` to `SkillData` interface

### `packages/bees/hivetool/src/ui/app.ts`
- Skill detail: render "Allowed Tools" as tool-badge chips
- Skill detail: "Used by Templates" and "Used by Tickets" backlink sections
- Template detail: "Used by Tickets" backlink section
- Ticket detail: renamed "playbook" chip label to "template", made it a clickable link to Templates tab
- Ticket detail: fixed parent link to use `creator_ticket_id` (matching tree derivation) instead of `parent_ticket_id`
- Skill chips in ticket and template views now click through to Skills tab
- Added `navigateToSkill()` and `navigateToTemplate()` navigation methods

### `packages/bees/hivetool/src/ui/app.styles.ts`
- Added `.backlink-list` and `.backlink-chip` styles for the new backlink sections

## Testing
Run `npm run dev:hivetool -w packages/bees`, open the hivetool, select a skill → verify title/description/allowed-tools render correctly, backlinks appear. Click a skill chip on a ticket → navigates to Skills tab. Click template chip on a ticket → navigates to Templates tab.
