### PR TITLE
[bees] Decouple Bees Storage from Global Filesystem

### DIFF
--- a/packages/bees/app/add_ticket.py
+++ b/packages/bees/app/add_ticket.py
@@ -14,7 +14,10 @@ from __future__ import annotations
 import argparse
 import sys
 
-from bees.ticket import create_ticket
+from bees import TaskStore
+from bees.config import HIVE_DIR
+
+task_store = TaskStore(HIVE_DIR / "tickets")
 
 
 def main() -> None:
@@ -64,7 +67,7 @@ def main() -> None:
     if args.skills:
         skills = [f.strip() for f in args.skills.split(",") if f.strip()]
 
-    ticket = create_ticket(objective, tags=tags, functions=functions, skills=skills)  # noqa: positional ok — objective is before *
+    ticket = task_store.create(objective, tags=tags, functions=functions, skills=skills)
 
     print(f"Created ticket {ticket.id}", file=sys.stderr)
     print(f"  objective: {objective!r}", file=sys.stderr)

--- a/packages/bees/app/edit_tags.py
+++ b/packages/bees/app/edit_tags.py
@@ -14,7 +14,10 @@ from __future__ import annotations
 import argparse
 import sys
 
-from bees.ticket import load_ticket
+from bees import TaskStore
+from bees.config import HIVE_DIR
+
+task_store = TaskStore(HIVE_DIR / "tickets")
 
 
 def main() -> None:
@@ -35,7 +38,7 @@ def main() -> None:
     
     args = parser.parse_args()
 
-    ticket = load_ticket(args.ticket_id)
+    ticket = task_store.get(args.ticket_id)
     if not ticket:
         print(f"Error: Ticket {args.ticket_id} not found", file=sys.stderr)
         sys.exit(1)

--- a/packages/bees/app/respond.py
+++ b/packages/bees/app/respond.py
@@ -18,7 +18,10 @@ import json
 import sys
 from typing import Any
 
-from bees.ticket import Ticket, list_tickets
+from bees import Task, TaskStore
+from bees.config import HIVE_DIR
+
+task_store = TaskStore(HIVE_DIR / "tickets")
 
 
 def _format_prompt(suspend_event: dict[str, Any] | None) -> str:
@@ -48,7 +51,7 @@ def _format_choices(suspend_event: dict[str, Any] | None) -> list[dict] | None:
     return payload.get("choices", [])
 
 
-def _respond_to_ticket(ticket: Ticket) -> bool:
+def _respond_to_ticket(ticket: Task) -> bool:
     """Prompt the user and save their response. Returns True if responded."""
     label = ticket.id[:8]
     prompt_text = _format_prompt(ticket.metadata.suspend_event)
@@ -91,13 +94,8 @@ def _respond_to_ticket(ticket: Ticket) -> bool:
     else:
         response = {"text": answer}
 
-    # Write response and update assignee.
-    response_path = ticket.dir / "response.json"
-    response_path.write_text(
-        json.dumps(response, indent=2, ensure_ascii=False) + "\n"
-    )
-    ticket.metadata.assignee = "agent"
-    ticket.save_metadata()
+    # Write response and update assignee via store.
+    task_store.respond(ticket.id, response)
 
     print(f"  ✅ Response saved. Run 'npm run ticket:drain' to resume.")
     return True
@@ -106,7 +104,7 @@ def _respond_to_ticket(ticket: Ticket) -> bool:
 def main() -> None:
     """CLI entry point for ticket:respond."""
     suspended = [
-        t for t in list_tickets(status="suspended")
+        t for t in task_store.query_all(status="suspended")
         if t.metadata.assignee == "user"
     ]
 

--- a/packages/bees/app/server.py
+++ b/packages/bees/app/server.py
@@ -34,15 +34,13 @@ from sse_starlette.sse import EventSourceResponse
 
 from bees.scheduler import Scheduler, SchedulerHooks
 from app.auth import load_gemini_key
-from bees.ticket import (
-    Ticket,
-    TaskStore,
-    TICKETS_DIR,
-)
+from bees import Task, TaskStore
+from bees.config import HIVE_DIR
 from opal_backend.local.backend_client_impl import HttpBackendClient
 
 logger = logging.getLogger(__name__)
 
+TICKETS_DIR = HIVE_DIR / "tickets"
 task_store = TaskStore(TICKETS_DIR)
 
 
@@ -80,7 +78,7 @@ scheduler: Scheduler | None = None
 # ---------------------------------------------------------------------------
 
 
-async def _on_ticket_added(ticket: Ticket) -> None:
+async def _on_ticket_added(ticket: Task) -> None:
     """Broadcast a newly added ticket."""
     await broadcaster.broadcast({
         "type": "ticket_added",
@@ -105,7 +103,7 @@ async def _on_ticket_event(ticket_id: str, event: dict[str, Any]) -> None:
     })
 
 
-async def _on_ticket_start(ticket: Ticket) -> None:
+async def _on_ticket_start(ticket: Task) -> None:
     """Broadcast when a ticket transitions to running."""
     await broadcaster.broadcast({
         "type": "ticket_update",
@@ -113,7 +111,7 @@ async def _on_ticket_start(ticket: Ticket) -> None:
     })
 
 
