### PR TITLE
[bees] Hot mutations — respond-to-task and create-task-group

### DIFF
--- a/packages/bees/bees/box.py
+++ b/packages/bees/bees/box.py
@@ -35,6 +35,7 @@ from pathlib import Path
 from typing import Literal
 
 from bees.mutations import process_all as process_mutations
+from bees.mutations import process_cold, process_inline
 
 import httpx
 from watchfiles import awatch, Change
@@ -146,8 +147,13 @@ async def run(hive_dir: Path, backend: HttpBackendClient) -> None:
     This function runs indefinitely until cancelled or interrupted.
     Config changes cause a restart (inner loop breaks, outer loop
     re-creates ``Bees``). Task changes trigger the scheduler.
-    Mutations are processed in the quiescent gap between shutdown
-    and restart, guaranteeing atomicity.
+
+    Mutations come in two flavors:
+
+    - **Hot** (e.g., respond-to-task) — processed inline, then the
+      scheduler is triggered.
+    - **Cold** (e.g., reset) — processed in the quiescent gap between
+      shutdown and restart.
     """
     logger.info("Box starting — watching %s", hive_dir)
 
@@ -169,7 +175,7 @@ async def run(hive_dir: Path, backend: HttpBackendClient) -> None:
         logger.info("Bees started — watching for changes")
 
         restart = False
-        mutation_pending = False
+        cold_pending = False
         try:
             async for changes in awatch(hive_dir):
                 needs_restart = False
@@ -185,12 +191,17 @@ async def run(hive_dir: Path, backend: HttpBackendClient) -> None:
                     elif kind == "mutation":
                         needs_mutation = True
 
-                # Mutations take priority — require shutdown + processing.
+                # Process mutations: hot mutations run inline,
+                # cold mutations signal a restart.
                 if needs_mutation:
-                    logger.info("Mutation detected — shutting down for processing")
-                    mutation_pending = True
-                    restart = True
-                    break
+                    outcome = process_inline(hive_dir)
+                    if outcome.hot_processed > 0:
+                        needs_trigger = True
+                    if outcome.cold_pending:
+                        logger.info("Cold mutation pending — shutting down")
+                        cold_pending = True
+                        restart = True
+                        break
 
                 if needs_restart:
                     logger.info("Config change detected — restarting")
@@ -208,9 +219,9 @@ async def run(hive_dir: Path, backend: HttpBackendClient) -> None:
 
         await bees.shutdown()
 
-        # Process mutations in the quiescent gap between shutdown and restart.
-        if mutation_pending:
-            process_mutations(hive_dir)
+        # Process cold mutations in the quiescent gap.
+        if cold_pending:
+            process_cold(hive_dir)
 
         if not restart:
             return

--- a/packages/bees/bees/mutations.py
+++ b/packages/bees/bees/mutations.py
@@ -6,16 +6,27 @@ Mutation log — filesystem-based command channel.
 
 The ``mutations/`` directory in the hive acts as a write-ahead log.
 Clients (hivetool, scripts) write mutation files; the box processes
-them atomically in the quiescent gap between shutdown and restart.
+them atomically.
 
 Each mutation is a JSON file (``{uuid}.json``) with a ``type`` field.
 After processing, the box writes a result file (``{uuid}.result.json``)
 with a ``status`` field (``"ok"`` or ``"error"``).
 
+Two processing modes:
+
+- **Cold** mutations (e.g., ``reset``) require quiescence — the box
+  shuts down Bees, processes the mutation, then restarts.
+- **Hot** mutations (e.g., ``respond-to-task``, ``create-task-group``)
+  are processed inline while the scheduler is running.  The box
+  executes all writes atomically, then triggers the scheduler once.
+
 Supported mutation types:
 
-- **reset** — Deletes all tasks (``tickets/``) and session logs
-  (``logs/``). The root template re-boots automatically on restart.
+- **reset** (cold) — Deletes all tasks and session logs.
+- **respond-to-task** (hot) — Writes ``response.json`` and flips
+  ``assignee`` to ``"agent"`` atomically.
+- **create-task-group** (hot) — Creates multiple tasks with
+  intra-batch dependency resolution via named refs.
 """
 
 from __future__ import annotations
