### PR TITLE
[bees] Pause / Resume for tasks

### DIFF
--- a/packages/bees/bees/bees.py
+++ b/packages/bees/bees/bees.py
@@ -42,6 +42,28 @@ class Bees:
         """Registers an event listener."""
         self._events[event_name].append(callback)
 
+    def pause_all(self) -> int:
+        """Pause all non-terminal tasks.
+
+        Cancels in-flight asyncio tasks and flips statuses to ``paused``,
+        preserving the original status in ``paused_from`` for later resume.
+        Returns the number of tasks paused.
+        """
+        return self._scheduler.pause_all_tasks()
+
+    def resume_all(self) -> int:
+        """Resume all paused tasks, restoring their pre-pause status.
+
+        Returns the number of tasks resumed.
+        """
+        count = 0
+        for task in self._store.query_all(status="paused"):
+            task.metadata.status = task.metadata.paused_from or "available"
+            task.metadata.paused_from = None
+            self._store.save_metadata(task)
+            count += 1
+        return count
+
     async def listen(self):
         """Starts the scheduler loop."""
         await self._scheduler.startup()

--- a/packages/bees/bees/box.py
+++ b/packages/bees/bees/box.py
@@ -194,7 +194,7 @@ async def run(hive_dir: Path, backend: HttpBackendClient) -> None:
                 # Process mutations: hot mutations run inline,
                 # cold mutations signal a restart.
                 if needs_mutation:
-                    outcome = process_inline(hive_dir)
+                    outcome = process_inline(hive_dir, bees=bees)
                     if outcome.hot_processed > 0:
                         needs_trigger = True
                     if outcome.cold_pending:

--- a/packages/bees/bees/mutations.py
+++ b/packages/bees/bees/mutations.py
@@ -20,6 +20,10 @@ Two processing modes:
   are processed inline while the scheduler is running.  The box
   executes all writes atomically, then triggers the scheduler once.
 
+Some hot mutations (``pause-all``) need runtime access to cancel
+in-flight asyncio tasks.  The box passes a ``Bees`` reference via
+``process_inline``.
+
 Supported mutation types:
 
 - **reset** (cold) — Deletes all tasks and session logs.
@@ -27,6 +31,12 @@ Supported mutation types:
   ``assignee`` to ``"agent"`` atomically.
 - **create-task-group** (hot) — Creates multiple tasks with
   intra-batch dependency resolution via named refs.
+- **cancel-all** (hot) — Cancels all in-flight tasks and flips
+  non-terminal statuses to ``paused``.
+- **resume-paused** (hot) — Flips all ``paused`` tasks back
+  to their pre-pause status.
+- **pause-task** (hot) — Pauses a single task by ID.
+- **resume-task** (hot) — Resumes a single paused task by ID.
 """
 
 from __future__ import annotations
@@ -37,9 +47,12 @@ import shutil
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from bees.task_store import TaskStore
+
+if TYPE_CHECKING:
+    from bees.bees import Bees
 
 logger = logging.getLogger("bees.mutations")
 
@@ -157,11 +170,17 @@ def process_all(hive_dir: Path) -> bool:
     return True
 
 
-def process_inline(hive_dir: Path) -> MutationOutcome:
+def process_inline(
+    hive_dir: Path,
+    bees: Bees | None = None,
+) -> MutationOutcome:
     """Process hot mutations inline while the scheduler is running.
 
     Cold mutations are not processed — they're flagged in the outcome
     so the caller can initiate a shutdown/restart cycle.
+
+    ``bees`` is passed through to handlers that need runtime
+    access (e.g., ``pause-all`` needs to cancel asyncio tasks).
 
     Returns a ``MutationOutcome`` indicating what happened.
     """
@@ -174,7 +193,7 @@ def process_inline(hive_dir: Path) -> MutationOutcome:
             continue
 
         logger.info("Processing hot mutation: %s (%s)", mutation.mutation_type, mutation.path.name)
-        result = _dispatch(mutation, hive_dir)
+        result = _dispatch(mutation, hive_dir, bees=bees)
         if result:
             outcome.hot_processed += 1
             if result.get("created"):
@@ -208,7 +227,12 @@ def process_cold(hive_dir: Path) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def _dispatch(mutation: PendingMutation, hive_dir: Path) -> dict[str, Any] | None:
+def _dispatch(
+    mutation: PendingMutation,
+    hive_dir: Path,
+    *,
+    bees: Bees | None = None,
+) -> dict[str, Any] | None:
     """Dispatch a mutation by type and write the result.
 
     Returns extra result data on success (e.g., created task IDs),
