### PR TITLE
[bees] Editing polish — keyboard shortcuts & navigation guards

### DIFF
--- a/PROJECT_BEESWAX.md
+++ b/PROJECT_BEESWAX.md
@@ -158,11 +158,11 @@ via browser back — the list updates correctly.
 
 ### Changes
 
-- [ ] Cmd+S to save, Escape to cancel edit mode.
-- [ ] `beforeunload` guard + in-app tab-switch guard when dirty.
-- [ ] Save button spinner → "Saved ✓" flash (already in `<bees-edit-controls>`).
-- [ ] Error banner on write failure (permission revoked, disk full).
-- [ ] Browser-native Cmd+Z within edit session (no custom undo system).
+- [x] Cmd+S to save, Escape to cancel edit mode.
+- [x] `beforeunload` guard + in-app tab-switch guard when dirty.
+- [x] Save button spinner → "Saved ✓" flash (already in `<bees-edit-controls>`).
+- [x] Error banner on write failure (permission revoked, disk full).
+- [x] Browser-native Cmd+Z within edit session (no custom undo system).
 
 ---
 

--- a/packages/bees/hivetool/src/ui/app.ts
+++ b/packages/bees/hivetool/src/ui/app.ts
@@ -39,6 +39,14 @@ export { BeesApp };
 
 type TabId = "logs" | "tickets" | "events" | "templates" | "skills";
 
