### PR TITLE
[bees] Introduce TaskStore and clean up API surface

### DIFF
--- a/packages/bees/app/server.py
+++ b/packages/bees/app/server.py
@@ -36,13 +36,14 @@ from bees.scheduler import Scheduler, SchedulerHooks
 from app.auth import load_gemini_key
 from bees.ticket import (
     Ticket,
-    create_ticket,
-    list_tickets,
-    load_ticket,
+    TaskStore,
+    TICKETS_DIR,
 )
 from opal_backend.local.backend_client_impl import HttpBackendClient
 
 logger = logging.getLogger(__name__)
+
+task_store = TaskStore(TICKETS_DIR)
 
 
 # ---------------------------------------------------------------------------
@@ -176,7 +177,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         on_ticket_done=_on_ticket_done,
         on_cycle_complete=_on_cycle_complete,
     )
-    scheduler = Scheduler(http=http_client, backend=backend, hooks=hooks)
+    scheduler = Scheduler(http=http_client, backend=backend, hooks=hooks, store=task_store)
 
     # Startup scheduler (recovers tickets and boots root if needed)
     await scheduler.startup()
@@ -237,7 +238,7 @@ def _read_chat_log(ticket: Ticket) -> list[dict[str, str]]:
 @app.get("/tickets")
 async def get_tickets(tag: str | None = None) -> list[dict[str, Any]]:
     """List all tickets, sorted by created_at latest first, optionally filtered by tag."""
-    tickets = list_tickets()
+    tickets = task_store.query_all()
 
     if tag:
         tickets = [t for t in tickets if t.metadata.tags and tag in t.metadata.tags]
@@ -251,7 +252,7 @@ async def get_tickets(tag: str | None = None) -> list[dict[str, Any]]:
 @app.get("/tickets/{ticket_id}")
 async def get_ticket(ticket_id: str) -> dict[str, Any]:
     """Get a single ticket."""
-    ticket = load_ticket(ticket_id)
+    ticket = task_store.get(ticket_id)
     if not ticket:
         raise HTTPException(404, f"Ticket {ticket_id} not found")
     return _ticket_to_dict(ticket)
@@ -260,7 +261,7 @@ async def get_ticket(ticket_id: str) -> dict[str, Any]:
 @app.get("/tickets/{ticket_id}/files")
 async def list_ticket_files(ticket_id: str) -> list[str]:
     """List files in the ticket's filesystem directory."""
-    ticket = load_ticket(ticket_id)
+    ticket = task_store.get(ticket_id)
     if not ticket:
         raise HTTPException(404, f"Ticket {ticket_id} not found")
 
@@ -278,7 +279,7 @@ async def list_ticket_files(ticket_id: str) -> list[str]:
 @app.get("/tickets/{ticket_id}/files/{path:path}")
 async def get_ticket_file(ticket_id: str, path: str) -> FileResponse:
     """Serve files from the ticket's filesystem."""
-    ticket = load_ticket(ticket_id)
+    ticket = task_store.get(ticket_id)
     if not ticket:
         raise HTTPException(404, f"Ticket {ticket_id} not found")
 
@@ -316,7 +317,7 @@ async def respond_to_ticket(
     ticket_id: str, req: RespondRequest,
 ) -> dict[str, Any]:
     """Submit a response to a suspended ticket and trigger scheduling."""
-    ticket = load_ticket(ticket_id)
+    ticket = task_store.get(ticket_id)
     if not ticket:
         raise HTTPException(404, f"Ticket {ticket_id} not found")
     if ticket.metadata.status != "suspended":
@@ -356,7 +357,7 @@ async def update_ticket_tags(
     ticket_id: str, req: UpdateTagsRequest
 ) -> dict[str, Any]:
     """Update tags for a ticket and broadcast."""
-    ticket = load_ticket(ticket_id)
+    ticket = task_store.get(ticket_id)
     if not ticket:
         raise HTTPException(404, f"Ticket {ticket_id} not found")
 
