### PR TITLE
[bees] Box — filesystem-driven orchestrator for Bees

### DIFF
--- a/packages/bees/bees/bees.py
+++ b/packages/bees/bees/bees.py
@@ -48,8 +48,8 @@ class Bees:
         self._loop_task = asyncio.create_task(self._scheduler.start_loop())
         self._scheduler.trigger()
 
-    def _trigger(self):
-        """Triggers the scheduler to process tasks."""
+    def trigger(self):
+        """Wake the scheduler to re-evaluate available work."""
         self._scheduler.trigger()
 
     async def shutdown(self):

--- a/packages/bees/bees/box.py
+++ b/packages/bees/bees/box.py
@@ -1,0 +1,243 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Box — filesystem-driven orchestrator for Bees.
+
+Named after the hive box, the physical structure that houses bees.
+Instead of an HTTP server, the box watches the hive directory for
+changes and drives the scheduler through filesystem events.
+
+Two conceptual watchers share a single ``watchfiles.awatch`` stream:
+
+- **Config watcher** (cold restart): changes to ``config/SYSTEM.yaml``,
+  ``config/TEMPLATES.yaml``, ``config/hooks/``, or ``skills/`` cause
+  the box to shut down the current ``Bees`` instance and restart with
+  fresh configuration.
+
+- **Task watcher** (hot trigger): changes under ``tickets/`` wake the
+  scheduler to re-evaluate available work.
+
+Usage::
+
+    python -m bees.box
+    # or
+    npm run dev:box -w packages/bees
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import signal
+import sys
+from pathlib import Path
+from typing import Literal
+
+import httpx
+from watchfiles import awatch, Change
+
+from app.auth import load_gemini_key
+from app.config import load_hive_dir
+from bees import Bees
+from bees.ticket import Ticket
+from opal_backend.local.backend_client_impl import HttpBackendClient
+
+logger = logging.getLogger("bees.box")
+
+
+# ---------------------------------------------------------------------------
+# Change classification
+# ---------------------------------------------------------------------------
+
+ChangeKind = Literal["config", "task", "ignore"]
+
+
+def classify_change(path: Path, hive_dir: Path) -> ChangeKind:
+    """Classify a changed path relative to the hive directory.
+
+    Returns:
+        ``"config"`` for configuration files that require a restart,
+        ``"task"`` for ticket changes that should trigger the scheduler,
+        ``"ignore"`` for everything else (logs, temp files, etc.).
+    """
+    try:
+        rel = path.relative_to(hive_dir)
+    except ValueError:
+        return "ignore"
+
+    parts = rel.parts
+    if not parts:
+        return "ignore"
+
+    top = parts[0]
+
+    # Config paths → cold restart.
+    if top == "config":
+        return "config"
+    if top == "skills":
+        return "config"
+
+    # Task paths → hot trigger.
+    if top == "tickets":
+        return "task"
+
+    return "ignore"
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle hooks → logging
+# ---------------------------------------------------------------------------
+
+
+async def _on_task_added(task: Ticket) -> None:
+    logger.info("Agent added: %s (%s)", task.metadata.title or task.id[:8], task.id[:8])
+
+
+async def _on_cycle_start(cycle: int, new: int, resumable: int) -> None:
+    logger.info(
+        "Cycle %d: %d new + %d resumable",
+        cycle, new, resumable,
+    )
+
+
+async def _on_task_event(task_id: str, event: dict) -> None:
+    logger.debug("Event [%s]: %s", task_id[:8], event.get("type", "unknown"))
+
+
+async def _on_task_start(task: Ticket) -> None:
+    logger.info(
+        "Agent running: %s (%s)",
+        task.metadata.title or task.id[:8], task.id[:8],
+    )
+
+
+async def _on_task_done(task: Ticket) -> None:
+    logger.info(
+        "Agent %s: %s (%s)",
+        task.metadata.status,
+        task.metadata.title or task.id[:8],
+        task.id[:8],
+    )
+
+
+async def _on_cycle_complete(cycles: int) -> None:
+    logger.info("All cycles complete (%d total)", cycles)
+
+
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+
+
+async def run(hive_dir: Path, backend: HttpBackendClient) -> None:
+    """Run the box — outer restart loop + inner file-watch loop.
+
+    This function runs indefinitely until cancelled or interrupted.
+    Config changes cause a restart (inner loop breaks, outer loop
+    re-creates ``Bees``). Task changes trigger the scheduler.
+    """
+    logger.info("Box starting — watching %s", hive_dir)
+
+    while True:
+        bees = Bees(hive_dir, backend)
+
+        bees.on("task_added", _on_task_added)
+        bees.on("cycle_start", _on_cycle_start)
+        bees.on("task_event", _on_task_event)
+        bees.on("task_start", _on_task_start)
+        bees.on("task_done", _on_task_done)
+        bees.on("cycle_complete", _on_cycle_complete)
+
+        await bees.listen()
+        logger.info("Bees started — watching for changes")
+
+        restart = False
+        try:
+            async for changes in awatch(hive_dir):
+                needs_restart = False
+                needs_trigger = False
+
+                for _change_type, changed_path in changes:
+                    kind = classify_change(Path(changed_path), hive_dir)
+                    if kind == "config":
+                        needs_restart = True
+                    elif kind == "task":
+                        needs_trigger = True
+
+                if needs_restart:
+                    logger.info("Config change detected — restarting")
+                    restart = True
+                    break
+
+                if needs_trigger:
+                    logger.debug("Task change detected — triggering scheduler")
+                    bees.trigger()
+
+        except asyncio.CancelledError:
+            logger.info("Box cancelled — shutting down")
+            await bees.shutdown()
+            return
+
+        await bees.shutdown()
+        if not restart:
+            return
+
+        logger.info("Restarting bees...")
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    """CLI entry point for ``python -m bees.box``."""
+    from dotenv import load_dotenv
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+        stream=sys.stderr,
+    )
+
+    load_dotenv()
+
+    gemini_key = load_gemini_key()
+    hive_dir = load_hive_dir()
+
+    http_client = httpx.AsyncClient(timeout=httpx.Timeout(300.0))
+    backend = HttpBackendClient(
+        upstream_base="",
+        httpx_client=http_client,
+        access_token="",
+        gemini_key=gemini_key,
+    )
+
+    loop = asyncio.new_event_loop()
+
+    async def _run() -> None:
+        try:
+            await run(hive_dir, backend)
+        finally:
+            await http_client.aclose()
+
+    # Clean shutdown on SIGINT/SIGTERM.
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, lambda: _cancel_all(loop))
+
+    try:
+        loop.run_until_complete(_run())
+    finally:
+        loop.close()
+
+
+def _cancel_all(loop: asyncio.AbstractEventLoop) -> None:
+    """Cancel all running tasks for clean shutdown."""
+    for task in asyncio.all_tasks(loop):
+        task.cancel()
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/bees/bees/task_node.py
+++ b/packages/bees/bees/task_node.py
@@ -136,7 +136,7 @@ class TaskNode:
                 payload["selectedIds"] = selectedIds
 
         self._task = self._store.respond(self.id, payload)
