### PR TITLE
[bees] Modularize scheduler and rename ticket → task

### DIFF
--- a/packages/bees/bees/bees.py
+++ b/packages/bees/bees/bees.py
@@ -23,11 +23,11 @@ class Bees:
         self._loop_task = None
         
         hooks = SchedulerHooks(
-            on_ticket_added=lambda t: self._emit("task_added", t),
+            on_task_added=lambda t: self._emit("task_added", t),
             on_cycle_start=lambda c, a, r: self._emit("cycle_start", c, a, r),
-            on_ticket_event=lambda t, e: self._emit("task_event", t, e),
-            on_ticket_start=lambda t: self._emit("task_start", t),
-            on_ticket_done=lambda t: self._emit("task_done", t),
+            on_task_event=lambda t, e: self._emit("task_event", t, e),
+            on_task_start=lambda t: self._emit("task_start", t),
+            on_task_done=lambda t: self._emit("task_done", t),
             on_cycle_complete=lambda c: self._emit("cycle_complete", c),
         )
         self._scheduler = Scheduler(backend=backend, hooks=hooks, store=self._store)

--- a/packages/bees/bees/coordination.py
+++ b/packages/bees/bees/coordination.py
@@ -1,0 +1,139 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Coordination task routing — event dispatch for cross-agent signals.
+
+Routes coordination tasks (lightweight tasks carrying event payloads)
+to matching subscribers.  Delivery is durable: the coordination task
+stays ``available`` until every subscriber has been delivered to.
+
+This module is extracted as-is from the scheduler with an eye toward
+future replacement by a purpose-built event dispatcher.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable
+
+from bees.playbook import run_event_hooks
+from bees.task_store import TaskStore
+from bees.ticket import Ticket
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["route_coordination_task"]
+
+
+async def route_coordination_task(
+    task: Ticket,
+    store: TaskStore,
+    running_tasks: set[str],
+    on_task_done: Callable[[Ticket], Awaitable[None]] | None = None,
+) -> None:
+    """Route a coordination task's signal to matching subscribers.
+
+    Delivery is durable: the coordination task stays ``available``
+    until every matching subscriber has been delivered to. Subscribers
+    that are busy (running or not idle) are skipped and retried in the
+    next scheduler cycle.
+
+    This design survives server restarts — undelivered coordination
+    tasks remain ``available`` on disk and are re-routed on startup.
+    """
+    signal_type = task.metadata.signal_type or ""
+    payload = task.metadata.context or ""
+    source_tags = set(task.metadata.tags or [])
+    delivered = set(task.metadata.delivered_to or [])
+
+    # Find all matching subscribers.
+    source_run_id = task.metadata.playbook_run_id
+    subscribers: list[Ticket] = []
+    for candidate in store.query_all():
+        if candidate.id == task.id:
+            continue
+        if not candidate.metadata.watch_events:
+            continue
+        # Run-ID scoping: if the signal is scoped to a run,
+        # only deliver to subscribers in that same run.
+        if source_run_id and candidate.metadata.playbook_run_id != source_run_id:
+            continue
+        for watch in candidate.metadata.watch_events:
+            if watch.get("type") != signal_type:
+                continue
+            # Tag filtering.
+            tag_filters = watch.get("tags", [])
+            exclude = {f[1:] for f in tag_filters if f.startswith("!")}
+            require = {f for f in tag_filters if not f.startswith("!")}
+            if source_tags & exclude:
+                continue
+            if require and not (source_tags & require):
+                continue
+            subscribers.append(candidate)
+            break
+
+    # Try to deliver to each subscriber not yet delivered.
+    all_delivered = True
+    for sub in subscribers:
+        if sub.id in delivered:
+            continue
+
+        # Let the playbook hook intercept before delivery.
+        result = run_event_hooks(signal_type, payload, sub, store)
+        if result is None:
+            # Hook ate the event — mark delivered, skip agent.
+            delivered.add(sub.id)
+            store.save_metadata(sub)
+            logger.info(
+                "Coordination %s eaten by hook for %s",
+                task.id[:8],
+                sub.id[:8],
+            )
+            continue
+
+        if (
+            sub.metadata.status == "suspended"
+            and sub.metadata.assignee == "user"
+            and sub.id not in running_tasks
+        ):
+            # Idle — deliver immediately.
+            response_path = sub.dir / "response.json"
+            response_path.write_text(
+                json.dumps(
+                    {"context_updates": [result]},
+                    indent=2,
+                    ensure_ascii=False,
+                )
+                + "\n"
+            )
+            sub.metadata.assignee = "agent"
+            store.save_metadata(sub)
+            delivered.add(sub.id)
+            logger.info(
+                "Coordination %s delivered to %s",
+                task.id[:8],
+                sub.id[:8],
+            )
+        else:
+            # Busy — skip, will retry next cycle.
+            all_delivered = False
+
+    # Update delivery tracking.
+    task.metadata.delivered_to = list(delivered)
+
+    if all_delivered:
+        task.metadata.status = "completed"
+        task.metadata.completed_at = datetime.now(timezone.utc).isoformat()
+        logger.info(
+            "Coordination task %s fully delivered (signal_type=%s)",
+            task.id[:8],
+            signal_type,
+        )
+
+    store.save_metadata(task)
+
+    # Broadcast the updated coordination task to the UI.
+    if on_task_done:
+        await on_task_done(task)

