### PR TITLE
[bees] Fix Task Tree Traversal to use creator_ticket_id

### DIFF
--- a/packages/bees/bees/task_node.py
+++ b/packages/bees/bees/task_node.py
@@ -35,9 +35,9 @@ class TaskNode:
     @property
     def parent(self) -> TaskNode | None:
         """Returns the parent of this task."""
-        if not self._task.metadata.owning_task_id:
+        if not self._task.metadata.creator_ticket_id:
             return None
-        parent_task = self._store.get(self._task.metadata.owning_task_id)
+        parent_task = self._store.get(self._task.metadata.creator_ticket_id)
         return TaskNode(parent_task, self._bees) if parent_task else None
 
     def query(self, tags: list[str]) -> list[TaskNode]:
@@ -50,8 +50,8 @@ class TaskNode:
         ticket_map = {}
         for t in all_tickets:
             ticket_map[t.id] = t
-            if t.metadata.owning_task_id:
-                child_map[t.metadata.owning_task_id].append(t.id)
+            if t.metadata.creator_ticket_id:
+                child_map[t.metadata.creator_ticket_id].append(t.id)
                 
         # Find all descendants of current node
         descendants = []
@@ -82,6 +82,7 @@ class TaskNode:
     async def create_child(self, objective: str, **kwargs) -> TaskNode:
         """Creates a child task under this task."""
         kwargs['owning_task_id'] = self.id
+        kwargs['creator_ticket_id'] = self.id
         ticket = await self._bees._scheduler.create_task(objective, **kwargs)
         return TaskNode(ticket, self._bees)
 

--- a/packages/bees/bees/task_store.py
+++ b/packages/bees/bees/task_store.py
@@ -66,8 +66,8 @@ class TaskStore:
     def get_children(self, task_id: str | None = None) -> list[Ticket]:
         """Returns children of the given task, or roots if task_id is None."""
         if task_id is None:
-            return [t for t in self.query_all() if not t.metadata.owning_task_id]
-        return [t for t in self.query_all() if t.metadata.owning_task_id == task_id]
+            return [t for t in self.query_all() if not t.metadata.creator_ticket_id]
+        return [t for t in self.query_all() if t.metadata.creator_ticket_id == task_id]
 
 
 
@@ -118,6 +118,7 @@ class TaskStore:
         playbook_id: str | None = None,
         playbook_run_id: str | None = None,
         owning_task_id: str | None = None,
+        creator_ticket_id: str | None = None,
         model: str | None = None,
         context: str | None = None,
         watch_events: list[dict[str, Any]] | None = None,
@@ -167,6 +168,7 @@ class TaskStore:
                 playbook_id=playbook_id,
                 playbook_run_id=playbook_run_id,
                 owning_task_id=owning_task_id,
+                creator_ticket_id=creator_ticket_id,
                 model=model,
                 context=context,
                 watch_events=watch_events,

--- a/packages/bees/tests/test_tree.py
+++ b/packages/bees/tests/test_tree.py
@@ -29,10 +29,10 @@ def test_tree_traversal(temp_hive):
     root1 = store.create("Root 1")
     root2 = store.create("Root 2")
 
-    child1 = store.create("Child 1", owning_task_id=root1.id)
-    child2 = store.create("Child 2", owning_task_id=root1.id)
+    child1 = store.create("Child 1", creator_ticket_id=root1.id)
+    child2 = store.create("Child 2", creator_ticket_id=root1.id)
 
-    grandchild1 = store.create("Grandchild 1", owning_task_id=child1.id)
+    grandchild1 = store.create("Grandchild 1", creator_ticket_id=child1.id)
 
     # Test get_children
     roots = bees.children
@@ -85,7 +85,7 @@ def test_query_by_tags(temp_hive):
     t3 = store.create("Task 3", tags=["bug"])
     
     # Create a child task with tags
-    t4 = store.create("Task 4", tags=["bug", "ui"], owning_task_id=t2.id)
+    t4 = store.create("Task 4", tags=["bug", "ui"], creator_ticket_id=t2.id)
 
     # Test global query
     ui_tasks = bees.query(["ui"])
@@ -144,7 +144,7 @@ async def test_task_node_create_child(temp_hive):
     
     child_node = await parent_node.create_child("Child Task")
     
-    bees._scheduler.create_task.assert_called_once_with("Child Task", owning_task_id="parent1")
+    bees._scheduler.create_task.assert_called_once_with("Child Task", owning_task_id="parent1", creator_ticket_id="parent1")
     assert child_node.id == "child1"
 
 


### PR DESCRIPTION
## What
Changed the task tree traversal API in Bees to use `creator_ticket_id` instead of `owning_task_id` for determining parent/child relationships, while preserving `owning_task_id` for filesystem scoping.

## Why
`owning_task_id` indicates file system ownership (sharing a workspace), which has a broader scope than ancestry. `creator_ticket_id` correctly identifies the creator of the task, leading to accurate tree representations.

## Changes
### `packages/bees/bees`
- `task_store.py`: Added `creator_ticket_id` to `create` method and updated `get_children` to use it.
- `task_node.py`: Updated `parent` and `query` to use `creator_ticket_id`, and updated `create_child` to set it.

### `packages/bees/tests`
- `test_tree.py`: Updated tests to use `creator_ticket_id` for tree structure verification.

## Testing
- Ran all tests in `packages/bees/tests/` and all 153 passed.
