### PR TITLE
[bees] Enable browser back/forward in hivetool

### DIFF
--- a/packages/bees/hivetool/src/data/router.ts
+++ b/packages/bees/hivetool/src/data/router.ts
@@ -10,8 +10,8 @@
  * URL format: #/{tab}/{selectionId}
  * Examples: #/logs/abc123, #/tickets/def456, #/events/ghi789
  *
- * Uses history.replaceState so hash updates don't clutter browser history.
- * The hashchange listener only fires on external changes (manual URL edits).
+ * Uses history.pushState so each navigation creates a history entry,
+ * enabling browser back/forward buttons.
  */
 
 export { parseRoute, writeRoute, type Route };
@@ -56,5 +56,5 @@ function parseRoute(hash = location.hash): Route {
 function writeRoute(tab: string, id?: string | null): void {
   const hash = id ? `#/${tab}/${id}` : `#/${tab}`;
   if (location.hash === hash) return;
-  history.replaceState(null, "", hash);
+  history.pushState(null, "", hash);
 }

--- a/packages/bees/hivetool/src/ui/app.ts
+++ b/packages/bees/hivetool/src/ui/app.ts
@@ -55,14 +55,14 @@ class BeesApp extends SignalWatcher(LitElement) {
     super.connectedCallback();
     this.initStores();
     this.restoreRoute();
-    window.addEventListener("hashchange", this.onHashChange);
+    window.addEventListener("popstate", this.onHashChange);
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
     this.logStore.destroy();
     this.ticketStore.destroy();
-    window.removeEventListener("hashchange", this.onHashChange);
+    window.removeEventListener("popstate", this.onHashChange);
   }
 
   // --- Store Initialization ---


### PR DESCRIPTION
## What
Switch hivetool's hash router from `replaceState` to `pushState` so browser back/forward buttons work across cross-entity link clicks.

## Why
All the new cross-entity links (skill → template, ticket → skill, etc.) called `writeRoute` which used `replaceState`, silently replacing history. Clicking back did nothing.

## Changes

### `packages/bees/hivetool/src/data/router.ts`
- `history.replaceState` → `history.pushState` in `writeRoute()`

### `packages/bees/hivetool/src/ui/app.ts`
- Event listener switched from `hashchange` to `popstate` — `pushState`-driven back/forward fires `popstate`, not `hashchange`

## Testing
Run `npm run dev:hivetool -w packages/bees`. Click through several cross-entity links (ticket → template → skill). Press browser back button — should return to previous view. Forward button should restore the navigation.
