### PR TITLE
[bees] Opinionated Agent API for Bees

### DIFF
--- a/packages/bees/app/server.py
+++ b/packages/bees/app/server.py
@@ -4,9 +4,8 @@
 """
 Bees HTTP server — REST API + scheduler + SSE event stream.
 
-Provides the same functionality as the CLI tools (ticket:add,
-ticket:drain, ticket:respond) via HTTP, plus auto-scheduling and
-real-time status updates via Server-Sent Events.
+Provides an agent-centric API for the Opal shell, plus
+auto-scheduling and real-time status updates via Server-Sent Events.
 
 Usage::
 
@@ -16,12 +15,9 @@ Usage::
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import json
 import logging
-import sys
 from contextlib import asynccontextmanager
-from datetime import datetime, timezone
 from typing import Any, AsyncIterator
 
 import httpx
@@ -77,16 +73,16 @@ bees: Bees | None = None
 
 
 async def _on_ticket_added(ticket: Task) -> None:
-    """Broadcast a newly added ticket."""
+    """Broadcast a newly added agent."""
     await broadcaster.broadcast({
-        "type": "ticket_added",
-        "ticket": _ticket_to_dict(ticket),
+        "type": "agent:added",
+        "agent": _agent_to_dict(ticket),
     })
 
 
 async def _on_cycle_start(cycle: int, new: int, resumable: int) -> None:
     await broadcaster.broadcast({
-        "type": "drain_start",
+        "type": "scheduler:started",
         "wave": cycle,
         "new": new,
         "resumable": resumable,
@@ -95,34 +91,31 @@ async def _on_cycle_start(cycle: int, new: int, resumable: int) -> None:
 
 async def _on_ticket_event(ticket_id: str, event: dict[str, Any]) -> None:
     await broadcaster.broadcast({
-        "type": "session_event",
+        "type": "session:event",
         "ticket_id": ticket_id,
         "event": event,
     })
 
 
 async def _on_ticket_start(ticket: Task) -> None:
-    """Broadcast when a ticket transitions to running."""
+    """Broadcast when an agent transitions to running."""
     await broadcaster.broadcast({
-        "type": "ticket_update",
-        "ticket": _ticket_to_dict(ticket),
+        "type": "agent:updated",
+        "agent": _agent_to_dict(ticket),
     })
 
 
 async def _on_ticket_done(ticket: Task) -> None:
-    """Post-completion hook: broadcast and run playbook hooks."""
+    """Post-completion hook: broadcast updated agent state."""
     await broadcaster.broadcast({
-        "type": "ticket_update",
-        "ticket": _ticket_to_dict(ticket),
+        "type": "agent:updated",
+        "agent": _agent_to_dict(ticket),
     })
 
 
 
 async def _on_cycle_complete(cycles: int) -> None:
-    await broadcaster.broadcast({"type": "drain_complete", "waves": cycles})
-
-
-
+    await broadcaster.broadcast({"type": "scheduler:stopped", "waves": cycles})
 
 
 # ---------------------------------------------------------------------------
@@ -130,21 +123,21 @@ async def _on_cycle_complete(cycles: int) -> None:
 # ---------------------------------------------------------------------------
 
 
-class AddTicketRequest(BaseModel):
-    objective: str
-    tags: list[str] | None = None
-    functions: list[str] | None = None
-    skills: list[str] | None = None
+class ReplyRequest(BaseModel):
+    text: str
 
 
-class RespondRequest(BaseModel):
-    text: str | None = None
-    selectedIds: list[str] | None = None
-    contextUpdates: list[str] | None = None
+class ChooseRequest(BaseModel):
+    selectedIds: list[str]
 
 
 class UpdateTagsRequest(BaseModel):
     tags: list[str]
+
+
+class BundleResponse(BaseModel):
+    js: str
+    css: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -192,18 +185,18 @@ app.add_middleware(
 
 
 # ---------------------------------------------------------------------------
-# REST endpoints
+# Helpers
 # ---------------------------------------------------------------------------
 
 
-def _ticket_to_dict(ticket: Task) -> dict[str, Any]:
-    """Serialize a ticket for JSON response."""
+def _agent_to_dict(ticket: Task) -> dict[str, Any]:
+    """Serialize an agent (ticket) for JSON response."""
     d = {
         "id": ticket.id,
         "objective": ticket.objective,
         **ticket.metadata.to_dict(),
     }
-    # Include chat history for chat-tagged tickets so the shell can
+    # Include chat history for chat-tagged agents so the shell can
     # restore conversation after page reload / server restart.
     if ticket.metadata.tags and "chat" in ticket.metadata.tags:
         d["chat_history"] = _read_chat_log(ticket)
@@ -211,7 +204,7 @@ def _ticket_to_dict(ticket: Task) -> dict[str, Any]:
 
 
 def _read_chat_log(ticket: Task) -> list[dict[str, str]]:
-    """Read the ticket's chat log written by the chat function.
+    """Read the agent's chat log written by the chat function.
 
     Returns a list of ``{"role": "agent"|"user", "text": "..."}`` entries.
     """
@@ -224,43 +217,162 @@ def _read_chat_log(ticket: Task) -> list[dict[str, str]]:
         return []
 
 
-@app.get("/tickets")
-async def get_tickets(tag: str | None = None) -> list[dict[str, Any]]:
-    """List all tickets, sorted by created_at latest first, optionally filtered by tag."""
+def _require_bees() -> Bees:
+    """Return the Bees instance, raising 500 if not yet initialized."""
     if not bees:
         raise HTTPException(500, "Bees not initialized")
-        
-    if tag:
-        nodes = bees.query([tag])
-    else:
-        nodes = bees.all
-
-    # Sort by created_at latest first (ISO string sorting works for chronological order).
-    nodes.sort(key=lambda n: n.task.metadata.created_at or "", reverse=True)
-
-    return [_ticket_to_dict(n.task) for n in nodes]
+    return bees
 
 
-@app.get("/tickets/{ticket_id}")
-async def get_ticket(ticket_id: str) -> dict[str, Any]:
-    """Get a single ticket."""
-    if not bees:
-        raise HTTPException(500, "Bees not initialized")
-        
-    node = bees.get_by_id(ticket_id)
+def _get_node(agent_id: str):
+    """Look up a node by agent ID, raising 404 if not found."""
+    b = _require_bees()
+    node = b.get_by_id(agent_id)
     if not node:
