### PR TITLE
[folio] Add basic styles

### DIFF
--- a/packages/folio/frontend/components/pages/agent.ts
+++ b/packages/folio/frontend/components/pages/agent.ts
@@ -22,7 +22,11 @@ export class PageAgent extends SignalWatcher(LitElement) {
     sharedStyles,
     css`
       :host {
-        display: block;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-direction: column;
+        gap: 32px;
       }
     `,
   ];
@@ -32,8 +36,15 @@ export class PageAgent extends SignalWatcher(LitElement) {
   }
 
   render() {
+    const url = this.sca.controller.router.parsedUrl;
+    const agentId = url.page === "agent" ? url.agentId : undefined;
+    const agent = this.sca.controller.agent.agents.find(
+      (a) => a.id === agentId
+    );
+    const name = agent ? agent.name : "Unknown Agent";
+
     return [
-      html`<h1>${msg("Agent")}</h1>`,
+      html`<h1>${msg(name)}</h1>`,
       html`<button @click=${() => this.#onClick()}>Home</button>`,
     ];
   }

--- a/packages/folio/frontend/components/pages/home.ts
+++ b/packages/folio/frontend/components/pages/home.ts
@@ -12,6 +12,8 @@ import { scaContext } from "../../sca/context/context.js";
 import { SCA } from "../../sca/sca.js";
 import { sharedStyles } from "../../ui/shared-styles.js";
 
+import "../primitives/primitive-card.js";
+
 @localized()
 @customElement("o-page-home")
 export class PageHome extends SignalWatcher(LitElement) {
@@ -22,19 +24,19 @@ export class PageHome extends SignalWatcher(LitElement) {
     sharedStyles,
     css`
       :host {
-        display: block;
+        display: flex;
+        align-items: center;
+        justify-content: center;
       }
     `,
   ];
 
-  #onClick() {
-    this.sca.controller.router.go({ agentId: "foobar", page: "agent" });
-  }
-
   render() {
-    return [
-      html`<h1>${msg("Home")}</h1>`,
-      html`<button @click=${() => this.#onClick()}>Agent</button>`,
-    ];
+    return html`<o-primitive-card>
+      <h1 slot="header">${msg("Home")}</h1>
+      <div slot="content">
+        <p>${msg("Hello, World!")}</p>
+      </div>
+    </o-primitive-card>`;
   }
 }

