### PR TITLE
[bees] Refactoring Bees to DOM-Like API

### DIFF
--- a/packages/bees/app/server.py
+++ b/packages/bees/app/server.py
@@ -32,16 +32,14 @@ from pydantic import BaseModel
 from sse_starlette.sse import EventSourceResponse
 
 
-from bees.scheduler import Scheduler, SchedulerHooks
 from app.auth import load_gemini_key
 from app.config import load_hive_dir
-from bees import Task, TaskStore
+from bees import Task, Bees
 from opal_backend.local.backend_client_impl import HttpBackendClient
 
 logger = logging.getLogger(__name__)
 
 hive_dir = load_hive_dir()
-task_store = TaskStore(hive_dir)
 
 
 # ---------------------------------------------------------------------------
@@ -70,7 +68,7 @@ class Broadcaster:
 
 
 broadcaster = Broadcaster()
-scheduler: Scheduler | None = None
+bees: Bees | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -156,7 +154,7 @@ class UpdateTagsRequest(BaseModel):
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncIterator[None]:
-    global scheduler
+    global bees
 
     gemini_key = load_gemini_key()
     http_client = httpx.AsyncClient(timeout=httpx.Timeout(300.0))
@@ -167,27 +165,20 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         gemini_key=gemini_key,
     )
 
-    hooks = SchedulerHooks(
-        on_ticket_added=_on_ticket_added,
-        on_cycle_start=_on_cycle_start,
-        on_ticket_event=_on_ticket_event,
-        on_ticket_start=_on_ticket_start,
-        on_ticket_done=_on_ticket_done,
-        on_cycle_complete=_on_cycle_complete,
-    )
-    scheduler = Scheduler(http=http_client, backend=backend, hooks=hooks, store=task_store)
+    bees = Bees(hive_dir, http_client, backend)
 
-    # Startup scheduler (recovers tickets and boots root if needed)
-    await scheduler.startup()
+    bees.on("ticket_added", _on_ticket_added)
+    bees.on("cycle_start", _on_cycle_start)
+    bees.on("ticket_event", _on_ticket_event)
+    bees.on("ticket_start", _on_ticket_start)
+    bees.on("ticket_done", _on_ticket_done)
+    bees.on("cycle_complete", _on_cycle_complete)
 
-    loop_task = asyncio.create_task(scheduler.start_loop())
-
-    # Auto-schedule any existing available tickets on startup.
-    scheduler.trigger()
+    await bees.listen()
 
     yield
 
-    loop_task.cancel()
+    await bees.shutdown()
     await http_client.aclose()
 
 
@@ -236,34 +227,42 @@ def _read_chat_log(ticket: Task) -> list[dict[str, str]]:
 @app.get("/tickets")
 async def get_tickets(tag: str | None = None) -> list[dict[str, Any]]:
     """List all tickets, sorted by created_at latest first, optionally filtered by tag."""
-    tickets = task_store.query_all()
-
+    if not bees:
+        raise HTTPException(500, "Bees not initialized")
+        
     if tag:
-        tickets = [t for t in tickets if t.metadata.tags and tag in t.metadata.tags]
+        nodes = bees.query([tag])
+    else:
+        nodes = bees.all
 
     # Sort by created_at latest first (ISO string sorting works for chronological order).
-    tickets.sort(key=lambda t: t.metadata.created_at or "", reverse=True)
+    nodes.sort(key=lambda n: n.task.metadata.created_at or "", reverse=True)
 
-    return [_ticket_to_dict(t) for t in tickets]
+    return [_ticket_to_dict(n.task) for n in nodes]
 
 
 @app.get("/tickets/{ticket_id}")
 async def get_ticket(ticket_id: str) -> dict[str, Any]:
     """Get a single ticket."""
-    ticket = task_store.get(ticket_id)
-    if not ticket:
+    if not bees:
+        raise HTTPException(500, "Bees not initialized")
+        
+    node = bees.get_by_id(ticket_id)
+    if not node:
         raise HTTPException(404, f"Ticket {ticket_id} not found")
