### PR TITLE
[bees] Fix skill `allowed-tools` not filtering functions

### DIFF
--- a/packages/bees/bees/session.py
+++ b/packages/bees/bees/session.py
@@ -38,7 +38,7 @@ from opal_backend.sessions.api import (
     update_context,
 )
 from opal_backend.sessions.in_memory_store import InMemorySessionStore
-from bees.functions.skills import get_skills_function_group, scan_skills
+from bees.functions.skills import get_skills_function_group
 from bees.functions.simple_files import get_simple_files_function_group_factory
 from bees.functions.system import get_system_function_group_factory
 from bees.functions.sandbox import get_sandbox_function_group_factory
@@ -49,14 +49,7 @@ from bees.context_updates import updates_to_context_parts
 from bees.config import HIVE_DIR, PACKAGE_DIR
 from bees.disk_file_system import DiskFileSystem
 from bees.subagent_scope import SubagentScope
-
-_SKILLS_CACHE = {}
-
-
-def _get_skills(hive_dir: Path):
-    if hive_dir not in _SKILLS_CACHE:
-        _SKILLS_CACHE[hive_dir] = scan_skills(hive_dir)
-    return _SKILLS_CACHE[hive_dir]
+from bees.skill_filter import filter_skills, merge_function_filter
 
 CHAT_LOG_FILENAME = "chat_log.json"
 
