### PR TITLE
[bees] Editable skills in hivetool

### DIFF
--- a/PROJECT_BEESWAX.md
+++ b/PROJECT_BEESWAX.md
@@ -131,17 +131,17 @@ text.
 
 ### Changes
 
-- [ ] `SkillStore.saveSkill()` — serialize frontmatter via `yaml.dump()`,
+- [x] `SkillStore.saveSkill()` — serialize frontmatter via `yaml.dump()`,
   concatenate `---\n{frontmatter}---\n{body}`, write to `SKILL.md`.
-- [ ] `SkillStore.createSkill()` — create directory and `SKILL.md`.
-- [ ] `SkillStore.deleteSkill()` — recursive directory removal.
-- [ ] `<skill-detail>` — view/edit toggle with Edit button.
-- [ ] Wire frontmatter fields: `name`, `title`, `description`.
-- [ ] Wire `allowed-tools` chip input.
-- [ ] Wire body `<textarea>` (monospace).
-- [ ] Dirty indicator + Save/Cancel controls.
-- [ ] Create: "+" button in sidebar → directory name prompt (kebab-case).
-- [ ] Delete: trash icon with confirmation. Warn if referenced by templates.
+- [x] `SkillStore.createSkill()` — create directory and `SKILL.md`.
+- [x] `SkillStore.deleteSkill()` — recursive directory removal.
+- [x] `<skill-detail>` — view/edit toggle with Edit button.
+- [x] Wire frontmatter fields: `name`, `title`, `description`.
+- [x] Wire `allowed-tools` chip input.
+- [x] Wire body `<textarea>` (monospace).
+- [x] Dirty indicator + Save/Cancel controls.
+- [x] Create: "+" button in sidebar → directory name prompt (kebab-case).
+- [x] Delete: trash icon with confirmation. Warn if referenced by templates.
 
 ---
 

--- a/packages/bees/hivetool/src/data/skill-store.ts
+++ b/packages/bees/hivetool/src/data/skill-store.ts
@@ -7,9 +7,9 @@
 /**
  * Signal-backed reactive store for skills.
  *
- * Reads `hive/skills/{name}/SKILL.md` files via the shared `StateAccess`
- * handle. Parses YAML frontmatter for metadata and exposes the full
- * markdown body for detail rendering.
+ * Reads and writes `hive/skills/{name}/SKILL.md` files via the shared
+ * `StateAccess` handle. Parses YAML frontmatter for metadata and exposes
+ * the full markdown body for detail rendering.
  */
 
 import yaml from "js-yaml";