@@ -224,6 +248,14 @@ def _dispatch(mutation: PendingMutation, hive_dir: Path) -> dict[str, Any] | Non
                 _execute_respond(hive_dir, mutation)
             case "create-task-group":
                 extra = _execute_create_group(hive_dir, mutation)
+            case "cancel-all" | "pause-all":
+                extra = _execute_pause_all(hive_dir, bees)
+            case "resume-cancelled" | "resume-paused":
+                extra = _execute_resume_paused(hive_dir, bees)
+            case "pause-task":
+                extra = _execute_pause_task(hive_dir, mutation, bees)
+            case "resume-task":
+                extra = _execute_resume_task(hive_dir, mutation, bees)
             case _:
                 _write_result(
                     mutation.result_path,
@@ -357,6 +389,117 @@ def _execute_create_group(hive_dir: Path, mutation: PendingMutation) -> dict[str
         )
 
     return {"created": ref_to_id}
+
+
+def _execute_pause_all(
+    hive_dir: Path,
+    bees: Bees | None,
+) -> dict[str, Any]:
+    """Pause all non-terminal tasks.
+
+    When a ``Bees`` instance is available (inline processing), delegates
+    to the high-level ``pause_all()`` API.  Falls back to pure filesystem
+    operations when processing at startup without a live scheduler.
+    """
+    if bees:
+        count = bees.pause_all()
+    else:
+        # Startup fallback: no live scheduler, just flip metadata.
+        store = TaskStore(hive_dir)
+        count = 0
+        for status in ("available", "blocked", "running", "suspended"):
+            for task in store.query_all(status=status):
+                task.metadata.paused_from = task.metadata.status
+                task.metadata.status = "paused"
+                store.save_metadata(task)
+                count += 1
+
+    logger.info("Paused %d task(s)", count)
+    return {"paused": count}
+
+
+def _execute_resume_paused(
+    hive_dir: Path,
+    bees: Bees | None,
+) -> dict[str, Any]:
+    """Flip all paused tasks back to their pre-pause status."""
+    if bees:
+        count = bees.resume_all()
+    else:
+        store = TaskStore(hive_dir)
+        paused = store.query_all(status="paused")
+        for task in paused:
+            task.metadata.status = task.metadata.paused_from or "available"
+            task.metadata.paused_from = None
+            store.save_metadata(task)
+        count = len(paused)
+
+    logger.info("Resumed %d paused task(s)", count)
+    return {"resumed": count}
+
+
+def _execute_pause_task(
+    hive_dir: Path,
+    mutation: PendingMutation,
+    bees: Bees | None,
+) -> dict[str, Any]:
+    """Pause a single task by ID."""
+    task_id = mutation.data.get("task_id")
+    if not task_id:
+        raise ValueError("pause-task mutation missing 'task_id'")
+
+    if bees:
+        node = bees.get_by_id(task_id)
+        paused = node.pause() if node else False
+    else:
+        store = TaskStore(hive_dir)
+        task = store.get(task_id)
+        if not task or task.metadata.status in ("completed", "failed", "cancelled", "paused"):
+            paused = False
+        else:
+            task.metadata.paused_from = task.metadata.status
+            task.metadata.status = "paused"
+            store.save_metadata(task)
+            paused = True
+
+    if paused:
+        logger.info("Paused task %s", task_id[:8])
+    else:
+        logger.warning("Could not pause task %s", task_id[:8])
+
+    return {"paused": paused}
+
+
+def _execute_resume_task(
+    hive_dir: Path,
+    mutation: PendingMutation,
+    bees: Bees | None,
+) -> dict[str, Any]:
+    """Resume a single paused task by ID."""
+    task_id = mutation.data.get("task_id")
+    if not task_id:
+        raise ValueError("resume-task mutation missing 'task_id'")
+
+    if bees:
+        node = bees.get_by_id(task_id)
+        resumed = node.resume() if node else False
+    else:
+        store = TaskStore(hive_dir)
+        task = store.get(task_id)
+        if not task or task.metadata.status != "paused":
+            logger.warning("Could not resume task %s (not paused)", task_id[:8])
+            return {"resumed": False}
+        task.metadata.status = task.metadata.paused_from or "available"
+        task.metadata.paused_from = None
+        store.save_metadata(task)
+        resumed = True
+
+    if resumed:
+        logger.info("Resumed task %s", task_id[:8])
+    else:
+        logger.warning("Could not resume task %s (not paused)", task_id[:8])
+
+    return {"resumed": resumed}
 
 
 # ---------------------------------------------------------------------------

--- a/packages/bees/bees/scheduler.py
+++ b/packages/bees/bees/scheduler.py
@@ -295,6 +295,53 @@ class Scheduler:
             
         return cancelled
 
+    def pause_all_tasks(self) -> int:
+        """Pause all running, available, suspended, blocked, and paused tasks.
+
+        Cancels in-flight asyncio tasks and flips metadata to ``paused``.
+        Stashes the pre-pause status in ``paused_from`` so resume can
+        restore it.  Returns the number of tasks paused.
+        """
+        # Cancel all in-flight asyncio tasks.
+        for task_id, async_task in list(self._active_tasks.items()):
+            async_task.cancel()
+
+        # Flip all non-terminal tasks to paused.
+        NON_TERMINAL = ("available", "blocked", "running", "suspended")
+        count = 0
+        for status in NON_TERMINAL:
+            for task in self.store.query_all(status=status):
+                task.metadata.paused_from = task.metadata.status
+                task.metadata.status = "paused"
+                self.store.save_metadata(task)
+                count += 1
+
+        return count
+
+    def pause_task(self, task_id: str) -> bool:
+        """Pause a single task.
+
+        Cancels its asyncio task if running, then flips status to
+        ``paused`` with ``paused_from`` set for later resume.
+        Returns True if the task was found and paused.
+        """
+        task = self.store.get(task_id)
+        if not task:
+            return False
+
+        # Already in a terminal or paused state — nothing to do.
+        if task.metadata.status in ("completed", "failed", "cancelled", "paused"):
+            return False
+
+        # Cancel the asyncio task if it's actively running.
+        if task_id in self._active_tasks:
+            self._active_tasks[task_id].cancel()
+
+        task.metadata.paused_from = task.metadata.status
+        task.metadata.status = "paused"
+        self.store.save_metadata(task)
+        return True
+
     def deliver_to_task(
         self,
         task_id: str,
@@ -423,15 +470,27 @@ class Scheduler:
                 self._running = False
 
     async def recover_stuck_tasks(self) -> list[Ticket]:
-        """Flip any ``running`` or ``paused`` tasks back to ``available``.
+        """Flip any ``running`` or ``paused`` tasks back to a runnable state.
+
+        For ``paused`` tasks with ``paused_from`` set, the original status
+        is restored.  Otherwise they become ``available``.
 
         Returns the full task list (for ``on_startup``).
         """
         tickets = self.store.query_all()
         for t in tickets:
-            if t.metadata.status in ("running", "paused"):
-                logger.info("Recovered stuck %s task: %s", t.metadata.status, t.id)
+            if t.metadata.status == "running":
+                logger.info("Recovered stuck running task: %s", t.id)
                 t.metadata.status = "available"
+                self.store.save_metadata(t)
+            elif t.metadata.status == "paused":
+                restored = t.metadata.paused_from or "available"
+                logger.info(
+                    "Recovered paused task: %s (restoring to %s)",
+                    t.id, restored,
+                )
+                t.metadata.status = restored
+                t.metadata.paused_from = None
                 self.store.save_metadata(t)
         return tickets
 

--- a/packages/bees/bees/task_node.py
+++ b/packages/bees/bees/task_node.py
@@ -149,3 +149,33 @@ class TaskNode:
         self._task.metadata.error = None
         self.save()
         self._bees.trigger()
+
+    def pause(self) -> bool:
+        """Pause this task.
+
+        Cancels the asyncio task if running, stashes the current status
+        in ``paused_from``, and sets status to ``paused``.
+        Returns True if the task was paused, False if it was already
+        in a terminal or paused state.
+        """
+        paused = self._bees._scheduler.pause_task(self.id)
+        if paused:
+            # Refresh our snapshot.
+            refreshed = self._store.get(self.id)
+            if refreshed:
+                self._task = refreshed
+        return paused
+
+    def resume(self) -> bool:
+        """Resume this task from a paused state.
+
+        Restores the pre-pause status from ``paused_from``.
+        Returns True if the task was resumed, False if it wasn't paused.
+        """
+        if self._task.metadata.status != "paused":
+            return False
+        self._task.metadata.status = self._task.metadata.paused_from or "available"
+        self._task.metadata.paused_from = None
+        self.save()
+        self._bees.trigger()
+        return True

--- a/packages/bees/bees/ticket.py
+++ b/packages/bees/bees/ticket.py
@@ -65,6 +65,8 @@ class TicketMetadata:
     parent_task_id: str | None = None
     slug: str | None = None
     pending_context_updates: list[dict[str, Any]] | None = None
+    paused_from: str | None = None
+    """The status this task had before it was paused (set by pause-all / pause-task)."""
 
     def to_dict(self) -> dict[str, Any]:
         d = asdict(self)
@@ -106,6 +108,7 @@ class TicketMetadata:
             parent_task_id=data.get("parent_task_id") or data.get("creator_ticket_id"),
             slug=data.get("slug"),
             pending_context_updates=data.get("pending_context_updates"),
+            paused_from=data.get("paused_from"),
         )
 
 

--- a/packages/bees/docs/api.md
+++ b/packages/bees/docs/api.md
@@ -71,6 +71,19 @@ Starts the scheduler loop and begins processing tasks.
 
 Stops the scheduler loop and cleans up resources.
 
+#### `pause_all(self) -> int`
+
+Pauses all non-terminal tasks. Cancels in-flight asyncio tasks and sets
+status to `paused`, preserving the original status in `paused_from`.
+
+- **Returns**: The number of tasks paused.
+
+#### `resume_all(self) -> int`
+
+Resumes all paused tasks, restoring their pre-pause status from `paused_from`.
+
+- **Returns**: The number of tasks resumed.
+
 ### `TaskNode`
 
 A wrapper around a task that provides DOM-like traversal properties and manipulation methods.
@@ -122,3 +135,16 @@ Saves the task's current state to persistent storage.
 #### `retry(self)`
 
 Retries a paused task by resetting its status to available and clearing errors.
+
+#### `pause(self) -> bool`
+
+Pauses this task. Cancels the asyncio task if running, stashes the current
+status in `paused_from`, and sets status to `paused`.
+
+- **Returns**: `True` if the task was paused, `False` if already terminal or paused.
+
+#### `resume(self) -> bool`
+
+Resumes this task from a paused state, restoring the pre-pause status.
+
+- **Returns**: `True` if the task was resumed, `False` if it wasn't paused.

--- a/packages/bees/docs/mutations.md
+++ b/packages/bees/docs/mutations.md
@@ -153,6 +153,73 @@ Result includes the ref → task ID mapping:
 }
 ```
 
+### `pause-all` (hot)
+
+Cancels all in-flight asyncio tasks and flips every non-terminal task
+(`available`, `blocked`, `running`, `suspended`) to `paused`. Stashes the
+pre-pause status in `paused_from` so resume can restore it. When processed
+inline, the box passes the scheduler reference so the handler can cancel
+live coroutines — not just update metadata. Aliases: `cancel-all`.
+
+```json
+{
+  "type": "pause-all"
+}
+```
+
+Result includes the count of affected tasks:
+
+```json
+{
+  "status": "ok",
+  "paused": 5
+}
+```
+
+### `resume-paused` (hot)
+
+Flips all `paused` tasks back to their pre-pause status (from `paused_from`).
+Pure filesystem operation. Aliases: `resume-cancelled`.
+
+```json
+{
+  "type": "resume-paused"
+}
+```
+
+Result:
+
+```json
+{
+  "status": "ok",
+  "resumed": 5
+}
+```
+
+### `pause-task` (hot)
+
+Pauses a single task by ID. Cancels its asyncio task if running, then
+flips status to `paused` with `paused_from` set for later resume.
+
+```json
+{
+  "type": "pause-task",
+  "task_id": "uuid"
+}
+```
+
+### `resume-task` (hot)
+
+Resumes a single paused task by ID, restoring its pre-pause status.
+
+```json
+{
+  "type": "resume-task",
+  "task_id": "uuid"
+}
+```
+
+
 ## Driving Mutations from the Command Line
 
 ```bash
@@ -205,7 +272,6 @@ direct writes.
 |----------|---------------------|
 | `create-task` (single) | One `mkdir` + two file writes. `watchfiles` debounce usually batches them. The risk is low and the latency cost of a mutation is disproportionate. |
 | `config-update` | Already handled by the config restart path. Could become a mutation if config updates need to carry metadata (e.g., "who changed this and why"). |
-| `cancel-all` | Emergency stop: cancel running asyncio tasks and set status to `cancelled`. The filesystem alone can't stop in-flight coroutines — only the box can. But without a `resume-task` mutation, the recovery story is thin: cancelled tasks stay cancelled, and the system freezes. Needs a resume path to justify its own mutation type. |
 
 ### Not candidates (direct writes are fine)
 

--- a/packages/bees/hivetool/src/data/mutation-client.ts
+++ b/packages/bees/hivetool/src/data/mutation-client.ts
@@ -84,6 +84,41 @@ class MutationClient {
     });
   }
 
+  /**
+   * Pause all running and pending tasks.
+   *
+   * Hot mutation: the box cancels in-flight asyncio tasks and flips
+   * all non-terminal task statuses to `paused`, preserving prior
+   * status in `paused_from` for later resume.
+   */
+  async requestPauseAll(): Promise<string> {
+    return this.#writeMutation({ type: "pause-all" });
+  }
+
+  /**
+   * Resume all paused tasks — restores their pre-pause status.
+   *
+   * Hot mutation: the box restores each task's `paused_from` status
+   * and triggers the scheduler.
+   */
+  async requestResumeAll(): Promise<string> {
+    return this.#writeMutation({ type: "resume-paused" });
+  }
+
+  /**
+   * Pause a single task by ID.
+   */
+  async pauseTask(taskId: string): Promise<string> {
+    return this.#writeMutation({ type: "pause-task", task_id: taskId });
+  }
+
+  /**
+   * Resume a single paused task by ID.
+   */
+  async resumeTask(taskId: string): Promise<string> {
+    return this.#writeMutation({ type: "resume-task", task_id: taskId });
+  }
+
   // -- internal -----------------------------------------------------------
 
   async #writeMutation(data: Record<string, unknown>): Promise<string> {

--- a/packages/bees/hivetool/src/data/ticket-tree.ts
+++ b/packages/bees/hivetool/src/data/ticket-tree.ts
@@ -11,7 +11,7 @@
  * (devtools should show everything).
  */
 
-import type { TicketData } from "../../../common/types.js";
+import type { TaskData as TicketData } from "../../../common/types.js";
 
 export { deriveTicketTree };
 export type { TicketTreeNode };

--- a/packages/bees/hivetool/src/ui/app.styles.ts
+++ b/packages/bees/hivetool/src/ui/app.styles.ts
@@ -284,6 +284,9 @@ export const styles = css`
   .job-status.suspended {
     background: #f59e0b;
   }
+  .job-status.paused {
+    background: #f87171;
+  }
 
   .job-meta {
     font-size: 0.75rem;
@@ -370,6 +373,11 @@ export const styles = css`
     background: #92400e33;
     color: #fbbf24;
     border: 1px solid #92400e;
+  }
+  .job-detail-badge.paused {
+    background: #991b1b33;
+    color: #f87171;
+    border: 1px solid #991b1b;
   }
 
   .job-detail-meta {

--- a/packages/bees/hivetool/src/ui/app.ts
+++ b/packages/bees/hivetool/src/ui/app.ts
@@ -238,6 +238,48 @@ class BeesApp extends SignalWatcher(LitElement) {
     .lightning-flash {
       animation: lightning-flash 15s ease-out !important;
     }
+
+    /* --- Hive control button --- */
+    .hive-control-btn {
+      padding: 4px 12px;
+      font-size: 0.7rem;
+      font-weight: 600;
+      border-radius: 4px;
+      cursor: pointer;
+      transition: all 0.15s;
+      font-family: inherit;
+      white-space: nowrap;
+    }
+
+    .hive-control-btn.stop {
+      background: transparent;
+      color: #f87171;
+      border: 1px solid #991b1b;
+    }
+
+    .hive-control-btn.stop:hover {
+      background: #991b1b33;
+      border-color: #f87171;
+    }
+
+    .hive-control-btn.resume {
+      background: transparent;
+      color: #4ade80;
+      border: 1px solid #166534;
+    }
+
+    .hive-control-btn.resume:hover {
+      background: #16653422;
+      border-color: #4ade80;
+    }
+
+    .hive-control-btn.start {
+      background: transparent;
+      color: #475569;
+      border: 1px solid #1e293b;
+      cursor: default;
+      opacity: 0.6;
+    }
   `,
   ];
 
@@ -525,6 +567,7 @@ class BeesApp extends SignalWatcher(LitElement) {
         <div class="top-bar-header">
           <h1>${APP_ICON} ${APP_NAME} Hivetool</h1>
           <div class="hive-switcher">
+            ${this.renderHiveControl()}
             <span class="hive-name" title="Current hive directory">
               📂 ${this.stateAccess.hiveName.get() ?? ""}
             </span>
@@ -571,6 +614,65 @@ class BeesApp extends SignalWatcher(LitElement) {
         <div class="main">${this.renderMain(flashTicketId)}</div>
       </div>
     `;
+  }
+
+  private renderHiveControl() {
+    const tickets = this.ticketStore.tickets.get();
+
+    const hasActive = tickets.some(
+      (t) =>
+        t.status === "running" ||
+        t.status === "available" ||
+        t.status === "suspended"
+    );
+    const hasPaused = tickets.some((t) => t.status === "paused");
+
+    if (hasActive) {
+      return html`
+        <button
+          class="hive-control-btn stop"
+          @click=${() => this.handleStop()}
+        >
+          ⏹ Pause All
+        </button>
+      `;
+    }
+
+    if (hasPaused) {
+      return html`
+        <button
+          class="hive-control-btn resume"
+          @click=${() => this.handleResume()}
+        >
+          ▶ Resume
+        </button>
+      `;
+    }
+
+    return html`
+      <button class="hive-control-btn start" disabled>⏸ Idle</button>
+    `;
+  }
+
+  private async handleStop() {
+    const confirmed = confirm("Pause all running and pending tasks?");
+    if (!confirmed) return;
+
+    try {
+      const id = await this.mutationClient.requestPauseAll();
+      console.info("Pause-all mutation submitted:", id);
+    } catch (e) {
+      console.error("Failed to submit pause-all mutation:", e);
+    }
+  }
+
+  private async handleResume() {
+    try {
+      const id = await this.mutationClient.requestResumeAll();
+      console.info("Resume-paused mutation submitted:", id);
+    } catch (e) {
+      console.error("Failed to submit resume-paused mutation:", e);
+    }
   }
 
   private renderSidebar(

--- a/packages/bees/hivetool/src/ui/shared-styles.ts
+++ b/packages/bees/hivetool/src/ui/shared-styles.ts
@@ -114,6 +114,9 @@ const sharedStyles = css`
   .job-status.suspended {
     background: #f59e0b;
   }
+  .job-status.paused {
+    background: #f87171;
+  }
 
   .job-meta {
     font-size: 0.75rem;
@@ -181,6 +184,11 @@ const sharedStyles = css`
     background: #92400e33;
     color: #fbbf24;
     border: 1px solid #92400e;
+  }
+  .job-detail-badge.paused {
+    background: #991b1b33;
+    color: #f87171;
+    border: 1px solid #991b1b;
   }
 
   .job-detail-meta {

--- a/packages/bees/hivetool/src/ui/ticket-detail.ts
+++ b/packages/bees/hivetool/src/ui/ticket-detail.ts
@@ -432,7 +432,10 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
         <div class="job-detail-header">
           <div class="job-detail-header-top">
             <h2 class="job-detail-title">${ticket.title || "Ticket"}</h2>
-            <div class="job-detail-badge ${ticket.status}">${statusLabel}</div>
+            <div style="display:flex;align-items:center;gap:8px">
+              ${this.renderTaskControl(ticket.id, ticket.status)}
+              <div class="job-detail-badge ${ticket.status}">${statusLabel}</div>
+            </div>
           </div>
           <div class="job-detail-meta">
             <span
@@ -731,6 +734,60 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
         bubbles: true,
       })
     );
+  }
+
+  // ── Per-task pause / resume ──
+
+  private renderTaskControl(taskId: string, status: string) {
+    const ACTIVE = new Set(["running", "available", "suspended", "blocked"]);
+
+    if (ACTIVE.has(status)) {
+      return html`
+        <button
+          style="padding:3px 10px;font-size:0.65rem;font-weight:600;
+                 background:transparent;color:#f87171;border:1px solid #991b1b;
+                 border-radius:4px;cursor:pointer;font-family:inherit;
+                 transition:all 0.15s"
+          @click=${() => this.handlePauseTask(taskId)}
+        >
+          ⏸ Pause
+        </button>
+      `;
+    }
+
+    if (status === "paused") {
+      return html`
+        <button
+          style="padding:3px 10px;font-size:0.65rem;font-weight:600;
+                 background:transparent;color:#4ade80;border:1px solid #166534;
+                 border-radius:4px;cursor:pointer;font-family:inherit;
+                 transition:all 0.15s"
+          @click=${() => this.handleResumeTask(taskId)}
+        >
+          ▶ Resume
+        </button>
+      `;
+    }
+
+    return nothing;
+  }
+
+  private async handlePauseTask(taskId: string) {
+    if (!this.mutationClient) return;
+    try {
+      await this.mutationClient.pauseTask(taskId);
+    } catch (e) {
+      console.error("Failed to pause task:", e);
+    }
+  }
+
+  private async handleResumeTask(taskId: string) {
+    if (!this.mutationClient) return;
+    try {
+      await this.mutationClient.resumeTask(taskId);
+    } catch (e) {
+      console.error("Failed to resume task:", e);
+    }
   }
 
   // ── Suspend / Response ──


### PR DESCRIPTION
## What
Adds pause/resume controls to Bees — both hive-wide (`Bees.pause_all()` / `resume_all()`) and per-task (`TaskNode.pause()` / `resume()`), with hivetool UI buttons and mutation support.

## Why
There was no way to stop running tasks without a full hive reset. Paused tasks preserve their pre-pause state (via `paused_from`), so suspended tasks awaiting user input resume correctly instead of restarting from scratch.

## Changes

### Framework API (`bees/`)
- **`bees.py`** — `pause_all()` and `resume_all()` on the `Bees` class (no leaked `scheduler` property)
- **`task_node.py`** — `pause()` and `resume()` on `TaskNode`
- **`scheduler.py`** — Internal `pause_all_tasks()` and `pause_task()` methods
- **`ticket.py`** — `paused_from` metadata field for state preservation
- **`api.md`** — Documented new API surface

### Mutation system
- **`mutations.py`** — Four new hot mutations (`pause-all`, `resume-paused`, `pause-task`, `resume-task`) with backward-compatible aliases; threads `Bees` (not `Scheduler`) for clean abstraction
- **`box.py`** — Passes `bees=bees` to `process_inline()`
- **`mutations.md`** — Full documentation
- **`scheduler.py`** — Fixed `recover_stuck_tasks()` to respect `paused_from` on startup

### Hivetool UI
- **`mutation-client.ts`** — Four new methods
- **`app.ts`** — Reactive hive control button (Pause All / Resume / Idle)
- **`ticket-detail.ts`** — Per-task Pause / Resume buttons
- **`shared-styles.ts` / `app.styles.ts`** — Red-ish `paused` status styling

## Testing
Manually verified all four mutations via the box logs (pause-task, resume-task, pause-all, resume-paused all processing correctly with accurate task counts).
