### PR TITLE
[bees] Delegated Sessions — Conceptual Design Docs

### DIFF
--- a/packages/bees/docs/delegated-sessions-2.md
+++ b/packages/bees/docs/delegated-sessions-2.md
@@ -1,0 +1,366 @@
+> [!NOTE] This is a conceptual exploration, not documentation of current
+> capabilities. Nothing described here is implemented yet. This builds on the
+> ideas in `delegated-sessions.md` and takes them to their logical conclusion.
+
+# Delegated Sessions — The General Case
+
+What if _all_ sessions are delegated? What if bees never closes over the model
+conversation at all?
+
+## The observation
+
+The current architecture configurations three concerns into one process:
+
+1. **Orchestration** — scheduling tasks, managing dependencies, tracking
+   lifecycle.
+2. **Tool provisioning and dispatch** — assembling FunctionGroups, executing
+   tool handlers.
+3. **Session execution** — connecting to Gemini, streaming turns, managing the
+   context window.
+
+Concern #3 is the one that varies by transport. Batch sessions use
+`GenerateContent` over HTTP. Live sessions use a persistent WebSocket. Future
+session types might use different models, different protocols, or different
+providers entirely.
+
+If bees owns #1 and #2 but delegates #3, it becomes transport-agnostic. The
+`Loop`, `GeminiClient`, `stream_generate_content` — all of that moves out of
+bees and into the session runner. Bees becomes a pure orchestration and tooling
+framework.
+
+## What bees becomes
+
+Three roles, and nothing more:
+
+### 1. Task orchestrator
+
+The scheduler manages task lifecycle, dependency promotion, cycle execution, and
+the agent tree. This is unchanged. The scheduler still decides _when_ a task
+runs and _what_ it depends on.
+
+### 2. Tool provisioner
+
+On request, bees assembles everything a session runner needs:
+
+```python
+@dataclass
+class SessionConfiguration:
+    """Everything an external runner needs to start a session."""
+
+    task_id: str
+    system_instruction: str        # Assembled from objective + skills + groups
+    tool_declarations: list[dict]  # JSON schemas from enabled FunctionGroups
+    model: str                     # Model identifier
+    config: dict                   # Modality, voice, temperature, etc.
+```
+
+Notice what's absent: **auth**. The runner brings its own credentials. Bees
+never needs an API key, an access token, or any model-provider auth. This
+eliminates the `backend` parameter that currently threads through `Scheduler` →
+`TaskRunner` → `run_session` → `Loop`.
+
+The configuration is assembled using the same code paths that `run_session` uses
+today — segment resolution, skill merging, function filtering — but stops before
+calling the model. It hands the assembled ingredients to the session runner
+rather than consuming them internally.
+
+### 3. Tool dispatch service
+
+When a session runner receives a tool call from the model, it forwards it to
+bees for execution. Bees validates the call against the session's allowed
+functions, dispatches it through the FunctionGroup handler, and returns the
+result.
+
+```
+Runner → POST /dispatch { task_id, calls: [{name, args, id}] }
+Bees   → validate scope → execute handler → return results
+Runner ← { responses: [{id, name, response}] }
+```
+
+The handlers are the same Python async functions that `FunctionCaller` invokes
+today. The only difference is who's calling them — an in-process loop vs. a
+network request.
+
+## What bees stops being
+
+Bees no longer:
+
+- Accepts or threads auth credentials (`backend`, API keys).
+- Manages the context window or conversation history.
+- Handles streaming chunks from the model.
+
+The `opal_backend` dependency doesn't leave bees — it moves to
+`bees/runners/batch.py`, isolated from the rest of the framework. The scheduler,
+task store, coordination, and provisioner never import it.
+
+## Session runners
+
+A session runner is anything that can:
+
+1. Accept a `SessionConfiguration`.
+2. Connect to a model (bringing its own auth).
+3. Run the conversation loop.
+4. Report session events and completion.
+
+Runners are **part of bees** — shipped as reference implementations, not pushed
+to the app layer:
+
+```
+bees/
+  runners/
+    protocol.py    # SessionRunner protocol
+    batch.py       # Uses opal_backend Loop + GenerateContent
+    live.py        # Uses google-genai SDK + Live API WebSocket
+```
+
+| Runner        | Transport            | Model connection   | Where it runs |
+| ------------- | -------------------- | ------------------ | ------------- |
+| `BatchRunner` | GenerateContent HTTP | `Loop` (from opal) | Server        |
+| `LiveRunner`  | WebSocket            | Gemini Live API    | Browser relay |
+| `TestRunner`  | Mock                 | Scripted responses | Test harness  |
+
+### Runner as constructor parameter
+
+The runner is injected into `Bees` at construction time. The app layer chooses
+which runners to wire in and supplies their auth:
+
+```python
+# The app creates the runner with credentials — bees never sees them.
+runner = BatchRunner(
+    api_key=load_gemini_key(),
+    http_client=httpx.AsyncClient(timeout=httpx.Timeout(300.0)),
+)
+
+# Bees takes the runner as a parameter. No backend, no auth.
+bees = Bees(hive_dir, runner=runner)
+```
+
+This means both the box and the reference app are thin shells:
+
+```python
+# box.py — filesystem-driven
+runner = BatchRunner(api_key=load_gemini_key(), ...)
+bees = Bees(hive_dir, runner=runner)
+await bees.listen()
+async for changes in awatch(hive_dir):
+    bees.trigger()
+
+# server.py — REST/SSE-driven
+runner = BatchRunner(api_key=load_gemini_key(), ...)
+bees = Bees(hive_dir, runner=runner)
+app = build_fastapi_app(bees)
+```
+
+Neither constructs an `HttpBackendClient`. Neither threads auth through the
+scheduler. The runner encapsulates all model-provider concerns.
+
+## The context channel
+
+Dynamic steering — pushing context updates into a running session mid-turn — is
+essential. The current `context_queue` (`asyncio.Queue`) is the implementation,
+but the abstraction is: **the scheduler can push a message into any running
+session**.
+
+In the delegated model, the context channel becomes a named, transport-aware
+pipe:
+
+```python
+class ContextChannel(Protocol):
+    """Push context updates into a running session."""
+
+    def push(self, parts: list[dict]) -> None: ...
+```
+
+Implementations vary by runner location:
+
+| Runner location | Channel implementation                                  |
+| --------------- | ------------------------------------------------------- |
+| In-process      | `asyncio.Queue` (unchanged from today)                  |
+| Same server     | Direct function call to the runner's injection point    |
+| Browser (SSE)   | SSE event → browser calls `session.send_client_content` |
+| Remote server   | Webhook POST to runner's callback URL                   |
+| Disconnected    | Buffer in metadata, drain on next poll                  |
+
+### How context flows in each case
+
+**Batch (in-process):**
+
+```
+Child agent calls events_send_to_parent
+  → Scheduler._deliver_context_update(parent_id, update)
+    → queue.put_nowait(parts)          # asyncio.Queue, same as today
+      → Loop drains queue at turn boundary
+        → parts appended to contents
+```
+
+No change from today. The delegation is conceptual — the implementation
+short-circuits because runner and dispatcher share a process.
+
+**Live (browser via SSE):**
+
+```
+Child agent calls events_send_to_parent
+  → Scheduler._deliver_context_update(parent_id, update)
+    → Broadcaster.broadcast({type: "context:update", task_id, parts})
+      → SSE pushes to browser
+        → Browser receives event
+          → session.send_client_content(turns={parts})
+            → Gemini Live API receives context mid-session
+```
+
+The Live API's `send_client_content` is designed exactly for this — injecting
+context into a running session without interrupting the audio stream.
+
+### The three delivery paths, generalized
+
+The scheduler's `_deliver_context_update` currently has three paths:
+
+1. Mid-stream injection (live queue)
+2. Immediate resume (write response.json)
+3. Buffer in metadata
+
+These generalize cleanly:
+
+| Current path       | Generalized                                    |
+| ------------------ | ---------------------------------------------- |
+| Mid-stream (queue) | Push to the session's `ContextChannel`         |
+| Resume             | Unchanged — write response.json, flip assignee |
+| Buffer             | Unchanged — stash in metadata for later drain  |
+
+Path 1 changes implementation (queue → channel). Paths 2 and 3 are already
+transport-independent — they operate on the filesystem regardless of session
+type.
+
+## The co-located optimization
+
+Full delegation doesn't mean full indirection. When the session runner and the
+tool dispatcher share a process — the common case for batch sessions — the
+system short-circuits:
+
+- **Tool dispatch**: direct function calls, no network hop.
+- **Context channel**: `asyncio.Queue`, no serialization.
+- **Lifecycle events**: in-process callbacks, no SSE.
+
+The delegation model is the _conceptual_ architecture. The in-process path is
+the _optimized_ implementation for the common case. Both conform to the same
+interface, so the system works identically when the runner is remote.
+
+```python
+# bees/runners/protocol.py
+class SessionRunner(Protocol):
+    async def run(
+        self, configuration: SessionConfiguration, channel: ContextChannel,
+    ) -> SessionResult: ...
+
+# bees/runners/batch.py — in-process, calls handlers directly
+class BatchRunner:
+    def __init__(self, api_key: str, http_client: httpx.AsyncClient): ...
+
+    async def run(
+        self, configuration: SessionConfiguration, channel: ContextChannel,
+    ) -> SessionResult:
+        loop = Loop(...)  # From opal_backend
+        args = AgentRunArgs(
+            objective=configuration.system_instruction,
+            function_groups=configuration.tool_declarations,
+            context_queue=channel,  # asyncio.Queue for in-process
+            ...
+        )
+        return await loop.run(args)
+```
+
+## What this changes in the codebase
+
+### Moves within `bees/`
+
+| Current location       | New location            | What                            |
+| ---------------------- | ----------------------- | ------------------------------- |
+| `bees/session.py`      | `bees/runners/batch.py` | `run_session`, `resume_session` |
+| `opal_backend` imports | `bees/runners/batch.py` | Loop, streaming (isolated)      |
+
+### Stays in `bees/`
+
+| Module                  | What                                       |
+| ----------------------- | ------------------------------------------ |
+| `bees/scheduler.py`     | Task orchestration, cycle logic            |
+| `bees/task_runner.py`   | Metadata bookkeeping (delegates to runner) |
+| `bees/functions/`       | FunctionGroup handlers                     |
+| `bees/declarations/`    | Tool schemas and instructions              |
+| `bees/segments.py`      | Prompt assembly                            |
+| `bees/disk_file_system` | File system for tool handlers              |
+| `bees/task_store.py`    | Task persistence                           |
+| `bees/coordination.py`  | Cross-task event routing                   |
+
+### New in `bees/`
+
+| Module                     | What                                          |
+| -------------------------- | --------------------------------------------- |
+| `bees/runners/protocol.py` | SessionRunner protocol                        |
+| `bees/runners/batch.py`    | BatchRunner (current session.py, reorganized) |
+| `bees/runners/live.py`     | LiveRunner (Gemini Live API, new)             |
+| `bees/provisioner.py`      | SessionConfiguration assembly from templates  |
+| `bees/dispatch.py`         | Tool dispatch validation and execution        |
+| `bees/channel.py`          | ContextChannel protocol and implementations   |
+
+### Simplified in `app/`
+
+Both the box and the reference app get simpler — they stop constructing
+`HttpBackendClient` and threading it through bees. They just pick a runner:
+
+| Module          | Before                                        | After                                   |
+| --------------- | --------------------------------------------- | --------------------------------------- |
+| `app/server.py` | Creates `HttpBackendClient`, passes to `Bees` | Creates `BatchRunner`, passes to `Bees` |
+| `bees/box.py`   | Creates `HttpBackendClient`, passes to `Bees` | Creates `BatchRunner`, passes to `Bees` |
+
+Live API support is added by passing a `LiveRunner` alongside the `BatchRunner`.
+The app decides which runners to enable; bees routes tasks to the appropriate
+runner based on the template's `session_type`.
+
+## Implications
+
+**The framework boundary sharpens.** Today, bees is a framework that happens to
+include a session executor. After this change, bees is a framework that
+provisions sessions and dispatches tools. The runners ship with bees as
+reference implementations, but the boundary between orchestration and execution
+is explicit. This aligns with the extraction goal in `docs/future.md` — bees as
+an installable library with a clean API.
+
+**Auth drops out of the core.** The `backend` parameter — currently threaded
+through `Bees` → `Scheduler` → `TaskRunner` → `run_session` → `Loop` — moves to
+the runner's constructor. The scheduler, task store, coordination layer, and
+provisioner never see credentials. Auth is the app's concern, handed to the
+runner at construction time.
+
+**Testing simplifies.** Bees' orchestration tests cover scheduling,
+provisioning, and tool dispatch — no Gemini mocking needed. Runner tests mock
+the model client in isolation. A `TestRunner` with scripted responses makes
+integration tests deterministic.
+
+**The reference app gets simpler, not more complex.** The app doesn't gain the
+session execution responsibility — bees ships the runners. The app just chooses
+which runner to instantiate and supplies credentials. Both the box and the
+reference app shrink to thin shell code.
+
+**Live sessions become first-class.** They're not a special case bolted onto a
+batch-centric framework. They're a runner that speaks a different protocol to
+the same provisioning and dispatch infrastructure. The framework doesn't
+privilege any transport.
+
+## Open questions
+
+**Suspend/resume across runners.** Batch sessions suspend by serializing
+conversation state. The `BatchRunner` handles this internally (it has access to
+the `Loop`'s contents). But bees needs to know the session is suspended (to
+track status). The runner reports status changes; bees doesn't own the
+mechanics.
+
+**MCP lifecycle.** MCP server connections are currently established per-session
+inside bees. Under delegation, the dispatch endpoint needs active MCP
+connections. Who manages their lifecycle — bees (as part of tool dispatch
+infrastructure) or the runner? Bees seems right, since MCP tools are dispatched
+through bees regardless of runner type.
+
+**Gradual migration.** This doesn't have to happen all at once. The first step
+is the `SessionConfiguration` + dispatch endpoint (for Live sessions). The
+second step is extracting `BatchRunner` from `session.py` into the reference
+app. The existing code path continues to work throughout.