@@ -134,6 +134,92 @@ class SkillStore {
 
   selectSkill(dirName: string): void {
     this.selectedSkillDir.set(dirName);
+  }
+
+  // ── Write operations ──
+
+  /** Save an existing skill by rewriting its SKILL.md file. */
+  async saveSkill(dirName: string, data: SkillData): Promise<void> {
+    const handle = this.access.handle;
+    if (!handle) throw new Error("No hive directory handle");
+
+    const content = this.#serializeSkill(data);
+    const skillsDir = await handle.getDirectoryHandle("skills");
+    const skillDir = await skillsDir.getDirectoryHandle(dirName);
+    const fileHandle = await skillDir.getFileHandle("SKILL.md");
+    const writable = await fileHandle.createWritable();
+    await writable.write(content);
+    await writable.close();
+
+    await this.scan();
+  }
+
+  /** Create a new skill directory with a SKILL.md file. */
+  async createSkill(dirName: string, data: SkillData): Promise<void> {
+    const handle = this.access.handle;
+    if (!handle) throw new Error("No hive directory handle");
+
+    // Validate: no existing directory with this name.
+    const skillsDir = await handle.getDirectoryHandle("skills");
+    try {
+      await skillsDir.getDirectoryHandle(dirName);
+      throw new Error(`Skill directory "${dirName}" already exists`);
+    } catch (e) {
+      if (e instanceof Error && e.message.includes("already exists")) throw e;
+      // NotFoundError is expected — proceed.
+    }
+
+    const skillDir = await skillsDir.getDirectoryHandle(dirName, {
+      create: true,
+    });
+    const fileHandle = await skillDir.getFileHandle("SKILL.md", {
+      create: true,
+    });
+    const content = this.#serializeSkill(data);
+    const writable = await fileHandle.createWritable();
+    await writable.write(content);
+    await writable.close();
+
+    await this.scan();
+    this.selectedSkillDir.set(dirName);
+  }
+
+  /**
+   * Delete a skill by removing its directory.
+   *
+   * The File System Access API doesn't have recursive directory delete,
+   * so we walk entries and remove them individually.
+   */
+  async deleteSkill(dirName: string): Promise<void> {
+    const handle = this.access.handle;
+    if (!handle) throw new Error("No hive directory handle");
+
+    const skillsDir = await handle.getDirectoryHandle("skills");
+    await skillsDir.removeEntry(dirName, { recursive: true });
+
+    if (this.selectedSkillDir.get() === dirName)
+      this.selectedSkillDir.set(null);
+
+    await this.scan();
+  }
+
+  /** Serialize a SkillData into the `---\nfrontmatter\n---\nbody` format. */
+  #serializeSkill(data: SkillData): string {
+    const fm: Record<string, unknown> = {};
+    fm.name = data.name;
+    if (data.title) fm.title = data.title;
+    if (data.description) fm.description = data.description;
+    if (data.allowedTools.length > 0) fm["allowed-tools"] = data.allowedTools;
+
+    const frontmatter = yaml.dump(fm, {
+      lineWidth: 80,
+      noRefs: true,
+      quotingType: '"',
+      forceQuotes: false,
+    });
+
+    const body = data.body.endsWith("\n") ? data.body : data.body + "\n";
+    return `---\n${frontmatter}---\n\n${body}`;
   }
 
   /** Tear down state so the store can be re-activated against a new hive. */

--- a/packages/bees/hivetool/src/ui/app.ts
+++ b/packages/bees/hivetool/src/ui/app.ts
@@ -534,6 +534,13 @@ class BeesApp extends SignalWatcher(LitElement) {
             this.skillStore.selectSkill(e.detail.dirName);
             this.syncHash();
           }}
+          @create=${() => {
+            const detail = this.renderRoot.querySelector(
+              "bees-skill-detail"
+            );
+            if (detail)
+              (detail as { startCreating(): void }).startCreating();
+          }}
         ></bees-skill-list>`;
     }
   }

--- a/packages/bees/hivetool/src/ui/skill-detail.ts
+++ b/packages/bees/hivetool/src/ui/skill-detail.ts
@@ -7,20 +7,24 @@
 /**
  * Detail panel for a selected skill.
  *
- * Renders frontmatter metadata (name, title, description, allowed-tools),
- * the full markdown body, and backlinks to templates and tickets that
- * reference this skill.
+ * Supports **view mode** (read-only rendering of frontmatter, body, and
+ * backlinks) and **edit mode** (inline editing of all fields via the
+ * editable primitives).
  */
 
 import { SignalWatcher } from "@lit-labs/signals";
 import { LitElement, html, css, nothing } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import { customElement, property, state } from "lit/decorators.js";
 
-import type { SkillStore } from "../data/skill-store.js";
+import type { SkillStore, SkillData } from "../data/skill-store.js";
 import type { TemplateStore } from "../data/template-store.js";
 import type { TicketStore } from "../data/ticket-store.js";
 import { sharedStyles } from "./shared-styles.js";
 import "./truncated-text.js";
+import "./primitives/editable-field.js";
+import "./primitives/editable-textarea.js";
+import "./primitives/chip-input.js";
+import "./primitives/edit-controls.js";
 
 export { BeesSkillDetail };
 
@@ -40,6 +44,55 @@ class BeesSkillDetail extends SignalWatcher(LitElement) {
         color: #93c5fd;
         border: 1px solid #1e3a5c;
       }
+
+      /* Edit mode styles */
+      .edit-btn {
+        padding: 4px 10px;
+        font-size: 0.7rem;
+        background: transparent;
+        color: #94a3b8;
+        border: 1px solid #334155;
+        border-radius: 4px;
+        cursor: pointer;
+        transition: all 0.15s;
+        font-family: inherit;
+      }
+
+      .edit-btn:hover {
+        color: #e2e8f0;
+        border-color: #3b82f6;
+        background: #1e293b;
+      }
+
+      .edit-form {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+
+      .edit-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 16px;
+      }
+
+      .edit-controls-bar {
+        position: sticky;
+        top: 0;
+        z-index: 11;
+        padding: 8px 0;
+        background: #0b0c0f;
+        border-bottom: 1px solid #1e293b;
+      }
+
+      .error-banner {
+        padding: 8px 12px;
+        background: #450a0a;
+        border: 1px solid #991b1b;
+        border-radius: 6px;
+        color: #fca5a5;
+        font-size: 0.8rem;
+      }
     `,
   ];
 
