### PR TITLE
[bees] MCP Server Integration

### DIFF
--- a/packages/bees/AGENTS.md
+++ b/packages/bees/AGENTS.md
@@ -57,6 +57,9 @@ packages/bees/
   frontmatter.
 - **Function groups** are the extensibility seam for the session layer. Each
   group bundles declarations, handlers, and a system prompt fragment.
+- **MCP servers** are external tool providers registered in `SYSTEM.yaml`. Each
+  MCP server becomes a function group that agents access via the `functions`
+  filter (e.g., `weather.*`). See `bees/functions/mcp_bridge.py`.
 - **The Hive** is the on-disk directory that holds all configuration and runtime
   state.
 

--- a/packages/bees/bees/bees.py
+++ b/packages/bees/bees/bees.py
@@ -54,6 +54,7 @@ class Bees:
 
     async def shutdown(self):
         """Stops the scheduler loop and cleans up."""
+        await self._scheduler.shutdown()
         if self._loop_task:
             self._loop_task.cancel()
             try:

--- a/packages/bees/bees/functions/mcp_bridge.py
+++ b/packages/bees/bees/functions/mcp_bridge.py
@@ -1,0 +1,384 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""MCP bridge — turns external MCP servers into bees function groups.
+
+Each MCP server registered in ``SYSTEM.yaml`` becomes a function group
+that agents can use via the existing ``functions`` filter.  For example,
+a server named ``weather`` with tool ``get_forecast`` becomes the
+function group ``weather`` containing ``weather_get_forecast``.
+
+Lifecycle:
+- ``MCPRegistry.connect_all()`` at scheduler startup
+- ``MCPRegistry.get_factories()`` for each session
+- ``MCPRegistry.disconnect_all()`` at scheduler shutdown
+
+Connections are shared across agent sessions.  MCP uses JSON-RPC with
+unique request IDs, so concurrent tool calls from parallel agents are
+multiplexed correctly.
+
+.. note::
+   Stateful MCP servers that assume sequential usage may behave
+   unexpectedly in a parallel swarm.  TODO: add a ``stateful`` flag
+   that forces per-agent connections.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from contextlib import AsyncExitStack
+from dataclasses import dataclass, field
+from typing import Any
+
+from opal_backend.function_definition import (
+    FunctionGroup,
+    FunctionGroupFactory,
+    FunctionDefinition,
+    SessionHooks,
+)
+
+logger = logging.getLogger(__name__)
+
+_BUILTIN_GROUP_NAMES = frozenset({
+    "system", "chat", "simple-files", "sandbox",
+    "events", "tasks", "skills", "generate",
+})
+
+
+# ---------------------------------------------------------------------------
+# Environment variable expansion
+# ---------------------------------------------------------------------------
+
+_ENV_VAR_PATTERN = re.compile(r"\$\{([^}]+)\}")
+
+
+def _expand_env_values(
+    mapping: dict[str, str] | None,
+) -> dict[str, str] | None:
+    """Expand ``${VAR}`` references in a dict's values.
+
+    Reads from ``os.environ``.  Missing variables expand to the empty
+    string and log a warning.
+    """
+    if not mapping:
+        return mapping
+
+    def _replace(match: re.Match) -> str:
+        var = match.group(1)
+        value = os.environ.get(var)
+        if value is None:
+            logger.warning(
+                "Environment variable '%s' not set (referenced in MCP config)",
+                var,
+            )
+            return ""
+        return value
+
+    return {
+        key: _ENV_VAR_PATTERN.sub(_replace, val)
+        for key, val in mapping.items()
+    }
+
+
+# ---------------------------------------------------------------------------
+# MCP connection
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MCPConnection:
+    """A live connection to a single MCP server."""
+
+    name: str
+    description: str
+    tools: list[dict[str, Any]]
+    session: Any  # mcp.ClientSession
+
+
+# ---------------------------------------------------------------------------
+# Schema translation
+# ---------------------------------------------------------------------------
+
+
+def _mcp_tool_to_declaration(
+    server_name: str, tool: dict[str, Any],
+) -> dict[str, Any]:
+    """Translate an MCP tool definition to a Gemini function declaration.
+
+    The function name is prefixed with the server name to avoid
+    cross-server collisions: MCP tool ``get_forecast`` on server
+    ``weather`` becomes ``weather_get_forecast``.
+    """
+    prefixed_name = f"{server_name}_{tool['name']}"
+    decl: dict[str, Any] = {
+        "name": prefixed_name,
+        "description": tool.get("description", ""),
+    }
+    input_schema = tool.get("inputSchema")
+    if input_schema:
+        decl["parametersJsonSchema"] = input_schema
+    return decl
+
+
+def _make_proxy_handler(
+    session: Any, tool_name: str, server_name: str,
+):
+    """Create an async handler that proxies a tool call to the MCP server."""
+
+    async def handler(args: dict[str, Any], status_cb: Any) -> dict[str, Any]:
+        prefixed = f"{server_name}_{tool_name}"
+        if status_cb:
+            status_cb(f"Calling {prefixed}")
+
+        try:
+            result = await session.call_tool(tool_name, arguments=args)
+        except Exception as exc:
+            logger.error(
+                "MCP tool call failed: %s on %s: %s",
+                tool_name, server_name, exc,
+            )
+            if status_cb:
+                status_cb(None, None)
+            return {"error": f"MCP tool call failed: {exc}"}
+
+        if status_cb:
+            status_cb(None, None)
+
+        # Flatten MCP content array into a result dict.
+        texts = []
+        for item in (result.content or []):
+            if hasattr(item, "text"):
+                texts.append(item.text)
+            elif hasattr(item, "type") and item.type == "text":
+                texts.append(getattr(item, "text", ""))
+
+        if result.isError:
+            return {"error": "\n".join(texts) if texts else "MCP tool returned error"}
+
+        return {"result": "\n".join(texts) if texts else "(no output)"}
+
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# Factory construction
+# ---------------------------------------------------------------------------
+
+
+def _build_function_group(conn: MCPConnection) -> FunctionGroup:
+    """Build a FunctionGroup from a live MCP connection."""
+    definitions: list[FunctionDefinition] = []
+    declarations: list[dict[str, Any]] = []
+
+    for tool in conn.tools:
+        decl = _mcp_tool_to_declaration(conn.name, tool)
+        declarations.append(decl)
+
+        func_def = FunctionDefinition(
+            name=decl["name"],
+            description=decl.get("description", ""),
+            handler=_make_proxy_handler(
+                conn.session, tool["name"], conn.name,
+            ),
+            parameters_json_schema=decl.get("parametersJsonSchema"),
+        )
+        definitions.append(func_def)
+
+    instruction = (
+        f"## {conn.name}\n\n{conn.description}"
+        if conn.description
+        else None
+    )
+
+    return FunctionGroup(
+        name=conn.name,
+        definitions=[(d.name, d) for d in definitions],
+        declarations=declarations,
+        instruction=instruction,
+    )
+
+
+def _mcp_function_group_factory(conn: MCPConnection) -> FunctionGroupFactory:
+    """Return a factory that builds the function group for an MCP server.
+
+    The factory is called once per session with ``SessionHooks``.
+    MCP function groups don't use session hooks (they proxy to the
+    external server), so the hooks argument is ignored.
+    """
+    # Build once — the group is stateless (shared connection).
+    group = _build_function_group(conn)
+
+    def factory(hooks: SessionHooks) -> FunctionGroup:
+        return group
+
+    return factory
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class MCPRegistry:
+    """Manages the lifecycle of all registered MCP server connections.
+
+    Usage::
+
+        registry = MCPRegistry()
+        await registry.connect_all(configs)  # at startup
+        factories = registry.get_factories()  # per session
+        await registry.disconnect_all()       # at shutdown
+    """
+
+    def __init__(self) -> None:
+        self._connections: list[MCPConnection] = []
+        self._factories: list[FunctionGroupFactory] = []
+        self._exit_stack = AsyncExitStack()
+
+    async def connect_all(self, configs: list[dict[str, Any]]) -> None:
+        """Connect to all MCP servers described in the config list.
+
+        Each config dict has:
+        - ``name``: server name (becomes the function group name)
+        - ``description``: optional system instruction fragment
+        - ``command``: shell command for stdio transport
+        - ``url``: URL for Streamable HTTP transport
+        - ``headers``: optional HTTP headers (values support ``${ENV_VAR}``)
+        - ``env``: optional environment variables for stdio (values support
+          ``${ENV_VAR}``)
+
+        Exactly one of ``command`` or ``url`` must be provided.
+        Raises on connection failure (fail-fast at startup).
+        """
+        # Validate all configs before connecting.
+        for config in configs:
+            name = config.get("name", "")
+            if not name:
+                raise ValueError("MCP server config missing 'name'.")
+
+            if name in _BUILTIN_GROUP_NAMES:
+                raise ValueError(
+                    f"MCP server name '{name}' collides with built-in "
+                    f"function group. Choose a different name."
+                )
+
+            has_command = bool(config.get("command"))
+            has_url = bool(config.get("url"))
+            if not has_command and not has_url:
+                raise ValueError(
+                    f"MCP server '{name}' requires either 'command' "
+                    f"(stdio) or 'url' (HTTP)."
+                )
+
+        for config in configs:
+            name = config["name"]
+            url = config.get("url")
+
+            if url:
+                await self._connect_http(config)
+            else:
+                await self._connect_stdio(config)
+
+    async def _connect_stdio(self, config: dict[str, Any]) -> None:
+        """Connect to an MCP server via stdio transport."""
+        from mcp import ClientSession, StdioServerParameters
+        from mcp.client.stdio import stdio_client
+
+        name = config["name"]
+        command = config["command"]
+
+        # Parse command into executable + args.
+        parts = command.split()
+        env = _expand_env_values(config.get("env"))
+
+        server_params = StdioServerParameters(
+            command=parts[0],
+            args=parts[1:] if len(parts) > 1 else [],
+            env=env,
+        )
+
+        logger.info("Connecting to MCP server '%s' (stdio): %s", name, command)
+
+        transport = await self._exit_stack.enter_async_context(
+            stdio_client(server_params)
+        )
+        read_stream, write_stream = transport
+
+        session = await self._exit_stack.enter_async_context(
+            ClientSession(read_stream, write_stream)
+        )
+        await session.initialize()
+        await self._register_connection(config, session)
+
+    async def _connect_http(self, config: dict[str, Any]) -> None:
+        """Connect to an MCP server via Streamable HTTP transport."""
+        import httpx
+        from mcp import ClientSession
+        from mcp.client.streamable_http import streamable_http_client
+
+        name = config["name"]
+        url = config["url"]
+        headers = _expand_env_values(config.get("headers"))
+
+        logger.info("Connecting to MCP server '%s' (HTTP): %s", name, url)
+
+        # Headers are passed via a custom httpx client.
+        http_client = httpx.AsyncClient(headers=headers) if headers else None
+
+        transport = await self._exit_stack.enter_async_context(
+            streamable_http_client(url=url, http_client=http_client)
+        )
+        read_stream, write_stream, _ = transport
+
+        session = await self._exit_stack.enter_async_context(
+            ClientSession(read_stream, write_stream)
+        )
+        await session.initialize()
+        await self._register_connection(config, session)
+
+    async def _register_connection(
+        self, config: dict[str, Any], session: Any,
+    ) -> None:
+        """Discover tools and register the connection."""
+        name = config["name"]
+
+        tools_result = await session.list_tools()
+        tools = [
+            {
+                "name": t.name,
+                "description": getattr(t, "description", ""),
+                "inputSchema": (
+                    t.inputSchema if hasattr(t, "inputSchema")
+                    else {}
+                ),
+            }
+            for t in tools_result.tools
+        ]
+
+        conn = MCPConnection(
+            name=name,
+            description=config.get("description", ""),
+            tools=tools,
+            session=session,
+        )
+        self._connections.append(conn)
+        self._factories.append(_mcp_function_group_factory(conn))
+
+        tool_names = [t["name"] for t in tools]
+        logger.info(
+            "MCP server '%s' connected: %d tools (%s)",
+            name, len(tools), ", ".join(tool_names[:10]),
+        )
+
+    def get_factories(self) -> list[FunctionGroupFactory]:
+        """Return function group factories for all connected MCP servers."""
+        return list(self._factories)
+
+    async def disconnect_all(self) -> None:
+        """Disconnect from all MCP servers and clean up."""
+        logger.info("Disconnecting from %d MCP server(s)", len(self._connections))
+        await self._exit_stack.aclose()
+        self._connections.clear()
+        self._factories.clear()