@@ -23,12 +34,22 @@ from __future__ import annotations
 import json
 import logging
 import shutil
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from bees.task_store import TaskStore
+
 logger = logging.getLogger("bees.mutations")
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Mutations that require shutdown → process → restart.
+COLD_MUTATIONS = frozenset({"reset"})
 
 
 # ---------------------------------------------------------------------------
@@ -50,6 +71,20 @@ class PendingMutation:
     @property
     def result_path(self) -> Path:
         return self.path.with_suffix(".result.json")
+
+    @property
+    def is_cold(self) -> bool:
+        return self.mutation_type in COLD_MUTATIONS
+
+
+@dataclass
+class MutationOutcome:
+    """Result of inline mutation processing."""
+
+    hot_processed: int = 0
+    cold_pending: bool = False
+    created_tasks: dict[str, str] = field(default_factory=dict)
+    """Mapping of ref → task_id for create-task-group results."""
 
 
 # ---------------------------------------------------------------------------
@@ -99,15 +134,17 @@ def scan_pending(hive_dir: Path) -> list[PendingMutation]:
 
 
 # ---------------------------------------------------------------------------
-# Processing
+# Processing — two modes
 # ---------------------------------------------------------------------------
 
 
 def process_all(hive_dir: Path) -> bool:
-    """Process all pending mutations.
+    """Process all pending mutations (startup).
 
-    Returns ``True`` if any mutations were processed (callers typically
-    use this to decide whether a restart is needed).
+    Handles both hot and cold mutations.  Used when the box starts
+    and no Bees instance is running yet.
+
+    Returns ``True`` if any mutations were processed.
     """
     pending = scan_pending(hive_dir)
     if not pending:
@@ -120,12 +157,73 @@ def process_all(hive_dir: Path) -> bool:
     return True
 
 
-def _dispatch(mutation: PendingMutation, hive_dir: Path) -> None:
-    """Dispatch a mutation by type and write the result."""
+def process_inline(hive_dir: Path) -> MutationOutcome:
+    """Process hot mutations inline while the scheduler is running.
+
+    Cold mutations are not processed — they're flagged in the outcome
+    so the caller can initiate a shutdown/restart cycle.
+
+    Returns a ``MutationOutcome`` indicating what happened.
+    """
+    pending = scan_pending(hive_dir)
+    outcome = MutationOutcome()
+
+    for mutation in pending:
+        if mutation.is_cold:
+            outcome.cold_pending = True
+            continue
+
+        logger.info("Processing hot mutation: %s (%s)", mutation.mutation_type, mutation.path.name)
+        result = _dispatch(mutation, hive_dir)
+        if result:
+            outcome.hot_processed += 1
+            if result.get("created"):
+                outcome.created_tasks.update(result["created"])
+
+    return outcome
+
+
+def process_cold(hive_dir: Path) -> bool:
+    """Process cold mutations only (requires quiescent state).
+
+    Called in the gap between Bees shutdown and restart.
+    Returns ``True`` if any cold mutations were processed.
+    """
+    pending = scan_pending(hive_dir)
+    processed = False
+
+    for mutation in pending:
+        if not mutation.is_cold:
+            continue
+
+        logger.info("Processing cold mutation: %s (%s)", mutation.mutation_type, mutation.path.name)
+        _dispatch(mutation, hive_dir)
+        processed = True
+
+    return processed
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+
+def _dispatch(mutation: PendingMutation, hive_dir: Path) -> dict[str, Any] | None:
+    """Dispatch a mutation by type and write the result.
+
+    Returns extra result data on success (e.g., created task IDs),
+    or ``None`` on failure.
+    """
     try:
+        extra: dict[str, Any] = {}
+
         match mutation.mutation_type:
             case "reset":
                 _execute_reset(hive_dir)
+            case "respond-to-task":
+                _execute_respond(hive_dir, mutation)
+            case "create-task-group":
+                extra = _execute_create_group(hive_dir, mutation)
             case _:
                 _write_result(
                     mutation.result_path,
@@ -134,10 +232,12 @@ def _dispatch(mutation: PendingMutation, hive_dir: Path) -> None:
                         "error": f"Unknown mutation type: {mutation.mutation_type}",
                     },
                 )
-                return
+                return None
 
-        _write_result(mutation.result_path, {"status": "ok"})
+        result = {"status": "ok", **extra}
+        _write_result(mutation.result_path, result)
         logger.info("Mutation complete: %s", mutation.mutation_type)
+        return result
 
     except Exception as exc:
         logger.exception("Mutation failed: %s", mutation.mutation_type)
@@ -145,6 +245,7 @@ def _dispatch(mutation: PendingMutation, hive_dir: Path) -> None:
             mutation.result_path,
             {"status": "error", "error": str(exc)},
         )
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -158,7 +259,7 @@ def _execute_reset(hive_dir: Path) -> None:
     Removes the contents of ``tickets/`` and ``logs/`` while preserving
     the directories themselves (so watchers don't lose their handles).
     """
