### PR TITLE
[bees]  Enrich Bees API with `query`, `get_by_id`, and task accessor

### DIFF
--- a/packages/bees/bees/bees.py
+++ b/packages/bees/bees/bees.py
@@ -16,11 +16,22 @@ class Bees:
     def __init__(self, hive_dir: Path):
         self.store = TaskStore(hive_dir)
 
-    def get_children(self) -> list[TaskNode]:
+    @property
+    def children(self) -> list[TaskNode]:
         """Returns all tasks that have no parents, as TaskNodes."""
         return [TaskNode(task, self.store) for task in self.store.get_children(None)]
 
-    def get_node(self, task_id: str) -> TaskNode | None:
+    def get_by_id(self, task_id: str) -> TaskNode | None:
         """Looks up a task by ID and returns it as a TaskNode."""
         task = self.store.get(task_id)
         return TaskNode(task, self.store) if task else None
+
+    def query(self, tags: list[str]) -> list[TaskNode]:
+        """Searches for tasks that contain all of the specified tags."""
+        all_tickets = self.store.query_all()
+        matching_nodes: list[TaskNode] = []
+        for ticket in all_tickets:
+            ticket_tags = ticket.metadata.tags or []
+            if all(tag in ticket_tags for tag in tags):
+                matching_nodes.append(TaskNode(ticket, self.store))
+        return matching_nodes

--- a/packages/bees/bees/task_node.py
+++ b/packages/bees/bees/task_node.py
@@ -10,24 +10,68 @@ class TaskNode:
     """Wraps a Ticket and a TaskStore to provide a tree traversal API."""
 
     def __init__(self, task: Ticket, store: TaskStore):
-        self.task = task
+        self._task = task
         self.store = store
+
+    @property
+    def task(self) -> Ticket:
+        """Returns the underlying Ticket object."""
+        return self._task
 
     @property
     def id(self) -> str:
         """Returns the task ID."""
-        return self.task.id
+        return self._task.id
 
     @property
     def children(self) -> list[TaskNode]:
         """Returns children of this task."""
-        tasks = self.store.get_children(self.task.id)
+        tasks = self.store.get_children(self._task.id)
         return [TaskNode(t, self.store) for t in tasks]
 
     @property
     def parent(self) -> TaskNode | None:
         """Returns the parent of this task."""
-        if not self.task.metadata.parent_ticket_id:
+        if not self._task.metadata.parent_ticket_id:
             return None
-        parent_task = self.store.get(self.task.metadata.parent_ticket_id)
+        parent_task = self.store.get(self._task.metadata.parent_ticket_id)
         return TaskNode(parent_task, self.store) if parent_task else None
+
+    def query(self, tags: list[str]) -> list[TaskNode]:
+        """Searches for tasks in the subtree that contain all of the specified tags."""
+        all_tickets = self.store.query_all()
+        
+        # Build child map
+        from collections import defaultdict
+        child_map = defaultdict(list)
+        ticket_map = {}
+        for t in all_tickets:
+            ticket_map[t.id] = t
+            if t.metadata.parent_ticket_id:
+                child_map[t.metadata.parent_ticket_id].append(t.id)
+                
+        # Find all descendants of current node
+        descendants = []
+        def get_descendants(node_id):
+            for child_id in child_map[node_id]:
+                descendants.append(child_id)
+                get_descendants(child_id)
+                
+        get_descendants(self._task.id)
+        
+        # Filter by tags
+        matching_nodes: list[TaskNode] = []
+        
+        # Check self
+        ticket_tags = self._task.metadata.tags or []
+        if all(tag in ticket_tags for tag in tags):
+            matching_nodes.append(self)
+            
+        # Check descendants
+        for d_id in descendants:
+            t = ticket_map[d_id]
+            t_tags = t.metadata.tags or []
+            if all(tag in t_tags for tag in tags):
+                matching_nodes.append(TaskNode(t, self.store))
+                
+        return matching_nodes

--- a/packages/bees/docs/api.md
+++ b/packages/bees/docs/api.md
@@ -20,18 +20,25 @@ Initializes a new `Bees` instance.
 
 - **`hive_dir`**: The root directory of the hive where tasks are stored.
 
-#### `get_children(self) -> list[TaskNode]`
+#### `children`
 
-Returns all root tasks (tasks that have no parents) in the hive.
+Property that returns all root tasks (tasks that have no parents) in the hive.
 
 - **Returns**: A list of `TaskNode` objects representing the root tasks.
 
-#### `get_node(self, task_id: str) -> TaskNode | None`
+#### `get_by_id(self, task_id: str) -> TaskNode | None`
 
 Looks up a task by its unique ID.
 
 - **`task_id`**: The UUID string of the task.
 - **Returns**: A `TaskNode` if found, or `None` if the task does not exist.
+
+#### `query(self, tags: list[str]) -> list[TaskNode]`
+
+Searches for tasks in the hive that contain all of the specified tags.
+
+- **`tags`**: A list of tags to search for.
+- **Returns**: A list of `TaskNode` objects matching all tags.
 
 ### `TaskNode`
 