--- a/packages/folio/frontend/components/primitives/primitive-avatar.ts
+++ b/packages/folio/frontend/components/primitives/primitive-avatar.ts
@@ -1,0 +1,270 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { LitElement, css, html, svg } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import { SignalWatcher } from "@lit-labs/signals";
+import { classMap } from "lit/directives/class-map.js";
+
+@customElement("o-primitive-avatar")
+export class PrimitiveAvatar extends SignalWatcher(LitElement) {
+  @property({ type: Boolean, reflect: true })
+  accessor small = false;
+
+  @property({ type: Boolean, reflect: true })
+  accessor selected = false;
+
+  @property({ type: String })
+  accessor bgColor = "#D98880";
+
+  @property({ type: String })
+  accessor fgColor = "#7E5109";
+
+  @property({ type: Number })
+  accessor count = 3;
+
+  @state()
+  accessor lookDirection: "left" | "center" | "right" = "center";
+
+  @state()
+  accessor blinking = false;
+
+  #blinkTimeout: ReturnType<typeof setTimeout> | undefined;
+  #filterId = `avatar-noise-${Math.random().toString(36).slice(2, 9)}`;
+  #seed = Math.floor(Math.random() * 1000);
+
+  static styles = css`
+    :host {
+      display: inline-flex;
+      justify-content: center;
+      align-items: flex-start;
+      width: var(--opal-grid-10);
+      height: var(--opal-grid-10);
+      box-sizing: border-box;
+      position: relative;
+      cursor: pointer;
+    }
+
+    :host([selected]) {
+      cursor: auto;
+    }
+
+    :host::after {
+      content: "";
+      position: absolute;
+      top: -4px;
+      left: -4px;
+      right: -4px;
+      bottom: -4px;
+      border: 2px solid var(--opal-color-avatar-hover-ring);
+      border-radius: 50%;
+      pointer-events: none;
+      opacity: 0;
+      transition:
+        opacity 0.2s ease,
+        border-color 0.2s ease;
+    }
+
+    :host(:hover)::after {
+      opacity: 1;
+      border-color: var(--opal-color-avatar-hover-ring);
+    }
+
+    :host([selected])::after {
+      opacity: 1;
+      border-color: var(--opal-color-avatar-selected-ring);
+    }
+
+    .clipper {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      border-radius: 50%;
+      overflow: hidden;
+      z-index: 1;
+    }
+
+    .bg {
+      width: 100%;
+      height: 100%;
+      background: var(--opal-color-avatar-background);
+      filter: var(--avatar-filter);
+    }
+
+    .eyes {
+      display: flex;
+      gap: 5px;
+      margin-top: 11px;
+      transition: transform 0.1s ease-in-out;
+      z-index: 2; /* Above background! */
+    }
+
+    .eyes.left {
+      transform: translateX(-2px);
+    }
+
+    .eyes.right {
+      transform: translateX(2px);
+    }
+
+    .eye {
+      width: 5px;
+      height: 10px;
+      background: var(--opal-color-avatar-eyes);
+      border-radius: 2px;
+      transition: transform 0.1s ease-in-out;
+      transform-origin: center;
+    }
+
+    .bubble {
+      display: flex;
+      width: var(--opal-grid-4);
+      height: var(--opal-grid-4);
+      justify-content: center;
+      align-items: center;
+      position: absolute;
+      right: -8px;
+      top: -6px;
+      border-radius: 50%;
+      border: 2px solid var(--opal-color-bubble-border);
+      background: var(--opal-color-bubble-background);
+      color: var(--opal-color-bubble-text);
+      font-family: "Google Sans Flex";
+      font-size: var(--opal-font-size-bubble);
+      font-weight: 500;
+      line-height: 16px;
+      letter-spacing: 0.1px;
+      text-align: center;
+      font-feature-settings: "ss02" on;
+      leading-trim: both;
+      text-edge: cap;
+      z-index: 3;
+    }
+
+    .eye.blink {
+      transform: scaleY(0);
+    }
+
+    .eye:nth-child(2) {
+      transition-delay: 0.03s;
+    }
+
+    :host([small]) {
+      width: var(--opal-grid-5);
+      height: var(--opal-grid-5);
+    }
+
+    :host([small]) .eyes {
+      gap: 2px;
+      margin-top: 5px;
+    }
+
+    :host([small]) .eyes.left {
+      transform: translateX(-1px);
+    }
+
+    :host([small]) .eyes.right {
+      transform: translateX(1px);
+    }
+
+    :host([small]) .eye {
+      width: 2px;
+      height: 5px;
+      border-radius: 1px;
+    }
+  `;
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.#scheduleBlink();
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    clearTimeout(this.#blinkTimeout);
+  }
+
+  #scheduleBlink() {
+    const delay = 3000 + Math.random() * 2000;
+    this.#blinkTimeout = setTimeout(() => {
+      this.#blink();
+    }, delay);
+  }
+
+  #blink() {
+    this.blinking = true;
+    setTimeout(() => {
+      this.blinking = false;
+      const directions: Array<"left" | "center" | "right"> = [
+        "left",
+        "center",
+        "right",
+      ];
+      this.lookDirection =
+        directions[Math.floor(Math.random() * directions.length)];
+      this.#scheduleBlink();
+    }, 150);
+  }
+
+  render() {
+    return html`
+      <div class="clipper">
+        <div class="bg" style="--avatar-filter: url(#${this.#filterId})"></div>
+      </div>
+      <div class="${classMap({ eyes: true, [this.lookDirection]: true })}">
+        <div class="${classMap({ eye: true, blink: this.blinking })}"></div>
+        <div class="${classMap({ eye: true, blink: this.blinking })}"></div>
+      </div>
+
+      ${this.count > 0 ? html`<div class="bubble">${this.count}</div>` : ""}
+
+      <!-- Hidden SVG for the filter -->
+      ${svg`
+        <svg width="0" height="0" style="position: absolute;">
+          <filter id="${this.#filterId}">
+            <!-- 1. Generate noise with lower frequency for larger blobs -->
+            <feTurbulence type="fractalNoise" baseFrequency="0.03" numOctaves="2" seed="${this.#seed}" result="noise">
+              <animate attributeName="baseFrequency" values="0.03;0.035;0.03" dur="10s" repeatCount="indefinite"/>
+            </feTurbulence>
+
+            <!-- 2. Convert to grayscale -->
+            <feColorMatrix type="matrix" values="
+              0.33 0.33 0.33 0 0
+              0.33 0.33 0.33 0 0
+              0.33 0.33 0.33 0 0
+              0    0    0    1 0" in="noise" result="gray"/>
+
+            <!-- 4. Flood background color -->
+            <feFlood flood-color="${this.bgColor}" result="bg"/>
+
+            <!-- 5. Flood foreground color -->
+            <feFlood flood-color="${this.fgColor}" result="fg"/>
+
+            <!-- 6. Mask foreground with the soft grayscale noise -->
+            <feComposite operator="in" in="fg" in2="gray" result="maskedFg"/>
+
+            <!-- 7. Merge -->
+            <feComposite operator="over" in="maskedFg" in2="bg" result="coloredNoise"/>
+
+            <!-- 8. Generate static high-frequency noise -->
+            <feTurbulence type="fractalNoise" baseFrequency="1" numOctaves="1" result="rawStaticNoise"/>
+
+            <!-- 8.5 Convert static noise to grayscale and set opacity to 0.4 -->
+            <feColorMatrix type="matrix" values="
+              0.33 0.33 0.33 0 0
+              0.33 0.33 0.33 0 0
+              0.33 0.33 0.33 0 0
+              0    0    0    0.8 0" in="rawStaticNoise" result="staticNoise"/>
+
+            <!-- 9. Blend static noise with colored noise -->
+            <feBlend mode="overlay" in="coloredNoise" in2="staticNoise"/>
+          </filter>
+        </svg>
+      `}
+    `;
+  }
+}

