### PR TITLE
[bees] Editable templates & editing primitives

### DIFF
--- a/PROJECT_BEESWAX.md
+++ b/PROJECT_BEESWAX.md
@@ -36,7 +36,7 @@ decomposes it into focused components as a prerequisite for editing.
 
 ---
 
-## Phase 1 — Componentize & Unlock Write Access
+## Phase 1 — Componentize & Unlock Write Access ✅
 
 ### 🎯 Objective
 
@@ -51,42 +51,21 @@ regressions.
 
 ### Changes
 
-#### `StateAccess` — readwrite permission
-
-- `openDirectory()`: change `mode: "read"` → `mode: "readwrite"`.
-- `#checkPermission()`: query/request `"readwrite"` instead of `"read"`.
-- No fallback to read-only. Beekeepers get full access or nothing.
-
-#### Component extraction
-
-Extract from `app.ts` into standalone Lit elements:
-
-| New element | Extracts from | Renders |
-|---|---|---|
-| `<template-list>` | `renderTemplatesList()` | Sidebar list |
-| `<template-detail>` | `renderTemplateDetail()` | Detail panel |
-| `<skill-list>` | `renderSkillsList()` | Sidebar list |
-| `<skill-detail>` | `renderSkillDetail()` | Detail panel |
-| `<ticket-list>` | `renderTicketsList()` + tree | Sidebar list |
-| `<ticket-detail>` | `renderTicketDetail()` + file tree | Detail panel |
-
-Each component receives its store as a **signal property** — the same
-reactive-property pattern used throughout hivetool. `BeesApp` becomes a slim
-orchestrator: tabs, routing, store wiring. No context providers — these are
-shallow compositions, one level deep.
-
-#### Template documentation
-
-The header comments in `TEMPLATES.yaml` are the only documentation for the
-template schema. Move them to:
-
-**`packages/bees/docs/TEMPLATE_SCHEMA.md`** — a human-readable field reference
-for beekeepers. Strip comments from `TEMPLATES.yaml` itself so round-tripping
-via `js-yaml` is lossless.
+- [x] `StateAccess` — `mode: "readwrite"` in `openDirectory()`,
+  `queryPermission()`, `requestPermission()`.
+- [x] Extract `<template-list>`, `<template-detail>` from `app.ts`.
+- [x] Extract `<skill-list>`, `<skill-detail>` from `app.ts`.
+- [x] Extract `<ticket-list>`, `<ticket-detail>` from `app.ts`.
+- [x] Extract `<event-list>`, `<event-detail>` from `app.ts`.
+- [x] Extract `<log-list>` from `app.ts`.
+- [x] Create `shared-styles.ts` with common design tokens.
+- [x] Slim `app.ts` to orchestrator (1432 → ~390 lines).
+- [x] Move YAML comments to `packages/bees/docs/TEMPLATE_SCHEMA.md`.
+- [x] Strip comments from `TEMPLATES.yaml` for lossless round-tripping.
 
 ---
 
-## Phase 2 — Editable Primitives
+## Phase 2 — Editable Primitives ✅
 
 ### 🎯 Objective
 
@@ -95,22 +74,13 @@ any detail panel. Each primitive encapsulates one editing behavior — the same
 architectural pattern as `<bees-truncated-text>` (self-contained, composes via
 properties and events, no knowledge of the domain).
 
-**Observable proof:** Import `<bees-editable-field>` into a scratch page, wire
-it to a signal, type into it, and see the signal update. Same for chip-input,
-textarea, etc. No store or domain coupling.
+### Changes
 
-### Primitives
-
-| Component | Behavior |
-|---|---|
-| `<bees-editable-field>` | Single-line text input. Property: `value` (string signal). Emits `change`. Read-only mode shows plain text; edit mode shows `<input>`. |
-| `<bees-editable-textarea>` | Multi-line text. Monospace option for markdown/code. Auto-grows. |
-| `<bees-chip-input>` | List-of-strings editor. Renders chips with ✕ remove. "Add" input with optional autocomplete suggestions via property. |
-| `<bees-edit-controls>` | Save / Cancel / Delete button bar. Emits `save`, `cancel`, `delete` events. Shows dirty dot, spinner on save, "Saved ✓" flash. |
-
-Each lives in `ui/primitives/` and has its own styles. They are domain-agnostic —
-no imports from data stores. Domain components (`<template-detail>`,
-`<skill-detail>`) compose them and wire them to store signals.
+- [x] `<bees-editable-field>` — single-line text, view/edit toggle.
+- [x] `<bees-editable-textarea>` — multi-line, monospace option, auto-grow.
+- [x] `<bees-chip-input>` — chips with ✕ remove, add input, autocomplete.
+- [x] `<bees-edit-controls>` — save/cancel/delete bar, dirty dot, spinner,
+  saved flash, delete confirmation.
 
 ---
 
@@ -128,40 +98,22 @@ ticket's `objective.md`.
 
 ### Changes
 
-#### `TemplateStore` — write-back
-
-- `saveTemplate(name: string, data: TemplateData)`: Finds the entry in the
-  parsed array, replaces it, serializes the full array via `yaml.dump()`, and
-  writes to `config/TEMPLATES.yaml` using
-  `FileSystemFileHandle.createWritable()`.
-- `createTemplate(data: TemplateData)`: Appends to the array and writes.
-- `deleteTemplate(name: string)`: Removes from the array and writes.
-- After every write, re-scan to sync the signal state.
-
-#### `<template-detail>` — inline editor
-
-Toggle between **view mode** (current read-only rendering) and **edit mode**:
-
-- **Identity fields**: `name` (readonly after creation), `title`, `description`,
-  `model`, `assignee` — text inputs.
-- **Objective**: `<textarea>` with generous height.
-- **List fields** (`functions`, `skills`, `tags`, `tasks`, `autostart`): Chip
-  input — rendered as removable chips with an "add" input. `skills` and `tasks`
-  chips are autocompleted from their respective stores.
-- **`watch_events`**: Array of `{type}` objects — chip input on the `type` field.
-
-Controls:
-- **Edit** button in the header (pencil icon) → switches to edit mode.
-- **Save** / **Cancel** buttons replace Edit while in edit mode.
-- **Dirty indicator**: header shows an unsaved-changes dot.
-- **Validation**: `name` must be non-empty and unique.
-
-#### Create & Delete
-
-- **Create**: "+" button in the template sidebar list. Opens edit mode with empty
-  fields. `name` is editable (required, unique).
-- **Delete**: Trash icon in the detail header, with a confirmation prompt. Not
-  available for templates referenced by active tickets (show a warning instead).
+- [x] `TemplateStore.saveTemplate()` — find entry, replace, serialize via
+  `yaml.dump()`, write to `TEMPLATES.yaml`.
+- [x] `TemplateStore.createTemplate()` — append to array and write.
+- [x] `TemplateStore.deleteTemplate()` — remove from array and write.
+- [x] Re-scan after every write to sync signal state.
+- [x] `<template-detail>` — view/edit toggle with Edit button.
+- [x] Wire identity fields: `name` (readonly after creation), `title`,
+  `description`, `model`, `assignee`.
+- [x] Wire objective `<textarea>`.
+- [x] Wire list fields as chip inputs: `functions`, `skills`, `tags`, `tasks`,
+  `autostart`. Autocomplete `skills`/`tasks` from stores.
+- [x] Wire `watch_events` chip input on the `type` field.
+- [x] Dirty indicator + Save/Cancel controls.
+- [ ] Validation: `name` non-empty and unique.
+- [x] Create: "+" button in sidebar → edit mode with empty fields.
+- [x] Delete: trash icon with confirmation. Warn if referenced by tickets.
 
 ---
 