@@ -41,8 +48,17 @@ A wrapper around a task that provides DOM-like traversal properties.
 
 - **`id`**: `str` (Read-only) The unique identifier of the task.
 
+- **`task`**: `Ticket` (Read-only) The underlying ticket object containing task details.
+
 - **`children`**: `list[TaskNode]` (Read-only) A list of child tasks that have
   this task as their parent.
 
 - **`parent`**: `TaskNode | None` (Read-only) The parent task of this task, or
   `None` if it is a root task.
+
+#### `query(self, tags: list[str]) -> list[TaskNode]`
+
+Searches for tasks in the subtree that contain all of the specified tags.
+
+- **`tags`**: A list of tags to search for.
+- **Returns**: A list of `TaskNode` objects matching all tags.

--- a/packages/bees/tests/test_tree.py
+++ b/packages/bees/tests/test_tree.py
@@ -33,13 +33,13 @@ def test_tree_traversal(temp_hive):
     grandchild1 = store.create("Grandchild 1", parent_ticket_id=child1.id)
 
     # Test get_children
-    roots = bees.get_children()
+    roots = bees.children
     assert len(roots) == 2
     root_ids = {r.id for r in roots}
     assert root_ids == {root1.id, root2.id}
 
     # Test children traversal
-    root1_node = bees.get_node(root1.id)
+    root1_node = bees.get_by_id(root1.id)
     assert root1_node is not None
     children = root1_node.children
     assert len(children) == 2
@@ -47,13 +47,13 @@ def test_tree_traversal(temp_hive):
     assert child_ids == {child1.id, child2.id}
 
     # Test parent traversal
-    child1_node = bees.get_node(child1.id)
+    child1_node = bees.get_by_id(child1.id)
     assert child1_node is not None
     assert child1_node.parent is not None
     assert child1_node.parent.id == root1.id
 
     # Test deep traversal
-    grandchild1_node = bees.get_node(grandchild1.id)
+    grandchild1_node = bees.get_by_id(grandchild1.id)
     assert grandchild1_node is not None
     assert grandchild1_node.parent is not None
     assert grandchild1_node.parent.id == child1.id
@@ -61,7 +61,7 @@ def test_tree_traversal(temp_hive):
     assert grandchild1_node.parent.parent.id == root1.id
 
     # Test edge cases
-    root2_node = bees.get_node(root2.id)
+    root2_node = bees.get_by_id(root2.id)
     assert root2_node is not None
     assert len(root2_node.children) == 0
     assert root2_node.parent is None
@@ -69,5 +69,37 @@ def test_tree_traversal(temp_hive):
 
 def test_empty_store(temp_hive):
     bees = Bees(temp_hive)
-    assert len(bees.get_children()) == 0
-    assert bees.get_node("non-existent") is None
+    assert len(bees.children) == 0
+    assert bees.get_by_id("non-existent") is None
+
+
+def test_query_by_tags(temp_hive):
+    bees = Bees(temp_hive)
+    store = bees.store
+
+    # Create tasks with tags
+    t1 = store.create("Task 1", tags=["bug", "ui"])
+    t2 = store.create("Task 2", tags=["ui"])
+    t3 = store.create("Task 3", tags=["bug"])
+    
+    # Create a child task with tags
+    t4 = store.create("Task 4", tags=["bug", "ui"], parent_ticket_id=t2.id)
+
+    # Test global query
+    ui_tasks = bees.query(["ui"])
+    assert len(ui_tasks) == 3  # t1, t2, t4
+    ui_ids = {t.id for t in ui_tasks}
+    assert ui_ids == {t1.id, t2.id, t4.id}
+
+    bug_ui_tasks = bees.query(["bug", "ui"])
+    assert len(bug_ui_tasks) == 2  # t1, t4
+    bug_ui_ids = {t.id for t in bug_ui_tasks}
+    assert bug_ui_ids == {t1.id, t4.id}
+
+    # Test subtree query
+    t2_node = bees.get_by_id(t2.id)
+    assert t2_node is not None
+    
+    subtree_bug_tasks = t2_node.query(["bug"])
+    assert len(subtree_bug_tasks) == 1  # t4
+    assert subtree_bug_tasks[0].id == t4.id


### PR DESCRIPTION
## What
Enriched the `Bees` and `TaskNode` APIs by adding `query` (tag search) and `get_by_id` methods, exposing the underlying `Ticket` via a `task` accessor on `TaskNode`, and updating documentation and tests.

## Why
To provide a more robust, DOM-like API for traversing and querying tasks in the Bees framework, making it easier to find tasks by tags and access their details.

## Changes
### `packages/bees`
- **`bees.py`**: Renamed `get_node` to `get_by_id`. Added `query` method for global tag search.
- **`task_node.py`**: Added `query` method for subtree tag search. Added `task` property to expose the underlying `Ticket`. Refactored internal uses to use `self._task`.
- **`docs/api.md`**: Updated documentation for `get_by_id`, `query`, and `task` property.
- **`tests/test_tree.py`**: Updated tests to use `get_by_id`. Added `test_query_by_tags` to verify new functionality.

## Testing
Ran pytest on the tree tests:
```bash
./packages/bees/.venv/bin/python -m pytest packages/bees/tests/test_tree.py
```