--- a/packages/folio/frontend/components/primitives/primitive-card.ts
+++ b/packages/folio/frontend/components/primitives/primitive-card.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { SignalWatcher } from "@lit-labs/signals";
+import { LitElement, css, html } from "lit";
+import { customElement } from "lit/decorators.js";
+
+@customElement("o-primitive-card")
+export class PrimitiveCard extends SignalWatcher(LitElement) {
+  static styles = css`
+    :host {
+      display: flex;
+      flex-direction: column;
+      background: var(--opal-color-surface-container);
+      color: var(--opal-color-on-surface);
+      border-radius: var(--opal-radius-pill);
+      box-sizing: border-box;
+      min-width: 400px;
+      padding: var(--opal-grid-6);
+      gap: var(--opal-grid-6);
+    }
+  `;
+
+  #renderHeader() {
+    return html`<slot name="header"></slot>`;
+  }
+
+  render() {
+    return html`
+      <header>${this.#renderHeader()}</header>
+      <div class="content">
+        <slot name="content"></slot>
+      </div>
+    `;
+  }
+}

--- a/packages/folio/frontend/components/shell/shell-header.ts
+++ b/packages/folio/frontend/components/shell/shell-header.ts
@@ -20,20 +20,44 @@ export class ShellHeader extends LitElement {
         height: var(--opal-grid-10);
         padding: var(--opal-grid-4) var(--opal-grid-6);
       }
+
       h1 {
         margin: 0;
         color: var(--opal-color-header-foreground);
         font-family: var(--opal-font-display);
-        font-size: var(--opal-font-size-header);
-        font-weight: var(--opal-font-weight-header);
-        line-height: var(--opal-line-height-header);
+        font-size: var(--opal-headline-small-size);
+        font-weight: var(--opal-headline-small-weight);
+        line-height: var(--opal-headline-small-line-height);
+        font-variation-settings: var(--opal-headline-small-font-variation);
+      }
+
+      section {
+        display: flex;
+        align-items: center;
+        gap: var(--opal-grid-2);
+      }
+
+      aside {
+        color: var(--opal-color-header-foreground);
+        text-align: center;
+        font-family: var(--opal-font-text);
+        font-size: var(--opal-label-medium-size);
+        font-weight: var(--opal-label-medium-weight);
+        line-height: var(--opal-label-medium-line-height);
+        text-transform: uppercase;
+        border-radius: var(--opal-radius-pill);
+        border: 1px solid var(--opal-color-header-foreground);
+        padding: 0 var(--opal-grid-2);
       }
     `,
   ];
 
   render() {
     return html`
-      <h1>${msg("Folio")}</h1>
+      <section>
+        <h1>${msg("Folio")}</h1>
+        <aside>${msg("Experiment")}</aside>
+      </section>
       <o-shell-theme-selector></o-shell-theme-selector>
     `;
   }

--- a/packages/folio/frontend/components/shell/shell-main.ts
+++ b/packages/folio/frontend/components/shell/shell-main.ts
@@ -13,6 +13,7 @@ import { scaContext } from "../../sca/context/context.js";
 import { SCA } from "../../sca/sca.js";
 
 import "./shell-header.js";
+import "./shell-sidebar.js";
 import "../pages/home.js";
 import "../pages/agent.js";
 
@@ -24,11 +25,16 @@ export class ShellMain extends SignalWatcher(LitElement) {
 
   static styles = css`
     :host {
-      display: block;
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      height: 100%;
     }
+
     .content {
-      padding: var(--opal-grid-6) var(--opal-grid-6) var(--opal-grid-6)
-        var(--opal-grid-8);
+      display: grid;
+      grid-template-columns: var(--opal-width-sidebar) auto;
+      flex: 1;
     }
   `;
 
@@ -50,6 +56,10 @@ export class ShellMain extends SignalWatcher(LitElement) {
     return html`<o-page-agent></o-page-agent>`;
   }
 
+  #renderSidebar() {
+    return html`<o-shell-sidebar></o-shell-sidebar>`;
+  }
+
   #renderContent() {
     const url = this.sca.controller.router.parsedUrl;
     let content;
@@ -61,7 +71,7 @@ export class ShellMain extends SignalWatcher(LitElement) {
         content = this.#renderAgent();
         break;
     }
-    return html`<div class="content">${content}</div>`;
+    return html`<div class="content">${[this.#renderSidebar(), content]}</div>`;
   }
 
   render() {

--- a/packages/folio/frontend/components/shell/shell-sidebar.ts
+++ b/packages/folio/frontend/components/shell/shell-sidebar.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { SignalWatcher } from "@lit-labs/signals";
+import { LitElement, css, html } from "lit";
+import { customElement } from "lit/decorators.js";
+
+import "../primitives/primitive-avatar.js";
+import { consume } from "@lit/context";
+import { scaContext } from "../../sca/context/context.js";
+import { SCA } from "../../sca/sca.js";
+import { map } from "lit/directives/map.js";
+
+@customElement("o-shell-sidebar")
+export class ShellSidebar extends SignalWatcher(LitElement) {
+  @consume({ context: scaContext })
+  accessor sca!: SCA;
+
+  static styles = css`
+    :host {
+      display: flex;
+      flex-direction: column;
+      width: var(--opal-width-sidebar);
+      padding: 0 var(--opal-grid-4);
+      box-sizing: border-box;
+      color: var(--opal-color-on-surface);
+      height: 100%;
+      align-items: center;
+      justify-content: center;
+      gap: var(--opal-grid-3);
+    }
+  `;
+
+  #onClick(agentId: string) {
+    this.sca.controller.router.go({ agentId, page: "agent" });
+  }
+
+  #renderAvatars() {
+    const configs = this.sca.controller.agent.agents;
+
+    const url = this.sca.controller.router.parsedUrl;
+    const currentAgentId = url.page === "agent" ? url.agentId : undefined;
+
+    return map(configs, (config) => {
+      return html`<o-primitive-avatar
+        .bgColor=${config.bgColor}
+        .fgColor=${config.fgColor}
+        ?selected=${config.id === currentAgentId}
+        .count=${config.count}
+        @click=${() => this.#onClick(config.id)}
+      ></o-primitive-avatar>`;
+    });
+  }
+
+  render() {
+    return this.#renderAvatars();
+  }
+}

