### PR TITLE
[bees] Improve TaskNode ergonomics and type safety

### DIFF
--- a/packages/bees/bees/task_node.py
+++ b/packages/bees/bees/task_node.py
@@ -2,11 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict, overload
 from bees.ticket import Ticket
 
 if TYPE_CHECKING:
     from bees.bees import Bees
+
+class ReplyResponse(TypedDict):
+    text: str
+
+class ChooseResponse(TypedDict):
+    selectedIds: list[str]
+
 
 class TaskNode:
     """Wraps a Ticket and provides a tree traversal and manipulation API."""
@@ -39,6 +46,11 @@ class TaskNode:
             return None
         parent_task = self._store.get(self._task.metadata.parent_task_id)
         return TaskNode(parent_task, self._bees) if parent_task else None
+
+    @property
+    def awaiting_response(self) -> bool:
+        """Returns True if the task is suspended and assigned to the user."""
+        return self._task.metadata.status == "suspended" and self._task.metadata.assignee == "user"
 
     def query(self, tags: list[str]) -> list[TaskNode]:
         """Searches for tasks in the subtree that contain all of the specified tags."""
@@ -86,9 +98,44 @@ class TaskNode:
         ticket = await self._bees._scheduler.create_task(objective, **kwargs)
         return TaskNode(ticket, self._bees)
 
-    def respond(self, response: dict):
+    @overload
+    def respond(self, response: ReplyResponse) -> Ticket: ...
+    
+    @overload
+    def respond(self, response: ChooseResponse) -> Ticket: ...
+    
+    @overload
+    def respond(self, *, text: str) -> Ticket: ...
+    
+    @overload
+    def respond(self, *, selectedIds: list[str]) -> Ticket: ...
+    
+    def respond(
+        self, 
+        response: dict | None = None, 
+        *, 
+        text: str | None = None, 
+        selectedIds: list[str] | None = None
+    ) -> Ticket:
         """Delivers a response to this task."""
-        self._task = self._store.respond(self.id, response)
+        
+        if response is not None:
+            if text is not None or selectedIds is not None:
+                raise ValueError("Cannot provide both a dictionary response and keyword arguments")
+            payload = response
+        else:
+            if text is not None and selectedIds is not None:
+                raise ValueError("Cannot provide both 'text' and 'selectedIds'")
+            if text is None and selectedIds is None:
+                raise ValueError("Must provide either 'text' or 'selectedIds' (or a dictionary response)")
+            
+            payload = {}
+            if text is not None:
+                payload["text"] = text
+            else:
+                payload["selectedIds"] = selectedIds
+
+        self._task = self._store.respond(self.id, payload)
         self._bees._trigger()
         return self._task
 

--- a/packages/bees/docs/api.md
+++ b/packages/bees/docs/api.md
@@ -85,6 +85,8 @@ A wrapper around a task that provides DOM-like traversal properties and manipula
 
 - **`parent`**: `TaskNode | None` (Read-only) The parent task of this task, or `None` if it is a root task.
 
+- **`awaiting_response`**: `bool` (Read-only) Returns `True` if the task is suspended and assigned to the user, indicating it is waiting for a response.
+
 #### Methods
 
 #### `query(self, tags: list[str]) -> list[TaskNode]`
@@ -102,11 +104,16 @@ Creates a child task under this task.
 - **`**kwargs`**: Additional arguments for task creation.
 - **Returns**: A `TaskNode` representing the newly created child task.
 
-#### `respond(self, response: dict)`
+#### `respond(self, response: dict | None = None, *, text: str | None = None, selectedIds: list[str] | None = None)`
 
-Submits a response to the task (e.g., answering a question or providing data).
+Submits a response to the task (e.g., answering a question or providing data). Supports both dictionary style and specific keyword arguments for improved ergonomics.
 
-- **`response`**: The data to respond with.
+- **`response`**: A dictionary containing the response data (e.g., `{"text": "..."}`).
+- **`text`**: (Keyword only) The text response to provide.
+- **`selectedIds`**: (Keyword only) A list of selected choice IDs.
+
+> [!NOTE]
+> You must provide either `text` or `selectedIds` when using keyword arguments, or pass a dictionary as the `response` argument. You cannot provide both keyword arguments, nor can you mix a dictionary response with keyword arguments.
 
 #### `save(self)`
 