+/** Shared interface for editable detail panels. */
+interface EditablePanel {
+  readonly isEditing: boolean;
+  readonly hasDirtyEdits: boolean;
+  triggerSave(): void;
+  cancelEditing(): void;
+}
+
 @customElement("bees-app")
 class BeesApp extends SignalWatcher(LitElement) {
   @state() accessor activeTab: TabId = "tickets";
@@ -229,6 +237,8 @@ class BeesApp extends SignalWatcher(LitElement) {
     this.initStores();
     this.restoreRoute();
     window.addEventListener("popstate", this.onHashChange);
+    window.addEventListener("keydown", this.#onKeyDown);
+    window.addEventListener("beforeunload", this.#onBeforeUnload);
   }
 
   disconnectedCallback() {
@@ -236,6 +246,8 @@ class BeesApp extends SignalWatcher(LitElement) {
     this.logStore.destroy();
     this.ticketStore.destroy();
     window.removeEventListener("popstate", this.onHashChange);
+    window.removeEventListener("keydown", this.#onKeyDown);
+    window.removeEventListener("beforeunload", this.#onBeforeUnload);
   }
 
   // --- Store Initialization ---
@@ -374,6 +386,73 @@ class BeesApp extends SignalWatcher(LitElement) {
 
     this.syncHash();
   }
+  // --- Keyboard shortcuts & navigation guards ---
+
+  /**
+   * Get the currently active editable panel, if one exists for the
+   * current tab. Returns null for tabs without editing (tickets, events, logs).
+   */
+  #getActiveEditor(): EditablePanel | null {
+    if (this.activeTab === "templates") {
+      return this.renderRoot.querySelector(
+        "bees-template-detail"
+      ) as EditablePanel | null;
+    }
+    if (this.activeTab === "skills") {
+      return this.renderRoot.querySelector(
+        "bees-skill-detail"
+      ) as EditablePanel | null;
+    }
+    return null;
+  }
+
+  /** Guard tab switches: confirm if dirty edits would be lost. */
+  private switchTab(tab: TabId) {
+    if (tab === this.activeTab) return;
+
+    const editor = this.#getActiveEditor();
+    if (editor?.hasDirtyEdits) {
+      const discard = confirm(
+        "You have unsaved changes. Discard and switch tabs?"
+      );
+      if (!discard) return;
+      editor.cancelEditing();
+    }
+
+    this.activeTab = tab;
+    this.syncHash();
+  }
+
+  #onKeyDown = (e: KeyboardEvent) => {
+    // Cmd+S / Ctrl+S → save active editor.
+    if ((e.metaKey || e.ctrlKey) && e.key === "s") {
+      const editor = this.#getActiveEditor();
+      if (editor?.isEditing) {
+        e.preventDefault();
+        editor.triggerSave();
+      }
+    }
+
+    // Escape → cancel active editor.
+    if (e.key === "Escape") {
+      const editor = this.#getActiveEditor();
+      if (editor?.isEditing) {
+        e.preventDefault();
+        if (editor.hasDirtyEdits) {
+          const discard = confirm("Discard unsaved changes?");
+          if (!discard) return;
+        }
+        editor.cancelEditing();
+      }
+    }
+  };
+
+  #onBeforeUnload = (e: BeforeUnloadEvent) => {
+    const editor = this.#getActiveEditor();
+    if (editor?.hasDirtyEdits) {
+      e.preventDefault();
+    }
+  };
 
   // --- Render ---
 
@@ -455,10 +534,7 @@ class BeesApp extends SignalWatcher(LitElement) {
                 class="sidebar-tab ${this.activeTab === id
                   ? "active"
                   : ""} ${flash ? "lightning-flash" : ""}"
-                @click=${() => {
-                  this.activeTab = id;
-                  this.syncHash();
-                }}
+                @click=${() => this.switchTab(id)}
               >
                 ${label}
               </div>

--- a/packages/bees/hivetool/src/ui/skill-detail.ts
+++ b/packages/bees/hivetool/src/ui/skill-detail.ts
@@ -339,7 +339,22 @@ class BeesSkillDetail extends SignalWatcher(LitElement) {
     this.error = null;
   }
 
-  private cancelEditing() {
+  /** Whether the component is currently in edit/create mode. */
+  get isEditing(): boolean {
+    return this.editing || this.creating;
+  }
+
+  /** Whether there are unsaved changes. */
+  get hasDirtyEdits(): boolean {
+    return this.isEditing && this.isDirty();
+  }
+
+  /** Programmatically trigger a save (e.g. from Cmd+S). */
+  triggerSave() {
+    if (this.isEditing && this.isDirty()) this.handleSave();
+  }
+
+  cancelEditing() {
     this.editing = false;
     this.creating = false;
     this.draft = null;

--- a/packages/bees/hivetool/src/ui/template-detail.ts
+++ b/packages/bees/hivetool/src/ui/template-detail.ts
@@ -536,7 +536,22 @@ class BeesTemplateDetail extends SignalWatcher(LitElement) {
     this.error = null;
   }
 
-  private cancelEditing() {
+  /** Whether the component is currently in edit/create mode. */
+  get isEditing(): boolean {
+    return this.editing || this.creating;
+  }
+
+  /** Whether there are unsaved changes. */
+  get hasDirtyEdits(): boolean {
+    return this.isEditing && this.isDirty();
+  }
+
+  /** Programmatically trigger a save (e.g. from Cmd+S). */
+  triggerSave() {
+    if (this.isEditing && this.isDirty()) this.handleSave();
+  }
+
+  cancelEditing() {
     this.editing = false;
     this.creating = false;
     this.draft = null;


### PR DESCRIPTION
## What

Adds keyboard shortcuts and navigation guards to the hivetool template/skill
editors, completing Phase 5 of PROJECT_BEESWAX.

## Why

Editing without Cmd+S and dirty guards feels unsafe. These are the table-stakes
affordances that make the editing flow feel solid.

## Changes

### `app.ts` — orchestrator
- **Cmd+S / Ctrl+S**: Saves the active editor (template or skill detail).
  Prevents the browser's default save-page behavior.
- **Escape**: Cancels editing. Shows a confirmation if edits are dirty.
- **Tab-switch guard**: Clicking a different tab while editing prompts "You have
  unsaved changes. Discard and switch tabs?"
- **`beforeunload` guard**: Browser's native "Leave site?" prompt when
  closing/refreshing with dirty edits.
- `EditablePanel` interface + `#getActiveEditor()` helper to query the active
  detail component without coupling to concrete types.

### `template-detail.ts` / `skill-detail.ts` — public API
Both detail components now expose:
- `isEditing` — whether the component is in edit/create mode.
- `hasDirtyEdits` — whether there are unsaved changes.
- `triggerSave()` — programmatic save (for Cmd+S).
- `cancelEditing()` — made public (was private).

### `PROJECT_BEESWAX.md`
- All Phase 5 items checked off. All 5 phases complete.

## Testing
- TypeScript compiles clean (`tsc --noEmit`).
- Manual: Cmd+S saves, Escape cancels, tab switch prompts, beforeunload fires.