--- a/packages/folio/frontend/components/shell/shell-theme-selector.ts
+++ b/packages/folio/frontend/components/shell/shell-theme-selector.ts
@@ -26,9 +26,9 @@ export class ShellThemeSelector extends SignalWatcher(LitElement) {
     }
 
     select {
-      padding: var(--opal-grid-2);
-      border-radius: var(--opal-grid-1);
-      background: var(--opal-color-surface);
+      padding: var(--opal-grid-2) var(--opal-grid-4);
+      border-radius: var(--opal-grid-6);
+      background: var(--opal-color-surface-container);
       color: var(--opal-color-on-surface);
       border: 1px solid var(--opal-color-spinner-track);
       font-family: var(--opal-font-family);

--- a/packages/folio/frontend/public/palette.css
+++ b/packages/folio/frontend/public/palette.css
@@ -1,0 +1,218 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+:root {
+  /* Global Neutrals */
+  --palette-neutral-50: #F8F9FA;
+  --palette-neutral-100: #F1F3F4;
+  --palette-neutral-200: #E8EAED;
+  --palette-neutral-300: #DADCE0;
+  --palette-neutral-400: #BDC1C6;
+  --palette-neutral-500: #9AA0A6;
+  --palette-neutral-600: #80868B;
+  --palette-neutral-700: #5F6368;
+  --palette-neutral-800: #3C4043;
+  --palette-neutral-900: #202124;
+  --palette-neutral-white: #FFFFFF;
+  --palette-neutral-black: #000000;
+
+  /* Global States */
+  --palette-state-white-10: rgba(218, 220, 224, 0.1);
+  --palette-state-white-15: rgba(218, 220, 224, 0.15);
+  --palette-state-white-25: rgba(218, 220, 224, 0.25);
+  --palette-state-white-50: rgba(218, 220, 224, 0.5);
+  --palette-state-white-75: rgba(218, 220, 224, 0.75);
+  --palette-state-white-90: rgba(218, 220, 224, 0.9);
+  --palette-state-white-05: rgba(218, 220, 224, 0.05);
+  --palette-state-grey-10: rgba(22, 23, 24, 0.1);
+  --palette-state-grey-15: rgba(22, 23, 24, 0.15);
+  --palette-state-grey-25: rgba(22, 23, 24, 0.25);
+  --palette-state-grey-50: rgba(22, 23, 24, 0.5);
+  --palette-state-grey-75: rgba(22, 23, 24, 0.75);
+  --palette-state-grey-90: rgba(22, 23, 24, 0.9);
+  --palette-state-grey-05: rgba(22, 23, 24, 0.05);
+
+  /* BLUE Palette */
+  --palette-blue-color-100: #CFE1FF;
+  --palette-blue-color-200: #9ABFFD;
+  --palette-blue-color-300: #6BA0F8;
+  --palette-blue-color-500: #2B6AD2;
+  --palette-blue-color-600: #1855B8;
+  --palette-blue-color-700: #0B1A34;
+  --palette-blue-color-400-base: #4285F4;
+  --palette-blue-state-color-15: rgba(66, 133, 244, 0.15);
+  --palette-blue-state-color-25: rgba(66, 133, 244, 0.25);
+  --palette-blue-state-color-50: rgba(66, 133, 244, 0.5);
+  --palette-blue-state-color-75: rgba(66, 133, 244, 0.75);
+  --palette-blue-state-color-90: rgba(66, 133, 244, 0.9);
+  --palette-blue-state-color-05: rgba(66, 133, 244, 0.05);
+
+  /* BLURPLE Palette */
+  --palette-blurple-color-100: #D3D4FF;
+  --palette-blurple-color-200: #989AFF;
+  --palette-blurple-color-300: #7168F6;
+  --palette-blurple-color-500: #4F44E1;
+  --palette-blurple-color-600: #322B96;
+  --palette-blurple-color-700: #19182F;
+  --palette-blurple-color-400-base: #6056F0;
+  --palette-blurple-state-color-15: rgba(96, 86, 240, 0.15);
+  --palette-blurple-state-color-25: rgba(96, 86, 240, 0.25);
+  --palette-blurple-state-color-50: rgba(96, 86, 240, 0.5);
+  --palette-blurple-state-color-75: rgba(96, 86, 240, 0.75);
+  --palette-blurple-state-color-90: rgba(96, 86, 240, 0.9);
+  --palette-blurple-state-color-05: rgba(96, 86, 240, 0.05);
+
+  /* BROWN Palette */
+  --palette-brown-color-100: #F3E1D1;
+  --palette-brown-color-200: #D4BAA2;
+  --palette-brown-color-300: #AE9075;
+  --palette-brown-color-500: #644A33;
+  --palette-brown-color-600: #533C28;
+  --palette-brown-color-700: #281C13;
+  --palette-brown-color-400-base: #755940;
+  --palette-brown-state-color-15: rgba(117, 89, 64, 0.15);
+  --palette-brown-state-color-25: rgba(117, 89, 64, 0.25);
+  --palette-brown-state-color-50: rgba(117, 89, 64, 0.5);
+  --palette-brown-state-color-75: rgba(117, 89, 64, 0.75);
+  --palette-brown-state-color-90: rgba(117, 89, 64, 0.9);
+  --palette-brown-state-color-05: rgba(117, 89, 64, 0.05);
+
+  /* GOLD Palette */
+  --palette-gold-color-100: #FAECC0;
+  --palette-gold-color-200: #F8DA82;
+  --palette-gold-color-300: #F6C024;
+  --palette-gold-color-500: #A67B00;
+  --palette-gold-color-600: #7B5D06;
+  --palette-gold-color-700: #413103;
+  --palette-gold-color-400-base: #FABB05;
+  --palette-gold-state-color-15: rgba(166, 123, 0, 0.15);
+  --palette-gold-state-color-25: rgba(166, 123, 0, 0.25);
+  --palette-gold-state-color-50: rgba(166, 123, 0, 0.5);
+  --palette-gold-state-color-75: rgba(166, 123, 0, 0.75);
+  --palette-gold-state-color-90: rgba(166, 123, 0, 0.9);
+  --palette-gold-state-color-05: rgba(166, 123, 0, 0.05);
+
+  /* GREEN Palette */
+  --palette-green-color-100: #BEE1C7;
+  --palette-green-color-200: #78D390;
+  --palette-green-color-300: #5ACB78;
+  --palette-green-color-500: #269443;
+  --palette-green-color-600: #207737;
+  --palette-green-color-700: #0A2D13;
+  --palette-green-color-400-base: #34A853;
+  --palette-green-state-color-15: rgba(52, 168, 83, 0.15);
+  --palette-green-state-color-25: rgba(52, 168, 83, 0.25);
+  --palette-green-state-color-50: rgba(52, 168, 83, 0.5);
+  --palette-green-state-color-75: rgba(52, 168, 83, 0.75);
+  --palette-green-state-color-90: rgba(52, 168, 83, 0.9);
+  --palette-green-state-color-05: rgba(52, 168, 83, 0.05);
+
+  /* GREYSCALE Palette */
+  --palette-greyscale-color-100: #F1F3F4;
+  --palette-greyscale-color-200: #E8EAED;
+  --palette-greyscale-color-300: #DADCE0;
+  --palette-greyscale-color-500: #80868B;
+  --palette-greyscale-color-600: #3C4043;
+  --palette-greyscale-color-700: #202124;
+  --palette-greyscale-color-400-base: #9AA0A6;
+  --palette-greyscale-state-color-15: rgba(154, 160, 166, 0.15);
+  --palette-greyscale-state-color-25: rgba(154, 160, 166, 0.25);
+  --palette-greyscale-state-color-50: rgba(154, 160, 166, 0.5);
+  --palette-greyscale-state-color-75: rgba(154, 160, 166, 0.75);
+  --palette-greyscale-state-color-90: rgba(154, 160, 166, 0.9);
+  --palette-greyscale-state-color-05: rgba(154, 160, 166, 0.05);
+
+  /* ORANGE Palette */
+  --palette-orange-color-100: #FFDED3;
+  --palette-orange-color-200: #FFBBA5;
+  --palette-orange-color-300: #FF906C;
+  --palette-orange-color-500: #A14629;
+  --palette-orange-color-600: #8D3114;
+  --palette-orange-color-700: #401F14;
+  --palette-orange-color-400-base: #D4633E;
+  --palette-orange-state-color-15: rgba(212, 99, 62, 0.15);
+  --palette-orange-state-color-25: rgba(212, 99, 62, 0.25);
+  --palette-orange-state-color-50: rgba(212, 99, 62, 0.5);
+  --palette-orange-state-color-75: rgba(212, 99, 62, 0.75);
+  --palette-orange-state-color-90: rgba(212, 99, 62, 0.9);
+  --palette-orange-state-color-05: rgba(212, 99, 62, 0.05);
+
+  /* PINK Palette */
+  --palette-pink-color-100: #FFD7FC;
+  --palette-pink-color-200: #FAB2F4;
+  --palette-pink-color-300: #F793EF;
+  --palette-pink-color-500: #DB48CF;
+  --palette-pink-color-600: #93308B;
+  --palette-pink-color-700: #461842;
+  --palette-pink-color-400-base: #F468E9;
+  --palette-pink-state-color-15: rgba(244, 104, 233, 0.15);
+  --palette-pink-state-color-25: rgba(244, 104, 233, 0.25);
+  --palette-pink-state-color-50: rgba(244, 104, 233, 0.5);
+  --palette-pink-state-color-75: rgba(244, 104, 233, 0.75);
+  --palette-pink-state-color-90: rgba(244, 104, 233, 0.9);
+  --palette-pink-state-color-05: rgba(244, 104, 233, 0.05);
+
+  /* PURPLE Palette */
+  --palette-purple-color-100: #E9D9FF;
+  --palette-purple-color-200: #D0B3FA;
+  --palette-purple-color-300: #BA8BFC;
+  --palette-purple-color-500: #7C3CD5;
+  --palette-purple-color-600: #6429B9;
+  --palette-purple-color-700: #34185B;
+  --palette-purple-color-400-base: #9154E7;
+  --palette-purple-state-color-15: rgba(145, 84, 231, 0.15);
+  --palette-purple-state-color-25: rgba(145, 84, 231, 0.25);
+  --palette-purple-state-color-50: rgba(145, 84, 231, 0.5);
+  --palette-purple-state-color-75: rgba(145, 84, 231, 0.75);
+  --palette-purple-state-color-90: rgba(145, 84, 231, 0.9);
+  --palette-purple-state-color-05: rgba(145, 84, 231, 0.05);
+
+  /* RED Palette */
+  --palette-red-color-100: #FFD2CD;
+  --palette-red-color-200: #FE6E6E;
+  --palette-red-color-300: #E9493C;
+  --palette-red-color-500: #B22F25;
+  --palette-red-color-600: #AA1A0F;
+  --palette-red-color-700: #330F0C;
+  --palette-red-color-400-base: #E94235;
+  --palette-red-state-color-15: rgba(233, 66, 53, 0.15);
+  --palette-red-state-color-25: rgba(233, 66, 53, 0.25);
+  --palette-red-state-color-50: rgba(233, 66, 53, 0.5);
+  --palette-red-state-color-75: rgba(233, 66, 53, 0.75);
+  --palette-red-state-color-90: rgba(233, 66, 53, 0.9);
+  --palette-red-state-color-05: rgba(233, 66, 53, 0.05);
+
+  /* TEAL Palette */
+  --palette-teal-color-100: #C7EFEA;
+  --palette-teal-color-200: #A7ECE3;
+  --palette-teal-color-300: #56E2D0;
+  --palette-teal-color-500: #1F7E72;
+  --palette-teal-color-600: #165950;
+  --palette-teal-color-700: #112E2A;
+  --palette-teal-color-400-base: #40D9C6;
+  --palette-teal-state-color-15: rgba(31, 126, 114, 0.15);
+  --palette-teal-state-color-25: rgba(31, 126, 114, 0.25);
+  --palette-teal-state-color-50: rgba(31, 126, 114, 0.5);
+  --palette-teal-state-color-75: rgba(31, 126, 114, 0.75);
+  --palette-teal-state-color-90: rgba(31, 126, 114, 0.9);
+  --palette-teal-state-color-05: rgba(31, 126, 114, 0.05);
+
+  /* YELLOW Palette */
+  --palette-yellow-color-100: #E8ECB1;
+  --palette-yellow-color-200: #D7DE6D;
+  --palette-yellow-color-300: #D0DC30;
+  --palette-yellow-color-500: #909B06;
+  --palette-yellow-color-600: #676F02;
+  --palette-yellow-color-700: #2A2E01;
+  --palette-yellow-color-400-base: #D0DD1E;
+  --palette-yellow-state-color-15: rgba(144, 155, 6, 0.15);
+  --palette-yellow-state-color-25: rgba(144, 155, 6, 0.25);
+  --palette-yellow-state-color-50: rgba(144, 155, 6, 0.5);
+  --palette-yellow-state-color-75: rgba(144, 155, 6, 0.75);
+  --palette-yellow-state-color-90: rgba(144, 155, 6, 0.9);
+  --palette-yellow-state-color-05: rgba(144, 155, 6, 0.05);
+
+}

--- a/packages/folio/frontend/public/styles.css
+++ b/packages/folio/frontend/public/styles.css
@@ -13,9 +13,13 @@ body.light-theme {
   color-scheme: light;
 }
 
+html,
 body {
   background: var(--opal-color-surface);
   color: var(--opal-color-on-surface);
   margin: 0;
+  padding: 0;
   font-family: var(--opal-font-family);
+  width: 100svw;
+  height: 100svh;
 }

--- a/packages/folio/frontend/sca/controller/controller.ts
+++ b/packages/folio/frontend/sca/controller/controller.ts
@@ -8,6 +8,7 @@ import { GlobalController } from "./subcontrollers/global/global.js";
 import { RouterController } from "./subcontrollers/router/router-controller.js";
 import { RootController } from "./subcontrollers/root-controller.js";
 import { ThemeController } from "./subcontrollers/global/theme-controller.js";
+import { AgentController } from "./subcontrollers/agent/agent-controller.js";
 
 /**
  * The root application controller for Folio.
@@ -16,12 +17,14 @@ class Controller extends RootController implements AppController {
   global: GlobalController;
   router: RouterController;
   theme: ThemeController;
+  agent: AgentController;
 
   constructor(_env: AppEnvironment) {
     super("App", "AppController");
     this.global = new GlobalController();
     this.router = new RouterController();
     this.theme = new ThemeController();
+    this.agent = new AgentController();
   }
 }
 

--- a/packages/folio/frontend/sca/controller/subcontrollers/agent/agent-controller.ts
+++ b/packages/folio/frontend/sca/controller/subcontrollers/agent/agent-controller.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Agent } from "../../../types.js";
+import { field } from "../../decorators/field.js";
+import { RootController } from "../root-controller.js";
+
+/**
+ * The Agent Controller for Folio.
+ */
+export class AgentController extends RootController {
+  @field({ deep: true })
+  accessor agents: Agent[] = [
+    {
+      id: "top-level-agent",
+      name: "Top Level Agent",
+      bgColor: "#AEAEAE",
+      fgColor: "#525252",
+      count: 0,
+    },
+    {
+      id: "agent-2",
+      name: "Creative Agent",
+      bgColor: "#C27A6E",
+      fgColor: "#6C3E38",
+      count: 2,
+    },
+    {
+      id: "agent-3",
+      name: "Research Agent",
+      bgColor: "#A07B9F",
+      fgColor: "#5A3E58",
+      count: 3,
+    },
+    {
+      id: "agent-1",
+      name: "Search Agent",
+      bgColor: "#8A8B45",
+      fgColor: "#4C4D22",
+      count: 1,
+    },
+  ];
+
+  constructor() {
+    super("Agent", "AgentController");
+  }
+}

--- a/packages/folio/frontend/sca/types.ts
+++ b/packages/folio/frontend/sca/types.ts
@@ -22,7 +22,8 @@ import type { Signal } from "@lit-labs/signals";
 import { PENDING_HYDRATION } from "./utils/sentinel.js";
 import type { GlobalController } from "./controller/subcontrollers/global/global.js";
 import type { RouterController } from "./controller/subcontrollers/router/router-controller.js";
-import { ThemeController } from "./controller/subcontrollers/global/theme-controller.js";
+import type { ThemeController } from "./controller/subcontrollers/global/theme-controller.js";
+import type { AgentController } from "./controller/subcontrollers/agent/agent-controller.js";
 
 export type pending = typeof PENDING_HYDRATION;
 
@@ -126,10 +127,19 @@ export interface Storage {
   delete(name: string): Promise<void>;
 }
 
+export interface Agent {
+  id: string;
+  name: string;
+  bgColor: string;
+  fgColor: string;
+  count: number;
+}
+
 export interface AppController extends HydratedController {
   global: GlobalController;
   theme: ThemeController;
   router: RouterController;
+  agent: AgentController;
 }
 
 export interface HydratedController {

--- a/packages/folio/frontend/ui/shared-styles.ts
+++ b/packages/folio/frontend/ui/shared-styles.ts
@@ -9,10 +9,37 @@ export const sharedStyles = css`
   h1 {
     color: var(--opal-color-on-surface);
     font-family: var(--opal-font-headline);
-    font-size: var(--opal-font-size-h1);
-    font-weight: var(--opal-font-weight-h1);
-    line-height: var(--opal-line-height-h1);
-    font-feature-settings: var(--opal-font-feature-h1);
+    font-size: var(--opal-headline-large-size);
+    font-weight: var(--opal-headline-large-weight);
+    line-height: var(--opal-headline-large-line-height);
+    font-feature-settings: var(--opal-headline-large-font-feature);
     margin: 0;
+  }
+
+  p {
+    color: var(--opal-color-on-surface-variant);
+    font-family: var(--opal-font-headline);
+    font-size: var(--opal-body-large-size);
+    font-weight: var(--opal-body-large-weight);
+    line-height: var(--opal-body-large-line-height);
+    font-feature-settings: var(--opal-body-large-font-feature);
+    margin: 0;
+  }
+
+  button {
+    display: flex;
+    height: var(--opal-grid-10);
+    padding: 0 var(--opal-grid-6);
+    justify-content: center;
+    align-items: center;
+    gap: var(--opal-grid-2);
+    border-radius: var(--opal-radius-pill);
+    background: var(--opal-color-button-background);
+    color: var(--opal-color-on-surface);
+    border: none;
+    cursor: pointer;
+    font-family: var(--opal-font-text);
+    font-size: var(--opal-label-medium-size);
+    font-weight: var(--opal-label-medium-weight);
   }
 `;

--- a/packages/folio/frontend/ui/tokens.json
+++ b/packages/folio/frontend/ui/tokens.json
@@ -17,20 +17,75 @@
     "grid-15": { "value": "60px" },
     "grid-16": { "value": "64px" },
     "color-primary": {
-      "light": "hsl(220, 90%, 56%)",
-      "dark": "hsl(220, 90%, 65%)"
+      "light": "var(--palette-blue-color-400-base)",
+      "dark": "var(--palette-blue-color-300)"
     },
     "color-surface": {
-      "light": "hsl(0, 0%, 100%)",
-      "dark": "hsl(220, 20%, 10%)"
+      "light": "var(--palette-neutral-300)",
+      "dark": "var(--palette-neutral-900)"
+    },
+    "color-surface-container": {
+      "light": "var(--palette-neutral-white)",
+      "dark": "var(--palette-neutral-800)"
     },
     "color-on-surface": {
-      "light": "hsl(220, 20%, 20%)",
-      "dark": "hsl(220, 20%, 90%)"
+      "light": "var(--palette-neutral-800)",
+      "dark": "var(--palette-neutral-100)"
+    },
+    "color-on-surface-variant": {
+      "light": "var(--palette-neutral-700)",
+      "dark": "var(--palette-neutral-400)"
+    },
+    "color-button-background": {
+      "light": "var(--palette-neutral-50)",
+      "dark": "var(--palette-neutral-800)"
+    },
+    "color-avatar-background": {
+      "value": "var(--palette-neutral-black)"
+    },
+    "color-avatar-eyes": {
+      "value": "var(--palette-neutral-white)"
+    },
+    "color-bubble-background": {
+      "value": "var(--palette-neutral-black)"
+    },
+    "color-bubble-text": {
+      "value": "var(--palette-neutral-white)"
+    },
+    "color-bubble-border": {
+      "light": "var(--palette-neutral-200)",
+      "dark": "var(--palette-neutral-800)"
+    },
+    "font-size-bubble": {
+      "value": "8px"
+    },
+    "color-avatar-1-bg": {
+      "value": "var(--palette-red-color-300)"
+    },
+    "color-avatar-1-fg": {
+      "value": "var(--palette-brown-color-700)"
+    },
+    "color-avatar-2-bg": {
+      "value": "var(--palette-teal-color-300)"
+    },
+    "color-avatar-2-fg": {
+      "value": "var(--palette-blue-color-700)"
+    },
+    "color-avatar-3-bg": {
+      "value": "var(--palette-gold-color-300)"
+    },
+    "color-avatar-3-fg": {
+      "value": "var(--palette-purple-color-700)"
+    },
+    "color-avatar-selected-ring": {
+      "value": "var(--palette-neutral-black)"
+    },
+    "color-avatar-hover-ring": {
+      "value": "var(--palette-neutral-400)"
     },
     "color-spinner-track": {
-      "light": "hsl(220, 20%, 90%)",
-      "dark": "hsl(220, 20%, 20%)"
+      "light": "var(--palette-neutral-100)",
+      "dark": "var(--palette-neutral-800)"
     },
     "color-spinner-head": {
       "value": "var(--opal-color-primary)"
@@ -39,35 +94,68 @@
       "value": "\"Google Sans\", system-ui, sans-serif"
     },
     "color-header-foreground": {
-      "light": "#000000",
-      "dark": "#ffffff"
+      "light": "var(--palette-neutral-black)",
+      "dark": "var(--palette-neutral-white)"
     },
     "font-display": {
-      "value": "\"Google Sans Display\", \"Google Sans\", system-ui, sans-serif"
+      "value": "\"Google Sans Flex\", system-ui, sans-serif"
     },
-    "font-size-header": {
+    "headline-small-size": {
       "value": "24px"
     },
-    "font-weight-header": {
+    "headline-small-weight": {
       "value": "500"
     },
-    "line-height-header": {
+    "headline-small-line-height": {
       "value": "133.333%"
     },
     "font-headline": {
       "value": "\"Google Sans Flex\", system-ui, sans-serif"
     },
-    "font-size-h1": {
+    "headline-large-size": {
       "value": "32px"
     },
-    "font-weight-h1": {
+    "headline-large-weight": {
       "value": "400"
     },
-    "line-height-h1": {
+    "headline-large-line-height": {
       "value": "40px"
     },
-    "font-feature-h1": {
+    "headline-large-font-feature": {
       "value": "'ss02' on"
+    },
+    "font-text": {
+      "value": "\"Google Sans Text\", system-ui, sans-serif"
+    },
+    "label-medium-size": {
+      "value": "12px"
+    },
+    "label-medium-weight": {
+      "value": "500"
+    },
+    "label-medium-line-height": {
+      "value": "15px"
+    },
+    "headline-small-font-variation": {
+      "value": "'opsz' 24"
+    },
+    "body-large-size": {
+      "value": "16px"
+    },
+    "body-large-weight": {
+      "value": "400"
+    },
+    "body-large-line-height": {
+      "value": "24px"
+    },
+    "body-large-font-feature": {
+      "value": "'ss02' on"
+    },
+    "radius-pill": {
+      "value": "24px"
+    },
+    "width-sidebar": {
+      "value": "80px"
     }
   }
 }

--- a/packages/folio/index.html
+++ b/packages/folio/index.html
@@ -6,7 +6,8 @@
     <title>Folio</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Google+Sans+Code&family=Google+Sans+Flex:opsz,wght,ROND@6..144,1..1000,0..100&family=Google+Sans:opsz,wght@17..18,400..700&display=block" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Google+Sans+Code&family=Google+Sans+Flex:opsz,wght,ROND@6..144,1..1000,0..100&family=Google+Sans:opsz,wght@17..18,400..700&family=Google+Sans+Text:ital,wght@0,400;0,500;0,700;1,400;1,500;1,700&display=swap" rel="stylesheet" />
+    <link href="/palette.css" rel="stylesheet" />
     <link href="/tokens.css" rel="stylesheet" />
     <link href="/styles.css" rel="stylesheet" />
   </head>


### PR DESCRIPTION
## What
Implements a high-fidelity, theme-aware avatar system for Folio, including a dynamic sidebar and a dedicated `AgentController` to manage agent state.

## Why
To provide a polished, interactive user interface for navigating between agents in Folio, aligning with the SCA architecture and visual design specs.

## Changes
### Primitives
- **`primitive-avatar.ts`**: Added dynamic blink/gaze logic, unique Perlin noise textures via SVG filters, and a smooth selection ring transition.

### Shell & Pages
- **`shell-sidebar.ts`**: Rewired to render avatars from `AgentController` and handle navigation with unique agent IDs.
- **`agent.ts`**: Updated to display the active agent's name by looking it up in the controller.

### SCA Architecture
- **`agent-controller.ts`**: Created new subcontroller to manage the list of agents, their names, and visual configurations.
- **`controller.ts` & `types.ts`**: Registered `AgentController` in the app root.

### Styling & Tokens
- **`tokens.json`**: Added palette colors and semantic tokens for avatar rings and backgrounds.

## Testing
- Verify that avatars render with unique noise textures in the sidebar.
- Click on avatars to ensure route updates and the active state ring moves.
- Verify that the agent page displays the correct agent name when navigated to.