-    return _ticket_to_dict(ticket)
+    return _ticket_to_dict(node.task)
 
 
 @app.get("/tickets/{ticket_id}/files")
 async def list_ticket_files(ticket_id: str) -> list[str]:
     """List files in the ticket's filesystem directory."""
-    ticket = task_store.get(ticket_id)
-    if not ticket:
+    if not bees:
+        raise HTTPException(500, "Bees not initialized")
+    node = bees.get_by_id(ticket_id)
+    if not node:
         raise HTTPException(404, f"Ticket {ticket_id} not found")
 
-    fs_dir = ticket.fs_dir
+    fs_dir = node.task.fs_dir
     if not fs_dir.is_dir():
         return []
 
@@ -277,16 +276,18 @@ async def list_ticket_files(ticket_id: str) -> list[str]:
 @app.get("/tickets/{ticket_id}/files/{path:path}")
 async def get_ticket_file(ticket_id: str, path: str) -> FileResponse:
     """Serve files from the ticket's filesystem."""
-    ticket = task_store.get(ticket_id)
-    if not ticket:
+    if not bees:
+        raise HTTPException(500, "Bees not initialized")
+    node = bees.get_by_id(ticket_id)
+    if not node:
         raise HTTPException(404, f"Ticket {ticket_id} not found")
 
-    file_path = ticket.fs_dir / path
+    file_path = node.task.fs_dir / path
     if not file_path.is_file():
         raise HTTPException(404, f"File {path} not found")
 
     try:
-        file_path.resolve().relative_to(ticket.fs_dir.resolve())
+        file_path.resolve().relative_to(node.task.fs_dir.resolve())
     except ValueError:
         raise HTTPException(403, "Access denied")
 
@@ -297,17 +298,17 @@ async def get_ticket_file(ticket_id: str, path: str) -> FileResponse:
 @app.post("/tickets")
 async def add_ticket(req: AddTicketRequest) -> dict[str, Any]:
     """Create a new ticket and trigger scheduling."""
-    if not scheduler:
-        raise HTTPException(500, "Scheduler not initialized")
+    if not bees:
+        raise HTTPException(500, "Bees not initialized")
 
