### PR TITLE
[bees] Add DOM-traversal-like API for Tasks in Bees

### DIFF
--- a/packages/bees/bees/__init__.py
+++ b/packages/bees/bees/__init__.py
@@ -6,5 +6,6 @@
 from .ticket import Ticket as Task
 from .task_store import TaskStore
 from .scheduler import Scheduler, SchedulerHooks
+from .bees import Bees
 
-__all__ = ["Task", "TaskStore", "Scheduler", "SchedulerHooks"]
+__all__ = ["Task", "TaskStore", "Scheduler", "SchedulerHooks", "Bees"]

--- a/packages/bees/bees/bees.py
+++ b/packages/bees/bees/bees.py
@@ -1,0 +1,26 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+from pathlib import Path
+from bees.task_store import TaskStore
+from bees.task_node import TaskNode
+
+
+class Bees:
+    """The high-level entry point for the Bees library.
+
+    Acts like the 'Document' in the DOM analogy.
+    """
+
+    def __init__(self, hive_dir: Path):
+        self.store = TaskStore(hive_dir)
+
+    def get_children(self) -> list[TaskNode]:
+        """Returns all tasks that have no parents, as TaskNodes."""
+        return [TaskNode(task, self.store) for task in self.store.get_children(None)]
+
+    def get_node(self, task_id: str) -> TaskNode | None:
+        """Looks up a task by ID and returns it as a TaskNode."""
+        task = self.store.get(task_id)
+        return TaskNode(task, self.store) if task else None

--- a/packages/bees/bees/task_node.py
+++ b/packages/bees/bees/task_node.py
@@ -1,0 +1,33 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+from bees.task_store import TaskStore
+from bees.ticket import Ticket
+
+
+class TaskNode:
+    """Wraps a Ticket and a TaskStore to provide a tree traversal API."""
+
+    def __init__(self, task: Ticket, store: TaskStore):
+        self.task = task
+        self.store = store
+
+    @property
+    def id(self) -> str:
+        """Returns the task ID."""
+        return self.task.id
+
+    @property
+    def children(self) -> list[TaskNode]:
+        """Returns children of this task."""
+        tasks = self.store.get_children(self.task.id)
+        return [TaskNode(t, self.store) for t in tasks]
+
+    @property
+    def parent(self) -> TaskNode | None:
+        """Returns the parent of this task."""
+        if not self.task.metadata.parent_ticket_id:
+            return None
+        parent_task = self.store.get(self.task.metadata.parent_ticket_id)
+        return TaskNode(parent_task, self.store) if parent_task else None

--- a/packages/bees/bees/task_store.py
+++ b/packages/bees/bees/task_store.py
@@ -63,6 +63,14 @@ class TaskStore:
         tickets.sort(key=lambda t: t.metadata.created_at or "", reverse=True)
         return tickets
 
+    def get_children(self, task_id: str | None = None) -> list[Ticket]:
+        """Returns children of the given task, or roots if task_id is None."""
+        if task_id is None:
+            return [t for t in self.query_all() if not t.metadata.parent_ticket_id]
+        return [t for t in self.query_all() if t.metadata.parent_ticket_id == task_id]
+
+
+
     def save(self, ticket: Ticket) -> None:
         """Persist ticket to disk."""
         ticket_dir = self.tickets_dir / ticket.id

--- a/packages/bees/docs/api.md
+++ b/packages/bees/docs/api.md
@@ -1,0 +1,48 @@
+# Bees API Reference
+
+The `bees` library is a framework for building agent swarm systems.
+
+## Core Concepts
+
+- **`Bees`**: The high-level entry point for the library
+- **`TaskNode`**: Represents a task in the tree, providing traversal properties
+  like `children` and `parent`.
+
+## Classes
+
+### `Bees`
+
+The main entry point for interacting with a hive of tasks.
+
+#### `__init__(self, hive_dir: Path)`
+
+Initializes a new `Bees` instance.
+
+- **`hive_dir`**: The root directory of the hive where tasks are stored.
+
+#### `get_children(self) -> list[TaskNode]`
+
+Returns all root tasks (tasks that have no parents) in the hive.
+
+- **Returns**: A list of `TaskNode` objects representing the root tasks.
+
+#### `get_node(self, task_id: str) -> TaskNode | None`
+
+Looks up a task by its unique ID.
+
+- **`task_id`**: The UUID string of the task.
+- **Returns**: A `TaskNode` if found, or `None` if the task does not exist.
+
+### `TaskNode`
+
+A wrapper around a task that provides DOM-like traversal properties.
+
+#### Properties
+
+- **`id`**: `str` (Read-only) The unique identifier of the task.
+
+- **`children`**: `list[TaskNode]` (Read-only) A list of child tasks that have
+  this task as their parent.
+
+- **`parent`**: `TaskNode | None` (Read-only) The parent task of this task, or
+  `None` if it is a root task.