-async def _on_ticket_done(ticket: Ticket) -> None:
+async def _on_ticket_done(ticket: Task) -> None:
     """Post-completion hook: broadcast and run playbook hooks."""
     await broadcaster.broadcast({
         "type": "ticket_update",
@@ -207,7 +205,7 @@ app.add_middleware(
 # ---------------------------------------------------------------------------
 
 
-def _ticket_to_dict(ticket: Ticket) -> dict[str, Any]:
+def _ticket_to_dict(ticket: Task) -> dict[str, Any]:
     """Serialize a ticket for JSON response."""
     d = {
         "id": ticket.id,
@@ -221,7 +219,7 @@ def _ticket_to_dict(ticket: Ticket) -> dict[str, Any]:
     return d
 
 
-def _read_chat_log(ticket: Ticket) -> list[dict[str, str]]:
+def _read_chat_log(ticket: Task) -> list[dict[str, str]]:
     """Read the ticket's chat log written by the chat function.
 
     Returns a list of ``{"role": "agent"|"user", "text": "..."}`` entries.
@@ -325,9 +323,6 @@ async def respond_to_ticket(
     if ticket.metadata.assignee != "user":
         raise HTTPException(400, f"Ticket is not assigned to user")
 
-    # Write response and flip assignee.
-    response_path = ticket.dir / "response.json"
-
     response: dict[str, Any] = {}
     if req.selectedIds is not None:
         response["selectedIds"] = req.selectedIds
@@ -336,11 +331,7 @@ async def respond_to_ticket(
     if req.contextUpdates:
         response["context_updates"] = req.contextUpdates
 
-    response_path.write_text(
-        json.dumps(response, indent=2, ensure_ascii=False) + "\n"
-    )
-    ticket.metadata.assignee = "agent"
-    ticket.save_metadata()
+    ticket = task_store.respond(ticket_id, response)
 
     await broadcaster.broadcast({
         "type": "ticket_update",
@@ -409,7 +400,7 @@ async def retry_ticket(ticket_id: str) -> dict[str, Any]:
 
 
 def should_include_ticket(
-    ticket: Ticket,
+    ticket: Task,
     status: str | None = None,
     tags: str | None = None,
     kind: str | None = None,
@@ -473,7 +464,7 @@ async def get_status(
     """Return a status response containing both the summary text and structured tasks."""
     tickets = task_store.query_all()
 
-    by_run: dict[str, list[Ticket]] = {}
+    by_run: dict[str, list[Task]] = {}
     active_running = []
 
     for t in tickets:

--- a/packages/bees/bees/__init__.py
+++ b/packages/bees/bees/__init__.py
@@ -2,3 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Bees — agent swarm orchestration framework."""
+
+from .ticket import Ticket as Task
+from .ticket import TaskStore
+from .scheduler import Scheduler, SchedulerHooks
+
+__all__ = ["Task", "TaskStore", "Scheduler", "SchedulerHooks"]

--- a/packages/bees/bees/functions/chat.py
+++ b/packages/bees/bees/functions/chat.py
@@ -39,6 +39,7 @@ _LOADED = load_declarations("chat", declarations_dir=_DECLARATIONS_DIR)
 def get_chat_function_group_factory(
     on_chat_entry: "ChatEntryCallback" = None,
     workspace_root_id: str | None = None,
+    scheduler: Any | None = None,
 ) -> "FunctionGroupFactory":
     """Return a factory that builds the bees chat function group.
 
@@ -75,9 +76,8 @@ def get_chat_function_group_factory(
             # If updates are already buffered, return immediately
             # without suspending — the updates are emitted as text
             # parts via CONTEXT_PARTS_KEY.
-            if workspace_root_id:
-                from bees.ticket import load_ticket
-                ticket = load_ticket(workspace_root_id)
+            if workspace_root_id and scheduler:
+                ticket = scheduler.store.get(workspace_root_id)
                 if ticket and ticket.metadata.pending_context_updates:
                     updates = ticket.metadata.pending_context_updates
                     ticket.metadata.pending_context_updates = []

--- a/packages/bees/bees/functions/events.py
+++ b/packages/bees/bees/functions/events.py
@@ -24,7 +24,7 @@ from opal_backend.function_definition import (
     FunctionGroupFactory,
 )
 
-from bees.ticket import Ticket, create_ticket
+from bees.ticket import Ticket
 
 __all__ = ["get_events_function_group_factory"]
 
@@ -42,6 +42,7 @@ def _make_handlers(
     deliver_to_parent: Callable[[dict[str, Any]], None] | None = None,
     ticket_id: str | None = None,
     scope: SubagentScope | None = None,
+    scheduler: Any | None = None,
 ) -> dict[str, Any]:
     """Build the handler map for the events function group."""
 
@@ -95,7 +96,9 @@ def _make_handlers(
             status_cb(f"Broadcasting event: {event_type}")
 
         try:
-            ticket = create_ticket(
+            if not scheduler:
+                return {"error": "Scheduler not available"}
+            ticket = scheduler.store.create(
                 "",  # No objective — event tickets carry context, not work.
                 kind="coordination",
                 signal_type=event_type,
@@ -129,6 +132,7 @@ def get_events_function_group_factory(
     deliver_to_parent: Callable[[dict[str, Any]], None] | None = None,
     ticket_id: str | None = None,
     scope: SubagentScope | None = None,
+    scheduler: Any | None = None,
 ) -> FunctionGroupFactory:
     """Build a FunctionGroupFactory for events."""
     def factory(hooks: SessionHooks) -> FunctionGroup:
@@ -137,6 +141,7 @@ def get_events_function_group_factory(
             deliver_to_parent=deliver_to_parent,
             ticket_id=ticket_id,
             scope=scope,
+            scheduler=scheduler,
         )
         return assemble_function_group(_LOADED, handlers)
     return factory

--- a/packages/bees/bees/functions/tasks.py
+++ b/packages/bees/bees/functions/tasks.py
@@ -41,8 +41,7 @@ def _make_handlers(
             
         allowed_tasks = []
         if caller_ticket_id:
-            from bees.ticket import load_ticket
-            ticket = load_ticket(caller_ticket_id)
+            ticket = scheduler.store.get(caller_ticket_id) if scheduler else None
             if ticket and ticket.metadata.tasks:
                 allowed_tasks = ticket.metadata.tasks
                 
@@ -89,8 +88,7 @@ def _make_handlers(
 
 
         try:
-            from bees.ticket import load_ticket as _load
-            parent = _load(caller_ticket_id) if caller_ticket_id else None
+            parent = scheduler.store.get(caller_ticket_id) if scheduler and caller_ticket_id else None
             if not parent:
                 return {"error": "Parent ticket not found"}
 
@@ -98,6 +96,7 @@ def _make_handlers(
                 task_type,
                 parent_ticket=parent,
                 slug=slug,
+                store=scheduler.store,
                 context=objective,
                 title=title or summary,
                 scope=scope,
@@ -118,8 +117,7 @@ def _make_handlers(
                 status_cb(None, None)
                 
             if status == "completed":
-                from bees.ticket import load_ticket
-                fresh = load_ticket(ticket.id)
+                fresh = scheduler.store.get(ticket.id) if scheduler else None
                 return {"outcome": fresh.metadata.outcome if fresh else "completed"}
             else:
                 return {"task_id": ticket.id, "status": status}
@@ -134,11 +132,9 @@ def _make_handlers(
         if caller_ticket_id:
             from collections import defaultdict
 
-            from bees.ticket import list_tickets as _list_tickets
-
             # Build an index: creator_ticket_id -> list of child tickets.
             children_of: dict[str, list[Any]] = defaultdict(list)
-            for t in _list_tickets():
+            for t in (scheduler.store.query_all() if scheduler else []):
                 if t.metadata.creator_ticket_id:
                     children_of[t.metadata.creator_ticket_id].append(t)
 

--- a/packages/bees/bees/playbook.py
+++ b/packages/bees/bees/playbook.py
@@ -24,7 +24,8 @@ import yaml
 
 from bees.config import HIVE_DIR
 from bees.subagent_scope import SubagentScope
-from bees.ticket import Ticket, create_ticket
+from bees import TaskStore
+from bees.ticket import Ticket
 
 logger = logging.getLogger(__name__)
 
@@ -101,6 +102,7 @@ def _load_hooks(name: str) -> ModuleType | None:
 def run_playbook(
     name: str,
     *,
+    store: TaskStore,
     context: str | None = None,
     parent_ticket_id: str | None = None,
     slug: str | None = None,
@@ -131,7 +133,7 @@ def run_playbook(
     playbook_id = data.get("name", name)
     playbook_run_id = str(uuid.uuid4())
 
-    ticket = create_ticket(
+    ticket = store.create(
         data.get("objective", ""),
         title=data.get("title"),
         functions=data.get("functions"),
@@ -155,6 +157,7 @@ def run_playbook(
                 child_name,
                 parent_ticket=ticket,
                 slug=child_name,
+                store=store,
             )
         except Exception as exc:
             logger.warning(
@@ -170,6 +173,7 @@ def stamp_child_ticket(
     *,
     parent_ticket: Ticket,
     slug: str,
+    store: TaskStore,
     context: str | None = None,
     title: str | None = None,
     scope: SubagentScope | None = None,
@@ -188,6 +192,7 @@ def stamp_child_ticket(
 
     child = run_playbook(
         template_name,
+        store=store,
         context=context,
         parent_ticket_id=child_scope.workspace_root_id,
         slug=child_scope.slug_path,

--- a/packages/bees/bees/scheduler.py
+++ b/packages/bees/bees/scheduler.py
@@ -62,7 +62,6 @@ from bees.ticket import (
     Ticket,
     _DEP_PATTERN,
     TaskStore,
-    get_default_store,
 )
 from bees.subagent_scope import SubagentScope
 from opal_backend.local.backend_client_impl import HttpBackendClient
@@ -258,13 +257,13 @@ class Scheduler:
         *,
         http: httpx.AsyncClient,
         backend: HttpBackendClient,
+        store: TaskStore,
         hooks: SchedulerHooks | None = None,
-        store: TaskStore | None = None,
     ) -> None:
         self._http = http
         self._backend = backend
         self._hooks = hooks or SchedulerHooks()
-        self.store = store or get_default_store()
+        self.store = store
         self._trigger = asyncio.Event()
         self._running = False
         self._running_tickets: set[str] = set()
@@ -315,7 +314,7 @@ class Scheduler:
             return None
 
         logger.info("Booting root template '%s'", root)
-        ticket = run_playbook(root)
+        ticket = run_playbook(root, store=self.store)
         
         if self._hooks.on_ticket_added:
             await self._hooks.on_ticket_added(ticket)
@@ -423,17 +422,7 @@ class Scheduler:
             and target.metadata.assignee == "user"
             and target_id not in self._running_tickets
         ):
-            response_path = target.dir / "response.json"
-            response_path.write_text(
-                json.dumps(
-                    {"context_updates": [update]},
-                    indent=2,
-                    ensure_ascii=False,
-                )
-                + "\n"
-            )
-            target.metadata.assignee = "agent"
-            target.save_metadata()
+            self.store.respond(target_id, {"context_updates": [update]})
             logger.info("Context update delivered to %s via response.json", target_id)
         else:
             # Path 3: buffer in metadata.

--- a/packages/bees/bees/session.py
+++ b/packages/bees/bees/session.py
@@ -508,6 +508,7 @@ async def run_session(
                 deliver_to_parent=deliver_to_parent,
                 ticket_id=ticket_id,
                 scope=scope,
+                scheduler=scheduler,
             ),
             get_tasks_function_group_factory(
                 scope=scope,
@@ -518,6 +519,7 @@ async def run_session(
             get_chat_function_group_factory(
                 on_chat_entry=_make_chat_log_writer(ticket_dir) if ticket_dir else None,
                 workspace_root_id=workspace_root_id,
+                scheduler=scheduler,
             ),
         ],
         function_filter=function_filter,
@@ -692,6 +694,7 @@ async def resume_session(
                 deliver_to_parent=deliver_to_parent,
                 ticket_id=ticket_id,
                 scope=scope,
+                scheduler=scheduler,
             ),
             get_tasks_function_group_factory(
                 scope=scope,
@@ -702,6 +705,7 @@ async def resume_session(
             get_chat_function_group_factory(
                 on_chat_entry=_make_chat_log_writer(ticket_dir),
                 workspace_root_id=workspace_root_id,
+                scheduler=scheduler,
             ),
         ],
         file_system=disk_fs,
@@ -722,8 +726,12 @@ async def resume_session(
         all_updates.extend(response_updates)
 
     if ticket_id:
-        from bees.ticket import load_ticket
-        own_ticket = load_ticket(ticket_id)
+        if scheduler:
+            own_ticket = scheduler.store.get(ticket_id)
+        else:
+            from bees.ticket import get_default_store
+            own_ticket = get_default_store().get(ticket_id)
+            
         if own_ticket and own_ticket.metadata.pending_context_updates:
             all_updates.extend(own_ticket.metadata.pending_context_updates)
             own_ticket.metadata.pending_context_updates = []

--- a/packages/bees/bees/ticket.py
+++ b/packages/bees/bees/ticket.py
@@ -21,7 +21,7 @@ from typing import Any, Literal
 
 from bees.config import HIVE_DIR
 
-TICKETS_DIR = HIVE_DIR / "tickets"
+
 
 TicketStatus = Literal[
     "available", "blocked", "running", "suspended", "paused",
@@ -116,11 +116,8 @@ class Ticket:
 
     id: str
     objective: str
+    dir: Path
     metadata: TicketMetadata = field(default_factory=TicketMetadata)
-
-    @property
-    def dir(self) -> Path:
-        return TICKETS_DIR / self.id
 
     @property
     def fs_dir(self) -> Path:
@@ -133,7 +130,7 @@ class Ticket:
         parent = self.metadata.parent_ticket_id
         
         if parent:
-            base = TICKETS_DIR / parent / "filesystem"
+            base = self.dir.parent / parent / "filesystem"
         else:
             base = self.dir / "filesystem"
             
@@ -181,6 +178,7 @@ class TaskStore:
         return Ticket(
             id=ticket_id,
             objective=objective_path.read_text(),
+            dir=ticket_dir,
             metadata=TicketMetadata.from_dict(
                 json.loads(metadata_path.read_text())
             ),
@@ -220,6 +218,22 @@ class TaskStore:
             json.dumps(ticket.metadata.to_dict(), indent=2, ensure_ascii=False)
             + "\n"
         )
+
+    def respond(self, ticket_id: str, response: dict[str, Any]) -> Ticket:
+        """Save user response to a suspended ticket."""
+        ticket = self.get(ticket_id)
+        if not ticket:
+            raise ValueError(f"Ticket {ticket_id} not found")
+        
+        ticket_dir = self.tickets_dir / ticket_id
+        response_path = ticket_dir / "response.json"
+        response_path.write_text(
+            json.dumps(response, indent=2, ensure_ascii=False) + "\n"
+        )
+        
+        ticket.metadata.assignee = "agent"
+        self.save_metadata(ticket)
+        return ticket
 
     def create(
         self,
@@ -265,9 +279,11 @@ class TaskStore:
                     resolved_deps.append(dep_ref)
             status = "blocked"
 
+        ticket_id = str(uuid.uuid4())
         ticket = Ticket(
-            id=str(uuid.uuid4()),
+            id=ticket_id,
             objective=objective,
+            dir=self.tickets_dir / ticket_id,
             metadata=TicketMetadata(
                 status=status,
                 created_at=datetime.now(timezone.utc).isoformat(),
@@ -293,53 +309,7 @@ class TaskStore:
         return ticket
 
 
-def get_default_store() -> TaskStore:
-    return TaskStore(TICKETS_DIR)
 
-
-def create_ticket(
-    objective: str,
-    *,
-    tags: list[str] | None = None,
-    functions: list[str] | None = None,
-    skills: list[str] | None = None,
-    tasks: list[str] | None = None,
-    title: str | None = None,
-    assignee: str | None = None,
-    playbook_id: str | None = None,
-    playbook_run_id: str | None = None,
-    parent_ticket_id: str | None = None,
-    model: str | None = None,
-    context: str | None = None,
-    watch_events: list[dict[str, Any]] | None = None,
-    kind: TicketKind = "work",
-    signal_type: str | None = None,
-    slug: str | None = None,
-) -> Ticket:
-    """Create a new ticket.
-
-    Scans the objective for ``{{id}}`` references. If any are found,
-    the ticket is created with status ``blocked`` and a ``depends_on``
-    list of the referenced ticket IDs (resolved by prefix match).
-    """
-    return get_default_store().create(
-        objective=objective,
-        tags=tags,
-        functions=functions,
-        skills=skills,
-        tasks=tasks,
-        title=title,
-        assignee=assignee,
-        playbook_id=playbook_id,
-        playbook_run_id=playbook_run_id,
-        parent_ticket_id=parent_ticket_id,
-        model=model,
-        context=context,
-        watch_events=watch_events,
-        kind=kind,
-        signal_type=signal_type,
-        slug=slug,
-    )
 
 
 def _resolve_ticket_id(
@@ -352,13 +322,4 @@ def _resolve_ticket_id(
     return None
 
 
-def load_ticket(ticket_id: str, ticket_dir: Path | None = None) -> Ticket | None:
-    """Load a ticket from disk by ID. If ticket_dir is provided, skips path lookup."""
-    if ticket_dir is not None:
-        return TaskStore(ticket_dir.parent).get(ticket_id)
-    return get_default_store().get(ticket_id)
 
-
-def list_tickets(*, status: TicketStatus | None = None) -> list[Ticket]:
-    """List all tickets, optionally filtered by status."""
-    return get_default_store().query_all(status=status)

--- a/packages/bees/docs/api-surface.md
+++ b/packages/bees/docs/api-surface.md
@@ -18,11 +18,11 @@ The application layer (`app/`) consumes `bees` primarily for:
 
 - [x] TODO: Consider introducing a `TaskStore` (Repository pattern) to encapsulate task CRUD operations (`create_ticket`, `list_tickets`, `load_ticket`), preparing for non-filesystem storage backends.
 - `Ticket`: The task data model. Used in `app/server.py` and `app/respond.py`.
-  - [ ] TODO: Alias to `Task` when exposing in the public API.
+  - [x] TODO: Alias to `Task` when exposing in the public API. (DONE)
 - `create_ticket(...)`: Used in `app/add_ticket.py`. (Note: `app/server.py` now uses `scheduler.create_task()`).
 - `list_tickets(...)`: Used in `app/respond.py` and `app/server.py` to list tasks.
 - `load_ticket(id: str)`: Used in `app/edit_tags.py` and `app/server.py` to load a specific task.
-- [ ] TODO: `app/respond.py` directly manipulates ticket files (writing `response.json`). We need a proper API for updating task state (e.g., responding to a task) to fix this abstraction leak.
+- [x] TODO: `app/respond.py` directly manipulates ticket files (writing `response.json`). We need a proper API for updating task state (e.g., responding to a task) to fix this abstraction leak.
 
 ### `bees.scheduler`
 
@@ -35,6 +35,7 @@ The application layer (`app/`) consumes `bees` primarily for:
 ## Completed Refactors
 
 - [x] Introduce `TaskStore` to encapsulate task CRUD operations (DONE)
+- [x] Fix abstraction leak in `app/respond.py` by adding `TaskStore.respond` (DONE)
 - [x] Move `boot_root_template` to `Scheduler` (DONE)
 - [x] Remove `run_playbook` from public API and CLI (DONE)
 - [x] Move key loading to the app layer (DONE)

--- a/packages/bees/tests/test_chat.py
+++ b/packages/bees/tests/test_chat.py
@@ -8,29 +8,30 @@ from __future__ import annotations
 import pytest
 from unittest.mock import MagicMock
 from bees.functions.chat import get_chat_function_group_factory
-from bees.ticket import create_ticket, load_ticket
+from bees import TaskStore
 from bees.context_updates import CONTEXT_UPDATE_TAG
 from opal_backend.function_caller import CONTEXT_PARTS_KEY
 
 
-@pytest.fixture(autouse=True)
-def _temp_tickets(tmp_path, monkeypatch):
-    """Redirect ticket storage to a temp directory for each test."""
+@pytest.fixture
+def task_store(tmp_path):
+    """Create a TaskStore in a temp directory."""
     tickets_dir = tmp_path / "tickets"
     tickets_dir.mkdir()
-    monkeypatch.setattr("bees.ticket.TICKETS_DIR", tickets_dir)
-    yield tickets_dir
+    return TaskStore(tickets_dir)
 
 
 @pytest.mark.asyncio
-async def test_chat_await_context_update_from_metadata(monkeypatch):
+async def test_chat_await_context_update_from_metadata(task_store, monkeypatch):
     # 1. Create a ticket with pending updates
-    ticket = create_ticket("Objective")
+    ticket = task_store.create("Objective")
     ticket.metadata.pending_context_updates = [{"task_id": "sub-1", "outcome": "done"}]
     ticket.save_metadata()
 
     # 2. Get handlers via factory
-    factory = get_chat_function_group_factory(workspace_root_id=ticket.id)
+    mock_scheduler = MagicMock()
+    mock_scheduler.store = task_store
+    factory = get_chat_function_group_factory(workspace_root_id=ticket.id, scheduler=mock_scheduler)
     mock_hooks = MagicMock()
     
     # Mock assemble_function_group to just return the handlers
@@ -56,6 +57,7 @@ async def test_chat_await_context_update_from_metadata(monkeypatch):
     assert "done" in part["text"]
     
     # Verify metadata cleared
-    updated_ticket = load_ticket(ticket.id)
+    updated_ticket = task_store.get(ticket.id)
     assert updated_ticket.metadata.pending_context_updates == []
+
 

--- a/packages/bees/tests/test_events.py
+++ b/packages/bees/tests/test_events.py
@@ -9,29 +9,30 @@ from __future__ import annotations
 import pytest
 from unittest.mock import MagicMock
 
-from bees.ticket import TICKETS_DIR
+from bees import TaskStore
 from bees.subagent_scope import SubagentScope
 
 
-@pytest.fixture(autouse=True)
-def tickets_dir(tmp_path, monkeypatch):
-    """Point TICKETS_DIR to a temp directory."""
+@pytest.fixture
+def task_store(tmp_path):
+    """Create a TaskStore in a temp directory."""
     tickets_dir = tmp_path / "tickets"
     tickets_dir.mkdir()
-    monkeypatch.setattr("bees.ticket.TICKETS_DIR", tickets_dir)
-    return tickets_dir
+    return TaskStore(tickets_dir)
 
 
 # ---- events_broadcast ----
 
 
 @pytest.mark.asyncio
-async def test_events_broadcast_creates_ticket(tickets_dir):
+async def test_events_broadcast_creates_ticket(task_store):
     """events_broadcast creates a coordination ticket and calls the callback."""
     from bees.functions.events import _make_handlers
 
     callback = MagicMock()
-    handlers = _make_handlers(on_events_broadcast=callback)
+    mock_scheduler = MagicMock()
+    mock_scheduler.store = task_store
+    handlers = _make_handlers(on_events_broadcast=callback, scheduler=mock_scheduler)
 
     result = await handlers["events_broadcast"](
         {"type": "app_update", "message": "New app"}, None,
@@ -111,6 +112,7 @@ async def test_events_send_to_parent_no_parent():
         {"type": "progress", "message": "hello"}, None,
     )
     assert "error" in result
+
 
 
 

--- a/packages/bees/tests/test_playbook.py
+++ b/packages/bees/tests/test_playbook.py
@@ -14,19 +14,30 @@ import yaml
 from bees.playbook import (
     load_playbook,
     load_system_config,
-    run_playbook,
+    run_playbook as _real_run_playbook,
     run_event_hooks,
-    stamp_child_ticket,
+    stamp_child_ticket as _real_stamp_child_ticket,
 )
-from bees.ticket import TICKETS_DIR, _DEP_PATTERN
+from bees.ticket import _DEP_PATTERN
+from bees import TaskStore
 
+GLOBAL_STORE = None
+
+def run_playbook(name: str, **kwargs):
+    assert GLOBAL_STORE is not None, "GLOBAL_STORE not initialized"
+    return _real_run_playbook(name, store=GLOBAL_STORE, **kwargs)
+
+def stamp_child_ticket(template_name: str, *, parent_ticket, slug, **kwargs):
+    assert GLOBAL_STORE is not None, "GLOBAL_STORE not initialized"
+    return _real_stamp_child_ticket(template_name, parent_ticket=parent_ticket, slug=slug, store=GLOBAL_STORE, **kwargs)
 
 @pytest.fixture(autouse=True)
 def _temp_dirs(tmp_path, monkeypatch):
     """Redirect ticket and template storage to temp directories."""
+    global GLOBAL_STORE
     tickets_dir = tmp_path / "tickets"
     tickets_dir.mkdir()
-    monkeypatch.setattr("bees.ticket.TICKETS_DIR", tickets_dir)
+    GLOBAL_STORE = TaskStore(tickets_dir)
 
     config_dir = tmp_path / "config"
     config_dir.mkdir()
@@ -174,8 +185,7 @@ class TestRunPlaybook:
 class TestRunEventHooks:
 
     def test_no_playbook_passes_through(self, write_template):
-        from bees.ticket import create_ticket
-        ticket = create_ticket("standalone objective")
+        ticket = GLOBAL_STORE.create("standalone objective")
         result = run_event_hooks("some_signal", "payload", ticket)
         assert result == "payload"
 
@@ -256,56 +266,65 @@ class TestTicketPaths:
     """Tests for Ticket.dir and Ticket.fs_dir path resolution."""
 
     def test_dir_always_top_level(self, _temp_dirs):
-        from bees.ticket import Ticket, TicketMetadata, TICKETS_DIR
+        from bees.ticket import Ticket, TicketMetadata
 
         t = Ticket(
             id="abc-123",
             objective="test",
+            dir=GLOBAL_STORE.tickets_dir / "abc-123",
             metadata=TicketMetadata(
                 playbook_run_id="run-456",
                 parent_ticket_id="run-789",
             ),
         )
-        assert t.dir == TICKETS_DIR / "abc-123"
+        assert t.dir == GLOBAL_STORE.tickets_dir / "abc-123"
 
     def test_fs_dir_with_parent_ticket_id(self, _temp_dirs):
-        from bees.ticket import Ticket, TicketMetadata, TICKETS_DIR
+        from bees.ticket import Ticket, TicketMetadata
 
         t = Ticket(
             id="abc-123",
             objective="test",
+            dir=GLOBAL_STORE.tickets_dir / "abc-123",
             metadata=TicketMetadata(parent_ticket_id="parent-ticket"),
         )
-        assert t.fs_dir == TICKETS_DIR / "parent-ticket" / "filesystem"
+        assert t.fs_dir == GLOBAL_STORE.tickets_dir / "parent-ticket" / "filesystem"
 
     def test_fs_dir_plain_ticket(self, _temp_dirs):
-        from bees.ticket import Ticket, TicketMetadata, TICKETS_DIR
+        from bees.ticket import Ticket, TicketMetadata
 
-        t = Ticket(id="abc-123", objective="test", metadata=TicketMetadata())
-        assert t.fs_dir == TICKETS_DIR / "abc-123" / "filesystem"
+        t = Ticket(
+            id="abc-123",
+            objective="test",
+            dir=GLOBAL_STORE.tickets_dir / "abc-123",
+            metadata=TicketMetadata(),
+        )
+        assert t.fs_dir == GLOBAL_STORE.tickets_dir / "abc-123" / "filesystem"
 
     def test_fs_dir_playbook_run_id_alone_uses_own_dir(self, _temp_dirs):
-        from bees.ticket import Ticket, TicketMetadata, TICKETS_DIR
+        from bees.ticket import Ticket, TicketMetadata
 
         t = Ticket(
             id="abc-123",
             objective="test",
+            dir=GLOBAL_STORE.tickets_dir / "abc-123",
             metadata=TicketMetadata(playbook_run_id="pb-run"),
         )
-        assert t.fs_dir == TICKETS_DIR / "abc-123" / "filesystem"
+        assert t.fs_dir == GLOBAL_STORE.tickets_dir / "abc-123" / "filesystem"
 
     def test_fs_dir_parent_takes_precedence(self, _temp_dirs):
-        from bees.ticket import Ticket, TicketMetadata, TICKETS_DIR
+        from bees.ticket import Ticket, TicketMetadata
 
         t = Ticket(
             id="abc-123",
             objective="test",
+            dir=GLOBAL_STORE.tickets_dir / "abc-123",
             metadata=TicketMetadata(
                 playbook_run_id="pb-run",
                 parent_ticket_id="parent-ticket",
             ),
         )
-        assert t.fs_dir == TICKETS_DIR / "parent-ticket" / "filesystem"
+        assert t.fs_dir == GLOBAL_STORE.tickets_dir / "parent-ticket" / "filesystem"
 
 
 
@@ -421,8 +440,7 @@ class TestAutostart:
 
         parent = run_playbook("boss")
 
-        from bees.ticket import list_tickets
-        all_tickets = list_tickets()
+        all_tickets = GLOBAL_STORE.query_all()
         children = [t for t in all_tickets if t.metadata.creator_ticket_id == parent.id]
 
         assert len(children) == 1
@@ -438,8 +456,7 @@ class TestAutostart:
 
         parent = run_playbook("solo")
 
-        from bees.ticket import list_tickets
-        all_tickets = list_tickets()
+        all_tickets = GLOBAL_STORE.query_all()
         children = [t for t in all_tickets if t.metadata.creator_ticket_id == parent.id]
 
         assert len(children) == 0
@@ -462,8 +479,7 @@ class TestAutostart:
 
         parent = run_playbook("boss")
 
-        from bees.ticket import list_tickets
-        all_tickets = list_tickets()
+        all_tickets = GLOBAL_STORE.query_all()
         children = [t for t in all_tickets if t.metadata.creator_ticket_id == parent.id]
 
         assert len(children) == 2

--- a/packages/bees/tests/test_query.py
+++ b/packages/bees/tests/test_query.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
+from pathlib import Path
 from bees.ticket import Ticket, TicketMetadata
 from app.server import should_include_ticket
 
@@ -11,6 +12,7 @@ class TestQueryParser(unittest.TestCase):
         self.ticket = Ticket(
             id="test-id",
             objective="test objective",
+            dir=Path("/tmp/test-ticket"),
             metadata=TicketMetadata(
                 status="available",
                 tags=["foo", "bar"],

--- a/packages/bees/tests/test_sandbox.py
+++ b/packages/bees/tests/test_sandbox.py
@@ -14,16 +14,6 @@ from unittest.mock import MagicMock
 
 from bees.functions.sandbox import get_sandbox_function_group_factory
 from bees.subagent_scope import SubagentScope
-from bees.ticket import create_ticket
-
-
-@pytest.fixture(autouse=True)
-def _temp_tickets(tmp_path, monkeypatch):
-    """Redirect ticket storage to a temp directory for each test."""
-    tickets_dir = tmp_path / "tickets"
-    tickets_dir.mkdir()
-    monkeypatch.setattr("bees.ticket.TICKETS_DIR", tickets_dir)
-    yield tickets_dir
 
 
 @pytest.mark.asyncio

--- a/packages/bees/tests/test_scheduler.py
+++ b/packages/bees/tests/test_scheduler.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import yaml
 
 from bees.scheduler import Scheduler
-from bees.ticket import create_ticket
+from bees import TaskStore
 
 
 @pytest.fixture
@@ -20,12 +20,15 @@ def mock_clients():
     return AsyncMock(), MagicMock()
 
 
+GLOBAL_STORE = None
+
 @pytest.fixture(autouse=True)
 def tickets_dir(tmp_path, monkeypatch):
     """Point TICKETS_DIR to a temp directory."""
+    global GLOBAL_STORE
     tickets_dir = tmp_path / "tickets"
     tickets_dir.mkdir()
-    monkeypatch.setattr("bees.ticket.TICKETS_DIR", tickets_dir)
+    GLOBAL_STORE = TaskStore(tickets_dir)
     return tickets_dir
 
 @pytest.fixture
@@ -49,9 +52,9 @@ def write_template(tmp_path):
 @pytest.mark.asyncio
 async def test_wait_for_ticket_already_completed(mock_clients):
     http, backend = mock_clients
-    scheduler = Scheduler(http=http, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, http=http, backend=backend)
     
-    ticket = create_ticket("Objective")
+    ticket = GLOBAL_STORE.create("Objective")
     ticket.metadata.status = "completed"
     ticket.save_metadata()
     
@@ -62,9 +65,9 @@ async def test_wait_for_ticket_already_completed(mock_clients):
 @pytest.mark.asyncio
 async def test_wait_for_ticket_blocks_and_completes(mock_clients):
     http, backend = mock_clients
-    scheduler = Scheduler(http=http, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, http=http, backend=backend)
     
-    ticket = create_ticket("Objective")
+    ticket = GLOBAL_STORE.create("Objective")
     
     async def simulate_completion():
         await asyncio.sleep(0.05)
@@ -83,9 +86,9 @@ async def test_wait_for_ticket_blocks_and_completes(mock_clients):
 @pytest.mark.asyncio
 async def test_wait_for_ticket_timeout(mock_clients):
     http, backend = mock_clients
-    scheduler = Scheduler(http=http, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, http=http, backend=backend)
     
-    ticket = create_ticket("Objective")
+    ticket = GLOBAL_STORE.create("Objective")
     ticket.metadata.status = "running"
     ticket.save_metadata()
     
@@ -96,9 +99,9 @@ async def test_wait_for_ticket_timeout(mock_clients):
 @pytest.mark.asyncio
 async def test_wait_for_ticket_returns_early_on_suspend(mock_clients):
     http, backend = mock_clients
-    scheduler = Scheduler(http=http, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, http=http, backend=backend)
     
-    ticket = create_ticket("Objective")
+    ticket = GLOBAL_STORE.create("Objective")
     ticket.metadata.status = "running"
     ticket.save_metadata()
     
@@ -118,9 +121,9 @@ async def test_wait_for_ticket_returns_early_on_suspend(mock_clients):
 @pytest.mark.asyncio
 async def test_wait_for_ticket_returns_early_on_fail(mock_clients):
     http, backend = mock_clients
-    scheduler = Scheduler(http=http, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, http=http, backend=backend)
     
-    ticket = create_ticket("Objective")
+    ticket = GLOBAL_STORE.create("Objective")
     ticket.metadata.status = "running"
     ticket.save_metadata()
     
@@ -140,9 +143,9 @@ async def test_wait_for_ticket_returns_early_on_fail(mock_clients):
 @pytest.mark.asyncio
 async def test_deliver_context_update_immediate(mock_clients):
     http, backend = mock_clients
-    scheduler = Scheduler(http=http, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, http=http, backend=backend)
     
-    creator = create_ticket("Parent Objective")
+    creator = GLOBAL_STORE.create("Parent Objective")
     creator.metadata.status = "suspended"
     creator.metadata.assignee = "user"
     creator.save_metadata()
@@ -158,8 +161,7 @@ async def test_deliver_context_update_immediate(mock_clients):
     assert "context_updates" in content
     assert content["context_updates"][0]["task_id"] == "sub-1"
     
-    from bees.ticket import load_ticket
-    fresh_creator = load_ticket(creator.id)
+    fresh_creator = GLOBAL_STORE.get(creator.id)
     assert fresh_creator.metadata.assignee == "agent"
 
 
@@ -172,10 +174,10 @@ async def test_deliver_context_update_immediate(mock_clients):
 async def test_enrich_creator_tags_merges(mock_clients):
     """Child tags are merged (union) into the creator's existing tags."""
     http, backend = mock_clients
-    scheduler = Scheduler(http=http, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, http=http, backend=backend)
 
-    creator = create_ticket("Parent", tags=["b", "c"])
-    child = create_ticket("Child", tags=["a", "b"])
+    creator = GLOBAL_STORE.create("Parent", tags=["b", "c"])
+    child = GLOBAL_STORE.create("Child", tags=["a", "b"])
     child.metadata.creator_ticket_id = creator.id
     child.save_metadata()
 
@@ -183,8 +185,7 @@ async def test_enrich_creator_tags_merges(mock_clients):
 
     assert result is not None
     assert result.id == creator.id
-    from bees.ticket import load_ticket
-    fresh = load_ticket(creator.id)
+    fresh = GLOBAL_STORE.get(creator.id)
     assert fresh.metadata.tags == ["a", "b", "c"]
 
 
@@ -192,9 +193,9 @@ async def test_enrich_creator_tags_merges(mock_clients):
 async def test_enrich_creator_tags_no_creator(mock_clients):
     """No crash when creator_ticket_id points to a nonexistent ticket."""
     http, backend = mock_clients
-    scheduler = Scheduler(http=http, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, http=http, backend=backend)
 
-    child = create_ticket("Child", tags=["a"])
+    child = GLOBAL_STORE.create("Child", tags=["a"])
     child.metadata.creator_ticket_id = "nonexistent-id"
     child.save_metadata()
 
@@ -206,17 +207,16 @@ async def test_enrich_creator_tags_no_creator(mock_clients):
 async def test_enrich_creator_tags_no_tags(mock_clients):
     """Creator is unchanged when the child has no tags."""
     http, backend = mock_clients
-    scheduler = Scheduler(http=http, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, http=http, backend=backend)
 
-    creator = create_ticket("Parent", tags=["x"])
-    child = create_ticket("Child")  # No tags.
+    creator = GLOBAL_STORE.create("Parent", tags=["x"])
+    child = GLOBAL_STORE.create("Child")  # No tags.
     child.metadata.creator_ticket_id = creator.id
     child.save_metadata()
 
     assert scheduler._enrich_creator_tags(child) is None
 
-    from bees.ticket import load_ticket
-    fresh = load_ticket(creator.id)
+    fresh = GLOBAL_STORE.get(creator.id)
     assert fresh.metadata.tags == ["x"]
 
 
@@ -224,18 +224,17 @@ async def test_enrich_creator_tags_no_tags(mock_clients):
 async def test_enrich_creator_tags_creator_has_no_tags(mock_clients):
     """Creator with None tags receives the child's tags."""
     http, backend = mock_clients
-    scheduler = Scheduler(http=http, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, http=http, backend=backend)
 
-    creator = create_ticket("Parent")  # tags=None
-    child = create_ticket("Child", tags=["a"])
+    creator = GLOBAL_STORE.create("Parent")  # tags=None
+    child = GLOBAL_STORE.create("Child", tags=["a"])
     child.metadata.creator_ticket_id = creator.id
     child.save_metadata()
 
     result = scheduler._enrich_creator_tags(child)
 
     assert result is not None
-    from bees.ticket import load_ticket
-    fresh = load_ticket(creator.id)
+    fresh = GLOBAL_STORE.get(creator.id)
     assert fresh.metadata.tags == ["a"]
 
 
@@ -265,9 +264,9 @@ def test_update_metadata_paused(mock_clients):
     from bees.session import SessionResult
 
     http, backend = mock_clients
-    scheduler = Scheduler(http=http, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, http=http, backend=backend)
 
-    ticket = create_ticket("Objective")
+    ticket = GLOBAL_STORE.create("Objective")
     result = SessionResult(
         session_id="s1",
         status="paused",
@@ -291,9 +290,9 @@ def test_handle_pause_sets_status(mock_clients):
     from bees.session import SessionResult
 
     http, backend = mock_clients
-    scheduler = Scheduler(http=http, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, http=http, backend=backend)
 
-    ticket = create_ticket("Objective")
+    ticket = GLOBAL_STORE.create("Objective")
     ticket.metadata.status = "running"
     ticket.metadata.assignee = "agent"
 
@@ -315,21 +314,19 @@ def test_handle_pause_sets_status(mock_clients):
 def test_promote_does_not_cascade_paused(mock_clients):
     """A blocked ticket with a paused dep stays blocked (no cascade)."""
     from bees.scheduler import promote_blocked_tickets
-    from bees.ticket import get_default_store
 
-    parent = create_ticket("Parent")
+    parent = GLOBAL_STORE.create("Parent")
     parent.metadata.status = "paused"
     parent.save_metadata()
 
-    child = create_ticket("Child")
+    child = GLOBAL_STORE.create("Child")
     child.metadata.status = "blocked"
     child.metadata.depends_on = [parent.id]
     child.save_metadata()
 
-    promote_blocked_tickets(get_default_store())
+    promote_blocked_tickets(GLOBAL_STORE)
 
-    from bees.ticket import load_ticket
-    fresh_child = load_ticket(child.id)
+    fresh_child = GLOBAL_STORE.get(child.id)
     # Should still be blocked, NOT failed.
     assert fresh_child.metadata.status == "blocked"
 
@@ -346,7 +343,7 @@ async def test_boots_when_no_root_ticket_exists(mock_clients, write_template, tm
     monkeypatch.setattr("bees.playbook.TEMPLATES_PATH", tmp_path / "config" / "TEMPLATES.yaml")
 
     http, backend = mock_clients
-    scheduler = Scheduler(http=http, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, http=http, backend=backend)
 
     ticket = await scheduler._boot_root_template([])
 
@@ -364,10 +361,10 @@ async def test_skips_when_root_already_booted(mock_clients, write_template, tmp_
     monkeypatch.setattr("bees.playbook.TEMPLATES_PATH", tmp_path / "config" / "TEMPLATES.yaml")
 
     from bees.playbook import run_playbook
-    existing = run_playbook("opie")
+    existing = run_playbook("opie", store=GLOBAL_STORE)
     
     http, backend = mock_clients
-    scheduler = Scheduler(http=http, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, http=http, backend=backend)
 
     ticket = await scheduler._boot_root_template([existing])
 
@@ -383,7 +380,7 @@ async def test_returns_none_when_no_root_configured(mock_clients, tmp_path, monk
     monkeypatch.setattr("bees.playbook.SYSTEM_PATH", system_path)
 
     http, backend = mock_clients
-    scheduler = Scheduler(http=http, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, http=http, backend=backend)
 
     ticket = await scheduler._boot_root_template([])
     assert ticket is None
@@ -394,7 +391,7 @@ async def test_returns_none_when_no_system_yaml(mock_clients, tmp_path, monkeypa
     monkeypatch.setattr("bees.playbook.SYSTEM_PATH", tmp_path / "config" / "SYSTEM.yaml")
     
     http, backend = mock_clients
-    scheduler = Scheduler(http=http, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, http=http, backend=backend)
 
     ticket = await scheduler._boot_root_template([])
     assert ticket is None

--- a/packages/bees/tests/test_tasks.py
+++ b/packages/bees/tests/test_tasks.py
@@ -13,15 +13,18 @@ from unittest.mock import MagicMock, AsyncMock
 
 from bees.functions.tasks import _make_handlers
 from bees.subagent_scope import SubagentScope
-from bees.ticket import create_ticket
+from bees import TaskStore
 
+
+GLOBAL_STORE = None
 
 @pytest.fixture(autouse=True)
 def _temp_dirs(tmp_path, monkeypatch):
     """Redirect ticket and template storage to temp directories."""
+    global GLOBAL_STORE
     tickets_dir = tmp_path / "tickets"
     tickets_dir.mkdir()
-    monkeypatch.setattr("bees.ticket.TICKETS_DIR", tickets_dir)
+    GLOBAL_STORE = TaskStore(tickets_dir)
 
     config_dir = tmp_path / "config"
     config_dir.mkdir()
@@ -68,12 +71,14 @@ async def test_tasks_list_types_scoped(write_template):
         },
     )
 
-    ticket = create_ticket("Objective")
+    ticket = GLOBAL_STORE.create("Objective")
     ticket.metadata.tasks = ["task-a"]  # Only task-a is allowed
     ticket.save_metadata()
 
     scope = SubagentScope(workspace_root_id=ticket.id)
-    handlers = _make_handlers(scope=scope, caller_ticket_id=ticket.id)
+    mock_scheduler = MagicMock()
+    mock_scheduler.store = GLOBAL_STORE
+    handlers = _make_handlers(scope=scope, caller_ticket_id=ticket.id, scheduler=mock_scheduler)
 
     result = await handlers["tasks_list_types"]({}, None)
 
@@ -103,12 +108,14 @@ async def test_tasks_list_types_filters_by_allowlist(write_template):
         },
     )
 
-    ticket = create_ticket("Objective")
+    ticket = GLOBAL_STORE.create("Objective")
     ticket.metadata.tasks = ["allowed-task"]  # Only allowed-task
     ticket.save_metadata()
 
     scope = SubagentScope(workspace_root_id=ticket.id)
-    handlers = _make_handlers(scope=scope, caller_ticket_id=ticket.id)
+    mock_scheduler = MagicMock()
+    mock_scheduler.store = GLOBAL_STORE
+    handlers = _make_handlers(scope=scope, caller_ticket_id=ticket.id, scheduler=mock_scheduler)
 
     result = await handlers["tasks_list_types"]({}, None)
 
@@ -119,18 +126,20 @@ async def test_tasks_list_types_filters_by_allowlist(write_template):
 
 @pytest.mark.asyncio
 async def test_tasks_check_status(write_template):
-    task_ticket = create_ticket("Do something")
+    task_ticket = GLOBAL_STORE.create("Do something")
     task_ticket.metadata.creator_ticket_id = "caller-id"
     task_ticket.metadata.title = "My Task"
     task_ticket.metadata.status = "running"
     task_ticket.save_metadata()
 
-    other_ticket = create_ticket("Do something else")
+    other_ticket = GLOBAL_STORE.create("Do something else")
     other_ticket.metadata.creator_ticket_id = "other-id"
     other_ticket.save_metadata()
 
     scope = SubagentScope(workspace_root_id="caller-id")
-    handlers = _make_handlers(scope=scope, caller_ticket_id="caller-id")
+    mock_scheduler = MagicMock()
+    mock_scheduler.store = GLOBAL_STORE
+    handlers = _make_handlers(scope=scope, caller_ticket_id="caller-id", scheduler=mock_scheduler)
 
     result = await handlers["tasks_check_status"]({}, None)
 
@@ -145,7 +154,9 @@ async def test_tasks_check_status(write_template):
 @pytest.mark.asyncio
 async def test_tasks_check_status_empty():
     scope = SubagentScope(workspace_root_id="caller-id")
-    handlers = _make_handlers(scope=scope, caller_ticket_id="caller-id")
+    mock_scheduler = MagicMock()
+    mock_scheduler.store = GLOBAL_STORE
+    handlers = _make_handlers(scope=scope, caller_ticket_id="caller-id", scheduler=mock_scheduler)
     result = await handlers["tasks_check_status"]({}, None)
     assert "message" in result
     assert result["message"] == "There are no tasks."
@@ -160,9 +171,11 @@ async def test_tasks_create_task_async(write_template):
         "objective": "Do it.",
     })
 
-    caller = create_ticket("I'm the caller")
+    caller = GLOBAL_STORE.create("I'm the caller")
     scope = SubagentScope(workspace_root_id=caller.id)
-    handlers = _make_handlers(scope=scope, caller_ticket_id=caller.id)
+    mock_scheduler = MagicMock()
+    mock_scheduler.store = GLOBAL_STORE
+    handlers = _make_handlers(scope=scope, caller_ticket_id=caller.id, scheduler=mock_scheduler)
 
     args = {
         "type": "my-task",
@@ -175,8 +188,7 @@ async def test_tasks_create_task_async(write_template):
     assert "task_id" in result
     assert result["status"] == "available"
 
-    from bees.ticket import load_ticket
-    ticket = load_ticket(result["task_id"])
+    ticket = GLOBAL_STORE.get(result["task_id"])
     assert ticket is not None
 
     assert ticket.metadata.creator_ticket_id == caller.id
@@ -198,7 +210,7 @@ async def test_tasks_create_task_sync_wait_timeout(write_template, monkeypatch):
     mock_scheduler = MagicMock()
     mock_scheduler.wait_for_ticket = AsyncMock(return_value="running")
 
-    caller = create_ticket("I'm the caller")
+    caller = GLOBAL_STORE.create("I'm the caller")
     scope = SubagentScope(workspace_root_id=caller.id)
     handlers = _make_handlers(scope=scope, caller_ticket_id=caller.id, scheduler=mock_scheduler)
 
@@ -258,14 +270,17 @@ async def test_tasks_create_task_nested_slug(write_template):
         "objective": "Do it.",
     })
 
-    caller = create_ticket("I'm the caller")
+    caller = GLOBAL_STORE.create("I'm the caller")
     parent_scope = SubagentScope(
         workspace_root_id=caller.id,
         slug_path="research",
     )
+    mock_scheduler = MagicMock()
+    mock_scheduler.store = GLOBAL_STORE
     handlers = _make_handlers(
         scope=parent_scope,
         caller_ticket_id=caller.id,
+        scheduler=mock_scheduler,
     )
 
     args = {
@@ -278,8 +293,7 @@ async def test_tasks_create_task_nested_slug(write_template):
 
     assert "task_id" in result
 
-    from bees.ticket import load_ticket
-    ticket = load_ticket(result["task_id"])
+    ticket = GLOBAL_STORE.get(result["task_id"])
     assert ticket is not None
 
     assert ticket.metadata.slug == "research/deep-dive"


### PR DESCRIPTION
## What
Decoupled the Bees framework from global filesystem storage by introducing a `TaskStore` repository pattern and updating all core components and tests to use it.

## Why
To enable better isolation, testability, and flexibility in where tasks are stored, removing hardcoded dependencies on a global `TICKETS_DIR`.

## Changes
### Bees Core
- Introduced `TaskStore` in `bees.ticket` to manage ticket CRUD operations.
- Updated `Ticket` to require an explicit `dir` path.
- Refactored `playbook`, `scheduler`, and `session` to accept and use `TaskStore`.
- Refactored function groups (`tasks`, `events`, `chat`) to use injected store via scheduler.
- Fixed remaining legacy import of `load_ticket` in `bees/session.py`.

### Tests
- Updated all tests to use `TaskStore` fixture or mock it.
- Fixed legacy imports of `create_ticket`, `load_ticket`, and `TICKETS_DIR` in tests.
- Verified all 161 tests pass.

## Testing
Ran all python tests in `packages/bees` with `.venv/bin/python -m pytest`. All 161 tests passed.