-    ticket = await scheduler.create_task(
+    node = await bees.create_child(
         req.objective,
         tags=req.tags,
         functions=req.functions,
         skills=req.skills,
     )
 
-    return _ticket_to_dict(ticket)
+    return _ticket_to_dict(node.task)
 
 
 @app.post("/tickets/{ticket_id}/respond")
@@ -315,9 +316,14 @@ async def respond_to_ticket(
     ticket_id: str, req: RespondRequest,
 ) -> dict[str, Any]:
     """Submit a response to a suspended ticket and trigger scheduling."""
-    ticket = task_store.get(ticket_id)
-    if not ticket:
+    if not bees:
+        raise HTTPException(500, "Bees not initialized")
+        
+    node = bees.get_by_id(ticket_id)
+    if not node:
         raise HTTPException(404, f"Ticket {ticket_id} not found")
+        
+    ticket = node.task
     if ticket.metadata.status != "suspended":
         raise HTTPException(400, f"Ticket is not suspended")
     if ticket.metadata.assignee != "user":
@@ -331,15 +337,13 @@ async def respond_to_ticket(
     if req.contextUpdates:
         response["context_updates"] = req.contextUpdates
 
-    ticket = task_store.respond(ticket_id, response)
+    ticket = node.respond(response)
 
     await broadcaster.broadcast({
         "type": "ticket_update",
         "ticket": _ticket_to_dict(ticket),
     })
 
-    if scheduler:
-        scheduler.trigger()
     return _ticket_to_dict(ticket)
 
 
@@ -348,19 +352,21 @@ async def update_ticket_tags(
     ticket_id: str, req: UpdateTagsRequest
 ) -> dict[str, Any]:
     """Update tags for a ticket and broadcast."""
-    ticket = task_store.get(ticket_id)
-    if not ticket:
+    if not bees:
+        raise HTTPException(500, "Bees not initialized")
+    node = bees.get_by_id(ticket_id)
+    if not node:
         raise HTTPException(404, f"Ticket {ticket_id} not found")
 
-    ticket.metadata.tags = req.tags
-    task_store.save_metadata(ticket)
+    node.task.metadata.tags = req.tags
+    node.save()
 
     await broadcaster.broadcast({
         "type": "ticket_update",
-        "ticket": _ticket_to_dict(ticket),
+        "ticket": _ticket_to_dict(node.task),
     })
 
-    return _ticket_to_dict(ticket)
+    return _ticket_to_dict(node.task)
 
 
 @app.post("/tickets/{ticket_id}/retry")
@@ -371,24 +377,22 @@ async def retry_ticket(ticket_id: str) -> dict[str, Any]:
     (e.g. 503).  Retrying clears the error and re-queues the ticket
     for the scheduler to pick up.
     """
-    ticket = task_store.get(ticket_id)
-    if not ticket:
+    if not bees:
+        raise HTTPException(500, "Bees not initialized")
+    node = bees.get_by_id(ticket_id)
+    if not node:
         raise HTTPException(404, f"Ticket {ticket_id} not found")
-    if ticket.metadata.status != "paused":
+    if node.task.metadata.status != "paused":
         raise HTTPException(400, "Ticket is not paused")
 
-    ticket.metadata.status = "available"
-    ticket.metadata.error = None
-    task_store.save_metadata(ticket)
+    node.retry()
 
     await broadcaster.broadcast({
         "type": "ticket_update",
-        "ticket": _ticket_to_dict(ticket),
+        "ticket": _ticket_to_dict(node.task),
     })
 
-    if scheduler:
-        scheduler.trigger()
-    return _ticket_to_dict(ticket)
+    return _ticket_to_dict(node.task)
 
 
 
@@ -462,7 +466,9 @@ async def get_status(
     kind: str | None = None,
 ) -> dict[str, Any]:
     """Return a status response containing both the summary text and structured tasks."""
-    tickets = task_store.query_all()
+    if not bees:
+        raise HTTPException(500, "Bees not initialized")
+    tickets = [n.task for n in bees.all]
 
     by_run: dict[str, list[Task]] = {}
     active_running = []
@@ -534,6 +540,9 @@ async def get_status(
 @app.get("/events")
 async def events() -> EventSourceResponse:
     """Server-Sent Events stream for real-time updates."""
+    if not bees:
+        raise HTTPException(500, "Bees not initialized")
+        
     queue = broadcaster.subscribe()
 
     async def event_generator() -> AsyncIterator[dict]:
@@ -542,7 +551,7 @@ async def events() -> EventSourceResponse:
             yield {
                 "event": "init",
                 "data": json.dumps([
-                    _ticket_to_dict(t) for t in task_store.query_all()
+                    _ticket_to_dict(n.task) for n in bees.all
                 ]),
             }
             while True:

--- a/packages/bees/bees/bees.py
+++ b/packages/bees/bees/bees.py
@@ -2,9 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
+import asyncio
+from collections import defaultdict
 from pathlib import Path
 from bees.task_store import TaskStore
 from bees.task_node import TaskNode
+from bees.scheduler import Scheduler, SchedulerHooks
 
 
 class Bees:
@@ -13,25 +16,78 @@ class Bees:
     Acts like the 'Document' in the DOM analogy.
     """
 
-    def __init__(self, hive_dir: Path):
-        self.store = TaskStore(hive_dir)
+    def __init__(self, hive_dir: Path, http, backend):
+        self._store = TaskStore(hive_dir)
+        self.http = http
+        self.backend = backend
+        self._events = defaultdict(list)
+        self._loop_task = None
+        
+        hooks = SchedulerHooks(
+            on_ticket_added=lambda t: self._emit("ticket_added", t),
+            on_cycle_start=lambda c, a, r: self._emit("cycle_start", c, a, r),
+            on_ticket_event=lambda t, e: self._emit("ticket_event", t, e),
+            on_ticket_start=lambda t: self._emit("ticket_start", t),
+            on_ticket_done=lambda t: self._emit("ticket_done", t),
+            on_cycle_complete=lambda c: self._emit("cycle_complete", c),
+        )
+        self._scheduler = Scheduler(http=http, backend=backend, hooks=hooks, store=self._store)
+
+    async def _emit(self, event_name: str, *args):
+        for callback in self._events[event_name]:
+            res = callback(*args)
+            if asyncio.iscoroutine(res):
+                await res
+
+    def on(self, event_name: str, callback):
+        """Registers an event listener."""
+        self._events[event_name].append(callback)
+
+    async def listen(self):
+        """Starts the scheduler loop."""
+        await self._scheduler.startup()
+        self._loop_task = asyncio.create_task(self._scheduler.start_loop())
+        self._scheduler.trigger()
+
+    def trigger(self):
+        """Triggers the scheduler to process tasks."""
+        self._scheduler.trigger()
+
+    async def shutdown(self):
+        """Stops the scheduler loop and cleans up."""
+        if self._loop_task:
+            self._loop_task.cancel()
+            try:
+                await self._loop_task
+            except asyncio.CancelledError:
+                pass
 
     @property
     def children(self) -> list[TaskNode]:
         """Returns all tasks that have no parents, as TaskNodes."""
-        return [TaskNode(task, self.store) for task in self.store.get_children(None)]
+        return [TaskNode(task, self) for task in self._store.get_children(None)]
+
+    @property
+    def all(self) -> list[TaskNode]:
+        """Returns all tasks in the hive."""
+        return [TaskNode(task, self) for task in self._store.query_all()]
 
     def get_by_id(self, task_id: str) -> TaskNode | None:
         """Looks up a task by ID and returns it as a TaskNode."""
-        task = self.store.get(task_id)
-        return TaskNode(task, self.store) if task else None
+        task = self._store.get(task_id)
+        return TaskNode(task, self) if task else None
 
     def query(self, tags: list[str]) -> list[TaskNode]:
         """Searches for tasks that contain all of the specified tags."""
-        all_tickets = self.store.query_all()
+        all_tickets = self._store.query_all()
         matching_nodes: list[TaskNode] = []
         for ticket in all_tickets:
             ticket_tags = ticket.metadata.tags or []
             if all(tag in ticket_tags for tag in tags):
-                matching_nodes.append(TaskNode(ticket, self.store))
+                matching_nodes.append(TaskNode(ticket, self))
         return matching_nodes
+
+    async def create_child(self, objective: str, **kwargs) -> TaskNode:
+        """Creates a root task."""
+        ticket = await self._scheduler.create_task(objective, **kwargs)
+        return TaskNode(ticket, self)

--- a/packages/bees/bees/task_node.py
+++ b/packages/bees/bees/task_node.py
@@ -2,16 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
-from bees.task_store import TaskStore
+from typing import TYPE_CHECKING
 from bees.ticket import Ticket
 
+if TYPE_CHECKING:
+    from bees.bees import Bees
 
 class TaskNode:
-    """Wraps a Ticket and a TaskStore to provide a tree traversal API."""
+    """Wraps a Ticket and provides a tree traversal and manipulation API."""
 
-    def __init__(self, task: Ticket, store: TaskStore):
+    def __init__(self, task: Ticket, bees: Bees):
         self._task = task
-        self.store = store
+        self.bees = bees
+        self._store = bees._store
 
     @property
     def task(self) -> Ticket:
@@ -26,20 +29,20 @@ class TaskNode:
     @property
     def children(self) -> list[TaskNode]:
         """Returns children of this task."""
-        tasks = self.store.get_children(self._task.id)
-        return [TaskNode(t, self.store) for t in tasks]
+        tasks = self._store.get_children(self._task.id)
+        return [TaskNode(t, self.bees) for t in tasks]
 
     @property
     def parent(self) -> TaskNode | None:
         """Returns the parent of this task."""
         if not self._task.metadata.parent_ticket_id:
             return None
-        parent_task = self.store.get(self._task.metadata.parent_ticket_id)
-        return TaskNode(parent_task, self.store) if parent_task else None
+        parent_task = self._store.get(self._task.metadata.parent_ticket_id)
+        return TaskNode(parent_task, self.bees) if parent_task else None
 
     def query(self, tags: list[str]) -> list[TaskNode]:
         """Searches for tasks in the subtree that contain all of the specified tags."""
-        all_tickets = self.store.query_all()
+        all_tickets = self._store.query_all()
         
         # Build child map
         from collections import defaultdict
@@ -72,6 +75,29 @@ class TaskNode:
             t = ticket_map[d_id]
             t_tags = t.metadata.tags or []
             if all(tag in t_tags for tag in tags):
-                matching_nodes.append(TaskNode(t, self.store))
+                matching_nodes.append(TaskNode(t, self.bees))
                 
         return matching_nodes
+
+    async def create_child(self, objective: str, **kwargs) -> TaskNode:
+        """Creates a child task under this task."""
+        kwargs['parent_ticket_id'] = self.id
+        ticket = await self.bees._scheduler.create_task(objective, **kwargs)
+        return TaskNode(ticket, self.bees)
+
+    def respond(self, response: dict):
+        """Delivers a response to this task."""
+        self._task = self._store.respond(self.id, response)
+        self.bees.trigger()
+        return self._task
+
+    def save(self):
+        """Saves the task metadata."""
+        self._store.save_metadata(self._task)
+
+    def retry(self):
+        """Retries a paused task."""
+        self._task.metadata.status = "available"
+        self._task.metadata.error = None
+        self.save()
+        self.bees.trigger()

--- a/packages/bees/docs/api.md
+++ b/packages/bees/docs/api.md
@@ -4,9 +4,8 @@ The `bees` library is a framework for building agent swarm systems.
 
 ## Core Concepts
 
-- **`Bees`**: The high-level entry point for the library
-- **`TaskNode`**: Represents a task in the tree, providing traversal properties
-  like `children` and `parent`.
+- **`Bees`**: The high-level entry point for the library, analogous to `document` in the DOM.
+- **`TaskNode`**: Represents a task in the tree, analogous to an `Element` in the DOM.
 
 ## Classes
 
@@ -14,17 +13,26 @@ The `bees` library is a framework for building agent swarm systems.
 
 The main entry point for interacting with a hive of tasks.
 
-#### `__init__(self, hive_dir: Path)`
+#### `__init__(self, hive_dir: Path, *, http: httpx.AsyncClient, backend: HttpBackendClient, hooks: SchedulerHooks | None = None)`
 
 Initializes a new `Bees` instance.
 
 - **`hive_dir`**: The root directory of the hive where tasks are stored.
+- **`http`**: An async HTTP client for external requests.
+- **`backend`**: A client for interacting with the backend service.
+- **`hooks`**: Optional scheduler hooks.
 
 #### `children`
 
 Property that returns all root tasks (tasks that have no parents) in the hive.
 
 - **Returns**: A list of `TaskNode` objects representing the root tasks.
+
+#### `all`
+
+Property that returns all tasks in the hive.
+
+- **Returns**: A list of `TaskNode` objects representing all tasks.
 
 #### `get_by_id(self, task_id: str) -> TaskNode | None`
 
@@ -40,9 +48,36 @@ Searches for tasks in the hive that contain all of the specified tags.
 - **`tags`**: A list of tags to search for.
 - **Returns**: A list of `TaskNode` objects matching all tags.
 
+#### `create_child(self, objective: str, **kwargs) -> TaskNode` (Async)
+
+Creates a new root task in the hive.
+
+- **`objective`**: The description of the task.
+- **`**kwargs`**: Additional arguments for task creation (e.g., `tags`).
+- **Returns**: A `TaskNode` representing the newly created task.
+
+#### `on(self, event_name: str, handler: Callable)`
+
+Registers an event handler for the specified event.
+
+- **`event_name`**: The name of the event (e.g., `ticket_done`).
+- **`handler`**: The callback function to run when the event fires.
+
+#### `listen(self)` (Async)
+
+Starts the scheduler loop and begins processing tasks.
+
+#### `trigger(self)`
+
+Triggers the scheduler to process tasks immediately.
+
+#### `shutdown(self)` (Async)
+
+Stops the scheduler loop and cleans up resources.
+
 ### `TaskNode`
 
-A wrapper around a task that provides DOM-like traversal properties.
+A wrapper around a task that provides DOM-like traversal properties and manipulation methods.
 
 #### Properties
 
@@ -50,11 +85,11 @@ A wrapper around a task that provides DOM-like traversal properties.
 
 - **`task`**: `Ticket` (Read-only) The underlying ticket object containing task details.
 
-- **`children`**: `list[TaskNode]` (Read-only) A list of child tasks that have
-  this task as their parent.
+- **`children`**: `list[TaskNode]` (Read-only) A list of child tasks that have this task as their parent.
 
-- **`parent`**: `TaskNode | None` (Read-only) The parent task of this task, or
-  `None` if it is a root task.
+- **`parent`**: `TaskNode | None` (Read-only) The parent task of this task, or `None` if it is a root task.
+
+#### Methods
 
 #### `query(self, tags: list[str]) -> list[TaskNode]`
 
@@ -62,3 +97,25 @@ Searches for tasks in the subtree that contain all of the specified tags.
 
 - **`tags`**: A list of tags to search for.
 - **Returns**: A list of `TaskNode` objects matching all tags.
+
+#### `create_child(self, objective: str, **kwargs) -> TaskNode` (Async)
+
+Creates a child task under this task.
+
+- **`objective`**: The description of the task.
+- **`**kwargs`**: Additional arguments for task creation.
+- **Returns**: A `TaskNode` representing the newly created child task.
+
+#### `respond(self, response: dict)`
+
+Submits a response to the task (e.g., answering a question or providing data).
+
+- **`response`**: The data to respond with.
+
+#### `save(self)`
+
+Saves the task's current state to persistent storage.
+
+#### `retry(self)`
+
+Retries a paused task by resetting its status to available and clearing errors.

--- a/packages/bees/tests/test_tree.py
+++ b/packages/bees/tests/test_tree.py
@@ -3,8 +3,10 @@
 
 import tempfile
 from pathlib import Path
+from unittest.mock import Mock, AsyncMock
 import pytest
 from bees import Bees
+from bees.task_node import TaskNode
 
 
 @pytest.fixture
@@ -14,8 +16,8 @@ def temp_hive():
 
 
 def test_tree_traversal(temp_hive):
-    bees = Bees(temp_hive)
-    store = bees.store
+    bees = Bees(temp_hive, http=Mock(), backend=Mock())
+    store = bees._store
 
     # Create a tree structure
     # root1
@@ -68,14 +70,14 @@ def test_tree_traversal(temp_hive):
 
 
 def test_empty_store(temp_hive):
-    bees = Bees(temp_hive)
+    bees = Bees(temp_hive, http=Mock(), backend=Mock())
     assert len(bees.children) == 0
     assert bees.get_by_id("non-existent") is None
 
 
 def test_query_by_tags(temp_hive):
-    bees = Bees(temp_hive)
-    store = bees.store
+    bees = Bees(temp_hive, http=Mock(), backend=Mock())
+    store = bees._store
 
     # Create tasks with tags
     t1 = store.create("Task 1", tags=["bug", "ui"])
@@ -103,3 +105,81 @@ def test_query_by_tags(temp_hive):
     subtree_bug_tasks = t2_node.query(["bug"])
     assert len(subtree_bug_tasks) == 1  # t4
     assert subtree_bug_tasks[0].id == t4.id
+
+
+@pytest.mark.asyncio
+async def test_bees_create_child(temp_hive):
+    bees = Bees(temp_hive, http=Mock(), backend=Mock())
+    bees._scheduler = Mock()
+    
+    mock_ticket = Mock()
+    mock_ticket.id = "task1"
+    mock_ticket.metadata = Mock()
+    mock_ticket.metadata.tags = []
+    bees._scheduler.create_task = AsyncMock(return_value=mock_ticket)
+    
+    node = await bees.create_child("New Task", tags=["test"])
+    
+    bees._scheduler.create_task.assert_called_once_with("New Task", tags=["test"])
+    assert node.id == "task1"
+
+
+@pytest.mark.asyncio
+async def test_task_node_create_child(temp_hive):
+    bees = Bees(temp_hive, http=Mock(), backend=Mock())
+    bees._scheduler = Mock()
+    
+    mock_ticket = Mock()
+    mock_ticket.id = "child1"
+    mock_ticket.metadata = Mock()
+    mock_ticket.metadata.tags = []
+    bees._scheduler.create_task = AsyncMock(return_value=mock_ticket)
+    
+    parent_ticket = Mock()
+    parent_ticket.id = "parent1"
+    parent_ticket.metadata = Mock()
+    parent_ticket.metadata.tags = []
+    
+    parent_node = TaskNode(parent_ticket, bees)
+    
+    child_node = await parent_node.create_child("Child Task")
+    
+    bees._scheduler.create_task.assert_called_once_with("Child Task", parent_ticket_id="parent1")
+    assert child_node.id == "child1"
+
+
+def test_task_node_respond(temp_hive):
+    bees = Bees(temp_hive, http=Mock(), backend=Mock())
+    store_mock = Mock()
+    bees._store = store_mock
+    
+    ticket = Mock()
+    ticket.id = "task1"
+    node = TaskNode(ticket, bees)
+    
+    node.respond({"text": "reply"})
+    
+    store_mock.respond.assert_called_once_with("task1", {"text": "reply"})
+
+
+def test_bees_all(temp_hive):
+    bees = Bees(temp_hive, http=Mock(), backend=Mock())
+    store_mock = Mock()
+    bees._store = store_mock
+    
+    t1 = Mock()
+    t1.id = "t1"
+    t1.metadata = Mock()
+    t1.metadata.tags = []
+    
+    t2 = Mock()
+    t2.id = "t2"
+    t2.metadata = Mock()
+    t2.metadata.tags = []
+    
+    store_mock.query_all.return_value = [t1, t2]
+    
+    all_nodes = bees.all
+    assert len(all_nodes) == 2
+    assert all_nodes[0].id == "t1"
+    assert all_nodes[1].id == "t2"


### PR DESCRIPTION
## What
Refactored the Bees framework to use a DOM-inspired API, submerging `TaskStore` and `Scheduler` into a unified `Bees` facade and `TaskNode` elements.

## Why
To provide a cleaner, more ergonomic, and fully encapsulated API for application layers (like `server.py`), reducing coupling and improving maintainability.

## Changes
### Core API (`packages/bees/bees/`)
- **`Bees`**: Added `all`, `create_child`, `on`, `listen`, `trigger`, and `shutdown` methods. Renamed internal attributes to use leading underscores (`_store`, `_scheduler`, `_events`, `_loop_task`) to clarify they are not public API.
- **`TaskNode`**: Added `create_child`, `respond`, `save`, and `retry` methods. Decoupled from direct store access by carrying the `Bees` instance.

### Server (`packages/bees/app/`)
- **`server.py`**: Refactored all endpoints to use the new `Bees` and `TaskNode` APIs instead of directly accessing `task_store` and `scheduler`.

### Documentation (`packages/bees/docs/`)
- **`api.md`**: Updated to document the new public API surface.

### Tests (`packages/bees/tests/`)
- **`test_tree.py`**: Updated to use underscored internal attributes in tests and added new tests for `create_child`, `respond`, and `all`.

## Testing
Ran `pytest` in `packages/bees`. All 168 tests passed.