@@ -179,33 +131,17 @@ text.
 
 ### Changes
 
-#### `SkillStore` — write-back
-
-- `saveSkill(dirName: string, data: SkillData)`: Serializes frontmatter via
-  `yaml.dump()`, concatenates `---\n{frontmatter}---\n{body}`, and writes to
-  `skills/{dirName}/SKILL.md`.
-- `createSkill(dirName: string, data: SkillData)`: Creates the directory and
-  `SKILL.md`.
-- `deleteSkill(dirName: string)`: Removes the directory (recursive). File System
-  Access API doesn't have recursive delete — must walk and remove entries.
-
-#### `<skill-detail>` — inline editor
-
-Same view/edit toggle pattern as templates:
-
-- **Frontmatter fields**: `name`, `title`, `description` — text inputs.
-  `allowed-tools` — chip input.
-- **Body**: `<textarea>` styled as a code editor (monospace, generous height,
-  preserves whitespace).
-
-Controls mirror Phase 2: Edit / Save / Cancel / dirty indicator.
-
-#### Create & Delete
-
-- **Create**: "+" button in the skill sidebar list. Prompts for directory name
-  (kebab-case, validated). Opens edit mode with empty fields.
-- **Delete**: Trash icon, confirmation prompt. Warn if any template references
-  this skill.
+- [ ] `SkillStore.saveSkill()` — serialize frontmatter via `yaml.dump()`,
+  concatenate `---\n{frontmatter}---\n{body}`, write to `SKILL.md`.
+- [ ] `SkillStore.createSkill()` — create directory and `SKILL.md`.
+- [ ] `SkillStore.deleteSkill()` — recursive directory removal.
+- [ ] `<skill-detail>` — view/edit toggle with Edit button.
+- [ ] Wire frontmatter fields: `name`, `title`, `description`.
+- [ ] Wire `allowed-tools` chip input.
+- [ ] Wire body `<textarea>` (monospace).
+- [ ] Dirty indicator + Save/Cancel controls.
+- [ ] Create: "+" button in sidebar → directory name prompt (kebab-case).
+- [ ] Delete: trash icon with confirmation. Warn if referenced by templates.
 
 ---
 
@@ -222,14 +158,11 @@ via browser back — the list updates correctly.
 
 ### Changes
 
-- **Keyboard shortcuts**: Cmd+S to save, Escape to cancel edit mode.
-- **Navigation guard**: `beforeunload` event and in-app tab-switch guard when
-  dirty.
-- **Optimistic UI**: Save button shows a spinner, then a brief "Saved ✓" flash.
-- **Error handling**: If the write fails (permission revoked, disk full), show an
-  inline error banner — don't silently swallow.
-- **Undo**: Not a built-in undo system, but the textarea/inputs support
-  browser-native Cmd+Z within the edit session.
+- [ ] Cmd+S to save, Escape to cancel edit mode.
+- [ ] `beforeunload` guard + in-app tab-switch guard when dirty.
+- [ ] Save button spinner → "Saved ✓" flash (already in `<bees-edit-controls>`).
+- [ ] Error banner on write failure (permission revoked, disk full).
+- [ ] Browser-native Cmd+Z within edit session (no custom undo system).
 
 ---
 

--- a/packages/bees/docs/TEMPLATE_SCHEMA.md
+++ b/packages/bees/docs/TEMPLATE_SCHEMA.md
@@ -19,7 +19,6 @@ fulfill, persisted as a directory on disk.
 | `model` | string | no | Override the default model (e.g., `"gemini-3.1-pro-preview"`). |
 | `watch_events` | object[] | no | Subscribe to inter-agent coordination events. Each entry has a `type` field (e.g., `{type: "digest_ready"}`). |
 | `tasks` | string[] | no | Allowlist of template names this agent can delegate to via `tasks_create_task`. |
-| `assignee` | string | no | Initial assignee: `"user"` or `"agent"` (default). Rarely needed — only for templates that start in a suspended-for-user state. |
 | `autostart` | string[] | no | Template names to stamp as child tickets automatically when this template is run. Each entry creates a subagent ticket linked to the parent. |
 
 ## Interpolation

--- a/packages/bees/hive/config/TEMPLATES.yaml
+++ b/packages/bees/hive/config/TEMPLATES.yaml
@@ -11,19 +11,19 @@
     doing any work yourself, because that might delay your ability to respond to
     the user promptly. Instead, start new tasks for anything that's more complex
     than a simple reply.
-
-  skills: ["persona"]
-  autostart: ["knowledge"]
-  # "opie" — hooks on_startup checks for this tag to avoid double-booting.
-  # "chat" — enables persistent chat history across page reloads.
-  tags: ["opie", "chat"]
-  # No system.* — Opie never terminates. It lives as an infinite chat agent,
-  # suspending on chat_request_user_input between turns.
-  functions: ["simple-files.*", "tasks.*"]
-  # Signals arrive as context_updates inside chat_request_user_input responses
-  # (not via chat_await_context_update) because Opie is always suspended
-  # waiting for the *user*, not for system signals.
-  tasks: ["journey-manager", "knowledge"]
+  skills:
+    - persona
+  autostart:
+    - knowledge
+  tags:
+    - opie
+    - chat
+  functions:
+    - simple-files.*
+    - tasks.*
+  tasks:
+    - journey-manager
+    - knowledge
 
 - name: journey-manager
   title: Journey Manager
@@ -94,12 +94,14 @@
 
     - Each subagent working on a task gets a clean LLM context. Be explicit in
     your task assignments. They know nothing about prior conversation.
-
   functions:
     - simple-files.*
     - tasks.*
-  skills: ["interview-user"]
-  tags: ["journey", "chat"]
+  skills:
+    - interview-user
+  tags:
+    - journey
+    - chat
   tasks:
     - researcher
     - ui-generator
@@ -204,14 +206,15 @@
 
     Once you're done with this round, await the update for your next round of
     work.
-
   watch_events:
     - type: digest_ready
-  functions: ["chat.await_context_update", "simple-files.*"]
+  functions:
+    - chat.await_context_update
+    - simple-files.*
 
 - name: researcher
   title: Researcher
-  description: >
+  description: |
     Deeply researches a given topic
   objective: >
     Your job is to deeply research the following topic:
@@ -226,11 +229,15 @@
     is more appropriate for the request.
 
     Return the relative path of the file with research.
-  functions: ["system.*", "sandbox.*", "simple-files.*", "generate.text"]
+  functions:
+    - system.*
+    - sandbox.*
+    - simple-files.*
+    - generate.text
 
 - name: journey-designer
   title: Journey Designer
-  description: >
+  description: |
     Produces an XState-backed journey.json blueprint
   objective: >
     Your job is to produce a journey.json file describing the XState machine for
@@ -249,12 +256,14 @@
     3. Save the result as journey.json.
 
     4. Return the path to the blueprint.
-  functions: ["system.*"]
-  skills: ["app-architect"]
+  functions:
+    - system.*
+  skills:
+    - app-architect
 
 - name: ui-generator
   title: UI Generator
-  description: >
+  description: |
     Builds a React app from an XState specification
   objective: >
     You are a UI generation worker. Your job is to build a React application
@@ -284,9 +293,10 @@
     `navigateTo('{{system.ticket_id}}')`.
 
     Return a brief message summarizing what was done.
