### PR TITLE
[bees] Update documentation for extracted app layout

### DIFF
--- a/packages/bees/AGENTS.md
+++ b/packages/bees/AGENTS.md
@@ -21,14 +21,16 @@ For the full architecture reference, see
 
 ```
 packages/bees/
-  bees/                  # Python source — the library
+  bees/                  # Python source — the core library
     session.py           # Session layer: agent loop, context, suspend/resume
     scheduler.py         # Scheduler layer: task lifecycle, coordination
-    server.py            # Reference FastAPI server (will be extracted)
     playbook.py          # Template loading, task creation from templates
     ticket.py            # Task data model (on-disk "ticket" format)
     functions/           # Function group implementations
     declarations/        # Function declarations (JSON schemas)
+  app/                   # Reference application and CLI tools
+    server.py            # FastAPI server (REST API + SSE)
+    cli.py               # Main CLI entry point
   hive/                  # Runtime configuration — the "hive" directory
     config/
       SYSTEM.yaml        # Boot config: title, root template

--- a/packages/bees/docs/architecture.md
+++ b/packages/bees/docs/architecture.md
@@ -431,16 +431,14 @@ entire web app, complete with backend and frontend.
 
 The current codebase includes a reference application:
 
-- **`bees/server.py`** — A FastAPI server that projects scheduler state as REST
+- **`app/server.py`** — A FastAPI server that projects scheduler state as REST
   endpoints and SSE events. Every endpoint is a thin view: `GET /tickets`
   queries the task list, `POST /tickets/{id}/respond` writes a response file and
   triggers the scheduler.
 - **`web/`** — A chat-based web shell that connects to the server via SSE.
   Renders agent conversations and iframe-hosted React apps.
 
-This reference application will be extracted from the bees package in the
-future. Bees will become an installable library; application authors will build
-their own frontends and backends on top of the scheduler.
+This reference application has been extracted from the core `bees` package into `app/`. Bees is designed to be an installable library; application authors will build their own frontends and backends on top of the scheduler.
 
 ## Hivetool
 

--- a/packages/bees/docs/flux.md
+++ b/packages/bees/docs/flux.md
@@ -103,7 +103,7 @@ abstractions, and incomplete contracts.
 This is the biggest open question in bees: **how do applications build on this
 framework?**
 
-Today, the answer is ad-hoc. `bees/server.py` wires `SchedulerHooks` to SSE
+Today, the answer is ad-hoc. `app/server.py` wires `SchedulerHooks` to SSE
 broadcasting and exposes REST endpoints. The web shell consumes those endpoints.
 But this isn't a designed API — it's the first thing that worked. The boundary
 between "bees the library" and "the application built on bees" is blurry:

--- a/packages/bees/docs/reference-app.md
+++ b/packages/bees/docs/reference-app.md
@@ -28,7 +28,7 @@ The server is the glue layer that projects the scheduler's model as REST
 endpoints and SSE events. The web shell consumes those projections and renders
 them as a chat UI with an embedded app stage.
 
-## The Server (`bees/server.py`)
+## The Server (`app/server.py`)
 
 The server has three responsibilities:
 
@@ -71,7 +71,7 @@ API.
 #### Querying tasks
 
 Tasks can be filtered by metadata fields. The reference app's `/status` endpoint
-exposes this, but the filtering logic (`should_include_ticket` in `server.py`)
+exposes this, but the filtering logic (`should_include_ticket` in `app/server.py`)
 operates on the task model directly.
 
 | Filter   | Example                 | Effect                        |

--- a/packages/bees/docs/scheduler.md
+++ b/packages/bees/docs/scheduler.md
@@ -113,7 +113,7 @@ Applications wire into the scheduler via `SchedulerHooks`:
 | `on_events_broadcast` | Agent broadcasts an event mid-session.                       |
 | `on_cycle_complete`   | No more work (total cycles count).                           |
 
-The reference application (`bees/server.py`) wires these hooks to SSE
+The reference application (`app/server.py`) wires these hooks to SSE
 broadcasting.
 
 ## Context delivery


### PR DESCRIPTION
## What
Updated documentation in `packages/bees` to reflect the extraction of the reference application and CLI tools into `packages/bees/app`.

## Why
The app extraction logic has already landed, and the documentation needs to be brought up to date to reflect the new layout.

## Changes
### `packages/bees`
- Updated references to `bees/server.py` to `app/server.py` in:
  - `docs/reference-app.md`
  - `docs/flux.md`
  - `docs/scheduler.md`
  - `docs/architecture.md`
- Updated `AGENTS.md` to show the new directory structure with `app/`.

## Testing
- N/A (Documentation only changes)