-    for subdir_name in ("tickets", "logs"):
+    for subdir_name in ("tickets", "logs", "mutations"):
         subdir = hive_dir / subdir_name
         if not subdir.exists():
             continue
@@ -170,6 +271,92 @@ def _execute_reset(hive_dir: Path) -> None:
                 child.unlink()
 
         logger.info("Cleared %s/", subdir_name)
+
+
+def _execute_respond(hive_dir: Path, mutation: PendingMutation) -> None:
+    """Write response and flip assignee atomically.
+
+    Both writes happen before the scheduler is triggered, so the
+    scheduler never sees a metadata flip without a response file.
+    """
+    task_id = mutation.data.get("task_id")
+    response = mutation.data.get("response")
+
+    if not task_id:
+        raise ValueError("respond-to-task mutation missing 'task_id'")
+    if response is None:
+        raise ValueError("respond-to-task mutation missing 'response'")
+
+    store = TaskStore(hive_dir)
+    store.respond(task_id, response)
+    logger.info("Response written for task %s", task_id[:8])
+
+
+def _execute_create_group(hive_dir: Path, mutation: PendingMutation) -> dict[str, Any]:
+    """Create multiple tasks with intra-batch dependency resolution.
+
+    Tasks are created sequentially.  Each task may include a ``ref``
+    name and a ``depends_on`` list of refs.  Refs are resolved to real
+    task IDs within the batch.
+
+    Returns ``{"created": {"ref": "task-id", ...}}`` for the result file.
+    """
+    tasks = mutation.data.get("tasks")
+    if not tasks or not isinstance(tasks, list):
+        raise ValueError("create-task-group mutation missing 'tasks' array")
+
+    store = TaskStore(hive_dir)
+    ref_to_id: dict[str, str] = {}
+
+    for task_spec in tasks:
+        ref = task_spec.get("ref")
+        depends_on_refs = task_spec.get("depends_on", [])
+
+        # Resolve ref-based dependencies to real task IDs.
+        resolved_deps: list[str] | None = None
+        if depends_on_refs:
+            resolved_deps = []
+            for dep_ref in depends_on_refs:
+                dep_id = ref_to_id.get(dep_ref)
+                if not dep_id:
+                    raise ValueError(
+                        f"Unresolved dependency ref '{dep_ref}' in task "
+                        f"'{ref or '(unnamed)'}'. Refs must reference "
+                        f"earlier tasks in the group."
+                    )
+                resolved_deps.append(dep_id)
+
+        # Create the task — if it has resolved deps, it starts blocked.
+        task = store.create(
+            objective=task_spec.get("objective", ""),
+            title=task_spec.get("title"),
+            playbook_id=task_spec.get("playbook_id"),
+            tags=task_spec.get("tags"),
+            functions=task_spec.get("functions"),
+            skills=task_spec.get("skills"),
+            tasks=task_spec.get("tasks"),
+            model=task_spec.get("model"),
+            context=task_spec.get("context"),
+            watch_events=task_spec.get("watch_events"),
+            kind=task_spec.get("kind", "work"),
+        )
+
+        # Override dependency state if ref-based deps were specified.
+        if resolved_deps:
+            task.metadata.depends_on = resolved_deps
+            task.metadata.status = "blocked"
+            store.save_metadata(task)
+
+        if ref:
+            ref_to_id[ref] = task.id
+
+        logger.info(
+            "Created task %s%s",
+            task.id[:8],
+            f" (ref={ref})" if ref else "",
+        )
+
+    return {"created": ref_to_id}
 
 
 # ---------------------------------------------------------------------------

