### PR TITLE
[bees] Decouple Bees library from environment configuration

### DIFF
--- a/packages/bees/app/add_ticket.py
+++ b/packages/bees/app/add_ticket.py
@@ -15,9 +15,9 @@ import argparse
 import sys
 
 from bees import TaskStore
-from bees.config import HIVE_DIR
+from app.config import load_hive_dir
 
-task_store = TaskStore(HIVE_DIR / "tickets")
+task_store = TaskStore(load_hive_dir())
 
 
 def main() -> None:

--- a/packages/bees/app/config.py
+++ b/packages/bees/app/config.py
@@ -1,0 +1,28 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration helpers for the Bees reference application."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from dotenv import load_dotenv
+
+
+def load_hive_dir() -> Path:
+    """Load the hive directory from environment or default.
+
+    Loads .env file if present. Relative paths are resolved relative to
+    the packages/bees directory.
+    """
+    load_dotenv()
+    
+    package_dir = Path(__file__).resolve().parent.parent
+    
+    hive_dir_str = os.environ.get("BEES_HIVE_DIR", "hive")
+    hive_dir = Path(hive_dir_str)
+    
+    if not hive_dir.is_absolute():
+        return (package_dir / hive_dir).resolve()
+    return hive_dir.resolve()

--- a/packages/bees/app/edit_tags.py
+++ b/packages/bees/app/edit_tags.py
@@ -15,9 +15,9 @@ import argparse
 import sys
 
 from bees import TaskStore
-from bees.config import HIVE_DIR
+from app.config import load_hive_dir
 
-task_store = TaskStore(HIVE_DIR / "tickets")
+task_store = TaskStore(load_hive_dir())
 
 
 def main() -> None:

--- a/packages/bees/app/respond.py
+++ b/packages/bees/app/respond.py
@@ -19,9 +19,9 @@ import sys
 from typing import Any
 
 from bees import Task, TaskStore
-from bees.config import HIVE_DIR
+from app.config import load_hive_dir
 
-task_store = TaskStore(HIVE_DIR / "tickets")
+task_store = TaskStore(load_hive_dir())
 
 
 def _format_prompt(suspend_event: dict[str, Any] | None) -> str:

--- a/packages/bees/app/server.py
+++ b/packages/bees/app/server.py
@@ -34,14 +34,14 @@ from sse_starlette.sse import EventSourceResponse
 
 from bees.scheduler import Scheduler, SchedulerHooks
 from app.auth import load_gemini_key
+from app.config import load_hive_dir
 from bees import Task, TaskStore
-from bees.config import HIVE_DIR
 from opal_backend.local.backend_client_impl import HttpBackendClient
 
 logger = logging.getLogger(__name__)
 
-TICKETS_DIR = HIVE_DIR / "tickets"
-task_store = TaskStore(TICKETS_DIR)
+hive_dir = load_hive_dir()
+task_store = TaskStore(hive_dir)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/bees/bees/config.py
+++ b/packages/bees/bees/config.py
@@ -11,17 +11,10 @@ that compute directory paths at the module level.
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
-
-from dotenv import load_dotenv
 
 PACKAGE_DIR = Path(__file__).resolve().parent.parent
 
-# Load .env early so BEES_HIVE_DIR (and GEMINI_KEY, etc.) are available
-# before any module-level path constants are computed.
-load_dotenv(PACKAGE_DIR / ".env")
-
 # The root directory where Bees stores runtime data (tickets, logs).
-# Configurable via the BEES_HIVE_DIR environment variable; defaults to "hive".
-HIVE_DIR = PACKAGE_DIR / os.environ.get("BEES_HIVE_DIR", "hive")
+# Defaults to "hive" relative to the package directory.
+HIVE_DIR = PACKAGE_DIR / "hive"