-        raise HTTPException(404, f"Ticket {ticket_id} not found")
-    return _ticket_to_dict(node.task)
+        raise HTTPException(404, f"Agent {agent_id} not found")
+    return node
 
 
-@app.get("/tickets/{ticket_id}/files")
-async def list_ticket_files(ticket_id: str) -> list[str]:
-    """List files in the ticket's filesystem directory."""
-    if not bees:
-        raise HTTPException(500, "Bees not initialized")
-    node = bees.get_by_id(ticket_id)
-    if not node:
-        raise HTTPException(404, f"Ticket {ticket_id} not found")
+# ---------------------------------------------------------------------------
+# REST endpoints — Commands (writes)
+# ---------------------------------------------------------------------------
+
+
+@app.post("/agents/{agent_id}/reply")
+async def reply_to_agent(agent_id: str, req: ReplyRequest) -> dict[str, Any]:
+    """Send a chat reply to a suspended agent."""
+    node = _get_node(agent_id)
+    ticket = node.task
+    if ticket.metadata.status != "suspended":
+        raise HTTPException(400, "Agent is not suspended")
+    if ticket.metadata.assignee != "user":
+        raise HTTPException(400, "Agent is not assigned to user")
+
+    ticket = node.respond({"text": req.text})
+
+    await broadcaster.broadcast({
+        "type": "agent:updated",
+        "agent": _agent_to_dict(ticket),
+    })
+
+    return _agent_to_dict(ticket)
+
+
+@app.post("/agents/{agent_id}/choose")
+async def choose_for_agent(
+    agent_id: str, req: ChooseRequest,
+) -> dict[str, Any]:
+    """Submit a choice selection to a suspended agent."""
+    node = _get_node(agent_id)
+    ticket = node.task
+    if ticket.metadata.status != "suspended":
+        raise HTTPException(400, "Agent is not suspended")
+    if ticket.metadata.assignee != "user":
+        raise HTTPException(400, "Agent is not assigned to user")
+
+    ticket = node.respond({"selectedIds": req.selectedIds})
+
+    await broadcaster.broadcast({
+        "type": "agent:updated",
+        "agent": _agent_to_dict(ticket),
+    })
+
+    return _agent_to_dict(ticket)
+
+
+@app.post("/agents/{agent_id}/retry")
+async def retry_agent(agent_id: str) -> dict[str, Any]:
+    """Retry a paused agent by flipping it back to available.
+
+    Paused agents are those that hit a transient Gemini API error
+    (e.g. 503).  Retrying clears the error and re-queues the agent
+    for the scheduler to pick up.
+    """
+    node = _get_node(agent_id)
+    if node.task.metadata.status != "paused":
+        raise HTTPException(400, "Agent is not paused")
+
+    node.retry()
+
+    await broadcaster.broadcast({
+        "type": "agent:updated",
+        "agent": _agent_to_dict(node.task),
+    })
+
+    return _agent_to_dict(node.task)
+
+
+@app.post("/agents/{agent_id}/tags")
+async def update_agent_tags(
+    agent_id: str, req: UpdateTagsRequest
+) -> dict[str, Any]:
+    """Update tags for an agent and broadcast."""
+    node = _get_node(agent_id)
+
+    node.task.metadata.tags = req.tags
+    node.save()
+
+    await broadcaster.broadcast({
+        "type": "agent:updated",
+        "agent": _agent_to_dict(node.task),
+    })
+
+    return _agent_to_dict(node.task)
+
+
+# ---------------------------------------------------------------------------
+# REST endpoints — Queries (reads)
+# ---------------------------------------------------------------------------
+
+
+@app.get("/agents/{agent_id}/bundle")
+async def get_agent_bundle(
+    agent_id: str, slug: str | None = None,
+) -> dict[str, Any]:
+    """Return the resolved JS (and optional CSS) bundle for an agent.
+
+    When ``slug`` is provided, only files under the slug subdirectory
+    are considered. This prevents loading a sibling agent's bundle from
+    the shared workspace.
+    """
+    node = _get_node(agent_id)
+    fs_dir = node.task.fs_dir
+    if not fs_dir.is_dir():
+        raise HTTPException(404, "No files for this agent")
+
+    all_files = [
+        str(p.relative_to(fs_dir))
+        for p in fs_dir.rglob("*")
+        if p.is_file()
+    ]
+
+    # Scope to the agent's slug subdirectory when present.
+    files = (
+        [f for f in all_files if f.startswith(slug + "/")]
+        if slug
+        else all_files
+    )
+
+    js_file = next((f for f in files if f.endswith(".js")), None)
+    if not js_file:
+        raise HTTPException(404, "No JS bundle found")
+
+    js_content = (fs_dir / js_file).read_text(encoding="utf-8")
+
+    css_file = next((f for f in files if f.endswith(".css")), None)
+    css_content = (
+        (fs_dir / css_file).read_text(encoding="utf-8")
+        if css_file
+        else None
+    )
+
+    return {"js": js_content, "css": css_content}
+
+
+@app.get("/agents/{agent_id}/files")
+async def list_agent_files(agent_id: str) -> list[str]:
+    """List files in the agent's filesystem directory."""
+    node = _get_node(agent_id)
 
     fs_dir = node.task.fs_dir
     if not fs_dir.is_dir():
@@ -273,14 +385,10 @@ async def list_ticket_files(ticket_id: str) -> list[str]:
     ]
 
 
-@app.get("/tickets/{ticket_id}/files/{path:path}")
-async def get_ticket_file(ticket_id: str, path: str) -> FileResponse:
-    """Serve files from the ticket's filesystem."""
-    if not bees:
-        raise HTTPException(500, "Bees not initialized")
-    node = bees.get_by_id(ticket_id)
-    if not node:
-        raise HTTPException(404, f"Ticket {ticket_id} not found")
+@app.get("/agents/{agent_id}/files/{path:path}")
+async def get_agent_file(agent_id: str, path: str) -> FileResponse:
+    """Serve files from the agent's filesystem."""
+    node = _get_node(agent_id)
 
     file_path = node.task.fs_dir / path
     if not file_path.is_file():