--- a/packages/bees/docs/mutations.md
+++ b/packages/bees/docs/mutations.md
@@ -1,19 +1,26 @@
 # Mutation Log — Atomic Filesystem Commands
 
 The mutation log (`hive/mutations/`) is a filesystem-based command channel.
-Clients write mutation files; the box processes them atomically between
-shutdown and restart.
+Clients write mutation files; the box processes them atomically.
 
 ## Why
 
 The box and hivetool both observe the hive directory, but the filesystem
-is not transactional. Multi-step operations like "reset" (delete all tasks
-and logs) need to appear atomic to both sides. The mutation log solves this
-by funneling destructive operations through the box — the single writer —
-which processes them in a quiescent gap where no tasks are running and no
-observers are reacting.
+is not transactional. Multi-step operations need to appear atomic to both
+sides. The mutation log solves this by funneling operations through the
+box — the single writer — which executes all writes before triggering the
+scheduler.
 
-## How It Works
+## Processing Modes
+
+Mutations come in two flavors:
+
+- **Hot** mutations are processed inline while the scheduler is running.
+  The box executes the writes, then triggers the scheduler once.
+  Examples: `respond-to-task`, `create-task-group`.
+
+- **Cold** mutations require quiescence. The box shuts down Bees, processes
+  the mutation in the gap between shutdown and restart. Examples: `reset`.
 
 ```
 ┌─────────────────────────────────────────────────────────┐
@@ -28,19 +35,20 @@ observers are reacting.
 │       ↓ watchfiles detects new .json file               │
 ├─────────────────────────────────────────────────────────┤
 │                Box (bees.box)                           │
-│   1. Break inner loop (like config restart)             │
-│   2. Shutdown Bees (cancel tasks, disconnect MCP)       │
-│   3. Process mutation (delete tickets/, logs/)          │
-│   4. Write mutations/{uuid}.result.json                 │
-│   5. Restart Bees (re-boots root template)              │
-├─────────────────────────────────────────────────────────┤
-│                Bees Framework                           │
-│           Fresh Scheduler → Root Template               │
+│                                                         │
+│   Hot path:                                             │
+│     1. Execute writes (response.json, metadata.json)    │
+│     2. Write result file                                │
+│     3. Trigger scheduler                                │
+│                                                         │
+│   Cold path:                                            │
+│     1. Break inner loop                                 │
+│     2. Shutdown Bees (cancel tasks, disconnect MCP)     │
+│     3. Execute mutation (delete tickets/, logs/)        │
+│     4. Write result file                                │
+│     5. Restart Bees (re-boots root template)            │
 └─────────────────────────────────────────────────────────┘
 ```
-
-The key insight: mutations are processed in the same gap the box already uses
-for config restarts. No new concurrency model is needed.
 
 ## File Format
 
@@ -86,12 +94,64 @@ Or on failure:
 
 ## Supported Mutations
 
-### `reset`
+### `reset` (cold)
 
 Deletes all tasks (`tickets/`) and session logs (`logs/`). The directories
 themselves are preserved (so filesystem handles and observers remain valid).
 After restart, the root template re-boots automatically because no task with
 a matching `playbook_id` exists.
+
+### `respond-to-task` (hot)
+
+Writes `response.json` and flips `metadata.assignee` to `"agent"` atomically.
+Both writes complete before the scheduler is triggered, preventing the race
+where the scheduler sees the assignee flip before the response file exists.
+
+```json
+{
+  "type": "respond-to-task",
+  "task_id": "uuid",
+  "response": { "text": "user's reply" }
+}
+```
+
+### `create-task-group` (hot)
+
+Creates multiple tasks as a batch with intra-group dependency resolution.
+Each task may include a `ref` name and a `depends_on` list of refs. Refs
+are resolved to real task IDs within the batch. The scheduler is triggered
+once after all tasks are created.
+
+```json
+{
+  "type": "create-task-group",
+  "tasks": [
+    {
+      "ref": "research",
+      "objective": "Research the topic",
+      "playbook_id": "researcher"
+    },
+    {
+      "ref": "writer",
+      "depends_on": ["research"],
+      "objective": "Write a summary",
+      "playbook_id": "writer"
+    }
+  ]
+}
+```
+
+Result includes the ref → task ID mapping:
+
+```json
+{
+  "status": "ok",
+  "created": {
+    "research": "abc123...",
+    "writer": "def456..."
+  }
+}
+```
 
 ## Driving Mutations from the Command Line
 