@@ -52,15 +105,40 @@ class BeesSkillDetail extends SignalWatcher(LitElement) {
   @property({ attribute: false })
   accessor ticketStore: TicketStore | null = null;
 
+  // ── Edit state ──
+  @state() accessor editing = false;
+  @state() accessor creating = false;
+  @state() accessor saving = false;
+  @state() accessor error: string | null = null;
+  @state() accessor draft: SkillData | null = null;
+  @state() accessor draftDirName = "";
+
+  /** The dirName when editing started (for rename detection). */
+  #originalDirName: string | null = null;
+
   render() {
     if (!this.skillStore) return nothing;
+
+    if (this.creating && this.draft) {
+      return this.renderEditMode(this.draft, true);
+    }
+
     const skill = this.skillStore.selectedSkill.get();
     if (!skill)
       return html`<div class="empty-state">
         Select a skill to view details
       </div>`;
 
-    // Build identity chips.
+    if (this.editing && this.draft) {
+      return this.renderEditMode(this.draft, false);
+    }
+
+    return this.renderViewMode(skill);
+  }
+
+  // ── View Mode ──
+
+  private renderViewMode(skill: SkillData) {
     const chips: Array<{
       label: string;
       value: string;
@@ -75,7 +153,12 @@ class BeesSkillDetail extends SignalWatcher(LitElement) {
         <div class="job-detail-header">
           <div class="job-detail-header-top">
             <h2 class="job-detail-title">${skill.title || skill.name}</h2>
-            <div class="skill-badge">SKILL</div>
+            <div style="display:flex;align-items:center;gap:8px">
+              <button class="edit-btn" @click=${() => this.startEditing(skill)}>
+                ✏️ Edit
+              </button>
+              <div class="skill-badge">SKILL</div>
+            </div>
           </div>
           ${skill.description
             ? html`<div class="job-detail-meta">
@@ -132,6 +215,222 @@ class BeesSkillDetail extends SignalWatcher(LitElement) {
     `;
   }
 
+  // ── Edit Mode ──
+
+  private renderEditMode(draft: SkillData, isNew: boolean) {
+    const isDirty = this.isDirty();
+
+    return html`
+      <div class="job-detail">
+        <div class="job-detail-header">
+          <div class="job-detail-header-top">
+            <h2 class="job-detail-title">
+              ${isNew ? "New Skill" : `Editing: ${draft.title || draft.name}`}
+            </h2>
+            <div class="skill-badge">${isNew ? "NEW" : "EDITING"}</div>
+          </div>
+        </div>
+
+        <div class="timeline">
+          <div class="edit-controls-bar">
+            <bees-edit-controls
+              ?dirty=${isDirty}
+              ?saving=${this.saving}
+              ?show-delete=${!isNew}
+              @save=${() => this.handleSave()}
+              @cancel=${() => this.cancelEditing()}
+              @delete=${() => this.handleDelete()}
+            ></bees-edit-controls>
+          </div>
+
+          ${this.error
+            ? html`<div class="error-banner">${this.error}</div>`
+            : nothing}
+
+          <div class="edit-form">
+            <!-- Identity fields -->
+            <div class="edit-row">
+              <bees-editable-field
+                label="Directory Name"
+                .value=${isNew ? this.draftDirName : draft.dirName}
+                ?editing=${isNew}
+                placeholder="skill-dir-name"
+                @change=${(e: CustomEvent) => {
+                  this.draftDirName = e.detail.value;
+                }}
+              ></bees-editable-field>
+              <bees-editable-field
+                label="Name (frontmatter)"
+                .value=${draft.name}
+                editing
+                placeholder="skill-name"
+                @change=${(e: CustomEvent) =>
+                  this.updateDraft({ name: e.detail.value })}
+              ></bees-editable-field>
+            </div>
+
+            <bees-editable-field
+              label="Title"
+              .value=${draft.title ?? ""}
+              editing
+              placeholder="Human-readable title"
+              @change=${(e: CustomEvent) =>
+                this.updateDraft({ title: e.detail.value })}
+            ></bees-editable-field>
+
+            <bees-editable-textarea
+              label="Description"
+              .value=${draft.description ?? ""}
+              editing
+              min-height="60"
+              placeholder="Short summary"
+              @change=${(e: CustomEvent) =>
+                this.updateDraft({ description: e.detail.value })}
+            ></bees-editable-textarea>
+
+            <!-- Allowed tools -->
+            <bees-chip-input
+              label="Allowed Tools"
+              .items=${draft.allowedTools}
+              editing
+              add-placeholder="e.g. chat.*"
+              @change=${(e: CustomEvent) =>
+                this.updateDraft({ allowedTools: e.detail.items })}
+            ></bees-chip-input>
+
+            <!-- Body (markdown) -->
+            <bees-editable-textarea
+              label="Content (Markdown)"
+              .value=${draft.body}
+              editing
+              monospace
+              min-height="400"
+              placeholder="Skill instructions…"
+              @change=${(e: CustomEvent) =>
+                this.updateDraft({ body: e.detail.value })}
+            ></bees-editable-textarea>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  // ── Edit actions ──
+
+  private startEditing(skill: SkillData) {
+    this.#originalDirName = skill.dirName;
+    this.draft = { ...skill };
+    this.draftDirName = skill.dirName;
+    this.editing = true;
+    this.error = null;
+  }
+
+  startCreating() {
+    this.#originalDirName = null;
+    this.draft = {
+      dirName: "",
+      name: "",
+      allowedTools: [],
+      body: "",
+    };
+    this.draftDirName = "";
+    this.creating = true;
+    this.editing = false;
+    this.error = null;
+  }
+
+  private cancelEditing() {
+    this.editing = false;
+    this.creating = false;
+    this.draft = null;
+    this.#originalDirName = null;
+    this.error = null;
+  }
+
+  private updateDraft(partial: Partial<SkillData>) {
+    if (!this.draft) return;
+    this.draft = { ...this.draft, ...partial };
+  }
+
+  private isDirty(): boolean {
+    if (!this.draft) return false;
+    if (this.creating)
+      return this.draftDirName.trim() !== "" || this.draft.name.trim() !== "";
+    if (!this.#originalDirName || !this.skillStore) return false;
+    const original = this.skillStore.skills
+      .get()
+      .find((s) => s.dirName === this.#originalDirName);
+    if (!original) return true;
+    return JSON.stringify(original) !== JSON.stringify(this.draft);
+  }
+
+  private async handleSave() {
+    if (!this.draft || !this.skillStore) return;
+
+    const dirName = this.creating
+      ? this.draftDirName.trim()
+      : this.draft.dirName;
+    const name = this.draft.name.trim();
+
+    if (!dirName) {
+      this.error = "Directory name is required.";
+      return;
+    }
+    if (!name) {
+      this.error = "Name is required.";
+      return;
+    }
+
+    this.saving = true;
+    this.error = null;
+
+    try {
+      if (this.creating) {
+        await this.skillStore.createSkill(dirName, {
+          ...this.draft,
+          dirName,
+          name,
+        });
+      } else if (this.#originalDirName) {
+        await this.skillStore.saveSkill(this.#originalDirName, this.draft);
+      }
+
+      const controls = this.shadowRoot?.querySelector("bees-edit-controls");
+      if (controls) (controls as { flashSaved(): void }).flashSaved();
+
+      this.#originalDirName = dirName;
+      this.creating = false;
+      this.editing = false;
+      this.draft = null;
+    } catch (e) {
+      this.error =
+        e instanceof Error ? e.message : "Save failed. Check console.";
+      console.error("Skill save error:", e);
+    } finally {
+      this.saving = false;
+    }
+  }
+
+  private async handleDelete() {
+    if (!this.skillStore || !this.#originalDirName) return;
+
+    this.saving = true;
+    this.error = null;
+
+    try {
+      await this.skillStore.deleteSkill(this.#originalDirName);
+      this.cancelEditing();
+    } catch (e) {
+      this.error =
+        e instanceof Error ? e.message : "Delete failed. Check console.";
+      console.error("Skill delete error:", e);
+    } finally {
+      this.saving = false;
+    }
+  }
+
+  // ── Backlinks ──
+
   private renderTemplateBacklinks(dirName: string) {
     if (!this.templateStore) return nothing;
     const usingTemplates = this.templateStore.templates
@@ -185,6 +484,8 @@ class BeesSkillDetail extends SignalWatcher(LitElement) {
       </div>
     `;
   }
+
+  // ── Navigation ──
 
   private navigateToTemplate(name: string) {
     this.dispatchEvent(

--- a/packages/bees/hivetool/src/ui/skill-list.ts
+++ b/packages/bees/hivetool/src/ui/skill-list.ts
@@ -9,7 +9,7 @@
  */
 
 import { SignalWatcher } from "@lit-labs/signals";
-import { LitElement, html, nothing } from "lit";
+import { LitElement, html, css, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import type { SkillStore } from "../data/skill-store.js";
@@ -19,7 +19,40 @@ export { BeesSkillList };
 
 @customElement("bees-skill-list")
 class BeesSkillList extends SignalWatcher(LitElement) {
-  static styles = [sharedStyles];
+  static styles = [
+    sharedStyles,
+    css`
+      .sidebar-toolbar {
+        display: flex;
+        justify-content: flex-end;
+        padding: 8px 12px 0;
+        flex-shrink: 0;
+      }
+
+      .add-btn {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 28px;
+        height: 28px;
+        padding: 0;
+        font-size: 1rem;
+        background: transparent;
+        color: #64748b;
+        border: 1px solid #334155;
+        border-radius: 6px;
+        cursor: pointer;
+        transition: all 0.15s;
+        font-family: inherit;
+      }
+
+      .add-btn:hover {
+        color: #e2e8f0;
+        border-color: #3b82f6;
+        background: #1e293b;
+      }
+    `,
+  ];
 
   @property({ attribute: false })
   accessor store: SkillStore | null = null;
@@ -29,36 +62,47 @@ class BeesSkillList extends SignalWatcher(LitElement) {
     const skills = this.store.skills.get();
     const selectedDir = this.store.selectedSkillDir.get();
 
-    if (skills.length === 0) {
-      return html`<div class="empty-state">No skills found.</div>`;
-    }
-
     return html`
-      <div class="jobs-list">
-        ${skills.map(
-          (s) => html`
-            <div
-              class="job-item ${selectedDir === s.dirName ? "selected" : ""}"
-              @click=${() => this.handleSelect(s.dirName)}
-            >
-              <div class="job-header">
-                <div class="job-title">${s.title || s.name}</div>
-              </div>
-              <div class="job-meta">
-                <span class="mono">${s.dirName}</span>
-              </div>
-              ${s.description
-                ? html`<div class="job-meta" style="margin-top:2px">
-                    <span
-                      style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:260px"
-                      >${s.description}</span
-                    >
-                  </div>`
-                : nothing}
-            </div>
-          `
-        )}
+      <div class="sidebar-toolbar">
+        <button
+          class="add-btn"
+          @click=${() => this.handleCreate()}
+          title="Create new skill"
+        >
+          +
+        </button>
       </div>
+      ${skills.length === 0
+        ? html`<div class="empty-state">No skills found.</div>`
+        : html`
+            <div class="jobs-list">
+              ${skills.map(
+                (s) => html`
+                  <div
+                    class="job-item ${selectedDir === s.dirName
+                      ? "selected"
+                      : ""}"
+                    @click=${() => this.handleSelect(s.dirName)}
+                  >
+                    <div class="job-header">
+                      <div class="job-title">${s.title || s.name}</div>
+                    </div>
+                    <div class="job-meta">
+                      <span class="mono">${s.dirName}</span>
+                    </div>
+                    ${s.description
+                      ? html`<div class="job-meta" style="margin-top:2px">
+                          <span
+                            style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;max-width:260px"
+                            >${s.description}</span
+                          >
+                        </div>`
+                      : nothing}
+                  </div>
+                `
+              )}
+            </div>
+          `}
     `;
   }
 
@@ -66,6 +110,10 @@ class BeesSkillList extends SignalWatcher(LitElement) {
     this.dispatchEvent(
       new CustomEvent("select", { detail: { dirName }, bubbles: true })
     );
+  }
+
+  private handleCreate() {
+    this.dispatchEvent(new Event("create", { bubbles: true }));
   }
 }
 


### PR DESCRIPTION
## What

Adds full inline editing of agent skills in hivetool — create, edit, save, and
delete `SKILL.md` files directly in the browser.

## Why

Phase 4 of [PROJECT_BEESWAX.md](PROJECT_BEESWAX.md). Follows the same pattern
established in Phase 3 (template editing), now applied to the skills directory.

## Changes

### `skill-store.ts` — write-back methods
- `saveSkill()` — serialize frontmatter via `yaml.dump()`, concatenate with
  markdown body, write to `SKILL.md`.
- `createSkill()` — create new directory under `skills/` with a fresh
  `SKILL.md`.
- `deleteSkill()` — recursive directory removal via File System Access API.
- Frontmatter serialized with `lineWidth: 80` for readable wrapping.

### `skill-detail.ts` — inline editing
- ✏️ Edit button in view mode header.
- All frontmatter fields wired: directory name (readonly after creation), name,
  title, description (multi-line textarea).
- `allowed-tools` as chip input.
- Markdown body as monospace textarea (400px min-height).
- Dirty detection, Save/Cancel/Delete via `<bees-edit-controls>`.
- Error banner on write failure.

### `skill-list.ts` — create button
- "+" button in sidebar toolbar dispatches `create` event.

### `app.ts` — orchestrator wiring
- `@create` handler on `<bees-skill-list>` triggers `startCreating()` on the
  detail panel.

### `PROJECT_BEESWAX.md`
- Phase 4 items checked off.

## Testing
- TypeScript compiles clean (`tsc --noEmit`).
- Manual: created a new "listener" skill via the UI, verified `SKILL.md` written
  to disk with correct frontmatter format.
- Manual: edited existing skill, saved, confirmed round-trip fidelity.
