### PR TITLE
[bees] Add `worker` tags and update projection roadmap

### DIFF
--- a/packages/bees/docs/agent-projection.md
+++ b/packages/bees/docs/agent-projection.md
@@ -140,12 +140,25 @@ This is ~50-100 lines of projection logic in the server, replacing ~300 lines of
 
 ### Frontend
 
-#### Deleted
-- `sca/utils/agent-tree.ts` (127 lines) — entire file
-- Tree derivation in sidebar `render()` — replaced by iterating the typed structure
+#### Current State: `AgentTreeService` (seam in place)
+
+All tree derivation, filtering, and querying now goes through
+`AgentTreeService` (`sca/services/agent-tree-service.ts`). The service
+listens to the SSE event bus directly, maintains its own ticket store, and
+exposes a query interface (`tree`, `perspectives()`, `ancestorPath()`,
+`children()`, `ticket()`). No UI component imports `agent-tree.ts`
+directly — the service is the sole caller.
+
+This is the **seam**. Today the service derives the tree locally from raw
+tickets. When the server ships typed `AgentProjection`, the service swaps
+its internals — same interface, zero UI changes.
+
+#### What Remains (after server projection ships)
+- `sca/utils/agent-tree.ts` — derivation logic, deleted (server does it)
 - `suspend_event` introspection in `chat-actions.ts` — prompt/choices arrive pre-extracted
 - `signal_type` detection in `stage-actions.ts` — middleware handles digest refresh
-- `kind !== "coordination"` filters everywhere
+- `kind !== "coordination"` filters — gone from the wire entirely
+- `controller.global.tickets` — replaced by service-owned state
 
 #### Simplified
 - **Sidebar**: Three flat lists (assistant header, journey sections, worker items) instead of recursive `#renderNode`. ~350 lines → ~100 lines.
@@ -170,13 +183,19 @@ tags:
 
 ## Migration Path
 
+0. ~~**Introduce `AgentTreeService`**~~ ✅ — Service boundary in place.
+   Tree derivation, filtering, and querying behind `AgentTreeService`.
+   UI components query the service; the service delegates to pure
+   functions in `agent-tree.ts`. The seam is ready.
 1. **Add `worker` tags** to the three visible leaf templates.
 2. **Build the projection layer** in the server alongside the current flat emission.
 3. **Ship a new SSE event type** (`init_v2` or a query parameter) so the frontend can opt in.
-4. **Migrate the frontend** to consume the typed projection.
-5. **Remove the old flat emission** and delete the client-side derivation code.
+4. **Swap `AgentTreeService` internals** to consume the typed projection
+   instead of deriving locally. Delete `agent-tree.ts`.
+5. **Remove the old flat emission** and delete `controller.global.tickets`.
 
 Steps 2-3 allow rolling this out without a coordinated server+client deploy.
+Step 4 is a single-file change inside the service — no UI work.
 
 ## Resolved Decisions
 

--- a/packages/bees/hive/config/TEMPLATES.yaml
+++ b/packages/bees/hive/config/TEMPLATES.yaml
@@ -23,7 +23,6 @@
     - tasks.*
   tasks:
     - journey-manager
-    - knowledge
 
 - name: journey-manager
   title: Journey Manager
@@ -234,6 +233,8 @@
     - sandbox.*
     - simple-files.*
     - generate.text
+  tags:
+    - worker
 
 - name: journey-designer
   title: Journey Designer
@@ -260,6 +261,8 @@
     - system.*
   skills:
     - app-architect
+  tags:
+    - worker
 
 - name: ui-generator
   title: UI Generator
@@ -296,6 +299,7 @@
   skills:
     - ui-generator
   tags:
+    - worker
     - bundle
   model: gemini-3.1-pro-preview
 


### PR DESCRIPTION
## What
Added `worker` tag to the three visible leaf templates (researcher, journey-designer, ui-generator) and updated the Agent Projection doc to reflect completed migration steps.

## Why
Step 0 (AgentTreeService seam) and step 1 (worker tags) of the [Agent Projection migration path](packages/bees/docs/agent-projection.md) — preparing for server-side tree projection.

## Changes

### Templates
- **`TEMPLATES.yaml`** — Added `worker` tag to `researcher`, `journey-designer`, and `ui-generator`. `digest-tile-writer` intentionally stays untagged (infrastructure). Removed `knowledge` from opie's `tasks` list.

### Documentation
- **`agent-projection.md`** — Updated frontend section to document the `AgentTreeService` seam now in place. Revised migration path: step 0 (service boundary) marked ✅, steps 4-5 sharpened to reflect that the frontend swap is a single-file change inside the service.

## Testing
- Run `npm run dev -w packages/bees` and verify agents spawn with correct tags visible in the sidebar.
