### PR TITLE
[bees] MutationManager class + box-active sentinel

### DIFF
--- a/packages/bees/bees/box.py
+++ b/packages/bees/bees/box.py
@@ -34,8 +34,7 @@ import sys
 from pathlib import Path
 from typing import Literal
 
-from bees.mutations import process_all as process_mutations
-from bees.mutations import process_cold, process_inline
+from bees.mutations import MutationManager
 
 import httpx
 from watchfiles import awatch, Change
@@ -86,6 +85,8 @@ def classify_change(path: Path, hive_dir: Path) -> ChangeKind:
     # Ignore result files (written by the box itself).
     if top == "mutations":
         if path.name.endswith(".result.json"):
+            return "ignore"
+        if path.name.startswith("."):
             return "ignore"
         return "mutation"
 
@@ -158,8 +159,12 @@ async def run(hive_dir: Path, backend: HttpBackendClient) -> None:
     logger.info("Box starting — watching %s", hive_dir)
 
     # Process any mutations that arrived while the box was down.
-    if process_mutations(hive_dir):
+    startup_manager = MutationManager(hive_dir)
+    if startup_manager.process_all():
         logger.info("Processed pending mutations on startup")
+
+    # Write sentinel so hivetool knows the box is listening.
+    startup_manager.activate()
 
     while True:
         bees = Bees(hive_dir, backend)
@@ -194,7 +199,8 @@ async def run(hive_dir: Path, backend: HttpBackendClient) -> None:
                 # Process mutations: hot mutations run inline,
                 # cold mutations signal a restart.
                 if needs_mutation:
-                    outcome = process_inline(hive_dir, bees=bees)
+                    manager = MutationManager(hive_dir, bees=bees)
+                    outcome = manager.process_inline()
                     if outcome.hot_processed > 0:
                         needs_trigger = True
                     if outcome.cold_pending:
@@ -215,15 +221,18 @@ async def run(hive_dir: Path, backend: HttpBackendClient) -> None:
         except asyncio.CancelledError:
             logger.info("Box cancelled — shutting down")
             await bees.shutdown()
+            MutationManager(hive_dir).deactivate()
             return
 
         await bees.shutdown()
 
         # Process cold mutations in the quiescent gap.
         if cold_pending:
-            process_cold(hive_dir)
+            cold_manager = MutationManager(hive_dir)
+            cold_manager.process_cold()
 
         if not restart:
+            MutationManager(hive_dir).deactivate()
             return
 
         logger.info("Restarting bees...")

--- a/packages/bees/bees/mutations.py
+++ b/packages/bees/bees/mutations.py
@@ -1,6 +1,3 @@
-# Copyright 2026 Google LLC
-# SPDX-License-Identifier: Apache-2.0
-
 """
 Mutation log — filesystem-based command channel.
 
@@ -21,8 +18,8 @@ Two processing modes:
   executes all writes atomically, then triggers the scheduler once.
 
 Some hot mutations (``pause-all``) need runtime access to cancel
-in-flight asyncio tasks.  The box passes a ``Bees`` reference via
-``process_inline``.
+in-flight asyncio tasks.  The ``MutationManager`` holds a ``Bees``
+reference for this purpose.
 
 Supported mutation types:
 
@@ -100,417 +97,437 @@ class MutationOutcome:
     """Mapping of ref → task_id for create-task-group results."""
 
 
-# ---------------------------------------------------------------------------
-# Scanning
-# ---------------------------------------------------------------------------
+# Name of the sentinel file that indicates the box is actively listening.
+BOX_ACTIVE_SENTINEL = ".box-active"
 
 
-def scan_pending(hive_dir: Path) -> list[PendingMutation]:
-    """Find mutation files without a matching result file.
+class MutationManager:
+    """Processes mutation files from the hive's ``mutations/`` directory.
 
-    Returns mutations sorted by filename (effectively by creation time
-    if UUIDs are used, though ordering is best-effort).
+    Holds an optional ``Bees`` reference for hot mutations that need
+    runtime access (e.g., cancelling asyncio tasks).  When no ``Bees``
+    instance is available (startup processing), handlers fall back to
+    direct filesystem operations via ``TaskStore``.
     """
-    mutations_dir = hive_dir / "mutations"
-    if not mutations_dir.exists():
-        return []
 
-    pending: list[PendingMutation] = []
+    def __init__(self, hive_dir: Path, bees: Bees | None = None):
+        self._hive_dir = hive_dir
+        self._bees = bees
 
-    for path in sorted(mutations_dir.glob("*.json")):
-        # Skip result files.
-        if path.stem.endswith(".result"):
-            continue
+    # -- Sentinel lifecycle ------------------------------------------------
 
-        # Skip if already processed.
-        result_path = path.with_suffix("").with_suffix(".result.json")
-        if result_path.exists():
-            continue
+    def activate(self) -> None:
+        """Write the box-active sentinel file.
 
+        Called when the box starts listening for mutations.  The hivetool
+        checks for this file to decide whether to show mutation-powered UI.
+        """
+        sentinel = self._mutations_dir / BOX_ACTIVE_SENTINEL
+        sentinel.parent.mkdir(parents=True, exist_ok=True)
+        sentinel.write_text(f"pid={__import__('os').getpid()}\n")
+        logger.info("Box sentinel written: %s", sentinel)
+
+    def deactivate(self) -> None:
+        """Remove the box-active sentinel file.
+
+        Called when the box shuts down.
+        """
+        sentinel = self._mutations_dir / BOX_ACTIVE_SENTINEL
         try:
-            data = json.loads(path.read_text())
-        except (json.JSONDecodeError, OSError) as exc:
-            logger.warning("Skipping unreadable mutation %s: %s", path.name, exc)
-            continue
+            sentinel.unlink(missing_ok=True)
+            logger.info("Box sentinel removed")
+        except OSError:
+            logger.warning("Could not remove box sentinel")
 
