### PR TITLE
[bees] Introduce AgentTreeService — tree derivation behind the service line

### DIFF
--- a/packages/bees/web/src/sca/actions/tree/tree-actions.ts
+++ b/packages/bees/web/src/sca/actions/tree/tree-actions.ts
@@ -37,7 +37,7 @@ export const syncAgentSelection = asAction(
 
     // Sync chat to the selected agent.
     if (agentId) {
-      const task = controller.global.tickets.find((t) => t.id === agentId);
+      const task = services.agentTree.ticket(agentId);
 
       // If the agent has a chat thread, activate it.
       if (task?.tags?.includes("chat")) {

--- a/packages/bees/web/src/sca/services/agent-tree-service.ts
+++ b/packages/bees/web/src/sca/services/agent-tree-service.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Signal } from "@lit-labs/signals";
+import type { TaskData } from "../../../../common/types.js";
+import {
+  deriveAgentTree,
+  deriveChildAgents,
+  derivePerspectives,
+  deriveAncestorPath,
+  type AgentTreeNode,
+  type AgentPerspectives,
+} from "../utils/agent-tree.js";
+
+export { AgentTreeService };
+export type { AgentTreeNode, AgentPerspectives };
+
+/**
+ * Owns the agent tree: receives ticket events from the SSE event bus,
+ * maintains an internal ticket store, and derives a cached tree.
+ *
+ * UI components query the tree through this service rather than calling
+ * derivation functions directly. This creates the seam for the future
+ * Agent Projection: when the server sends typed tree data, this service
+ * simply stores it — same interface, different source.
+ */
+class AgentTreeService {
+  #tickets: TaskData[] = [];
+  #tree: AgentTreeNode[] = [];
+
+  /**
+   * Bumped on every ticket change. UI components read this inside
+   * `SignalWatcher` renders to trigger reactive re-renders.
+   */
+  readonly version = new Signal.State(0);
+
+  constructor(bus: EventTarget) {
+    bus.addEventListener("init_tickets", (e) => this.#handleInit(e));
+    bus.addEventListener("agent_added", (e) => this.#handleUpsert(e));
+    bus.addEventListener("agent_updated", (e) => this.#handleUpsert(e));
+  }
+
+  // ── Query Interface ──────────────────────────────────────────
+
+  /** The full derived tree (filtered, sorted). */
+  get tree(): AgentTreeNode[] {
+    return this.#tree;
+  }
+
+  /** Perspectives for a given agent. */
+  perspectives(agentId: string): AgentPerspectives {
+    const ticket = this.ticket(agentId);
+    if (!ticket) return { hasSubagents: false, hasChat: false, hasBundle: false };
+    return derivePerspectives(ticket, this.#tickets);
+  }
+
+  /** Ancestor path from root to agent. */
+  ancestorPath(agentId: string): string[] {
+    return deriveAncestorPath(this.#tickets, agentId);
+  }
+
+  /** Direct children of a given agent (filtered, sorted). */
+  children(parentId: string): TaskData[] {
+    return deriveChildAgents(this.#tickets, parentId);
+  }
+
+  /** Look up a single ticket by ID. */
+  ticket(id: string): TaskData | undefined {
+    return this.#tickets.find((t) => t.id === id);
+  }
+
+  // ── Event Handlers ───────────────────────────────────────────
+
+  #handleInit(e: Event) {
+    const tickets = (e as CustomEvent<TaskData[]>).detail;
+    this.#tickets = tickets;
+    this.#rederive();
+  }
+
+  #handleUpsert(e: Event) {
+    const ticket = (e as CustomEvent<TaskData>).detail;
+    if (!ticket) return;
+
+    const idx = this.#tickets.findIndex((t) => t.id === ticket.id);
+    if (idx >= 0) {
+      const updated = [...this.#tickets];
+      updated[idx] = ticket;
+      this.#tickets = updated;
+    } else {
+      this.#tickets = [ticket, ...this.#tickets];
+    }
+
+    this.#rederive();
+  }
+
+  #rederive() {
+    this.#tree = deriveAgentTree(this.#tickets);
+    this.version.set(this.version.get() + 1);
+  }
+}

--- a/packages/bees/web/src/sca/services/services.ts
+++ b/packages/bees/web/src/sca/services/services.ts
@@ -7,6 +7,7 @@
 import { BeesAPI } from "./api.js";
 import { SSEClient } from "./sse.js";
 import { HostCommunicationService } from "./host-communication.js";
+import { AgentTreeService } from "./agent-tree-service.js";
 
 import { AppServices } from "../types.js";
 
@@ -18,11 +19,13 @@ export function services(): AppServices {
     const api = new BeesAPI();
     const sse = new SSEClient(stateEventBus);
     const hostCommunication = new HostCommunicationService(stateEventBus);
+    const agentTree = new AgentTreeService(stateEventBus);
 
     instance = {
       api,
       sse,
       hostCommunication,
+      agentTree,
       stateEventBus,
     } satisfies AppServices;
   }

--- a/packages/bees/web/src/sca/types.ts
+++ b/packages/bees/web/src/sca/types.ts
@@ -61,11 +61,13 @@ export type FileHandler = (path: string) => Promise<string | null>;
 import { BeesAPI } from "./services/api.js";
 import { SSEClient } from "./services/sse.js";
 import { HostCommunicationService } from "./services/host-communication.js";
+import { AgentTreeService } from "./services/agent-tree-service.js";
 
 export interface AppServices {
   api: BeesAPI;
   sse: SSEClient;
   hostCommunication: HostCommunicationService;
+  agentTree: AgentTreeService;
   stateEventBus: EventTarget;
 }
 

--- a/packages/bees/web/src/shell/components/opal-sidebar.ts
+++ b/packages/bees/web/src/shell/components/opal-sidebar.ts
@@ -12,13 +12,7 @@ import { scaContext } from "../../sca/context/context.js";
 import { type SCA } from "../../sca/sca.js";
 import { sharedStyles } from "./shared.styles.js";
 
-import {
-  deriveAgentTree,
-  derivePerspectives,
-  deriveAncestorPath,
-  type AgentTreeNode,
-} from "../../sca/utils/agent-tree.js";
-import type { TaskData } from "../../../../common/types.js";
+import type { AgentTreeNode } from "../../sca/services/agent-tree-service.js";
 
 const styles = css`
   :host {
@@ -238,8 +232,10 @@ export class OpalSidebar extends SignalWatcher(LitElement) {
   static styles = [sharedStyles, styles];
 
   render() {
-    const tickets = this.sca.controller.global.tickets;
-    const tree = deriveAgentTree(tickets);
+    const agentTree = this.sca.services.agentTree;
+    // Read version signal to trigger reactive re-renders.
+    agentTree.version.get();
+    const tree = agentTree.tree;
     const selectedId = this.sca.controller.agentTree.selectedAgentId;
 
     return html`
@@ -247,21 +243,27 @@ export class OpalSidebar extends SignalWatcher(LitElement) {
         <div class="section-title">Agents</div>
         ${tree.length === 0
           ? html`<div class="empty-state">No agents running yet</div>`
-          : tree.map((node) => this.#renderNode(node, selectedId, tickets))}
+          : tree.map((node) => this.#renderNode(node, selectedId))}
       </div>
     `;
   }
 
   updated() {
-    const tickets = this.sca.controller.global.tickets;
+    const agentTree = this.sca.services.agentTree;
+
+    // Walk the tree to collect visible tickets for status tracking.
+    const collectTickets = (nodes: AgentTreeNode[]): AgentTreeNode[] =>
+      nodes.flatMap((n) => [n, ...collectTickets(n.children)]);
+    const allNodes = collectTickets(agentTree.tree);
 
     // Detect newly running agents and auto-expand their ancestor path.
-    for (const ticket of tickets) {
+    for (const node of allNodes) {
+      const ticket = node.ticket;
       const isRunning = ticket.status === "running";
       const isNew = !this.#knownTicketIds.has(ticket.id);
 
       if ((isNew || isRunning) && ticket.creator_ticket_id) {
-        const ancestorPath = deriveAncestorPath(tickets, ticket.id);
+        const ancestorPath = agentTree.ancestorPath(ticket.id);
         // Set `open` on all ancestor <details> elements.
         for (const ancestorId of ancestorPath) {
           const details = this.renderRoot.querySelector(
@@ -275,19 +277,18 @@ export class OpalSidebar extends SignalWatcher(LitElement) {
     }
 
     // Update status tracking for pulse detection, and track new tickets.
-    for (const ticket of tickets) {
-      this.#previousStatuses.set(ticket.id, ticket.status);
-      this.#knownTicketIds.add(ticket.id);
+    for (const node of allNodes) {
+      this.#previousStatuses.set(node.ticket.id, node.ticket.status);
+      this.#knownTicketIds.add(node.ticket.id);
     }
   }
 
   #renderNode(
     node: AgentTreeNode,
-    selectedId: string | null,
-    allTickets: TaskData[]
+    selectedId: string | null
   ): TemplateResult | typeof nothing {
     const t = node.ticket;
-    const perspectives = derivePerspectives(t, allTickets);
+    const perspectives = this.sca.services.agentTree.perspectives(t.id);
 
     // Hide agents with no interesting perspectives — they're noise.
     const hasAnyPerspective =
@@ -344,7 +345,7 @@ export class OpalSidebar extends SignalWatcher(LitElement) {
         <summary>${nodeRow}</summary>
         <div class="children">
           ${node.children.map((child) =>
-            this.#renderNode(child, selectedId, allTickets)
+            this.#renderNode(child, selectedId)
           )}
         </div>
       </details>

--- a/packages/bees/web/src/shell/components/opal-stage.ts
+++ b/packages/bees/web/src/shell/components/opal-stage.ts
@@ -12,10 +12,7 @@ import { scaContext } from "../../sca/context/context.js";
 import { type SCA } from "../../sca/sca.js";
 import { sharedStyles } from "./shared.styles.js";
 import { styles as baseStyles } from "./opal-stage.styles.js";
-import {
-  derivePerspectives,
-  deriveAncestorPath,
-} from "../../sca/utils/agent-tree.js";
+
 
 import { parseAgentHash, updateAgentHash } from "../../sca/utils/agent-hash.js";
 import { loadBundleAsync } from "../../sca/utils/load-bundle.js";
@@ -185,9 +182,7 @@ export class OpalStage extends SignalWatcher(LitElement) {
       if (changedProperties.has("activeTab") && this.activeTab === "app") {
         const selectedId = this.sca.controller.agentTree.selectedAgentId;
         if (selectedId) {
-          const ticket = this.sca.controller.global.tickets.find(
-            (t) => t.id === selectedId
-          );
+          const ticket = this.sca.services.agentTree.ticket(selectedId);
           loadBundleAsync(selectedId, this.sca.services, ticket?.slug);
         }
       }
@@ -196,6 +191,9 @@ export class OpalStage extends SignalWatcher(LitElement) {
 
   render() {
     const selectedId = this.sca.controller.agentTree.selectedAgentId;
+    const agentTree = this.sca.services.agentTree;
+    // Read version signal to trigger reactive re-renders.
+    agentTree.version.get();
 
     // No agent selected — fall back to the legacy stage behavior.
     if (!selectedId) {
@@ -203,15 +201,14 @@ export class OpalStage extends SignalWatcher(LitElement) {
       return this.#renderLegacyStage();
     }
 
-    const tickets = this.sca.controller.global.tickets;
-    const ticket = tickets.find((t) => t.id === selectedId);
+    const ticket = agentTree.ticket(selectedId);
     if (!ticket) {
       // Orphan: selected agent no longer exists — clear selection.
       this.sca.controller.agentTree.selectedAgentId = null;
       return this.#renderLegacyStage();
     }
 
-    const perspectives = derivePerspectives(ticket, tickets);
+    const perspectives = agentTree.perspectives(selectedId);
     const tabs: { id: StageTab; label: string }[] = [];
 
     if (perspectives.hasBundle) tabs.push({ id: "app", label: "App" });
@@ -233,7 +230,7 @@ export class OpalStage extends SignalWatcher(LitElement) {
       this.activeTab = tabs[0].id;
     }
 
-    const breadcrumb = this.#renderBreadcrumb(tickets, selectedId);
+    const breadcrumb = this.#renderBreadcrumb(selectedId);
 
     // No tabs at all — show agent summary.
     if (tabs.length === 0) {
@@ -282,17 +279,15 @@ export class OpalStage extends SignalWatcher(LitElement) {
     `;
   }
 
-  #renderBreadcrumb(
-    tickets: import("../../../../common/types.js").TaskData[],
-    selectedId: string
-  ) {
-    const path = deriveAncestorPath(tickets, selectedId);
+  #renderBreadcrumb(selectedId: string) {
+    const agentTree = this.sca.services.agentTree;
+    const path = agentTree.ancestorPath(selectedId);
     if (path.length <= 1) return nothing;
 
     return html`
       <nav class="breadcrumb" aria-label="Agent path">
         ${path.map((id, i) => {
-          const t = tickets.find((t) => t.id === id);
+          const t = agentTree.ticket(id);
           const label =
             t?.title || t?.playbook_id?.replace(/-/g, " ") || id.slice(0, 8);
           const isCurrent = i === path.length - 1;
@@ -378,8 +373,7 @@ export class OpalStage extends SignalWatcher(LitElement) {
     const currentView = this.sca.controller.stage.currentView;
     const isBundle =
       currentView !== null &&
-      this.sca.controller.global.tickets
-        .find((t) => t.id === currentView)
+      this.sca.services.agentTree.ticket(currentView)
         ?.tags?.includes("bundle");
 
     return html`

--- a/packages/bees/web/src/shell/components/opal-subagent-panel.ts
+++ b/packages/bees/web/src/shell/components/opal-subagent-panel.ts
@@ -11,7 +11,6 @@ import { consume } from "@lit/context";
 import { scaContext } from "../../sca/context/context.js";
 import { type SCA } from "../../sca/sca.js";
 import { sharedStyles } from "./shared.styles.js";
-import { deriveChildAgents } from "../../sca/utils/agent-tree.js";
 import type { TaskData } from "../../../../common/types.js";
 
 /** Digest tile data written by the digest-tile-writer playbook. */
@@ -266,8 +265,11 @@ export class OpalSubagentPanel extends SignalWatcher(LitElement) {
       </div>`;
     }
 
+    const agentTree = this.sca.services.agentTree;
+    // Read version signal to trigger reactive re-renders.
+    agentTree.version.get();
     const tickets = this.sca.controller.global.tickets;
-    const children = deriveChildAgents(tickets, this.parentTicketId).sort(
+    const children = agentTree.children(this.parentTicketId).sort(
       (a, b) => (a.created_at ?? "").localeCompare(b.created_at ?? "")
     );
 


### PR DESCRIPTION
## What
Introduces `AgentTreeService`, a service that owns agent tree data by listening to SSE events directly, maintaining its own ticket store, and caching the derived tree. UI components now query the service instead of calling derivation functions inline.

## Why
Preparation for [Agent Projection](packages/bees/docs/agent-projection.md): moving tree derivation server-side. By placing the derivation behind a service boundary now, the future migration becomes a backend change — swap the service's internal implementation from local derivation to consuming server-sent typed data, same interface for all consumers.

## Changes

### New
- **`agent-tree-service.ts`** — Service that listens to `stateEventBus` for `init_tickets`, `agent_added`, `agent_updated` events. Maintains internal ticket store, derives cached tree, exposes query methods (`tree`, `perspectives()`, `ancestorPath()`, `children()`, `ticket()`). Drives reactivity via a `version` signal.

### Wiring
- **`types.ts`** — Added `agentTree: AgentTreeService` to `AppServices`
- **`services.ts`** — Construct service with `stateEventBus`

### UI Migration
- **`opal-sidebar.ts`** — Replaced `deriveAgentTree`, `derivePerspectives`, `deriveAncestorPath` imports → `services.agentTree.*`. Removed `TaskData` import and `allTickets` parameter threading.
- **`opal-stage.ts`** — Replaced `derivePerspectives`, `deriveAncestorPath`, `tickets.find()` → `services.agentTree.*`. Simplified `#renderBreadcrumb` signature.
- **`opal-subagent-panel.ts`** — Replaced `deriveChildAgents` → `services.agentTree.children()`
- **`tree-actions.ts`** — Replaced `controller.global.tickets.find()` → `services.agentTree.ticket()`

### Deleted
- **`api-surface.md`** — Obsolete doc (prior commit on branch)

## Testing
- Run `npm run dev -w packages/bees` and verify sidebar tree, stage breadcrumb, subagent panel, and agent selection all work identically to before.