@@ -379,7 +380,7 @@ async def retry_ticket(ticket_id: str) -> dict[str, Any]:
     (e.g. 503).  Retrying clears the error and re-queues the ticket
     for the scheduler to pick up.
     """
-    ticket = load_ticket(ticket_id)
+    ticket = task_store.get(ticket_id)
     if not ticket:
         raise HTTPException(404, f"Ticket {ticket_id} not found")
     if ticket.metadata.status != "paused":
@@ -470,7 +471,7 @@ async def get_status(
     kind: str | None = None,
 ) -> dict[str, Any]:
     """Return a status response containing both the summary text and structured tasks."""
-    tickets = list_tickets()
+    tickets = task_store.query_all()
 
     by_run: dict[str, list[Ticket]] = {}
     active_running = []
@@ -550,7 +551,7 @@ async def events() -> EventSourceResponse:
             yield {
                 "event": "init",
                 "data": json.dumps([
-                    _ticket_to_dict(t) for t in list_tickets()
+                    _ticket_to_dict(t) for t in task_store.query_all()
                 ]),
             }
             while True:

--- a/packages/bees/bees/scheduler.py
+++ b/packages/bees/bees/scheduler.py
@@ -61,9 +61,8 @@ from bees.session import (
 from bees.ticket import (
     Ticket,
     _DEP_PATTERN,
-    create_ticket,
-    list_tickets,
-    load_ticket,
+    TaskStore,
+    get_default_store,
 )
 from bees.subagent_scope import SubagentScope
 from opal_backend.local.backend_client_impl import HttpBackendClient
@@ -120,7 +119,7 @@ class SchedulerHooks:
 # ---------------------------------------------------------------------------
 
 
-def resolve_segments(ticket: Ticket) -> list[dict[str, Any]]:
+def resolve_segments(ticket: Ticket, store: TaskStore) -> list[dict[str, Any]]:
     """Build segments from a ticket's objective, resolving ``{{…}}`` references.
 
     References are resolved by namespace:
@@ -139,7 +138,7 @@ def resolve_segments(ticket: Ticket) -> list[dict[str, Any]]:
     # Build a lookup from dep ID to resolved outcome.
     dep_outcomes: dict[str, dict[str, Any]] = {}
     for dep_id in deps:
-        dep = load_ticket(dep_id)
+        dep = store.get(dep_id)
         if dep and dep.metadata.outcome_content:
             dep_outcomes[dep_id] = dep.metadata.outcome_content
 
@@ -197,12 +196,12 @@ def _find_dep_id(ref: str, dep_ids: list[str]) -> str | None:
 # ---------------------------------------------------------------------------
 
 
-def promote_blocked_tickets() -> int:
+def promote_blocked_tickets(store: TaskStore) -> int:
     """Check blocked tickets and promote those whose deps are met.
 
     Returns the number of tickets promoted.
     """
-    blocked = list_tickets(status="blocked")
+    blocked = store.query_all(status="blocked")
     promoted = 0
 
     for ticket in blocked:
@@ -211,7 +210,7 @@ def promote_blocked_tickets() -> int:
         any_failed = False
 
         for dep_id in deps:
-            dep = load_ticket(dep_id)
+            dep = store.get(dep_id)
             if dep is None:
                 all_met = False
                 continue
@@ -260,10 +259,12 @@ class Scheduler:
         http: httpx.AsyncClient,
         backend: HttpBackendClient,
         hooks: SchedulerHooks | None = None,
+        store: TaskStore | None = None,
     ) -> None:
         self._http = http
         self._backend = backend
         self._hooks = hooks or SchedulerHooks()
+        self.store = store or get_default_store()
         self._trigger = asyncio.Event()
         self._running = False
         self._running_tickets: set[str] = set()
@@ -292,7 +293,7 @@ class Scheduler:
 
     async def create_task(self, objective: str, **kwargs) -> Ticket:
         """Create a new task and notify hooks."""
-        ticket = create_ticket(objective, **kwargs)
+        ticket = self.store.create(objective, **kwargs)
         
         if self._hooks.on_ticket_added:
             await self._hooks.on_ticket_added(ticket)
@@ -334,7 +335,7 @@ class Scheduler:
         except asyncio.TimeoutError:
             pass
             