@@ -116,11 +176,13 @@ down.
 
 1. Add a handler function in `bees/mutations.py`.
 2. Add a `case` to `_dispatch()`.
-3. Add a method to `MutationClient` in `hivetool/src/data/mutation-client.ts`.
-4. Wire up UI in the appropriate component.
+3. If it's a cold mutation, add its type to `COLD_MUTATIONS`.
+4. Add a method to `MutationClient` in `hivetool/src/data/mutation-client.ts`.
+5. Wire up UI in the appropriate component.
 
-The handler runs in a fully quiescent state — no tasks running, no MCP
-connections open. Safe for any destructive operation.
+Hot mutation handlers run while the scheduler is live — they should only
+write files, not delete directories or cancel tasks. Cold mutation handlers
+run in a fully quiescent state — safe for any destructive operation.
 
 ## Garbage Collection
 
@@ -137,18 +199,11 @@ just see stale data), it's a mutation candidate. Simple single-file writes
 where the worst case is "scheduler picks it up a beat late" are fine as
 direct writes.
 
-### Strong candidates (intermediate state is dangerous)
-
-| Mutation | Why |
-|----------|-----|
-| `respond-to-task` | Currently two writes: `response.json` then `metadata.json` (flip assignee). The box could see the metadata flip before the response file lands, resuming the agent with no response. |
-| `create-task-group` | Template-driven multi-task creation with `{{dep-ref}}` dependencies. If the box triggers the scheduler after task 1 is written but before tasks 2–5 exist, dependency resolution fails. |
-
 ### Weak candidates (could benefit but aren't urgent)
 
 | Mutation | Why it's borderline |
 |----------|---------------------|
-| `create-task` (single) | One `mkdir` + two file writes. `watchfiles` debounce usually batches them. The risk is low and the latency cost of a mutation (shutdown/restart) is disproportionate. |
+| `create-task` (single) | One `mkdir` + two file writes. `watchfiles` debounce usually batches them. The risk is low and the latency cost of a mutation is disproportionate. |
 | `config-update` | Already handled by the config restart path. Could become a mutation if config updates need to carry metadata (e.g., "who changed this and why"). |
 | `cancel-all` | Emergency stop: cancel running asyncio tasks and set status to `cancelled`. The filesystem alone can't stop in-flight coroutines — only the box can. But without a `resume-task` mutation, the recovery story is thin: cancelled tasks stay cancelled, and the system freezes. Needs a resume path to justify its own mutation type. |
 
@@ -159,4 +214,3 @@ direct writes.
 | Reads / scans | Inherently safe. Stale data self-corrects on next observer tick. |
 | Single-file edits (skill content, template YAML) | One write, one observer reaction. No intermediate state. |
 | Log file writes (box → disk) | Box is the sole writer. No cross-process race. |
-

--- a/packages/bees/hivetool/src/data/mutation-client.ts
+++ b/packages/bees/hivetool/src/data/mutation-client.ts
@@ -7,15 +7,35 @@
 /**
  * Client for the mutation log — writes mutation files to `hive/mutations/`.
  *
- * The box watches this directory and processes mutations atomically
- * in the quiescent gap between shutdown and restart. This client is
- * fire-and-forget: it writes the command file and returns. The effects
- * are observed through existing store observers (TicketStore, LogStore).
+ * The box watches this directory and processes mutations atomically.
+ * Hot mutations (respond-to-task, create-task-group) are processed inline
+ * while the scheduler is running. Cold mutations (reset) are processed in
+ * the quiescent gap between shutdown and restart.
+ *
+ * This client is fire-and-forget: it writes the command file and returns.
+ * Effects are observed through existing store observers.
  */
 
 import type { StateAccess } from "./state-access.js";
 
 export { MutationClient };