@@ -294,244 +402,6 @@ async def get_ticket_file(ticket_id: str, path: str) -> FileResponse:
     return FileResponse(file_path)
 
 
-
-@app.post("/tickets")
-async def add_ticket(req: AddTicketRequest) -> dict[str, Any]:
-    """Create a new ticket and trigger scheduling."""
-    if not bees:
-        raise HTTPException(500, "Bees not initialized")
-
-    node = await bees.create_child(
-        req.objective,
-        tags=req.tags,
-        functions=req.functions,
-        skills=req.skills,
-    )
-
-    return _ticket_to_dict(node.task)
-
-
-@app.post("/tickets/{ticket_id}/respond")
-async def respond_to_ticket(
-    ticket_id: str, req: RespondRequest,
-) -> dict[str, Any]:
-    """Submit a response to a suspended ticket and trigger scheduling."""
-    if not bees:
-        raise HTTPException(500, "Bees not initialized")
-        
-    node = bees.get_by_id(ticket_id)
-    if not node:
-        raise HTTPException(404, f"Ticket {ticket_id} not found")
-        
-    ticket = node.task
-    if ticket.metadata.status != "suspended":
-        raise HTTPException(400, f"Ticket is not suspended")
-    if ticket.metadata.assignee != "user":
-        raise HTTPException(400, f"Ticket is not assigned to user")
-
-    response: dict[str, Any] = {}
-    if req.selectedIds is not None:
-        response["selectedIds"] = req.selectedIds
-    if req.text is not None:
-        response["text"] = req.text
-    if req.contextUpdates:
-        response["context_updates"] = req.contextUpdates
-
-    ticket = node.respond(response)
-
-    await broadcaster.broadcast({
-        "type": "ticket_update",
-        "ticket": _ticket_to_dict(ticket),
-    })
-
-    return _ticket_to_dict(ticket)
-
-
-@app.post("/tickets/{ticket_id}/tags")
-async def update_ticket_tags(
-    ticket_id: str, req: UpdateTagsRequest
-) -> dict[str, Any]:
-    """Update tags for a ticket and broadcast."""
-    if not bees:
-        raise HTTPException(500, "Bees not initialized")
-    node = bees.get_by_id(ticket_id)
-    if not node:
-        raise HTTPException(404, f"Ticket {ticket_id} not found")
-
-    node.task.metadata.tags = req.tags
-    node.save()
-
-    await broadcaster.broadcast({
-        "type": "ticket_update",
-        "ticket": _ticket_to_dict(node.task),
-    })
-
-    return _ticket_to_dict(node.task)
-
-
-@app.post("/tickets/{ticket_id}/retry")
-async def retry_ticket(ticket_id: str) -> dict[str, Any]:
-    """Retry a paused ticket by flipping it back to available.
-
-    Paused tickets are those that hit a transient Gemini API error
-    (e.g. 503).  Retrying clears the error and re-queues the ticket
-    for the scheduler to pick up.
-    """
-    if not bees:
-        raise HTTPException(500, "Bees not initialized")
-    node = bees.get_by_id(ticket_id)
-    if not node:
-        raise HTTPException(404, f"Ticket {ticket_id} not found")
-    if node.task.metadata.status != "paused":
-        raise HTTPException(400, "Ticket is not paused")
-
-    node.retry()
-
-    await broadcaster.broadcast({
-        "type": "ticket_update",
-        "ticket": _ticket_to_dict(node.task),
-    })
-
-    return _ticket_to_dict(node.task)
-
-
-
-
-
-# ---------------------------------------------------------------------------
-# System Pulse — Flash-powered status summary
-# ---------------------------------------------------------------------------
-
-
-def should_include_ticket(
-    ticket: Task,
-    status: str | None = None,
-    tags: str | None = None,
-    kind: str | None = None,
-) -> bool:
-    """Evaluate if a ticket matches the query parameters."""
-    
-    # 1. Kind filter
-    if kind:
-        is_neg = kind.startswith("!")
-        val = kind[1:] if is_neg else kind
-        match = ticket.metadata.kind == val
-        if is_neg and match:
-            return False
-        if not is_neg and not match:
-            return False
-
-    # 2. Status filter
-    if status:
-        is_neg = status.startswith("!")
-        val = status[1:] if is_neg else status
-        allowed_statuses = set(val.split(","))
-        match = ticket.metadata.status in allowed_statuses
-        if is_neg and match:
-            return False
-        if not is_neg and not match:
-            return False
-
-    # 3. Tags filter
-    if tags:
-        tag_list = tags.split(",")
-        ticket_tags = set(ticket.metadata.tags or [])
-        
-        positive_reqs = []
-        negative_reqs = []
-        for t in tag_list:
-            if t.startswith("!"):
-                negative_reqs.append(t[1:])
-            else:
-                positive_reqs.append(t)
-                
-        for nt in negative_reqs:
-            if nt in ticket_tags:
-                return False
-                
-        if positive_reqs:
-            if not any(pt in ticket_tags for pt in positive_reqs):
-                return False
-
-    return True
-
-
-_pulse_cache: dict[str, Any] = {"hash": "", "text": "", "active": False}
-
-
-@app.get("/status")
-async def get_status(
-    status: str | None = None,
-    tags: str | None = None,
-    kind: str | None = None,
-) -> dict[str, Any]:
-    """Return a status response containing both the summary text and structured tasks."""
-    if not bees:
-        raise HTTPException(500, "Bees not initialized")
-    tickets = [n.task for n in bees.all]
-
-    by_run: dict[str, list[Task]] = {}
-    active_running = []
-
-    for t in tickets:
-        if not should_include_ticket(t, status=status, tags=tags, kind=kind):
-            continue
-
-        run_id = t.metadata.playbook_run_id or f"standalone-{t.id}"
-        by_run.setdefault(run_id, []).append(t)
-
-        if t.metadata.status in ("available", "running", "blocked", "suspended"):
-            active_running.append(t)
-
-    # 1. Generate text
-    if not active_running:
-        text = ""
-    else:
-        first_ticket = active_running[0]
-        title = first_ticket.metadata.title or "a task"
-        if len(active_running) == 1:
-            text = f"Working on {title}…"
-        elif len(active_running) == 2:
-            text = f"Working on {title} and 1 other task…"
-        else:
-            text = f"Working on {title} and {len(active_running) - 1} other tasks…"
-
-    # 2. Build task objects
-    active_statuses = {"available", "running", "blocked", "suspended"}
-    tasks = []
-    for run_id, group in by_run.items():
-        if not any(t.metadata.status in active_statuses for t in group):
-            continue
-
-        group.sort(key=lambda t: t.metadata.created_at or "")
-        first_ticket = group[0]
-        title = "Task"
-        if first_ticket.metadata.playbook_id:
-            title = first_ticket.metadata.playbook_id.replace("-", " ").title()
-        elif first_ticket.metadata.title:
-            title = first_ticket.metadata.title
-
-        completed_steps = sum(1 for t in group if t.metadata.status in ("success", "error"))
-        total_steps = len(group)
-        active_tickets = [t for t in group if t.metadata.status in active_statuses]
-        current_ticket = active_tickets[0] if active_tickets else group[-1]
-
-        tasks.append({
-            "id": run_id,
-            "title": title,
-            "context": first_ticket.metadata.context or "",
-            "current_step": current_ticket.metadata.title or "Working...",
-            "status": current_ticket.metadata.status,
-            "completed_steps": completed_steps,
-            "total_steps": total_steps,
-            "created_at": first_ticket.metadata.created_at,
-            "tags": list(set(first_ticket.metadata.tags or []))
-        })
-
-    tasks.sort(key=lambda x: x["created_at"] or "", reverse=True)
-    return {"text": text, "active": bool(active_running), "tasks": tasks}
-
-
 # ---------------------------------------------------------------------------
 # SSE endpoint
 # ---------------------------------------------------------------------------