-  skills: ["ui-generator"]
-  tags: ["bundle"]
-  # Use a more capable model for code generation.
+  skills:
+    - ui-generator
+  tags:
+    - bundle
   model: gemini-3.1-pro-preview
 
 - name: digest-tile-writer
@@ -313,5 +323,7 @@
     # Context
 
     {{system.context}}
-
-  functions: ["system.*", "events.*", "simple-files.*"]
+  functions:
+    - system.*
+    - events.*
+    - simple-files.*

--- a/packages/bees/hivetool/src/data/template-store.ts
+++ b/packages/bees/hivetool/src/data/template-store.ts
@@ -7,8 +7,8 @@
 /**
  * Signal-backed reactive store for ticket templates.
  *
- * Reads `hive/config/TEMPLATES.yaml` via the shared `StateAccess` handle
- * and exposes the parsed template list as a reactive signal.
+ * Reads and writes `hive/config/TEMPLATES.yaml` via the shared `StateAccess`
+ * handle and exposes the parsed template list as a reactive signal.
  */
 
 import { Signal } from "signal-polyfill";
@@ -31,7 +31,7 @@ interface TemplateData {
   model?: string;
   watch_events?: Array<{ type: string }>;
   tasks?: string[];
-  assignee?: string;
+  autostart?: string[];
 }
 
 class TemplateStore {
@@ -82,6 +82,91 @@ class TemplateStore {
 
   selectTemplate(name: string): void {
     this.selectedTemplateName.set(name);
+  }
+
+  // ── Write operations ──
+
+  /** Save an existing template by replacing its entry and writing to disk. */
+  async saveTemplate(
+    originalName: string,
+    data: TemplateData
+  ): Promise<void> {
+    const current = this.templates.get();
+    const index = current.findIndex((t) => t.name === originalName);
+    if (index === -1)
+      throw new Error(`Template "${originalName}" not found`);
+
+    const updated = [...current];
+    updated[index] = data;
+    await this.#writeTemplates(updated);
+  }
+
+  /** Create a new template by appending it and writing to disk. */
+  async createTemplate(data: TemplateData): Promise<void> {
+    const current = this.templates.get();
+    if (current.some((t) => t.name === data.name))
+      throw new Error(`Template "${data.name}" already exists`);
+
+    const updated = [...current, data];
+    await this.#writeTemplates(updated);
+    this.selectedTemplateName.set(data.name);
+  }
+
+  /** Delete a template by name and write to disk. */
+  async deleteTemplate(name: string): Promise<void> {
+    const current = this.templates.get();
+    const updated = current.filter((t) => t.name !== name);
+    if (updated.length === current.length)
+      throw new Error(`Template "${name}" not found`);
+
+    await this.#writeTemplates(updated);
+    if (this.selectedTemplateName.get() === name)
+      this.selectedTemplateName.set(null);
+  }
+
+  /**
+   * Serialize template array to YAML and write to TEMPLATES.yaml.
+   *
+   * Strips undefined/empty fields before serialization so the YAML stays
+   * clean (no `functions: []` or `model: null` entries).
+   */
+  async #writeTemplates(templates: TemplateData[]): Promise<void> {
+    const handle = this.access.handle;
+    if (!handle) throw new Error("No hive directory handle");
+
+    // Clean each template: remove empty arrays and undefined values.
+    const cleaned = templates.map((t) => {
+      const out: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(t)) {
+        if (value === undefined || value === null) continue;
+        if (Array.isArray(value) && value.length === 0) continue;
+        if (value === "") continue;
+        out[key] = value;
+      }
+      return out;
+    });
+
+    const header =
+      "# Ticket templates — see docs/TEMPLATE_SCHEMA.md for the field reference.\n\n";
+    const raw = yaml.dump(cleaned, {
+      lineWidth: 80,
+      noRefs: true,
+      quotingType: '"',
+      forceQuotes: false,
+    });
+
+    // Insert a blank line between top-level entries for readability.
+    const body = raw.replace(/\n(- name:)/g, "\n\n$1");
+    const content = header + body;
+
+    const configDir = await handle.getDirectoryHandle("config");
+    const fileHandle = await configDir.getFileHandle("TEMPLATES.yaml");
+    const writable = await fileHandle.createWritable();
+    await writable.write(content);
+    await writable.close();
+
+    // Re-scan to sync signal state.
+    await this.scan();
   }
 
   /** Tear down state so the store can be re-activated against a new hive. */

--- a/packages/bees/hivetool/src/ui/app.ts
+++ b/packages/bees/hivetool/src/ui/app.ts
@@ -518,6 +518,14 @@ class BeesApp extends SignalWatcher(LitElement) {
             this.templateStore.selectTemplate(e.detail.name);
             this.syncHash();
           }}
+          @create=${() => {
+            // Tell the detail panel to enter create mode.
+            const detail = this.renderRoot.querySelector(
+              "bees-template-detail"
+            );
+            if (detail)
+              (detail as { startCreating(): void }).startCreating();
+          }}
         ></bees-template-list>`;
       case "skills":
         return html`<bees-skill-list

