### PR TITLE
[bees] Rename creator_ticket_id to parent_task_id in Bees framework

### DIFF
--- a/packages/bees/bees/functions/tasks.py
+++ b/packages/bees/bees/functions/tasks.py
@@ -135,11 +135,11 @@ def _make_handlers(
         if caller_ticket_id:
             from collections import defaultdict
 
-            # Build an index: creator_ticket_id -> list of child tickets.
+            # Build an index: parent_task_id -> list of child tickets.
             children_of: dict[str, list[Any]] = defaultdict(list)
             for t in (scheduler.store.query_all() if scheduler else []):
-                if t.metadata.creator_ticket_id:
-                    children_of[t.metadata.creator_ticket_id].append(t)
+                if t.metadata.parent_task_id:
+                    children_of[t.metadata.parent_task_id].append(t)
 
             def _build_tree(parent_id: str) -> list[dict[str, Any]]:
                 result: list[dict[str, Any]] = []

--- a/packages/bees/bees/playbook.py
+++ b/packages/bees/bees/playbook.py
@@ -183,7 +183,7 @@ def stamp_child_ticket(
     """Create a child ticket from a template under a parent.
 
     Handles SubagentScope composition, sandbox instructions, writable
-    directory creation, and ``creator_ticket_id`` assignment — the
+    directory creation, and ``parent_task_id`` assignment — the
     shared logic for both ``autostart`` and ``tasks_create_task``.
 
     If *scope* is not provided, one is derived from the parent ticket.
@@ -217,7 +217,7 @@ def stamp_child_ticket(
     if title:
         child.metadata.title = title
 
-    child.metadata.creator_ticket_id = parent_ticket.id
+    child.metadata.parent_task_id = parent_ticket.id
     store.save_metadata(child)
 
     return child

--- a/packages/bees/bees/scheduler.py
+++ b/packages/bees/bees/scheduler.py
@@ -369,14 +369,14 @@ class Scheduler:
         Returns ``None`` on success, or an error string on failure.
 
         When ``expected_creator`` is provided the target ticket's
-        ``creator_ticket_id`` must match — this prevents one agent from
+        ``parent_task_id`` must match — this prevents one agent from
         injecting updates into another agent's tasks.
         """
         ticket = self.store.get(ticket_id)
         if not ticket:
             return f"Task {ticket_id} not found"
 
-        if expected_creator and ticket.metadata.creator_ticket_id != expected_creator:
+        if expected_creator and ticket.metadata.parent_task_id != expected_creator:
             return f"Task {ticket_id} is not owned by this agent"
 
         self._deliver_context_update(ticket_id, update)
@@ -427,42 +427,42 @@ class Scheduler:
             self.store.save_metadata(target)
             logger.info("Context update buffered for %s", target_id)
 
-    def _enrich_creator_tags(self, ticket: Ticket) -> Ticket | None:
-        """Merge a completed ticket's tags into its creator's tags.
+    def _enrich_parent_tags(self, ticket: Ticket) -> Ticket | None:
+        """Merge a completed ticket's tags into its parent's tags.
 
         Called when a subagent finishes (any terminal status).  Performs
         a deduplicated union — one level up only.
 
-        Returns the enriched creator ticket so the caller can broadcast
+        Returns the enriched parent ticket so the caller can broadcast
         a ``ticket_update`` via SSE, or ``None`` if nothing changed.
         """
-        creator_id = ticket.metadata.creator_ticket_id
+        parent_id = ticket.metadata.parent_task_id
         child_tags = ticket.metadata.tags
-        if not creator_id or not child_tags:
+        if not parent_id or not child_tags:
             return None
 
-        creator = self.store.get(creator_id)
-        if not creator:
+        parent = self.store.get(parent_id)
+        if not parent:
             logger.warning(
-                "Tag enrichment: creator %s not found for %s",
-                creator_id, ticket.id[:8],
+                "Tag enrichment: parent %s not found for %s",
+                parent_id, ticket.id[:8],
             )
             return None
 
-        existing = set(creator.metadata.tags or [])
+        existing = set(parent.metadata.tags or [])
         merged = existing | set(child_tags)
         if merged == existing:
             return None  # Nothing new.
 
-        creator.metadata.tags = sorted(merged)
-        self.store.save_metadata(creator)
+        parent.metadata.tags = sorted(merged)
+        self.store.save_metadata(parent)
         logger.info(
             "Tag enrichment: %s -> %s (added %s)",
             ticket.id[:8],
-            creator_id[:8],
+            parent_id[:8],
             sorted(merged - existing),
         )
-        return creator
+        return parent
 
     async def start_loop(self) -> None:
         """Background loop that runs cycles whenever triggered."""
@@ -839,13 +839,13 @@ class Scheduler:
         self.trigger()
 
     def _make_deliver_to_parent(self, ticket: Ticket) -> Callable[[dict[str, Any]], None] | None:
-        """Create a callback that delivers an update to this ticket's creator."""
-        creator_id = ticket.metadata.creator_ticket_id
-        if not creator_id:
+        """Create a callback that delivers an update to this task's parent."""
+        parent_id = ticket.metadata.parent_task_id
+        if not parent_id:
             return None
 
         def deliver(update: dict[str, Any]) -> None:
-            self._deliver_context_update(creator_id, update)
+            self._deliver_context_update(parent_id, update)
 
         return deliver
 
@@ -1022,11 +1022,11 @@ class Scheduler:
                         run_ticket_done_hooks(updated)
                         self._notify_ticket_done(t.id)
 
-                        creator_id = updated.metadata.creator_ticket_id
-                        if creator_id and updated.metadata.status in ("completed", "failed"):
+                        parent_id = updated.metadata.parent_task_id
+                        if parent_id and updated.metadata.status in ("completed", "failed"):
                             update = {"task_id": updated.id, "status": updated.metadata.status, "outcome": updated.metadata.outcome or updated.metadata.error or "(no outcome)"}
-                            self._deliver_context_update(creator_id, update)
-                        enriched = self._enrich_creator_tags(updated)
+                            self._deliver_context_update(parent_id, update)
+                        enriched = self._enrich_parent_tags(updated)
                         if enriched and self._hooks.on_ticket_done:
                             await self._hooks.on_ticket_done(enriched)
                         if self._hooks.on_ticket_done:
@@ -1052,11 +1052,11 @@ class Scheduler:
                         run_ticket_done_hooks(updated)
                         self._notify_ticket_done(t.id)
 
-                        creator_id = updated.metadata.creator_ticket_id
-                        if creator_id and updated.metadata.status in ("completed", "failed"):
+                        parent_id = updated.metadata.parent_task_id
+                        if parent_id and updated.metadata.status in ("completed", "failed"):
                             update = {"task_id": updated.id, "status": updated.metadata.status, "outcome": updated.metadata.outcome or updated.metadata.error or "(no outcome)"}
-                            self._deliver_context_update(creator_id, update)
-                        enriched = self._enrich_creator_tags(updated)
+                            self._deliver_context_update(parent_id, update)
+                        enriched = self._enrich_parent_tags(updated)
                         if enriched and self._hooks.on_ticket_done:
                             await self._hooks.on_ticket_done(enriched)
                         if self._hooks.on_ticket_done:

--- a/packages/bees/bees/task_node.py
+++ b/packages/bees/bees/task_node.py
@@ -35,9 +35,9 @@ class TaskNode:
     @property
     def parent(self) -> TaskNode | None:
         """Returns the parent of this task."""
-        if not self._task.metadata.creator_ticket_id:
+        if not self._task.metadata.parent_task_id:
             return None
-        parent_task = self._store.get(self._task.metadata.creator_ticket_id)
+        parent_task = self._store.get(self._task.metadata.parent_task_id)
         return TaskNode(parent_task, self._bees) if parent_task else None
 
     def query(self, tags: list[str]) -> list[TaskNode]:
@@ -50,8 +50,8 @@ class TaskNode:
         ticket_map = {}
         for t in all_tickets:
             ticket_map[t.id] = t
-            if t.metadata.creator_ticket_id:
-                child_map[t.metadata.creator_ticket_id].append(t.id)
+            if t.metadata.parent_task_id:
+                child_map[t.metadata.parent_task_id].append(t.id)
                 
         # Find all descendants of current node
         descendants = []
@@ -82,7 +82,7 @@ class TaskNode:
     async def create_child(self, objective: str, **kwargs) -> TaskNode:
         """Creates a child task under this task."""
         kwargs['owning_task_id'] = self.id
-        kwargs['creator_ticket_id'] = self.id
+        kwargs['parent_task_id'] = self.id
         ticket = await self._bees._scheduler.create_task(objective, **kwargs)
         return TaskNode(ticket, self._bees)
 

--- a/packages/bees/bees/task_store.py
+++ b/packages/bees/bees/task_store.py
@@ -66,8 +66,8 @@ class TaskStore:
     def get_children(self, task_id: str | None = None) -> list[Ticket]:
         """Returns children of the given task, or roots if task_id is None."""
         if task_id is None:
-            return [t for t in self.query_all() if not t.metadata.creator_ticket_id]
-        return [t for t in self.query_all() if t.metadata.creator_ticket_id == task_id]
+            return [t for t in self.query_all() if not t.metadata.parent_task_id]
+        return [t for t in self.query_all() if t.metadata.parent_task_id == task_id]
 
 
 
@@ -118,7 +118,7 @@ class TaskStore:
         playbook_id: str | None = None,
         playbook_run_id: str | None = None,
         owning_task_id: str | None = None,
-        creator_ticket_id: str | None = None,
+        parent_task_id: str | None = None,
         model: str | None = None,
         context: str | None = None,
         watch_events: list[dict[str, Any]] | None = None,
@@ -168,7 +168,7 @@ class TaskStore:
                 playbook_id=playbook_id,
                 playbook_run_id=playbook_run_id,
                 owning_task_id=owning_task_id,
-                creator_ticket_id=creator_ticket_id,
+                parent_task_id=parent_task_id,
                 model=model,
                 context=context,
                 watch_events=watch_events,

--- a/packages/bees/bees/ticket.py
+++ b/packages/bees/bees/ticket.py
@@ -62,7 +62,7 @@ class TicketMetadata:
     signal_type: str | None = None
     delivered_to: list[str] | None = None
     tasks: list[str] | None = None
-    creator_ticket_id: str | None = None
+    parent_task_id: str | None = None
     slug: str | None = None
     pending_context_updates: list[dict[str, Any]] | None = None
 
@@ -102,7 +102,8 @@ class TicketMetadata:
             signal_type=data.get("signal_type"),
             delivered_to=data.get("delivered_to"),
             tasks=data.get("tasks"),
-            creator_ticket_id=data.get("creator_ticket_id"),
+            # Fallback for legacy creator_ticket_id
+            parent_task_id=data.get("parent_task_id") or data.get("creator_ticket_id"),
             slug=data.get("slug"),
             pending_context_updates=data.get("pending_context_updates"),
         )

--- a/packages/bees/common/types.ts
+++ b/packages/bees/common/types.ts
@@ -30,6 +30,8 @@ export interface TicketData {
   playbook_id?: string;
   playbook_run_id?: string;
   owning_task_id?: string;
+  parent_task_id?: string;
+  /** Legacy fallback creator_ticket_id -> parent_task_id */
   creator_ticket_id?: string;
   slug?: string;
   kind?: string;

--- a/packages/bees/docs/agent-projection.md
+++ b/packages/bees/docs/agent-projection.md
@@ -5,7 +5,7 @@
 The server currently ships a flat bag of `TicketData` objects to the frontend via SSE. The frontend then does significant work to make sense of this bag:
 
 - Filters out `coordination` and `digest` tickets (framework internals)
-- Builds a recursive tree from `creator_ticket_id` chains
+- Builds a recursive tree from `parent_task_id` chains
 - Scans tags to determine agent capabilities (`chat`, `bundle`)
 - Introspects `suspend_event` to extract prompts and choices
 - Detects `signal_type === "digest_ready"` to know when to reload the stage
@@ -108,7 +108,7 @@ The client upserts by `id` using `location` to know which list to update. No tre
 | `digest-tile-writer` agents | Infrastructure — filtered out at the worker level. |
 | `knowledge` agent | Background agent — filtered out at the journey level. |
 | `suspend_event` raw object | Middleware extracts `prompt` and `choices` — client never sees the raw event shape. |
-| `playbook_run_id`, `creator_ticket_id`, `kind`, `signal_type` | Framework internals. Not in the wire format. |
+| `playbook_run_id`, `parent_task_id`, `kind`, `signal_type` | Framework internals. Not in the wire format. |
 
 ### Session Events (Thoughts/Tool Calls)
 

--- a/packages/bees/docs/scheduler.md
+++ b/packages/bees/docs/scheduler.md
@@ -36,7 +36,7 @@ on `TicketMetadata`:
 | `assignee`                | `"user"`, `"agent"`, or `None`.                                   |
 | `playbook_id`             | Template name (pending rename to `template_id`).                  |
 | `playbook_run_id`         | UUID grouping tasks in the same run (pending rename to `run_id`). |
-| `creator_ticket_id`       | Parent task that created this one.                                |
+| `parent_task_id`          | Parent task that created this one.                                |
 | `owning_task_id`          | Task whose filesystem this task shares.                           |
 | `slug`                    | Writable subdirectory within the shared workspace.                |
 | `depends_on`              | List of task IDs that must complete first.                        |
@@ -209,7 +209,7 @@ Key operations:
 - **`run_playbook(name)`** — Creates a task from a template. Runs
   `on_run_playbook` hook if present. Stamps child tasks for `autostart` entries.
 - **`stamp_child_ticket(name, parent, slug)`** — Creates a child task with
-  proper scope composition, sandbox instructions, and `creator_ticket_id`
+  proper scope composition, sandbox instructions, and `parent_task_id`
   assignment. Shared by both `autostart` and `tasks_create_task`.
 - **`boot_root_template(tickets)`** — Reads `root` from `SYSTEM.yaml`. If no
   existing task has a matching `playbook_id`, creates one.

--- a/packages/bees/hivetool/src/data/ticket-tree.ts
+++ b/packages/bees/hivetool/src/data/ticket-tree.ts
@@ -6,8 +6,9 @@
 
 /**
  * Derives a parent–child tree from a flat ticket list using
- * `creator_ticket_id`. Hivetool-specific copy — no filtering beyond
- * what the caller provides (devtools should show everything).
+ * `parent_task_id` (falling back to `creator_ticket_id`).
+ * Hivetool-specific copy — no filtering beyond what the caller provides
+ * (devtools should show everything).
  */
 
 import type { TicketData } from "../../../common/types.js";
@@ -24,7 +25,7 @@ interface TicketTreeNode {
 /**
  * Build a forest of ticket trees from a flat list.
  *
- * Root nodes are tickets with no `creator_ticket_id`.
+ * Root nodes are tickets with no `parent_task_id` (or legacy `creator_ticket_id`).
  * Children are sorted by `created_at` ascending (oldest first) so the
  * tree reads in chronological order.
  */
@@ -33,10 +34,12 @@ function deriveTicketTree(tickets: TicketData[]): TicketTreeNode[] {
   const roots: TicketData[] = [];
 
   for (const t of tickets) {
-    if (t.creator_ticket_id) {
-      const siblings = childrenOf.get(t.creator_ticket_id) ?? [];
+    // Fallback for legacy creator_ticket_id
+    const parentId = t.parent_task_id || t.creator_ticket_id;
+    if (parentId) {
+      const siblings = childrenOf.get(parentId) ?? [];
       siblings.push(t);
-      childrenOf.set(t.creator_ticket_id, siblings);
+      childrenOf.set(parentId, siblings);
     } else {
       roots.push(t);
     }

--- a/packages/bees/tests/test_playbook.py
+++ b/packages/bees/tests/test_playbook.py
@@ -358,7 +358,7 @@ class TestStampChildTicket:
             "worker", parent_ticket=parent, slug="my-worker",
         )
 
-        assert child.metadata.creator_ticket_id == parent.id
+        assert child.metadata.parent_task_id == parent.id
         assert child.metadata.owning_task_id == parent.id
         assert child.metadata.slug == "my-worker"
         assert child.metadata.playbook_id == "worker"
@@ -435,7 +435,7 @@ class TestAutostart:
         parent = run_playbook("boss")
 
         all_tickets = GLOBAL_STORE.query_all()
-        children = [t for t in all_tickets if t.metadata.creator_ticket_id == parent.id]
+        children = [t for t in all_tickets if t.metadata.parent_task_id == parent.id]
 
         assert len(children) == 1
         child = children[0]
@@ -451,7 +451,7 @@ class TestAutostart:
         parent = run_playbook("solo")
 
         all_tickets = GLOBAL_STORE.query_all()
-        children = [t for t in all_tickets if t.metadata.creator_ticket_id == parent.id]
+        children = [t for t in all_tickets if t.metadata.parent_task_id == parent.id]
 
         assert len(children) == 0
 
@@ -474,7 +474,7 @@ class TestAutostart:
         parent = run_playbook("boss")
 
         all_tickets = GLOBAL_STORE.query_all()
-        children = [t for t in all_tickets if t.metadata.creator_ticket_id == parent.id]
+        children = [t for t in all_tickets if t.metadata.parent_task_id == parent.id]
 
         assert len(children) == 2
         slugs = {c.metadata.slug for c in children}

--- a/packages/bees/tests/test_scheduler.py
+++ b/packages/bees/tests/test_scheduler.py
@@ -171,70 +171,70 @@ async def test_deliver_context_update_immediate(mock_clients):
 
 
 @pytest.mark.asyncio
-async def test_enrich_creator_tags_merges(mock_clients):
-    """Child tags are merged (union) into the creator's existing tags."""
+async def test_enrich_parent_tags_merges(mock_clients):
+    """Child tags are merged (union) into the parent's existing tags."""
     _, backend = mock_clients
     scheduler = Scheduler(store=GLOBAL_STORE, backend=backend)
 
-    creator = GLOBAL_STORE.create("Parent", tags=["b", "c"])
+    parent = GLOBAL_STORE.create("Parent", tags=["b", "c"])
     child = GLOBAL_STORE.create("Child", tags=["a", "b"])
-    child.metadata.creator_ticket_id = creator.id
+    child.metadata.parent_task_id = parent.id
     GLOBAL_STORE.save_metadata(child)
 
-    result = scheduler._enrich_creator_tags(child)
+    result = scheduler._enrich_parent_tags(child)
 
     assert result is not None
-    assert result.id == creator.id
-    fresh = GLOBAL_STORE.get(creator.id)
+    assert result.id == parent.id
+    fresh = GLOBAL_STORE.get(parent.id)
     assert fresh.metadata.tags == ["a", "b", "c"]
 
 
 @pytest.mark.asyncio
-async def test_enrich_creator_tags_no_creator(mock_clients):
-    """No crash when creator_ticket_id points to a nonexistent ticket."""
+async def test_enrich_parent_tags_no_parent(mock_clients):
+    """No crash when parent_task_id points to a nonexistent ticket."""
     _, backend = mock_clients
     scheduler = Scheduler(store=GLOBAL_STORE, backend=backend)
 
     child = GLOBAL_STORE.create("Child", tags=["a"])
-    child.metadata.creator_ticket_id = "nonexistent-id"
+    child.metadata.parent_task_id = "nonexistent-id"
     GLOBAL_STORE.save_metadata(child)
 
     # Should not raise, returns None.
-    assert scheduler._enrich_creator_tags(child) is None
+    assert scheduler._enrich_parent_tags(child) is None
 
 
 @pytest.mark.asyncio
-async def test_enrich_creator_tags_no_tags(mock_clients):
-    """Creator is unchanged when the child has no tags."""
+async def test_enrich_parent_tags_no_tags(mock_clients):
+    """Parent is unchanged when the child has no tags."""
     _, backend = mock_clients
     scheduler = Scheduler(store=GLOBAL_STORE, backend=backend)
 
-    creator = GLOBAL_STORE.create("Parent", tags=["x"])
+    parent = GLOBAL_STORE.create("Parent", tags=["x"])
     child = GLOBAL_STORE.create("Child")  # No tags.
-    child.metadata.creator_ticket_id = creator.id
+    child.metadata.parent_task_id = parent.id
     GLOBAL_STORE.save_metadata(child)
 
-    assert scheduler._enrich_creator_tags(child) is None
+    assert scheduler._enrich_parent_tags(child) is None
 
-    fresh = GLOBAL_STORE.get(creator.id)
+    fresh = GLOBAL_STORE.get(parent.id)
     assert fresh.metadata.tags == ["x"]
 
 
 @pytest.mark.asyncio
-async def test_enrich_creator_tags_creator_has_no_tags(mock_clients):
-    """Creator with None tags receives the child's tags."""
+async def test_enrich_parent_tags_parent_has_no_tags(mock_clients):
+    """Parent with None tags receives the child's tags."""
     _, backend = mock_clients
     scheduler = Scheduler(store=GLOBAL_STORE, backend=backend)
 
-    creator = GLOBAL_STORE.create("Parent")  # tags=None
+    parent = GLOBAL_STORE.create("Parent")  # tags=None
     child = GLOBAL_STORE.create("Child", tags=["a"])
-    child.metadata.creator_ticket_id = creator.id
+    child.metadata.parent_task_id = parent.id
     GLOBAL_STORE.save_metadata(child)
 
-    result = scheduler._enrich_creator_tags(child)
+    result = scheduler._enrich_parent_tags(child)
 
     assert result is not None
-    fresh = GLOBAL_STORE.get(creator.id)
+    fresh = GLOBAL_STORE.get(parent.id)
     assert fresh.metadata.tags == ["a"]
 
 

--- a/packages/bees/tests/test_tasks.py
+++ b/packages/bees/tests/test_tasks.py
@@ -124,13 +124,13 @@ async def test_tasks_list_types_filters_by_allowlist(write_template):
 @pytest.mark.asyncio
 async def test_tasks_check_status(write_template):
     task_ticket = GLOBAL_STORE.create("Do something")
-    task_ticket.metadata.creator_ticket_id = "caller-id"
+    task_ticket.metadata.parent_task_id = "caller-id"
     task_ticket.metadata.title = "My Task"
     task_ticket.metadata.status = "running"
     GLOBAL_STORE.save_metadata(task_ticket)
 
     other_ticket = GLOBAL_STORE.create("Do something else")
-    other_ticket.metadata.creator_ticket_id = "other-id"
+    other_ticket.metadata.parent_task_id = "other-id"
     GLOBAL_STORE.save_metadata(other_ticket)
 
     scope = SubagentScope(workspace_root_id="caller-id")
@@ -188,7 +188,7 @@ async def test_tasks_create_task_async(write_template):
     ticket = GLOBAL_STORE.get(result["task_id"])
     assert ticket is not None
 
-    assert ticket.metadata.creator_ticket_id == caller.id
+    assert ticket.metadata.parent_task_id == caller.id
     assert ticket.metadata.slug == "my-slug"
     assert ticket.metadata.title == "Testing create"
     assert "You are assigned to work in the subdirectory: ./my-slug" in ticket.objective
@@ -295,6 +295,6 @@ async def test_tasks_create_task_nested_slug(write_template):
     assert ticket is not None
 
     assert ticket.metadata.slug == "research/deep-dive"
-    assert ticket.metadata.creator_ticket_id == caller.id
+    assert ticket.metadata.parent_task_id == caller.id
     assert "./research/deep-dive" in ticket.objective
     assert (ticket.fs_dir / "research" / "deep-dive").exists()

--- a/packages/bees/tests/test_tree.py
+++ b/packages/bees/tests/test_tree.py
@@ -29,10 +29,10 @@ def test_tree_traversal(temp_hive):
     root1 = store.create("Root 1")
     root2 = store.create("Root 2")
 
-    child1 = store.create("Child 1", creator_ticket_id=root1.id)
-    child2 = store.create("Child 2", creator_ticket_id=root1.id)
+    child1 = store.create("Child 1", parent_task_id=root1.id)
+    child2 = store.create("Child 2", parent_task_id=root1.id)
 
-    grandchild1 = store.create("Grandchild 1", creator_ticket_id=child1.id)
+    grandchild1 = store.create("Grandchild 1", parent_task_id=child1.id)
 
     # Test get_children
     roots = bees.children
@@ -85,7 +85,7 @@ def test_query_by_tags(temp_hive):
     t3 = store.create("Task 3", tags=["bug"])
     
     # Create a child task with tags
-    t4 = store.create("Task 4", tags=["bug", "ui"], creator_ticket_id=t2.id)
+    t4 = store.create("Task 4", tags=["bug", "ui"], parent_task_id=t2.id)
 
     # Test global query
     ui_tasks = bees.query(["ui"])
@@ -144,7 +144,7 @@ async def test_task_node_create_child(temp_hive):
     
     child_node = await parent_node.create_child("Child Task")
     
-    bees._scheduler.create_task.assert_called_once_with("Child Task", owning_task_id="parent1", creator_ticket_id="parent1")
+    bees._scheduler.create_task.assert_called_once_with("Child Task", owning_task_id="parent1", parent_task_id="parent1")
     assert child_node.id == "child1"
 
 

--- a/packages/bees/web/src/sca/utils/agent-tree.ts
+++ b/packages/bees/web/src/sca/utils/agent-tree.ts
@@ -30,7 +30,7 @@ interface AgentPerspectives {
 /**
  * Derive a forest of agent trees from a flat ticket list.
  *
- * Root nodes are tickets with no `creator_ticket_id` (user-initiated).
+ * Root nodes are tickets with no `parent_task_id` (or legacy `creator_ticket_id`) (user-initiated).
  * Coordination and internal-only tickets are excluded.
  */
 function deriveAgentTree(tickets: TicketData[]): AgentTreeNode[] {
@@ -47,10 +47,12 @@ function deriveAgentTree(tickets: TicketData[]): AgentTreeNode[] {
   const roots: TicketData[] = [];
 
   for (const t of agentTickets) {
-    if (t.creator_ticket_id) {
-      const siblings = childrenOf.get(t.creator_ticket_id) ?? [];
+    // Fallback for legacy creator_ticket_id
+    const parentId = t.parent_task_id || t.creator_ticket_id;
+    if (parentId) {
+      const siblings = childrenOf.get(parentId) ?? [];
       siblings.push(t);
-      childrenOf.set(t.creator_ticket_id, siblings);
+      childrenOf.set(parentId, siblings);
     } else {
       roots.push(t);
     }
@@ -75,7 +77,8 @@ function deriveChildAgents(
 ): TicketData[] {
   return tickets.filter(
     (t) =>
-      t.creator_ticket_id === parentId &&
+      // Fallback for legacy creator_ticket_id
+      (t.parent_task_id || t.creator_ticket_id) === parentId &&
       t.kind !== "coordination" &&
       !t.tags?.includes("digest")
   );
@@ -90,7 +93,8 @@ function derivePerspectives(
   const hasBundle = ticket.tags?.includes("bundle") ?? false;
   const hasSubagents = allTickets.some(
     (t) =>
-      t.creator_ticket_id === ticket.id &&
+      // Fallback for legacy creator_ticket_id
+      (t.parent_task_id || t.creator_ticket_id) === ticket.id &&
       t.kind !== "coordination" &&
       !t.tags?.includes("digest")
   );
@@ -102,7 +106,7 @@ function derivePerspectives(
  * Derive the ancestor path from root to the given agent.
  *
  * Returns an ordered array of ticket IDs: `[root, ..., parent, agentId]`.
- * Walks the `creator_ticket_id` chain upward, then reverses.
+ * Walks the `parent_task_id` (or `creator_ticket_id`) chain upward, then reverses.
  * Returns an empty array if the agent is not found.
  *
  * Guards against cycles with a visited set.
@@ -118,8 +122,10 @@ function deriveAncestorPath(tickets: TicketData[], agentId: string): string[] {
     visited.add(current);
     path.push(current);
     const ticket = byId.get(current);
-    if (!ticket?.creator_ticket_id) break;
-    current = ticket.creator_ticket_id;
+    // Fallback for legacy creator_ticket_id
+    const parentId = ticket?.parent_task_id || ticket?.creator_ticket_id;
+    if (!parentId) break;
+    current = parentId;
   }
 
   return path.reverse();


### PR DESCRIPTION
## What
Renamed `creator_ticket_id` to `parent_task_id` across the Bees framework (Python backend, TypeScript frontend, tests, and docs) to improve architectural consistency, while maintaining backward compatibility for legacy data.

## Why
To better reflect the hierarchical nature of tasks and clearly distinguish between task hierarchy and workspace ownership.

## Changes

### Backend (Python)
- **`bees/ticket.py`**: Renamed `creator_ticket_id` to `parent_task_id` in `TicketMetadata` and added fallback in `from_dict`.
- **`bees/scheduler.py`**: Updated references and renamed `_enrich_creator_tags` to `_enrich_parent_tags`.
- **`bees/playbook.py`**: Updated `stamp_child_ticket` to assign `parent_task_id`.
- **`bees/task_store.py`**: Updated store operations to use `parent_task_id`.
- **`bees/task_node.py`**: Updated properties to use `parent_task_id`.
- **Tests**: Updated `test_tasks.py`, `test_scheduler.py`, `test_playbook.py`, and `test_tree.py`.

### Frontend (TypeScript)
- **`common/types.ts`**: Updated `TicketData` interface, keeping `creator_ticket_id` as optional for fallback support.
- **`hivetool/src/data/ticket-tree.ts`**: Added fallback logic for tree derivation.
- **`web/src/sca/utils/agent-tree.ts`**: Added fallback logic in multiple tree-walking functions.
- Added explanatory comments for all fallback checks.

### Documentation
- Updated `docs/scheduler.md` and `docs/agent-projection.md` to reflect the new field name.

## Testing
- Ran Python test suite: `npm run test:python -w packages/bees` (153 passed).