--- a/packages/bees/docs/delegated-sessions.md
+++ b/packages/bees/docs/delegated-sessions.md
@@ -1,0 +1,248 @@
+> [!NOTE]
+> This is a conceptual exploration, not documentation of current capabilities.
+> Nothing described here is implemented yet.
+
+# Delegated Sessions
+
+A delegated session is a session whose execution is owned by an external party
+— typically the browser — rather than by the scheduler. The scheduler provisions
+the session (tools, system instruction, auth) and provides a tool dispatch
+service, but the model connection itself lives elsewhere.
+
+The motivating use case is the Gemini Live API: real-time, bidirectional audio
+conversations that require a persistent WebSocket between the browser and
+Gemini. The scheduler can't own that connection — it's a batch orchestrator, not
+a streaming audio relay. But it still needs to provision the agent's tools and
+track the session in the agent tree.
+
+## Why not just a new session type?
+
+The existing session layer (`session.py` → `Loop`) is a synchronous
+request-response loop: accumulate context, call GenerateContent, dispatch
+function calls, repeat. The Live API is fundamentally different — full-duplex
+WebSocket, continuous audio streams, server-managed context, barge-in.
+
+Trying to make the existing `Loop` bidirectional would fight the grain of both
+APIs. Instead, delegated sessions acknowledge that the *transport* is someone
+else's problem while keeping the *tooling and lifecycle* inside bees.
+
+## The split
+
+A delegated session separates two concerns that the current session layer
+bundles together:
+
+| Concern              | Current session              | Delegated session            |
+| -------------------- | ---------------------------- | ---------------------------- |
+| Model connection     | Bees (via `Loop`)            | Browser (via Live API WS)    |
+| Tool provisioning    | Bees (FunctionGroup assembly)| Bees (same)                  |
+| Tool execution       | Bees (FunctionCaller)        | Bees (via dispatch endpoint) |
+| System instruction   | Bees (segment assembly)      | Bees (same, in bundle)       |
+| Audio I/O            | N/A                          | Browser (MediaStream API)    |
+| Session lifecycle    | Scheduler (run/resume)       | Scheduler (provision/observe)|
+| Agent tree visibility| Yes                          | Yes                          |
+
+The browser gains ownership of the model connection and audio path. Everything
+else stays in bees.
+
+## How it works
+
+### 1. Template declaration
+
+A template opts into delegated execution via `session_type`:
+
+```yaml
+- name: opie-live
+  title: Opie (Live)
+  session_type: delegated
+  objective: >
+    You are Opie, an executive assistant. Use the "persona" skill to learn
+    how to behave. You are in a live audio conversation with the user.
+  skills:
+    - persona
+  functions:
+    - simple-files.*
+    - tasks.*
+```
+
+The `functions` and `skills` fields work identically to batch sessions. The
+template author controls what tools the agent has access to.
+
+### 2. Session provisioning
+
+When the scheduler encounters a delegated task, it does not call `run_session`.
+Instead, it assembles a **session bundle** — everything an external client needs
+to start a session:
+
+- **System instruction** — assembled from the objective, skill instructions, and
+  function group instructions, exactly as `run_session` does today.
+- **Tool declarations** — the JSON schemas from each enabled FunctionGroup,
+  filtered by the template's `functions` list.
+- **Server tool names** — which tools require server-side dispatch (vs. tools
+  the client could hypothetically handle locally).
+- **Auth token** — an ephemeral token for direct Gemini API access.
+- **Model** — the Live API model identifier.
+- **Session config** — response modalities, voice settings, etc.
+
+The bundle is exposed via the reference app's REST API:
+
+```
+GET /agents/{agent_id}/session-bundle → SessionBundle
+```
+
+### 3. Browser session lifecycle
+
+The browser receives the bundle and:
+
+1. Opens a WebSocket to the Gemini Live API using the ephemeral token.
+2. Configures the session with the system instruction, tool declarations, and
+   response modalities from the bundle.
+3. Starts audio capture and playback.
+4. Enters an event loop: receives model responses (audio, text, tool calls) and
+   sends user input (audio, text).
+
+When the model makes a tool call, the browser dispatches it to the bees server.
+
+### 4. Tool dispatch
+
+The reference app exposes a tool dispatch endpoint:
+
+```
+POST /agents/{agent_id}/tool-dispatch
+```
+
+```json
+{
+  "calls": [
+    { "id": "call_123", "name": "tasks_create_task", "args": { ... } }
+  ]
+}
+```
+
+The server:
+
+1. Looks up the provisioned session for this agent.
+2. Validates that each tool name is in the session's allowed function set.
+3. Dispatches each call through the corresponding FunctionGroup handler — the
+   same handler that `FunctionCaller` would use in a batch session.
+4. Returns the results.
+
+```json
+{
+  "responses": [
+    { "id": "call_123", "name": "tasks_create_task", "response": { ... } }
+  ]
+}
+```
+
+The browser sends these back to the Live API as `FunctionResponse`s.
+
+### 5. Scheduler observation
+
+The scheduler tracks delegated sessions through status transitions:
+
+```
+available → provisioned → live → completed / failed
+```
+
+- **provisioned** — bundle assembled, waiting for browser to connect.
+- **live** — browser has an active session. The scheduler skips this task in
+  batch cycles but keeps it visible in the agent tree.
+- **completed / failed** — browser reports session end.
+
+The browser reports lifecycle events via REST:
+
+```
+POST /agents/{agent_id}/session-status
+{ "status": "live" | "completed" | "failed", "summary": "..." }
+```
+
+## Async tool calling and task delegation
+
+The Live API supports `NON_BLOCKING` function declarations. A tool marked
+non-blocking runs asynchronously — the model continues the conversation while
+the tool executes. When the result arrives, it can interrupt the conversation
+(`INTERRUPT`), wait for a pause (`WHEN_IDLE`), or be absorbed silently
+(`SILENT`).
+
+This maps naturally to task delegation. When the Live agent calls
+`tasks_create_task`, the server creates a batch subagent. The tool is declared
+`NON_BLOCKING` so the agent keeps talking to the user. When the batch subagent
+completes, the server returns the tool response with `scheduling: "INTERRUPT"`,
+and the agent incorporates the result conversationally.
+
+```
+User:   "Can you research market trends for Q3?"
+Agent:  "Sure, let me set that up."
+        → tasks_create_task (NON_BLOCKING)
+        ← server creates batch research subagent
+Agent:  "I've started a research task. What else can I help with?"
+User:   "What's on my calendar today?"
+Agent:  "Let me check..." (continues conversation)
+        ← research task completes
+        ← FunctionResponse arrives with scheduling=INTERRUPT
+Agent:  "By the way, the research is done. Here's what I found..."
+```
+
+This is the opie pattern — delegate work, stay available — made native by the
+Live API's async function calling.
+
+## What the browser needs
+
+The browser's responsibilities in a delegated session:
+
+1. **WebSocket management** — connect to Gemini Live API, handle reconnection
+   on transient errors.
+2. **Audio I/O** — capture microphone input (16kHz PCM), play model audio output
+   (24kHz PCM). Uses MediaStream API and AudioContext.
+3. **Tool dispatch relay** — when the model calls a tool, POST to the bees
+   server's dispatch endpoint, send the response back to the Live API.
+4. **Lifecycle reporting** — inform the server when the session starts, ends, or
+   encounters an error.
+5. **Transcription display** — the Live API provides input and output
+   transcriptions alongside audio. The UI renders these as a conversation log.
+
+The browser does NOT:
+
+- Assemble system instructions (bees does this).
+- Decide which tools are available (the template controls this).
+- Execute tools locally (all dispatch goes to the server, at least initially).
+
+## Relationship to the existing session layer
+
+Delegated sessions reuse the session layer's infrastructure without using its
+execution path:
+
+| Component               | Reused? | How                                                   |
+| ----------------------- | ------- | ----------------------------------------------------- |
+| FunctionGroup assembly  | Yes     | Same factory, same filter, same declarations          |
+| System instruction      | Yes     | Same segment resolution, same skill merging           |
+| FunctionGroup handlers  | Yes     | Same handlers, invoked via dispatch endpoint          |
+| DiskFileSystem          | Yes     | Same working directory, same VFS layer                |
+| SubagentScope           | Yes     | Same permission model for tool dispatch               |
+| EvalCollector           | Partial | Tool dispatch events logged; audio content is not     |
+| Loop / FunctionCaller   | No      | Replaced by browser + Live API                        |
+| Suspend / resume        | No      | Live sessions don't suspend — they're always-on       |
+| InteractionStore        | No      | No state serialization needed — session is transient  |
+
+## Open questions
+
+**Session duration.** Live API sessions have a maximum duration. When a session
+expires, the browser needs to re-provision (request a new bundle) and reconnect.
+The Live API supports session resumption — whether this is transparent to the
+user or requires a brief interruption is an open design question.
+
+**Subagent results.** When a batch subagent completes and its result needs to
+flow back into the Live session, the server holds the `FunctionResponse` until
+the browser polls for it or pushes it via an SSE sidecar. The exact delivery
+mechanism needs design.
+
+**Observability.** Batch sessions produce detailed eval logs (per-turn context
+size, token usage, function calls). Delegated sessions are partially opaque —
+the model interaction happens in the browser. Tool dispatch calls are logged
+server-side, but the conversation content is not. Whether this needs to change
+depends on audit requirements.
+
+**Client-side tool execution.** Some tools could run in the browser (e.g., a
+"display this to the user" tool). The initial design routes everything through
+the server. Moving tools client-side is an optimization that trades server
+round-trips for client complexity.


