### PR TITLE
[bees] Add System tab to Hivetool

### DIFF
--- a/packages/bees/hivetool/src/data/system-store.ts
+++ b/packages/bees/hivetool/src/data/system-store.ts
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Signal-backed reactive store for hive system configuration.
+ *
+ * Reads and writes `hive/config/SYSTEM.yaml` via the shared `StateAccess`
+ * handle and exposes the parsed config as a reactive signal.
+ */
+
+import { Signal } from "signal-polyfill";
+import yaml from "js-yaml";
+
+import type { StateAccess } from "./state-access.js";
+
+export { SystemStore };
+export type { SystemData };
+
+/** The shape of SYSTEM.yaml. */
+interface SystemData {
+  title: string;
+  description: string;
+  root: string;
+}
+
+const EMPTY: SystemData = { title: "", description: "", root: "" };
+
+class SystemStore {
+  constructor(private access: StateAccess) {}
+
+  readonly config = new Signal.State<SystemData>(EMPTY);
+
+  #activated = false;
+
+  /** Activate the store — resolve config dir, parse SYSTEM.yaml. */
+  async activate(): Promise<void> {
+    if (this.#activated) return;
+    if (this.access.accessState.get() !== "ready") return;
+    this.#activated = true;
+    await this.scan();
+  }
+
+  /** Read and parse SYSTEM.yaml from the hive handle. */
+  async scan(): Promise<void> {
+    const handle = this.access.handle;
+    if (!handle) return;
+
+    try {
+      const configDir = await handle.getDirectoryHandle("config");
+      const fileHandle = await configDir.getFileHandle("SYSTEM.yaml");
+      const file = await fileHandle.getFile();
+      const text = await file.text();
+      const data = yaml.load(text);
+
+      if (!data || typeof data !== "object") {
+        console.warn("SYSTEM.yaml must be a mapping; got", typeof data);
+        this.config.set(EMPTY);
+        return;
+      }
+
+      const raw = data as Record<string, unknown>;
+      this.config.set({
+        title: String(raw.title ?? ""),
+        description: String(raw.description ?? ""),
+        root: String(raw.root ?? ""),
+      });
+    } catch (e) {
+      console.warn("Could not read SYSTEM.yaml:", e);
+      this.config.set(EMPTY);
+    }
+  }
+
+  // ── Write operations ──
+
+  /** Save the system config to disk. */
+  async save(data: SystemData): Promise<void> {
+    const handle = this.access.handle;
+    if (!handle) throw new Error("No hive directory handle");
+
+    const header = [
+      "# Hive system configuration.",
+      "#",
+      "# title       — Display name for this hive instance.",
+      "# description — Short summary shown in UI.",
+      "# root        — Template name to auto-boot at startup. The system creates a",
+      "#               ticket from this template if none with a matching playbook_id",
+      "#               exists yet.",
+      "",
+    ].join("\n");
+
+    const body = yaml.dump(data, {
+      lineWidth: 80,
+      noRefs: true,
+      quotingType: '"',
+      forceQuotes: false,
+    });
+
+    const content = header + body;
+
+    const configDir = await handle.getDirectoryHandle("config");
+    const fileHandle = await configDir.getFileHandle("SYSTEM.yaml");
+    const writable = await fileHandle.createWritable();
+    await writable.write(content);
+    await writable.close();
+
+    // Re-scan to sync signal state.
+    await this.scan();
+  }
+
+  /** Tear down state so the store can be re-activated against a new hive. */
+  reset(): void {
+    this.#activated = false;
+    this.config.set(EMPTY);
+  }
+}

--- a/packages/bees/hivetool/src/ui/app.ts
+++ b/packages/bees/hivetool/src/ui/app.ts
@@ -20,6 +20,7 @@ import { LogStore } from "../data/log-store.js";
 import { parseRoute, writeRoute } from "../data/router.js";
 import { StateAccess } from "../data/state-access.js";
 import { SkillStore } from "../data/skill-store.js";
+import { SystemStore } from "../data/system-store.js";
 import { TicketStore } from "../data/ticket-store.js";
 import { TemplateStore } from "../data/template-store.js";
 
@@ -34,10 +35,11 @@ import "./event-list.js";
 import "./event-detail.js";
 import "./log-list.js";
 import "./log-detail.js";
+import "./system-detail.js";
 
 export { BeesApp };
 
-type TabId = "logs" | "tickets" | "events" | "templates" | "skills";
+type TabId = "logs" | "tickets" | "events" | "templates" | "skills" | "system";
 
 /** Shared interface for editable detail panels. */
 interface EditablePanel {
@@ -57,6 +59,7 @@ class BeesApp extends SignalWatcher(LitElement) {
   private ticketStore = new TicketStore(this.stateAccess);
   private templateStore = new TemplateStore(this.stateAccess);
   private skillStore = new SkillStore(this.stateAccess);
+  private systemStore = new SystemStore(this.stateAccess);
 
   static styles = css`
     :host {
@@ -265,6 +268,7 @@ class BeesApp extends SignalWatcher(LitElement) {
       this.ticketStore.activate(),
       this.templateStore.activate(),
       this.skillStore.activate(),
+      this.systemStore.activate(),
     ]);
   }
 
@@ -289,6 +293,7 @@ class BeesApp extends SignalWatcher(LitElement) {
     this.ticketStore.reset();
     this.templateStore.reset();
     this.skillStore.reset();
+    this.systemStore.reset();
     this.selectedEventId = null;
     await this.stateAccess.openDirectory();
     if (this.stateAccess.accessState.get() === "ready") {
@@ -329,6 +334,7 @@ class BeesApp extends SignalWatcher(LitElement) {
       "events",
       "templates",
       "skills",
+      "system",
     ];
     const tab = validTabs.includes(route.tab as TabId)
       ? (route.tab as TabId)
@@ -401,6 +407,11 @@ class BeesApp extends SignalWatcher(LitElement) {
     if (this.activeTab === "skills") {
       return this.renderRoot.querySelector(
         "bees-skill-detail"
+      ) as EditablePanel | null;
+    }
+    if (this.activeTab === "system") {
+      return this.renderRoot.querySelector(
+        "bees-system-detail"
       ) as EditablePanel | null;
     }
     return null;
@@ -527,6 +538,7 @@ class BeesApp extends SignalWatcher(LitElement) {
               ["logs", "Sessions", flashLogId],
               ["templates", "Templates", null],
               ["skills", "Skills", null],
+              ["system", "System", null],
             ] as const
           ).map(
             ([id, label, flash]) => html`
@@ -618,6 +630,8 @@ class BeesApp extends SignalWatcher(LitElement) {
               (detail as { startCreating(): void }).startCreating();
           }}
         ></bees-skill-list>`;
+      case "system":
+        return html``;
     }
   }
 
@@ -651,6 +665,11 @@ class BeesApp extends SignalWatcher(LitElement) {
           .templateStore=${this.templateStore}
           .ticketStore=${this.ticketStore}
         ></bees-skill-detail>`;
+      case "system":
+        return html`<bees-system-detail
+          .systemStore=${this.systemStore}
+          .templateStore=${this.templateStore}
+        ></bees-system-detail>`;
     }
   }
 }