--- a/packages/bees/bees/functions/tasks.py
+++ b/packages/bees/bees/functions/tasks.py
@@ -48,9 +48,11 @@ def _make_handlers(
         task_types = []
         from bees.playbook import list_playbooks, load_playbook
         
-        for name in list_playbooks():
+        config_dir = scheduler.store.hive_dir / "config"
+        
+        for name in list_playbooks(config_dir):
             try:
-                data = load_playbook(name)
+                data = load_playbook(name, config_dir)
                 task_name = data.get("name", name)
                 if task_name in allowed_tasks:
                     task_types.append({
@@ -81,8 +83,9 @@ def _make_handlers(
             status_cb(f"Creating task of type: {task_type}")
             
         from bees.playbook import load_playbook, stamp_child_ticket
+        config_dir = scheduler.store.hive_dir / "config"
         try:
-            load_playbook(task_type)
+            load_playbook(task_type, config_dir)
         except FileNotFoundError:
             return {"error": f"Task type not found: {task_type}"}
 

--- a/packages/bees/bees/playbook.py
+++ b/packages/bees/bees/playbook.py
@@ -29,10 +29,7 @@ from bees.ticket import Ticket
 
 logger = logging.getLogger(__name__)
 
-CONFIG_DIR = HIVE_DIR / "config"
-TEMPLATES_PATH = CONFIG_DIR / "TEMPLATES.yaml"
-SYSTEM_PATH = CONFIG_DIR / "SYSTEM.yaml"
-HOOKS_DIR = CONFIG_DIR / "hooks"
+
 
 
 class PlaybookAborted(Exception):
@@ -44,11 +41,12 @@ class PlaybookAborted(Exception):
 # ---------------------------------------------------------------------------
 
 
-def _load_templates() -> list[dict[str, Any]]:
+def _load_templates(config_dir: Path) -> list[dict[str, Any]]:
     """Parse TEMPLATES.yaml and return the list of template dicts."""
-    if not TEMPLATES_PATH.exists():
+    templates_path = config_dir / "TEMPLATES.yaml"
+    if not templates_path.exists():
         return []
-    with open(TEMPLATES_PATH) as f:
+    with open(templates_path) as f:
         data = yaml.safe_load(f)
     if not isinstance(data, list):
         logger.warning("TEMPLATES.yaml must be a list; got %s", type(data).__name__)
@@ -56,17 +54,17 @@ def _load_templates() -> list[dict[str, Any]]:
     return data
 
 
-def list_playbooks() -> list[str]:
+def list_playbooks(config_dir: Path) -> list[str]:
     """Return the names of all available templates."""
-    return [t["name"] for t in _load_templates() if "name" in t]
+    return [t["name"] for t in _load_templates(config_dir) if "name" in t]
 
 
-def load_playbook(name: str) -> dict[str, Any]:
+def load_playbook(name: str, config_dir: Path) -> dict[str, Any]:
     """Load a template by name.
 
     Returns the template dict directly (flat — no ``steps`` wrapper).
     """
-    for t in _load_templates():
+    for t in _load_templates(config_dir):
         if t.get("name") == name:
             return t
     raise FileNotFoundError(f"Template not found: {name}")
@@ -74,12 +72,12 @@ def load_playbook(name: str) -> dict[str, Any]:
 
 
 
-def _load_hooks(name: str) -> ModuleType | None:
+def _load_hooks(name: str, hooks_dir: Path) -> ModuleType | None:
     """Import a template's hooks module if it exists.
 
     Looks for ``hive/config/hooks/{name}.py``.
     """
-    hooks_path = HOOKS_DIR / f"{name}.py"
+    hooks_path = hooks_dir / f"{name}.py"
     if not hooks_path.exists():
         return None
 
@@ -119,10 +117,14 @@ def run_playbook(
 
     Returns the created ticket.
     """
-    data = load_playbook(name)
+    hive_dir = store.hive_dir
+    config_dir = hive_dir / "config"
+    hooks_dir = config_dir / "hooks"
+
+    data = load_playbook(name, config_dir)
 
     # Run on_run_playbook hook if present.
-    hooks = _load_hooks(name)
+    hooks = _load_hooks(name, hooks_dir)
     if hooks and hasattr(hooks, "on_run_playbook"):
         context = hooks.on_run_playbook(context)
         if context is None:
@@ -221,15 +223,16 @@ def stamp_child_ticket(
     return child
 
 
-def load_system_config() -> dict[str, Any]:
+def load_system_config(config_dir: Path) -> dict[str, Any]:
     """Load the hive system configuration from ``SYSTEM.yaml``.
 
     Returns a dict with keys like ``title``, ``description``, and ``root``.
     Returns an empty dict if the file doesn't exist.
     """
-    if not SYSTEM_PATH.exists():
+    system_path = config_dir / "SYSTEM.yaml"
+    if not system_path.exists():
         return {}
-    with open(SYSTEM_PATH) as f:
+    with open(system_path) as f:
         data = yaml.safe_load(f)
     if not isinstance(data, dict):
         logger.warning("SYSTEM.yaml must be a mapping; got %s", type(data).__name__)
@@ -250,7 +253,10 @@ def run_ticket_done_hooks(ticket: Ticket) -> None:
     if not playbook_id:
         return
 
-    hooks = _load_hooks(playbook_id)
+    hive_dir = ticket.dir.parent.parent
+    hooks_dir = hive_dir / "config" / "hooks"
+
+    hooks = _load_hooks(playbook_id, hooks_dir)
     if hooks and hasattr(hooks, "on_ticket_done"):
         try:
             hooks.on_ticket_done(ticket)
@@ -278,7 +284,10 @@ def run_event_hooks(
     if not playbook_id:
         return payload
 
-    hooks = _load_hooks(playbook_id)
+    hive_dir = ticket.dir.parent.parent
+    hooks_dir = hive_dir / "config" / "hooks"
+
+    hooks = _load_hooks(playbook_id, hooks_dir)
     if not hooks or not hasattr(hooks, "on_event"):
         return payload
 

--- a/packages/bees/bees/scheduler.py
+++ b/packages/bees/bees/scheduler.py
@@ -302,7 +302,7 @@ class Scheduler:
 
     async def _boot_root_template(self, tickets: list[Ticket]) -> Ticket | None:
         """Boot the root template if it isn't already running."""
-        config = load_system_config()
+        config = load_system_config(self.store.hive_dir / "config")
         root = config.get("root")
         if not root:
             return None

--- a/packages/bees/bees/session.py
+++ b/packages/bees/bees/session.py
@@ -50,10 +50,13 @@ from bees.config import HIVE_DIR, PACKAGE_DIR
 from bees.disk_file_system import DiskFileSystem
 from bees.subagent_scope import SubagentScope
 
-# Scan skills once at import time.
-_SKILLS_LISTING, _SKILLS_FILES, _SKILLS_LIST = scan_skills(HIVE_DIR)
+_SKILLS_CACHE = {}
 
-OUT_DIR = HIVE_DIR / "logs"
+
+def _get_skills(hive_dir: Path):
+    if hive_dir not in _SKILLS_CACHE:
+        _SKILLS_CACHE[hive_dir] = scan_skills(hive_dir)
+    return _SKILLS_CACHE[hive_dir]
 
 CHAT_LOG_FILENAME = "chat_log.json"
 
@@ -389,7 +392,9 @@ def extract_files(
 
 
 
-def _filter_skills(allowed_skills: list[str] | None) -> tuple[str, dict[str, str], list[str]]:
+def _filter_skills(
+    allowed_skills: list[str] | None, hive_dir: Path
+) -> tuple[str, dict[str, str], list[str]]:
     """Filter skills based on allowed_skills and return listing, files, and tool globs.
 
     Returns:
@@ -398,12 +403,14 @@ def _filter_skills(allowed_skills: list[str] | None) -> tuple[str, dict[str, str
         - ``files``: Dict of ``{vfs_name: content}`` for seeding.
         - ``skill_tools``: Merged ``allowed-tools`` from all selected skills.
     """
+    _, skills_files, skills_list = _get_skills(hive_dir)
+
     skills_to_use = allowed_skills if allowed_skills is not None else []
 
     if "*" in skills_to_use:
-        filtered_skills = _SKILLS_LIST
+        filtered_skills = skills_list
     else:
-        filtered_skills = [s for s in _SKILLS_LIST if s.name in skills_to_use]
+        filtered_skills = [s for s in skills_list if s.name in skills_to_use]
 
     lines = []
     skill_tools: list[str] = []
@@ -415,7 +422,7 @@ def _filter_skills(allowed_skills: list[str] | None) -> tuple[str, dict[str, str
     session_listing = "\n".join(lines)
 
     session_files = {}
-    for k, v in _SKILLS_FILES.items():
+    for k, v in skills_files.items():
         if any(f"skills/{s.dir_name}/" in k for s in filtered_skills):
             session_files[k] = v
 
@@ -446,6 +453,7 @@ async def run_session(
     scope: SubagentScope | None = None,
     scheduler: Any | None = None,
     context_queue: Any | None = None,
+    hive_dir: Path | None = None,
 ) -> SessionResult:
     """Run a single agent session and return the result.
 
@@ -455,6 +463,14 @@ async def run_session(
     If ``ticket_dir`` is provided, session state is persisted on
     suspend so it can be resumed later.
     """
+    if hive_dir is None:
+        if ticket_dir:
+            hive_dir = ticket_dir.parent.parent
+        else:
+            from bees.config import HIVE_DIR
+
+            hive_dir = HIVE_DIR
+
     session_store = InMemorySessionStore()
     interaction_store = InMemoryInteractionStore()
     subscribers = Subscribers()
@@ -465,10 +481,12 @@ async def run_session(
 
     date_stamp = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
     log_prefix = f"bees-{ticket_id[:8]}" if ticket_id else "bees-session"
-    out_path = OUT_DIR / f"{log_prefix}-{date_stamp}.log.json"
+    out_dir = hive_dir / "logs"
+    out_path = out_dir / f"{log_prefix}-{date_stamp}.log.json"
 
-
-    session_listing, session_files, skill_tools = _filter_skills(allowed_skills)
+    session_listing, session_files, skill_tools = _filter_skills(
+        allowed_skills, hive_dir
+    )
 
     # Union skill-declared tools into the template's function filter.
     # Also inject skills.* automatically when any skills are selected —
@@ -622,12 +640,16 @@ async def resume_session(
     scope: SubagentScope | None = None,
     scheduler: Any | None = None,
     context_queue: Any | None = None,
+    hive_dir: Path | None = None,
 ) -> SessionResult:
     """Resume a suspended session from saved state on disk.
 
     Loads session state from ``ticket_dir``, reconstructs the session
     infrastructure, and calls the sessions API ``resume_session()``.
     """
+    if hive_dir is None:
+        hive_dir = ticket_dir.parent.parent
+
     context = load_session_state(ticket_dir)
     if context is None:
         return SessionResult(
@@ -643,7 +665,8 @@ async def resume_session(
 
     date_stamp = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
     log_prefix = f"bees-{ticket_id[:8]}" if ticket_id else "bees-session"
-    out_path = OUT_DIR / f"{log_prefix}-{date_stamp}.log.json"
+    out_dir = hive_dir / "logs"
+    out_path = out_dir / f"{log_prefix}-{date_stamp}.log.json"
 
     interaction_state = InteractionState.from_dict(context["interaction_state"])
 
@@ -661,7 +684,7 @@ async def resume_session(
         except Exception:
             pass
 
-    session_listing, _, _ = _filter_skills(allowed_skills)
+    session_listing, _, _ = _filter_skills(allowed_skills, hive_dir)
 
     # Create disk-backed file system — files are already on disk from
     # the previous run, so no seeding needed.

--- a/packages/bees/bees/ticket.py
+++ b/packages/bees/bees/ticket.py
@@ -19,8 +19,6 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
 
-from bees.config import HIVE_DIR
-
 
 
 TicketStatus = Literal[
@@ -163,8 +161,9 @@ class Ticket:
 class TaskStore:
     """Encapsulates task CRUD operations."""
 
-    def __init__(self, tickets_dir: Path):
-        self.tickets_dir = tickets_dir
+    def __init__(self, hive_dir: Path):
+        self.hive_dir = hive_dir
+        self.tickets_dir = hive_dir / "tickets"
 
     def get(self, ticket_id: str) -> Ticket | None:
         """Load a specific task."""

--- a/packages/bees/tests/test_chat.py
+++ b/packages/bees/tests/test_chat.py
@@ -16,9 +16,7 @@ from opal_backend.function_caller import CONTEXT_PARTS_KEY
 @pytest.fixture
 def task_store(tmp_path):
     """Create a TaskStore in a temp directory."""
-    tickets_dir = tmp_path / "tickets"
-    tickets_dir.mkdir()
-    return TaskStore(tickets_dir)
+    return TaskStore(tmp_path)
 
 
 @pytest.mark.asyncio

--- a/packages/bees/tests/test_events.py
+++ b/packages/bees/tests/test_events.py
@@ -16,9 +16,7 @@ from bees.subagent_scope import SubagentScope
 @pytest.fixture
 def task_store(tmp_path):
     """Create a TaskStore in a temp directory."""
-    tickets_dir = tmp_path / "tickets"
-    tickets_dir.mkdir()
-    return TaskStore(tickets_dir)
+    return TaskStore(tmp_path)
 
 
 # ---- events_broadcast ----

--- a/packages/bees/tests/test_playbook.py
+++ b/packages/bees/tests/test_playbook.py
@@ -32,23 +32,17 @@ def stamp_child_ticket(template_name: str, *, parent_ticket, slug, **kwargs):
     return _real_stamp_child_ticket(template_name, parent_ticket=parent_ticket, slug=slug, store=GLOBAL_STORE, **kwargs)
 
 @pytest.fixture(autouse=True)
-def _temp_dirs(tmp_path, monkeypatch):
+def _temp_dirs(tmp_path):
     """Redirect ticket and template storage to temp directories."""
     global GLOBAL_STORE
     tickets_dir = tmp_path / "tickets"
     tickets_dir.mkdir()
-    GLOBAL_STORE = TaskStore(tickets_dir)
+    GLOBAL_STORE = TaskStore(tmp_path)
 
     config_dir = tmp_path / "config"
     config_dir.mkdir()
-    templates_path = config_dir / "TEMPLATES.yaml"
     hooks_dir = config_dir / "hooks"
     hooks_dir.mkdir()
-
-    monkeypatch.setattr("bees.playbook.CONFIG_DIR", config_dir)
-    monkeypatch.setattr("bees.playbook.TEMPLATES_PATH", templates_path)
-    monkeypatch.setattr("bees.playbook.SYSTEM_PATH", config_dir / "SYSTEM.yaml")
-    monkeypatch.setattr("bees.playbook.HOOKS_DIR", hooks_dir)
     yield
 
 
@@ -339,12 +333,12 @@ class TestLoadSystemConfig:
             "root": "opie",
         }))
 
-        config = load_system_config()
+        config = load_system_config(tmp_path / "config")
         assert config["title"] == "Opal"
         assert config["root"] == "opie"
 
-    def test_returns_empty_when_missing(self):
-        config = load_system_config()
+    def test_returns_empty_when_missing(self, tmp_path):
+        config = load_system_config(tmp_path / "config")
         assert config == {}
 
 

--- a/packages/bees/tests/test_scheduler.py
+++ b/packages/bees/tests/test_scheduler.py
@@ -28,7 +28,7 @@ def tickets_dir(tmp_path, monkeypatch):
     global GLOBAL_STORE
     tickets_dir = tmp_path / "tickets"
     tickets_dir.mkdir()
-    GLOBAL_STORE = TaskStore(tickets_dir)
+    GLOBAL_STORE = TaskStore(tmp_path)
     return tickets_dir
 
 @pytest.fixture
@@ -338,9 +338,6 @@ async def test_boots_when_no_root_ticket_exists(mock_clients, write_template, tm
     write_template({"name": "opie", "title": "Opie", "objective": "Be helpful."})
     system_path = tmp_path / "config" / "SYSTEM.yaml"
     system_path.write_text(yaml.dump({"root": "opie"}))
-    
-    monkeypatch.setattr("bees.playbook.SYSTEM_PATH", system_path)
-    monkeypatch.setattr("bees.playbook.TEMPLATES_PATH", tmp_path / "config" / "TEMPLATES.yaml")
 
     http, backend = mock_clients
     scheduler = Scheduler(store=GLOBAL_STORE, http=http, backend=backend)
@@ -357,9 +354,6 @@ async def test_skips_when_root_already_booted(mock_clients, write_template, tmp_
     system_path = tmp_path / "config" / "SYSTEM.yaml"
     system_path.write_text(yaml.dump({"root": "opie"}))
     
-    monkeypatch.setattr("bees.playbook.SYSTEM_PATH", system_path)
-    monkeypatch.setattr("bees.playbook.TEMPLATES_PATH", tmp_path / "config" / "TEMPLATES.yaml")
-
     from bees.playbook import run_playbook
     existing = run_playbook("opie", store=GLOBAL_STORE)
     
@@ -376,8 +370,6 @@ async def test_returns_none_when_no_root_configured(mock_clients, tmp_path, monk
     system_path = tmp_path / "config" / "SYSTEM.yaml"
     system_path.parent.mkdir(parents=True, exist_ok=True)
     system_path.write_text(yaml.dump({"title": "My Hive"}))
-    
-    monkeypatch.setattr("bees.playbook.SYSTEM_PATH", system_path)
 
     http, backend = mock_clients
     scheduler = Scheduler(store=GLOBAL_STORE, http=http, backend=backend)
@@ -387,8 +379,7 @@ async def test_returns_none_when_no_root_configured(mock_clients, tmp_path, monk
 
 
 @pytest.mark.asyncio
-async def test_returns_none_when_no_system_yaml(mock_clients, tmp_path, monkeypatch):
-    monkeypatch.setattr("bees.playbook.SYSTEM_PATH", tmp_path / "config" / "SYSTEM.yaml")
+async def test_returns_none_when_no_system_yaml(mock_clients, tmp_path):
     
     http, backend = mock_clients
     scheduler = Scheduler(store=GLOBAL_STORE, http=http, backend=backend)

--- a/packages/bees/tests/test_tasks.py
+++ b/packages/bees/tests/test_tasks.py
@@ -19,12 +19,12 @@ from bees import TaskStore
 GLOBAL_STORE = None
 
 @pytest.fixture(autouse=True)
-def _temp_dirs(tmp_path, monkeypatch):
+def _temp_dirs(tmp_path):
     """Redirect ticket and template storage to temp directories."""
     global GLOBAL_STORE
     tickets_dir = tmp_path / "tickets"
     tickets_dir.mkdir()
-    GLOBAL_STORE = TaskStore(tickets_dir)
+    GLOBAL_STORE = TaskStore(tmp_path)
 
     config_dir = tmp_path / "config"
     config_dir.mkdir()
@@ -32,9 +32,6 @@ def _temp_dirs(tmp_path, monkeypatch):
     hooks_dir = config_dir / "hooks"
     hooks_dir.mkdir()
 
-    monkeypatch.setattr("bees.playbook.CONFIG_DIR", config_dir)
-    monkeypatch.setattr("bees.playbook.TEMPLATES_PATH", templates_path)
-    monkeypatch.setattr("bees.playbook.HOOKS_DIR", hooks_dir)
     yield tickets_dir
 
 
@@ -208,6 +205,7 @@ async def test_tasks_create_task_sync_wait_timeout(write_template, monkeypatch):
     })
 
     mock_scheduler = MagicMock()
+    mock_scheduler.store = GLOBAL_STORE
     mock_scheduler.wait_for_ticket = AsyncMock(return_value="running")
 
     caller = GLOBAL_STORE.create("I'm the caller")


### PR DESCRIPTION
Decouple Bees library from environment configuration

## What
Moved the responsibility of loading the hive directory from the environment from `packages/bees/bees` (the library) to `packages/bees/app` (the application), and removed module-level side effects (like `.env` loading and eager path computations) from the library.

## Why
To improve abstraction boundaries, making the library more reusable and testable without relying on environment variables or global state.

## Changes
- **Bees Library**:
  - `ticket.py`: `TaskStore` now accepts and stores `hive_dir`.
  - `playbook.py`: Removed module-level path constants; functions now accept `config_dir`.
  - `session.py`: Removed module-level path computations; added lazy loading and caching for skills.
  - `config.py`: Removed `dotenv` loading and environment variable lookups.
  - `scheduler.py` & `functions/tasks.py`: Updated to pass `config_dir` to playbook functions.
- **Bees App**:
  - `config.py`: Added `load_hive_dir` to read from environment.
  - `server.py` & scripts: Updated to use `load_hive_dir` and pass it to `TaskStore`.
- **Tests**:
  - Removed monkeypatches for removed global constants and updated tests to pass paths explicitly.

## Testing
Ran all Python tests in `packages/bees` via `PYTHONPATH=. .venv/bin/pytest tests`. All 161 tests passed.