--- a/packages/bees/tests/test_tree.py
+++ b/packages/bees/tests/test_tree.py
@@ -1,0 +1,73 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import tempfile
+from pathlib import Path
+import pytest
+from bees import Bees
+
+
+@pytest.fixture
+def temp_hive():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield Path(tmpdir)
+
+
+def test_tree_traversal(temp_hive):
+    bees = Bees(temp_hive)
+    store = bees.store
+
+    # Create a tree structure
+    # root1
+    #   ├── child1
+    #   │     └── grandchild1
+    #   └── child2
+    # root2
+
+    root1 = store.create("Root 1")
+    root2 = store.create("Root 2")
+
+    child1 = store.create("Child 1", parent_ticket_id=root1.id)
+    child2 = store.create("Child 2", parent_ticket_id=root1.id)
+
+    grandchild1 = store.create("Grandchild 1", parent_ticket_id=child1.id)
+
+    # Test get_children
+    roots = bees.get_children()
+    assert len(roots) == 2
+    root_ids = {r.id for r in roots}
+    assert root_ids == {root1.id, root2.id}
+
+    # Test children traversal
+    root1_node = bees.get_node(root1.id)
+    assert root1_node is not None
+    children = root1_node.children
+    assert len(children) == 2
+    child_ids = {c.id for c in children}
+    assert child_ids == {child1.id, child2.id}
+
+    # Test parent traversal
+    child1_node = bees.get_node(child1.id)
+    assert child1_node is not None
+    assert child1_node.parent is not None
+    assert child1_node.parent.id == root1.id
+
+    # Test deep traversal
+    grandchild1_node = bees.get_node(grandchild1.id)
+    assert grandchild1_node is not None
+    assert grandchild1_node.parent is not None
+    assert grandchild1_node.parent.id == child1.id
+    assert grandchild1_node.parent.parent is not None
+    assert grandchild1_node.parent.parent.id == root1.id
+
+    # Test edge cases
+    root2_node = bees.get_node(root2.id)
+    assert root2_node is not None
+    assert len(root2_node.children) == 0
+    assert root2_node.parent is None
+
+
+def test_empty_store(temp_hive):
+    bees = Bees(temp_hive)
+    assert len(bees.get_children()) == 0
+    assert bees.get_node("non-existent") is None


### PR DESCRIPTION
## What
Added a high-level `Bees` facade and `TaskNode` wrapper to provide a DOM-like API for exploring tasks as a tree, along with tests and initial API documentation.

## Why
To allow consumers of the `bees` library to easily navigate tasks, their children, and parents, facilitating building and inspecting agent swarm hierarchies.

## Changes
### Bees Core
- **`packages/bees/bees/task_store.py`**: Added unified `get_children` method (supporting roots when `task_id` is None).
- **`packages/bees/bees/task_node.py`**: Added `TaskNode` class with `children` and `parent` properties.
- **`packages/bees/bees/bees.py`**: Added `Bees` class as high-level entry point with `get_children` and `get_node`.
- **`packages/bees/bees/__init__.py`**: Exported `Bees`.

### Tests
- **`packages/bees/tests/test_tree.py`**: Added comprehensive tests for the tree API.

### Documentation
- **`packages/bees/docs/api.md`**: Added initial API documentation.

## Testing
Ran `npm run test:python -w packages/bees`. All 163 tests passed.
