### PR TITLE
[bees] Rename ticket events to task events in Bees

### DIFF
--- a/packages/bees/app/server.py
+++ b/packages/bees/app/server.py
@@ -72,11 +72,11 @@ bees: Bees | None = None
 # ---------------------------------------------------------------------------
 
 
-async def _on_ticket_added(ticket: Task) -> None:
+async def _on_task_added(task: Task) -> None:
     """Broadcast a newly added agent."""
     await broadcaster.broadcast({
         "type": "agent:added",
-        "agent": _agent_to_dict(ticket),
+        "agent": _agent_to_dict(task),
     })
 
 
@@ -89,27 +89,27 @@ async def _on_cycle_start(cycle: int, new: int, resumable: int) -> None:
     })
 
 
-async def _on_ticket_event(ticket_id: str, event: dict[str, Any]) -> None:
+async def _on_task_event(task_id: str, event: dict[str, Any]) -> None:
     await broadcaster.broadcast({
         "type": "session:event",
-        "ticket_id": ticket_id,
+        "ticket_id": task_id,
         "event": event,
     })
 
 
-async def _on_ticket_start(ticket: Task) -> None:
+async def _on_task_start(task: Task) -> None:
     """Broadcast when an agent transitions to running."""
     await broadcaster.broadcast({
         "type": "agent:updated",
-        "agent": _agent_to_dict(ticket),
+        "agent": _agent_to_dict(task),
     })
 
 
-async def _on_ticket_done(ticket: Task) -> None:
+async def _on_task_done(task: Task) -> None:
     """Post-completion hook: broadcast updated agent state."""
     await broadcaster.broadcast({
         "type": "agent:updated",
-        "agent": _agent_to_dict(ticket),
+        "agent": _agent_to_dict(task),
     })
 
 
@@ -160,11 +160,11 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     bees = Bees(hive_dir, backend)
 
-    bees.on("ticket_added", _on_ticket_added)
+    bees.on("task_added", _on_task_added)
     bees.on("cycle_start", _on_cycle_start)
-    bees.on("ticket_event", _on_ticket_event)
-    bees.on("ticket_start", _on_ticket_start)
-    bees.on("ticket_done", _on_ticket_done)
+    bees.on("task_event", _on_task_event)
+    bees.on("task_start", _on_task_start)
+    bees.on("task_done", _on_task_done)
     bees.on("cycle_complete", _on_cycle_complete)
 
     await bees.listen()