-        self._bees._trigger()
+        self._bees.trigger()
         return self._task
 
     def save(self):
@@ -148,4 +148,4 @@ class TaskNode:
         self._task.metadata.status = "available"
         self._task.metadata.error = None
         self.save()
-        self._bees._trigger()
+        self._bees.trigger()

--- a/packages/bees/docs/README.md
+++ b/packages/bees/docs/README.md
@@ -27,6 +27,8 @@
 
 ## Tooling
 
+- [box.md](box.md) — The filesystem-driven orchestrator. Watches the hive for
+  changes and drives the scheduler without an HTTP server.
 - [hivetool.md](hivetool.md) — The built-in developer workbench for inspecting
   and editing hive configuration.
 

--- a/packages/bees/docs/box.md
+++ b/packages/bees/docs/box.md
@@ -1,0 +1,171 @@
+# Box — Filesystem-Driven Orchestrator
+
+The box is a file-watching alternative to the HTTP server. Instead of exposing
+a REST API, it watches the hive directory for changes and drives the scheduler
+through filesystem events. Named after the hive box — the physical structure
+that houses bees.
+
+## Overview
+
+```
+┌──────────────────────────────────────────────────┐
+│               Hivetool (browser)                 │
+│    File System Access API — reads and writes     │
+│                      │                           │
+│              filesystem ↕                        │
+├──────────────────────────────────────────────────┤
+│              Hive Directory (disk)               │
+│   config/   skills/   tickets/   logs/           │
+│                      │                           │
+│            watchfiles ↕                           │
+├──────────────────────────────────────────────────┤
+│                Box (bees.box)                    │
+│         classify → restart or trigger            │
+│                      │                           │
+│               Bees hooks ↕                       │
+├──────────────────────────────────────────────────┤
+│                Bees Framework                    │
+│           Scheduler → Session → LLM             │
+└──────────────────────────────────────────────────┘
+```
+
+The filesystem is the API. Any process that writes files in the right shape —
+hivetool, a shell script, VS Code, `echo` — can drive the system. The box
+never needs to know who wrote the files.
+
+## How it works
+
+The box runs a single `asyncio` event loop with two conceptually distinct
+watchers sharing one `watchfiles.awatch()` stream on the hive root.
+
+### Config watcher (cold restart)
+
+Changes to configuration files cause the box to shut down the current `Bees`
+instance and restart with fresh configuration. This covers:
+
+| Path                      | What changed                    |
+| ------------------------- | ------------------------------- |
+| `config/SYSTEM.yaml`      | System identity, root template  |
+| `config/TEMPLATES.yaml`   | Template definitions            |
+| `config/hooks/*.py`       | Template lifecycle hooks        |
+| `skills/**`               | Agent skill files                |
+
+On restart, `Bees` re-reads all configuration, reconnects MCP servers, recovers
+stuck tasks, and re-boots the root template if needed — the same startup
+sequence as the HTTP server.
+
+### Task watcher (hot trigger)
+
+Changes under `tickets/` wake the scheduler to re-evaluate available work.
+The scheduler's existing cycle logic handles all the details:
+
+- New ticket directory appears → scheduler finds it as `available`, runs it.
+- `metadata.json` changes (status flipped, assignee changed) → scheduler
+  promotes blocked tasks, resumes responded tasks.
+- `response.json` written → scheduler picks up the response and resumes the
+  suspended agent.
+
+The box calls `bees.trigger()` — the same mechanism the HTTP server uses after
+processing a REST request.
+
+### Ignored paths
+
+Changes to `logs/` and other directories outside `config/`, `skills/`, and
+`tickets/` are silently ignored.
+
+## The two-loop structure
+
+```python
+# Pseudocode — see bees/box.py for the real implementation.
+
+async def run(hive_dir, backend):
+    while True:                          # Outer: cold restart loop
+        bees = Bees(hive_dir, backend)
+        bees.listen()
+
+        async for changes in awatch(hive_dir):   # Inner: file watch
+            for path in changes:
+                kind = classify_change(path, hive_dir)
+                if kind == "config":
+                    break  # → restart
+                if kind == "task":
+                    bees.trigger()
+
+        bees.shutdown()
+```
+
+Config changes break the inner loop. The outer loop restarts `Bees` from
+scratch. Task changes trigger the scheduler without restarting. Graceful
+shutdown on `SIGINT`/`SIGTERM` cancels and cleans up.
+
+## Usage
+
+```bash
+# Default hive (packages/bees/hive):
+npm run dev:box -w packages/bees
+
+# Custom hive:
+BEES_HIVE_DIR=/path/to/hive npm run dev:box -w packages/bees
+
+# Direct invocation:
+python -m bees.box
+```
+
+The box reads `GEMINI_KEY` and `BEES_HIVE_DIR` from the environment (or
+`.env`), identical to the HTTP server.
+
+## Comparison with the HTTP server
+
+| Concern                | HTTP Server (`app/server.py`)     | Box (`bees/box.py`)               |
+| ---------------------- | --------------------------------- | --------------------------------- |
+| Client communication   | REST + SSE                        | Filesystem                        |
+| Task creation          | `POST /agents/{id}/reply`         | Write `response.json` + metadata  |
+| State observation      | SSE event stream                  | `FileSystemObserver` (hivetool)   |
+| Config reload          | `uvicorn --reload`                | Built-in config watcher           |
+| Dependencies           | FastAPI, uvicorn, sse-starlette   | watchfiles                        |
+| Use case               | Reference app (web shell)         | Local dev, headless, CI           |
+
+The HTTP server is part of the reference application — a full web-based product.
+The box is a library-level tool — minimal infrastructure for running bees
+locally without a server.
+
+## Observability
+
+The box wires `SchedulerHooks` to Python's `logging` module. All lifecycle
+events appear on stderr:
+
+```
+18:25:01 [INFO] bees.box: Box starting — watching /path/to/hive
+18:25:01 [INFO] bees.box: Bees started — watching for changes
+18:25:03 [INFO] bees.box: Agent added: planner (a3cb7443)
+18:25:03 [INFO] bees.box: Cycle 1: 1 new + 0 resumable
+18:25:03 [INFO] bees.box: Agent running: planner (a3cb7443)
+18:25:15 [INFO] bees.box: Agent completed: planner (a3cb7443)
+18:30:22 [INFO] bees.box: Config change detected — restarting
+18:30:22 [INFO] bees.box: Restarting bees...
+```
+
+## Driving the box from the command line
+
+Since the filesystem is the API, you can interact with the box using standard
+Unix tools:
+
+```bash
+# Create a new task:
+TASK_ID=$(uuidgen)
+mkdir -p hive/tickets/$TASK_ID
+echo "Summarize the project README" > hive/tickets/$TASK_ID/objective.md
+echo '{"status":"available","created_at":"2026-04-15T00:00:00Z"}' \
+  > hive/tickets/$TASK_ID/metadata.json
+
+# Reply to a suspended task:
+echo '{"text":"Yes, proceed with that approach"}' \
+  > hive/tickets/$TASK_ID/response.json
+# Then flip assignee in metadata.json to "agent"
+
+# Retry a paused task:
+# Edit metadata.json: set status to "available", clear error
+```
+
+This makes the box scriptable, testable, and composable with any tool that can
+write files.