+
+/** Task specification for batch creation. */
+interface TaskSpec {
+  ref?: string;
+  objective: string;
+  title?: string;
+  playbook_id?: string;
+  tags?: string[];
+  functions?: string[];
+  skills?: string[];
+  tasks?: string[];
+  model?: string;
+  context?: string;
+  watch_events?: string[];
+  kind?: string;
+  depends_on?: string[];
+}
 
 class MutationClient {
   constructor(private access: StateAccess) {}
@@ -23,20 +43,57 @@ class MutationClient {
   /**
    * Request a hive reset — deletes all tasks and session logs.
    *
-   * Writes a `reset` mutation file to `mutations/{uuid}.json`.
-   * The box processes it on the next watch cycle, clearing `tickets/`
-   * and `logs/` atomically, then restarting to re-boot the root template.
-   *
-   * Returns the mutation ID (UUID) for debugging.
+   * Cold mutation: the box shuts down, clears `tickets/` and `logs/`,
+   * then restarts to re-boot the root template.
    */
   async requestReset(): Promise<string> {
+    return this.#writeMutation({ type: "reset" });
+  }
+
+  /**
+   * Respond to a suspended task — writes response and flips assignee
+   * atomically.
+   *
+   * Hot mutation: the box writes `response.json` and updates
+   * `metadata.json` in a single pass before triggering the scheduler,
+   * preventing the race where the scheduler sees the assignee flip
+   * before the response file exists.
+   */
+  async respondToTask(
+    taskId: string,
+    response: Record<string, unknown>
+  ): Promise<string> {
+    return this.#writeMutation({
+      type: "respond-to-task",
+      task_id: taskId,
+      response,
+    });
+  }
+
+  /**
+   * Create multiple tasks as a group with intra-batch dependencies.
+   *
+   * Hot mutation: the box creates all tasks sequentially, resolving
+   * `depends_on` refs to real task IDs within the batch.  The scheduler
+   * is triggered once after all tasks are created.
+   */
+  async createTaskGroup(tasks: TaskSpec[]): Promise<string> {
+    return this.#writeMutation({
+      type: "create-task-group",
+      tasks,
+    });
+  }
+
+  // -- internal -----------------------------------------------------------
+
+  async #writeMutation(data: Record<string, unknown>): Promise<string> {
     const mutationsDir = await this.#getMutationsDir();
 
     const mutationId = crypto.randomUUID();
     const filename = `${mutationId}.json`;
 
     const mutation = {
-      type: "reset",
+      ...data,
       timestamp: new Date().toISOString(),
     };
 
@@ -56,3 +113,4 @@ class MutationClient {
     return handle.getDirectoryHandle("mutations", { create: true });
   }
 }
+

--- a/packages/bees/hivetool/src/data/ticket-store.ts
+++ b/packages/bees/hivetool/src/data/ticket-store.ts
@@ -184,47 +184,6 @@ class TicketStore {
     return taskId;
   }
 