@@ -189,26 +189,26 @@ app.add_middleware(
 # ---------------------------------------------------------------------------
 
 
-def _agent_to_dict(ticket: Task) -> dict[str, Any]:
-    """Serialize an agent (ticket) for JSON response."""
+def _agent_to_dict(task: Task) -> dict[str, Any]:
+    """Serialize an agent (task) for JSON response."""
     d = {
-        "id": ticket.id,
-        "objective": ticket.objective,
-        **ticket.metadata.to_dict(),
+        "id": task.id,
+        "objective": task.objective,
+        **task.metadata.to_dict(),
     }
     # Include chat history for chat-tagged agents so the shell can
     # restore conversation after page reload / server restart.
-    if ticket.metadata.tags and "chat" in ticket.metadata.tags:
-        d["chat_history"] = _read_chat_log(ticket)
+    if task.metadata.tags and "chat" in task.metadata.tags:
+        d["chat_history"] = _read_chat_log(task)
     return d
 
 
-def _read_chat_log(ticket: Task) -> list[dict[str, str]]:
+def _read_chat_log(task: Task) -> list[dict[str, str]]:
     """Read the agent's chat log written by the chat function.
 
     Returns a list of ``{"role": "agent"|"user", "text": "..."}`` entries.
     """
-    log_path = ticket.dir / "chat_log.json"
+    log_path = task.dir / "chat_log.json"
     if not log_path.exists():
         return []
     try:
@@ -242,20 +242,20 @@ def _get_node(agent_id: str):
 async def reply_to_agent(agent_id: str, req: ReplyRequest) -> dict[str, Any]:
     """Send a chat reply to a suspended agent."""
     node = _get_node(agent_id)
-    ticket = node.task
-    if ticket.metadata.status != "suspended":
+    task = node.task
+    if task.metadata.status != "suspended":
         raise HTTPException(400, "Agent is not suspended")
-    if ticket.metadata.assignee != "user":
+    if task.metadata.assignee != "user":
         raise HTTPException(400, "Agent is not assigned to user")
 
-    ticket = node.respond({"text": req.text})
+    task = node.respond({"text": req.text})
 
     await broadcaster.broadcast({
         "type": "agent:updated",
-        "agent": _agent_to_dict(ticket),
+        "agent": _agent_to_dict(task),
     })
 
-    return _agent_to_dict(ticket)
+    return _agent_to_dict(task)
 
 
 @app.post("/agents/{agent_id}/choose")
@@ -264,20 +264,20 @@ async def choose_for_agent(
 ) -> dict[str, Any]:
     """Submit a choice selection to a suspended agent."""
     node = _get_node(agent_id)
-    ticket = node.task
-    if ticket.metadata.status != "suspended":
+    task = node.task
+    if task.metadata.status != "suspended":
         raise HTTPException(400, "Agent is not suspended")
-    if ticket.metadata.assignee != "user":
+    if task.metadata.assignee != "user":
         raise HTTPException(400, "Agent is not assigned to user")
 
-    ticket = node.respond({"selectedIds": req.selectedIds})
+    task = node.respond({"selectedIds": req.selectedIds})
 
     await broadcaster.broadcast({
         "type": "agent:updated",
-        "agent": _agent_to_dict(ticket),
+        "agent": _agent_to_dict(task),
     })
 
-    return _agent_to_dict(ticket)
+    return _agent_to_dict(task)
 
 
 @app.post("/agents/{agent_id}/retry")

--- a/packages/bees/bees/bees.py
+++ b/packages/bees/bees/bees.py
@@ -23,11 +23,11 @@ class Bees:
         self._loop_task = None
         
         hooks = SchedulerHooks(
-            on_ticket_added=lambda t: self._emit("ticket_added", t),
+            on_ticket_added=lambda t: self._emit("task_added", t),
             on_cycle_start=lambda c, a, r: self._emit("cycle_start", c, a, r),
-            on_ticket_event=lambda t, e: self._emit("ticket_event", t, e),
-            on_ticket_start=lambda t: self._emit("ticket_start", t),
-            on_ticket_done=lambda t: self._emit("ticket_done", t),
+            on_ticket_event=lambda t, e: self._emit("task_event", t, e),
+            on_ticket_start=lambda t: self._emit("task_start", t),
+            on_ticket_done=lambda t: self._emit("task_done", t),
             on_cycle_complete=lambda c: self._emit("cycle_complete", c),
         )
         self._scheduler = Scheduler(backend=backend, hooks=hooks, store=self._store)

--- a/packages/bees/docs/api.md
+++ b/packages/bees/docs/api.md
@@ -60,7 +60,7 @@ Creates a new root task in the hive.
 
 Registers an event handler for the specified event.
 
-- **`event_name`**: The name of the event (e.g., `ticket_done`).
+- **`event_name`**: The name of the event. Supported events: `task_added`, `cycle_start`, `task_event`, `task_start`, `task_done`, `cycle_complete`.
 - **`handler`**: The callback function to run when the event fires.
 
 #### `listen(self)` (Async)


### PR DESCRIPTION
## What
Renamed event strings emitted by `Bees` and corresponding listeners/handlers in `server.py` from "ticket" to "task".

## Why
To align with the architectural decision to use "task" instead of "ticket" for better terminology consistency in the Bees framework.

## Changes

### Bees Framework
- `packages/bees/bees/bees.py`: Renamed emitted events `"ticket_added"`, `"ticket_event"`, `"ticket_start"`, and `"ticket_done"` to use `"task_"` prefix.
- `packages/bees/app/server.py`:
  - Renamed event handling functions to `_on_task_*`.
  - Updated event subscriptions in `lifespan` to use new event names and handlers.
  - Renamed parameters and local variables from `ticket` to `task` in helper functions and endpoints.
  - Kept `"ticket_id"` in the `"session:event"` SSE payload to preserve the external contract.

## Testing
- Ran Python tests in `packages/bees` (`npm run test:python`), all 153 tests passed.
- Verified that the dev server starts and handles requests correctly.