--- a/packages/bees/package.json
+++ b/packages/bees/package.json
@@ -8,6 +8,7 @@
 
     "dev": "npm run dev:server & npm run dev:web",
     "dev:clean": "rm -rf hive/tickets hive/logs && npm run dev",
+    "dev:box": ".venv/bin/python -m bees.box",
     "dev:server": ".venv/bin/python -m app.server",
     "dev:web": "cd web && npm run dev",
     "dev:hivetool": "cd hivetool && npm run dev",

--- a/packages/bees/pyproject.toml
+++ b/packages/bees/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "fastapi>=0.115.0",
     "uvicorn>=0.34.0",
     "sse-starlette>=2.0.0",
+    "watchfiles>=1.0.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/bees/tests/test_box.py
+++ b/packages/bees/tests/test_box.py
@@ -1,0 +1,79 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for bees.box — change classification and watcher logic."""
+
+from __future__ import annotations
+
+import pytest
+from pathlib import Path
+
+from bees.box import classify_change
+
+
+HIVE = Path("/tmp/test-hive")
+
+
+class TestClassifyChange:
+    """classify_change routes paths to the right category."""
+
+    # -- Config paths (cold restart) --
+
+    def test_system_yaml(self):
+        assert classify_change(HIVE / "config" / "SYSTEM.yaml", HIVE) == "config"
+
+    def test_templates_yaml(self):
+        assert classify_change(HIVE / "config" / "TEMPLATES.yaml", HIVE) == "config"
+
+    def test_hooks_module(self):
+        assert classify_change(
+            HIVE / "config" / "hooks" / "planner.py", HIVE
+        ) == "config"
+
+    def test_skill_file(self):
+        assert classify_change(
+            HIVE / "skills" / "listener" / "SKILL.md", HIVE
+        ) == "config"
+
+    def test_skills_dir_itself(self):
+        assert classify_change(HIVE / "skills", HIVE) == "config"
+
+    def test_config_dir_itself(self):
+        assert classify_change(HIVE / "config", HIVE) == "config"
+
+    # -- Task paths (hot trigger) --
+
+    def test_ticket_metadata(self):
+        assert classify_change(
+            HIVE / "tickets" / "abc-123" / "metadata.json", HIVE
+        ) == "task"
+
+    def test_ticket_objective(self):
+        assert classify_change(
+            HIVE / "tickets" / "abc-123" / "objective.md", HIVE
+        ) == "task"
+
+    def test_ticket_response(self):
+        assert classify_change(
+            HIVE / "tickets" / "abc-123" / "response.json", HIVE
+        ) == "task"
+
+    def test_ticket_dir_created(self):
+        assert classify_change(HIVE / "tickets" / "abc-123", HIVE) == "task"
+
+    def test_tickets_dir_itself(self):
+        assert classify_change(HIVE / "tickets", HIVE) == "task"
+
+    # -- Ignored paths --
+
+    def test_logs_ignored(self):
+        assert classify_change(HIVE / "logs" / "session.log", HIVE) == "ignore"
+
+    def test_hive_root_ignored(self):
+        assert classify_change(HIVE, HIVE) == "ignore"
+
+    def test_outside_hive_ignored(self):
+        assert classify_change(Path("/other/place/file.txt"), HIVE) == "ignore"
+
+    def test_dot_files_ignored(self):
+        assert classify_change(HIVE / ".DS_Store", HIVE) == "ignore"


### PR DESCRIPTION
## What

Adds `bees/box.py`, a file-watching alternative to the HTTP server that drives
the scheduler through filesystem events instead of REST requests.

## Why

The hive directory is already the canonical state. By watching it directly, we
remove the need for an HTTP server in local development. Any tool that writes
files — hivetool, a shell script, VS Code — can drive the system. This is the
first step toward making hivetool a fully serverless workbench.

## Changes

### New files
- **`bees/box.py`** — The hive box. Two-watcher loop: config changes (cold
  restart) and task changes (hot trigger via `bees.trigger()`). Wires
  `SchedulerHooks` to `logging` for dev observability.
- **`docs/box.md`** — Architecture, usage, and comparison with the HTTP server.
- **`tests/test_box.py`** — 15 unit tests for `classify_change`.

### Modified files
- **`bees/bees.py`** — Made `trigger()` public (was `_trigger()`).
- **`bees/task_node.py`** — Updated two call sites to use `trigger()`.
- **`pyproject.toml`** — Added `watchfiles>=1.0.0` as explicit dependency.
- **`package.json`** — Added `dev:box` script.
- **`docs/README.md`** — Added box.md to the Tooling section.

## Testing

```bash
# Unit tests (15 passing):
.venv/bin/python -m pytest tests/test_box.py -v

# Full suite (195 passing):
.venv/bin/python -m pytest tests/ -v

# Manual:
npm run dev:box -w packages/bees
```
