### PR TITLE
[bees]  Renaming Ticket to Task across Bees

### DIFF
--- a/packages/bees/app/server.py
+++ b/packages/bees/app/server.py
@@ -92,7 +92,7 @@ async def _on_cycle_start(cycle: int, new: int, resumable: int) -> None:
 async def _on_task_event(task_id: str, event: dict[str, Any]) -> None:
     await broadcaster.broadcast({
         "type": "session:event",
-        "ticket_id": task_id,
+        "task_id": task_id,
         "event": event,
     })
 

--- a/packages/bees/bees/bees.py
+++ b/packages/bees/bees/bees.py
@@ -78,15 +78,16 @@ class Bees:
 
     def query(self, tags: list[str]) -> list[TaskNode]:
         """Searches for tasks that contain all of the specified tags."""
-        all_tickets = self._store.query_all()
+        all_tasks = self._store.query_all()
         matching_nodes: list[TaskNode] = []
-        for ticket in all_tickets:
-            ticket_tags = ticket.metadata.tags or []
-            if all(tag in ticket_tags for tag in tags):
-                matching_nodes.append(TaskNode(ticket, self))
+        for task in all_tasks:
+            task_tags = task.metadata.tags or []
+            if all(tag in task_tags for tag in tags):
+                matching_nodes.append(TaskNode(task, self))
         return matching_nodes
 
     async def create_child(self, objective: str, **kwargs) -> TaskNode:
         """Creates a root task."""
-        ticket = await self._scheduler.create_task(objective, **kwargs)
-        return TaskNode(ticket, self)
+        task = await self._scheduler.create_task(objective, **kwargs)
+        return TaskNode(task, self)
+