@@ -540,9 +410,8 @@ async def get_status(
 @app.get("/events")
 async def events() -> EventSourceResponse:
     """Server-Sent Events stream for real-time updates."""
-    if not bees:
-        raise HTTPException(500, "Bees not initialized")
-        
+    b = _require_bees()
+
     queue = broadcaster.subscribe()
 
     async def event_generator() -> AsyncIterator[dict]:
@@ -551,7 +420,7 @@ async def events() -> EventSourceResponse:
             yield {
                 "event": "init",
                 "data": json.dumps([
-                    _ticket_to_dict(n.task) for n in bees.all
+                    _agent_to_dict(n.task) for n in b.all
                 ]),
             }
             while True:

--- a/packages/bees/bees/playbook.py
+++ b/packages/bees/bees/playbook.py
@@ -24,7 +24,7 @@ import yaml
 
 from bees.config import HIVE_DIR
 from bees.subagent_scope import SubagentScope
-from bees import TaskStore
+from bees.task_store import TaskStore
 from bees.ticket import Ticket
 
 logger = logging.getLogger(__name__)

--- a/packages/bees/docs/reference-app.md
+++ b/packages/bees/docs/reference-app.md
@@ -15,16 +15,16 @@ consumption model described in `patterns.md`.
 │                    SSE ↓ REST ↑                          │
 ├─────────────────────────────────────────────────────────┤
 │                   Server (FastAPI)                       │
-│          REST endpoints · SSE broadcaster               │
+│            Agent API · SSE broadcaster                  │
 │                          │                               │
-│               SchedulerHooks ↕                          │
+│                 Bees hooks ↕                             │
 ├─────────────────────────────────────────────────────────┤
 │                   Bees Framework                        │
 │              Scheduler → Session → LLM                  │
 └─────────────────────────────────────────────────────────┘
 ```
 
-The server is the glue layer that projects the scheduler's model as REST
+The server is the glue layer that projects the framework's model as REST
 endpoints and SSE events. The web shell consumes those projections and renders
 them as a chat UI with an embedded app stage.
 
@@ -34,75 +34,63 @@ The server has three responsibilities:
 
 ### 1. Boot the system
 
-On startup, the server:
-
-1. Creates a `Scheduler` instance with an `HttpBackendClient`.
-2. Recovers stuck tickets (tasks that were running when the server last shut
-   down) by resetting them to `available`.
-3. Calls `boot_root_template()` — reads `SYSTEM.yaml` and creates the root task
-   if none exists.
-4. Starts the scheduler loop (`scheduler.start_loop()`), which continuously
-   drains available tasks.
+On startup, the server creates a `Bees` instance with an `HttpBackendClient`
+and calls `bees.listen()`, which recovers stuck tasks, boots the root template
+from `SYSTEM.yaml`, and starts the scheduler loop.
 
 ### 2. Project the model as REST
 
 Every endpoint is a thin view over the task list. The server does no business
-logic beyond serializing task data and writing user responses.
+logic beyond serializing task data and writing user responses. All endpoints
+use the `/agents` prefix.
 
-| Endpoint                     | Method | Purpose                                    |
-| ---------------------------- | ------ | ------------------------------------------ |
-| `/tickets`                   | GET    | List all tasks, optionally filtered by tag |
-| `/tickets/{id}`              | GET    | Single task with chat history              |
-| `/tickets/{id}/respond`      | POST   | Write user response, flip assignee         |
-| `/tickets/{id}/retry`        | POST   | Reset a paused task to available           |
-| `/tickets/{id}/tags`         | POST   | Update task tags                           |
-| `/tickets/{id}/files`        | GET    | List files in the task's workspace         |
-| `/tickets/{id}/files/{path}` | GET    | Serve a file from the task's workspace     |
-| `/tickets`                   | POST   | Create a new ad-hoc task                   |
-| `/status`                    | GET    | Summary of active tasks grouped by run     |
+#### Commands (writes)
 
-The `respond` endpoint is the **controller** interaction point: when an agent
-suspends with `assignee == "user"`, the web shell calls this endpoint to deliver
-the user's response. Under the hood, it writes `response.json` and flips
-`assignee` to `"agent"`, then triggers the scheduler. This is the direct
+| Endpoint                      | Method | Purpose                                |
+| ----------------------------- | ------ | -------------------------------------- |
+| `/agents/{id}/reply`          | POST   | Send a chat message to a suspended agent |
+| `/agents/{id}/choose`         | POST   | Submit a choice selection to a suspended agent |
+| `/agents/{id}/retry`          | POST   | Reset a paused agent to available      |
+| `/agents/{id}/tags`           | POST   | Update agent tags                      |
+
+`reply` and `choose` are the **controller** interaction points: when an agent
+suspends with `assignee == "user"`, the web shell calls one of these endpoints
+to deliver the user's response. Under the hood, they write `response.json` and
+flip `assignee` to `"agent"`, then trigger the scheduler. This is the direct
 model-editing pattern noted in `patterns.md` as the main gap in the consumption
 API.
 
-#### Querying tasks
+#### Queries (reads)
 
-Tasks can be filtered by metadata fields. The reference app's `/status` endpoint
-exposes this, but the filtering logic (`should_include_ticket` in `app/server.py`)
-operates on the task model directly.
+| Endpoint                       | Method | Purpose                                    |
+| ------------------------------ | ------ | ------------------------------------------ |
+| `/agents/{id}/bundle?slug=`    | GET    | Resolved JS/CSS bundle for an agent        |
+| `/agents/{id}/files`           | GET    | List files in the agent's workspace        |
+| `/agents/{id}/files/{path}`    | GET    | Serve a file from the agent's workspace    |
 
-| Filter   | Example                 | Effect                        |
-| -------- | ----------------------- | ----------------------------- |
-| `kind`   | `work`, `!coordination` | Match/exclude by ticket kind  |
-| `status` | `running,suspended`     | OR across statuses            |
-| `tags`   | `chat`, `!opie`         | OR across tags, `!` to negate |
-
-- Prefix with `!` to negate.
-- Comma-separated values within a filter are OR'd.
-- Multiple filters are AND'd.
+The `bundle` endpoint resolves the agent's JS and CSS files server-side,
+eliminating a multi-step client-side fetch dance. The optional `slug` query
+parameter scopes the search to a subagent's subdirectory.
 
 ### 3. Broadcast state changes via SSE
 
 The server uses a `Broadcaster` (fan-out queue) to deliver real-time state
 changes to all connected clients via Server-Sent Events.
 
-The wiring: each `SchedulerHooks` callback maps to an SSE event type.
+The wiring: each `Bees` event callback maps to an SSE event type.
 
-| SchedulerHook         | SSE event type   | What happened                    |
-| --------------------- | ---------------- | -------------------------------- |
-| `on_startup`          | `ticket_added`   | Root task was created at boot    |
-| `on_ticket_start`     | `ticket_update`  | Task transitioned to running     |
-| `on_ticket_done`      | `ticket_update`  | Task reached a resting state     |
-| `on_ticket_event`     | `session_event`  | Running session emitted an event |
-| `on_events_broadcast` | `ticket_added`   | Agent created a task mid-session |
-| `on_cycle_start`      | `drain_start`    | Scheduler cycle beginning        |
-| `on_cycle_complete`   | `drain_complete` | Scheduler has no more work       |
+| Bees hook             | SSE event type      | What happened                    |
+| --------------------- | ------------------- | -------------------------------- |
+| `ticket_added`        | `agent:added`       | A new agent was created          |
+| `ticket_start`        | `agent:updated`     | Agent transitioned to running    |
+| `ticket_done`         | `agent:updated`     | Agent reached a resting state    |
+| `ticket_event`        | `session:event`     | Running session emitted an event |
+| `cycle_start`         | `scheduler:started` | Scheduler cycle beginning        |
+| `cycle_complete`      | `scheduler:stopped` | Scheduler has no more work       |
 
 On initial connection, the SSE stream sends an `init` event with the full task
-list. After that, clients receive incremental updates.
+list. After that, clients receive incremental updates. There is no REST endpoint
+to list all tasks — SSE `init` is the sole source of truth.
 
 ## The Web Shell (`web/`)
 
@@ -112,11 +100,11 @@ broader codebase.
 
 ### Services
 
-| Service                    | Responsibility                                                         |
-| -------------------------- | ---------------------------------------------------------------------- |
-| `BeesAPI`                  | Thin REST wrapper — `respond()`, `retry()`, `getFile()`, etc.          |
-| `SSEClient`                | Connects to `/events`, parses SSE, dispatches to an `EventTarget` bus. |
-| `HostCommunicationService` | postMessage bridge to the iframe-hosted React apps.                    |
+| Service                    | Responsibility                                                                |
+| -------------------------- | ----------------------------------------------------------------------------- |
+| `BeesAPI`                  | REST wrapper — `reply()`, `choose()`, `retry()`, `getBundle()`, `getFile()`   |
+| `SSEClient`                | Connects to `/events`, parses SSE, dispatches to an `EventTarget` bus.        |
+| `HostCommunicationService` | postMessage bridge to the iframe-hosted React apps.                           |
 
 The `SSEClient` is the pipeline from the server's model to the frontend's
 controller state. It listens for SSE events and dispatches them as DOM
@@ -141,12 +129,12 @@ tasks tagged `"chat"`).
 
 Actions are triggered by SSE events and transform the controller state.
 
-| Action group | Trigger                        | What it does                                 |
-| ------------ | ------------------------------ | -------------------------------------------- |
-| `sync/`      | SSE events (init, add, update) | Upsert tasks into `GlobalController.tickets` |
-| `chat/`      | User input, agent messages     | Send responses via `BeesAPI.respond()`       |
-| `stage/`     | Bundle events                  | Load React apps into the iframe stage        |
-| `tree/`      | Agent selection in sidebar     | Update `AgentTreeController.selectedAgentId` |
+| Action group | Trigger                          | What it does                                     |
+| ------------ | -------------------------------- | ------------------------------------------------ |
+| `sync/`      | SSE events (init, added, updated)| Upsert tasks into `GlobalController.tickets`     |
+| `chat/`      | User input, agent messages       | Send responses via `BeesAPI.reply()` / `choose()`|
+| `stage/`     | Bundle events                    | Load React apps into the iframe stage            |
+| `tree/`      | Agent selection in sidebar       | Update `AgentTreeController.selectedAgentId`     |
 
 The sync actions are the MVC bridge: SSE events arrive → sync actions upsert
 into `GlobalController.tickets` → signal reactivity causes UI components to
@@ -200,9 +188,9 @@ concretely here:
 When the consumption API matures (see [flux.md](./flux.md)), the reference app
 would:
 
-1. Stop editing task files directly in `/respond` — use a framework-provided
-   interaction surface instead.
-2. Replace `SchedulerHooks` callbacks with a more principled observation API.
+1. Stop editing task files directly in `/reply` and `/choose` — use a
+   framework-provided interaction surface instead.
+2. Replace `Bees` event callbacks with a more principled observation API.
 3. Potentially extract into its own package, consuming bees as a library.
 
 The current implementation works but is tightly coupled to the framework's

--- a/packages/bees/web/src/sca/actions/chat/chat-actions.ts
+++ b/packages/bees/web/src/sca/actions/chat/chat-actions.ts
@@ -277,7 +277,7 @@ export const sendChat = asAction(
     controller.chat.threadMessages = updated;
 
     if (thread?.activeTicketId) {
-      await services.api.respond(thread.activeTicketId, text);
+      await services.api.reply(thread.activeTicketId, text);
     }
   }
 );
@@ -311,7 +311,7 @@ export const sendChoices = asAction(
     controller.chat.pendingChoices = [];
     controller.chat.selectedChoiceIds = [];
 
-    await services.api.respond(thread.activeTicketId, labels, ids);
+    await services.api.choose(thread.activeTicketId, ids);
   }
 );
 

--- a/packages/bees/web/src/sca/actions/sync/sync-actions.ts
+++ b/packages/bees/web/src/sca/actions/sync/sync-actions.ts
@@ -8,13 +8,12 @@ import { asAction, ActionMode } from "../../coordination.js";
 import { makeAction } from "../binder.js";
 import type { TicketData } from "../../../../../common/types.js";
 import {
-  onTicketAdded,
-  onTicketUpdate,
+  onAgentAdded,
+  onAgentUpdated,
   onSessionEvent,
   onInitTickets,
-  onDrainStart,
-  onDrainComplete,
-  onDrainError,
+  onSchedulerStarted,
+  onSchedulerStopped,
   onConnectionError,
 } from "./sync-triggers.js";
 
@@ -50,7 +49,7 @@ export const upsertTicketOnAdd = asAction(
   "Upsert Ticket On Add",
   {
     mode: ActionMode.Immediate,
-    triggeredBy: () => onTicketAdded(bind),
+    triggeredBy: () => onAgentAdded(bind),
   },
   async (evt?: Event) => {
     if (!evt) return;
@@ -63,7 +62,7 @@ export const upsertTicketOnUpdate = asAction(
   "Upsert Ticket On Update",
   {
     mode: ActionMode.Immediate,
-    triggeredBy: () => onTicketUpdate(bind),
+    triggeredBy: () => onAgentUpdated(bind),
   },
   async (evt?: Event) => {
     if (!evt) return;
@@ -115,11 +114,11 @@ export const initTickets = asAction(
   }
 );
 
-export const setDrainingStart = asAction(
-  "Set Draining Start",
+export const setSchedulerStarted = asAction(
+  "Set Scheduler Started",
   {
     mode: ActionMode.Immediate,
-    triggeredBy: () => onDrainStart(bind),
+    triggeredBy: () => onSchedulerStarted(bind),
   },
   async () => {
     const { controller } = bind;
@@ -127,30 +126,15 @@ export const setDrainingStart = asAction(
   }
 );
 
-async function doSetDrainingStop() {
-  const { controller } = bind;
-  controller.global.draining = false;
-}
-
-export const setDrainingStopComplete = asAction(
-  "Set Draining Stop Complete",
+export const setSchedulerStopped = asAction(
+  "Set Scheduler Stopped",
   {
     mode: ActionMode.Immediate,
-    triggeredBy: () => onDrainComplete(bind),
+    triggeredBy: () => onSchedulerStopped(bind),
   },
   async () => {
-    await doSetDrainingStop();
-  }
-);
-
-export const setDrainingStopError = asAction(
-  "Set Draining Stop Error",
-  {
-    mode: ActionMode.Immediate,
-    triggeredBy: () => onDrainError(bind),
-  },
-  async () => {
-    await doSetDrainingStop();
+    const { controller } = bind;
+    controller.global.draining = false;
   }
 );
 

--- a/packages/bees/web/src/sca/actions/sync/sync-triggers.ts
+++ b/packages/bees/web/src/sca/actions/sync/sync-triggers.ts
@@ -14,14 +14,14 @@ export function onInitTickets(bind: ActionBind): EventTrigger {
   return eventTrigger("Init Tickets", services.stateEventBus, "init_tickets");
 }
 
-export function onTicketAdded(bind: ActionBind): EventTrigger {
+export function onAgentAdded(bind: ActionBind): EventTrigger {
   const { services } = bind;
-  return eventTrigger("Ticket Added", services.stateEventBus, "ticket_added");
+  return eventTrigger("Agent Added", services.stateEventBus, "agent_added");
 }
 
-export function onTicketUpdate(bind: ActionBind): EventTrigger {
+export function onAgentUpdated(bind: ActionBind): EventTrigger {
   const { services } = bind;
-  return eventTrigger("Ticket Update", services.stateEventBus, "ticket_update");
+  return eventTrigger("Agent Updated", services.stateEventBus, "agent_updated");
 }
 
 export function onSessionEvent(bind: ActionBind): EventTrigger {
@@ -29,23 +29,22 @@ export function onSessionEvent(bind: ActionBind): EventTrigger {
   return eventTrigger("Session Event", services.stateEventBus, "session_event");
 }
 
-export function onDrainStart(bind: ActionBind): EventTrigger {
-  const { services } = bind;
-  return eventTrigger("Drain Start", services.stateEventBus, "drain_start");
-}
-
-export function onDrainComplete(bind: ActionBind): EventTrigger {
+export function onSchedulerStarted(bind: ActionBind): EventTrigger {
   const { services } = bind;
   return eventTrigger(
-    "Drain Complete",
+    "Scheduler Started",
     services.stateEventBus,
-    "drain_complete"
+    "scheduler_started"
   );
 }
 
-export function onDrainError(bind: ActionBind): EventTrigger {
+export function onSchedulerStopped(bind: ActionBind): EventTrigger {
   const { services } = bind;
-  return eventTrigger("Drain Error", services.stateEventBus, "drain_error");
+  return eventTrigger(
+    "Scheduler Stopped",
+    services.stateEventBus,
+    "scheduler_stopped"
+  );
 }
 
 export function onConnectionError(bind: ActionBind): EventTrigger {

--- a/packages/bees/web/src/sca/services/api.ts
+++ b/packages/bees/web/src/sca/services/api.ts
@@ -10,29 +10,35 @@ export { BeesAPI };
 
 /**
  * Thin wrapper around the Bees REST endpoints.
+ *
+ * All endpoints use the `/agents` prefix and semantic verbs.
  */
 class BeesAPI {
-  async addTicket(
-    objective: string,
-    tags?: string[],
-    functions?: string[],
-    skills?: string[]
-  ) {
-    await fetch("/tickets", {
+  async reply(agentId: string, text: string) {
+    await fetch(`/agents/${agentId}/reply`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        objective,
-        tags: tags?.length ? tags : undefined,
-        functions: functions?.length ? functions : undefined,
-        skills: skills?.length ? skills : undefined,
-      }),
+      body: JSON.stringify({ text }),
     });
   }
 
-  async updateTags(ticketId: string, tags: string[]): Promise<boolean> {
+  async choose(agentId: string, selectedIds: string[]) {
+    await fetch(`/agents/${agentId}/choose`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ selectedIds }),
+    });
+  }
+
+  async retry(agentId: string) {
+    await fetch(`/agents/${agentId}/retry`, {
+      method: "POST",
+    });
+  }
+
+  async updateTags(agentId: string, tags: string[]): Promise<boolean> {
     try {
-      const resp = await fetch(`/tickets/${ticketId}/tags`, {
+      const resp = await fetch(`/agents/${agentId}/tags`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ tags }),
@@ -44,48 +50,41 @@ class BeesAPI {
     }
   }
 
-  async respond(
-    ticketId: string,
-    text?: string,
-    selectedIds?: string[],
-    contextUpdates?: string[]
-  ) {
-    await fetch(`/tickets/${ticketId}/respond`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ text, selectedIds, contextUpdates }),
-    });
-  }
-
-  async retry(ticketId: string) {
-    await fetch(`/tickets/${ticketId}/retry`, {
-      method: "POST",
-    });
-  }
-
-
-
-  async getFile(ticketId: string, path: string): Promise<string | null> {
+  async getBundle(
+    agentId: string,
+    slug?: string | null
+  ): Promise<{ js: string; css?: string } | null> {
     try {
-      const resp = await fetch(`/tickets/${ticketId}/files/${path}`);
+      const params = slug ? `?slug=${encodeURIComponent(slug)}` : "";
+      const resp = await fetch(`/agents/${agentId}/bundle${params}`);
       if (!resp.ok) return null;
-      return resp.text();
+      return resp.json();
     } catch (e) {
-      console.error(`Error fetching file ${path} for ticket ${ticketId}:`, e);
+      console.error(`Error fetching bundle for agent ${agentId}:`, e);
       return null;
     }
   }
 
-  async listFiles(ticketId: string): Promise<string[]> {
+  async getFile(agentId: string, path: string): Promise<string | null> {
     try {
-      const resp = await fetch(`/tickets/${ticketId}/files`);
+      const resp = await fetch(`/agents/${agentId}/files/${path}`);
+      if (!resp.ok) return null;
+      return resp.text();
+    } catch (e) {
+      console.error(`Error fetching file ${path} for agent ${agentId}:`, e);
+      return null;
+    }
+  }
+
+  async listFiles(agentId: string): Promise<string[]> {
+    try {
+      const resp = await fetch(`/agents/${agentId}/files`);
       if (!resp.ok) return [];
       return resp.json();
     } catch (e) {
-      console.error(`Error listing files for ticket ${ticketId}:`, e);
+      console.error(`Error listing files for agent ${agentId}:`, e);
       return [];
     }
   }
 
 }
-

--- a/packages/bees/web/src/sca/services/sse.ts
+++ b/packages/bees/web/src/sca/services/sse.ts
@@ -21,34 +21,30 @@ export class SSEClient {
       );
     });
 
-    this.source.addEventListener("ticket_added", (e: MessageEvent) => {
+    this.source.addEventListener("agent:added", (e: MessageEvent) => {
       this.bus.dispatchEvent(
-        new CustomEvent("ticket_added", { detail: JSON.parse(e.data).ticket })
+        new CustomEvent("agent_added", { detail: JSON.parse(e.data).agent })
       );
     });
 
-    this.source.addEventListener("ticket_update", (e: MessageEvent) => {
+    this.source.addEventListener("agent:updated", (e: MessageEvent) => {
       this.bus.dispatchEvent(
-        new CustomEvent("ticket_update", { detail: JSON.parse(e.data).ticket })
+        new CustomEvent("agent_updated", { detail: JSON.parse(e.data).agent })
       );
     });
 
-    this.source.addEventListener("session_event", (e: MessageEvent) => {
+    this.source.addEventListener("session:event", (e: MessageEvent) => {
       this.bus.dispatchEvent(
         new CustomEvent("session_event", { detail: JSON.parse(e.data) })
       );
     });
 
-    this.source.addEventListener("drain_start", () => {
-      this.bus.dispatchEvent(new CustomEvent("drain_start"));
+    this.source.addEventListener("scheduler:started", () => {
+      this.bus.dispatchEvent(new CustomEvent("scheduler_started"));
     });
 
-    this.source.addEventListener("drain_complete", () => {
-      this.bus.dispatchEvent(new CustomEvent("drain_complete"));
-    });
-
-    this.source.addEventListener("drain_error", () => {
-      this.bus.dispatchEvent(new CustomEvent("drain_error"));
+    this.source.addEventListener("scheduler:stopped", () => {
+      this.bus.dispatchEvent(new CustomEvent("scheduler_stopped"));
     });
 
     this.source.onerror = () => {

--- a/packages/bees/web/src/sca/utils/load-bundle.ts
+++ b/packages/bees/web/src/sca/utils/load-bundle.ts
@@ -9,58 +9,38 @@ import type { AppServices } from "../types.js";
 export { loadBundleAsync };
 
 /**
- * Fetches the JS (and optional CSS) bundle for a ticket and sends it
- * to the sandboxed iframe via the host communication service.
- *
- * When `slug` is provided (subagent), only files under the slug
- * subdirectory are considered. This prevents loading a sibling
- * agent's bundle from the shared workspace.
+ * Fetches the resolved JS (and optional CSS) bundle for an agent
+ * from the server and sends it to the sandboxed iframe via the host
+ * communication service.
  *
  * After rendering, installs a file handler so the iframe can read
- * arbitrary files from the ticket's shared filesystem via
+ * arbitrary files from the agent's shared filesystem via
  * `window.opalSDK.readFile(path)`.
  */
 async function loadBundleAsync(
-  ticketId: string,
+  agentId: string,
   services: AppServices,
   slug?: string | null
 ): Promise<void> {
-  const allFiles = await services.api.listFiles(ticketId);
-
-  // Scope to the agent's slug subdirectory when present.
-  const files = slug
-    ? allFiles.filter((f) => f.startsWith(slug + "/"))
-    : allFiles;
-
-  const jsFile = files.find((f) => f.endsWith(".js"));
-  if (!jsFile) {
-    console.error(`[load-bundle] No JS file found for ticket ${ticketId} (slug: ${slug ?? "root"})`);
-    return;
-  }
-
-  const code = await services.api.getFile(ticketId, jsFile);
-  if (!code) {
+  const bundle = await services.api.getBundle(agentId, slug);
+  if (!bundle) {
     console.error(
-      `[load-bundle] Failed to load ${jsFile} for ticket ${ticketId}`
+      `[load-bundle] No bundle found for agent ${agentId} (slug: ${slug ?? "root"})`
     );
     return;
   }
 
-  const cssFile = files.find((f) => f.endsWith(".css"));
-  const css = cssFile ? await services.api.getFile(ticketId, cssFile) : null;
-
   await services.hostCommunication.send({
     type: "render",
-    code,
-    css: css || undefined,
+    code: bundle.js,
+    css: bundle.css || undefined,
     props: {},
   });
 
   // Install file handler so the iframe can read files from the
-  // ticket's shared filesystem. Paths are NOT scoped by slug —
+  // agent's shared filesystem. Paths are NOT scoped by slug —
   // the component can reach any file in the workspace.
   services.hostCommunication.setFileHandler((path) =>
-    services.api.getFile(ticketId, path)
+    services.api.getFile(agentId, path)
   );
 }
-

--- a/packages/bees/web/vite.config.ts
+++ b/packages/bees/web/vite.config.ts
@@ -13,9 +13,7 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
-      "/tickets": "http://localhost:3200",
-      "/playbooks": "http://localhost:3200",
-      "/status": "http://localhost:3200",
+      "/agents": "http://localhost:3200",
       "/events": {
         target: "http://localhost:3200",
         // SSE needs special handling.


### PR DESCRIPTION
## What
Redesigned the server↔shell API surface from generic ticket CRUD to a narrow, agent-centric API with semantic verbs. Net deletion of ~190 lines.

## Why
The server exposed a wide-open REST API (generic CRUD over tickets) that didn't match how the frontend actually used it. Several endpoints were dead code, the `respond` endpoint mashed together three distinct operations, bundle loading required a multi-step client-side dance, and the wire protocol said "tickets" while the UI said "agents."

## Changes

### Backend (`app/server.py`)
- **Removed** dead endpoints: `GET /tickets`, `GET /tickets/:id`, `POST /tickets`, `GET /status` (+ `should_include_ticket`, `_pulse_cache`)
- **Renamed** all routes from `/tickets/` to `/agents/`
- **Split** `POST /respond` into `POST /agents/:id/reply` (chat text) and `POST /agents/:id/choose` (choice selection)
- **Added** `GET /agents/:id/bundle?slug=` — server-resolved JS/CSS bundle in one call
- **Renamed** SSE events: `ticket_added`→`agent:added`, `ticket_update`→`agent:updated`, `drain_start`→`scheduler:started`, `drain_complete`/`drain_error`→`scheduler:stopped`
- **Extracted** `_require_bees()` / `_get_node()` helpers to reduce boilerplate

### Frontend (`web/`)
- `api.ts`: Removed `addTicket`/`respond`, added `reply`/`choose`/`getBundle`, renamed all paths
- `sse.ts`: Updated event listeners, merged `drain_error` into `scheduler:stopped`
- `sync-triggers.ts` / `sync-actions.ts`: Renamed triggers, merged two drain-stop actions into one
- `chat-actions.ts`: `respond()` → `reply()` / `choose()`
- `load-bundle.ts`: Replaced 5-step fetch dance with single `getBundle()` call
- `vite.config.ts`: Updated proxy routes

### Fixes
- `bees/playbook.py`: Fixed circular import (`from bees import TaskStore` → `from bees.task_store import TaskStore`)

### Docs
- `docs/reference-app.md`: Updated to reflect the new API contract

## Testing
- TypeScript compiles clean (`tsc --noEmit`)
- Python parses clean
- Dev server starts and processes agents end-to-end (verified manually)