--- a/packages/bees/bees/scheduler.py
+++ b/packages/bees/bees/scheduler.py
@@ -61,6 +61,7 @@ from bees.session import (
 from bees.ticket import Ticket
 from bees.task_store import TaskStore, _DEP_PATTERN
 from bees.subagent_scope import SubagentScope
+from bees.functions.mcp_bridge import MCPRegistry
 from opal_backend.local.backend_client_impl import HttpBackendClient
 
 logger = logging.getLogger(__name__)
@@ -265,6 +266,7 @@ class Scheduler:
         self._completion_events: dict[str, asyncio.Event] = {}
         self._active_tasks: dict[str, asyncio.Task] = {}
         self._context_queues: dict[str, asyncio.Queue] = {}
+        self._mcp_registry: MCPRegistry | None = None
 
     # -- public API --------------------------------------------------------
 
@@ -275,7 +277,14 @@ class Scheduler:
     async def startup(self) -> Ticket | None:
         """Recover stuck tickets, boot root template if needed, and fire startup hook."""
         tasks = await self.recover_stuck_tickets()
-        
+
+        # Connect to MCP servers declared in SYSTEM.yaml.
+        config = load_system_config(self.store.hive_dir / "config")
+        mcp_configs = config.get("mcp", [])
+        if mcp_configs:
+            self._mcp_registry = MCPRegistry()
+            await self._mcp_registry.connect_all(mcp_configs)
+
         root_task = await self._boot_root_template(tasks)
         if root_task:
             tasks.append(root_task)
@@ -284,6 +293,12 @@ class Scheduler:
             await self._hooks.on_startup(tasks)
             
         return root_task
+
+    async def shutdown(self) -> None:
+        """Clean up MCP connections and other resources."""
+        if self._mcp_registry:
+            await self._mcp_registry.disconnect_all()
+            self._mcp_registry = None
 
     async def create_task(self, objective: str, **kwargs) -> Ticket:
         """Create a new task and notify hooks."""
@@ -626,6 +641,10 @@ class Scheduler:
                 scope=scope,
                 scheduler=self,
                 context_queue=ctx_queue,
+                mcp_factories=(
+                    self._mcp_registry.get_factories()
+                    if self._mcp_registry else None
+                ),
             )
         except Exception as exc:
             ticket.metadata.status = "failed"
@@ -702,6 +721,10 @@ class Scheduler:
                 scope=scope,
                 scheduler=self,
                 context_queue=ctx_queue,
+                mcp_factories=(
+                    self._mcp_registry.get_factories()
+                    if self._mcp_registry else None
+                ),
             )
         except Exception as exc:
             ticket.metadata.status = "failed"

--- a/packages/bees/bees/session.py
+++ b/packages/bees/bees/session.py
@@ -453,6 +453,7 @@ async def run_session(
     scheduler: Any | None = None,
     context_queue: Any | None = None,
     hive_dir: Path | None = None,
+    mcp_factories: list | None = None,
 ) -> SessionResult:
     """Run a single agent session and return the result.
 
@@ -538,7 +539,7 @@ async def run_session(
                 workspace_root_id=workspace_root_id,
                 scheduler=scheduler,
             ),
-        ],
+        ] + (mcp_factories or []),
         function_filter=function_filter,
         model=model,
         file_system=disk_fs,
@@ -639,6 +640,7 @@ async def resume_session(
     scheduler: Any | None = None,
     context_queue: Any | None = None,
     hive_dir: Path | None = None,
+    mcp_factories: list | None = None,
 ) -> SessionResult:
     """Resume a suspended session from saved state on disk.
 