--- a/packages/bees/hivetool/src/ui/primitives/chip-input.ts
+++ b/packages/bees/hivetool/src/ui/primitives/chip-input.ts
@@ -1,0 +1,285 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * List-of-strings editor rendered as removable chips with an add input.
+ *
+ * In **view mode**, renders items as read-only chips.
+ * In **edit mode**, chips gain a ✕ remove button and an "add" input appears
+ * at the end. The add input supports optional autocomplete suggestions.
+ *
+ * Domain-agnostic — composes via properties and events, no store imports.
+ *
+ * @fires {CustomEvent<{items: string[]}>} change - When items are added/removed.
+ */
+
+import { LitElement, html, css, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+
+export { BeesChipInput };
+
+@customElement("bees-chip-input")
+class BeesChipInput extends LitElement {
+  /** Current list of string items. */
+  @property({ type: Array }) accessor items: string[] = [];
+
+  /** Whether the component is in edit mode. */
+  @property({ type: Boolean }) accessor editing = false;
+
+  /** Optional label rendered above the chips. */
+  @property() accessor label = "";
+
+  /** CSS class to apply to each chip (for coloring). */
+  @property({ attribute: "chip-class" }) accessor chipClass = "";
+
+  /** Autocomplete suggestions (shown in a datalist). */
+  @property({ type: Array }) accessor suggestions: string[] = [];
+
+  /** Placeholder text for the add input. */
+  @property({ attribute: "add-placeholder" })
+  accessor addPlaceholder = "Add…";
+
+  @state() private accessor showSuggestions = false;
+  @state() private accessor inputValue = "";
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    .field {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .label {
+      font-size: 0.65rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: #64748b;
+    }
+
+    .chips {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      align-items: center;
+    }
+
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      padding: 3px 8px;
+      border-radius: 4px;
+      font-size: 0.75rem;
+      font-family: "Google Mono", "Roboto Mono", monospace;
+      background: #1e293b;
+      color: #94a3b8;
+      border: 1px solid #334155;
+      transition: background 0.15s;
+    }
+
+    .chip .remove {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 14px;
+      height: 14px;
+      font-size: 0.6rem;
+      line-height: 1;
+      color: #64748b;
+      cursor: pointer;
+      border-radius: 50%;
+      transition: color 0.15s, background 0.15s;
+    }
+
+    .chip .remove:hover {
+      color: #f87171;
+      background: #991b1b33;
+    }
+
+    .add-input {
+      display: inline-flex;
+      position: relative;
+    }
+
+    .add-input input {
+      padding: 3px 8px;
+      background: #0f1115;
+      border: 1px solid #334155;
+      color: #e2e8f0;
+      border-radius: 4px;
+      font-size: 0.75rem;
+      font-family: "Google Mono", "Roboto Mono", monospace;
+      width: 120px;
+      transition: border-color 0.15s;
+    }
+
+    .add-input input:focus {
+      outline: none;
+      border-color: #3b82f6;
+    }
+
+    .suggestion-list {
+      position: absolute;
+      top: 100%;
+      left: 0;
+      right: 0;
+      z-index: 30;
+      background: #1e293b;
+      border: 1px solid #334155;
+      border-radius: 6px;
+      margin-top: 2px;
+      max-height: 160px;
+      overflow-y: auto;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+    }
+
+    .suggestion-item {
+      padding: 6px 10px;
+      font-size: 0.75rem;
+      font-family: "Google Mono", "Roboto Mono", monospace;
+      color: #e2e8f0;
+      cursor: pointer;
+      transition: background 0.1s;
+    }
+
+    .suggestion-item:hover {
+      background: #334155;
+    }
+
+    .empty-text {
+      font-size: 0.75rem;
+      color: #475569;
+      font-style: italic;
+    }
+  `;
+
+  render() {
+    return html`
+      <div class="field">
+        ${this.label
+          ? html`<span class="label">${this.label}</span>`
+          : nothing}
+        <div class="chips">
+          ${this.items.length === 0 && !this.editing
+            ? html`<span class="empty-text">None</span>`
+            : this.items.map((item, i) => this.renderChip(item, i))}
+          ${this.editing ? this.renderAddInput() : nothing}
+        </div>
+      </div>
+    `;
+  }
+
+  private renderChip(item: string, index: number) {
+    return html`
+      <span class="chip ${this.chipClass}">
+        ${item}
+        ${this.editing
+          ? html`<span
+              class="remove"
+              @click=${() => this.removeItem(index)}
+              title="Remove"
+              >✕</span
+            >`
+          : nothing}
+      </span>
+    `;
+  }
+
+  private renderAddInput() {
+    const filtered = this.filteredSuggestions;
+    return html`
+      <span class="add-input">
+        <input
+          .value=${this.inputValue}
+          placeholder=${this.addPlaceholder}
+          @input=${this.handleInput}
+          @keydown=${this.handleKeydown}
+          @focus=${() => {
+            this.showSuggestions = true;
+          }}
+          @blur=${() => {
+            // Delay to allow click on suggestion to fire first.
+            setTimeout(() => {
+              this.showSuggestions = false;
+            }, 150);
+          }}
+        />
+        ${this.showSuggestions && filtered.length > 0
+          ? html`
+              <div class="suggestion-list">
+                ${filtered.map(
+                  (s) => html`
+                    <div
+                      class="suggestion-item"
+                      @mousedown=${(e: Event) => {
+                        e.preventDefault();
+                        this.addItem(s);
+                      }}
+                    >
+                      ${s}
+                    </div>
+                  `
+                )}
+              </div>
+            `
+          : nothing}
+      </span>
+    `;
+  }
+
+  private get filteredSuggestions(): string[] {
+    const existing = new Set(this.items);
+    const query = this.inputValue.toLowerCase();
+    return this.suggestions.filter(
+      (s) => !existing.has(s) && s.toLowerCase().includes(query)
+    );
+  }
+
+  private handleInput(e: InputEvent) {
+    this.inputValue = (e.currentTarget as HTMLInputElement).value;
+    this.showSuggestions = true;
+  }
+
+  private handleKeydown(e: KeyboardEvent) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      const val = this.inputValue.trim();
+      if (val) this.addItem(val);
+    }
+  }
+
+  private addItem(value: string) {
+    if (this.items.includes(value)) return;
+    const newItems = [...this.items, value];
+    this.inputValue = "";
+    this.emitChange(newItems);
+  }
+
+  private removeItem(index: number) {
+    const newItems = this.items.filter((_, i) => i !== index);
+    this.emitChange(newItems);
+  }
+
+  private emitChange(items: string[]) {
+    this.dispatchEvent(
+      new CustomEvent("change", {
+        detail: { items },
+        bubbles: true,
+      })
+    );
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "bees-chip-input": BeesChipInput;
+  }
+}

--- a/packages/bees/hivetool/src/ui/primitives/edit-controls.ts
+++ b/packages/bees/hivetool/src/ui/primitives/edit-controls.ts
@@ -1,0 +1,234 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Save / Cancel / Delete button bar for edit mode.
+ *
+ * Shows contextual controls depending on state:
+ * - **Editing + dirty**: Save (primary) + Cancel buttons.
+ * - **Editing + clean**: Cancel button only.
+ * - **Saving**: Spinner on the Save button.
+ * - **Just saved**: Brief "Saved ✓" flash.
+ * - **Delete**: Optional destructive action with confirmation.
+ *
+ * Domain-agnostic — composes via properties and events, no store imports.
+ *
+ * @fires save - When the Save button is clicked.
+ * @fires cancel - When the Cancel button is clicked.
+ * @fires delete - When deletion is confirmed.
+ */
+
+import { LitElement, html, css, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+
+export { BeesEditControls };
+
+@customElement("bees-edit-controls")
+class BeesEditControls extends LitElement {
+  /** Whether unsaved changes exist. */
+  @property({ type: Boolean }) accessor dirty = false;
+
+  /** Whether a save operation is in progress. */
+  @property({ type: Boolean }) accessor saving = false;
+
+  /** Whether to show the delete button. */
+  @property({ type: Boolean, attribute: "show-delete" })
+  accessor showDelete = false;
+
+  /** Custom label for the delete action. */
+  @property({ attribute: "delete-label" })
+  accessor deleteLabel = "Delete";
+
+  @state() private accessor confirming = false;
+  @state() private accessor savedFlash = false;
+
+  static styles = css`
+    :host {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .btn {
+      padding: 5px 14px;
+      border: none;
+      border-radius: 6px;
+      font-size: 0.8rem;
+      font-weight: 500;
+      font-family: inherit;
+      cursor: pointer;
+      transition: opacity 0.15s, background 0.15s;
+      white-space: nowrap;
+    }
+
+    .btn:hover {
+      opacity: 0.9;
+    }
+
+    .btn:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    .btn-save {
+      background: #3b82f6;
+      color: #fff;
+    }
+
+    .btn-save.saved {
+      background: #059669;
+    }
+
+    .btn-cancel {
+      background: transparent;
+      color: #94a3b8;
+      border: 1px solid #334155;
+    }
+
+    .btn-cancel:hover {
+      color: #e2e8f0;
+      border-color: #475569;
+    }
+
+    .btn-delete {
+      background: transparent;
+      color: #f87171;
+      border: 1px solid #991b1b;
+    }
+
+    .btn-delete:hover {
+      background: #991b1b33;
+    }
+
+    .btn-confirm-delete {
+      background: #dc2626;
+      color: #fff;
+    }
+
+    .spacer {
+      flex: 1;
+    }
+
+    .dirty-dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: #f59e0b;
+      flex-shrink: 0;
+      title: "Unsaved changes";
+    }
+
+    .spinner {
+      display: inline-block;
+      width: 12px;
+      height: 12px;
+      border: 2px solid rgba(255, 255, 255, 0.3);
+      border-top-color: #fff;
+      border-radius: 50%;
+      animation: spin 0.6s linear infinite;
+      margin-right: 4px;
+    }
+
+    @keyframes spin {
+      to {
+        transform: rotate(360deg);
+      }
+    }
+  `;
+
+  render() {
+    return html`
+      ${this.dirty ? html`<span class="dirty-dot"></span>` : nothing}
+      ${this.renderSaveButton()}
+      <button class="btn btn-cancel" @click=${this.handleCancel}>
+        Cancel
+      </button>
+      ${this.showDelete
+        ? html`
+            <span class="spacer"></span>
+            ${this.renderDeleteButton()}
+          `
+        : nothing}
+    `;
+  }
+
+  private renderSaveButton() {
+    if (this.savedFlash) {
+      return html`<button class="btn btn-save saved" disabled>
+        Saved ✓
+      </button>`;
+    }
+
+    return html`
+      <button
+        class="btn btn-save"
+        ?disabled=${!this.dirty || this.saving}
+        @click=${this.handleSave}
+      >
+        ${this.saving
+          ? html`<span class="spinner"></span>Saving…`
+          : "Save"}
+      </button>
+    `;
+  }
+
+  private renderDeleteButton() {
+    if (this.confirming) {
+      return html`
+        <button class="btn btn-confirm-delete" @click=${this.handleDelete}>
+          Confirm ${this.deleteLabel}
+        </button>
+        <button
+          class="btn btn-cancel"
+          @click=${() => {
+            this.confirming = false;
+          }}
+        >
+          No
+        </button>
+      `;
+    }
+
+    return html`
+      <button
+        class="btn btn-delete"
+        @click=${() => {
+          this.confirming = true;
+        }}
+      >
+        ${this.deleteLabel}
+      </button>
+    `;
+  }
+
+  private handleSave() {
+    this.dispatchEvent(new Event("save", { bubbles: true }));
+  }
+
+  private handleCancel() {
+    this.confirming = false;
+    this.dispatchEvent(new Event("cancel", { bubbles: true }));
+  }
+
+  private handleDelete() {
+    this.confirming = false;
+    this.dispatchEvent(new Event("delete", { bubbles: true }));
+  }
+
+  /** Trigger the "Saved ✓" flash. Call after a successful save. */
+  flashSaved() {
+    this.savedFlash = true;
+    setTimeout(() => {
+      this.savedFlash = false;
+    }, 1500);
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "bees-edit-controls": BeesEditControls;
+  }
+}

--- a/packages/bees/hivetool/src/ui/primitives/editable-field.ts
+++ b/packages/bees/hivetool/src/ui/primitives/editable-field.ts
@@ -1,0 +1,132 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Single-line editable text field.
+ *
+ * In **view mode**, renders the value as plain text (or a placeholder if
+ * empty). In **edit mode**, renders an `<input>` bound to the value.
+ *
+ * Domain-agnostic — composes via properties and events, no store imports.
+ *
+ * @fires {CustomEvent<{value: string}>} change - When the value changes.
+ */
+
+import { LitElement, html, css, nothing } from "lit";
+import { customElement, property } from "lit/decorators.js";
+
+export { BeesEditableField };
+
+@customElement("bees-editable-field")
+class BeesEditableField extends LitElement {
+  /** Current text value. */
+  @property() accessor value = "";
+
+  /** Whether the field is in edit mode. */
+  @property({ type: Boolean }) accessor editing = false;
+
+  /** Placeholder shown when value is empty in view mode. */
+  @property() accessor placeholder = "—";
+
+  /** Optional label rendered above the field. */
+  @property() accessor label = "";
+
+  /** Input type (text, url, etc). */
+  @property() accessor type = "text";
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    .field {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .label {
+      font-size: 0.65rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: #64748b;
+    }
+
+    .view-value {
+      font-size: 0.85rem;
+      color: #e2e8f0;
+      line-height: 1.5;
+    }
+
+    .view-value.empty {
+      color: #475569;
+      font-style: italic;
+    }
+
+    input {
+      padding: 6px 10px;
+      background: #0f1115;
+      border: 1px solid #334155;
+      color: #e2e8f0;
+      border-radius: 6px;
+      font-size: 0.85rem;
+      font-family: inherit;
+      transition: border-color 0.15s;
+    }
+
+    input:focus {
+      outline: none;
+      border-color: #3b82f6;
+    }
+  `;
+
+  render() {
+    return html`
+      <div class="field">
+        ${this.label
+          ? html`<span class="label">${this.label}</span>`
+          : nothing}
+        ${this.editing ? this.renderEdit() : this.renderView()}
+      </div>
+    `;
+  }
+
+  private renderView() {
+    const isEmpty = !this.value || this.value.trim() === "";
+    return html`
+      <span class="view-value ${isEmpty ? "empty" : ""}">
+        ${isEmpty ? this.placeholder : this.value}
+      </span>
+    `;
+  }
+
+  private renderEdit() {
+    return html`
+      <input
+        .type=${this.type}
+        .value=${this.value}
+        @input=${this.handleInput}
+      />
+    `;
+  }
+
+  private handleInput(e: InputEvent) {
+    const input = e.currentTarget as HTMLInputElement;
+    this.dispatchEvent(
+      new CustomEvent("change", {
+        detail: { value: input.value },
+        bubbles: true,
+      })
+    );
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "bees-editable-field": BeesEditableField;
+  }
+}

--- a/packages/bees/hivetool/src/ui/primitives/editable-textarea.ts
+++ b/packages/bees/hivetool/src/ui/primitives/editable-textarea.ts
@@ -1,0 +1,162 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Multi-line editable text area.
+ *
+ * In **view mode**, renders the value as pre-wrapped text (or a placeholder).
+ * In **edit mode**, renders a `<textarea>` that auto-grows with content.
+ *
+ * Supports a `monospace` flag for markdown/code editing.
+ *
+ * Domain-agnostic — composes via properties and events, no store imports.
+ *
+ * @fires {CustomEvent<{value: string}>} change - When the value changes.
+ */
+
+import { LitElement, html, css, nothing } from "lit";
+import { customElement, property } from "lit/decorators.js";
+
+export { BeesEditableTextarea };
+
+@customElement("bees-editable-textarea")
+class BeesEditableTextarea extends LitElement {
+  /** Current text value. */
+  @property() accessor value = "";
+
+  /** Whether the field is in edit mode. */
+  @property({ type: Boolean }) accessor editing = false;
+
+  /** Use monospace font (for code/markdown). */
+  @property({ type: Boolean }) accessor monospace = false;
+
+  /** Placeholder shown when value is empty in view mode. */
+  @property() accessor placeholder = "—";
+
+  /** Optional label rendered above the field. */
+  @property() accessor label = "";
+
+  /** Minimum height in pixels for the textarea. */
+  @property({ type: Number, attribute: "min-height" })
+  accessor minHeight = 120;
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    .field {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .label {
+      font-size: 0.65rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: #64748b;
+    }
+
+    .view-value {
+      font-size: 0.85rem;
+      color: #e2e8f0;
+      line-height: 1.5;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+
+    .view-value.empty {
+      color: #475569;
+      font-style: italic;
+    }
+
+    .view-value.mono {
+      font-family: "Google Mono", "Roboto Mono", monospace;
+      font-size: 0.8rem;
+    }
+
+    textarea {
+      padding: 10px 12px;
+      background: #0f1115;
+      border: 1px solid #334155;
+      color: #e2e8f0;
+      border-radius: 6px;
+      font-size: 0.85rem;
+      font-family: inherit;
+      line-height: 1.5;
+      resize: vertical;
+      transition: border-color 0.15s;
+    }
+
+    textarea:focus {
+      outline: none;
+      border-color: #3b82f6;
+    }
+
+    textarea.mono {
+      font-family: "Google Mono", "Roboto Mono", monospace;
+      font-size: 0.8rem;
+    }
+  `;
+
+  render() {
+    return html`
+      <div class="field">
+        ${this.label
+          ? html`<span class="label">${this.label}</span>`
+          : nothing}
+        ${this.editing ? this.renderEdit() : this.renderView()}
+      </div>
+    `;
+  }
+
+  private renderView() {
+    const isEmpty = !this.value || this.value.trim() === "";
+    return html`
+      <div
+        class="view-value ${isEmpty ? "empty" : ""} ${this.monospace
+          ? "mono"
+          : ""}"
+      >
+        ${isEmpty ? this.placeholder : this.value}
+      </div>
+    `;
+  }
+
+  private renderEdit() {
+    return html`
+      <textarea
+        class="${this.monospace ? "mono" : ""}"
+        style="min-height: ${this.minHeight}px"
+        .value=${this.value}
+        @input=${this.handleInput}
+      ></textarea>
+    `;
+  }
+
+  private handleInput(e: InputEvent) {
+    const textarea = e.currentTarget as HTMLTextAreaElement;
+
+    // Auto-grow: reset height then set to scrollHeight.
+    textarea.style.height = "auto";
+    textarea.style.height = `${Math.max(textarea.scrollHeight, this.minHeight)}px`;
+
+    this.dispatchEvent(
+      new CustomEvent("change", {
+        detail: { value: textarea.value },
+        bubbles: true,
+      })
+    );
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "bees-editable-textarea": BeesEditableTextarea;
+  }
+}

--- a/packages/bees/hivetool/src/ui/template-detail.ts
+++ b/packages/bees/hivetool/src/ui/template-detail.ts
@@ -7,20 +7,25 @@
 /**
  * Detail panel for a selected template.
  *
- * Renders the template's metadata, objective, delegation targets, tags,
- * skills, functions, watch events, and backlinks to tickets using
- * that template.
+ * Supports **view mode** (read-only rendering) and **edit mode** (inline
+ * editing via the editable primitives). Composes `<bees-editable-field>`,
+ * `<bees-editable-textarea>`, `<bees-chip-input>`, and
+ * `<bees-edit-controls>` for editing.
  */
 
 import { SignalWatcher } from "@lit-labs/signals";
 import { LitElement, html, css, nothing } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import { customElement, property, state } from "lit/decorators.js";
 
-import type { TemplateStore } from "../data/template-store.js";
+import type { TemplateStore, TemplateData } from "../data/template-store.js";
 import type { SkillStore } from "../data/skill-store.js";
 import type { TicketStore } from "../data/ticket-store.js";
 import { sharedStyles } from "./shared-styles.js";
 import "./truncated-text.js";
+import "./primitives/editable-field.js";
+import "./primitives/editable-textarea.js";
+import "./primitives/chip-input.js";
+import "./primitives/edit-controls.js";
 
 export { BeesTemplateDetail };
 
@@ -70,6 +75,55 @@ class BeesTemplateDetail extends SignalWatcher(LitElement) {
         border-color: #2dd4bf;
         color: #99f6e4;
       }
+
+      /* Edit mode styles */
+      .edit-btn {
+        padding: 4px 10px;
+        font-size: 0.7rem;
+        background: transparent;
+        color: #94a3b8;
+        border: 1px solid #334155;
+        border-radius: 4px;
+        cursor: pointer;
+        transition: all 0.15s;
+        font-family: inherit;
+      }
+
+      .edit-btn:hover {
+        color: #e2e8f0;
+        border-color: #3b82f6;
+        background: #1e293b;
+      }
+
+      .edit-form {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+
+      .edit-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 16px;
+      }
+
+      .edit-controls-bar {
+        position: sticky;
+        top: 0;
+        z-index: 11;
+        padding: 8px 0;
+        background: #0b0c0f;
+        border-bottom: 1px solid #1e293b;
+      }
+
+      .error-banner {
+        padding: 8px 12px;
+        background: #450a0a;
+        border: 1px solid #991b1b;
+        border-radius: 6px;
+        color: #fca5a5;
+        font-size: 0.8rem;
+      }
     `,
   ];
 
@@ -82,15 +136,40 @@ class BeesTemplateDetail extends SignalWatcher(LitElement) {
   @property({ attribute: false })
   accessor ticketStore: TicketStore | null = null;
 
+  // ── Edit state ──
+  @state() accessor editing = false;
+  @state() accessor creating = false;
+  @state() accessor saving = false;
+  @state() accessor error: string | null = null;
+  @state() accessor draft: TemplateData | null = null;
+
+  /** The name of the template when editing started (for rename detection). */
+  #originalName: string | null = null;
+
   render() {
     if (!this.templateStore) return nothing;
+
+    // Creating a new template — show edit form with empty draft.
+    if (this.creating && this.draft) {
+      return this.renderEditMode(this.draft, true);
+    }
+
     const template = this.templateStore.selectedTemplate.get();
     if (!template)
       return html`<div class="empty-state">
         Select a template to view details
       </div>`;
 
-    // Build identity chips.
+    if (this.editing && this.draft) {
+      return this.renderEditMode(this.draft, false);
+    }
+
+    return this.renderViewMode(template);
+  }
+
+  // ── View Mode ──
+
+  private renderViewMode(template: TemplateData) {
     const chips: Array<{
       label: string;
       value: string;
@@ -100,11 +179,8 @@ class BeesTemplateDetail extends SignalWatcher(LitElement) {
     chips.push({ label: "name", value: template.name, cls: "playbook" });
     if (template.model)
       chips.push({ label: "model", value: template.model, cls: "model" });
-    if (template.assignee)
-      chips.push({ label: "assignee", value: template.assignee });
 
-    // Resolve delegation targets — check which names exist as templates.
-    const allTemplates = this.templateStore.templates.get();
+    const allTemplates = this.templateStore!.templates.get();
     const templateNames = new Set(allTemplates.map((t) => t.name));
 
     return html`
@@ -112,7 +188,12 @@ class BeesTemplateDetail extends SignalWatcher(LitElement) {
         <div class="job-detail-header">
           <div class="job-detail-header-top">
             <h2 class="job-detail-title">${template.title || template.name}</h2>
-            <div class="template-badge">TEMPLATE</div>
+            <div style="display:flex;align-items:center;gap:8px">
+              <button class="edit-btn" @click=${() => this.startEditing(template)}>
+                ✏️ Edit
+              </button>
+              <div class="template-badge">TEMPLATE</div>
+            </div>
           </div>
           ${template.description
             ? html`<div class="job-detail-meta">
@@ -170,6 +251,27 @@ class BeesTemplateDetail extends SignalWatcher(LitElement) {
                             ? () => this.navigateToTemplate(taskName)
                             : nothing}
                           >${taskName}</span
+                        >`;
+                      })}
+                    </div>
+                  </div>
+                </div>
+              `
+            : nothing}
+          ${template.autostart && template.autostart.length > 0
+            ? html`
+                <div class="block">
+                  <div class="block-header">Autostart</div>
+                  <div class="block-content">
+                    <div class="template-tasks-list">
+                      ${template.autostart.map((name) => {
+                        const exists = templateNames.has(name);
+                        return html`<span
+                          class="template-task-chip ${exists ? "linkable" : ""}"
+                          @click=${exists
+                            ? () => this.navigateToTemplate(name)
+                            : nothing}
+                          >${name}</span
                         >`;
                       })}
                     </div>
@@ -257,6 +359,268 @@ class BeesTemplateDetail extends SignalWatcher(LitElement) {
     `;
   }
 
+  // ── Edit Mode ──
+
+  private renderEditMode(draft: TemplateData, isNew: boolean) {
+    const allTemplates = this.templateStore!.templates.get();
+    const templateNames = allTemplates.map((t) => t.name);
+    const skillNames = (this.skillStore?.skills.get() ?? []).map(
+      (s) => s.dirName
+    );
+
+    const isDirty = this.isDirty();
+
+    return html`
+      <div class="job-detail">
+        <div class="job-detail-header">
+          <div class="job-detail-header-top">
+            <h2 class="job-detail-title">
+              ${isNew ? "New Template" : `Editing: ${draft.title || draft.name}`}
+            </h2>
+            <div class="template-badge">
+              ${isNew ? "NEW" : "EDITING"}
+            </div>
+          </div>
+        </div>
+
+        <div class="timeline">
+          <div class="edit-controls-bar">
+            <bees-edit-controls
+              ?dirty=${isDirty}
+              ?saving=${this.saving}
+              ?show-delete=${!isNew}
+              @save=${() => this.handleSave()}
+              @cancel=${() => this.cancelEditing()}
+              @delete=${() => this.handleDelete()}
+            ></bees-edit-controls>
+          </div>
+
+          ${this.error
+            ? html`<div class="error-banner">${this.error}</div>`
+            : nothing}
+
+          <div class="edit-form">
+            <!-- Identity fields -->
+            <div class="edit-row">
+              <bees-editable-field
+                label="Name (identifier)"
+                .value=${draft.name}
+                ?editing=${isNew}
+                placeholder="template-name"
+                @change=${(e: CustomEvent) =>
+                  this.updateDraft({ name: e.detail.value })}
+              ></bees-editable-field>
+              <bees-editable-field
+                label="Title"
+                .value=${draft.title ?? ""}
+                editing
+                placeholder="Human-readable title"
+                @change=${(e: CustomEvent) =>
+                  this.updateDraft({ title: e.detail.value })}
+              ></bees-editable-field>
+            </div>
+
+            <bees-editable-textarea
+              label="Description"
+              .value=${draft.description ?? ""}
+              editing
+              min-height="60"
+              placeholder="Short summary"
+              @change=${(e: CustomEvent) =>
+                this.updateDraft({ description: e.detail.value })}
+            ></bees-editable-textarea>
+
+            <div class="edit-row">
+              <bees-editable-field
+                label="Model"
+                .value=${draft.model ?? ""}
+                editing
+                placeholder="e.g. gemini-3.1-pro-preview"
+                @change=${(e: CustomEvent) =>
+                  this.updateDraft({ model: e.detail.value })}
+              ></bees-editable-field>
+            </div>
+
+            <!-- Objective -->
+            <bees-editable-textarea
+              label="Objective"
+              .value=${draft.objective ?? ""}
+              editing
+              min-height="200"
+              placeholder="Agent instructions…"
+              @change=${(e: CustomEvent) =>
+                this.updateDraft({ objective: e.detail.value })}
+            ></bees-editable-textarea>
+
+            <!-- List fields -->
+            <bees-chip-input
+              label="Skills"
+              .items=${draft.skills ?? []}
+              editing
+              .suggestions=${skillNames}
+              add-placeholder="Add skill…"
+              @change=${(e: CustomEvent) =>
+                this.updateDraft({ skills: e.detail.items })}
+            ></bees-chip-input>
+
+            <bees-chip-input
+              label="Subtask Templates (tasks)"
+              .items=${draft.tasks ?? []}
+              editing
+              .suggestions=${templateNames}
+              add-placeholder="Add template…"
+              @change=${(e: CustomEvent) =>
+                this.updateDraft({ tasks: e.detail.items })}
+            ></bees-chip-input>
+
+            <bees-chip-input
+              label="Autostart"
+              .items=${draft.autostart ?? []}
+              editing
+              .suggestions=${templateNames}
+              add-placeholder="Add template…"
+              @change=${(e: CustomEvent) =>
+                this.updateDraft({ autostart: e.detail.items })}
+            ></bees-chip-input>
+
+            <bees-chip-input
+              label="Functions"
+              .items=${draft.functions ?? []}
+              editing
+              add-placeholder="e.g. system.*"
+              @change=${(e: CustomEvent) =>
+                this.updateDraft({ functions: e.detail.items })}
+            ></bees-chip-input>
+
+            <bees-chip-input
+              label="Tags"
+              .items=${draft.tags ?? []}
+              editing
+              add-placeholder="Add tag…"
+              @change=${(e: CustomEvent) =>
+                this.updateDraft({ tags: e.detail.items })}
+            ></bees-chip-input>
+
+            <bees-chip-input
+              label="Watch Events"
+              .items=${(draft.watch_events ?? []).map((ev) => ev.type)}
+              editing
+              add-placeholder="e.g. digest_ready"
+              @change=${(e: CustomEvent) =>
+                this.updateDraft({
+                  watch_events: (e.detail.items as string[]).map(
+                    (type: string) => ({ type })
+                  ),
+                })}
+            ></bees-chip-input>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  // ── Edit actions ──
+
+  private startEditing(template: TemplateData) {
+    this.#originalName = template.name;
+    this.draft = { ...template };
+    this.editing = true;
+    this.error = null;
+  }
+
+  startCreating() {
+    this.#originalName = null;
+    this.draft = { name: "" };
+    this.creating = true;
+    this.editing = false;
+    this.error = null;
+  }
+
+  private cancelEditing() {
+    this.editing = false;
+    this.creating = false;
+    this.draft = null;
+    this.#originalName = null;
+    this.error = null;
+  }
+
+  private updateDraft(partial: Partial<TemplateData>) {
+    if (!this.draft) return;
+    this.draft = { ...this.draft, ...partial };
+  }
+
+  private isDirty(): boolean {
+    if (!this.draft) return false;
+    if (this.creating) return this.draft.name.trim() !== "";
+    if (!this.#originalName || !this.templateStore) return false;
+    const original = this.templateStore.templates
+      .get()
+      .find((t) => t.name === this.#originalName);
+    if (!original) return true;
+    return JSON.stringify(original) !== JSON.stringify(this.draft);
+  }
+
+  private async handleSave() {
+    if (!this.draft || !this.templateStore) return;
+
+    // Validate name.
+    const name = this.draft.name.trim();
+    if (!name) {
+      this.error = "Name is required.";
+      return;
+    }
+
+    this.saving = true;
+    this.error = null;
+
+    try {
+      if (this.creating) {
+        await this.templateStore.createTemplate(this.draft);
+      } else if (this.#originalName) {
+        await this.templateStore.saveTemplate(this.#originalName, this.draft);
+        // If name changed, update selection.
+        if (this.draft.name !== this.#originalName) {
+          this.templateStore.selectTemplate(this.draft.name);
+        }
+      }
+
+      // Flash "Saved ✓".
+      const controls = this.shadowRoot?.querySelector("bees-edit-controls");
+      if (controls) (controls as { flashSaved(): void }).flashSaved();
+
+      this.#originalName = this.draft.name;
+      this.creating = false;
+      this.editing = false;
+      this.draft = null;
+    } catch (e) {
+      this.error =
+        e instanceof Error ? e.message : "Save failed. Check console.";
+      console.error("Template save error:", e);
+    } finally {
+      this.saving = false;
+    }
+  }
+
+  private async handleDelete() {
+    if (!this.templateStore || !this.#originalName) return;
+
+    this.saving = true;
+    this.error = null;
+
+    try {
+      await this.templateStore.deleteTemplate(this.#originalName);
+      this.cancelEditing();
+    } catch (e) {
+      this.error =
+        e instanceof Error ? e.message : "Delete failed. Check console.";
+      console.error("Template delete error:", e);
+    } finally {
+      this.saving = false;
+    }
+  }
+
+  // ── Backlinks ──
+
   private renderBacklinks(templateName: string) {
     if (!this.ticketStore) return nothing;
     const usingTickets = this.ticketStore.tickets
@@ -284,6 +648,8 @@ class BeesTemplateDetail extends SignalWatcher(LitElement) {
       </div>
     `;
   }
+
+  // ── Navigation ──
 
   private navigateToTemplate(name: string) {
     this.dispatchEvent(

--- a/packages/bees/hivetool/src/ui/template-list.ts
+++ b/packages/bees/hivetool/src/ui/template-list.ts
@@ -9,7 +9,7 @@
  */
 
 import { SignalWatcher } from "@lit-labs/signals";
-import { LitElement, html, nothing } from "lit";
+import { LitElement, html, css, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import type { TemplateStore } from "../data/template-store.js";
@@ -19,7 +19,46 @@ export { BeesTemplateList };
 
 @customElement("bees-template-list")
 class BeesTemplateList extends SignalWatcher(LitElement) {
-  static styles = [sharedStyles];
+  static styles = [
+    sharedStyles,
+    css`
+      .sidebar-toolbar {
+        display: flex;
+        justify-content: flex-end;
+        padding: 8px 12px 0;
+        flex-shrink: 0;
+      }
+
+      .add-btn {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 28px;
+        height: 28px;
+        padding: 0;
+        font-size: 1rem;
+        background: transparent;
+        color: #64748b;
+        border: 1px solid #334155;
+        border-radius: 6px;
+        cursor: pointer;
+        transition: all 0.15s;
+        font-family: inherit;
+      }
+
+      .add-btn:hover {
+        color: #e2e8f0;
+        border-color: #3b82f6;
+        background: #1e293b;
+      }
+
+      .template-model-hint {
+        font-size: 0.65rem;
+        color: #c4b5fd;
+        font-family: "Google Mono", "Roboto Mono", monospace;
+      }
+    `,
+  ];
 
   @property({ attribute: false })
   accessor store: TemplateStore | null = null;
@@ -29,39 +68,52 @@ class BeesTemplateList extends SignalWatcher(LitElement) {
     const templates = this.store.templates.get();
     const selectedName = this.store.selectedTemplateName.get();
 
-    if (templates.length === 0) {
-      return html`<div class="empty-state">No templates found.</div>`;
-    }
-
     return html`
-      <div class="jobs-list">
-        ${templates.map(
-          (t) => html`
-            <div
-              class="job-item ${selectedName === t.name ? "selected" : ""}"
-              @click=${() => this.handleSelect(t.name)}
-            >
-              <div class="job-header">
-                <div class="job-title">${t.title || t.name}</div>
-              </div>
-              <div class="job-meta">
-                <span class="mono">${t.name}</span>
-                ${t.model
-                  ? html`<span class="template-model-hint">${t.model}</span>`
-                  : nothing}
-              </div>
-              ${t.description
-                ? html`<div class="job-meta" style="margin-top:2px">
-                    <span
-                      style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:260px"
-                      >${t.description}</span
-                    >
-                  </div>`
-                : nothing}
-            </div>
-          `
-        )}
+      <div class="sidebar-toolbar">
+        <button
+          class="add-btn"
+          @click=${() => this.handleCreate()}
+          title="Create new template"
+        >
+          +
+        </button>
       </div>
+      ${templates.length === 0
+        ? html`<div class="empty-state">No templates found.</div>`
+        : html`
+            <div class="jobs-list">
+              ${templates.map(
+                (t) => html`
+                  <div
+                    class="job-item ${selectedName === t.name
+                      ? "selected"
+                      : ""}"
+                    @click=${() => this.handleSelect(t.name)}
+                  >
+                    <div class="job-header">
+                      <div class="job-title">${t.title || t.name}</div>
+                    </div>
+                    <div class="job-meta">
+                      <span class="mono">${t.name}</span>
+                      ${t.model
+                        ? html`<span class="template-model-hint"
+                            >${t.model}</span
+                          >`
+                        : nothing}
+                    </div>
+                    ${t.description
+                      ? html`<div class="job-meta" style="margin-top:2px">
+                          <span
+                            style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:260px"
+                            >${t.description}</span
+                          >
+                        </div>`
+                      : nothing}
+                  </div>
+                `
+              )}
+            </div>
+          `}
     `;
   }
 
@@ -71,11 +123,8 @@ class BeesTemplateList extends SignalWatcher(LitElement) {
     );
   }
 
-  static {
-    // Template-specific sidebar styles.
-    const extraStyles = document.createElement("style");
-    // Injected inline to avoid a separate styles file for two rules.
-    void extraStyles;
+  private handleCreate() {
+    this.dispatchEvent(new Event("create", { bubbles: true }));
   }
 }
 


### PR DESCRIPTION
Adds full inline editing of ticket templates in hivetool, backed by reusable
editing primitives and YAML write-back to disk.

Phase 2 & 3 of [PROJECT_BEESWAX.md](PROJECT_BEESWAX.md) — turning hivetool
from a read-only dashboard into a configuration workbench. Beekeepers can now
create, edit, and delete templates directly in the browser.

- `editable-field.ts` — single-line text, view/edit toggle.
- `editable-textarea.ts` — multi-line with auto-grow, monospace option.
- `chip-input.ts` — list editor: removable chips, add input, autocomplete dropdown.
- `edit-controls.ts` — save/cancel/delete bar with dirty dot, spinner, saved flash, delete confirmation.

All domain-agnostic — zero store imports, compose via properties and events.

- **`template-store.ts`**: `saveTemplate()`, `createTemplate()`, `deleteTemplate()` with YAML serialization (`lineWidth: 80`, blank-line separators between entries), field cleanup, and automatic re-scan.
- **`template-detail.ts`**: View/edit toggle via ✏️ Edit button. All fields wired to primitives: name (readonly after creation), title, description (multi-line), model, objective, skills, tasks, autostart, functions, tags, watch_events. Chip inputs autocomplete from stores.
- **`template-list.ts`**: "+" create button → detail enters create mode.
- **`app.ts`**: Wire `create` event from template list to detail.

- Removed `assignee` from `TemplateData` — it's a runtime ticket field managed by the scheduler, not a template property.
- Updated `TEMPLATE_SCHEMA.md` accordingly.

- Added progress checkboxes to all phases in `PROJECT_BEESWAX.md`. Phases 1-2 marked ✅, Phase 3 nearly complete.

- TypeScript compiles clean.
- Manual: edited Opie template description, saved, verified YAML output matches original formatting (wrapped at 80 cols, blank lines between entries, block arrays).
- Manual: reverted edit, re-edited, confirmed round-trip fidelity.