--- a/packages/bees/tests/test_tree.py
+++ b/packages/bees/tests/test_tree.py
@@ -162,6 +162,93 @@ def test_task_node_respond(temp_hive):
     store_mock.respond.assert_called_once_with("task1", {"text": "reply"})
 
 
+def test_task_node_respond_with_text_kwarg(temp_hive):
+    bees = Bees(temp_hive, backend=Mock())
+    store_mock = Mock()
+    bees._store = store_mock
+    
+    ticket = Mock()
+    ticket.id = "task1"
+    node = TaskNode(ticket, bees)
+    
+    node.respond(text="reply")
+    
+    store_mock.respond.assert_called_once_with("task1", {"text": "reply"})
+
+
+def test_task_node_respond_with_selected_ids_kwarg(temp_hive):
+    bees = Bees(temp_hive, backend=Mock())
+    store_mock = Mock()
+    bees._store = store_mock
+    
+    ticket = Mock()
+    ticket.id = "task1"
+    node = TaskNode(ticket, bees)
+    
+    node.respond(selectedIds=["choice1"])
+    
+    store_mock.respond.assert_called_once_with("task1", {"selectedIds": ["choice1"]})
+
+
+def test_task_node_respond_mutually_exclusive_kwargs(temp_hive):
+    bees = Bees(temp_hive, backend=Mock())
+    ticket = Mock()
+    ticket.id = "task1"
+    node = TaskNode(ticket, bees)
+    
+    with pytest.raises(ValueError, match="Cannot provide both 'text' and 'selectedIds'"):
+        node.respond(text="reply", selectedIds=["choice1"])
+
+
+def test_task_node_respond_missing_kwargs(temp_hive):
+    bees = Bees(temp_hive, backend=Mock())
+    ticket = Mock()
+    ticket.id = "task1"
+    node = TaskNode(ticket, bees)
+    
+    with pytest.raises(ValueError, match="Must provide either 'text' or 'selectedIds'"):
+        node.respond()
+
+
+def test_task_node_respond_dict_and_kwargs_conflict(temp_hive):
+    bees = Bees(temp_hive, backend=Mock())
+    ticket = Mock()
+    ticket.id = "task1"
+    node = TaskNode(ticket, bees)
+    
+    with pytest.raises(ValueError, match="Cannot provide both a dictionary response and keyword arguments"):
+        node.respond({"text": "reply"}, text="another reply")
+
+
+def test_task_node_awaiting_response(temp_hive):
+    bees = Bees(temp_hive, backend=Mock())
+    
+    ticket = Mock()
+    ticket.metadata = Mock()
+    
+    node = TaskNode(ticket, bees)
+    
+    # Case 1: Not suspended, not user
+    ticket.metadata.status = "running"
+    ticket.metadata.assignee = "agent"
+    assert not node.awaiting_response
+    
+    # Case 2: Suspended, but not user
+    ticket.metadata.status = "suspended"
+    ticket.metadata.assignee = "agent"
+    assert not node.awaiting_response
+    
+    # Case 3: Not suspended, but user
+    ticket.metadata.status = "running"
+    ticket.metadata.assignee = "user"
+    assert not node.awaiting_response
+    
+    # Case 4: Suspended and user
+    ticket.metadata.status = "suspended"
+    ticket.metadata.assignee = "user"
+    assert node.awaiting_response
+
+
 def test_bees_all(temp_hive):
     bees = Bees(temp_hive, backend=Mock())
     store_mock = Mock()


### PR DESCRIPTION
## What
Added type safety and structure to `TaskNode.respond` supporting both dicts and specific keyword arguments (`text`, `selectedIds`), and added an `awaiting_response` property to check if a task is waiting for user input.

## Why
To improve the ergonomics of the Bees library, making it easier and safer to respond to tasks and check their interactive state.

## Changes
### packages/bees
- **bees/task_node.py**:
    - Added `TypedDict`s for `ReplyResponse` and `ChooseResponse`.
    - Added `@overload` signatures to `respond` to support dicts and mutually exclusive kwargs (`text` and `selectedIds`).
    - Added `awaiting_response` property.
- **tests/test_tree.py**:
    - Added tests for `respond` with keyword arguments and error cases.
    - Added tests for `awaiting_response` property.
- **docs/api.md**:
    - Updated documentation for `respond` and `awaiting_response`.

## Testing
- Ran `npm run test:python` in `packages/bees` (all 159 tests passed).