--- a/packages/bees/hivetool/src/ui/system-detail.ts
+++ b/packages/bees/hivetool/src/ui/system-detail.ts
@@ -1,0 +1,366 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Detail panel for the hive system configuration.
+ *
+ * Displays the three SYSTEM.yaml fields (title, description, root) in
+ * view mode, with inline editing via the editable primitives. Implements
+ * the `EditablePanel` interface so `app.ts` can guard tab switches and
+ * wire Cmd+S / Escape.
+ */
+
+import { SignalWatcher } from "@lit-labs/signals";
+import { LitElement, html, css, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+
+import type { SystemStore, SystemData } from "../data/system-store.js";
+import type { TemplateStore } from "../data/template-store.js";
+import { sharedStyles } from "./shared-styles.js";
+import "./primitives/editable-field.js";
+import "./primitives/editable-textarea.js";
+import "./primitives/edit-controls.js";
+
+export { BeesSystemDetail };
+
+@customElement("bees-system-detail")
+class BeesSystemDetail extends SignalWatcher(LitElement) {
+  static styles = [
+    sharedStyles,
+    css`
+      .system-badge {
+        font-size: 0.65rem;
+        font-weight: 700;
+        padding: 3px 10px;
+        border-radius: 999px;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        background: #7c3aed22;
+        color: #a78bfa;
+        border: 1px solid #7c3aed55;
+      }
+
+      .edit-btn {
+        padding: 4px 10px;
+        font-size: 0.7rem;
+        background: transparent;
+        color: #94a3b8;
+        border: 1px solid #334155;
+        border-radius: 4px;
+        cursor: pointer;
+        transition: all 0.15s;
+        font-family: inherit;
+      }
+
+      .edit-btn:hover {
+        color: #e2e8f0;
+        border-color: #3b82f6;
+        background: #1e293b;
+      }
+
+      .edit-form {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+      }
+
+      .edit-controls-bar {
+        position: sticky;
+        top: 0;
+        z-index: 11;
+        padding: 8px 0;
+        background: #0b0c0f;
+        border-bottom: 1px solid #1e293b;
+      }
+
+      .error-banner {
+        padding: 8px 12px;
+        background: #450a0a;
+        border: 1px solid #991b1b;
+        border-radius: 6px;
+        color: #fca5a5;
+        font-size: 0.8rem;
+      }
+
+      .root-link {
+        cursor: pointer;
+        transition: color 0.15s;
+      }
+
+      .root-link:hover {
+        color: #93c5fd;
+      }
+    `,
+  ];
+
+  @property({ attribute: false })
+  accessor systemStore: SystemStore | null = null;
+
+  @property({ attribute: false })
+  accessor templateStore: TemplateStore | null = null;
+
+  // ── Edit state ──
+  @state() accessor editing = false;
+  @state() accessor saving = false;
+  @state() accessor error: string | null = null;
+  @state() accessor draft: SystemData | null = null;
+
+  #original: SystemData | null = null;
+
+  render() {
+    if (!this.systemStore) return nothing;
+
+    const config = this.systemStore.config.get();
+
+    if (this.editing && this.draft) {
+      return this.renderEditMode(this.draft);
+    }
+
+    return this.renderViewMode(config);
+  }
+
+  // ── View Mode ──
+
+  private renderViewMode(config: SystemData) {
+    const rootExists =
+      this.templateStore
+        ?.templates.get()
+        .some((t) => t.name === config.root) ?? false;
+
+    return html`
+      <div class="job-detail">
+        <div class="job-detail-header">
+          <div class="job-detail-header-top">
+            <h2 class="job-detail-title">${config.title || "Untitled Hive"}</h2>
+            <div style="display:flex;align-items:center;gap:8px">
+              <button class="edit-btn" @click=${() => this.startEditing(config)}>
+                ✏️ Edit
+              </button>
+              <div class="system-badge">SYSTEM</div>
+            </div>
+          </div>
+          ${config.description
+            ? html`<div class="job-detail-meta">
+                <span>${config.description}</span>
+              </div>`
+            : nothing}
+        </div>
+
+        <div class="timeline">
+          <div class="identity-row">
+            <span class="identity-chip playbook">
+              <span class="identity-label">title</span>
+              ${config.title || "—"}
+            </span>
+          </div>
+
+          <div class="block">
+            <div class="block-header">Description</div>
+            <div class="block-content">
+              ${config.description || html`<span style="color:#475569;font-style:italic">No description</span>`}
+            </div>
+          </div>
+
+          <div class="block">
+            <div class="block-header">Root Template</div>
+            <div class="block-content">
+              <span
+                class="identity-chip playbook ${rootExists ? "linkable" : ""}"
+                @click=${rootExists
+                  ? () => this.navigateToTemplate(config.root)
+                  : nothing}
+              >
+                <span class="identity-label">root</span>
+                ${config.root || "—"}
+              </span>
+              ${config.root && !rootExists
+                ? html`<span style="color:#f59e0b;font-size:0.75rem;margin-left:8px">
+                    ⚠ template not found
+                  </span>`
+                : nothing}
+            </div>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  // ── Edit Mode ──
+
+  private renderEditMode(draft: SystemData) {
+    const isDirty = this.isDirty();
+    const templateNames = (this.templateStore?.templates.get() ?? []).map(
+      (t) => t.name
+    );
+
+    return html`
+      <div class="job-detail">
+        <div class="job-detail-header">
+          <div class="job-detail-header-top">
+            <h2 class="job-detail-title">
+              Editing: System Configuration
+            </h2>
+            <div class="system-badge">EDITING</div>
+          </div>
+        </div>
+
+        <div class="timeline">
+          <div class="edit-controls-bar">
+            <bees-edit-controls
+              ?dirty=${isDirty}
+              ?saving=${this.saving}
+              @save=${() => this.handleSave()}
+              @cancel=${() => this.cancelEditing()}
+            ></bees-edit-controls>
+          </div>
+
+          ${this.error
+            ? html`<div class="error-banner">${this.error}</div>`
+            : nothing}
+
+          <div class="edit-form">
+            <bees-editable-field
+              label="Title"
+              .value=${draft.title}
+              editing
+              placeholder="Hive display name"
+              @change=${(e: CustomEvent) =>
+                this.updateDraft({ title: e.detail.value })}
+            ></bees-editable-field>
+
+            <bees-editable-textarea
+              label="Description"
+              .value=${draft.description}
+              editing
+              min-height="60"
+              placeholder="Short summary shown in UI"
+              @change=${(e: CustomEvent) =>
+                this.updateDraft({ description: e.detail.value })}
+            ></bees-editable-textarea>
+
+            <bees-editable-field
+              label="Root Template"
+              .value=${draft.root}
+              editing
+              placeholder="Template name to auto-boot at startup"
+              @change=${(e: CustomEvent) =>
+                this.updateDraft({ root: e.detail.value })}
+            ></bees-editable-field>
+
+            ${templateNames.length > 0
+              ? html`
+                  <div style="font-size:0.75rem;color:#64748b">
+                    Available templates:
+                    ${templateNames.map(
+                      (name) => html`
+                        <span
+                          class="identity-chip playbook linkable"
+                          style="font-size:0.7rem;margin:2px"
+                          @click=${() => this.updateDraft({ root: name })}
+                        >${name}</span>
+                      `
+                    )}
+                  </div>
+                `
+              : nothing}
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  // ── Edit actions ──
+
+  private startEditing(config: SystemData) {
+    this.#original = { ...config };
+    this.draft = { ...config };
+    this.editing = true;
+    this.error = null;
+  }
+
+  /** Whether the component is currently in edit mode. */
+  get isEditing(): boolean {
+    return this.editing;
+  }
+
+  /** Whether there are unsaved changes. */
+  get hasDirtyEdits(): boolean {
+    return this.editing && this.isDirty();
+  }
+
+  /** Programmatically trigger a save (e.g. from Cmd+S). */
+  triggerSave() {
+    if (this.editing && this.isDirty()) this.handleSave();
+  }
+
+  cancelEditing() {
+    this.editing = false;
+    this.draft = null;
+    this.#original = null;
+    this.error = null;
+  }
+
+  private updateDraft(partial: Partial<SystemData>) {
+    if (!this.draft) return;
+    this.draft = { ...this.draft, ...partial };
+  }
+
+  private isDirty(): boolean {
+    if (!this.draft || !this.#original) return false;
+    return JSON.stringify(this.#original) !== JSON.stringify(this.draft);
+  }
+
+  private async handleSave() {
+    if (!this.draft || !this.systemStore) return;
+
+    if (!this.draft.title.trim()) {
+      this.error = "Title is required.";
+      return;
+    }
+    if (!this.draft.root.trim()) {
+      this.error = "Root template is required.";
+      return;
+    }
+
+    this.saving = true;
+    this.error = null;
+
+    try {
+      await this.systemStore.save(this.draft);
+
+      // Flash "Saved ✓".
+      const controls = this.shadowRoot?.querySelector("bees-edit-controls");
+      if (controls) (controls as { flashSaved(): void }).flashSaved();
+
+      this.#original = { ...this.draft };
+      this.editing = false;
+      this.draft = null;
+    } catch (e) {
+      this.error =
+        e instanceof Error ? e.message : "Save failed. Check console.";
+      console.error("System config save error:", e);
+    } finally {
+      this.saving = false;
+    }
+  }
+
+  // ── Navigation ──
+
+  private navigateToTemplate(name: string) {
+    this.dispatchEvent(
+      new CustomEvent("navigate", {
+        detail: { tab: "templates", id: name },
+        bubbles: true,
+      })
+    );
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "bees-system-detail": BeesSystemDetail;
+  }
+}


### PR DESCRIPTION
## What
Adds a "System" tab to the Hivetool devtools that lets users view and edit the hive's `config/SYSTEM.yaml` (title, description, root template).

## Why
The system configuration was previously only editable by hand. This gives it the same inline-editing treatment as templates and skills, and lays the groundwork for a broader settings section.

## Changes

### `packages/bees/hivetool`

- **[NEW] `src/data/system-store.ts`** — Signal-backed store that reads/writes `config/SYSTEM.yaml`. Preserves the comment header on save.
- **[NEW] `src/ui/system-detail.ts`** — View/edit panel for the three system fields. Root template is a clickable link with a ⚠ warning when it doesn't resolve. Edit mode surfaces available templates as clickable chips. Implements `EditablePanel` for Cmd+S / Escape / tab-switch guards.
- **[MODIFY] `src/ui/app.ts`** — Adds `"system"` to `TabId`, wires `SystemStore` into lifecycle (activate/reset), adds tab + routing, blank sidebar (future settings sections), and renders `<bees-system-detail>`.

## Testing
1. Run `npm run dev:hivetool -w packages/bees` and open the Hivetool.
2. Click the **System** tab — verify the current SYSTEM.yaml values render.
3. Click **Edit**, change a field, and Save — verify `hive/config/SYSTEM.yaml` is updated with the comment header intact.
4. Verify Cmd+S and Escape shortcuts work in edit mode.
5. Verify switching tabs with dirty edits prompts a confirmation dialog.