@@ -728,7 +730,7 @@ async def resume_session(
                 workspace_root_id=workspace_root_id,
                 scheduler=scheduler,
             ),
-        ],
+        ] + (mcp_factories or []),
         file_system=disk_fs,
         context_queue=context_queue,
     )

--- a/packages/bees/docs/README.md
+++ b/packages/bees/docs/README.md
@@ -19,6 +19,12 @@
   consume the bees framework. Traces the MVC pattern from architecture through
   REST endpoints, SSE wiring, and the Lit frontend.
 
+## Configuration
+
+- [system-config.md](system-config.md) — The `SYSTEM.yaml` reference: hive
+  identity, root template, and MCP server registration (transports, env var
+  expansion, runtime behavior).
+
 ## Tooling
 
 - [hivetool.md](hivetool.md) — The built-in developer workbench for inspecting

--- a/packages/bees/docs/architecture.md
+++ b/packages/bees/docs/architecture.md
@@ -96,7 +96,7 @@ groups. Each **function group** contains:
 - a system prompt fragment that gets appended to the system prompt when the
   group is enabled.
 
-There are two kinds of function groups:
+There are three kinds of function groups:
 
 - **Built-in functions** — these are considered part of the session layer and
   provide the means for the agent to have some basic utility and to
@@ -104,6 +104,12 @@ There are two kinds of function groups:
 
 - **Custom functions** — these are provided by the session consumer and are used
   to extend the capabilities of the agent.
+
+- **MCP functions** — external tool servers registered in `SYSTEM.yaml`. Each
+  MCP server becomes a function group whose tools agents can call via proxy
+  handlers. MCP tools use the same filter mechanism as built-in groups (e.g.,
+  `weather.*` includes all tools from the `weather` MCP server). Connections are
+  shared across agent sessions. See `bees/functions/mcp_bridge.py`.
 
 The built-in functions are:
 