-  /**
-   * Respond to a suspended task.
-   *
-   * Writes `response.json` with the user's response and flips `assignee`
-   * to `"agent"` in `metadata.json`. The box's file watcher detects
-   * both changes and the scheduler resumes the task.
-   *
-   * For text replies:   `{ text: "user's message" }`
-   * For choice replies: `{ selectedIds: ["id1", ...] }`
-   */
-  async respondToTask(
-    ticketId: string,
-    response: Record<string, unknown>
-  ): Promise<void> {
-    if (!this.#ticketsHandle) throw new Error("Ticket store not activated");
-
-    const ticketDir = await this.#ticketsHandle.getDirectoryHandle(ticketId);
-
-    // Write response.json
-    const responseHandle = await ticketDir.getFileHandle("response.json", {
-      create: true,
-    });
-    const responseWritable = await responseHandle.createWritable();
-    await responseWritable.write(
-      JSON.stringify(response, null, 2) + "\n"
-    );
-    await responseWritable.close();
-
-    // Read, update, and write metadata.json — flip assignee to "agent".
-    const metadataHandle = await ticketDir.getFileHandle("metadata.json");
-    const metadataFile = await metadataHandle.getFile();
-    const metadata = JSON.parse(await metadataFile.text());
-    metadata.assignee = "agent";
-
-    const metadataWritable = await metadataHandle.createWritable();
-    await metadataWritable.write(
-      JSON.stringify(metadata, null, 2) + "\n"
-    );
-    await metadataWritable.close();
-  }
-
   // ── File tree ──
 
   /** Read the directory tree for a ticket's filesystem. */

--- a/packages/bees/hivetool/src/ui/app.ts
+++ b/packages/bees/hivetool/src/ui/app.ts
@@ -646,6 +646,7 @@ class BeesApp extends SignalWatcher(LitElement) {
       case "tickets":
         return html`<bees-ticket-detail
           .ticketStore=${this.ticketStore}
+          .mutationClient=${this.mutationClient}
           .templateStore=${this.templateStore}
           .skillStore=${this.skillStore}
           .flashTicketId=${flashTicketId}

--- a/packages/bees/hivetool/src/ui/ticket-detail.ts
+++ b/packages/bees/hivetool/src/ui/ticket-detail.ts
@@ -17,6 +17,7 @@ import { LitElement, html, css, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
 import type { TicketStore, FileTreeNode } from "../data/ticket-store.js";
+import type { MutationClient } from "../data/mutation-client.js";
 import type { TemplateStore } from "../data/template-store.js";
 import type { SkillStore } from "../data/skill-store.js";
 import { sharedStyles } from "./shared-styles.js";
@@ -308,6 +309,9 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
 
   @property({ attribute: false })
   accessor ticketStore: TicketStore | null = null;
+
+  @property({ attribute: false })
+  accessor mutationClient: MutationClient | null = null;
 
   @property({ attribute: false })
   accessor templateStore: TemplateStore | null = null;
@@ -910,11 +914,11 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
 
   private async handleTextReply(ticketId: string) {
     const text = this.replyText.trim();
-    if (!text || !this.ticketStore) return;
+    if (!text || !this.mutationClient) return;
 
     this.responding = true;
     try {
-      await this.ticketStore.respondToTask(ticketId, { text });
+      await this.mutationClient.respondToTask(ticketId, { text });
       this.replyText = "";
     } catch (e) {
       console.error("Failed to send reply:", e);
@@ -924,11 +928,11 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
   }
 
   private async handleChoiceReply(ticketId: string) {
-    if (this.selectedChoiceIds.size === 0 || !this.ticketStore) return;
+    if (this.selectedChoiceIds.size === 0 || !this.mutationClient) return;
 
     this.responding = true;
     try {
-      await this.ticketStore.respondToTask(ticketId, {
+      await this.mutationClient.respondToTask(ticketId, {
         selectedIds: [...this.selectedChoiceIds],
       });
       this.selectedChoiceIds = new Set();


### PR DESCRIPTION
## What
Evolves the mutation log to support **hot mutations** (processed inline while the scheduler is running) alongside cold mutations (which require shutdown/restart). Adds `respond-to-task` and `create-task-group` as hot mutation types, and moves task response handling from direct filesystem writes to the atomic mutation channel.

## Why
`respondToTask` previously performed two separate file writes (`response.json` then `metadata.json`). The box's scheduler could see the metadata flip (assignee → agent) before `response.json` existed, causing the task to fail with "No response.json found for resume." Routing responses through the mutation log ensures both writes complete before the scheduler is triggered.

## Changes

### Python — mutation model
- **`mutations.py`**: Split processing into `process_inline()` (hot) and `process_cold()` (cold). Added `COLD_MUTATIONS` set, `MutationOutcome` dataclass, `_execute_respond()` handler (delegates to `TaskStore.respond()`), and `_execute_create_group()` handler with ref→id dependency resolution. Reset now also clears `mutations/`.
- **`box.py`**: Run loop processes hot mutations inline and triggers the scheduler; only cold mutations cause shutdown/restart.

### TypeScript — client and UI
- **`mutation-client.ts`**: Added `respondToTask()` and `createTaskGroup()` methods, extracted `#writeMutation` helper.
- **`ticket-store.ts`**: Removed `respondToTask()` — the racy two-file write is eliminated.
- **`ticket-detail.ts`**: Uses `mutationClient.respondToTask()` instead of `ticketStore`.
- **`app.ts`**: Passes `mutationClient` to `bees-ticket-detail`.

### Documentation
- **`mutations.md`**: Updated for hot/cold model, documented `respond-to-task` and `create-task-group` with examples.

## Testing
1. Start box + hivetool, let a task suspend with `waitForInput`
2. Reply via the UI → verify response goes through mutation channel (mutation file appears in `mutations/`)
3. Verify the task resumes correctly (no "No response.json" failure)
4. Reset hive → verify `mutations/` is also cleared