--- a/packages/bees/bees/functions/chat.py
+++ b/packages/bees/bees/functions/chat.py
@@ -77,11 +77,11 @@ def get_chat_function_group_factory(
             # without suspending — the updates are emitted as text
             # parts via CONTEXT_PARTS_KEY.
             if workspace_root_id and scheduler:
-                ticket = scheduler.store.get(workspace_root_id)
-                if ticket and ticket.metadata.pending_context_updates:
-                    updates = ticket.metadata.pending_context_updates
-                    ticket.metadata.pending_context_updates = []
-                    scheduler.store.save_metadata(ticket)
+                task = scheduler.store.get(workspace_root_id)
+                if task and task.metadata.pending_context_updates:
+                    updates = task.metadata.pending_context_updates
+                    task.metadata.pending_context_updates = []
+                    scheduler.store.save_metadata(task)
                     return {
                         "resumed": True,
                         CONTEXT_PARTS_KEY: updates_to_context_parts(updates),

--- a/packages/bees/bees/functions/events.py
+++ b/packages/bees/bees/functions/events.py
@@ -98,7 +98,7 @@ def _make_handlers(
         try:
             if not scheduler:
                 return {"error": "Scheduler not available"}
-            ticket = scheduler.store.create(
+            task = scheduler.store.create(
                 "",  # No objective — event tickets carry context, not work.
                 kind="coordination",
                 signal_type=event_type,
@@ -112,10 +112,10 @@ def _make_handlers(
             status_cb(None, None)
 
         if on_events_broadcast:
-            on_events_broadcast(ticket)
+            on_events_broadcast(task)
 
         return {
-            "ticket_id": ticket.id,
+            "ticket_id": task.id,
             "type": event_type,
             "broadcast": True,
         }

--- a/packages/bees/bees/functions/tasks.py
+++ b/packages/bees/bees/functions/tasks.py
@@ -41,9 +41,9 @@ def _make_handlers(
             
         allowed_tasks = []
         if caller_ticket_id:
-            ticket = scheduler.store.get(caller_ticket_id) if scheduler else None
-            if ticket and ticket.metadata.tasks:
-                allowed_tasks = ticket.metadata.tasks
+            task = scheduler.store.get(caller_ticket_id) if scheduler else None
+            if task and task.metadata.tasks:
+                allowed_tasks = task.metadata.tasks
                 
         task_types = []
         from bees.playbook import list_playbooks, load_playbook
@@ -95,7 +95,7 @@ def _make_handlers(
             if not parent:
                 return {"error": "Parent ticket not found"}
 
-            ticket = stamp_child_ticket(
+            task = stamp_child_ticket(
                 task_type,
                 parent_ticket=parent,
                 slug=slug,
@@ -114,18 +114,18 @@ def _make_handlers(
             
         if wait_ms and scheduler:
             if status_cb:
-                status_cb(f"Waiting for task {ticket.id}...")
-            status = await scheduler.wait_for_ticket(ticket.id, wait_ms)
+                status_cb(f"Waiting for task {task.id}...")
+            status = await scheduler.wait_for_ticket(task.id, wait_ms)
             if status_cb:
                 status_cb(None, None)
                 
             if status == "completed":
-                fresh = scheduler.store.get(ticket.id) if scheduler else None
+                fresh = scheduler.store.get(task.id) if scheduler else None
                 return {"outcome": fresh.metadata.outcome if fresh else "completed"}
             else:
-                return {"task_id": ticket.id, "status": status}
+                return {"task_id": task.id, "status": status}
         
-        return {"task_id": ticket.id, "status": ticket.metadata.status}
+        return {"task_id": task.id, "status": task.metadata.status}
 
     async def _tasks_check_status(args: dict[str, Any], status_cb: Any) -> dict[str, Any]:
         if status_cb:

--- a/packages/bees/bees/playbook.py
+++ b/packages/bees/bees/playbook.py
@@ -135,7 +135,7 @@ def run_playbook(
     playbook_id = data.get("name", name)
     playbook_run_id = str(uuid.uuid4())
 
-    ticket = store.create(
+    task = store.create(
         data.get("objective", ""),
         title=data.get("title"),
         functions=data.get("functions"),
@@ -157,7 +157,7 @@ def run_playbook(
         try:
             stamp_child_ticket(
                 child_name,
-                parent_ticket=ticket,
+                parent_ticket=task,
                 slug=child_name,
                 store=store,
             )
@@ -167,7 +167,7 @@ def run_playbook(
                 child_name, name, exc,
             )
 
-    return ticket
+    return task
 
 
 def stamp_child_ticket(

--- a/packages/bees/bees/scheduler.py
+++ b/packages/bees/bees/scheduler.py
@@ -200,8 +200,8 @@ def promote_blocked_tickets(store: TaskStore) -> int:
     blocked = store.query_all(status="blocked")
     promoted = 0
 
-    for ticket in blocked:
-        deps = ticket.metadata.depends_on or []
+    for task in blocked:
+        deps = task.metadata.depends_on or []
         all_met = True
         any_failed = False
 
@@ -218,14 +218,14 @@ def promote_blocked_tickets(store: TaskStore) -> int:
             all_met = False
 
         if any_failed:
-            ticket.metadata.status = "failed"
-            ticket.metadata.error = "Dependency failed"
-            store.save_metadata(ticket)
+            task.metadata.status = "failed"
+            task.metadata.error = "Dependency failed"
+            store.save_metadata(task)
             continue
 
         if all_met:
-            ticket.metadata.status = "available"
-            store.save_metadata(ticket)
+            task.metadata.status = "available"
+            store.save_metadata(task)
             promoted += 1
 
     return promoted
@@ -274,26 +274,26 @@ class Scheduler:
 
     async def startup(self) -> Ticket | None:
         """Recover stuck tickets, boot root template if needed, and fire startup hook."""
-        tickets = await self.recover_stuck_tickets()
+        tasks = await self.recover_stuck_tickets()
         
-        root_ticket = await self._boot_root_template(tickets)
-        if root_ticket:
-            tickets.append(root_ticket)
+        root_task = await self._boot_root_template(tasks)
+        if root_task:
+            tasks.append(root_task)
             
         if self._hooks.on_startup:
-            await self._hooks.on_startup(tickets)
+            await self._hooks.on_startup(tasks)
             
-        return root_ticket
+        return root_task
 
     async def create_task(self, objective: str, **kwargs) -> Ticket:
         """Create a new task and notify hooks."""
-        ticket = self.store.create(objective, **kwargs)
+        task = self.store.create(objective, **kwargs)
         
         if self._hooks.on_ticket_added:
-            await self._hooks.on_ticket_added(ticket)
+            await self._hooks.on_ticket_added(task)
             
         self.trigger()
-        return ticket
+        return task
 
     async def _boot_root_template(self, tickets: list[Ticket]) -> Ticket | None:
         """Boot the root template if it isn't already running."""
@@ -309,12 +309,12 @@ class Scheduler:
             return None
 
         logger.info("Booting root template '%s'", root)
-        ticket = run_playbook(root, store=self.store)
+        task = run_playbook(root, store=self.store)
         
         if self._hooks.on_ticket_added:
-            await self._hooks.on_ticket_added(ticket)
+            await self._hooks.on_ticket_added(task)
             
-        return ticket
+        return task
 
     async def wait_for_ticket(self, ticket_id: str, timeout_ms: float) -> str:
         """Wait for a ticket to complete, fail, or suspend.
@@ -349,10 +349,10 @@ class Scheduler:
             self._active_tasks[ticket_id].cancel()
             cancelled = True
             
-        ticket = self.store.get(ticket_id)
-        if ticket:
-            ticket.metadata.status = "cancelled"
-            self.store.save_metadata(ticket)
+        task = self.store.get(ticket_id)
+        if task:
+            task.metadata.status = "cancelled"
+            self.store.save_metadata(task)
             cancelled = True
             
         return cancelled
@@ -372,11 +372,11 @@ class Scheduler:
         ``parent_task_id`` must match — this prevents one agent from
         injecting updates into another agent's tasks.
         """
-        ticket = self.store.get(ticket_id)
-        if not ticket:
+        task = self.store.get(ticket_id)
+        if not task:
             return f"Task {ticket_id} not found"
 
-        if expected_creator and ticket.metadata.parent_task_id != expected_creator:
+        if expected_creator and task.metadata.parent_task_id != expected_creator:
             return f"Task {ticket_id} is not owned by this agent"
 
         self._deliver_context_update(ticket_id, update)

--- a/packages/bees/common/types.ts
+++ b/packages/bees/common/types.ts
@@ -9,7 +9,7 @@
  * HiveTool devtools — any additions here must be reflected in the Python
  * server's serialisation logic.
  */
-export interface TicketData {
+export interface TaskData {
   id: string;
   objective: string;
   status: string;

--- a/packages/bees/common/utils.ts
+++ b/packages/bees/common/utils.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TicketData } from "./types.js";
+import type { TaskData } from "./types.js";
 
 export { extractPrompt, extractChoices };
 export type { Choice };
@@ -14,7 +14,7 @@ interface Choice {
   text: string;
 }
 
-function extractPrompt(ticket: TicketData): string {
+function extractPrompt(ticket: TaskData): string {
   const se = ticket.suspend_event;
   if (!se) return "(no prompt)";
   for (const key of ["waitForInput", "waitForChoice"]) {
@@ -28,7 +28,7 @@ function extractPrompt(ticket: TicketData): string {
   return "(no prompt)";
 }
 
-function extractChoices(ticket: TicketData): Choice[] {
+function extractChoices(ticket: TaskData): Choice[] {
   const se = ticket.suspend_event;
   if (!se || !se.waitForChoice) return [];
   const payload = se.waitForChoice as Record<string, unknown>;

--- a/packages/bees/hivetool/src/data/types.ts
+++ b/packages/bees/hivetool/src/data/types.ts
@@ -5,7 +5,7 @@
  */
 
 // Re-export the shared backend API contract.
-export type { TicketData } from "../../../common/types.js";
+export type { TaskData as TicketData } from "../../../common/types.js";
 
 // ---------------------------------------------------------------------------
 // Log file types (from EvalCollector output in packages/bees/hive/logs)

--- a/packages/bees/web/src/iframe/entry.ts
+++ b/packages/bees/web/src/iframe/entry.ts
@@ -27,7 +27,7 @@ export type HostMessage =
       props: Record<string, unknown>;
     }
   | { type: "update-props"; props: Record<string, unknown> }
-  | { type: "host.chat.switch"; payload: { ticket_id: string; role: string } }
+  | { type: "host.chat.switch"; payload: { task_id: string; role: string } }
   | {
       type: "readFile.response";
       requestId: string;

--- a/packages/bees/web/src/sca/actions/chat/chat-actions.ts
+++ b/packages/bees/web/src/sca/actions/chat/chat-actions.ts
@@ -6,7 +6,7 @@
 
 import { asAction, ActionMode } from "../../coordination.js";
 import { makeAction } from "../binder.js";
-import type { TicketData } from "../../../../../common/types.js";
+import type { TaskData } from "../../../../../common/types.js";
 import type { ChatThread, ChatMessage } from "../../types.js";
 import { onTicketsUpdate, onActiveThreadChange } from "./chat-triggers.js";
 import { extractPrompt, extractChoices } from "../../../../../common/utils.js";
@@ -37,9 +37,7 @@ export const deriveThreads = asAction(
       const suspendedForUser =
         t.status === "suspended" && t.assignee === "user";
       const isActive =
-        suspendedForUser ||
-        t.status === "running" ||
-        t.status === "available";
+        suspendedForUser || t.status === "running" || t.status === "available";
 
       const title =
         t.title ||
@@ -76,7 +74,7 @@ export const deriveThreads = asAction(
   }
 );
 
-function restoreThreadHistory(thread: ChatThread, tickets: TicketData[]) {
+function restoreThreadHistory(thread: ChatThread, tickets: TaskData[]) {
   const { controller } = bind;
   const messages: ChatMessage[] = [];
 
@@ -107,7 +105,7 @@ function restoreThreadHistory(thread: ChatThread, tickets: TicketData[]) {
 
 async function processTicketTransitions(
   threads: ChatThread[],
-  tickets: TicketData[]
+  tickets: TaskData[]
 ) {
   const { controller } = bind;
   const activeThreadId = controller.chat.activeThreadId;
@@ -206,9 +204,7 @@ export const applyPromptState = asAction(
       controller.chat.pendingChoices = [];
       return;
     }
-    const thread = controller.chat.threads.find(
-      (t) => t.id === activeThreadId
-    );
+    const thread = controller.chat.threads.find((t) => t.id === activeThreadId);
     if (!thread?.activeTicketId) {
       controller.chat.pendingChoices = [];
       return;
@@ -322,7 +318,7 @@ export const processHostSessionEvent = asAction(
     if (!evt) return;
     const { controller } = bind;
     const data = (evt as CustomEvent<Record<string, unknown>>).detail;
-    const ticketId = data.ticket_id as string;
+    const ticketId = data.task_id as string;
     const event = data.event as Record<string, unknown>;
 
     const thread = controller.chat.threads.find(

--- a/packages/bees/web/src/sca/actions/sync/sync-actions.ts
+++ b/packages/bees/web/src/sca/actions/sync/sync-actions.ts
@@ -6,7 +6,7 @@
 
 import { asAction, ActionMode } from "../../coordination.js";
 import { makeAction } from "../binder.js";
-import type { TicketData } from "../../../../../common/types.js";
+import type { TaskData } from "../../../../../common/types.js";
 import {
   onAgentAdded,
   onAgentUpdated,
@@ -19,7 +19,7 @@ import {
 
 export const bind = makeAction();
 
-async function doUpsertTicket(ticket: TicketData) {
+async function doUpsertTicket(ticket: TaskData) {
   const { controller } = bind;
   const c = controller.global;
   const current = c.tickets;
@@ -53,7 +53,7 @@ export const upsertTicketOnAdd = asAction(
   },
   async (evt?: Event) => {
     if (!evt) return;
-    const ticket = (evt as CustomEvent<TicketData>).detail;
+    const ticket = (evt as CustomEvent<TaskData>).detail;
     if (ticket) await doUpsertTicket(ticket);
   }
 );
@@ -66,7 +66,7 @@ export const upsertTicketOnUpdate = asAction(
   },
   async (evt?: Event) => {
     if (!evt) return;
-    const ticket = (evt as CustomEvent<TicketData>).detail;
+    const ticket = (evt as CustomEvent<TaskData>).detail;
     if (ticket) await doUpsertTicket(ticket);
   }
 );
@@ -80,14 +80,14 @@ export const appendSessionEvent = asAction(
   async (evt?: Event) => {
     if (!evt) return;
     const payload = (
-      evt as CustomEvent<{ ticket_id: string; event: Record<string, unknown> }>
+      evt as CustomEvent<{ task_id: string; event: Record<string, unknown> }>
     ).detail;
     if (!payload) return;
 
     const { controller } = bind;
     const c = controller.global;
     const current = c.tickets;
-    const idx = current.findIndex((t) => t.id === payload.ticket_id);
+    const idx = current.findIndex((t) => t.id === payload.task_id);
 
     if (idx < 0) return;
 
@@ -108,7 +108,7 @@ export const initTickets = asAction(
   },
   async (evt?: Event) => {
     if (!evt) return;
-    const tickets = (evt as CustomEvent<TicketData[]>).detail;
+    const tickets = (evt as CustomEvent<TaskData[]>).detail;
     const { controller } = bind;
     controller.global.tickets = tickets;
   }

--- a/packages/bees/web/src/sca/actions/tree/tree-actions.ts
+++ b/packages/bees/web/src/sca/actions/tree/tree-actions.ts
@@ -37,23 +37,20 @@ export const syncAgentSelection = asAction(
 
     // Sync chat to the selected agent.
     if (agentId) {
-      const ticket = controller.global.tickets.find((t) => t.id === agentId);
+      const task = controller.global.tickets.find((t) => t.id === agentId);
 
       // If the agent has a chat thread, activate it.
-      if (ticket?.tags?.includes("chat")) {
+      if (task?.tags?.includes("chat")) {
         controller.chat.activeThreadId = agentId;
         controller.chat.visitedThreadIds.add(agentId);
         controller.chat.pendingChoices = [];
         controller.chat.selectedChoiceIds = [];
 
         // Notify the host about the chat switch.
-        if (
-          ticket.status === "suspended" &&
-          ticket.assignee === "user"
-        ) {
+        if (task.status === "suspended" && task.assignee === "user") {
           services.hostCommunication.send({
             type: "host.chat.switch",
-            payload: { ticket_id: agentId, role: "user" },
+            payload: { task_id: agentId, role: "user" },
           });
         }
       } else {
@@ -63,11 +60,11 @@ export const syncAgentSelection = asAction(
       }
 
       // If the selected agent has a bundle, ensure the iframe gets it.
-      if (ticket?.tags?.includes("bundle")) {
+      if (task?.tags?.includes("bundle")) {
         controller.stage.currentView = agentId;
         // Small delay to let Lit render the iframe element.
         await new Promise((r) => setTimeout(r, 100));
-        await loadBundleAsync(agentId, services, ticket.slug);
+        await loadBundleAsync(agentId, services, task.slug);
       }
     } else {
       controller.chat.activeThreadId = null;

--- a/packages/bees/web/src/sca/controller/subcontrollers/global.ts
+++ b/packages/bees/web/src/sca/controller/subcontrollers/global.ts
@@ -7,7 +7,7 @@
 import { RootController } from "./root-controller.js";
 import type { ToastMessage } from "../../types.js";
 import { field } from "../decorators/field.js";
-import type { TicketData } from "../../../../../common/types.js";
+import type { TaskData } from "../../../../../common/types.js";
 
 export class GlobalController extends RootController {
   constructor() {
@@ -19,6 +19,6 @@ export class GlobalController extends RootController {
     string,
     string
   >();
-  @field({ deep: true }) accessor tickets: TicketData[] = [];
+  @field({ deep: true }) accessor tickets: TaskData[] = [];
   @field() accessor draining = false;
 }

--- a/packages/bees/web/src/sca/utils/agent-tree.ts
+++ b/packages/bees/web/src/sca/utils/agent-tree.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { TicketData } from "../../../../common/types.js";
+import type { TaskData } from "../../../../common/types.js";
 
 export {
   deriveAgentTree,
@@ -16,7 +16,7 @@ export type { AgentTreeNode, AgentPerspectives };
 
 /** A node in the agent tree. */
 interface AgentTreeNode {
-  ticket: TicketData;
+  ticket: TaskData;
   children: AgentTreeNode[];
 }
 
@@ -33,7 +33,7 @@ interface AgentPerspectives {
  * Root nodes are tickets with no `parent_task_id` (or legacy `creator_ticket_id`) (user-initiated).
  * Coordination and internal-only tickets are excluded.
  */
-function deriveAgentTree(tickets: TicketData[]): AgentTreeNode[] {
+function deriveAgentTree(tickets: TaskData[]): AgentTreeNode[] {
   // Filter out coordination tickets and cancelled tickets — they're infrastructure or noise, not active agents.
   const agentTickets = tickets.filter(
     (t) =>
@@ -43,8 +43,8 @@ function deriveAgentTree(tickets: TicketData[]): AgentTreeNode[] {
   );
 
   // Build parent → children index.
-  const childrenOf = new Map<string, TicketData[]>();
-  const roots: TicketData[] = [];
+  const childrenOf = new Map<string, TaskData[]>();
+  const roots: TaskData[] = [];
 
   for (const t of agentTickets) {
     // Fallback for legacy creator_ticket_id
@@ -58,7 +58,7 @@ function deriveAgentTree(tickets: TicketData[]): AgentTreeNode[] {
     }
   }
 
-  function buildNode(ticket: TicketData): AgentTreeNode {
+  function buildNode(ticket: TaskData): AgentTreeNode {
     const children = (childrenOf.get(ticket.id) ?? [])
       .sort((a, b) => (a.created_at ?? "").localeCompare(b.created_at ?? ""))
       .map(buildNode);
@@ -71,10 +71,7 @@ function deriveAgentTree(tickets: TicketData[]): AgentTreeNode[] {
 }
 
 /** Get the direct child agents of a given ticket ID. */
-function deriveChildAgents(
-  tickets: TicketData[],
-  parentId: string
-): TicketData[] {
+function deriveChildAgents(tickets: TaskData[], parentId: string): TaskData[] {
   return tickets.filter(
     (t) =>
       // Fallback for legacy creator_ticket_id
@@ -86,8 +83,8 @@ function deriveChildAgents(
 
 /** Determine which perspectives are present for a given ticket. */
 function derivePerspectives(
-  ticket: TicketData,
-  allTickets: TicketData[]
+  ticket: TaskData,
+  allTickets: TaskData[]
 ): AgentPerspectives {
   const hasChat = ticket.tags?.includes("chat") ?? false;
   const hasBundle = ticket.tags?.includes("bundle") ?? false;
@@ -111,7 +108,7 @@ function derivePerspectives(
  *
  * Guards against cycles with a visited set.
  */
-function deriveAncestorPath(tickets: TicketData[], agentId: string): string[] {
+function deriveAncestorPath(tickets: TaskData[], agentId: string): string[] {
   const byId = new Map(tickets.map((t) => [t.id, t]));
   const path: string[] = [];
   const visited = new Set<string>();

--- a/packages/bees/web/src/shell/components/opal-sidebar.ts
+++ b/packages/bees/web/src/shell/components/opal-sidebar.ts
@@ -12,14 +12,13 @@ import { scaContext } from "../../sca/context/context.js";
 import { type SCA } from "../../sca/sca.js";
 import { sharedStyles } from "./shared.styles.js";
 
-
 import {
   deriveAgentTree,
   derivePerspectives,
   deriveAncestorPath,
   type AgentTreeNode,
 } from "../../sca/utils/agent-tree.js";
-import type { TicketData } from "../../../../common/types.js";
+import type { TaskData } from "../../../../common/types.js";
 
 const styles = css`
   :host {
@@ -248,9 +247,7 @@ export class OpalSidebar extends SignalWatcher(LitElement) {
         <div class="section-title">Agents</div>
         ${tree.length === 0
           ? html`<div class="empty-state">No agents running yet</div>`
-          : tree.map((node) =>
-              this.#renderNode(node, selectedId, tickets)
-            )}
+          : tree.map((node) => this.#renderNode(node, selectedId, tickets))}
       </div>
     `;
   }
@@ -287,14 +284,16 @@ export class OpalSidebar extends SignalWatcher(LitElement) {
   #renderNode(
     node: AgentTreeNode,
     selectedId: string | null,
-    allTickets: TicketData[]
+    allTickets: TaskData[]
   ): TemplateResult | typeof nothing {
     const t = node.ticket;
     const perspectives = derivePerspectives(t, allTickets);
 
     // Hide agents with no interesting perspectives — they're noise.
     const hasAnyPerspective =
-      perspectives.hasChat || perspectives.hasBundle || perspectives.hasSubagents;
+      perspectives.hasChat ||
+      perspectives.hasBundle ||
+      perspectives.hasSubagents;
     if (!hasAnyPerspective) return nothing;
 
     const hasChildren = node.children.length > 0;
@@ -302,9 +301,11 @@ export class OpalSidebar extends SignalWatcher(LitElement) {
 
     const isNewNode = !this.#knownTicketIds.has(t.id);
     const previousStatus = this.#previousStatuses.get(t.id);
-    const statusChanged = previousStatus !== undefined && previousStatus !== t.status;
+    const statusChanged =
+      previousStatus !== undefined && previousStatus !== t.status;
 
-    const title = t.title || t.playbook_id?.replace(/-/g, " ") || t.id.slice(0, 8);
+    const title =
+      t.title || t.playbook_id?.replace(/-/g, " ") || t.id.slice(0, 8);
 
     const nodeRow = html`
       <div
@@ -312,8 +313,12 @@ export class OpalSidebar extends SignalWatcher(LitElement) {
         @click=${() => this.#selectNode(t.id)}
       >
         <span class="expand-toggle ${hasChildren ? "" : "leaf"}"
-          ><svg viewBox="0 0 24 24" fill="currentColor"><path d="M10 6l6 6-6 6z"/></svg></span>
-        <span class="status-dot ${t.status} ${statusChanged ? "pulse" : ""}"></span>
+          ><svg viewBox="0 0 24 24" fill="currentColor">
+            <path d="M10 6l6 6-6 6z" /></svg
+        ></span>
+        <span
+          class="status-dot ${t.status} ${statusChanged ? "pulse" : ""}"
+        ></span>
         <span class="node-title">${title}</span>
         <span class="perspective-icons">
           ${perspectives.hasChat ? "💬" : nothing}
@@ -326,15 +331,16 @@ export class OpalSidebar extends SignalWatcher(LitElement) {
     // Leaf node — no <details> needed.
     if (!hasChildren) {
       return html`
-        <div class="tree-node ${isNewNode ? "new-node" : ""}">
-          ${nodeRow}
-        </div>
+        <div class="tree-node ${isNewNode ? "new-node" : ""}">${nodeRow}</div>
       `;
     }
 
     // Branch node — use <details>/<summary> for native expand/collapse.
     return html`
-      <details class="tree-node ${isNewNode ? "new-node" : ""}" data-agent-id=${t.id}>
+      <details
+        class="tree-node ${isNewNode ? "new-node" : ""}"
+        data-agent-id=${t.id}
+      >
         <summary>${nodeRow}</summary>
         <div class="children">
           ${node.children.map((child) =>

--- a/packages/bees/web/src/shell/components/opal-stage.ts
+++ b/packages/bees/web/src/shell/components/opal-stage.ts
@@ -17,10 +17,7 @@ import {
   deriveAncestorPath,
 } from "../../sca/utils/agent-tree.js";
 
-import {
-  parseAgentHash,
-  updateAgentHash,
-} from "../../sca/utils/agent-hash.js";
+import { parseAgentHash, updateAgentHash } from "../../sca/utils/agent-hash.js";
 import { loadBundleAsync } from "../../sca/utils/load-bundle.js";
 
 import "./opal-timeline.js";
@@ -181,7 +178,7 @@ export class OpalStage extends SignalWatcher(LitElement) {
   updated(changedProperties: Map<string | number | symbol, unknown>) {
     super.updated(changedProperties);
     const iframe = this.renderRoot.querySelector("iframe");
-    
+
     if (iframe && this.sca.controller.stage.currentView !== null) {
       this.sca.services.hostCommunication.connect(iframe);
 
@@ -242,8 +239,7 @@ export class OpalStage extends SignalWatcher(LitElement) {
     if (tabs.length === 0) {
       return html`
         <div class="stage" id="stage">
-          ${breadcrumb}
-          ${this.#renderAgentSummary(ticket)}
+          ${breadcrumb} ${this.#renderAgentSummary(ticket)}
         </div>
       `;
     }
@@ -287,7 +283,7 @@ export class OpalStage extends SignalWatcher(LitElement) {
   }
 
   #renderBreadcrumb(
-    tickets: import("../../../../common/types.js").TicketData[],
+    tickets: import("../../../../common/types.js").TaskData[],
     selectedId: string
   ) {
     const path = deriveAncestorPath(tickets, selectedId);
@@ -323,7 +319,7 @@ export class OpalStage extends SignalWatcher(LitElement) {
 
   #renderTabContent(
     tab: StageTab,
-    ticket: import("../../../../common/types.js").TicketData
+    ticket: import("../../../../common/types.js").TaskData
   ) {
     switch (tab) {
       case "app":
@@ -349,7 +345,7 @@ export class OpalStage extends SignalWatcher(LitElement) {
     }
   }
 
-  #renderAgentSummary(ticket: import("../../../../common/types.js").TicketData) {
+  #renderAgentSummary(ticket: import("../../../../common/types.js").TaskData) {
     const isRunning = ticket.status === "running";
     const title =
       ticket.title ||

--- a/packages/bees/web/src/shell/components/opal-subagent-panel.ts
+++ b/packages/bees/web/src/shell/components/opal-subagent-panel.ts
@@ -12,7 +12,7 @@ import { scaContext } from "../../sca/context/context.js";
 import { type SCA } from "../../sca/sca.js";
 import { sharedStyles } from "./shared.styles.js";
 import { deriveChildAgents } from "../../sca/utils/agent-tree.js";
-import type { TicketData } from "../../../../common/types.js";
+import type { TaskData } from "../../../../common/types.js";
 
 /** Digest tile data written by the digest-tile-writer playbook. */
 interface DigestTileData {
@@ -296,7 +296,7 @@ export class OpalSubagentPanel extends SignalWatcher(LitElement) {
     `;
   }
 
-  #renderCard(child: TicketData) {
+  #renderCard(child: TaskData) {
     const isRunning = child.status === "running";
 
     const icon =
@@ -369,7 +369,7 @@ export class OpalSubagentPanel extends SignalWatcher(LitElement) {
     `;
   }
 
-  async #fetchDigestTiles(children: TicketData[]) {
+  async #fetchDigestTiles(children: TaskData[]) {
     if (this.#fetching || !this.parentTicketId) return;
     this.#fetching = true;
     try {

--- a/packages/bees/web/tests/sca/actions/chat-actions.test.ts
+++ b/packages/bees/web/tests/sca/actions/chat-actions.test.ts
@@ -11,11 +11,9 @@ import * as ChatActions from "../../../src/sca/actions/chat/chat-actions.js";
 import { makeTestController } from "../helpers/mock-controller.js";
 import { makeTestServices } from "../helpers/mock-services.js";
 import type { AppController, AppServices } from "../../../src/sca/types.js";
-import type { TicketData } from "../../../../common/types.js";
+import type { TaskData as TicketData } from "../../../../common/types.js";
 
-function ticket(
-  overrides: Partial<TicketData> & { id: string }
-): TicketData {
+function ticket(overrides: Partial<TicketData> & { id: string }): TicketData {
   return {
     objective: "",
     status: "completed",
@@ -223,16 +221,14 @@ describe("Chat Actions", () => {
         }),
       ];
 
-      await ChatActions.sendChat(
-        new CustomEvent("chat", { detail: "Hello" })
-      );
+      await ChatActions.sendChat(new CustomEvent("chat", { detail: "Hello" }));
 
-      const respondMock = services.api.respond as unknown as ReturnType<
+      const replyMock = services.api.reply as unknown as ReturnType<
         typeof mock.fn
       >;
-      assert.equal(respondMock.mock.calls.length, 1);
-      assert.equal(respondMock.mock.calls[0].arguments[0], "t-1");
-      assert.equal(respondMock.mock.calls[0].arguments[1], "Hello");
+      assert.equal(replyMock.mock.calls.length, 1);
+      assert.equal(replyMock.mock.calls[0].arguments[0], "t-1");
+      assert.equal(replyMock.mock.calls[0].arguments[1], "Hello");
     });
 
     it("appends user message to thread messages immediately", async () => {
@@ -260,14 +256,12 @@ describe("Chat Actions", () => {
     it("does nothing when no active thread", async () => {
       controller.chat.activeThreadId = null;
 
-      await ChatActions.sendChat(
-        new CustomEvent("chat", { detail: "Hello" })
-      );
+      await ChatActions.sendChat(new CustomEvent("chat", { detail: "Hello" }));
 
-      const respondMock = services.api.respond as unknown as ReturnType<
+      const replyMock = services.api.reply as unknown as ReturnType<
         typeof mock.fn
       >;
-      assert.equal(respondMock.mock.calls.length, 0);
+      assert.equal(replyMock.mock.calls.length, 0);
     });
   });
 
@@ -292,13 +286,12 @@ describe("Chat Actions", () => {
         new CustomEvent("choices", { detail: ["c1"] })
       );
 
-      const respondMock = services.api.respond as unknown as ReturnType<
+      const chooseMock = services.api.choose as unknown as ReturnType<
         typeof mock.fn
       >;
-      assert.equal(respondMock.mock.calls.length, 1);
-      assert.equal(respondMock.mock.calls[0].arguments[0], "t-1");
-      assert.equal(respondMock.mock.calls[0].arguments[1], "Option A");
-      assert.deepEqual(respondMock.mock.calls[0].arguments[2], ["c1"]);
+      assert.equal(chooseMock.mock.calls.length, 1);
+      assert.equal(chooseMock.mock.calls[0].arguments[0], "t-1");
+      assert.deepEqual(chooseMock.mock.calls[0].arguments[1], ["c1"]);
     });
 
     it("clears pending choices after sending", async () => {

--- a/packages/bees/web/tests/sca/helpers/mock-services.ts
+++ b/packages/bees/web/tests/sca/helpers/mock-services.ts
@@ -15,7 +15,8 @@ export function makeTestServices(): { services: AppServices } {
         listFiles: mock.fn(async () => []),
         getFile: mock.fn(),
         createTicket: mock.fn(),
-        respond: mock.fn(),
+        reply: mock.fn(),
+        choose: mock.fn(),
         sendEvent: mock.fn(),
       },
       sse: {

--- a/packages/bees/web/tests/sca/utils/agent-tree.test.ts
+++ b/packages/bees/web/tests/sca/utils/agent-tree.test.ts
@@ -13,7 +13,7 @@ import {
   derivePerspectives,
   deriveAncestorPath,
 } from "../../../src/sca/utils/agent-tree.js";
-import type { TicketData } from "../../../../common/types.js";
+import type { TaskData as TicketData } from "../../../../common/types.js";
 
 function ticket(overrides: Partial<TicketData> & { id: string }): TicketData {
   return {


### PR DESCRIPTION
## What
Continued the migration from "ticket" to "task" terminology across the Bees framework, including Python backend files, event names, and TypeScript types. Also fixed related test issues.

## Why
To align with the architectural decision to use "task" instead of "ticket" for consistency across the codebase.

## Changes

### Python Backend (`packages/bees/bees/` and `app/`)
- Renamed local variables and parameters from `ticket` to `task` in `chat.py`, `events.py`, `tasks.py`, `playbook.py`, and `scheduler.py`.
- Renamed event names in `bees.py` (e.g., `ticket_added` -> `task_added`, `ticket_event` -> `task_event`).
- Renamed `"ticket_id"` to `"task_id"` in `server.py` for `session:event` payload.

### Frontend (`packages/bees/web/`)
- Updated `sync-actions.ts` and `chat-actions.ts` to handle `task_id` instead of `ticket_id` for session events.
- Updated `tree-actions.ts` and `entry.ts` to use `task_id` in `host.chat.switch` payload.
- Updated UI components (`opal-stage.ts`, `opal-subagent-panel.ts`) to use `TaskData` instead of `TicketData`.

### Tests
- Fixed `chat-actions.test.ts` to mock `reply` and `choose` instead of `respond` on `BeesAPI`.
- Updated `mock-services.ts` to provide `reply` and `choose` mocks.

## Testing
- Verify compilation of frontend (`packages/bees/web`).
- Run unit tests in `packages/bees/web`.
