### PR TITLE
[bees] Fix non-scrollable left sidebar and inconsistent scrollbars in Hivetool

### DIFF
--- a/packages/bees/hivetool/src/ui/app.ts
+++ b/packages/bees/hivetool/src/ui/app.ts
@@ -36,6 +36,7 @@ import "./event-detail.js";
 import "./log-list.js";
 import "./log-detail.js";
 import "./system-detail.js";
+import { scrollbarStyles } from "./shared-styles.js";
 
 export { BeesApp };
 
@@ -61,8 +62,10 @@ class BeesApp extends SignalWatcher(LitElement) {
   private skillStore = new SkillStore(this.stateAccess);
   private systemStore = new SystemStore(this.stateAccess);
 
-  static styles = css`
-    :host {
+  static styles = [
+    scrollbarStyles,
+    css`
+      :host {
       display: flex;
       flex-direction: column;
       height: 100vh;
@@ -233,7 +236,8 @@ class BeesApp extends SignalWatcher(LitElement) {
     .lightning-flash {
       animation: lightning-flash 15s ease-out !important;
     }
-  `;
+  `,
+  ];
 
   connectedCallback() {
     super.connectedCallback();

--- a/packages/bees/hivetool/src/ui/event-list.ts
+++ b/packages/bees/hivetool/src/ui/event-list.ts
@@ -9,7 +9,7 @@
  */
 
 import { SignalWatcher } from "@lit-labs/signals";
-import { LitElement, html, nothing } from "lit";
+import { LitElement, html, css, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 
 import type { TicketStore } from "../data/ticket-store.js";
@@ -20,7 +20,16 @@ export { BeesEventList };
 
 @customElement("bees-event-list")
 class BeesEventList extends SignalWatcher(LitElement) {
-  static styles = [sharedStyles];
+  static styles = [
+    sharedStyles,
+    css`
+      :host {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+      }
+    `,
+  ];
 
   @property({ attribute: false })
   accessor store: TicketStore | null = null;

--- a/packages/bees/hivetool/src/ui/log-list.ts
+++ b/packages/bees/hivetool/src/ui/log-list.ts
@@ -23,6 +23,12 @@ class BeesLogList extends SignalWatcher(LitElement) {
   static styles = [
     sharedStyles,
     css`
+      :host {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+      }
+
       .job-item-group {
         display: flex;
         flex-direction: column;

--- a/packages/bees/hivetool/src/ui/shared-styles.ts
+++ b/packages/bees/hivetool/src/ui/shared-styles.ts
@@ -13,11 +13,10 @@
 
 import { css } from "lit";
 
-export { sharedStyles };
+export { sharedStyles, scrollbarStyles };
 
-const sharedStyles = css`
+const scrollbarStyles = css`
   * {
-    box-sizing: border-box;
     scrollbar-width: thin;
     scrollbar-color: #334155 transparent;
   }
@@ -38,6 +37,14 @@ const sharedStyles = css`
 
   *::-webkit-scrollbar-thumb:hover {
     background: #475569;
+  }
+`;
+
+const sharedStyles = css`
+  ${scrollbarStyles}
+
+  * {
+    box-sizing: border-box;
   }
 
   .mono {

--- a/packages/bees/hivetool/src/ui/skill-list.ts
+++ b/packages/bees/hivetool/src/ui/skill-list.ts
@@ -22,6 +22,12 @@ class BeesSkillList extends SignalWatcher(LitElement) {
   static styles = [
     sharedStyles,
     css`
+      :host {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+      }
+
       .sidebar-toolbar {
         display: flex;
         justify-content: flex-end;

--- a/packages/bees/hivetool/src/ui/template-list.ts
+++ b/packages/bees/hivetool/src/ui/template-list.ts
@@ -22,6 +22,12 @@ class BeesTemplateList extends SignalWatcher(LitElement) {
   static styles = [
     sharedStyles,
     css`
+      :host {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+      }
+
       .sidebar-toolbar {
         display: flex;
         justify-content: flex-end;

--- a/packages/bees/hivetool/src/ui/ticket-list.ts
+++ b/packages/bees/hivetool/src/ui/ticket-list.ts
@@ -28,6 +28,12 @@ class BeesTicketList extends SignalWatcher(LitElement) {
   static styles = [
     sharedStyles,
     css`
+      :host {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+      }
+
       /* Sidebar toolbar */
       .sidebar-toolbar {
         display: flex;


### PR DESCRIPTION
## What
Added `:host` styles to sidebar list components to constrain their height and enable scrolling for long lists. Also extracted scrollbar styles and applied them to the main app shell to fix inconsistent, thick scrollbars on the main content area.

## Why
The left sidebar was not scrollable because the custom elements rendered inside it (like `bees-ticket-list`) did not have a constrained height, preventing the internal `.jobs-list` (which has `overflow-y: auto`) from scrolling when content overflowed. The main content area had default browser scrollbars which looked thick and white, inconsistent with the rest of the dark theme UI.

## Changes
- `packages/bees/hivetool/src/ui/ticket-list.ts`: Added `:host` styles with `display: flex` and `height: 100%`.
- `packages/bees/hivetool/src/ui/template-list.ts`: Added `:host` styles with `display: flex` and `height: 100%`.
- `packages/bees/hivetool/src/ui/skill-list.ts`: Added `:host` styles with `display: flex` and `height: 100%`.
- `packages/bees/hivetool/src/ui/event-list.ts`: Added `:host` styles and imported `css` from `lit`.
- `packages/bees/hivetool/src/ui/log-list.ts`: Added `:host` styles with `display: flex` and `height: 100%`.
- `packages/bees/hivetool/src/ui/shared-styles.ts`: Extracted `scrollbarStyles` to a separate export and reused it in `sharedStyles`.
- `packages/bees/hivetool/src/ui/app.ts`: Imported `scrollbarStyles` and applied it to `static styles` array.

## Testing
- Manual verification by the user.