-        fresh = load_ticket(ticket_id)
+        fresh = self.store.get(ticket_id)
         return fresh.metadata.status if fresh else "unknown"
 
     def _notify_ticket_done(self, ticket_id: str) -> None:
@@ -354,8 +355,7 @@ class Scheduler:
             self._active_tasks[ticket_id].cancel()
             cancelled = True
             
-        from bees.ticket import load_ticket
-        ticket = load_ticket(ticket_id)
+        ticket = self.store.get(ticket_id)
         if ticket:
             ticket.metadata.status = "cancelled"
             ticket.save_metadata()
@@ -378,9 +378,7 @@ class Scheduler:
         ``creator_ticket_id`` must match — this prevents one agent from
         injecting updates into another agent's tasks.
         """
-        from bees.ticket import load_ticket
-
-        ticket = load_ticket(ticket_id)
+        ticket = self.store.get(ticket_id)
         if not ticket:
             return f"Task {ticket_id} not found"
 
@@ -403,7 +401,6 @@ class Scheduler:
            batch mode).  Append to ``pending_context_updates`` in
            metadata for later drain.
         """
-        from bees.ticket import load_ticket
         from bees.context_updates import updates_to_context_parts
         import json
 
@@ -415,7 +412,7 @@ class Scheduler:
             logger.info("Context update injected mid-stream for %s", target_id)
             return
 
-        target = load_ticket(target_id)
+        target = self.store.get(target_id)
         if not target:
             logger.warning("Failed to load ticket %s for context update", target_id)
             return
@@ -460,7 +457,7 @@ class Scheduler:
         if not creator_id or not child_tags:
             return None
 