--- a/packages/bees/bees/functions/tasks.py
+++ b/packages/bees/bees/functions/tasks.py
@@ -82,7 +82,7 @@ def _make_handlers(
         if status_cb:
             status_cb(f"Creating task of type: {task_type}")
             
-        from bees.playbook import load_playbook, stamp_child_ticket
+        from bees.playbook import load_playbook, stamp_child_task
         config_dir = scheduler.store.hive_dir / "config"
         try:
             load_playbook(task_type, config_dir)
@@ -95,9 +95,9 @@ def _make_handlers(
             if not parent:
                 return {"error": "Parent ticket not found"}
 
-            task = stamp_child_ticket(
+            task = stamp_child_task(
                 task_type,
-                parent_ticket=parent,
+                parent_task=parent,
                 slug=slug,
                 store=scheduler.store,
                 context=objective,
@@ -115,7 +115,7 @@ def _make_handlers(
         if wait_ms and scheduler:
             if status_cb:
                 status_cb(f"Waiting for task {task.id}...")
-            status = await scheduler.wait_for_ticket(task.id, wait_ms)
+            status = await scheduler.wait_for_task(task.id, wait_ms)
             if status_cb:
                 status_cb(None, None)
                 
@@ -176,7 +176,7 @@ def _make_handlers(
         if not scheduler:
             return {"error": "Scheduler not available in handler"}
             
-        cancelled = scheduler.cancel_ticket(task_id)
+        cancelled = scheduler.cancel_task(task_id)
         
         if status_cb:
             status_cb(None, None)
@@ -208,7 +208,7 @@ def _make_handlers(
                 "message": message,
                 "from_ticket_id": ticket_id,
             }
-            error = scheduler.deliver_to_ticket(
+            error = scheduler.deliver_to_task(
                 task_id,
                 update,
                 expected_creator=caller_ticket_id,

--- a/packages/bees/bees/playbook.py
+++ b/packages/bees/bees/playbook.py
@@ -5,10 +5,10 @@
 Template loader and runner.
 
 A template is an entry in ``hive/config/TEMPLATES.yaml`` that defines a
-single agent ticket: an objective, tools, skills, and metadata.
+single agent task: an objective, tools, skills, and metadata.
 
-Running a template creates one ticket and returns it.  If the template
-declares ``autostart``, child tickets are stamped automatically.
+Running a template creates one task and returns it.  If the template
+declares ``autostart``, child tasks are stamped automatically.
 """
 
 from __future__ import annotations
@@ -105,17 +105,17 @@ def run_playbook(
     owning_task_id: str | None = None,
     slug: str | None = None,
 ) -> Ticket:
-    """Create a ticket from a template.
+    """Create a task from a template.
 
-    If ``owning_task_id`` is provided, the created ticket shares the
-    parent ticket's workspace directory instead of getting its own.
+    If ``owning_task_id`` is provided, the created task shares the
+    parent task's workspace directory instead of getting its own.
 
     If the template has a hooks module with an ``on_run_playbook`` function,
-    it is called before ticket creation. The hook receives the
+    it is called before task creation. The hook receives the
     caller-supplied context and may return enriched context, or ``None``
     to abort the run (raises ``PlaybookAborted``).
 
-    Returns the created ticket.
+    Returns the created task.
     """
     hive_dir = store.hive_dir
     config_dir = hive_dir / "config"
@@ -152,12 +152,12 @@ def run_playbook(
         slug=slug,
     )
 
-    # Autostart: stamp child tickets declared in the template.
+    # Autostart: stamp child tasks declared in the template.
     for child_name in data.get("autostart", []):
         try:
-            stamp_child_ticket(
+            stamp_child_task(
                 child_name,
-                parent_ticket=task,
+                parent_task=task,
                 slug=child_name,
                 store=store,
             )
@@ -170,26 +170,26 @@ def run_playbook(
     return task
 
 
-def stamp_child_ticket(
+def stamp_child_task(
     template_name: str,
     *,
-    parent_ticket: Ticket,
+    parent_task: Ticket,
     slug: str,
     store: TaskStore,
     context: str | None = None,
     title: str | None = None,
     scope: SubagentScope | None = None,
 ) -> Ticket:
-    """Create a child ticket from a template under a parent.
+    """Create a child task from a template under a parent.
 
     Handles SubagentScope composition, sandbox instructions, writable
     directory creation, and ``parent_task_id`` assignment — the
     shared logic for both ``autostart`` and ``tasks_create_task``.
 
-    If *scope* is not provided, one is derived from the parent ticket.
+    If *scope* is not provided, one is derived from the parent task.
     """
     if scope is None:
-        scope = SubagentScope.for_ticket(parent_ticket)
+        scope = SubagentScope.for_ticket(parent_task)
     child_scope = scope.child(slug)
 
     child = run_playbook(
@@ -205,7 +205,7 @@ def stamp_child_ticket(
         child.objective = (
             f"{child.objective}\n\n"
             f"<subagent_context>\n"
-            f"Your parent id is: {parent_ticket.id}\n"
+            f"Your parent id is: {parent_task.id}\n"
             f"</subagent_context>\n"
             f"{sandbox_block}"
         )
@@ -217,7 +217,7 @@ def stamp_child_ticket(
     if title:
         child.metadata.title = title
 
-    child.metadata.parent_task_id = parent_ticket.id
+    child.metadata.parent_task_id = parent_task.id
     store.save_metadata(child)
 
     return child
@@ -242,12 +242,12 @@ def load_system_config(config_dir: Path) -> dict[str, Any]:
 
 
 
-def run_ticket_done_hooks(ticket: Ticket) -> None:
-    """Run ``on_ticket_done`` for the template that owns this ticket.
+def run_task_done_hooks(ticket: Ticket) -> None:
+    """Run ``on_task_done`` for the template that owns this task.
 
-    Looks up the ticket's ``playbook_id`` and, if the corresponding
-    template defines an ``on_ticket_done(ticket)`` hook, calls it.
-    Tickets not created by a template are silently skipped.
+    Looks up the task's ``playbook_id`` and, if the corresponding
+    template defines an ``on_task_done(ticket)`` hook, calls it.
+    Tasks not created by a template are silently skipped.
     """
     playbook_id = ticket.metadata.playbook_id
     if not playbook_id:
@@ -257,12 +257,12 @@ def run_ticket_done_hooks(ticket: Ticket) -> None:
     hooks_dir = hive_dir / "config" / "hooks"
 
     hooks = _load_hooks(playbook_id, hooks_dir)
-    if hooks and hasattr(hooks, "on_ticket_done"):
+    if hooks and hasattr(hooks, "on_task_done"):
         try:
-            hooks.on_ticket_done(ticket)
+            hooks.on_task_done(ticket)
         except Exception as exc:
             logger.warning(
-                "on_ticket_done hook for '%s' failed: %s", playbook_id, exc,
+                "on_task_done hook for '%s' failed: %s", playbook_id, exc,
             )
 
 

--- a/packages/bees/bees/scheduler.py
+++ b/packages/bees/bees/scheduler.py
@@ -2,35 +2,35 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Scheduler — unified ticket lifecycle and orchestration.
+Scheduler — unified task lifecycle and orchestration.
 
 Owns the decisions of *what runs when* and the metadata bookkeeping
-around each ticket's execution.  Consumers (server, CLI) plug in
+around each task's execution.  Consumers (server, CLI) plug in
 behaviour via ``SchedulerHooks``.
 
 The Concept of a Cycle
 ----------------------
 
-A **Cycle** is a single wave of dependency-aware ticket execution. The
-system operates by repeatedly evaluating ticket dependencies and firing all
+A **Cycle** is a single wave of dependency-aware task execution. The
+system operates by repeatedly evaluating task dependencies and firing all
 unblocked work simultaneously:
 
-1. **Promote**: The scheduler checks all ``blocked`` tickets. If their
+1. **Promote**: The scheduler checks all ``blocked`` tasks. If their
    dependencies are resolved (``completed``), it promotes them to ``available``.
 2. **Collect**: It gathers all runnable work:
-   - New ``available`` tickets.
-   - ``suspended`` tickets that have been responded to by a user and are
+   - New ``available`` tasks.
+   - ``suspended`` tasks that have been responded to by a user and are
      ready for the agent to resume.
-3. **Execute (Wave)**: All collected tickets are fired concurrently (either
+3. **Execute (Wave)**: All collected tasks are fired concurrently (either
    gathered in batch mode, or spawned as tasks in server mode).
-4. **Settle**: Active tickets run until they reach a resting state:
+4. **Settle**: Active tasks run until they reach a resting state:
    - ``completed`` or ``failed`` (resolved).
    - ``suspended`` (waiting for user input).
 5. **Trigger**: When work settles, the scheduler wakes up to evaluate the
-   next cycle. If previous tickets unblocked new ones, the loop continues.
+   next cycle. If previous tasks unblocked new ones, the loop continues.
    If no work remains, it goes idle (server) or finishes (CLI).
 
-This "wave orchestration" ensures that independent tickets (e.g., three
+This "wave orchestration" ensures that independent tasks (e.g., three
 separate search queries for children of a root task) can execute in parallel,
 while sequential dependencies are strictly preserved without blocking the system.
 """
@@ -38,30 +38,19 @@ while sequential dependencies are strictly preserved without blocking the system
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
 import sys
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable
 
-import httpx
-
-from bees.playbook import run_event_hooks, run_ticket_done_hooks, load_system_config, run_playbook
-from bees.session import (
-    SessionResult,
-    append_chat_log,
-    clear_session_state,
-    extract_files,
-
-    load_session_state,
-    resume_session,
-    run_session,
-)
+from bees.coordination import route_coordination_task
+from bees.playbook import run_task_done_hooks, load_system_config, run_playbook
+from bees.session import SessionResult
+from bees.task_runner import TaskRunner
 from bees.ticket import Ticket
-from bees.task_store import TaskStore, _DEP_PATTERN
-from bees.subagent_scope import SubagentScope
+from bees.task_store import TaskStore
 from bees.functions.mcp_bridge import MCPRegistry
+from bees.context_updates import updates_to_context_parts
 from opal_backend.local.backend_client_impl import HttpBackendClient
 
 logger = logging.getLogger(__name__)
@@ -78,114 +67,34 @@ class SchedulerHooks:
     """
 
     on_startup: Callable[[list[Ticket]], Awaitable[None]] | None = None
-    """Called once after recovery, with the full ticket list."""
+    """Called once after recovery, with the full task list."""
 
-    on_ticket_added: Callable[[Ticket], Awaitable[None]] | None = None
-    """Called when a new ticket is created."""
+    on_task_added: Callable[[Ticket], Awaitable[None]] | None = None
+    """Called when a new task is created."""
 
     on_cycle_start: Callable[[int, int, int], Awaitable[None]] | None = None
     """Called at the start of each cycle.
 
     Arguments passed to the callback:
     - cycle_number: The sequence number of the current cycle (1-based).
-    - available_count: The number of new ('available') tickets being processed.
-    - resumable_count: The number of suspended tickets being resumed.
+    - available_count: The number of new ('available') tasks being processed.
+    - resumable_count: The number of suspended tasks being resumed.
     """
 
-    on_ticket_event: Callable[[str, dict], Awaitable[None]] | None = None
-    """Called when a running session emits an event (ticket_id, event_dict)."""
+    on_task_event: Callable[[str, dict], Awaitable[None]] | None = None
+    """Called when a running session emits an event (task_id, event_dict)."""
 
-    on_ticket_start: Callable[[Ticket], Awaitable[None]] | None = None
-    """Called when a ticket transitions to running (for UI updates)."""
+    on_task_start: Callable[[Ticket], Awaitable[None]] | None = None
+    """Called when a task transitions to running (for UI updates)."""
 
-    on_ticket_done: Callable[[Ticket], Awaitable[None]] | None = None
-    """Called when a ticket reaches a resting state (completed/failed/suspended/paused)."""
-
+    on_task_done: Callable[[Ticket], Awaitable[None]] | None = None
+    """Called when a task reaches a resting state (completed/failed/suspended/paused)."""
 
     on_events_broadcast: Callable[[Ticket], None] | None = None
     """Called when an agent broadcasts an event mid-session."""
 
-
-
     on_cycle_complete: Callable[[int], Awaitable[None]] | None = None
     """Called when there is no more work (total_cycles)."""
-
-
-# ---------------------------------------------------------------------------
-# Segment resolution (pure data transform)
-# ---------------------------------------------------------------------------
-
-
-def resolve_segments(ticket: Ticket, store: TaskStore) -> list[dict[str, Any]]:
-    """Build segments from a ticket's objective, resolving ``{{…}}`` references.
-
-    References are resolved by namespace:
-
-    - ``{{system.context}}`` — replaced with the ticket's context string.
-    - ``{{system.ticket_id}}`` — replaced with the ticket's own ID.
-    - ``{{ticket-id}}`` — replaced with the dependency's outcome as an
-      ``input`` segment carrying LLMContent.
-
-    Plain text around references becomes text segments.
-    """
-    objective = ticket.objective
-    deps = ticket.metadata.depends_on or []
-    context = ticket.metadata.context or ""
-
-    # Build a lookup from dep ID to resolved outcome.
-    dep_outcomes: dict[str, dict[str, Any]] = {}
-    for dep_id in deps:
-        dep = store.get(dep_id)
-        if dep and dep.metadata.outcome_content:
-            dep_outcomes[dep_id] = dep.metadata.outcome_content
-
-    # Split objective on {{...}} boundaries.
-    parts = _DEP_PATTERN.split(objective)
-    segments: list[dict[str, Any]] = []
-
-    for i, part in enumerate(parts):
-        if i % 2 == 0:
-            # Text between refs.
-            if part:
-                segments.append({"type": "text", "text": part})
-        else:
-            # Resolve by namespace.
-            if part == "system.context":
-                if context:
-                    segments.append({"type": "text", "text": context})
-            elif part == "system.ticket_id":
-                segments.append({"type": "text", "text": ticket.id})
-            else:
-                # Dependency ref — resolve to input segment.
-                resolved_id = _find_dep_id(part, deps)
-                if resolved_id and resolved_id in dep_outcomes:
-                    segments.append({
-                        "type": "input",
-                        "title": f"ticket-{resolved_id[:8]}",
-                        "content": dep_outcomes[resolved_id],
-                    })
-                else:
-                    # Fallback: just include as text.
-                    segments.append({
-                        "type": "text",
-                        "text": f"(output of ticket {part})",
-                    })
-
-    return segments
-
-
-def _find_dep_id(ref: str, dep_ids: list[str]) -> str | None:
-    """Match a ref (prefix or full UUID) against resolved dep IDs."""
-    for dep_id in dep_ids:
-        if dep_id == ref or dep_id.startswith(ref):
-            return dep_id
-    return None
-
-# ---------------------------------------------------------------------------
-# Event formatting (structured data → text for agent consumption)
-# ---------------------------------------------------------------------------
-
-
 
 
 # ---------------------------------------------------------------------------
@@ -193,10 +102,10 @@ def _find_dep_id(ref: str, dep_ids: list[str]) -> str | None:
 # ---------------------------------------------------------------------------
 
 
-def promote_blocked_tickets(store: TaskStore) -> int:
-    """Check blocked tickets and promote those whose deps are met.
+def promote_blocked_tasks(store: TaskStore) -> int:
+    """Check blocked tasks and promote those whose deps are met.
 
-    Returns the number of tickets promoted.
+    Returns the number of tasks promoted.
     """
     blocked = store.query_all(status="blocked")
     promoted = 0
@@ -238,16 +147,15 @@ def promote_blocked_tickets(store: TaskStore) -> int:
 
 
 class Scheduler:
-    """Ticket lifecycle manager and orchestrator.
+    """Task lifecycle manager and orchestrator.
 
     Owns:
-    - Running and resuming individual tickets (metadata bookkeeping).
     - Cycle orchestration (promote → collect → fire → repeat).
+    - Context delivery (three-path model).
     - A trigger-based background loop for the server.
-    - Recovery of stuck tickets on startup.
+    - Recovery of stuck tasks on startup.
 
-    Does *not* own any application-specific behaviour — that plugs in
-    via ``SchedulerHooks``.
+    Delegates individual task execution to ``TaskRunner``.
     """
 
     def __init__(
@@ -262,11 +170,26 @@ class Scheduler:
         self.store = store
         self._trigger = asyncio.Event()
         self._running = False
-        self._running_tickets: set[str] = set()
+        self._running_tasks: set[str] = set()
         self._completion_events: dict[str, asyncio.Event] = {}
         self._active_tasks: dict[str, asyncio.Task] = {}
         self._context_queues: dict[str, asyncio.Queue] = {}
         self._mcp_registry: MCPRegistry | None = None
+
+        self._runner = TaskRunner(
+            backend=self._backend,
+            store=self.store,
+            scheduler_ref=self,
+            context_queues=self._context_queues,
+            get_mcp_factories=lambda: (
+                self._mcp_registry.get_factories()
+                if self._mcp_registry else None
+            ),
+            deliver_context_update=self._deliver_context_update,
+            on_events_broadcast=self._on_events_broadcast_internal,
+            on_task_start=self._hooks.on_task_start,
+            on_task_event=self._hooks.on_task_event,
+        )
 
     # -- public API --------------------------------------------------------
 
@@ -275,8 +198,8 @@ class Scheduler:
         self._trigger.set()
 
     async def startup(self) -> Ticket | None:
-        """Recover stuck tickets, boot root template if needed, and fire startup hook."""
-        tasks = await self.recover_stuck_tickets()
+        """Recover stuck tasks, boot root template if needed, and fire startup hook."""
+        tasks = await self.recover_stuck_tasks()
 
         # Connect to MCP servers declared in SYSTEM.yaml.
         config = load_system_config(self.store.hive_dir / "config")
@@ -304,8 +227,8 @@ class Scheduler:
         """Create a new task and notify hooks."""
         task = self.store.create(objective, **kwargs)
         
-        if self._hooks.on_ticket_added:
-            await self._hooks.on_ticket_added(task)
+        if self._hooks.on_task_added:
+            await self._hooks.on_task_added(task)
             
         self.trigger()
         return task
@@ -326,45 +249,45 @@ class Scheduler:
         logger.info("Booting root template '%s'", root)
         task = run_playbook(root, store=self.store)
         
-        if self._hooks.on_ticket_added:
-            await self._hooks.on_ticket_added(task)
+        if self._hooks.on_task_added:
+            await self._hooks.on_task_added(task)
             
         return task
 
-    async def wait_for_ticket(self, ticket_id: str, timeout_ms: float) -> str:
-        """Wait for a ticket to complete, fail, or suspend.
+    async def wait_for_task(self, task_id: str, timeout_ms: float) -> str:
+        """Wait for a task to complete, fail, or suspend.
 
         Races an in-memory completion event against a timeout. Returns
-        the ticket's status on exit.
+        the task's status on exit.
         """
-        event = self._completion_events.setdefault(ticket_id, asyncio.Event())
+        event = self._completion_events.setdefault(task_id, asyncio.Event())
         
         try:
             await asyncio.wait_for(event.wait(), timeout=timeout_ms / 1000.0)
         except asyncio.TimeoutError:
             pass
             
-        fresh = self.store.get(ticket_id)
+        fresh = self.store.get(task_id)
         return fresh.metadata.status if fresh else "unknown"
 
-    def _notify_ticket_done(self, ticket_id: str) -> None:
-        """Wake up anyone waiting for this ticket."""
-        if ticket_id in self._completion_events:
-            self._completion_events[ticket_id].set()
-            del self._completion_events[ticket_id]
+    def _notify_task_done(self, task_id: str) -> None:
+        """Wake up anyone waiting for this task."""
+        if task_id in self._completion_events:
+            self._completion_events[task_id].set()
+            del self._completion_events[task_id]
 
-    def cancel_ticket(self, ticket_id: str) -> bool:
-        """Cancel a running or pending ticket.
+    def cancel_task(self, task_id: str) -> bool:
+        """Cancel a running or pending task.
         
-        Returns True if the ticket was found and cancelled, False otherwise.
+        Returns True if the task was found and cancelled, False otherwise.
         """
         cancelled = False
         
-        if ticket_id in self._active_tasks:
-            self._active_tasks[ticket_id].cancel()
+        if task_id in self._active_tasks:
+            self._active_tasks[task_id].cancel()
             cancelled = True
             
-        task = self.store.get(ticket_id)
+        task = self.store.get(task_id)
         if task:
             task.metadata.status = "cancelled"
             self.store.save_metadata(task)
@@ -372,47 +295,46 @@ class Scheduler:
             
         return cancelled
 
-    def deliver_to_ticket(
+    def deliver_to_task(
         self,
-        ticket_id: str,
+        task_id: str,
         update: dict[str, Any],
         *,
         expected_creator: str | None = None,
     ) -> str | None:
-        """Deliver a context update to a ticket.
+        """Deliver a context update to a task.
 
         Returns ``None`` on success, or an error string on failure.
 
-        When ``expected_creator`` is provided the target ticket's
+        When ``expected_creator`` is provided the target task's
         ``parent_task_id`` must match — this prevents one agent from
         injecting updates into another agent's tasks.
         """
-        task = self.store.get(ticket_id)
+        task = self.store.get(task_id)
         if not task:
-            return f"Task {ticket_id} not found"
+            return f"Task {task_id} not found"
 
         if expected_creator and task.metadata.parent_task_id != expected_creator:
-            return f"Task {ticket_id} is not owned by this agent"
+            return f"Task {task_id} is not owned by this agent"
 
-        self._deliver_context_update(ticket_id, update)
+        self._deliver_context_update(task_id, update)
         return None
 
+    # -- context delivery --------------------------------------------------
+
     def _deliver_context_update(self, target_id: str, update: dict[str, Any]) -> None:
-        """Deliver, inject, or buffer a context update for a ticket.
+        """Deliver, inject, or buffer a context update for a task.
 
         Three delivery paths, tried in order:
-        1. **Mid-stream** — ticket is running and has a live context
+        1. **Mid-stream** — task is running and has a live context
            queue.  Push pre-formatted parts for injection at the next
            turn boundary.
-        2. **Immediate resume** — ticket is suspended and idle.  Write
+        2. **Immediate resume** — task is suspended and idle.  Write
            ``response.json`` and flip assignee to trigger resume.
-        3. **Buffer** — ticket is busy but has no live queue (e.g.
+        3. **Buffer** — task is busy but has no live queue (e.g.
            batch mode).  Append to ``pending_context_updates`` in
            metadata for later drain.
         """
-        from bees.context_updates import updates_to_context_parts
-        import json
-
         # Path 1: mid-stream injection via live queue.
         queue = self._context_queues.get(target_id)
         if queue is not None:
@@ -423,14 +345,14 @@ class Scheduler:
 
         target = self.store.get(target_id)
         if not target:
-            logger.warning("Failed to load ticket %s for context update", target_id)
+            logger.warning("Failed to load task %s for context update", target_id)
             return
 
         # Path 2: immediate resume via response.json.
         if (
             target.metadata.status == "suspended"
             and target.metadata.assignee == "user"
-            and target_id not in self._running_tickets
+            and target_id not in self._running_tasks
         ):
             self.store.respond(target_id, {"context_updates": [update]})
             logger.info("Context update delivered to %s via response.json", target_id)
@@ -442,17 +364,19 @@ class Scheduler:
             self.store.save_metadata(target)
             logger.info("Context update buffered for %s", target_id)
 
-    def _enrich_parent_tags(self, ticket: Ticket) -> Ticket | None:
-        """Merge a completed ticket's tags into its parent's tags.
+    # -- tag enrichment ----------------------------------------------------
+
+    def _enrich_parent_tags(self, task: Ticket) -> Ticket | None:
+        """Merge a completed task's tags into its parent's tags.
 
         Called when a subagent finishes (any terminal status).  Performs
         a deduplicated union — one level up only.
 
-        Returns the enriched parent ticket so the caller can broadcast
-        a ``ticket_update`` via SSE, or ``None`` if nothing changed.
+        Returns the enriched parent task so the caller can broadcast
+        a ``task_update`` via SSE, or ``None`` if nothing changed.
         """
-        parent_id = ticket.metadata.parent_task_id
-        child_tags = ticket.metadata.tags
+        parent_id = task.metadata.parent_task_id
+        child_tags = task.metadata.tags
         if not parent_id or not child_tags:
             return None
 
@@ -460,7 +384,7 @@ class Scheduler:
         if not parent:
             logger.warning(
                 "Tag enrichment: parent %s not found for %s",
-                parent_id, ticket.id[:8],
+                parent_id, task.id[:8],
             )
             return None
 
@@ -473,11 +397,13 @@ class Scheduler:
         self.store.save_metadata(parent)
         logger.info(
             "Tag enrichment: %s -> %s (added %s)",
-            ticket.id[:8],
+            task.id[:8],
             parent_id[:8],
             sorted(merged - existing),
         )
         return parent
+
+    # -- orchestration loops -----------------------------------------------
 
     async def start_loop(self) -> None:
         """Background loop that runs cycles whenever triggered."""
@@ -496,15 +422,15 @@ class Scheduler:
             finally:
                 self._running = False
 
-    async def recover_stuck_tickets(self) -> list[Ticket]:
-        """Flip any ``running`` or ``paused`` tickets back to ``available``.
+    async def recover_stuck_tasks(self) -> list[Ticket]:
+        """Flip any ``running`` or ``paused`` tasks back to ``available``.
 
-        Returns the full ticket list (for ``on_startup``).
+        Returns the full task list (for ``on_startup``).
         """
         tickets = self.store.query_all()
         for t in tickets:
             if t.metadata.status in ("running", "paused"):
-                logger.info("Recovered stuck %s ticket: %s", t.metadata.status, t.id)
+                logger.info("Recovered stuck %s task: %s", t.metadata.status, t.id)
                 t.metadata.status = "available"
                 self.store.save_metadata(t)
         return tickets
@@ -512,26 +438,29 @@ class Scheduler:
     async def run_all_waves(self) -> list[dict]:
         """Batch mode: run cycles until no work remains.
 
-        Used by the CLI drain.  Runs tickets via ``asyncio.gather``
+        Used by the CLI drain.  Runs tasks via ``asyncio.gather``
         (all-at-once per cycle) and collects summaries.
         """
         all_summaries: list[dict] = []
         cycle = 0
 
         while True:
-            promote_blocked_tickets(self.store)
+            promote_blocked_tasks(self.store)
 
             all_available = self.store.query_all(status="available")
 
-            # Route coordination tickets before processing work tickets.
+            # Route coordination tasks before processing work tasks.
             coordination = [
                 t for t in all_available
                 if t.metadata.kind == "coordination"
             ]
             for t in coordination:
-                await self._route_coordination_ticket(t)
+                await route_coordination_task(
+                    t, self.store, self._running_tasks,
+                    self._hooks.on_task_done,
+                )
 
-            tickets = [
+            items = [
                 t for t in all_available
                 if t.metadata.kind != "coordination"
             ]
@@ -540,54 +469,54 @@ class Scheduler:
                 if t.metadata.assignee == "agent"
             ]
 
-            if not tickets and not resumable:
+            if not items and not resumable:
                 if cycle == 0:
                     blocked = self.store.query_all(status="blocked")
                     if blocked:
                         print(
-                            f"No runnable tickets. "
-                            f"{len(blocked)} blocked ticket(s) remain.",
+                            f"No runnable tasks. "
+                            f"{len(blocked)} blocked task(s) remain.",
                             file=sys.stderr,
                         )
                     else:
                         print(
-                            "No available or resumable tickets.",
+                            "No available or resumable tasks.",
                             file=sys.stderr,
                         )
                 break
 
             cycle += 1
-            total = len(tickets) + len(resumable)
+            total = len(items) + len(resumable)
 
             if self._hooks.on_cycle_start:
-                await self._hooks.on_cycle_start(cycle, len(tickets), len(resumable))
+                await self._hooks.on_cycle_start(cycle, len(items), len(resumable))
 
             print(
-                f"Cycle {cycle}: {len(tickets)} new + {len(resumable)} "
-                f"resumable = {total} ticket(s)...",
+                f"Cycle {cycle}: {len(items)} new + {len(resumable)} "
+                f"resumable = {total} task(s)...",
                 file=sys.stderr,
             )
 
-            tasks = [
-                self.run_ticket(ticket)
-                for ticket in tickets
+            coros = [
+                self._runner.run_task(item)
+                for item in items
             ] + [
-                self.resume_ticket(ticket)
-                for ticket in resumable
+                self._runner.resume_task(item)
+                for item in resumable
             ]
-            results = await asyncio.gather(*tasks, return_exceptions=True)
+            results = await asyncio.gather(*coros, return_exceptions=True)
 
-            all_tickets_in_cycle = tickets + resumable
-            for ticket, result in zip(all_tickets_in_cycle, results):
+            all_items_in_cycle = items + resumable
+            for item, result in zip(all_items_in_cycle, results):
                 if isinstance(result, Exception):
                     all_summaries.append({
-                        "ticket": ticket.id,
+                        "ticket": item.id,
                         "status": "failed",
                         "error": str(result),
                     })
                 else:
                     all_summaries.append({
-                        "ticket": ticket.id,
+                        "ticket": item.id,
                         "status": result.status,
                         "events": result.events,
                         "output": result.output,
@@ -598,420 +527,74 @@ class Scheduler:
 
         return all_summaries
 
-    # -- ticket lifecycle --------------------------------------------------
-
-    async def run_ticket(
-        self,
-        ticket: Ticket,
-    ) -> SessionResult:
-        """Run a single ticket's session and update its metadata."""
-        # Reload title from disk — it may have been renamed by an on_event
-        # hook during coordination routing earlier in this cycle, while the
-        # in-memory ticket object (from list_tickets) still has the old value.
-        fresh = self.store.get(ticket.id)
-        if fresh and fresh.metadata.title != ticket.metadata.title:
-            ticket.metadata.title = fresh.metadata.title
-
-        ticket.metadata.status = "running"
-        self.store.save_metadata(ticket)
-        if self._hooks.on_ticket_start:
-            await self._hooks.on_ticket_start(ticket)
-
-        label = ticket.id[:8]
-        print(f"▶ [{label}] {ticket.objective!r}", file=sys.stderr)
-
-        try:
-            ctx_queue: asyncio.Queue = asyncio.Queue()
-            self._context_queues[ticket.id] = ctx_queue
-            segments = resolve_segments(ticket, self.store)
-            scope = SubagentScope.for_ticket(ticket)
-            result = await run_session(
-                segments=segments,
-                backend=self._backend,
-                label=label,
-                ticket_id=ticket.id,
-                ticket_dir=ticket.dir,
-                fs_dir=ticket.fs_dir,
-                on_event=self._make_on_event(ticket.id),
-                function_filter=ticket.metadata.functions,
-                allowed_skills=ticket.metadata.skills,
-                model=ticket.metadata.model,
-                on_events_broadcast=self._on_events_broadcast_internal,
-                deliver_to_parent=self._make_deliver_to_parent(ticket),
-                scope=scope,
-                scheduler=self,
-                context_queue=ctx_queue,
-                mcp_factories=(
-                    self._mcp_registry.get_factories()
-                    if self._mcp_registry else None
-                ),
-            )
-        except Exception as exc:
-            ticket.metadata.status = "failed"
-            ticket.metadata.completed_at = datetime.now(timezone.utc).isoformat()
-            ticket.metadata.error = str(exc)
-            self.store.save_metadata(ticket)
-            print(f"  [{label}] ❌ {exc}", file=sys.stderr)
-            return SessionResult(
-                session_id="",
-                status="failed",
-                events=0,
-                output="",
-                error=str(exc),
-            )
-        finally:
-            self._context_queues.pop(ticket.id, None)
-
-        self._update_metadata(ticket, result)
-        self._handle_suspend(ticket, result)
-        self._handle_pause(ticket, result)
-        self.store.save_metadata(ticket)
-        return result
-
-    async def resume_ticket(
-        self,
-        ticket: Ticket,
-    ) -> SessionResult:
-        """Resume a suspended ticket with the user's response."""
-        label = ticket.id[:8]
-        print(f"▶ [{label}] resuming {ticket.objective!r}", file=sys.stderr)
-
-        # Load the user's response.
-        response_path = ticket.dir / "response.json"
-        if not response_path.exists():
-            ticket.metadata.status = "failed"
-            ticket.metadata.error = "No response.json found for resume"
-            self.store.save_metadata(ticket)
-            return SessionResult(
-                session_id="",
-                status="failed",
-                events=0,
-                output="",
-                error="No response found",
-            )
-
-        response = json.loads(response_path.read_text())
-
-        # Log user's reply to the chat log (only actual user text,
-        # not context-update-only responses).
-        user_text = response.get("text", "")
-        if user_text:
-            append_chat_log(ticket.dir, "user", user_text)
-
-        ticket.metadata.status = "running"
-        ticket.metadata.assignee = "agent"
-        self.store.save_metadata(ticket)
-        if self._hooks.on_ticket_start:
-            await self._hooks.on_ticket_start(ticket)
-
-        try:
-            scope = SubagentScope.for_ticket(ticket)
-            ctx_queue: asyncio.Queue = asyncio.Queue()
-            self._context_queues[ticket.id] = ctx_queue
-            result = await resume_session(
-                ticket_id=ticket.id,
-                ticket_dir=ticket.dir,
-                fs_dir=ticket.fs_dir,
-                response=response,
-                backend=self._backend,
-                label=label,
-                on_event=self._make_on_event(ticket.id),
-                on_events_broadcast=self._on_events_broadcast_internal,
-                deliver_to_parent=self._make_deliver_to_parent(ticket),
-                scope=scope,
-                scheduler=self,
-                context_queue=ctx_queue,
-                mcp_factories=(
-                    self._mcp_registry.get_factories()
-                    if self._mcp_registry else None
-                ),
-            )
-        except Exception as exc:
-            ticket.metadata.status = "failed"
-            ticket.metadata.completed_at = datetime.now(timezone.utc).isoformat()
-            ticket.metadata.error = str(exc)
-            self.store.save_metadata(ticket)
-            print(f"  [{label}] ❌ {exc}", file=sys.stderr)
-            return SessionResult(
-                session_id="",
-                status="failed",
-                events=0,
-                output="",
-                error=str(exc),
-            )
-        finally:
-            self._context_queues.pop(ticket.id, None)
-
-        self._update_metadata(ticket, result, accumulate=True)
-        self._handle_suspend(ticket, result)
-        self._handle_pause(ticket, result)
-
-        if not result.suspended and not result.paused:
-            clear_session_state(ticket.dir)
-            # Clean up response file.
-            response_path.unlink(missing_ok=True)
-
-        self.store.save_metadata(ticket)
-        return result
-
     # -- internal ----------------------------------------------------------
 
-    def _update_metadata(
-        self,
-        ticket: Ticket,
-        result: SessionResult,
-        *,
-        accumulate: bool = False,
-    ) -> None:
-        """Update ticket metadata from a session result.
-
-        When ``accumulate`` is True (used on resume), turns and thoughts
-        are added to the existing values rather than replaced.
-        """
-        ticket.metadata.completed_at = datetime.now(timezone.utc).isoformat()
-
-        if result.status == "completed":
-            ticket.metadata.status = "completed"
-        elif result.paused:
-            # Transient Gemini error — don't set completed_at, the ticket
-            # is not done.  Status is set by _handle_pause below.
-            ticket.metadata.completed_at = None
-        else:
-            ticket.metadata.status = "failed"
-
-        if accumulate:
-            ticket.metadata.turns += result.turns
-            ticket.metadata.thoughts += result.thoughts
-        else:
-            ticket.metadata.turns = result.turns
-            ticket.metadata.thoughts = result.thoughts
-
-        if result.error:
-            ticket.metadata.error = result.error
-        if result.outcome:
-            ticket.metadata.outcome = result.outcome
-        if result.outcome_content:
-            ticket.metadata.outcome_content = result.outcome_content
-
-        # Extract agent file system to ticket directory.
-        file_manifest = extract_files(
-            result.intermediate, ticket.fs_dir,
-        )
-        if file_manifest:
-            ticket.metadata.files = file_manifest
-
-    def _handle_suspend(self, ticket: Ticket, result: SessionResult) -> None:
-        """Handle suspend state, including queued-update auto-resume."""
-        if result.suspended:
-            # Reload fields that may have been modified externally while
-            # the session was running (e.g., by on_event hooks or
-            # coordination delivery).  The in-memory ticket object is
-            # stale for these fields.
-            fresh = self.store.get(ticket.id)
-            if fresh:
-                if fresh.metadata.queued_updates:
-                    ticket.metadata.queued_updates = fresh.metadata.queued_updates
-                if fresh.metadata.title != ticket.metadata.title:
-                    ticket.metadata.title = fresh.metadata.title
-
-            # Annotate suspend_event with the triggering function name
-            # so the UI can differentiate (e.g., await_context_update
-            # vs. request_user_input). Read from saved session state.
-            suspend_event = dict(result.suspend_event) if result.suspend_event else {}
-            state = load_session_state(ticket.dir)
-            if state:
-                fcp = state.get("interaction_state", {}).get("function_call_part", {})
-                fn_name = fcp.get("functionCall", {}).get("name")
-                if fn_name:
-                    suspend_event["function_name"] = fn_name
-
-            if getattr(ticket.metadata, "queued_updates", None):
-                update = ticket.metadata.queued_updates.pop(0)
-                response_path = ticket.dir / "response.json"
-                response_path.write_text(
-                    json.dumps({"context_updates": [update]}, indent=2, ensure_ascii=False) + "\n"
-                )
-                ticket.metadata.status = "suspended"
-                ticket.metadata.assignee = "agent"
-                ticket.metadata.suspend_event = suspend_event
-                print(f"  [{ticket.id[:8]}] 📩 auto-resume with queued update", file=sys.stderr)
-            else:
-                ticket.metadata.status = "suspended"
-                ticket.metadata.assignee = "user"
-                ticket.metadata.suspend_event = suspend_event
-        else:
-            ticket.metadata.assignee = None
-            ticket.metadata.suspend_event = None
-
-    def _handle_pause(self, ticket: Ticket, result: SessionResult) -> None:
-        """Handle pause state from transient Gemini API errors."""
-        if result.paused:
-            ticket.metadata.status = "paused"
-            ticket.metadata.assignee = None
-            print(
-                f"  [{ticket.id[:8]}] ⏸ paused: {result.error}",
-                file=sys.stderr,
-            )
-
-
-    def _on_events_broadcast_internal(self, ticket: Ticket) -> None:
+    def _on_events_broadcast_internal(self, task: Ticket) -> None:
         if self._hooks.on_events_broadcast:
-            self._hooks.on_events_broadcast(ticket)
-        if self._hooks.on_ticket_added:
-            asyncio.create_task(self._hooks.on_ticket_added(ticket))
+            self._hooks.on_events_broadcast(task)
+        if self._hooks.on_task_added:
+            asyncio.create_task(self._hooks.on_task_added(task))
         self.trigger()
 
-    def _make_deliver_to_parent(self, ticket: Ticket) -> Callable[[dict[str, Any]], None] | None:
-        """Create a callback that delivers an update to this task's parent."""
-        parent_id = ticket.metadata.parent_task_id
-        if not parent_id:
-            return None
+    async def _wrap_execution(
+        self, task: Ticket, coro: Awaitable[SessionResult],
+    ) -> None:
+        """Run a task coroutine and handle post-completion cleanup."""
+        try:
+            await coro
+        finally:
+            self._running_tasks.discard(task.id)
+            self._active_tasks.pop(task.id, None)
+            updated = self.store.get(task.id) or task
+            run_task_done_hooks(updated)
+            self._notify_task_done(task.id)
 
-        def deliver(update: dict[str, Any]) -> None:
-            self._deliver_context_update(parent_id, update)
+            parent_id = updated.metadata.parent_task_id
+            if parent_id and updated.metadata.status in ("completed", "failed"):
+                update = {
+                    "task_id": updated.id,
+                    "status": updated.metadata.status,
+                    "outcome": (
+                        updated.metadata.outcome
+                        or updated.metadata.error
+                        or "(no outcome)"
+                    ),
+                }
+                self._deliver_context_update(parent_id, update)
 
-        return deliver
+            enriched = self._enrich_parent_tags(updated)
+            if enriched and self._hooks.on_task_done:
+                await self._hooks.on_task_done(enriched)
+            if self._hooks.on_task_done:
+                await self._hooks.on_task_done(updated)
 
-    def _make_on_event(self, ticket_id: str):
-        """Create an event callback wired to the ticket-event hook."""
-        hook = self._hooks.on_ticket_event
-
-        async def on_event(event: dict[str, Any]):
-            if hook:
-                await hook(ticket_id, event)
-
-        return on_event
-
-
-    async def _route_coordination_ticket(self, ticket: Ticket) -> None:
-        """Route a coordination ticket's signal to matching subscribers.
-
-        Delivery is durable: the coordination ticket stays ``available``
-        until every matching subscriber has been delivered to. Subscribers
-        that are busy (running or not idle) are skipped and retried in the
-        next scheduler cycle.
-
-        This design survives server restarts — undelivered coordination
-        tickets remain ``available`` on disk and are re-routed on startup.
-        """
-        signal_type = ticket.metadata.signal_type or ""
-        payload = ticket.metadata.context or ""
-        source_tags = set(ticket.metadata.tags or [])
-        delivered = set(ticket.metadata.delivered_to or [])
-
-        # Find all matching subscribers.
-        source_run_id = ticket.metadata.playbook_run_id
-        subscribers: list[Ticket] = []
-        for candidate in self.store.query_all():
-            if candidate.id == ticket.id:
-                continue
-            if not candidate.metadata.watch_events:
-                continue
-            # Run-ID scoping: if the signal is scoped to a run,
-            # only deliver to subscribers in that same run.
-            if source_run_id and candidate.metadata.playbook_run_id != source_run_id:
-                continue
-            for watch in candidate.metadata.watch_events:
-                if watch.get("type") != signal_type:
-                    continue
-                # Tag filtering.
-                tag_filters = watch.get("tags", [])
-                exclude = {f[1:] for f in tag_filters if f.startswith("!")}
-                require = {f for f in tag_filters if not f.startswith("!")}
-                if source_tags & exclude:
-                    continue
-                if require and not (source_tags & require):
-                    continue
-                subscribers.append(candidate)
-                break
-
-        # Try to deliver to each subscriber not yet delivered.
-        all_delivered = True
-        for sub in subscribers:
-            if sub.id in delivered:
-                continue
-
-            # Let the playbook hook intercept before delivery.
-            result = run_event_hooks(signal_type, payload, sub, self.store)
-            if result is None:
-                # Hook ate the event — mark delivered, skip agent.
-                delivered.add(sub.id)
-                self.store.save_metadata(sub)
-                logger.info(
-                    "Coordination %s eaten by hook for %s",
-                    ticket.id[:8],
-                    sub.id[:8],
-                )
-                continue
-
-            if (
-                sub.metadata.status == "suspended"
-                and sub.metadata.assignee == "user"
-                and sub.id not in self._running_tickets
-            ):
-                # Idle — deliver immediately.
-                response_path = sub.dir / "response.json"
-                response_path.write_text(
-                    json.dumps(
-                        {"context_updates": [result]},
-                        indent=2,
-                        ensure_ascii=False,
-                    )
-                    + "\n"
-                )
-                sub.metadata.assignee = "agent"
-                self.store.save_metadata(sub)
-                delivered.add(sub.id)
-                logger.info(
-                    "Coordination %s delivered to %s",
-                    ticket.id[:8],
-                    sub.id[:8],
-                )
-            else:
-                # Busy — skip, will retry next cycle.
-                all_delivered = False
-
-        # Update delivery tracking.
-        ticket.metadata.delivered_to = list(delivered)
-
-        if all_delivered:
-            ticket.metadata.status = "completed"
-            ticket.metadata.completed_at = datetime.now(timezone.utc).isoformat()
-            logger.info(
-                "Coordination ticket %s fully delivered (signal_type=%s)",
-                ticket.id[:8],
-                signal_type,
-            )
-
-        self.store.save_metadata(ticket)
-
-        # Broadcast the updated coordination ticket to the UI.
-        if self._hooks.on_ticket_done:
-            await self._hooks.on_ticket_done(ticket)
-
+            self.trigger()
 
     async def _run_cycles(self) -> None:
         """Run cycles until no more work is available (server mode).
 
-        Unlike ``run_all_waves`` (batch gather), this fires each ticket
+        Unlike ``run_all_waves`` (batch gather), this fires each task
         as an independent ``asyncio.Task`` for concurrent execution.
         """
         cycle = 0
 
         while True:
-            promote_blocked_tickets(self.store)
+            promote_blocked_tasks(self.store)
 
             all_available = self.store.query_all(status="available")
 
-            # Route coordination tickets before processing work tickets.
+            # Route coordination tasks before processing work tasks.
             coordination = [
                 t for t in all_available
                 if t.metadata.kind == "coordination"
             ]
             for t in coordination:
-                await self._route_coordination_ticket(t)
+                await route_coordination_task(
+                    t, self.store, self._running_tasks,
+                    self._hooks.on_task_done,
+                )
 
-            tickets = [
+            items = [
                 t for t in all_available
                 if t.metadata.kind != "coordination"
             ]
@@ -1020,75 +603,31 @@ class Scheduler:
                 if t.metadata.assignee == "agent"
             ]
 
-            if not tickets and not resumable:
+            if not items and not resumable:
                 break
 
             cycle += 1
 
             if self._hooks.on_cycle_start:
                 await self._hooks.on_cycle_start(
-                    cycle, len(tickets), len(resumable),
+                    cycle, len(items), len(resumable),
                 )
 
-            for ticket in tickets:
-                if ticket.id in self._running_tickets:
+            for item in items:
+                if item.id in self._running_tasks:
                     continue
-                self._running_tickets.add(ticket.id)
+                self._running_tasks.add(item.id)
+                coro = self._runner.run_task(item)
+                async_task = asyncio.create_task(self._wrap_execution(item, coro))
+                self._active_tasks[item.id] = async_task
 
-                async def wrap_run(t=ticket):
-                    try:
-                        await self.run_ticket(t)
-                    finally:
-                        self._running_tickets.discard(t.id)
-                        self._active_tasks.pop(t.id, None)
-                        updated = self.store.get(t.id) or t
-                        run_ticket_done_hooks(updated)
-                        self._notify_ticket_done(t.id)
-
-                        parent_id = updated.metadata.parent_task_id
-                        if parent_id and updated.metadata.status in ("completed", "failed"):
-                            update = {"task_id": updated.id, "status": updated.metadata.status, "outcome": updated.metadata.outcome or updated.metadata.error or "(no outcome)"}
-                            self._deliver_context_update(parent_id, update)
-                        enriched = self._enrich_parent_tags(updated)
-                        if enriched and self._hooks.on_ticket_done:
-                            await self._hooks.on_ticket_done(enriched)
-                        if self._hooks.on_ticket_done:
-                            await self._hooks.on_ticket_done(updated)
-
-                        self.trigger()
-
-                task = asyncio.create_task(wrap_run())
-                self._active_tasks[ticket.id] = task
-
-            for ticket in resumable:
-                if ticket.id in self._running_tickets:
+            for item in resumable:
+                if item.id in self._running_tasks:
                     continue
-                self._running_tickets.add(ticket.id)
-
-                async def wrap_resume(t=ticket):
-                    try:
-                        await self.resume_ticket(t)
-                    finally:
-                        self._running_tickets.discard(t.id)
-                        self._active_tasks.pop(t.id, None)
-                        updated = self.store.get(t.id) or t
-                        run_ticket_done_hooks(updated)
-                        self._notify_ticket_done(t.id)
-
-                        parent_id = updated.metadata.parent_task_id
-                        if parent_id and updated.metadata.status in ("completed", "failed"):
-                            update = {"task_id": updated.id, "status": updated.metadata.status, "outcome": updated.metadata.outcome or updated.metadata.error or "(no outcome)"}
-                            self._deliver_context_update(parent_id, update)
-                        enriched = self._enrich_parent_tags(updated)
-                        if enriched and self._hooks.on_ticket_done:
-                            await self._hooks.on_ticket_done(enriched)
-                        if self._hooks.on_ticket_done:
-                            await self._hooks.on_ticket_done(updated)
-
-                        self.trigger()
-
-                task = asyncio.create_task(wrap_resume())
-                self._active_tasks[ticket.id] = task
+                self._running_tasks.add(item.id)
+                coro = self._runner.resume_task(item)
+                async_task = asyncio.create_task(self._wrap_execution(item, coro))
+                self._active_tasks[item.id] = async_task
 
             await asyncio.sleep(1)
 

--- a/packages/bees/bees/segments.py
+++ b/packages/bees/bees/segments.py
@@ -1,0 +1,84 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Segment resolution — pure data transforms for objective references.
+
+Resolves ``{{…}}`` references in task objectives by substituting
+dependency outcomes and system variables.  Used by the task runner
+to build the structured input for a session.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from bees.task_store import TaskStore, _DEP_PATTERN
+from bees.ticket import Ticket
+
+__all__ = ["resolve_segments"]
+
+
+def resolve_segments(task: Ticket, store: TaskStore) -> list[dict[str, Any]]:
+    """Build segments from a task's objective, resolving ``{{…}}`` references.
+
+    References are resolved by namespace:
+
+    - ``{{system.context}}`` — replaced with the task's context string.
+    - ``{{system.ticket_id}}`` — replaced with the task's own ID.
+    - ``{{ticket-id}}`` — replaced with the dependency's outcome as an
+      ``input`` segment carrying LLMContent.
+
+    Plain text around references becomes text segments.
+    """
+    objective = task.objective
+    deps = task.metadata.depends_on or []
+    context = task.metadata.context or ""
+
+    # Build a lookup from dep ID to resolved outcome.
+    dep_outcomes: dict[str, dict[str, Any]] = {}
+    for dep_id in deps:
+        dep = store.get(dep_id)
+        if dep and dep.metadata.outcome_content:
+            dep_outcomes[dep_id] = dep.metadata.outcome_content
+
+    # Split objective on {{...}} boundaries.
+    parts = _DEP_PATTERN.split(objective)
+    segments: list[dict[str, Any]] = []
+
+    for i, part in enumerate(parts):
+        if i % 2 == 0:
+            # Text between refs.
+            if part:
+                segments.append({"type": "text", "text": part})
+        else:
+            # Resolve by namespace.
+            if part == "system.context":
+                if context:
+                    segments.append({"type": "text", "text": context})
+            elif part == "system.ticket_id":
+                segments.append({"type": "text", "text": task.id})
+            else:
+                # Dependency ref — resolve to input segment.
+                resolved_id = _find_dep_id(part, deps)
+                if resolved_id and resolved_id in dep_outcomes:
+                    segments.append({
+                        "type": "input",
+                        "title": f"ticket-{resolved_id[:8]}",
+                        "content": dep_outcomes[resolved_id],
+                    })
+                else:
+                    # Fallback: just include as text.
+                    segments.append({
+                        "type": "text",
+                        "text": f"(output of ticket {part})",
+                    })
+
+    return segments
+
+
+def _find_dep_id(ref: str, dep_ids: list[str]) -> str | None:
+    """Match a ref (prefix or full UUID) against resolved dep IDs."""
+    for dep_id in dep_ids:
+        if dep_id == ref or dep_id.startswith(ref):
+            return dep_id
+    return None

--- a/packages/bees/bees/task_runner.py
+++ b/packages/bees/bees/task_runner.py
@@ -1,0 +1,339 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Task runner — session wiring and metadata bookkeeping for individual tasks.
+
+Owns everything needed to execute a single task: building session input,
+calling the session layer, and updating metadata with the result.  Has no
+awareness of cycles, scheduling, or orchestration — that belongs to the
+``Scheduler``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable
+
+from bees.segments import resolve_segments
+from bees.session import (
+    SessionResult,
+    append_chat_log,
+    clear_session_state,
+    extract_files,
+    load_session_state,
+    resume_session,
+    run_session,
+)
+from bees.subagent_scope import SubagentScope
+from bees.task_store import TaskStore
+from bees.ticket import Ticket
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["TaskRunner"]
+
+
+class TaskRunner:
+    """Runs and resumes individual tasks.
+
+    Handles session wiring, metadata bookkeeping, suspend/pause state
+    transitions, and file extraction.  Receives its dependencies via
+    constructor injection — no back-reference to ``Scheduler``.
+    """
+
+    def __init__(
+        self,
+        *,
+        backend: Any,
+        store: TaskStore,
+        scheduler_ref: Any,
+        context_queues: dict[str, asyncio.Queue],
+        get_mcp_factories: Callable[[], list | None],
+        deliver_context_update: Callable[[str, dict[str, Any]], None],
+        on_events_broadcast: Callable[[Ticket], None],
+        on_task_start: Callable[[Ticket], Awaitable[None]] | None = None,
+        on_task_event: Callable[[str, dict], Awaitable[None]] | None = None,
+    ) -> None:
+        self._backend = backend
+        self._store = store
+        self._scheduler_ref = scheduler_ref
+        self._context_queues = context_queues
+        self._get_mcp_factories = get_mcp_factories
+        self._deliver_context_update = deliver_context_update
+        self._on_events_broadcast = on_events_broadcast
+        self._on_task_start = on_task_start
+        self._on_task_event = on_task_event
+
+    # -- public API --------------------------------------------------------
+
+    async def run_task(
+        self,
+        task: Ticket,
+    ) -> SessionResult:
+        """Run a single task's session and update its metadata."""
+        # Reload title from disk — it may have been renamed by an on_event
+        # hook during coordination routing earlier in this cycle, while the
+        # in-memory task object (from list_tickets) still has the old value.
+        fresh = self._store.get(task.id)
+        if fresh and fresh.metadata.title != task.metadata.title:
+            task.metadata.title = fresh.metadata.title
+
+        task.metadata.status = "running"
+        self._store.save_metadata(task)
+        if self._on_task_start:
+            await self._on_task_start(task)
+
+        label = task.id[:8]
+        print(f"▶ [{label}] {task.objective!r}", file=sys.stderr)
+
+        try:
+            ctx_queue: asyncio.Queue = asyncio.Queue()
+            self._context_queues[task.id] = ctx_queue
+            segments = resolve_segments(task, self._store)
+            scope = SubagentScope.for_ticket(task)
+            result = await run_session(
+                segments=segments,
+                backend=self._backend,
+                label=label,
+                ticket_id=task.id,
+                ticket_dir=task.dir,
+                fs_dir=task.fs_dir,
+                on_event=self._make_on_event(task.id),
+                function_filter=task.metadata.functions,
+                allowed_skills=task.metadata.skills,
+                model=task.metadata.model,
+                on_events_broadcast=self._on_events_broadcast,
+                deliver_to_parent=self._make_deliver_to_parent(task),
+                scope=scope,
+                scheduler=self._scheduler_ref,
+                context_queue=ctx_queue,
+                mcp_factories=self._get_mcp_factories(),
+            )
+        except Exception as exc:
+            task.metadata.status = "failed"
+            task.metadata.completed_at = datetime.now(timezone.utc).isoformat()
+            task.metadata.error = str(exc)
+            self._store.save_metadata(task)
+            print(f"  [{label}] ❌ {exc}", file=sys.stderr)
+            return SessionResult(
+                session_id="",
+                status="failed",
+                events=0,
+                output="",
+                error=str(exc),
+            )
+        finally:
+            self._context_queues.pop(task.id, None)
+
+        self._update_metadata(task, result)
+        self._handle_suspend(task, result)
+        self._handle_pause(task, result)
+        self._store.save_metadata(task)
+        return result
+
+    async def resume_task(
+        self,
+        task: Ticket,
+    ) -> SessionResult:
+        """Resume a suspended task with the user's response."""
+        label = task.id[:8]
+        print(f"▶ [{label}] resuming {task.objective!r}", file=sys.stderr)
+
+        # Load the user's response.
+        response_path = task.dir / "response.json"
+        if not response_path.exists():
+            task.metadata.status = "failed"
+            task.metadata.error = "No response.json found for resume"
+            self._store.save_metadata(task)
+            return SessionResult(
+                session_id="",
+                status="failed",
+                events=0,
+                output="",
+                error="No response found",
+            )
+
+        response = json.loads(response_path.read_text())
+
+        # Log user's reply to the chat log (only actual user text,
+        # not context-update-only responses).
+        user_text = response.get("text", "")
+        if user_text:
+            append_chat_log(task.dir, "user", user_text)
+
+        task.metadata.status = "running"
+        task.metadata.assignee = "agent"
+        self._store.save_metadata(task)
+        if self._on_task_start:
+            await self._on_task_start(task)
+
+        try:
+            scope = SubagentScope.for_ticket(task)
+            ctx_queue: asyncio.Queue = asyncio.Queue()
+            self._context_queues[task.id] = ctx_queue
+            result = await resume_session(
+                ticket_id=task.id,
+                ticket_dir=task.dir,
+                fs_dir=task.fs_dir,
+                response=response,
+                backend=self._backend,
+                label=label,
+                on_event=self._make_on_event(task.id),
+                on_events_broadcast=self._on_events_broadcast,
+                deliver_to_parent=self._make_deliver_to_parent(task),
+                scope=scope,
+                scheduler=self._scheduler_ref,
+                context_queue=ctx_queue,
+                mcp_factories=self._get_mcp_factories(),
+            )
+        except Exception as exc:
+            task.metadata.status = "failed"
+            task.metadata.completed_at = datetime.now(timezone.utc).isoformat()
+            task.metadata.error = str(exc)
+            self._store.save_metadata(task)
+            print(f"  [{label}] ❌ {exc}", file=sys.stderr)
+            return SessionResult(
+                session_id="",
+                status="failed",
+                events=0,
+                output="",
+                error=str(exc),
+            )
+        finally:
+            self._context_queues.pop(task.id, None)
+
+        self._update_metadata(task, result, accumulate=True)
+        self._handle_suspend(task, result)
+        self._handle_pause(task, result)
+
+        if not result.suspended and not result.paused:
+            clear_session_state(task.dir)
+            # Clean up response file.
+            response_path.unlink(missing_ok=True)
+
+        self._store.save_metadata(task)
+        return result
+
+    # -- internal ----------------------------------------------------------
+
+    def _update_metadata(
+        self,
+        task: Ticket,
+        result: SessionResult,
+        *,
+        accumulate: bool = False,
+    ) -> None:
+        """Update task metadata from a session result.
+
+        When ``accumulate`` is True (used on resume), turns and thoughts
+        are added to the existing values rather than replaced.
+        """
+        task.metadata.completed_at = datetime.now(timezone.utc).isoformat()
+
+        if result.status == "completed":
+            task.metadata.status = "completed"
+        elif result.paused:
+            # Transient Gemini error — don't set completed_at, the task
+            # is not done.  Status is set by _handle_pause below.
+            task.metadata.completed_at = None
+        else:
+            task.metadata.status = "failed"
+
+        if accumulate:
+            task.metadata.turns += result.turns
+            task.metadata.thoughts += result.thoughts
+        else:
+            task.metadata.turns = result.turns
+            task.metadata.thoughts = result.thoughts
+
+        if result.error:
+            task.metadata.error = result.error
+        if result.outcome:
+            task.metadata.outcome = result.outcome
+        if result.outcome_content:
+            task.metadata.outcome_content = result.outcome_content
+
+        # Extract agent file system to task directory.
+        file_manifest = extract_files(
+            result.intermediate, task.fs_dir,
+        )
+        if file_manifest:
+            task.metadata.files = file_manifest
+
+    def _handle_suspend(self, task: Ticket, result: SessionResult) -> None:
+        """Handle suspend state, including queued-update auto-resume."""
+        if result.suspended:
+            # Reload fields that may have been modified externally while
+            # the session was running (e.g., by on_event hooks or
+            # coordination delivery).  The in-memory task object is
+            # stale for these fields.
+            fresh = self._store.get(task.id)
+            if fresh:
+                if fresh.metadata.queued_updates:
+                    task.metadata.queued_updates = fresh.metadata.queued_updates
+                if fresh.metadata.title != task.metadata.title:
+                    task.metadata.title = fresh.metadata.title
+
+            # Annotate suspend_event with the triggering function name
+            # so the UI can differentiate (e.g., await_context_update
+            # vs. request_user_input). Read from saved session state.
+            suspend_event = dict(result.suspend_event) if result.suspend_event else {}
+            state = load_session_state(task.dir)
+            if state:
+                fcp = state.get("interaction_state", {}).get("function_call_part", {})
+                fn_name = fcp.get("functionCall", {}).get("name")
+                if fn_name:
+                    suspend_event["function_name"] = fn_name
+
+            if getattr(task.metadata, "queued_updates", None):
+                update = task.metadata.queued_updates.pop(0)
+                response_path = task.dir / "response.json"
+                response_path.write_text(
+                    json.dumps({"context_updates": [update]}, indent=2, ensure_ascii=False) + "\n"
+                )
+                task.metadata.status = "suspended"
+                task.metadata.assignee = "agent"
+                task.metadata.suspend_event = suspend_event
+                print(f"  [{task.id[:8]}] 📩 auto-resume with queued update", file=sys.stderr)
+            else:
+                task.metadata.status = "suspended"
+                task.metadata.assignee = "user"
+                task.metadata.suspend_event = suspend_event
+        else:
+            task.metadata.assignee = None
+            task.metadata.suspend_event = None
+
+    def _handle_pause(self, task: Ticket, result: SessionResult) -> None:
+        """Handle pause state from transient Gemini API errors."""
+        if result.paused:
+            task.metadata.status = "paused"
+            task.metadata.assignee = None
+            print(
+                f"  [{task.id[:8]}] ⏸ paused: {result.error}",
+                file=sys.stderr,
+            )
+
+    def _make_deliver_to_parent(self, task: Ticket) -> Callable[[dict[str, Any]], None] | None:
+        """Create a callback that delivers an update to this task's parent."""
+        parent_id = task.metadata.parent_task_id
+        if not parent_id:
+            return None
+
+        def deliver(update: dict[str, Any]) -> None:
+            self._deliver_context_update(parent_id, update)
+
+        return deliver
+
+    def _make_on_event(self, task_id: str):
+        """Create an event callback wired to the task-event hook."""
+        hook = self._on_task_event
+
+        async def on_event(event: dict[str, Any]):
+            if hook:
+                await hook(task_id, event)
+
+        return on_event

--- a/packages/bees/tests/test_playbook.py
+++ b/packages/bees/tests/test_playbook.py
@@ -16,7 +16,7 @@ from bees.playbook import (
     load_system_config,
     run_playbook as _real_run_playbook,
     run_event_hooks,
-    stamp_child_ticket as _real_stamp_child_ticket,
+    stamp_child_task as _real_stamp_child_task,
 )
 from bees.task_store import _DEP_PATTERN
 from bees.task_store import TaskStore
@@ -27,9 +27,9 @@ def run_playbook(name: str, **kwargs):
     assert GLOBAL_STORE is not None, "GLOBAL_STORE not initialized"
     return _real_run_playbook(name, store=GLOBAL_STORE, **kwargs)
 
-def stamp_child_ticket(template_name: str, *, parent_ticket, slug, **kwargs):
+def stamp_child_task(template_name: str, *, parent_task, slug, **kwargs):
     assert GLOBAL_STORE is not None, "GLOBAL_STORE not initialized"
-    return _real_stamp_child_ticket(template_name, parent_ticket=parent_ticket, slug=slug, store=GLOBAL_STORE, **kwargs)
+    return _real_stamp_child_task(template_name, parent_task=parent_task, slug=slug, store=GLOBAL_STORE, **kwargs)
 
 @pytest.fixture(autouse=True)
 def _temp_dirs(tmp_path):
@@ -342,10 +342,10 @@ class TestLoadSystemConfig:
         assert config == {}
 
 
-# --- stamp_child_ticket ---
+# --- stamp_child_task ---
 
 
-class TestStampChildTicket:
+class TestStampChildTask:
 
     def test_creates_child_with_correct_hierarchy(self, write_template):
         write_template(
@@ -354,8 +354,8 @@ class TestStampChildTicket:
         )
 
         parent = run_playbook("parent")
-        child = stamp_child_ticket(
-            "worker", parent_ticket=parent, slug="my-worker",
+        child = stamp_child_task(
+            "worker", parent_task=parent, slug="my-worker",
         )
 
         assert child.metadata.parent_task_id == parent.id
@@ -370,8 +370,8 @@ class TestStampChildTicket:
         )
 
         parent = run_playbook("parent")
-        child = stamp_child_ticket(
-            "worker", parent_ticket=parent, slug="my-worker",
+        child = stamp_child_task(
+            "worker", parent_task=parent, slug="my-worker",
         )
 
         assert "<sandbox_environment>" in child.objective
@@ -385,8 +385,8 @@ class TestStampChildTicket:
         )
 
         parent = run_playbook("parent")
-        child = stamp_child_ticket(
-            "worker", parent_ticket=parent, slug="my-worker",
+        child = stamp_child_task(
+            "worker", parent_task=parent, slug="my-worker",
         )
 
         writable = child.fs_dir / "my-worker"
@@ -399,8 +399,8 @@ class TestStampChildTicket:
         )
 
         parent = run_playbook("parent")
-        child = stamp_child_ticket(
-            "worker", parent_ticket=parent, slug="w",
+        child = stamp_child_task(
+            "worker", parent_task=parent, slug="w",
             context="the important thing",
         )
 
@@ -413,8 +413,8 @@ class TestStampChildTicket:
         )
 
         parent = run_playbook("parent")
-        child = stamp_child_ticket(
-            "worker", parent_ticket=parent, slug="w",
+        child = stamp_child_task(
+            "worker", parent_task=parent, slug="w",
             title="Custom Title",
         )
 

--- a/packages/bees/tests/test_scheduler.py
+++ b/packages/bees/tests/test_scheduler.py
@@ -1,7 +1,7 @@
 # Copyright 2026 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for the Scheduler wait_for_ticket mechanism."""
+"""Tests for the Scheduler wait_for_task mechanism."""
 
 from __future__ import annotations
 
@@ -50,7 +50,7 @@ def write_template(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_wait_for_ticket_already_completed(mock_clients):
+async def test_wait_for_task_already_completed(mock_clients):
     _, backend = mock_clients
     scheduler = Scheduler(store=GLOBAL_STORE, backend=backend)
     
@@ -58,12 +58,12 @@ async def test_wait_for_ticket_already_completed(mock_clients):
     ticket.metadata.status = "completed"
     GLOBAL_STORE.save_metadata(ticket)
     
-    status = await scheduler.wait_for_ticket(ticket.id, timeout_ms=100)
+    status = await scheduler.wait_for_task(ticket.id, timeout_ms=100)
     assert status == "completed"
 
 
 @pytest.mark.asyncio
-async def test_wait_for_ticket_blocks_and_completes(mock_clients):
+async def test_wait_for_task_blocks_and_completes(mock_clients):
     _, backend = mock_clients
     scheduler = Scheduler(store=GLOBAL_STORE, backend=backend)
     
@@ -73,10 +73,10 @@ async def test_wait_for_ticket_blocks_and_completes(mock_clients):
         await asyncio.sleep(0.05)
         ticket.metadata.status = "completed"
         GLOBAL_STORE.save_metadata(ticket)
-        scheduler._notify_ticket_done(ticket.id)
+        scheduler._notify_task_done(ticket.id)
 
     # Run wait and simulation concurrently
-    wait_task = asyncio.create_task(scheduler.wait_for_ticket(ticket.id, timeout_ms=1000))
+    wait_task = asyncio.create_task(scheduler.wait_for_task(ticket.id, timeout_ms=1000))
     await simulate_completion()
     
     status = await wait_task
@@ -84,7 +84,7 @@ async def test_wait_for_ticket_blocks_and_completes(mock_clients):
 
 
 @pytest.mark.asyncio
-async def test_wait_for_ticket_timeout(mock_clients):
+async def test_wait_for_task_timeout(mock_clients):
     _, backend = mock_clients
     scheduler = Scheduler(store=GLOBAL_STORE, backend=backend)
     
@@ -92,12 +92,12 @@ async def test_wait_for_ticket_timeout(mock_clients):
     ticket.metadata.status = "running"
     GLOBAL_STORE.save_metadata(ticket)
     
-    status = await scheduler.wait_for_ticket(ticket.id, timeout_ms=50)
+    status = await scheduler.wait_for_task(ticket.id, timeout_ms=50)
     assert status == "running" # Returns current status on timeout
 
 
 @pytest.mark.asyncio
-async def test_wait_for_ticket_returns_early_on_suspend(mock_clients):
+async def test_wait_for_task_returns_early_on_suspend(mock_clients):
     _, backend = mock_clients
     scheduler = Scheduler(store=GLOBAL_STORE, backend=backend)
     
@@ -109,9 +109,9 @@ async def test_wait_for_ticket_returns_early_on_suspend(mock_clients):
         await asyncio.sleep(0.05)
         ticket.metadata.status = "suspended"
         GLOBAL_STORE.save_metadata(ticket)
-        scheduler._notify_ticket_done(ticket.id)
+        scheduler._notify_task_done(ticket.id)
 
-    wait_task = asyncio.create_task(scheduler.wait_for_ticket(ticket.id, timeout_ms=1000))
+    wait_task = asyncio.create_task(scheduler.wait_for_task(ticket.id, timeout_ms=1000))
     await simulate_suspend()
     
     status = await wait_task
@@ -119,7 +119,7 @@ async def test_wait_for_ticket_returns_early_on_suspend(mock_clients):
 
 
 @pytest.mark.asyncio
-async def test_wait_for_ticket_returns_early_on_fail(mock_clients):
+async def test_wait_for_task_returns_early_on_fail(mock_clients):
     _, backend = mock_clients
     scheduler = Scheduler(store=GLOBAL_STORE, backend=backend)
     
@@ -131,9 +131,9 @@ async def test_wait_for_ticket_returns_early_on_fail(mock_clients):
         await asyncio.sleep(0.05)
         ticket.metadata.status = "failed"
         GLOBAL_STORE.save_metadata(ticket)
-        scheduler._notify_ticket_done(ticket.id)
+        scheduler._notify_task_done(ticket.id)
 
-    wait_task = asyncio.create_task(scheduler.wait_for_ticket(ticket.id, timeout_ms=1000))
+    wait_task = asyncio.create_task(scheduler.wait_for_task(ticket.id, timeout_ms=1000))
     await simulate_fail()
     
     status = await wait_task
@@ -191,7 +191,7 @@ async def test_enrich_parent_tags_merges(mock_clients):
 
 @pytest.mark.asyncio
 async def test_enrich_parent_tags_no_parent(mock_clients):
-    """No crash when parent_task_id points to a nonexistent ticket."""
+    """No crash when parent_task_id points to a nonexistent task."""
     _, backend = mock_clients
     scheduler = Scheduler(store=GLOBAL_STORE, backend=backend)
 
@@ -260,7 +260,7 @@ def test_eval_collector_detects_paused():
 
 
 def test_update_metadata_paused(mock_clients):
-    """Paused result → ticket status 'paused', completed_at is None."""
+    """Paused result → task status 'paused', completed_at is None."""
     from bees.session import SessionResult
 
     _, backend = mock_clients
@@ -276,7 +276,7 @@ def test_update_metadata_paused(mock_clients):
         error="503 Service Unavailable",
     )
 
-    scheduler._update_metadata(ticket, result)
+    scheduler._runner._update_metadata(ticket, result)
 
     # _update_metadata sets completed_at, but for paused it should be None.
     assert ticket.metadata.completed_at is None
@@ -286,7 +286,7 @@ def test_update_metadata_paused(mock_clients):
 
 
 def test_handle_pause_sets_status(mock_clients):
-    """_handle_pause sets ticket status to 'paused', assignee to None."""
+    """_handle_pause sets task status to 'paused', assignee to None."""
     from bees.session import SessionResult
 
     _, backend = mock_clients
@@ -305,15 +305,15 @@ def test_handle_pause_sets_status(mock_clients):
         error="503 Service Unavailable",
     )
 
-    scheduler._handle_pause(ticket, result)
+    scheduler._runner._handle_pause(ticket, result)
 
     assert ticket.metadata.status == "paused"
     assert ticket.metadata.assignee is None
 
 
 def test_promote_does_not_cascade_paused(mock_clients):
-    """A blocked ticket with a paused dep stays blocked (no cascade)."""
-    from bees.scheduler import promote_blocked_tickets
+    """A blocked task with a paused dep stays blocked (no cascade)."""
+    from bees.scheduler import promote_blocked_tasks
 
     parent = GLOBAL_STORE.create("Parent")
     parent.metadata.status = "paused"
@@ -324,7 +324,7 @@ def test_promote_does_not_cascade_paused(mock_clients):
     child.metadata.depends_on = [parent.id]
     GLOBAL_STORE.save_metadata(child)
 
-    promote_blocked_tickets(GLOBAL_STORE)
+    promote_blocked_tasks(GLOBAL_STORE)
 
     fresh_child = GLOBAL_STORE.get(child.id)
     # Should still be blocked, NOT failed.

--- a/packages/bees/tests/test_tasks.py
+++ b/packages/bees/tests/test_tasks.py
@@ -206,7 +206,7 @@ async def test_tasks_create_task_sync_wait_timeout(write_template, monkeypatch):
 
     mock_scheduler = MagicMock()
     mock_scheduler.store = GLOBAL_STORE
-    mock_scheduler.wait_for_ticket = AsyncMock(return_value="running")
+    mock_scheduler.wait_for_task = AsyncMock(return_value="running")
 
     caller = GLOBAL_STORE.create("I'm the caller")
     scope = SubagentScope(workspace_root_id=caller.id)
@@ -224,13 +224,13 @@ async def test_tasks_create_task_sync_wait_timeout(write_template, monkeypatch):
 
     assert "task_id" in result
     assert result["status"] == "running"
-    mock_scheduler.wait_for_ticket.assert_called_once()
+    mock_scheduler.wait_for_task.assert_called_once()
 
 
 @pytest.mark.asyncio
 async def test_tasks_cancel_task():
     mock_scheduler = MagicMock()
-    mock_scheduler.cancel_ticket = MagicMock(return_value=True)
+    mock_scheduler.cancel_task = MagicMock(return_value=True)
 
     scope = SubagentScope(workspace_root_id="caller-id")
     handlers = _make_handlers(scope=scope, caller_ticket_id="caller-id", scheduler=mock_scheduler)
@@ -240,13 +240,13 @@ async def test_tasks_cancel_task():
 
     assert "message" in result
     assert "cancellation requested" in result["message"]
-    mock_scheduler.cancel_ticket.assert_called_once_with("target-id")
+    mock_scheduler.cancel_task.assert_called_once_with("target-id")
 
 
 @pytest.mark.asyncio
 async def test_tasks_cancel_task_not_found():
     mock_scheduler = MagicMock()
-    mock_scheduler.cancel_ticket = MagicMock(return_value=False)
+    mock_scheduler.cancel_task = MagicMock(return_value=False)
 
     scope = SubagentScope(workspace_root_id="caller-id")
     handlers = _make_handlers(scope=scope, caller_ticket_id="caller-id", scheduler=mock_scheduler)


### PR DESCRIPTION
## What
Extracts three focused modules from `scheduler.py` (coordination routing, segment resolution, task runner) and renames all internal-only "ticket" references to "task" across the scheduler layer.

## Why
The scheduler was a 1000+ line monolith mixing orchestration, execution, and event routing. Extracting these into `coordination.py`, `segments.py`, and `TaskRunner` makes each concern independently readable and testable. The ticket→task rename aligns internal naming with the public API, which already uses "task" terminology (`create_task`, `parent_task_id`, etc.).

## Changes

### New modules (`packages/bees/bees/`)
- **`coordination.py`** — `route_coordination_task()`, extracted from scheduler's coordination routing logic
- **`segments.py`** — `resolve_segments()`, extracted objective `{{…}}` reference resolution
- **`task_runner.py`** — `TaskRunner` class, owns session wiring and metadata bookkeeping for individual task execution/resume

### Scheduler (`scheduler.py`)
- Delegates execution to `TaskRunner` instead of inline methods
- Unified `_wrap_execution()` replaces duplicated `wrap_run`/`wrap_resume` closures
- Renamed: `_running_tickets` → `_running_tasks`, `promote_blocked_tickets` → `promote_blocked_tasks`, `recover_stuck_tickets` → `recover_stuck_tasks`, `wait_for_ticket` → `wait_for_task`, `cancel_ticket` → `cancel_task`, `deliver_to_ticket` → `deliver_to_task`
- `SchedulerHooks` fields: `on_ticket_*` → `on_task_*`
- Loop variables renamed from `ticket` to `item` to avoid `asyncio.Task` shadowing

### Playbook (`playbook.py`)
- `stamp_child_ticket` → `stamp_child_task` (param `parent_ticket` → `parent_task`)
- `run_ticket_done_hooks` → `run_task_done_hooks`
- Hook attribute `on_ticket_done` → `on_task_done`

### Consumers
- **`bees.py`** — updated `SchedulerHooks` field names
- **`functions/tasks.py`** — updated all scheduler method calls and playbook imports

### Unchanged (wire format / cross-module API)
- `Ticket` class and related types
- `ticket_id`/`ticket_dir` params to `session.py`
- `SubagentScope.for_ticket()`
- Template variables (`system.ticket_id`, `ticket-{id}` labels)

## Testing
`python -m pytest tests/ -x` — 180 passed. Dev server verified with live hive.