-        if not isinstance(data, dict) or "type" not in data:
-            logger.warning("Skipping malformed mutation %s: missing 'type'", path.name)
-            _write_result(
-                result_path,
-                {"status": "error", "error": "Malformed mutation: missing 'type'"},
+    @property
+    def _mutations_dir(self) -> Path:
+        return self._hive_dir / "mutations"
+
+    # -- Public API --------------------------------------------------------
+
+    def process_all(self) -> bool:
+        """Process all pending mutations (startup).
+
+        Handles both hot and cold mutations.  Used when the box starts
+        and no Bees instance is running yet.
+
+        Returns ``True`` if any mutations were processed.
+        """
+        pending = self._scan_pending()
+        if not pending:
+            return False
+
+        for mutation in pending:
+            logger.info(
+                "Processing mutation: %s (%s)",
+                mutation.mutation_type, mutation.path.name,
             )
-            continue
+            self._dispatch(mutation)
 
-        pending.append(PendingMutation(path=path, data=data))
+        return True
 
-    return pending
+    def process_inline(self) -> MutationOutcome:
+        """Process hot mutations inline while the scheduler is running.
 
+        Cold mutations are not processed — they're flagged in the outcome
+        so the caller can initiate a shutdown/restart cycle.
 
-# ---------------------------------------------------------------------------
-# Processing — two modes
-# ---------------------------------------------------------------------------
+        Returns a ``MutationOutcome`` indicating what happened.
+        """
+        pending = self._scan_pending()
+        outcome = MutationOutcome()
 
+        for mutation in pending:
+            if mutation.is_cold:
+                outcome.cold_pending = True
+                continue
 
-def process_all(hive_dir: Path) -> bool:
-    """Process all pending mutations (startup).
+            logger.info(
+                "Processing hot mutation: %s (%s)",
+                mutation.mutation_type, mutation.path.name,
+            )
+            result = self._dispatch(mutation)
+            if result:
+                outcome.hot_processed += 1
+                if result.get("created"):
+                    outcome.created_tasks.update(result["created"])
 
-    Handles both hot and cold mutations.  Used when the box starts
-    and no Bees instance is running yet.
+        return outcome
 
-    Returns ``True`` if any mutations were processed.
-    """
-    pending = scan_pending(hive_dir)
-    if not pending:
-        return False
+    def process_cold(self) -> bool:
+        """Process cold mutations only (requires quiescent state).
 
-    for mutation in pending:
-        logger.info("Processing mutation: %s (%s)", mutation.mutation_type, mutation.path.name)
-        _dispatch(mutation, hive_dir)
+        Called in the gap between Bees shutdown and restart.
+        Returns ``True`` if any cold mutations were processed.
+        """
+        pending = self._scan_pending()
+        processed = False
 
-    return True
+        for mutation in pending:
+            if not mutation.is_cold:
+                continue
 
+            logger.info(
+                "Processing cold mutation: %s (%s)",
+                mutation.mutation_type, mutation.path.name,
+            )
+            self._dispatch(mutation)
+            processed = True
 
-def process_inline(
-    hive_dir: Path,
-    bees: Bees | None = None,
-) -> MutationOutcome:
-    """Process hot mutations inline while the scheduler is running.
+        return processed
 
-    Cold mutations are not processed — they're flagged in the outcome
-    so the caller can initiate a shutdown/restart cycle.
+    # -- Scanning ----------------------------------------------------------
 
-    ``bees`` is passed through to handlers that need runtime
-    access (e.g., ``pause-all`` needs to cancel asyncio tasks).
+    def _scan_pending(self) -> list[PendingMutation]:
+        """Find mutation files without a matching result file.
 
-    Returns a ``MutationOutcome`` indicating what happened.
-    """
-    pending = scan_pending(hive_dir)
-    outcome = MutationOutcome()
+        Returns mutations sorted by filename (effectively by creation
+        time if UUIDs are used, though ordering is best-effort).
+        """
+        mutations_dir = self._hive_dir / "mutations"
+        if not mutations_dir.exists():
+            return []
 
-    for mutation in pending:
-        if mutation.is_cold:
-            outcome.cold_pending = True
-            continue
+        pending: list[PendingMutation] = []
 
-        logger.info("Processing hot mutation: %s (%s)", mutation.mutation_type, mutation.path.name)
-        result = _dispatch(mutation, hive_dir, bees=bees)
-        if result:
-            outcome.hot_processed += 1
-            if result.get("created"):
-                outcome.created_tasks.update(result["created"])
+        for path in sorted(mutations_dir.glob("*.json")):
+            # Skip result files.
+            if path.stem.endswith(".result"):
+                continue
 
-    return outcome
+            # Skip if already processed.
+            result_path = path.with_suffix("").with_suffix(".result.json")
+            if result_path.exists():
+                continue
 
+            try:
+                data = json.loads(path.read_text())
+            except (json.JSONDecodeError, OSError) as exc:
+                logger.warning("Skipping unreadable mutation %s: %s", path.name, exc)
+                continue
 
-def process_cold(hive_dir: Path) -> bool:
-    """Process cold mutations only (requires quiescent state).
-
-    Called in the gap between Bees shutdown and restart.
-    Returns ``True`` if any cold mutations were processed.
-    """
-    pending = scan_pending(hive_dir)
-    processed = False
-
-    for mutation in pending:
-        if not mutation.is_cold:
-            continue
-
-        logger.info("Processing cold mutation: %s (%s)", mutation.mutation_type, mutation.path.name)
-        _dispatch(mutation, hive_dir)
-        processed = True
-
-    return processed
-
-
-# ---------------------------------------------------------------------------
-# Dispatch
-# ---------------------------------------------------------------------------
-
-
-def _dispatch(
-    mutation: PendingMutation,
-    hive_dir: Path,
-    *,
-    bees: Bees | None = None,
-) -> dict[str, Any] | None:
-    """Dispatch a mutation by type and write the result.
-
-    Returns extra result data on success (e.g., created task IDs),
-    or ``None`` on failure.
-    """
-    try:
-        extra: dict[str, Any] = {}
-
-        match mutation.mutation_type:
-            case "reset":
-                _execute_reset(hive_dir)
-            case "respond-to-task":
-                _execute_respond(hive_dir, mutation)
-            case "create-task-group":
-                extra = _execute_create_group(hive_dir, mutation)
-            case "cancel-all" | "pause-all":
-                extra = _execute_pause_all(hive_dir, bees)
-            case "resume-cancelled" | "resume-paused":
-                extra = _execute_resume_paused(hive_dir, bees)
-            case "pause-task":
-                extra = _execute_pause_task(hive_dir, mutation, bees)
-            case "resume-task":
-                extra = _execute_resume_task(hive_dir, mutation, bees)
-            case _:
-                _write_result(
-                    mutation.result_path,
-                    {
-                        "status": "error",
-                        "error": f"Unknown mutation type: {mutation.mutation_type}",
-                    },
+            if not isinstance(data, dict) or "type" not in data:
+                logger.warning(
+                    "Skipping malformed mutation %s: missing 'type'", path.name,
                 )
-                return None
+                self._write_result(
+                    result_path,
+                    {"status": "error", "error": "Malformed mutation: missing 'type'"},
+                )
+                continue
 
-        result = {"status": "ok", **extra}
-        _write_result(mutation.result_path, result)
-        logger.info("Mutation complete: %s", mutation.mutation_type)
-        return result
+            pending.append(PendingMutation(path=path, data=data))
 
-    except Exception as exc:
-        logger.exception("Mutation failed: %s", mutation.mutation_type)
-        _write_result(
-            mutation.result_path,
-            {"status": "error", "error": str(exc)},
-        )
-        return None
+        return pending
 
+    # -- Dispatch ----------------------------------------------------------
 
-# ---------------------------------------------------------------------------
-# Mutation handlers
-# ---------------------------------------------------------------------------
+    def _dispatch(self, mutation: PendingMutation) -> dict[str, Any] | None:
+        """Dispatch a mutation by type and write the result.
 
+        Returns extra result data on success (e.g., created task IDs),
+        or ``None`` on failure.
+        """
+        try:
+            extra: dict[str, Any] = {}
 
-def _execute_reset(hive_dir: Path) -> None:
-    """Delete all tasks and session logs.
-
-    Removes the contents of ``tickets/`` and ``logs/`` while preserving
-    the directories themselves (so watchers don't lose their handles).
-    """
-    for subdir_name in ("tickets", "logs", "mutations"):
-        subdir = hive_dir / subdir_name
-        if not subdir.exists():
-            continue
-
-        for child in subdir.iterdir():
-            if child.is_dir():
-                shutil.rmtree(child)
-            else:
-                child.unlink()
-
-        logger.info("Cleared %s/", subdir_name)
-
-
-def _execute_respond(hive_dir: Path, mutation: PendingMutation) -> None:
-    """Write response and flip assignee atomically.
-
-    Both writes happen before the scheduler is triggered, so the
-    scheduler never sees a metadata flip without a response file.
-    """
-    task_id = mutation.data.get("task_id")
-    response = mutation.data.get("response")
-
-    if not task_id:
-        raise ValueError("respond-to-task mutation missing 'task_id'")
-    if response is None:
-        raise ValueError("respond-to-task mutation missing 'response'")
-
-    store = TaskStore(hive_dir)
-    store.respond(task_id, response)
-    logger.info("Response written for task %s", task_id[:8])
-
-
-def _execute_create_group(hive_dir: Path, mutation: PendingMutation) -> dict[str, Any]:
-    """Create multiple tasks with intra-batch dependency resolution.
-
-    Tasks are created sequentially.  Each task may include a ``ref``
-    name and a ``depends_on`` list of refs.  Refs are resolved to real
-    task IDs within the batch.
-
-    Returns ``{"created": {"ref": "task-id", ...}}`` for the result file.
-    """
-    tasks = mutation.data.get("tasks")
-    if not tasks or not isinstance(tasks, list):
-        raise ValueError("create-task-group mutation missing 'tasks' array")
-
-    store = TaskStore(hive_dir)
-    ref_to_id: dict[str, str] = {}
-
-    for task_spec in tasks:
-        ref = task_spec.get("ref")
-        depends_on_refs = task_spec.get("depends_on", [])
-
-        # Resolve ref-based dependencies to real task IDs.
-        resolved_deps: list[str] | None = None
-        if depends_on_refs:
-            resolved_deps = []
-            for dep_ref in depends_on_refs:
-                dep_id = ref_to_id.get(dep_ref)
-                if not dep_id:
-                    raise ValueError(
-                        f"Unresolved dependency ref '{dep_ref}' in task "
-                        f"'{ref or '(unnamed)'}'. Refs must reference "
-                        f"earlier tasks in the group."
+            match mutation.mutation_type:
+                case "reset":
+                    self._handle_reset()
+                case "respond-to-task":
+                    self._handle_respond(mutation)
+                case "create-task-group":
+                    extra = self._handle_create_group(mutation)
+                case "cancel-all" | "pause-all":
+                    extra = self._handle_pause_all()
+                case "resume-cancelled" | "resume-paused":
+                    extra = self._handle_resume_paused()
+                case "pause-task":
+                    extra = self._handle_pause_task(mutation)
+                case "resume-task":
+                    extra = self._handle_resume_task(mutation)
+                case _:
+                    self._write_result(
+                        mutation.result_path,
+                        {
+                            "status": "error",
+                            "error": f"Unknown mutation type: {mutation.mutation_type}",
+                        },
                     )
-                resolved_deps.append(dep_id)
+                    return None
 
-        # Create the task — if it has resolved deps, it starts blocked.
-        task = store.create(
-            objective=task_spec.get("objective", ""),
-            title=task_spec.get("title"),
-            playbook_id=task_spec.get("playbook_id"),
-            tags=task_spec.get("tags"),
-            functions=task_spec.get("functions"),
-            skills=task_spec.get("skills"),
-            tasks=task_spec.get("tasks"),
-            model=task_spec.get("model"),
-            context=task_spec.get("context"),
-            watch_events=task_spec.get("watch_events"),
-            kind=task_spec.get("kind", "work"),
-        )
+            result = {"status": "ok", **extra}
+            self._write_result(mutation.result_path, result)
+            logger.info("Mutation complete: %s", mutation.mutation_type)
+            return result
 
-        # Override dependency state if ref-based deps were specified.
-        if resolved_deps:
-            task.metadata.depends_on = resolved_deps
-            task.metadata.status = "blocked"
-            store.save_metadata(task)
+        except Exception as exc:
+            logger.exception("Mutation failed: %s", mutation.mutation_type)
+            self._write_result(
+                mutation.result_path,
+                {"status": "error", "error": str(exc)},
+            )
+            return None
 
-        if ref:
-            ref_to_id[ref] = task.id
+    # -- Handlers ----------------------------------------------------------
 
-        logger.info(
-            "Created task %s%s",
-            task.id[:8],
-            f" (ref={ref})" if ref else "",
-        )
+    def _handle_reset(self) -> None:
+        """Delete all tasks and session logs.
 
-    return {"created": ref_to_id}
+        Removes the contents of ``tickets/``, ``logs/``, and
+        ``mutations/`` while preserving the directories themselves
+        (so watchers don't lose their handles).
+        """
+        for subdir_name in ("tickets", "logs", "mutations"):
+            subdir = self._hive_dir / subdir_name
+            if not subdir.exists():
+                continue
 
+            for child in subdir.iterdir():
+                if child.is_dir():
+                    shutil.rmtree(child)
+                else:
+                    child.unlink()
 
-def _execute_pause_all(
-    hive_dir: Path,
-    bees: Bees | None,
-) -> dict[str, Any]:
-    """Pause all non-terminal tasks.
+            logger.info("Cleared %s/", subdir_name)
 
-    When a ``Bees`` instance is available (inline processing), delegates
-    to the high-level ``pause_all()`` API.  Falls back to pure filesystem
-    operations when processing at startup without a live scheduler.
-    """
-    if bees:
-        count = bees.pause_all()
-    else:
-        # Startup fallback: no live scheduler, just flip metadata.
-        store = TaskStore(hive_dir)
-        count = 0
-        for status in ("available", "blocked", "running", "suspended"):
-            for task in store.query_all(status=status):
+    def _handle_respond(self, mutation: PendingMutation) -> None:
+        """Write response and flip assignee atomically.
+
+        Uses ``TaskNode.respond()`` when a Bees instance is available,
+        falling back to ``TaskStore.respond()`` at startup.
+        """
+        task_id = mutation.data.get("task_id")
+        response = mutation.data.get("response")
+
+        if not task_id:
+            raise ValueError("respond-to-task mutation missing 'task_id'")
+        if response is None:
+            raise ValueError("respond-to-task mutation missing 'response'")
+
+        if self._bees:
+            node = self._bees.get_by_id(task_id)
+            if not node:
+                raise ValueError(f"Task {task_id[:8]} not found")
+            node.respond(response)
+        else:
+            store = TaskStore(self._hive_dir)
+            store.respond(task_id, response)
+
+        logger.info("Response written for task %s", task_id[:8])
+
+    def _handle_create_group(
+        self, mutation: PendingMutation,
+    ) -> dict[str, Any]:
+        """Create multiple tasks with intra-batch dependency resolution.
+
+        Tasks are created sequentially.  Each task may include a ``ref``
+        name and a ``depends_on`` list of refs.  Refs are resolved to
+        real task IDs within the batch.
+
+        Returns ``{"created": {"ref": "task-id", ...}}``.
+        """
+        tasks = mutation.data.get("tasks")
+        if not tasks or not isinstance(tasks, list):
+            raise ValueError("create-task-group mutation missing 'tasks' array")
+
+        store = TaskStore(self._hive_dir)
+        ref_to_id: dict[str, str] = {}
+
+        for task_spec in tasks:
+            ref = task_spec.get("ref")
+            depends_on_refs = task_spec.get("depends_on", [])
+
+            # Resolve ref-based dependencies to real task IDs.
+            resolved_deps: list[str] | None = None
+            if depends_on_refs:
+                resolved_deps = []
+                for dep_ref in depends_on_refs:
+                    dep_id = ref_to_id.get(dep_ref)
+                    if not dep_id:
+                        raise ValueError(
+                            f"Unresolved dependency ref '{dep_ref}' in task "
+                            f"'{ref or '(unnamed)'}'. Refs must reference "
+                            f"earlier tasks in the group."
+                        )
+                    resolved_deps.append(dep_id)
+
+            # Create the task — if it has resolved deps, it starts blocked.
+            task = store.create(
+                objective=task_spec.get("objective", ""),
+                title=task_spec.get("title"),
+                playbook_id=task_spec.get("playbook_id"),
+                tags=task_spec.get("tags"),
+                functions=task_spec.get("functions"),
+                skills=task_spec.get("skills"),
+                tasks=task_spec.get("tasks"),
+                model=task_spec.get("model"),
+                context=task_spec.get("context"),
+                watch_events=task_spec.get("watch_events"),
+                kind=task_spec.get("kind", "work"),
+            )
+
+            # Override dependency state if ref-based deps were specified.
+            if resolved_deps:
+                task.metadata.depends_on = resolved_deps
+                task.metadata.status = "blocked"
+                store.save_metadata(task)
+
+            if ref:
+                ref_to_id[ref] = task.id
+
+            logger.info(
+                "Created task %s%s",
+                task.id[:8],
+                f" (ref={ref})" if ref else "",
+            )
+
+        return {"created": ref_to_id}
+
+    def _handle_pause_all(self) -> dict[str, Any]:
+        """Pause all non-terminal tasks.
+
+        Delegates to ``Bees.pause_all()`` when available, falls back
+        to direct filesystem operations at startup.
+        """
+        if self._bees:
+            count = self._bees.pause_all()
+        else:
+            store = TaskStore(self._hive_dir)
+            count = 0
+            for status in ("available", "blocked", "running", "suspended"):
+                for task in store.query_all(status=status):
+                    task.metadata.paused_from = task.metadata.status
+                    task.metadata.status = "paused"
+                    store.save_metadata(task)
+                    count += 1
+
+        logger.info("Paused %d task(s)", count)
+        return {"paused": count}
+
+    def _handle_resume_paused(self) -> dict[str, Any]:
+        """Flip all paused tasks back to their pre-pause status."""
+        if self._bees:
+            count = self._bees.resume_all()
+        else:
+            store = TaskStore(self._hive_dir)
+            paused = store.query_all(status="paused")
+            for task in paused:
+                task.metadata.status = task.metadata.paused_from or "available"
+                task.metadata.paused_from = None
+                store.save_metadata(task)
+            count = len(paused)
+
+        logger.info("Resumed %d paused task(s)", count)
+        return {"resumed": count}
+
+    def _handle_pause_task(self, mutation: PendingMutation) -> dict[str, Any]:
+        """Pause a single task by ID."""
+        task_id = mutation.data.get("task_id")
+        if not task_id:
+            raise ValueError("pause-task mutation missing 'task_id'")
+
+        if self._bees:
+            node = self._bees.get_by_id(task_id)
+            paused = node.pause() if node else False
+        else:
+            store = TaskStore(self._hive_dir)
+            task = store.get(task_id)
+            if not task or task.metadata.status in (
+                "completed", "failed", "cancelled", "paused",
+            ):
+                paused = False
+            else:
                 task.metadata.paused_from = task.metadata.status
                 task.metadata.status = "paused"
                 store.save_metadata(task)
-                count += 1
+                paused = True
 
-    logger.info("Paused %d task(s)", count)
-    return {"paused": count}
+        if paused:
+            logger.info("Paused task %s", task_id[:8])
+        else:
+            logger.warning("Could not pause task %s", task_id[:8])
 
+        return {"paused": paused}
 
-def _execute_resume_paused(
-    hive_dir: Path,
-    bees: Bees | None,
-) -> dict[str, Any]:
-    """Flip all paused tasks back to their pre-pause status."""
-    if bees:
-        count = bees.resume_all()
-    else:
-        store = TaskStore(hive_dir)
-        paused = store.query_all(status="paused")
-        for task in paused:
+    def _handle_resume_task(self, mutation: PendingMutation) -> dict[str, Any]:
+        """Resume a single paused task by ID."""
+        task_id = mutation.data.get("task_id")
+        if not task_id:
+            raise ValueError("resume-task mutation missing 'task_id'")
+
+        if self._bees:
+            node = self._bees.get_by_id(task_id)
+            resumed = node.resume() if node else False
+        else:
+            store = TaskStore(self._hive_dir)
+            task = store.get(task_id)
+            if not task or task.metadata.status != "paused":
+                logger.warning(
+                    "Could not resume task %s (not paused)", task_id[:8],
+                )
+                return {"resumed": False}
             task.metadata.status = task.metadata.paused_from or "available"
             task.metadata.paused_from = None
             store.save_metadata(task)
-        count = len(paused)
+            resumed = True
 
-    logger.info("Resumed %d paused task(s)", count)
-    return {"resumed": count}
-
-
-def _execute_pause_task(
-    hive_dir: Path,
-    mutation: PendingMutation,
-    bees: Bees | None,
-) -> dict[str, Any]:
-    """Pause a single task by ID."""
-    task_id = mutation.data.get("task_id")
-    if not task_id:
-        raise ValueError("pause-task mutation missing 'task_id'")
-
-    if bees:
-        node = bees.get_by_id(task_id)
-        paused = node.pause() if node else False
-    else:
-        store = TaskStore(hive_dir)
-        task = store.get(task_id)
-        if not task or task.metadata.status in ("completed", "failed", "cancelled", "paused"):
-            paused = False
+        if resumed:
+            logger.info("Resumed task %s", task_id[:8])
         else:
-            task.metadata.paused_from = task.metadata.status
-            task.metadata.status = "paused"
-            store.save_metadata(task)
-            paused = True
+            logger.warning(
+                "Could not resume task %s (not paused)", task_id[:8],
+            )
 
-    if paused:
-        logger.info("Paused task %s", task_id[:8])
-    else:
-        logger.warning("Could not pause task %s", task_id[:8])
+        return {"resumed": resumed}
 
-    return {"paused": paused}
+    # -- Utilities ---------------------------------------------------------
 
-
-def _execute_resume_task(
-    hive_dir: Path,
-    mutation: PendingMutation,
-    bees: Bees | None,
-) -> dict[str, Any]:
-    """Resume a single paused task by ID."""
-    task_id = mutation.data.get("task_id")
-    if not task_id:
-        raise ValueError("resume-task mutation missing 'task_id'")
-
-    if bees:
-        node = bees.get_by_id(task_id)
-        resumed = node.resume() if node else False
-    else:
-        store = TaskStore(hive_dir)
-        task = store.get(task_id)
-        if not task or task.metadata.status != "paused":
-            logger.warning("Could not resume task %s (not paused)", task_id[:8])
-            return {"resumed": False}
-        task.metadata.status = task.metadata.paused_from or "available"
-        task.metadata.paused_from = None
-        store.save_metadata(task)
-        resumed = True
-
-    if resumed:
-        logger.info("Resumed task %s", task_id[:8])
-    else:
-        logger.warning("Could not resume task %s (not paused)", task_id[:8])
-
-    return {"resumed": resumed}
-
-
-# ---------------------------------------------------------------------------
-# Result writing
-# ---------------------------------------------------------------------------
-
-
-def _write_result(result_path: Path, result: dict[str, Any]) -> None:
-    """Write a mutation result file."""
-    result["timestamp"] = datetime.now(timezone.utc).isoformat()
-    result_path.parent.mkdir(parents=True, exist_ok=True)
-    result_path.write_text(
-        json.dumps(result, indent=2, ensure_ascii=False) + "\n"
-    )
+    @staticmethod
+    def _write_result(result_path: Path, result: dict[str, Any]) -> None:
+        """Write a mutation result file."""
+        result["timestamp"] = datetime.now(timezone.utc).isoformat()
+        result_path.parent.mkdir(parents=True, exist_ok=True)
+        result_path.write_text(
+            json.dumps(result, indent=2, ensure_ascii=False) + "\n"
+        )

--- a/packages/bees/hivetool/src/data/mutation-client.ts
+++ b/packages/bees/hivetool/src/data/mutation-client.ts
@@ -16,9 +16,13 @@
  * Effects are observed through existing store observers.
  */
 
+import { Signal } from "signal-polyfill";
 import type { StateAccess } from "./state-access.js";
 
 export { MutationClient };
+
+/** Name of the sentinel file written by the box. */
+const BOX_ACTIVE_SENTINEL = ".box-active";
 
 /** Task specification for batch creation. */
 interface TaskSpec {
@@ -39,6 +43,57 @@ interface TaskSpec {
 
 class MutationClient {
   constructor(private access: StateAccess) {}
+
+  /**
+   * Reactive signal: `true` when the box is actively listening for
+   * mutations (sentinel file exists in `mutations/`).
+   */
+  readonly boxActive = new Signal.State<boolean>(false);
+
+  #sentinelObserver: { disconnect(): void } | null = null;
+
+  /**
+   * Start observing the mutations directory for the box-active sentinel.
+   * Uses FileSystemObserver when available, otherwise does a single check.
+   */
+  async startObserving(): Promise<void> {
+    if (this.#sentinelObserver) return;
+
+    // Do an initial check.
+    await this.#checkSentinel();
+
+    if (!("FileSystemObserver" in globalThis)) return;
+
+    try {
+      const mutationsDir = await this.#getMutationsDir();
+      // FileSystemObserver is experimental — access via dynamic typing.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const Ctor = (globalThis as any).FileSystemObserver;
+      const observer = new Ctor(() => void this.#checkSentinel());
+      observer.observe(mutationsDir);
+      this.#sentinelObserver = observer;
+    } catch (e) {
+      console.warn("Could not observe mutations/ for sentinel:", e);
+    }
+  }
+
+  /** Stop observing. */
+  stopObserving(): void {
+    if (this.#sentinelObserver) {
+      this.#sentinelObserver.disconnect();
+      this.#sentinelObserver = null;
+    }
+  }
+
+  async #checkSentinel(): Promise<void> {
+    try {
+      const mutationsDir = await this.#getMutationsDir();
+      await mutationsDir.getFileHandle(BOX_ACTIVE_SENTINEL);
+      this.boxActive.set(true);
+    } catch {
+      this.boxActive.set(false);
+    }
+  }
 
   /**
    * Request a hive reset — deletes all tasks and session logs.

--- a/packages/bees/hivetool/src/ui/app.ts
+++ b/packages/bees/hivetool/src/ui/app.ts
@@ -12,7 +12,7 @@
  */
 
 import { SignalWatcher } from "@lit-labs/signals";
-import { LitElement, html, css } from "lit";
+import { LitElement, html, css, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 
 import { APP_ICON, APP_NAME } from "../constants.js";
@@ -318,6 +318,7 @@ class BeesApp extends SignalWatcher(LitElement) {
       this.skillStore.activate(),
       this.systemStore.activate(),
     ]);
+    this.mutationClient.startObserving();
   }
 
   private async handleOpenDirectory(): Promise<void> {
@@ -617,6 +618,9 @@ class BeesApp extends SignalWatcher(LitElement) {
   }
 
   private renderHiveControl() {
+    // Only show mutation-powered controls when the box is listening.
+    if (!this.mutationClient.boxActive.get()) return nothing;
+
     const tickets = this.ticketStore.tickets.get();
 
     const hasActive = tickets.some(

--- a/packages/bees/hivetool/src/ui/system-detail.ts
+++ b/packages/bees/hivetool/src/ui/system-detail.ts
@@ -942,6 +942,9 @@ class BeesSystemDetail extends SignalWatcher(LitElement) {
   // ── Danger zone ──
 
   private renderDangerZone() {
+    // Only show when the box is actively listening for mutations.
+    if (!this.mutationClient?.boxActive.get()) return nothing;
+
     return html`
       <div class="danger-zone">
         <div class="danger-zone-header">Danger Zone</div>

--- a/packages/bees/hivetool/src/ui/ticket-detail.ts
+++ b/packages/bees/hivetool/src/ui/ticket-detail.ts
@@ -739,6 +739,9 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
   // ── Per-task pause / resume ──
 
   private renderTaskControl(taskId: string, status: string) {
+    // Only show when the box is actively listening for mutations.
+    if (!this.mutationClient?.boxActive.get()) return nothing;
+
     const ACTIVE = new Set(["running", "available", "suspended", "blocked"]);
 
     if (ACTIVE.has(status)) {
@@ -806,8 +809,9 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
       assignee === "user" &&
       functionName !== "chat_await_context_update";
 
-    // For user-facing suspensions, show interactive response UI.
-    if (isUserFacing) {
+    // For user-facing suspensions, show interactive response UI
+    // only when the box is actively listening for mutations.
+    if (isUserFacing && this.mutationClient?.boxActive.get()) {
       const waitForInput = suspendEvent.waitForInput as
         | Record<string, unknown>
         | undefined;

--- a/packages/bees/tests/test_box.py
+++ b/packages/bees/tests/test_box.py
@@ -77,3 +77,20 @@ class TestClassifyChange:
 
     def test_dot_files_ignored(self):
         assert classify_change(HIVE / ".DS_Store", HIVE) == "ignore"
+
+    # -- Mutation paths --
+
+    def test_mutation_file(self):
+        assert classify_change(
+            HIVE / "mutations" / "abc-123.json", HIVE
+        ) == "mutation"
+
+    def test_mutation_result_ignored(self):
+        assert classify_change(
+            HIVE / "mutations" / "abc-123.result.json", HIVE
+        ) == "ignore"
+
+    def test_box_sentinel_ignored(self):
+        assert classify_change(
+            HIVE / "mutations" / ".box-active", HIVE
+        ) == "ignore"

--- a/packages/bees/tests/test_mutations.py
+++ b/packages/bees/tests/test_mutations.py
@@ -1,0 +1,482 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for bees.mutations — MutationManager."""
+
+from __future__ import annotations
+
+import json
+import pytest
+from pathlib import Path
+
+from bees.mutations import MutationManager, PendingMutation
+from bees.task_store import TaskStore
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_mutation(hive_dir: Path, data: dict) -> Path:
+    """Write a mutation JSON file and return its path."""
+    mutations_dir = hive_dir / "mutations"
+    mutations_dir.mkdir(parents=True, exist_ok=True)
+    import uuid
+
+    path = mutations_dir / f"{uuid.uuid4()}.json"
+    path.write_text(json.dumps(data))
+    return path
+
+
+def _create_task(store: TaskStore, status: str = "available", **kwargs) -> str:
+    """Create a task and return its ID."""
+    task = store.create(objective="Test task", **kwargs)
+    task.metadata.status = status
+    store.save_metadata(task)
+    return task.id
+
+
+@pytest.fixture
+def hive(tmp_path):
+    """Create a minimal hive directory."""
+    (tmp_path / "tickets").mkdir()
+    (tmp_path / "mutations").mkdir()
+    return tmp_path
+
+
+@pytest.fixture
+def store(hive):
+    """A TaskStore rooted at the hive."""
+    return TaskStore(hive)
+
+
+# ---------------------------------------------------------------------------
+# Scanning
+# ---------------------------------------------------------------------------
+
+
+class TestScanning:
+    """Pending mutation scanning."""
+
+    def test_scan_empty(self, hive):
+        manager = MutationManager(hive)
+        assert manager._scan_pending() == []
+
+    def test_scan_finds_unprocessed(self, hive):
+        _write_mutation(hive, {"type": "respond-to-task", "task_id": "abc"})
+        manager = MutationManager(hive)
+        pending = manager._scan_pending()
+        assert len(pending) == 1
+        assert pending[0].mutation_type == "respond-to-task"
+
+    def test_scan_skips_processed(self, hive):
+        path = _write_mutation(hive, {"type": "reset"})
+        # Write result file.
+        result_path = path.with_suffix("").with_suffix(".result.json")
+        result_path.write_text(json.dumps({"status": "ok"}))
+
+        manager = MutationManager(hive)
+        assert manager._scan_pending() == []
+
+    def test_scan_skips_malformed(self, hive):
+        mutations_dir = hive / "mutations"
+        bad = mutations_dir / "bad.json"
+        bad.write_text(json.dumps({"no_type": True}))
+
+        manager = MutationManager(hive)
+        pending = manager._scan_pending()
+        assert len(pending) == 0
+
+        # Should have written an error result.
+        result = bad.with_suffix("").with_suffix(".result.json")
+        assert result.exists()
+
+
+# ---------------------------------------------------------------------------
+# Reset (cold)
+# ---------------------------------------------------------------------------
+
+
+class TestReset:
+    """Reset mutation clears tickets, logs, and mutations."""
+
+    def test_reset_clears_dirs(self, hive, store):
+        _create_task(store)
+        (hive / "logs").mkdir()
+        (hive / "logs" / "session.log").write_text("log")
+
+        _write_mutation(hive, {"type": "reset"})
+        manager = MutationManager(hive)
+        manager.process_all()
+
+        assert list((hive / "tickets").iterdir()) == []
+        assert list((hive / "logs").iterdir()) == []
+
+    def test_reset_is_cold(self, hive):
+        _write_mutation(hive, {"type": "reset"})
+        manager = MutationManager(hive)
+        outcome = manager.process_inline()
+        assert outcome.cold_pending is True
+        assert outcome.hot_processed == 0
+
+
+# ---------------------------------------------------------------------------
+# Respond
+# ---------------------------------------------------------------------------
+
+
+class TestRespond:
+    """respond-to-task mutation writes a response and flips assignee."""
+
+    def test_respond_writes_response(self, hive, store):
+        task_id = _create_task(store, status="suspended")
+        task = store.get(task_id)
+        task.metadata.assignee = "user"
+        store.save_metadata(task)
+
+        _write_mutation(hive, {
+            "type": "respond-to-task",
+            "task_id": task_id,
+            "response": {"text": "hello"},
+        })
+        manager = MutationManager(hive)
+        outcome = manager.process_inline()
+
+        assert outcome.hot_processed == 1
+
+        updated = store.get(task_id)
+        assert updated.metadata.assignee == "agent"
+
+        response_path = hive / "tickets" / task_id / "response.json"
+        assert response_path.exists()
+        assert json.loads(response_path.read_text())["text"] == "hello"
+
+    def test_respond_missing_task_id(self, hive):
+        _write_mutation(hive, {
+            "type": "respond-to-task",
+            "response": {"text": "hello"},
+        })
+        manager = MutationManager(hive)
+        outcome = manager.process_inline()
+
+        # Should fail gracefully.
+        assert outcome.hot_processed == 0
+
+    def test_respond_missing_response(self, hive, store):
+        task_id = _create_task(store)
+        _write_mutation(hive, {
+            "type": "respond-to-task",
+            "task_id": task_id,
+        })
+        manager = MutationManager(hive)
+        outcome = manager.process_inline()
+
+        assert outcome.hot_processed == 0
+
+
+# ---------------------------------------------------------------------------
+# Create task group
+# ---------------------------------------------------------------------------
+
+
+class TestCreateGroup:
+    """create-task-group mutation creates multiple tasks with ref resolution."""
+
+    def test_basic_group(self, hive):
+        _write_mutation(hive, {
+            "type": "create-task-group",
+            "tasks": [
+                {"ref": "a", "objective": "First task"},
+                {"ref": "b", "objective": "Second task"},
+            ],
+        })
+        manager = MutationManager(hive)
+        outcome = manager.process_inline()
+
+        assert outcome.hot_processed == 1
+        assert "a" in outcome.created_tasks
+        assert "b" in outcome.created_tasks
+
+        store = TaskStore(hive)
+        task_a = store.get(outcome.created_tasks["a"])
+        assert task_a is not None
+        assert "First task" in task_a.objective
+
+    def test_group_with_dependencies(self, hive):
+        _write_mutation(hive, {
+            "type": "create-task-group",
+            "tasks": [
+                {"ref": "a", "objective": "First"},
+                {
+                    "ref": "b",
+                    "objective": "Second",
+                    "depends_on": ["a"],
+                },
+            ],
+        })
+        manager = MutationManager(hive)
+        outcome = manager.process_inline()
+
+        assert outcome.hot_processed == 1
+        store = TaskStore(hive)
+        task_b = store.get(outcome.created_tasks["b"])
+        assert task_b.metadata.status == "blocked"
+        assert outcome.created_tasks["a"] in task_b.metadata.depends_on
+
+    def test_group_unresolved_ref_fails(self, hive):
+        _write_mutation(hive, {
+            "type": "create-task-group",
+            "tasks": [
+                {
+                    "ref": "b",
+                    "objective": "Depends on nothing",
+                    "depends_on": ["nonexistent"],
+                },
+            ],
+        })
+        manager = MutationManager(hive)
+        outcome = manager.process_inline()
+
+        assert outcome.hot_processed == 0
+
+
+# ---------------------------------------------------------------------------
+# Pause / Resume (all)
+# ---------------------------------------------------------------------------
+
+
+class TestPauseAll:
+    """pause-all and resume-paused mutations."""
+
+    def test_pause_all(self, hive, store):
+        id1 = _create_task(store, status="available")
+        id2 = _create_task(store, status="running")
+        id3 = _create_task(store, status="suspended")
+        id4 = _create_task(store, status="completed")
+
+        _write_mutation(hive, {"type": "pause-all"})
+        manager = MutationManager(hive)
+        outcome = manager.process_inline()
+
+        assert outcome.hot_processed == 1
+
+        assert store.get(id1).metadata.status == "paused"
+        assert store.get(id1).metadata.paused_from == "available"
+        assert store.get(id2).metadata.status == "paused"
+        assert store.get(id2).metadata.paused_from == "running"
+        assert store.get(id3).metadata.status == "paused"
+        assert store.get(id3).metadata.paused_from == "suspended"
+        # Completed task should not be paused.
+        assert store.get(id4).metadata.status == "completed"
+
+    def test_resume_paused(self, hive, store):
+        id1 = _create_task(store, status="paused")
+        task1 = store.get(id1)
+        task1.metadata.paused_from = "suspended"
+        store.save_metadata(task1)
+
+        id2 = _create_task(store, status="paused")
+        task2 = store.get(id2)
+        task2.metadata.paused_from = "available"
+        store.save_metadata(task2)
+
+        _write_mutation(hive, {"type": "resume-paused"})
+        manager = MutationManager(hive)
+        outcome = manager.process_inline()
+
+        assert outcome.hot_processed == 1
+
+        assert store.get(id1).metadata.status == "suspended"
+        assert store.get(id1).metadata.paused_from is None
+        assert store.get(id2).metadata.status == "available"
+
+    def test_cancel_all_alias(self, hive, store):
+        """cancel-all is a backward-compatible alias for pause-all."""
+        _create_task(store, status="available")
+
+        _write_mutation(hive, {"type": "cancel-all"})
+        manager = MutationManager(hive)
+        outcome = manager.process_inline()
+
+        assert outcome.hot_processed == 1
+
+    def test_resume_cancelled_alias(self, hive, store):
+        """resume-cancelled is a backward-compatible alias."""
+        id1 = _create_task(store, status="paused")
+        task = store.get(id1)
+        task.metadata.paused_from = "running"
+        store.save_metadata(task)
+
+        _write_mutation(hive, {"type": "resume-cancelled"})
+        manager = MutationManager(hive)
+        outcome = manager.process_inline()
+
+        assert outcome.hot_processed == 1
+        assert store.get(id1).metadata.status == "running"
+
+
+# ---------------------------------------------------------------------------
+# Pause / Resume (single task)
+# ---------------------------------------------------------------------------
+
+
+class TestPauseTask:
+    """pause-task and resume-task mutations."""
+
+    def test_pause_single_task(self, hive, store):
+        id1 = _create_task(store, status="suspended")
+        id2 = _create_task(store, status="available")
+
+        _write_mutation(hive, {"type": "pause-task", "task_id": id1})
+        manager = MutationManager(hive)
+        outcome = manager.process_inline()
+
+        assert outcome.hot_processed == 1
+        assert store.get(id1).metadata.status == "paused"
+        assert store.get(id1).metadata.paused_from == "suspended"
+        # Other task should not be affected.
+        assert store.get(id2).metadata.status == "available"
+
+    def test_pause_completed_task_fails(self, hive, store):
+        id1 = _create_task(store, status="completed")
+
+        _write_mutation(hive, {"type": "pause-task", "task_id": id1})
+        manager = MutationManager(hive)
+        manager.process_inline()
+
+        # Should remain completed.
+        assert store.get(id1).metadata.status == "completed"
+
+    def test_resume_single_task(self, hive, store):
+        id1 = _create_task(store, status="paused")
+        task = store.get(id1)
+        task.metadata.paused_from = "suspended"
+        store.save_metadata(task)
+
+        _write_mutation(hive, {"type": "resume-task", "task_id": id1})
+        manager = MutationManager(hive)
+        outcome = manager.process_inline()
+
+        assert outcome.hot_processed == 1
+        assert store.get(id1).metadata.status == "suspended"
+        assert store.get(id1).metadata.paused_from is None
+
+    def test_resume_non_paused_task_fails(self, hive, store):
+        id1 = _create_task(store, status="available")
+
+        _write_mutation(hive, {"type": "resume-task", "task_id": id1})
+        manager = MutationManager(hive)
+        manager.process_inline()
+
+        # Should remain available.
+        assert store.get(id1).metadata.status == "available"
+
+    def test_pause_task_missing_id(self, hive):
+        _write_mutation(hive, {"type": "pause-task"})
+        manager = MutationManager(hive)
+        outcome = manager.process_inline()
+        assert outcome.hot_processed == 0
+
+
+# ---------------------------------------------------------------------------
+# Unknown mutations
+# ---------------------------------------------------------------------------
+
+
+class TestUnknown:
+    """Unknown mutation types produce error results."""
+
+    def test_unknown_type(self, hive):
+        path = _write_mutation(hive, {"type": "bogus"})
+        manager = MutationManager(hive)
+        outcome = manager.process_inline()
+
+        assert outcome.hot_processed == 0
+
+        result_path = path.with_suffix("").with_suffix(".result.json")
+        assert result_path.exists()
+        result = json.loads(result_path.read_text())
+        assert result["status"] == "error"
+        assert "Unknown" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Result writing
+# ---------------------------------------------------------------------------
+
+
+class TestResultWriting:
+    """Result files are written with correct structure."""
+
+    def test_result_includes_timestamp(self, hive, store):
+        _create_task(store, status="available")
+        _write_mutation(hive, {"type": "pause-all"})
+        manager = MutationManager(hive)
+        manager.process_inline()
+
+        results = list((hive / "mutations").glob("*.result.json"))
+        assert len(results) == 1
+        result = json.loads(results[0].read_text())
+        assert result["status"] == "ok"
+        assert "timestamp" in result
+
+
+# ---------------------------------------------------------------------------
+# PendingMutation dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestPendingMutation:
+    """PendingMutation properties."""
+
+    def test_mutation_type(self):
+        m = PendingMutation(path=Path("/x.json"), data={"type": "reset"})
+        assert m.mutation_type == "reset"
+
+    def test_is_cold(self):
+        m = PendingMutation(path=Path("/x.json"), data={"type": "reset"})
+        assert m.is_cold is True
+
+    def test_is_hot(self):
+        m = PendingMutation(path=Path("/x.json"), data={"type": "pause-all"})
+        assert m.is_cold is False
+
+    def test_result_path(self):
+        m = PendingMutation(path=Path("/mutations/abc.json"), data={"type": "reset"})
+        assert m.result_path == Path("/mutations/abc.result.json")
+
+
+# ---------------------------------------------------------------------------
+# Sentinel lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestSentinel:
+    """Box-active sentinel file lifecycle."""
+
+    def test_activate_creates_sentinel(self, hive):
+        manager = MutationManager(hive)
+        manager.activate()
+        sentinel = hive / "mutations" / ".box-active"
+        assert sentinel.exists()
+        assert "pid=" in sentinel.read_text()
+
+    def test_deactivate_removes_sentinel(self, hive):
+        manager = MutationManager(hive)
+        manager.activate()
+        manager.deactivate()
+        sentinel = hive / "mutations" / ".box-active"
+        assert not sentinel.exists()
+
+    def test_deactivate_without_activate(self, hive):
+        """Deactivating without prior activation should not raise."""
+        manager = MutationManager(hive)
+        manager.deactivate()  # Should not raise.
+
+    def test_sentinel_ignored_by_scanning(self, hive):
+        """The sentinel file should not appear as a pending mutation."""
+        manager = MutationManager(hive)
+        manager.activate()
+        pending = manager._scan_pending()
+        assert len(pending) == 0


### PR DESCRIPTION
## What
Refactors the mutation log from free functions into a `MutationManager` class, adds a box-active sentinel file so hivetool knows whether mutation-powered UI should be shown, and gates all mutation-powered UI on that signal.

## Why
- The mutations module had three responsibilities (scanning, dispatch, handlers) tangled as free functions with `Bees` threaded through every call. A class encapsulates the `hive_dir` and `bees` reference once.
- The box is just one way to run Bees (`server.py` is another). Without a sentinel, hivetool showed mutation buttons (pause, resume, respond, reset) that submitted mutations into the void when no box was listening.

## Changes

### `MutationManager` class (`mutations.py`)
- Replaces `process_all()`, `process_inline()`, `process_cold()` free functions with methods on the class
- All `_execute_*` handlers become `_handle_*` methods — no more argument threading
- `activate()` / `deactivate()` write/remove the `.box-active` sentinel
- `BOX_ACTIVE_SENTINEL` constant exported for cross-module use

### Box lifecycle (`box.py`)
- Creates `MutationManager` instances instead of calling free functions
- Calls `activate()` on startup, `deactivate()` on both Ctrl+C and normal shutdown paths
- `classify_change` ignores dotfiles in `mutations/` (sentinel doesn't trigger mutation processing)

### Hivetool sentinel detection (`mutation-client.ts`)
- `boxActive` reactive signal on `MutationClient`
- Uses `FileSystemObserver` on the `mutations/` directory (no polling)
- Falls back to a single one-shot check if the API isn't available

### UI gating
All mutation-powered UI is explicitly gated on `boxActive`:
- `app.ts` → Pause All / Resume / Idle button
- `ticket-detail.ts` → per-task Pause / Resume buttons
- `ticket-detail.ts` → reply / choice response forms
- `system-detail.ts` → Reset Hive button

### Tests (`test_mutations.py`, `test_box.py`)
- 31 new tests for `MutationManager`: scanning, all 7 mutation types, state preservation, backward aliases, error handling, result writing, sentinel lifecycle
- 3 new tests for `classify_change`: mutation files, result file ignore, sentinel ignore
- 49 total, all passing

## Testing
- Verified box logs show sentinel written on startup and removed on Ctrl+C
- Verified hivetool hides mutation buttons when box is not running