-        creator = load_ticket(creator_id)
+        creator = self.store.get(creator_id)
         if not creator:
             logger.warning(
                 "Tag enrichment: creator %s not found for %s",
@@ -505,7 +502,7 @@ class Scheduler:
 
         Returns the full ticket list (for ``on_startup``).
         """
-        tickets = list_tickets()
+        tickets = self.store.query_all()
         for t in tickets:
             if t.metadata.status in ("running", "paused"):
                 logger.info("Recovered stuck %s ticket: %s", t.metadata.status, t.id)
@@ -523,9 +520,9 @@ class Scheduler:
         cycle = 0
 
         while True:
-            promote_blocked_tickets()
+            promote_blocked_tickets(self.store)
 
-            all_available = list_tickets(status="available")
+            all_available = self.store.query_all(status="available")
 
             # Route coordination tickets before processing work tickets.
             coordination = [
@@ -540,13 +537,13 @@ class Scheduler:
                 if t.metadata.kind != "coordination"
             ]
             resumable = [
-                t for t in list_tickets(status="suspended")
+                t for t in self.store.query_all(status="suspended")
                 if t.metadata.assignee == "agent"
             ]
 
             if not tickets and not resumable:
                 if cycle == 0:
-                    blocked = list_tickets(status="blocked")
+                    blocked = self.store.query_all(status="blocked")
                     if blocked:
                         print(
                             f"No runnable tickets. "
@@ -612,7 +609,7 @@ class Scheduler:
         # Reload title from disk — it may have been renamed by an on_event
         # hook during coordination routing earlier in this cycle, while the
         # in-memory ticket object (from list_tickets) still has the old value.
-        fresh = load_ticket(ticket.id)
+        fresh = self.store.get(ticket.id)
         if fresh and fresh.metadata.title != ticket.metadata.title:
             ticket.metadata.title = fresh.metadata.title
 
@@ -627,7 +624,7 @@ class Scheduler:
         try:
             ctx_queue: asyncio.Queue = asyncio.Queue()
             self._context_queues[ticket.id] = ctx_queue
-            segments = resolve_segments(ticket)
+            segments = resolve_segments(ticket, self.store)
             scope = SubagentScope.for_ticket(ticket)
             result = await run_session(
                 segments=segments,
@@ -805,7 +802,7 @@ class Scheduler:
             # the session was running (e.g., by on_event hooks or
             # coordination delivery).  The in-memory ticket object is
             # stale for these fields.
-            fresh = load_ticket(ticket.id)
+            fresh = self.store.get(ticket.id)
             if fresh:
                 if fresh.metadata.queued_updates:
                     ticket.metadata.queued_updates = fresh.metadata.queued_updates
@@ -900,7 +897,7 @@ class Scheduler:
         # Find all matching subscribers.
         source_run_id = ticket.metadata.playbook_run_id
         subscribers: list[Ticket] = []
-        for candidate in list_tickets():
+        for candidate in self.store.query_all():
             if candidate.id == ticket.id:
                 continue
             if not candidate.metadata.watch_events:
@@ -997,9 +994,9 @@ class Scheduler:
         cycle = 0
 
         while True:
-            promote_blocked_tickets()
+            promote_blocked_tickets(self.store)
 
-            all_available = list_tickets(status="available")
+            all_available = self.store.query_all(status="available")
 
             # Route coordination tickets before processing work tickets.
             coordination = [
@@ -1014,7 +1011,7 @@ class Scheduler:
                 if t.metadata.kind != "coordination"
             ]
             resumable = [
-                t for t in list_tickets(status="suspended")
+                t for t in self.store.query_all(status="suspended")
                 if t.metadata.assignee == "agent"
             ]
 
@@ -1039,7 +1036,7 @@ class Scheduler:
                     finally:
                         self._running_tickets.discard(t.id)
                         self._active_tasks.pop(t.id, None)
-                        updated = load_ticket(t.id) or t
+                        updated = self.store.get(t.id) or t
                         run_ticket_done_hooks(updated)
                         self._notify_ticket_done(t.id)
 
@@ -1069,7 +1066,7 @@ class Scheduler:
                     finally:
                         self._running_tickets.discard(t.id)
                         self._active_tasks.pop(t.id, None)
-                        updated = load_ticket(t.id) or t
+                        updated = self.store.get(t.id) or t
                         run_ticket_done_hooks(updated)
                         self._notify_ticket_done(t.id)
 

--- a/packages/bees/bees/ticket.py
+++ b/packages/bees/bees/ticket.py
@@ -163,6 +163,139 @@ class Ticket:
             + "\n"
         )
 
+class TaskStore:
+    """Encapsulates task CRUD operations."""
+
+    def __init__(self, tickets_dir: Path):
+        self.tickets_dir = tickets_dir
+
+    def get(self, ticket_id: str) -> Ticket | None:
+        """Load a specific task."""
+        ticket_dir = self.tickets_dir / ticket_id
+        if not ticket_dir.exists():
+            return None
+        objective_path = ticket_dir / "objective.md"
+        metadata_path = ticket_dir / "metadata.json"
+        if not objective_path.exists() or not metadata_path.exists():
+            return None
+        return Ticket(
+            id=ticket_id,
+            objective=objective_path.read_text(),
+            metadata=TicketMetadata.from_dict(
+                json.loads(metadata_path.read_text())
+            ),
+        )
+
+    def query_all(self, status: TicketStatus | None = None) -> list[Ticket]:
+        """List tasks, optionally filtered by status."""
+        if not self.tickets_dir.exists():
+            return []
+        tickets: list[Ticket] = []
+        for ticket_dir in sorted(self.tickets_dir.iterdir()):
+            if not ticket_dir.is_dir():
+                continue
+            ticket = self.get(ticket_dir.name)
+            if ticket is None:
+                continue
+            if status is not None and ticket.metadata.status != status:
+                continue
+            tickets.append(ticket)
+        tickets.sort(key=lambda t: t.metadata.created_at or "", reverse=True)
+        return tickets
+
+    def save(self, ticket: Ticket) -> None:
+        """Persist ticket to disk."""
+        ticket_dir = self.tickets_dir / ticket.id
+        ticket_dir.mkdir(parents=True, exist_ok=True)
+        (ticket_dir / "objective.md").write_text(ticket.objective)
+        (ticket_dir / "metadata.json").write_text(
+            json.dumps(ticket.metadata.to_dict(), indent=2, ensure_ascii=False)
+            + "\n"
+        )
+
+    def save_metadata(self, ticket: Ticket) -> None:
+        """Persist only the metadata."""
+        ticket_dir = self.tickets_dir / ticket.id
+        (ticket_dir / "metadata.json").write_text(
+            json.dumps(ticket.metadata.to_dict(), indent=2, ensure_ascii=False)
+            + "\n"
+        )
+
+    def create(
+        self,
+        objective: str,
+        *,
+        tags: list[str] | None = None,
+        functions: list[str] | None = None,
+        skills: list[str] | None = None,
+        tasks: list[str] | None = None,
+        title: str | None = None,
+        assignee: str | None = None,
+        playbook_id: str | None = None,
+        playbook_run_id: str | None = None,
+        parent_ticket_id: str | None = None,
+        model: str | None = None,
+        context: str | None = None,
+        watch_events: list[dict[str, Any]] | None = None,
+        kind: TicketKind = "work",
+        signal_type: str | None = None,
+        slug: str | None = None,
+    ) -> Ticket:
+        """Create a new task.
+
+        Scans the objective for ``{{id}}`` references. If any are found,
+        the ticket is created with status ``blocked`` and a ``depends_on``
+        list of the referenced ticket IDs (resolved by prefix match).
+        """
+        deps = [d for d in _DEP_PATTERN.findall(objective) if "." not in d]
+        resolved_deps: list[str] | None = None
+        status: TicketStatus = "available"
+        if deps:
+            all_tickets = self.query_all()
+            resolved_deps = []
+            for dep_ref in deps:
+                match = _resolve_ticket_id(dep_ref, all_tickets)
+                if match:
+                    resolved_deps.append(match)
+                else:
+                    print(
+                        f"Warning: no ticket matching '{dep_ref}'",
+                        file=__import__("sys").stderr,
+                    )
+                    resolved_deps.append(dep_ref)
+            status = "blocked"
+
+        ticket = Ticket(
+            id=str(uuid.uuid4()),
+            objective=objective,
+            metadata=TicketMetadata(
+                status=status,
+                created_at=datetime.now(timezone.utc).isoformat(),
+                depends_on=resolved_deps,
+                tags=tags,
+                functions=functions,
+                skills=skills,
+                tasks=tasks,
+                title=title,
+                assignee=assignee,
+                playbook_id=playbook_id,
+                playbook_run_id=playbook_run_id,
+                parent_ticket_id=parent_ticket_id,
+                model=model,
+                context=context,
+                watch_events=watch_events,
+                kind=kind,
+                signal_type=signal_type,
+                slug=slug,
+            ),
+        )
+        self.save(ticket)
+        return ticket
+
+
+def get_default_store() -> TaskStore:
+    return TaskStore(TICKETS_DIR)
+
 
 def create_ticket(
     objective: str,
@@ -189,54 +322,24 @@ def create_ticket(
     the ticket is created with status ``blocked`` and a ``depends_on``
     list of the referenced ticket IDs (resolved by prefix match).
     """
-    # Filter out namespaced parameter refs (e.g. system.context) —
-    # only bare refs (ticket IDs / prefixes) are real dependencies.
-    deps = [d for d in _DEP_PATTERN.findall(objective) if "." not in d]
-
-    # Resolve dependency prefixes to full ticket IDs.
-    resolved_deps: list[str] | None = None
-    status: TicketStatus = "available"
-    if deps:
-        all_tickets = list_tickets()
-        resolved_deps = []
-        for dep_ref in deps:
-            match = _resolve_ticket_id(dep_ref, all_tickets)
-            if match:
-                resolved_deps.append(match)
-            else:
-                print(
-                    f"Warning: no ticket matching '{dep_ref}'",
-                    file=__import__('sys').stderr,
-                )
-                resolved_deps.append(dep_ref)  # Keep raw for error visibility.
-        status = "blocked"
-
-    ticket = Ticket(
-        id=str(uuid.uuid4()),
+    return get_default_store().create(
         objective=objective,
-        metadata=TicketMetadata(
-            status=status,
-            created_at=datetime.now(timezone.utc).isoformat(),
-            depends_on=resolved_deps,
-            tags=tags,
-            functions=functions,
-            skills=skills,
-            tasks=tasks,
-            title=title,
-            assignee=assignee,
-            playbook_id=playbook_id,
-            playbook_run_id=playbook_run_id,
-            parent_ticket_id=parent_ticket_id,
-            model=model,
-            context=context,
-            watch_events=watch_events,
-            kind=kind,
-            signal_type=signal_type,
-            slug=slug,
-        ),
+        tags=tags,
+        functions=functions,
+        skills=skills,
+        tasks=tasks,
+        title=title,
+        assignee=assignee,
+        playbook_id=playbook_id,
+        playbook_run_id=playbook_run_id,
+        parent_ticket_id=parent_ticket_id,
+        model=model,
+        context=context,
+        watch_events=watch_events,
+        kind=kind,
+        signal_type=signal_type,
+        slug=slug,
     )
-    ticket.save()
-    return ticket
 
 
 def _resolve_ticket_id(
@@ -251,43 +354,11 @@ def _resolve_ticket_id(
 
 def load_ticket(ticket_id: str, ticket_dir: Path | None = None) -> Ticket | None:
     """Load a ticket from disk by ID. If ticket_dir is provided, skips path lookup."""
-    if ticket_dir is None:
-        ticket_dir = TICKETS_DIR / ticket_id
-        
-    if not ticket_dir.exists():
-        return None
-
-    objective_path = ticket_dir / "objective.md"
-    metadata_path = ticket_dir / "metadata.json"
-
-    if not objective_path.exists() or not metadata_path.exists():
-        return None
-
-    return Ticket(
-        id=ticket_id,
-        objective=objective_path.read_text(),
-        metadata=TicketMetadata.from_dict(
-            json.loads(metadata_path.read_text())
-        ),
-    )
+    if ticket_dir is not None:
+        return TaskStore(ticket_dir.parent).get(ticket_id)
+    return get_default_store().get(ticket_id)
 
 
 def list_tickets(*, status: TicketStatus | None = None) -> list[Ticket]:
     """List all tickets, optionally filtered by status."""
-    if not TICKETS_DIR.exists():
-        return []
-
-    tickets: list[Ticket] = []
-    for ticket_dir in sorted(TICKETS_DIR.iterdir()):
-        if not ticket_dir.is_dir():
-            continue
-        ticket = load_ticket(ticket_dir.name, ticket_dir=ticket_dir)
-        if ticket is None:
-            continue
-        if status is not None and ticket.metadata.status != status:
-            continue
-        tickets.append(ticket)
-
-    # Sort by created_at latest first
-    tickets.sort(key=lambda t: t.metadata.created_at or "", reverse=True)
-    return tickets
+    return get_default_store().query_all(status=status)

--- a/packages/bees/docs/api-surface.md
+++ b/packages/bees/docs/api-surface.md
@@ -14,17 +14,15 @@ The application layer (`app/`) consumes `bees` primarily for:
 
 ## API Surface by Module
 
-### `bees.playbook`
+### `bees.ticket`
 
-- `run_playbook(name: str)`: Used in `app/run_playbook.py` to create a task from a template.
-  - [x] TODO: Remove this capability and remove `run_playbook` from the public API. (DONE)
-
-### `bees.session`
-
-- `load_gemini_key()`: Used in `app/cli.py`, `app/drain.py`, and `app/server.py` to load the API key.
-  - [x] TODO: Move key loading to the `app` layer. The library should receive the key as a parameter. (DONE)
-- `run_session(...)`: Used in `app/cli.py` to run a session directly.
-  - [x] TODO: Remove this capability from the CLI and remove `run_session` from the public API. (DONE)
+- [x] TODO: Consider introducing a `TaskStore` (Repository pattern) to encapsulate task CRUD operations (`create_ticket`, `list_tickets`, `load_ticket`), preparing for non-filesystem storage backends.
+- `Ticket`: The task data model. Used in `app/server.py` and `app/respond.py`.
+  - [ ] TODO: Alias to `Task` when exposing in the public API.
+- `create_ticket(...)`: Used in `app/add_ticket.py`. (Note: `app/server.py` now uses `scheduler.create_task()`).
+- `list_tickets(...)`: Used in `app/respond.py` and `app/server.py` to list tasks.
+- `load_ticket(id: str)`: Used in `app/edit_tags.py` and `app/server.py` to load a specific task.
+- [ ] TODO: `app/respond.py` directly manipulates ticket files (writing `response.json`). We need a proper API for updating task state (e.g., responding to a task) to fix this abstraction leak.
 
 ### `bees.scheduler`
 
@@ -34,15 +32,13 @@ The application layer (`app/`) consumes `bees` primarily for:
 - `SchedulerHooks`: Interface for receiving callbacks from the scheduler. Used in `app/drain.py` and `app/server.py`.
   - Added `on_ticket_added` hook.
 
-### `bees.ticket`
+## Completed Refactors
 
-- `Ticket`: The task data model. Used in `app/server.py` and `app/respond.py`.
-  - [ ] TODO: Alias to `Task` when exposing in the public API.
-- `create_ticket(...)`: Used in `app/add_ticket.py`. (Note: `app/server.py` now uses `scheduler.create_task()`).
-- `list_tickets(...)`: Used in `app/respond.py` and `app/server.py` to list tasks.
-- `load_ticket(id: str)`: Used in `app/edit_tags.py` and `app/server.py` to load a specific task.
-- [ ] TODO: `app/respond.py` directly manipulates ticket files (writing `response.json`). We need a proper API for updating task state (e.g., responding to a task) to fix this abstraction leak.
-- [ ] TODO: Consider introducing a `TaskStore` (Repository pattern) to encapsulate task CRUD operations (`create_ticket`, `list_tickets`, `load_ticket`), preparing for non-filesystem storage backends.
+- [x] Introduce `TaskStore` to encapsulate task CRUD operations (DONE)
+- [x] Move `boot_root_template` to `Scheduler` (DONE)
+- [x] Remove `run_playbook` from public API and CLI (DONE)
+- [x] Move key loading to the app layer (DONE)
+- [x] Remove `run_session` from CLI and public API (DONE)
 
 ## Rationale for API Exposure
 

--- a/packages/bees/tests/test_scheduler.py
+++ b/packages/bees/tests/test_scheduler.py
@@ -315,6 +315,7 @@ def test_handle_pause_sets_status(mock_clients):
 def test_promote_does_not_cascade_paused(mock_clients):
     """A blocked ticket with a paused dep stays blocked (no cascade)."""
     from bees.scheduler import promote_blocked_tickets
+    from bees.ticket import get_default_store
 
     parent = create_ticket("Parent")
     parent.metadata.status = "paused"
@@ -325,7 +326,7 @@ def test_promote_does_not_cascade_paused(mock_clients):
     child.metadata.depends_on = [parent.id]
     child.save_metadata()
 
-    promote_blocked_tickets()
+    promote_blocked_tickets(get_default_store())
 
     from bees.ticket import load_ticket
     fresh_child = load_ticket(child.id)


### PR DESCRIPTION
## What
Introduced `TaskStore` to encapsulate task CRUD operations in `bees`, moving away from global functions that directly accessed the file system. Updated `Scheduler` and `app/server.py` to use this store, and renamed `queryAll` to `query_all` to follow Python conventions.

## Why
To clean up the API surface of `bees`, prepare for non-filesystem storage backends, and align with Python naming conventions (PEP 8).

## Changes
### packages/bees
- `bees/ticket.py`: Introduced `TaskStore`, refactored `create_ticket`, `load_ticket`, `list_tickets` to use it via `get_default_store()`. Renamed `queryAll` to `query_all`.
- `bees/scheduler.py`: Updated `Scheduler` to use `TaskStore` instead of global ticket functions.
- `app/server.py`: Created global `TaskStore` instance, passed it to `Scheduler`, and updated endpoints.

### tests
- Updated tests to pass store where needed and fixed `test_promote_does_not_cascade_paused`.

## Testing
- Ran `npm run test:python` in `packages/bees`. All 161 tests passed.