@@ -392,43 +385,6 @@ def extract_files(
 
 
 
-def _filter_skills(
-    allowed_skills: list[str] | None, hive_dir: Path
-) -> tuple[str, dict[str, str], list[str]]:
-    """Filter skills based on allowed_skills and return listing, files, and tool globs.
-
-    Returns:
-        A ``(listing, files, skill_tools)`` tuple:
-        - ``listing``: Formatted markdown for ``{{available_skills}}``.
-        - ``files``: Dict of ``{vfs_name: content}`` for seeding.
-        - ``skill_tools``: Merged ``allowed-tools`` from all selected skills.
-    """
-    _, skills_files, skills_list = _get_skills(hive_dir)
-
-    skills_to_use = allowed_skills if allowed_skills is not None else []
-
-    if "*" in skills_to_use:
-        filtered_skills = skills_list
-    else:
-        filtered_skills = [s for s in skills_list if s.name in skills_to_use]
-
-    lines = []
-    skill_tools: list[str] = []
-    for s in filtered_skills:
-        lines.append(f"- [{s.title}]({s.vfs_path})")
-        if s.description:
-            lines.append(f"  {s.description}")
-        skill_tools.extend(s.allowed_tools)
-    session_listing = "\n".join(lines)
-
-    session_files = {}
-    for k, v in skills_files.items():
-        if any(f"skills/{s.dir_name}/" in k for s in filtered_skills):
-            session_files[k] = v
-
-    return session_listing, session_files, skill_tools
-
-
 # ---------------------------------------------------------------------------
 # Core session runner
 # ---------------------------------------------------------------------------
@@ -484,16 +440,13 @@ async def run_session(
     out_dir = hive_dir / "logs"
     out_path = out_dir / f"{log_prefix}-{date_stamp}.log.json"
 
-    session_listing, session_files, skill_tools = _filter_skills(
+    session_listing, session_files, skill_tools = filter_skills(
         allowed_skills, hive_dir
     )
 
-    # Union skill-declared tools into the template's function filter.
-    # Also inject skills.* automatically when any skills are selected —
-    # the agent needs it to read skill instructions.
-    if function_filter is not None and allowed_skills:
-        skill_tools.append("skills.*")
-        function_filter = list(dict.fromkeys(function_filter + skill_tools))
+    function_filter = merge_function_filter(
+        function_filter, skill_tools, allowed_skills,
+    )
 
     # Create disk-backed file system.
     work_dir = fs_dir or (ticket_dir / "filesystem" if ticket_dir else Path(tempfile.mkdtemp(prefix="bees-fs-")))
@@ -677,14 +630,20 @@ async def resume_session(
     # Load allowed skills from ticket metadata
     metadata_path = ticket_dir / "metadata.json"
     allowed_skills = None
+    function_filter: list[str] | None = None
     if metadata_path.exists():
         try:
             meta = json.loads(metadata_path.read_text())
             allowed_skills = meta.get("skills")
+            function_filter = meta.get("functions")
         except Exception:
             pass
 
-    session_listing, _, _ = _filter_skills(allowed_skills, hive_dir)
+    session_listing, _, skill_tools = filter_skills(allowed_skills, hive_dir)
+
+    function_filter = merge_function_filter(
+        function_filter, skill_tools, allowed_skills,
+    )
 
     # Create disk-backed file system — files are already on disk from
     # the previous run, so no seeding needed.
@@ -731,6 +690,7 @@ async def resume_session(
                 scheduler=scheduler,
             ),
         ] + (mcp_factories or []),
+        function_filter=function_filter,
         file_system=disk_fs,
         context_queue=context_queue,
     )

--- a/packages/bees/bees/skill_filter.py
+++ b/packages/bees/bees/skill_filter.py
@@ -1,0 +1,83 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Skill filtering and function-filter merging.
+
+Resolves which skills are active for a session and merges their
+``allowed-tools`` declarations into the session's function filter.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from bees.functions.skills import scan_skills
+
+__all__ = ["filter_skills", "merge_function_filter"]
+
+_SKILLS_CACHE: dict = {}
+
+
+def _get_skills(hive_dir: Path):
+    if hive_dir not in _SKILLS_CACHE:
+        _SKILLS_CACHE[hive_dir] = scan_skills(hive_dir)
+    return _SKILLS_CACHE[hive_dir]
+
+
+def filter_skills(
+    allowed_skills: list[str] | None, hive_dir: Path
+) -> tuple[str, dict[str, str], list[str]]:
+    """Filter skills based on allowed_skills and return listing, files, and tool globs.
+
+    Returns:
+        A ``(listing, files, skill_tools)`` tuple:
+        - ``listing``: Formatted markdown for ``{{available_skills}}``.
+        - ``files``: Dict of ``{vfs_name: content}`` for seeding.
+        - ``skill_tools``: Merged ``allowed-tools`` from all selected skills.
+    """
+    _, skills_files, skills_list = _get_skills(hive_dir)
+
+    skills_to_use = allowed_skills if allowed_skills is not None else []
+
+    if "*" in skills_to_use:
+        filtered_skills = skills_list
+    else:
+        filtered_skills = [s for s in skills_list if s.name in skills_to_use]
+
+    lines = []
+    skill_tools: list[str] = []
+    for s in filtered_skills:
+        lines.append(f"- [{s.title}]({s.vfs_path})")
+        if s.description:
+            lines.append(f"  {s.description}")
+        skill_tools.extend(s.allowed_tools)
+    session_listing = "\n".join(lines)
+
+    session_files = {}
+    for k, v in skills_files.items():
+        if any(f"skills/{s.dir_name}/" in k for s in filtered_skills):
+            session_files[k] = v
+
+    return session_listing, session_files, skill_tools
+
+
+def merge_function_filter(
+    function_filter: list[str] | None,
+    skill_tools: list[str],
+    allowed_skills: list[str] | None,
+) -> list[str] | None:
+    """Merge skill-declared allowed-tools into a function filter.
+
+    When ``function_filter`` is ``None`` and skills declare tools,
+    the skill tools become the filter (rather than allowing everything).
+    Also injects ``skills.*`` so the agent can read skill instructions.
+    """
+    if not allowed_skills or not skill_tools:
+        return function_filter
+    skill_tools = list(skill_tools)  # Don't mutate the caller's list.
+    skill_tools.append("skills.*")
+    if function_filter is not None:
+        return list(dict.fromkeys(function_filter + skill_tools))
+    # Template has no functions field — skill-declared tools
+    # become the sole filter.
+    return list(dict.fromkeys(skill_tools))

--- a/packages/bees/tests/test_session_filter.py
+++ b/packages/bees/tests/test_session_filter.py
@@ -1,0 +1,75 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for merge_function_filter in bees.skill_filter."""
+
+import pytest
+from bees.skill_filter import merge_function_filter
+
+
+class TestMergeFunctionFilter:
+    """Covers the three cases for function filter merging."""
+
+    def test_template_filter_plus_skill_tools(self):
+        """Template functions + skill allowed-tools → union of both."""
+        result = merge_function_filter(
+            function_filter=["simple-files.*", "tasks.*"],
+            skill_tools=["sandbox.*", "events.*"],
+            allowed_skills=["ui-generator"],
+        )
+        assert result == [
+            "simple-files.*", "tasks.*", "sandbox.*", "events.*", "skills.*",
+        ]
+
+    def test_no_template_filter_with_skill_tools(self):
+        """No functions field + skill allowed-tools → skill tools only.
+
+        This is the bug case: ui-generator template has no `functions`
+        but its skill declares allowed-tools.
+        """
+        result = merge_function_filter(
+            function_filter=None,
+            skill_tools=["sandbox.*", "simple-files.*", "events.*", "system.*"],
+            allowed_skills=["ui-generator"],
+        )
+        assert result is not None, "Must not be None — would allow all functions"
+        assert "skills.*" in result
+        assert "sandbox.*" in result
+        assert "simple-files.*" in result
+
+    def test_no_skills_no_filter_stays_none(self):
+        """No skills, no filter → None (allow everything)."""
+        result = merge_function_filter(
+            function_filter=None,
+            skill_tools=[],
+            allowed_skills=None,
+        )
+        assert result is None
+
+    def test_skills_without_allowed_tools(self):
+        """Skills exist but declare no allowed-tools → filter unchanged."""
+        result = merge_function_filter(
+            function_filter=["tasks.*"],
+            skill_tools=[],
+            allowed_skills=["some-skill"],
+        )
+        assert result == ["tasks.*"]
+
+    def test_does_not_mutate_input(self):
+        """The caller's skill_tools list must not be mutated."""
+        original_tools = ["sandbox.*"]
+        merge_function_filter(
+            function_filter=None,
+            skill_tools=original_tools,
+            allowed_skills=["x"],
+        )
+        assert original_tools == ["sandbox.*"], "Input list was mutated"
+
+    def test_deduplication(self):
+        """Overlapping globs between template and skills are deduplicated."""
+        result = merge_function_filter(
+            function_filter=["sandbox.*", "system.*"],
+            skill_tools=["sandbox.*", "events.*"],
+            allowed_skills=["x"],
+        )
+        assert result == ["sandbox.*", "system.*", "events.*", "skills.*"]


### PR DESCRIPTION
## What
When a task template (e.g. `ui-generator`) has no `functions` field but its skill declares `allowed-tools`, the function filter was silently dropped — all functions were exposed to the agent.

## Why
The guard `if function_filter is not None and allowed_skills:` short-circuited when `function_filter` was `None` (no template `functions` field), discarding the skill's `allowed-tools` entirely. The same bug existed in `resume_session`, which additionally never loaded `functions` from metadata and never passed `function_filter` to `new_session`.

## Changes

### `bees/skill_filter.py` [NEW]
- Extracted `filter_skills` and `merge_function_filter` from `session.py` into a dedicated module
- `merge_function_filter` handles three cases: template+skills union, skills-only filter, and passthrough

### `bees/session.py`
- **`run_session`**: replaced inline merge logic with `merge_function_filter()` call
- **`resume_session`**: now loads both `skills` and `functions` from metadata, captures `skill_tools` from `filter_skills`, and passes `function_filter` to `new_session`
- Removed `_SKILLS_CACHE`, `_get_skills`, `_filter_skills`, `_merge_function_filter` (moved to `skill_filter.py`)

### `tests/test_session_filter.py` [NEW]
- 6 tests covering: union, skills-only (the bug case), no-filter passthrough, empty skill tools, input mutation safety, deduplication

## Testing
```bash
cd packages/bees
.venv/bin/python -m pytest tests/ -v
# 201 passed
```
