### PR TITLE
[bees] API Encapsulation Refinements

### DIFF
--- a/packages/bees/bees/bees.py
+++ b/packages/bees/bees/bees.py
@@ -18,8 +18,8 @@ class Bees:
 
     def __init__(self, hive_dir: Path, http, backend):
         self._store = TaskStore(hive_dir)
-        self.http = http
-        self.backend = backend
+        self._http = http
+        self._backend = backend
         self._events = defaultdict(list)
         self._loop_task = None
         
@@ -49,7 +49,7 @@ class Bees:
         self._loop_task = asyncio.create_task(self._scheduler.start_loop())
         self._scheduler.trigger()
 
-    def trigger(self):
+    def _trigger(self):
         """Triggers the scheduler to process tasks."""
         self._scheduler.trigger()
 

--- a/packages/bees/bees/task_node.py
+++ b/packages/bees/bees/task_node.py
@@ -13,7 +13,7 @@ class TaskNode:
 
     def __init__(self, task: Ticket, bees: Bees):
         self._task = task
-        self.bees = bees
+        self._bees = bees
         self._store = bees._store
 
     @property
@@ -30,7 +30,7 @@ class TaskNode:
     def children(self) -> list[TaskNode]:
         """Returns children of this task."""
         tasks = self._store.get_children(self._task.id)
-        return [TaskNode(t, self.bees) for t in tasks]
+        return [TaskNode(t, self._bees) for t in tasks]
 
     @property
     def parent(self) -> TaskNode | None:
@@ -38,7 +38,7 @@ class TaskNode:
         if not self._task.metadata.parent_ticket_id:
             return None
         parent_task = self._store.get(self._task.metadata.parent_ticket_id)
-        return TaskNode(parent_task, self.bees) if parent_task else None
+        return TaskNode(parent_task, self._bees) if parent_task else None
 
     def query(self, tags: list[str]) -> list[TaskNode]:
         """Searches for tasks in the subtree that contain all of the specified tags."""
@@ -75,20 +75,20 @@ class TaskNode:
             t = ticket_map[d_id]
             t_tags = t.metadata.tags or []
             if all(tag in t_tags for tag in tags):
-                matching_nodes.append(TaskNode(t, self.bees))
+                matching_nodes.append(TaskNode(t, self._bees))
                 
         return matching_nodes
 
     async def create_child(self, objective: str, **kwargs) -> TaskNode:
         """Creates a child task under this task."""
         kwargs['parent_ticket_id'] = self.id
-        ticket = await self.bees._scheduler.create_task(objective, **kwargs)
-        return TaskNode(ticket, self.bees)
+        ticket = await self._bees._scheduler.create_task(objective, **kwargs)
+        return TaskNode(ticket, self._bees)
 
     def respond(self, response: dict):
         """Delivers a response to this task."""
         self._task = self._store.respond(self.id, response)
-        self.bees.trigger()
+        self._bees._trigger()
         return self._task
 
     def save(self):
@@ -100,4 +100,4 @@ class TaskNode:
         self._task.metadata.status = "available"
         self._task.metadata.error = None
         self.save()
-        self.bees.trigger()
+        self._bees._trigger()

--- a/packages/bees/docs/api.md
+++ b/packages/bees/docs/api.md
@@ -67,10 +67,6 @@ Registers an event handler for the specified event.
 
 Starts the scheduler loop and begins processing tasks.
 
-#### `trigger(self)`
-
-Triggers the scheduler to process tasks immediately.
-
 #### `shutdown(self)` (Async)
 
 Stops the scheduler loop and cleans up resources.


### PR DESCRIPTION
## What
This follow-up PR completes the encapsulation of the Bees framework by marking remaining internal attributes and methods with a leading underscore.

## Why
To ensure a strict boundary for the public API, hiding implementation details like `http` clients, `backend` clients, and the internal `trigger` mechanism from external consumers.

## Changes
### Bees Core
- `Bees`: Renamed `http`, `backend`, and `trigger` to `_http`, `_backend`, and `_trigger`.
- `TaskNode`: Renamed the `bees` reference to `_bees` to prevent public access to the root instance.

### Documentation
- `api.md`: Removed the `trigger` method from the documented API surface.

### Tests
- Updated `test_tree.py` to use the new underscored names for mocking.

## Testing
Verified that all 168 unit tests continue to pass successfully.