--- a/packages/bees/docs/system-config.md
+++ b/packages/bees/docs/system-config.md
@@ -1,0 +1,187 @@
+# System Configuration
+
+The file `hive/config/SYSTEM.yaml` is the global configuration for a hive
+instance. It controls the hive's identity, startup behavior, and external tool
+integrations.
+
+## Schema
+
+```yaml
+# Required. Display name for this hive.
+title: My Hive
+
+# Optional. Short summary shown in the UI.
+description: A personal assistant hive
+
+# Required. Template name to auto-boot at startup. The scheduler creates a
+# task from this template if none with a matching playbook_id exists yet.
+root: opie
+
+# Optional. List of MCP server registrations (see below).
+mcp:
+  - name: weather
+    description: Weather data and forecasts
+    command: npx -y @example/weather-mcp
+```
+
+### Fields
+
+| Field         | Type     | Required | Description |
+| ------------- | -------- | -------- | ----------- |
+| `title`       | string   | yes      | Human-readable hive name. |
+| `description` | string   | no       | Short summary for the UI. |
+| `root`        | string   | yes      | Template name for the root agent. |
+| `mcp`         | list     | no       | MCP server registrations. |
+
+---
+
+## MCP servers
+
+The `mcp` section registers external tool providers using the
+[Model Context Protocol](https://modelcontextprotocol.io).
+Each entry becomes a **function group** that agents can access via the
+template `functions` filter — for example, a template with
+`functions: [weather.*]` gets all tools from the `weather` server.
+
+### Transport modes
+
+MCP servers connect via one of two transports. Each server entry must include
+exactly one of `command` or `url`.
+
+#### Local (stdio)
+
+The scheduler spawns the server as a child process and communicates over
+stdin/stdout.
+
+```yaml
+mcp:
+  - name: weather
+    description: Weather data and forecasts
+    command: npx -y @example/weather-mcp
+    env:
+      API_KEY: "${WEATHER_API_KEY}"
+```
+
+#### HTTP (Streamable HTTP)
+
+The scheduler connects to a remote server over HTTP.
+
+```yaml
+mcp:
+  - name: composio
+    description: Composio MCP Server
+    url: https://connect.composio.dev/mcp
+    headers:
+      x-consumer-api-key: "${COMPOSIO_API_KEY}"
+```
+
+### Server entry fields
+
+| Field         | Type              | Required | Description |
+| ------------- | ----------------- | -------- | ----------- |
+| `name`        | string            | yes      | Identifier. Becomes the function group name and the prefix for all tools (e.g., `weather_get_forecast`). Must not collide with built-in group names (`system`, `chat`, `sandbox`, etc.). |
+| `description` | string            | no       | Shown in system instructions when the group is active. |
+| `command`     | string            | one of   | Shell command for stdio transport. The first token is the executable; the rest are arguments. |
+| `url`         | string            | one of   | URL for Streamable HTTP transport. |
+| `headers`     | map\<str, str\>   | no       | HTTP headers sent with every request (HTTP only). |
+| `env`         | map\<str, str\>   | no       | Environment variables set on the child process (stdio only). |
+
+### Environment variable references
+
+Values in `headers` and `env` support `${VAR}` expansion from the host
+process environment. This keeps secrets out of the YAML file:
+
+```yaml
+headers:
+  Authorization: "Bearer ${MY_API_KEY}"
+```
+
+If `MY_API_KEY` is not set, it expands to an empty string and a warning is
+logged at startup.
+
+> **Tip.** Store secrets in a `.env` file at the hive root or in your shell
+> profile. The scheduler reads `os.environ` at connection time.
+
+### How it works at runtime
+
+1. **Startup.** The scheduler reads the `mcp` list and connects to each
+   server (stdio subprocess or HTTP). Connections are validated and opened
+   before the first scheduling cycle. If any connection fails, the
+   scheduler raises and refuses to start.
+
+2. **Tool discovery.** After connecting, the scheduler calls `list_tools()`
+   on each server. Each tool's MCP `inputSchema` is translated to a Gemini
+   `parametersJsonSchema` and its name is prefixed with the server name
+   (e.g., `get_forecast` → `weather_get_forecast`).
+
+3. **Session injection.** The resulting function groups are passed to every
+   agent session. The template's `functions` filter gates which groups each
+   agent can see. The filter supports three tiers:
+
+   | Pattern | Matches | Example |
+   |---|---|---|
+   | `zapier.*` | All tools in the group | every Zapier tool |
+   | `zapier.slack.*` | Tools prefixed `zapier_slack_` | `zapier_slack_send_message`, `zapier_slack_list_channels` |
+   | `zapier.slack.send_message` | Exact tool `zapier_slack_send_message` | just that one |
+
+   The dot in the pattern maps to an underscore in the actual tool name.
+   Sub-namespace wildcards are especially useful for large MCP servers
+   (e.g., Zapier exposes 70+ tools) where pulling in everything would
+   exceed the Gemini API's tool limit:
+
+   ```yaml
+   # Only give this agent Slack and Google Calendar tools:
+   functions:
+     - system.*
+     - chat.*
+     - zapier.slack.*
+     - zapier.google_calendar.*
+   ```
+
+4. **Proxied calls.** When an agent calls an MCP tool, the proxy handler
+   strips the server prefix, forwards the call via the MCP SDK's
+   `call_tool()`, and flattens the JSON-RPC response back into the agent's
+   context.
+
+5. **Shutdown.** On server shutdown (`^C` or API signal), all MCP
+   connections are cleanly closed via `AsyncExitStack`.
+
+### Limitations
+
+- **Stateless only.** All agent sessions share a single connection per
+  server. Servers that maintain per-session state (e.g., browser
+  automation) will not work correctly. A future `stateful: true` flag will
+  create per-agent connections.
+
+- **Text content only.** Binary/image content from MCP tool responses is
+  not yet supported — only `text` content items are forwarded.
+
+- **No resource or prompt support.** Only the MCP `tools` capability is
+  used; `resources` and `prompts` are not surfaced.
+
+### Editing in HiveTool
+
+The HiveTool workbench (System tab) provides a visual editor for MCP server
+entries. The transport chooser (HTTP / Local) toggles which fields are shown,
+and the key-value editors handle headers and environment variables inline.
+
+---
+
+## Full example
+
+```yaml
+title: Opal
+description: Personal assistant
+root: opie
+
+mcp:
+  - name: composio
+    description: Composio MCP Server
+    url: https://connect.composio.dev/mcp
+    headers:
+      x-consumer-api-key: "${COMPOSIO_API_KEY}"
+
+  - name: filesystem
+    description: Local filesystem tools
+    command: npx -y @modelcontextprotocol/server-filesystem /tmp/workspace
+```

--- a/packages/bees/hivetool/src/data/system-store.ts
+++ b/packages/bees/hivetool/src/data/system-store.ts
@@ -17,16 +17,31 @@ import yaml from "js-yaml";
 import type { StateAccess } from "./state-access.js";
 
 export { SystemStore };
-export type { SystemData };
+export type { SystemData, MCPServerConfig };
+
+/** A single MCP server registration in SYSTEM.yaml. */
+interface MCPServerConfig {
+  name: string;
+  description?: string;
+  /** Shell command for stdio transport. */
+  command?: string;
+  /** URL for Streamable HTTP transport. */
+  url?: string;
+  /** HTTP headers (values may contain ${ENV_VAR} references). */
+  headers?: Record<string, string>;
+  /** Environment variables for stdio (values may contain ${ENV_VAR}). */
+  env?: Record<string, string>;
+}
 
 /** The shape of SYSTEM.yaml. */
 interface SystemData {
   title: string;
   description: string;
   root: string;
+  mcp: MCPServerConfig[];
 }
 
-const EMPTY: SystemData = { title: "", description: "", root: "" };
+const EMPTY: SystemData = { title: "", description: "", root: "", mcp: [] };
 
 class SystemStore {
   constructor(private access: StateAccess) {}
@@ -62,10 +77,32 @@ class SystemStore {
       }
 
       const raw = data as Record<string, unknown>;
+      const rawMcp = Array.isArray(raw.mcp) ? raw.mcp : [];
+
       this.config.set({
         title: String(raw.title ?? ""),
         description: String(raw.description ?? ""),
         root: String(raw.root ?? ""),
+        mcp: rawMcp.map((entry: Record<string, unknown>) => ({
+          name: String(entry.name ?? ""),
+          description: entry.description ? String(entry.description) : undefined,
+          command: entry.command ? String(entry.command) : undefined,
+          url: entry.url ? String(entry.url) : undefined,
+          headers: entry.headers && typeof entry.headers === "object"
+            ? Object.fromEntries(
+                Object.entries(entry.headers as Record<string, unknown>).map(
+                  ([k, v]) => [k, String(v)]
+                )
+              )
+            : undefined,
+          env: entry.env && typeof entry.env === "object"
+            ? Object.fromEntries(
+                Object.entries(entry.env as Record<string, unknown>).map(
+                  ([k, v]) => [k, String(v)]
+                )
+              )
+            : undefined,
+        })),
       });
     } catch (e) {
       console.warn("Could not read SYSTEM.yaml:", e);
@@ -91,7 +128,30 @@ class SystemStore {
       "",
     ].join("\n");
 
-    const body = yaml.dump(data, {
+    // Build the serializable object, omitting empty mcp array.
+    const obj: Record<string, unknown> = {
+      title: data.title,
+      description: data.description,
+      root: data.root,
+    };
+
+    if (data.mcp.length > 0) {
+      obj.mcp = data.mcp.map((server) => {
+        const entry: Record<string, unknown> = { name: server.name };
+        if (server.description) entry.description = server.description;
+        if (server.command) entry.command = server.command;
+        if (server.url) entry.url = server.url;
+        if (server.headers && Object.keys(server.headers).length > 0) {
+          entry.headers = server.headers;
+        }
+        if (server.env && Object.keys(server.env).length > 0) {
+          entry.env = server.env;
+        }
+        return entry;
+      });
+    }
+
+    const body = yaml.dump(obj, {
       lineWidth: 80,
       noRefs: true,
       quotingType: '"',

--- a/packages/bees/hivetool/src/ui/system-detail.ts
+++ b/packages/bees/hivetool/src/ui/system-detail.ts
@@ -7,7 +7,7 @@
 /**
  * Detail panel for the hive system configuration.
  *
- * Displays the three SYSTEM.yaml fields (title, description, root) in
+ * Displays the SYSTEM.yaml fields (title, description, root, mcp) in
  * view mode, with inline editing via the editable primitives. Implements
  * the `EditablePanel` interface so `app.ts` can guard tab switches and
  * wire Cmd+S / Escape.
@@ -17,7 +17,11 @@ import { SignalWatcher } from "@lit-labs/signals";
 import { LitElement, html, css, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
-import type { SystemStore, SystemData } from "../data/system-store.js";
+import type {
+  SystemStore,
+  SystemData,
+  MCPServerConfig,
+} from "../data/system-store.js";
 import type { TemplateStore } from "../data/template-store.js";
 import { sharedStyles } from "./shared-styles.js";
 import "./primitives/editable-field.js";
@@ -92,6 +96,261 @@ class BeesSystemDetail extends SignalWatcher(LitElement) {
 
       .root-link:hover {
         color: #93c5fd;
+      }
+
+      /* MCP server cards */
+      .mcp-section-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+      }
+
+      .mcp-card {
+        background: #111318;
+        border: 1px solid #1e293b;
+        border-radius: 8px;
+        padding: 12px 16px;
+        margin-bottom: 8px;
+      }
+
+      .mcp-card-header {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-bottom: 8px;
+      }
+
+      .mcp-name {
+        font-family: "Google Mono", "Roboto Mono", monospace;
+        font-size: 0.85rem;
+        font-weight: 600;
+        color: #a78bfa;
+      }
+
+      .mcp-transport {
+        font-size: 0.6rem;
+        font-weight: 600;
+        padding: 2px 6px;
+        border-radius: 4px;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+
+      .mcp-transport.http {
+        background: #164e6322;
+        color: #38bdf8;
+        border: 1px solid #164e6355;
+      }
+
+      .mcp-transport.stdio {
+        background: #166534aa;
+        color: #86efac;
+        border: 1px solid #16653455;
+      }
+
+      .mcp-url,
+      .mcp-command {
+        font-family: "Google Mono", "Roboto Mono", monospace;
+        font-size: 0.75rem;
+        color: #94a3b8;
+        word-break: break-all;
+      }
+
+      .mcp-desc {
+        font-size: 0.75rem;
+        color: #64748b;
+        margin-bottom: 4px;
+      }
+
+      .kv-table {
+        display: grid;
+        grid-template-columns: auto 1fr;
+        gap: 2px 12px;
+        font-size: 0.7rem;
+        font-family: "Google Mono", "Roboto Mono", monospace;
+        margin-top: 6px;
+      }
+
+      .kv-key {
+        color: #64748b;
+      }
+
+      .kv-value {
+        color: #94a3b8;
+        word-break: break-all;
+      }
+
+      /* MCP edit mode */
+      .mcp-edit-card {
+        background: #0f1115;
+        border: 1px solid #334155;
+        border-radius: 8px;
+        padding: 16px;
+        margin-bottom: 12px;
+        position: relative;
+      }
+
+      .mcp-edit-card-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin-bottom: 12px;
+      }
+
+      .mcp-edit-fields {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      .mcp-edit-row {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 12px;
+      }
+
+      .remove-server-btn,
+      .add-server-btn {
+        padding: 4px 10px;
+        font-size: 0.7rem;
+        background: transparent;
+        border: 1px solid #334155;
+        border-radius: 4px;
+        cursor: pointer;
+        transition: all 0.15s;
+        font-family: inherit;
+      }
+
+      .remove-server-btn {
+        color: #f87171;
+        border-color: #991b1b55;
+      }
+
+      .remove-server-btn:hover {
+        background: #450a0a;
+        border-color: #991b1b;
+      }
+
+      .add-server-btn {
+        color: #a78bfa;
+        border-color: #7c3aed55;
+        align-self: flex-start;
+      }
+
+      .add-server-btn:hover {
+        background: #1e1338;
+        border-color: #7c3aed;
+      }
+
+      .kv-edit-table {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+
+      .kv-edit-row {
+        display: grid;
+        grid-template-columns: 1fr 2fr auto;
+        gap: 6px;
+        align-items: center;
+      }
+
+      .kv-edit-row input {
+        padding: 4px 8px;
+        background: #0b0c0f;
+        border: 1px solid #334155;
+        color: #e2e8f0;
+        border-radius: 4px;
+        font-size: 0.7rem;
+        font-family: "Google Mono", "Roboto Mono", monospace;
+        transition: border-color 0.15s;
+      }
+
+      .kv-edit-row input:focus {
+        outline: none;
+        border-color: #3b82f6;
+      }
+
+      .kv-remove {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 20px;
+        height: 20px;
+        font-size: 0.6rem;
+        color: #64748b;
+        cursor: pointer;
+        border-radius: 50%;
+        transition: color 0.15s, background 0.15s;
+      }
+
+      .kv-remove:hover {
+        color: #f87171;
+        background: #991b1b33;
+      }
+
+      .kv-add-btn {
+        padding: 2px 8px;
+        font-size: 0.65rem;
+        background: transparent;
+        color: #64748b;
+        border: 1px dashed #334155;
+        border-radius: 4px;
+        cursor: pointer;
+        transition: all 0.15s;
+        font-family: inherit;
+        align-self: flex-start;
+        margin-top: 4px;
+      }
+
+      .kv-add-btn:hover {
+        color: #94a3b8;
+        border-color: #64748b;
+      }
+
+      .kv-label {
+        font-size: 0.65rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        color: #64748b;
+        margin-bottom: 4px;
+      }
+
+      .transport-toggle {
+        display: flex;
+        gap: 0;
+        border-radius: 6px;
+        overflow: hidden;
+        border: 1px solid #334155;
+        align-self: flex-start;
+      }
+
+      .transport-toggle button {
+        padding: 4px 14px;
+        font-size: 0.7rem;
+        font-family: inherit;
+        font-weight: 600;
+        background: transparent;
+        color: #64748b;
+        border: none;
+        cursor: pointer;
+        transition: all 0.15s;
+        letter-spacing: 0.03em;
+      }
+
+      .transport-toggle button.active {
+        color: #e2e8f0;
+      }
+
+      .transport-toggle button.active.http {
+        background: #164e6333;
+        color: #38bdf8;
+      }
+
+      .transport-toggle button.active.local {
+        background: #16653422;
+        color: #86efac;
       }
     `,
   ];
@@ -183,7 +442,68 @@ class BeesSystemDetail extends SignalWatcher(LitElement) {
                 : nothing}
             </div>
           </div>
+
+          ${this.renderMCPViewSection(config.mcp)}
         </div>
+      </div>
+    `;
+  }
+
+  // ── MCP View Section ──
+
+  private renderMCPViewSection(servers: MCPServerConfig[]) {
+    return html`
+      <div class="block">
+        <div class="block-header">MCP Servers</div>
+        <div class="block-content">
+          ${servers.length === 0
+            ? html`<span style="color:#475569;font-style:italic">
+                No MCP servers registered
+              </span>`
+            : servers.map((server) => this.renderMCPViewCard(server))}
+        </div>
+      </div>
+    `;
+  }
+
+  private renderMCPViewCard(server: MCPServerConfig) {
+    const isHttp = !!server.url;
+    const kvEntries = server.headers
+      ? Object.entries(server.headers)
+      : server.env
+        ? Object.entries(server.env)
+        : [];
+    const kvLabel = server.headers ? "headers" : server.env ? "env" : "";
+
+    return html`
+      <div class="mcp-card">
+        <div class="mcp-card-header">
+          <span class="mcp-name">${server.name}</span>
+          <span class="mcp-transport ${isHttp ? "http" : "stdio"}">
+            ${isHttp ? "HTTP" : "stdio"}
+          </span>
+        </div>
+        ${server.description
+          ? html`<div class="mcp-desc">${server.description}</div>`
+          : nothing}
+        ${server.url
+          ? html`<div class="mcp-url">${server.url}</div>`
+          : nothing}
+        ${server.command
+          ? html`<div class="mcp-command">${server.command}</div>`
+          : nothing}
+        ${kvEntries.length > 0
+          ? html`
+              <div class="kv-table">
+                ${kvEntries.map(
+                  ([key, value]) => html`
+                    <span class="kv-key">${key}:</span>
+                    <span class="kv-value">${value}</span>
+                  `
+                )}
+              </div>
+            `
+          : nothing}
       </div>
     `;
   }
@@ -266,7 +586,189 @@ class BeesSystemDetail extends SignalWatcher(LitElement) {
                   </div>
                 `
               : nothing}
+
+            <!-- MCP Servers -->
+            <div class="block">
+              <div class="mcp-section-header">
+                <div class="block-header">MCP Servers</div>
+                <button
+                  class="add-server-btn"
+                  @click=${() => this.addMCPServer()}
+                >
+                  + Add Server
+                </button>
+              </div>
+              ${draft.mcp.map((server, i) =>
+                this.renderMCPEditCard(server, i)
+              )}
+            </div>
           </div>
+        </div>
+      </div>
+    `;
+  }
+
+  // ── MCP Edit Card ──
+
+  private renderMCPEditCard(server: MCPServerConfig, index: number) {
+    const isHttp = server.command === undefined;
+
+    return html`
+      <div class="mcp-edit-card">
+        <div class="mcp-edit-card-header">
+          <span class="mcp-name">#${index + 1}</span>
+          <button
+            class="remove-server-btn"
+            @click=${() => this.removeMCPServer(index)}
+          >
+            ✕ Remove
+          </button>
+        </div>
+
+        <div class="mcp-edit-fields">
+          <div class="mcp-edit-row">
+            <bees-editable-field
+              label="Name"
+              .value=${server.name}
+              editing
+              placeholder="server-name"
+              @change=${(e: CustomEvent) =>
+                this.updateMCPServer(index, { name: e.detail.value })}
+            ></bees-editable-field>
+
+            <bees-editable-field
+              label="Description"
+              .value=${server.description ?? ""}
+              editing
+              placeholder="Optional description"
+              @change=${(e: CustomEvent) =>
+                this.updateMCPServer(index, {
+                  description: e.detail.value || undefined,
+                })}
+            ></bees-editable-field>
+          </div>
+
+          <!-- Transport chooser -->
+          <div class="transport-toggle">
+            <button
+              class="http ${isHttp ? "active" : ""}"
+              @click=${() =>
+                this.updateMCPServer(index, {
+                  url: server.url ?? "",
+                  command: undefined,
+                  env: undefined,
+                })}
+            >HTTP</button>
+            <button
+              class="local ${!isHttp ? "active" : ""}"
+              @click=${() =>
+                this.updateMCPServer(index, {
+                  command: server.command ?? "",
+                  url: undefined,
+                  headers: undefined,
+                })}
+            >Local</button>
+          </div>
+
+          ${isHttp
+            ? html`
+                <bees-editable-field
+                  label="URL"
+                  .value=${server.url ?? ""}
+                  editing
+                  placeholder="https://example.com/mcp"
+                  @change=${(e: CustomEvent) =>
+                    this.updateMCPServer(index, {
+                      url: e.detail.value || undefined,
+                    })}
+                ></bees-editable-field>
+
+                ${this.renderKVEditor(
+                  "Headers",
+                  server.headers ?? {},
+                  (headers) => this.updateMCPServer(index, { headers })
+                )}
+              `
+            : html`
+                <bees-editable-field
+                  label="Command"
+                  .value=${server.command ?? ""}
+                  editing
+                  placeholder="npx -y @example/server"
+                  @change=${(e: CustomEvent) =>
+                    this.updateMCPServer(index, {
+                      command: e.detail.value || undefined,
+                    })}
+                ></bees-editable-field>
+
+                ${this.renderKVEditor(
+                  "Environment Variables",
+                  server.env ?? {},
+                  (env) => this.updateMCPServer(index, { env })
+                )}
+              `}
+        </div>
+      </div>
+    `;
+  }
+
+  // ── Key-Value Editor ──
+
+  private renderKVEditor(
+    label: string,
+    entries: Record<string, string>,
+    onChange: (updated: Record<string, string>) => void
+  ) {
+    const pairs = Object.entries(entries);
+
+    return html`
+      <div>
+        <div class="kv-label">${label}</div>
+        <div class="kv-edit-table">
+          ${pairs.map(
+            ([key, value], i) => html`
+              <div class="kv-edit-row">
+                <input
+                  .value=${key}
+                  placeholder="key"
+                  @input=${(e: InputEvent) => {
+                    const newKey = (e.currentTarget as HTMLInputElement).value;
+                    const updated = { ...entries };
+                    delete updated[key];
+                    updated[newKey] = value;
+                    onChange(updated);
+                  }}
+                />
+                <input
+                  .value=${value}
+                  placeholder="value"
+                  @input=${(e: InputEvent) => {
+                    const newVal = (e.currentTarget as HTMLInputElement).value;
+                    const updated = { ...entries, [key]: newVal };
+                    onChange(updated);
+                  }}
+                />
+                <span
+                  class="kv-remove"
+                  @click=${() => {
+                    const updated = { ...entries };
+                    delete updated[key];
+                    onChange(updated);
+                  }}
+                  title="Remove"
+                >✕</span>
+              </div>
+            `
+          )}
+          <button
+            class="kv-add-btn"
+            @click=${() => {
+              const updated = { ...entries, "": "" };
+              onChange(updated);
+            }}
+          >
+            + Add
+          </button>
         </div>
       </div>
     `;
@@ -275,8 +777,8 @@ class BeesSystemDetail extends SignalWatcher(LitElement) {
   // ── Edit actions ──
 
   private startEditing(config: SystemData) {
-    this.#original = { ...config };
-    this.draft = { ...config };
+    this.#original = structuredClone(config);
+    this.draft = structuredClone(config);
     this.editing = true;
     this.error = null;
   }
@@ -308,6 +810,29 @@ class BeesSystemDetail extends SignalWatcher(LitElement) {
     this.draft = { ...this.draft, ...partial };
   }
 
+  private addMCPServer() {
+    if (!this.draft) return;
+    this.draft = {
+      ...this.draft,
+      mcp: [...this.draft.mcp, { name: "" }],
+    };
+  }
+
+  private removeMCPServer(index: number) {
+    if (!this.draft) return;
+    this.draft = {
+      ...this.draft,
+      mcp: this.draft.mcp.filter((_, i) => i !== index),
+    };
+  }
+
+  private updateMCPServer(index: number, partial: Partial<MCPServerConfig>) {
+    if (!this.draft) return;
+    const mcp = [...this.draft.mcp];
+    mcp[index] = { ...mcp[index], ...partial };
+    this.draft = { ...this.draft, mcp };
+  }
+
   private isDirty(): boolean {
     if (!this.draft || !this.#original) return false;
     return JSON.stringify(this.#original) !== JSON.stringify(this.draft);
@@ -325,6 +850,18 @@ class BeesSystemDetail extends SignalWatcher(LitElement) {
       return;
     }
 
+    // Validate MCP servers.
+    for (const server of this.draft.mcp) {
+      if (!server.name.trim()) {
+        this.error = "Each MCP server must have a name.";
+        return;
+      }
+      if (!server.url && !server.command) {
+        this.error = `MCP server "${server.name}" needs either a URL or command.`;
+        return;
+      }
+    }
+
     this.saving = true;
     this.error = null;
 
@@ -335,7 +872,7 @@ class BeesSystemDetail extends SignalWatcher(LitElement) {
       const controls = this.shadowRoot?.querySelector("bees-edit-controls");
       if (controls) (controls as { flashSaved(): void }).flashSaved();
 
-      this.#original = { ...this.draft };
+      this.#original = structuredClone(this.draft);
       this.editing = false;
       this.draft = null;
     } catch (e) {

--- a/packages/bees/pyproject.toml
+++ b/packages/bees/pyproject.toml
@@ -5,6 +5,7 @@ description = "Bees — agent swarm orchestration framework"
 requires-python = ">=3.11"
 dependencies = [
     "httpx>=0.27.0",
+    "mcp>=1.0.0",
     "python-dotenv>=1.0.0",
     "fastapi>=0.115.0",
     "uvicorn>=0.34.0",

--- a/packages/bees/tests/test_mcp_bridge.py
+++ b/packages/bees/tests/test_mcp_bridge.py
@@ -1,0 +1,310 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the MCP bridge module."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bees.functions.mcp_bridge import (
+    MCPConnection,
+    MCPRegistry,
+    _build_function_group,
+    _expand_env_values,
+    _make_proxy_handler,
+    _mcp_tool_to_declaration,
+)
+
+
+# ---------------------------------------------------------------------------
+# Schema translation
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaTranslation:
+    """Test MCP tool → Gemini declaration translation."""
+
+    def test_basic_tool(self):
+        tool = {
+            "name": "get_forecast",
+            "description": "Get weather forecast",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string"},
+                },
+                "required": ["location"],
+            },
+        }
+        decl = _mcp_tool_to_declaration("weather", tool)
+
+        assert decl["name"] == "weather_get_forecast"
+        assert decl["description"] == "Get weather forecast"
+        assert decl["parametersJsonSchema"] == tool["inputSchema"]
+
+    def test_tool_without_schema(self):
+        tool = {
+            "name": "ping",
+            "description": "Health check",
+        }
+        decl = _mcp_tool_to_declaration("myserver", tool)
+
+        assert decl["name"] == "myserver_ping"
+        assert "parametersJsonSchema" not in decl
+
+    def test_tool_without_description(self):
+        tool = {
+            "name": "do_thing",
+            "inputSchema": {"type": "object"},
+        }
+        decl = _mcp_tool_to_declaration("srv", tool)
+
+        assert decl["name"] == "srv_do_thing"
+        assert decl["description"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Proxy handler
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeContent:
+    type: str = "text"
+    text: str = ""
+
+
+@dataclass
+class FakeToolResult:
+    content: list[FakeContent] = field(default_factory=list)
+    isError: bool = False
+
+
+class TestProxyHandler:
+    """Test the proxy handler that calls MCP tools."""
+
+    @pytest.mark.asyncio
+    async def test_successful_call(self):
+        session = AsyncMock()
+        session.call_tool.return_value = FakeToolResult(
+            content=[FakeContent(text="72°F, partly cloudy")],
+        )
+
+        handler = _make_proxy_handler(session, "get_forecast", "weather")
+        result = await handler({"location": "NYC"}, None)
+
+        session.call_tool.assert_called_once_with(
+            "get_forecast", arguments={"location": "NYC"},
+        )
+        assert result == {"result": "72°F, partly cloudy"}
+
+    @pytest.mark.asyncio
+    async def test_multiple_content_items(self):
+        session = AsyncMock()
+        session.call_tool.return_value = FakeToolResult(
+            content=[
+                FakeContent(text="Line 1"),
+                FakeContent(text="Line 2"),
+            ],
+        )
+
+        handler = _make_proxy_handler(session, "multi", "srv")
+        result = await handler({}, None)
+
+        assert result == {"result": "Line 1\nLine 2"}
+
+    @pytest.mark.asyncio
+    async def test_error_result(self):
+        session = AsyncMock()
+        session.call_tool.return_value = FakeToolResult(
+            content=[FakeContent(text="Rate limit exceeded")],
+            isError=True,
+        )
+
+        handler = _make_proxy_handler(session, "fetch", "api")
+        result = await handler({}, None)
+
+        assert "error" in result
+        assert "Rate limit" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_exception_during_call(self):
+        session = AsyncMock()
+        session.call_tool.side_effect = ConnectionError("Server down")
+
+        handler = _make_proxy_handler(session, "call", "broken")
+        result = await handler({}, None)
+
+        assert "error" in result
+        assert "Server down" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_status_callback(self):
+        session = AsyncMock()
+        session.call_tool.return_value = FakeToolResult(
+            content=[FakeContent(text="ok")],
+        )
+        status_cb = MagicMock()
+
+        handler = _make_proxy_handler(session, "tool", "srv")
+        await handler({}, status_cb)
+
+        # Called with status message, then cleared.
+        assert status_cb.call_count == 2
+        status_cb.assert_any_call("Calling srv_tool")
+        status_cb.assert_any_call(None, None)
+
+    @pytest.mark.asyncio
+    async def test_empty_content(self):
+        session = AsyncMock()
+        session.call_tool.return_value = FakeToolResult(content=[])
+
+        handler = _make_proxy_handler(session, "quiet", "srv")
+        result = await handler({}, None)
+
+        assert result == {"result": "(no output)"}
+
+
+# ---------------------------------------------------------------------------
+# Function group construction
+# ---------------------------------------------------------------------------
+
+
+class TestFunctionGroup:
+    """Test building a FunctionGroup from an MCPConnection."""
+
+    def test_group_name(self):
+        conn = MCPConnection(
+            name="weather",
+            description="Weather tools",
+            tools=[
+                {
+                    "name": "get_forecast",
+                    "description": "Forecast",
+                    "inputSchema": {"type": "object"},
+                },
+            ],
+            session=MagicMock(),
+        )
+        group = _build_function_group(conn)
+
+        assert group.name == "weather"
+
+    def test_instruction_from_description(self):
+        conn = MCPConnection(
+            name="weather",
+            description="Weather data and forecasts",
+            tools=[],
+            session=MagicMock(),
+        )
+        group = _build_function_group(conn)
+
+        assert group.instruction == "## weather\n\nWeather data and forecasts"
+
+    def test_no_instruction_when_no_description(self):
+        conn = MCPConnection(
+            name="weather",
+            description="",
+            tools=[],
+            session=MagicMock(),
+        )
+        group = _build_function_group(conn)
+
+        assert group.instruction is None
+
+    def test_declarations_match_tools(self):
+        conn = MCPConnection(
+            name="srv",
+            description="",
+            tools=[
+                {"name": "a", "description": "Tool A", "inputSchema": {}},
+                {"name": "b", "description": "Tool B"},
+            ],
+            session=MagicMock(),
+        )
+        group = _build_function_group(conn)
+
+        names = [d["name"] for d in group.declarations]
+        assert names == ["srv_a", "srv_b"]
+
+    def test_definitions_have_handlers(self):
+        conn = MCPConnection(
+            name="srv",
+            description="",
+            tools=[
+                {"name": "a", "description": "Tool A"},
+            ],
+            session=MagicMock(),
+        )
+        group = _build_function_group(conn)
+
+        assert len(group.definitions) == 1
+        name, func_def = group.definitions[0]
+        assert name == "srv_a"
+        assert callable(func_def.handler)
+
+
+# ---------------------------------------------------------------------------
+# Environment variable expansion
+# ---------------------------------------------------------------------------
+
+
+class TestEnvExpansion:
+    """Test ${VAR} expansion in config values."""
+
+    def test_expand_env_var(self, monkeypatch):
+        monkeypatch.setenv("MY_KEY", "secret123")
+        result = _expand_env_values({"Authorization": "Bearer ${MY_KEY}"})
+        assert result == {"Authorization": "Bearer secret123"}
+
+    def test_missing_env_var_becomes_empty(self, monkeypatch):
+        monkeypatch.delenv("MISSING_VAR", raising=False)
+        result = _expand_env_values({"key": "${MISSING_VAR}"})
+        assert result == {"key": ""}
+
+    def test_none_passthrough(self):
+        assert _expand_env_values(None) is None
+
+    def test_no_vars_passthrough(self):
+        result = _expand_env_values({"key": "plain-value"})
+        assert result == {"key": "plain-value"}
+
+    def test_multiple_vars_in_one_value(self, monkeypatch):
+        monkeypatch.setenv("A", "hello")
+        monkeypatch.setenv("B", "world")
+        result = _expand_env_values({"msg": "${A} ${B}"})
+        assert result == {"msg": "hello world"}
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    """Test MCPRegistry validation."""
+
+    @pytest.mark.asyncio
+    async def test_builtin_collision_raises(self):
+        """Registering a server with a built-in group name must fail."""
+        registry = MCPRegistry()
+        configs = [{"name": "system", "command": "echo"}]
+
+        with pytest.raises(ValueError, match="collides with built-in"):
+            await registry.connect_all(configs)
+
+    @pytest.mark.asyncio
+    async def test_missing_transport_raises(self):
+        """Registering a server without command or url must fail."""
+        registry = MCPRegistry()
+        configs = [{"name": "myserver"}]
+
+        with pytest.raises(ValueError, match="requires either"):
+            await registry.connect_all(configs)
+
+

--- a/packages/opal-backend/opal_backend/run.py
+++ b/packages/opal-backend/opal_backend/run.py
@@ -667,11 +667,16 @@ def _apply_function_filter(
     """Filter function groups using dot-notation patterns.
 
     Each pattern is one of:
-    - ``"group.*"`` — include all functions in the named group
-    - ``"group.function_name"`` — include a single function (the dot
-      translates to underscore for matching against the flat function
+
+    - ``"group.*"`` — include all functions in the named group.
+    - ``"group.sub.*"`` — include functions whose name starts with
+      ``group_sub_`` (hierarchical wildcard). This lets MCP servers
+      expose sub-namespaces: ``zapier.google_calendar.*`` matches
+      ``zapier_google_calendar_create_event`` etc.
+    - ``"group.function_name"`` — include a single function (dots
+      translate to underscores for matching against the flat function
       name convention, e.g. ``"system.objective_fulfilled"`` matches
-      ``system_objective_fulfilled``)
+      ``system_objective_fulfilled``).
 
     Groups whose name is ``None`` (unnamed) are always passed through
     unfiltered. Groups with no surviving functions are dropped.
@@ -680,12 +685,29 @@ def _apply_function_filter(
     """
     from .function_definition import FunctionGroup
 
-    # Pre-process patterns into (group, function_suffix | None) pairs.
-    wildcard_groups: set[str] = set()
+    # Pre-process patterns into three buckets:
+    #   1. Full-group wildcards:  "system.*"  → include entire group
+    #   2. Prefix wildcards:     "zapier.slack.*" → include tools with
+    #      name prefix "zapier_slack_" within the "zapier" group
+    #   3. Exact functions:      "system.list_dir" → "system_list_dir"
+    full_group_wildcards: set[str] = set()
+    # Maps group name → set of name prefixes (including trailing _).
+    prefix_wildcards: dict[str, set[str]] = {}
     specific_functions: set[str] = set()
+
     for pattern in patterns:
         if pattern.endswith(".*"):
-            wildcard_groups.add(pattern[:-2])
+            stem = pattern[:-2]  # e.g. "zapier.slack"
+            first_dot = stem.find(".")
+            if first_dot == -1:
+                # Simple: "group.*"
+                full_group_wildcards.add(stem)
+            else:
+                # Hierarchical: "zapier.slack.*" → group "zapier",
+                # prefix "zapier_slack_"
+                group_name = stem[:first_dot]
+                prefix = stem.replace(".", "_") + "_"
+                prefix_wildcards.setdefault(group_name, set()).add(prefix)
         else:
             # "group.func" → "group_func"
             specific_functions.add(pattern.replace(".", "_"))
@@ -697,20 +719,32 @@ def _apply_function_filter(
             filtered.append(group)
             continue
 
-        if group.name in wildcard_groups:
+        if group.name in full_group_wildcards:
             # Entire group is included.
             filtered.append(group)
             continue
 
-        # Check individual functions.
-        kept_definitions = [
-            (name, defn) for name, defn in group.definitions
-            if name in specific_functions
-        ]
-        kept_declarations = [
-            decl for decl in group.declarations
-            if decl.get("name") in specific_functions
-        ]
+        # Check for prefix wildcards targeting this group.
+        prefixes = prefix_wildcards.get(group.name)
+
+        # Collect individual functions by prefix match or exact name.
+        kept_definitions = []
+        kept_declarations = []
+
+        for name, defn in group.definitions:
+            if name in specific_functions:
+                kept_definitions.append((name, defn))
+            elif prefixes and any(name.startswith(p) for p in prefixes):
+                kept_definitions.append((name, defn))
+
+        for decl in group.declarations:
+            decl_name = decl.get("name")
+            if decl_name in specific_functions:
+                kept_declarations.append(decl)
+            elif prefixes and any(
+                decl_name.startswith(p) for p in prefixes
+            ):
+                kept_declarations.append(decl)
 
         if kept_definitions:
             filtered.append(FunctionGroup(

--- a/packages/opal-backend/tests/test_run.py
+++ b/packages/opal-backend/tests/test_run.py
@@ -870,6 +870,76 @@ class TestApplyFunctionFilter:
         assert None in group_names
         assert "system" in group_names
 
+    def test_hierarchical_wildcard_filters_by_prefix(self):
+        """'zapier.slack.*' includes only zapier_slack_* tools."""
+        zapier = self._make_group("zapier", [
+            "zapier_slack_send_message",
+            "zapier_slack_list_channels",
+            "zapier_google_calendar_create_event",
+            "zapier_gmail_find_email",
+        ])
+
+        result = _apply_function_filter([zapier], ["zapier.slack.*"])
+
+        assert len(result) == 1
+        names = [n for n, _ in result[0].definitions]
+        assert "zapier_slack_send_message" in names
+        assert "zapier_slack_list_channels" in names
+        assert "zapier_google_calendar_create_event" not in names
+        assert "zapier_gmail_find_email" not in names
+
+    def test_multiple_hierarchical_wildcards(self):
+        """Multiple prefix wildcards on the same group compose correctly."""
+        zapier = self._make_group("zapier", [
+            "zapier_slack_send_message",
+            "zapier_google_calendar_create_event",
+            "zapier_gmail_find_email",
+        ])
+
+        result = _apply_function_filter(
+            [zapier], ["zapier.slack.*", "zapier.gmail.*"]
+        )
+
+        assert len(result) == 1
+        names = [n for n, _ in result[0].definitions]
+        assert "zapier_slack_send_message" in names
+        assert "zapier_gmail_find_email" in names
+        assert "zapier_google_calendar_create_event" not in names
+
+    def test_full_wildcard_beats_prefix(self):
+        """'zapier.*' includes everything, even if prefix patterns also match."""
+        zapier = self._make_group("zapier", [
+            "zapier_slack_send_message",
+            "zapier_google_calendar_create_event",
+        ])
+
+        result = _apply_function_filter(
+            [zapier], ["zapier.*", "zapier.slack.*"]
+        )
+
+        assert len(result) == 1
+        names = [n for n, _ in result[0].definitions]
+        assert len(names) == 2
+
+    def test_prefix_and_exact_combined(self):
+        """Prefix wildcard and exact match can coexist."""
+        zapier = self._make_group("zapier", [
+            "zapier_slack_send_message",
+            "zapier_gmail_find_email",
+            "zapier_google_calendar_create_event",
+        ])
+
+        result = _apply_function_filter(
+            [zapier],
+            ["zapier.slack.*", "zapier.google_calendar.create_event"],
+        )
+
+        assert len(result) == 1
+        names = [n for n, _ in result[0].definitions]
+        assert "zapier_slack_send_message" in names
+        assert "zapier_google_calendar_create_event" in names
+        assert "zapier_gmail_find_email" not in names
+
 
 class TestProcessChatResponse:
     """Tests for _process_chat_response."""


### PR DESCRIPTION
## What

Registers external MCP (Model Context Protocol) servers in `SYSTEM.yaml` and exposes their tools to agents as first-class function groups. Adds hierarchical sub-namespace filtering so templates can cherry-pick tools from large MCP servers without exceeding Gemini's tool limit.

## Why

Agents need access to external tool ecosystems (Zapier, Composio, filesystem servers) without per-provider integration code. MCP provides the protocol; this PR wires it into the existing function group and `functions` filter infrastructure. The sub-namespace filter (`zapier.slack.*`) was needed because Zapier alone exposes 70+ tools, which causes Gemini 400 errors.

## Changes

### Backend — `packages/bees`

- **[NEW] `bees/functions/mcp_bridge.py`** — MCP ↔ Gemini bridge: schema translation with sanitization (strips JSON Schema keys Gemini rejects), proxy handlers, `MCPRegistry` with `AsyncExitStack` lifecycle. Supports stdio and Streamable HTTP transports with `${ENV_VAR}` expansion.
- **`scheduler.py`** — Initializes `MCPRegistry` at startup, passes MCP function group factories into sessions, adds `shutdown()` for clean disconnect.
- **`session.py`** — `run_session` / `resume_session` accept and forward `mcp_factories`.
- **`bees.py`** — `shutdown()` calls `scheduler.shutdown()` before cancelling the loop.
- **`pyproject.toml`** — Added `mcp>=1.0.0` dependency.

### Function filter — `packages/opal-backend`

- **`run.py`** — `_apply_function_filter` now supports three-tier patterns:
  - `zapier.*` — entire group
  - `zapier.slack.*` — sub-namespace prefix (`zapier_slack_*`)
  - `zapier.slack.send_message` — exact tool
- **`tests/test_run.py`** — 4 new tests covering hierarchical wildcards, multiple prefixes, full-beats-prefix, and prefix+exact combinations.

### HiveTool — `packages/bees/hivetool`

- **`system-store.ts`** — Extended `SystemData` with `MCPServerConfig[]` parsing/serialization.
- **`system-detail.ts`** — MCP server cards in view mode; full CRUD in edit mode with HTTP/Local transport toggle that gates which fields are shown.

### Documentation — `packages/bees/docs`

- **[NEW] `docs/system-config.md`** — Complete SYSTEM.yaml reference: schema, MCP transports, env var expansion, three-tier filter table, runtime walkthrough, limitations.
- **`docs/README.md`** — Added Configuration section.
- **`docs/architecture.md`** — Added MCP as a function group kind.
- **`AGENTS.md`** — Mentioned MCP servers.

### Tests — `packages/bees/tests`

- **[NEW] `tests/test_mcp_bridge.py`** — 24 tests: schema translation, sanitization, proxy handlers, function groups, env expansion, registry validation.

## Testing

```bash
# MCP bridge tests (bees)
npm run test:python -w packages/bees

# Function filter tests (opal-backend)
.venv/bin/python -m pytest packages/opal-backend/tests/test_run.py::TestApplyFunctionFilter -v
```

End-to-end: add an MCP entry to `SYSTEM.yaml`, set env vars, run `npm run dev -w packages/bees`, and use `zapier.slack.*` in a template's `functions` list.