### PR DESCRIPTION
## What
Two new conceptual design documents exploring how to integrate the Gemini Live API into the Bees framework by introducing "delegated sessions" — sessions where the model connection is owned externally (e.g., by the browser) while Bees handles orchestration, tool provisioning, and dispatch.

## Why
The Gemini Live API enables real-time bidirectional audio conversations, but its persistent WebSocket model is fundamentally incompatible with the scheduler's batch-oriented request-response loop. These docs trace the design from initial exploration through to a clean architectural resolution where session execution becomes a pluggable runner injected into `Bees` at construction time.

## Changes

### `packages/bees/docs/`
- **`delegated-sessions.md`** [NEW] — The specific case: how a Live API session works as a delegated session. Covers template declaration (`session_type: delegated`), session provisioning (bundle endpoint), tool dispatch (server-side REST callback), and the `NON_BLOCKING` tool pattern for opie-style task delegation with audio.
- **`delegated-sessions-2.md`** [NEW] — The general case: what if *all* sessions are delegated? Proposes `SessionRunner` protocol with reference implementations (`BatchRunner`, `LiveRunner`) shipped in `bees/runners/`. Auth moves to the runner constructor. Context queue generalizes to a transport-aware `ContextChannel`. Both box and reference app simplify to thin shells.

## Testing
These are conceptual design documents only — no code changes, no tests needed. Marked with a `[!NOTE]` disclaimer at the top.
