### PR TITLE
[bees] Concept docs — package split, framework improvements, tea leaves

### DIFF
--- a/.agent/rules/agents-md.md
+++ b/.agent/rules/agents-md.md
@@ -1,4 +1,0 @@
-When working in any package directory under `packages/`, check for an `AGENTS.md`
-file in that package root. If one exists, read it before making any changes. The
-`AGENTS.md` file contains agent-specific documentation: architecture context,
-coding conventions, directory structure, and pointers to deeper reference docs.

--- a/.agents/rules/agents-md.md
+++ b/.agents/rules/agents-md.md
@@ -1,0 +1,9 @@
+---
+trigger: always_on
+---
+
+When working in any package directory under `packages/`, check for an
+`AGENTS.md` file in that package root. If one exists, read it before making any
+changes. The `AGENTS.md` file contains agent-specific documentation:
+architecture context, coding conventions, directory structure, and pointers to
+deeper reference docs.

--- a/packages/bees/docs/framework-improvements.md
+++ b/packages/bees/docs/framework-improvements.md
@@ -1,0 +1,64 @@
+# Framework Improvements
+
+Concrete improvements to the bees framework. These are well-understood gaps with
+clear scope — not speculative, just not yet prioritized.
+
+## Event Delivery
+
+The event system works but is [settling](./flux.md#event-delivery). Three
+specific concerns:
+
+- **Discovery**: Agents must declare `watch_events` in their template to receive
+  events. There's no way for an agent to discover what event types exist at
+  runtime.
+- **Subscription scope**: `events_broadcast` goes to all subscribers.
+  `tasks_send_event` goes to a specific child. There's no middle ground (e.g.,
+  broadcast to a subtree, or to tasks matching a filter).
+- **Event typing**: Events are untyped dicts. As the system grows, there's
+  pressure for a schema — both for documentation and for runtime validation.
+
+These are not urgent but will compound if left unaddressed.
+
+## Filesystem Scoping
+
+The shared filesystem with slug-based write fencing is
+[settling](./flux.md#filesystem-sharing). One open question from the
+[patterns.md](./patterns.md#isolated-file-systems) dead ends:
+
+**Isolates**: A future need may arise for subagents that intentionally do _not_
+inherit the parent filesystem. No use case has required this yet, but the
+pressure may come as agents handle more sensitive or compartmentalized workloads.
+The current model is too open for some scenarios (e.g., an agent working on
+credentials should not share its workspace upward).
+
+## Template Open Questions
+
+From [flux.md](./flux.md#task-templates):
+
+- **Hooks**: The `on_ticket_done` / `on_event` Python hook mechanism has unclear
+  boundaries. Should hooks be replaced by event-driven templates? By a more
+  structured plugin system? The current mechanism works but feels like an escape
+  hatch rather than a design.
+- **Root template**: The `SYSTEM.yaml` → `boot_root_template` mechanism is a
+  special case that probably shouldn't be special. Why isn't the root template
+  just an `autostart` entry — the same mechanism used for all other automatic
+  task creation?
+- **Top-level entry points**: There's no clean external API for "start this
+  work." Today it requires calling `run_playbook` (code) or the server endpoints
+  (HTTP). The library API should make this a first-class operation.
+
+## Naming Migration
+
+The codebase uses legacy names (`ticket`, `playbook`, `playbook_id`) while the
+documentation uses the new names (`task`, `template`, `template_id`). This is a
+mechanical migration — well-suited for a codemod — but it needs to happen across
+Python source, TypeScript source, YAML config, REST endpoints, and SSE event
+types. The migration should be coordinated as a single change to avoid a
+prolonged mixed-terminology state.
+
+## Dead Code Removal
+
+The [DAG-based workflow model](./patterns.md#dag-based-workflows) left fossils
+in the codebase: `depends_on`, `blocked` status, `promote_blocked_tickets`,
+topological sort logic, and the old `GUIDE.md` playbook syntax. These should be
+removed once we're confident no downstream consumer depends on them.

--- a/packages/bees/docs/future.md
+++ b/packages/bees/docs/future.md
@@ -1,72 +1,73 @@
 # Future Direction
 
 Short- to medium-term work needed to close gaps in the framework and bring about
-the vision described in [architecture.md](./architecture.md). Each section
-identifies a concrete gap, explains why it matters, and sketches the direction.
+the vision described in [architecture.md](./architecture.md). Each concept doc
+explores a specific axis of the design space.
+
+## The Library Extraction
+
+The central architectural question: how does bees become a clean, installable
+library that applications `import` rather than fork?
+
+Three concept docs trace the path:
+
+### [Delegated Sessions](./delegated-sessions.md)
+
+What if session execution is owned by an external party rather than the
+scheduler? The motivating use case is the Gemini Live API, but the insight
+generalizes.
+
+### [Delegated Sessions — The General Case](./delegated-sessions-2.md)
+
+What if _all_ sessions are delegated? Bees becomes a pure orchestration and
+tooling framework. Auth drops out of the core. Testing simplifies. The
+`SessionRunner` protocol emerges as the key abstraction.
+
+### [Package Split](./package-split.md)
+
+The delegated sessions insight, stated as a packaging concern. Four packages:
+
+| Package           | What it is                    | External deps                       |
+| ----------------- | ----------------------------- | ----------------------------------- |
+| **`bees`**        | Orchestration library + tools | None (stdlib only)                  |
+| **`bees-gemini`** | Gemini model provider         | `google-genai`, `httpx`             |
+| **`box`**         | Filesystem-driven CLI runner  | `bees`, `bees-gemini`, `watchfiles` |
+| **`app`**         | Reference web application     | `bees`, `bees-gemini`, `fastapi`    |
+
+The key refinement: functions (tool declarations + handlers) stay in `bees` as
+framework capabilities. They're orthogonal to the model provider.
 
 ## The Consumption API
 
-The biggest open question in bees: how do applications build on this framework?
-
-Today's answer is ad-hoc. The [reference app](./reference-app.md) wires
-`SchedulerHooks` callbacks to SSE and exposes REST endpoints. This works, but
-the boundary between "bees the library" and "the application built on bees" is
-blurry. Three pieces need to crystallize.
+With the library extraction as the goal, three sub-problems need to
+crystallize.
 
 ### The Interaction Surface
 
-The controller side of the MVC model (see [patterns.md](./patterns.md#the-controller-in-progress))
-has no clean API. When an agent suspends with `assignee == "user"`, the consumer
-must reach into the task directory and write `response.json`, then flip
-`assignee` to `"agent"`. This is editing the model's internals.
-
-**What's needed**: A framework-provided method for responding to a suspended
-task — something like `scheduler.respond(ticket_id, response)`. The scheduler
-owns the task lifecycle; responding to a task is a lifecycle transition, not a
-file edit. The response format itself (text, selected choices, context updates)
-is already well-understood from the reference app's `RespondRequest` model.
+The controller side of the MVC model (see
+[patterns.md](./patterns.md#the-controller-in-progress)) is evolving. The
+[mutations system](./mutations.md) provides an atomic interaction model for
+the filesystem-based hive. The library API should make responding to suspended
+tasks and creating task groups first-class operations on `Bees` or `TaskNode`.
 
 ### The Observation API
 
 `SchedulerHooks` is a bag of callbacks with no lifecycle contract. It's
 invasive — the hooks reach deep into the scheduler's internals — and it only
-supports one consumer. There's no way to have two independent observers of the
-same scheduler (e.g., an SSE broadcaster and a metrics collector).
+supports one consumer.
 
-**Direction, not design**: The observation API should support multiple observers,
-provide a typed event stream rather than positional callbacks, and cleanly
-separate read-only observation from write-side interaction. Whether this is an
-`AsyncIterable`, a subscribe/unsubscribe pattern, or something else is an open
-design question. The reference app's SSE `Broadcaster` is evidence of the
-pattern: it already fans out to multiple clients. The framework should do the
-same at the scheduler level.
+**Direction**: The observation API should support multiple observers, provide a
+typed event stream rather than positional callbacks, and cleanly separate
+read-only observation from write-side interaction. The reference app's SSE
+`Broadcaster` is evidence of the pattern — it already fans out to multiple
+clients. The framework should do the same at the scheduler level.
 
-### The Library Extraction
-
-The architecture doc states: "This reference application will be extracted from
-the bees package." This means bees becomes a library that applications `import`,
-not a server they fork.
-
-**What extraction requires**:
-
-- A clean `Scheduler` constructor that accepts configuration and a storage
-  backend, with no implicit globals (currently the hive path is module-level).
-- The interaction and observation APIs above — without them, every consumer ends
-  up rebuilding `server.py`.
-- A pluggable storage backend interface so the task store can be backed by a
-  database, not just disk.
-
-## Hive Abstraction
+### Hive Abstraction
 
 The hive is currently hard-coded to the filesystem. The
 [patterns.md](./patterns.md#the-directory-as-universal-interchange) vision
-describes the hive directory as a "universal interchange" that works for local
-dev and as a live projection of production state. This requires two things:
-
-### Storage backend protocol
-
-The task store (reading/writing task state, listing tasks, filesystem access)
-needs a protocol that `Scheduler` consumes, with at least two implementations:
+describes the hive directory as a "universal interchange." The task store needs
+a protocol with at least two implementations:
 
 - **Disk** — what exists today. The local development and hivetool story.
 - **Database** — for production. Tasks persist in a database; the filesystem
@@ -75,82 +76,7 @@ needs a protocol that `Scheduler` consumes, with at least two implementations:
 The configuration surface (templates, skills, system config) can remain
 file-based — it's the task runtime state that needs to scale.
 
-### Production attachment
+## Further out
 
-The aspirational workflow: attach to a production instance and have task data
-stream to local disk for observation with hivetool. This is a sync protocol:
-the production store projects its state onto a local hive directory, and
-hivetool reads it as if it were a local run.
-
-This is further out, but the storage backend protocol is a prerequisite.
-
-## Multi-Hive Support
-
-A user should be able to run multiple hives simultaneously. Use cases: A/B
-testing different template configurations, running evaluations against a
-baseline, comparing swarm behavior across variants.
-
-**What's blocking**: The scheduler currently assumes a single hive. The hive
-path, template registry, and ticket store are effectively singletons. Supporting
-multiple hives means making these instance-scoped rather than module-scoped —
-which overlaps with the library extraction work above.
-
-## Event Delivery
-
-The event system works but is [settling](./flux.md#event-delivery). Three
-specific concerns:
-
-- **Discovery**: Agents must declare `watch_events` in their template to receive
-  events. There's no way for an agent to discover what event types exist at
-  runtime.
-- **Subscription scope**: `events_broadcast` goes to all subscribers.
-  `tasks_send_event` goes to a specific child. There's no middle ground (e.g.,
-  broadcast to a subtree, or to tasks matching a filter).
-- **Event typing**: Events are untyped dicts. As the system grows, there's
-  pressure for a schema — both for documentation and for runtime validation.
-
-These are not urgent but will compound if left unaddressed.
-
-## Filesystem Scoping
-
-The shared filesystem with slug-based write fencing is
-[settling](./flux.md#filesystem-sharing). One open question from the
-[patterns.md](./patterns.md#isolated-file-systems) dead ends:
-
-**Isolates**: A future need may arise for subagents that intentionally do _not_
-inherit the parent filesystem. No use case has required this yet, but the
-pressure may come as agents handle more sensitive or compartmentalized workloads.
-The current model is too open for some scenarios (e.g., an agent working on
-credentials should not share its workspace upward).
-
-## Template Open Questions
-
-From [flux.md](./flux.md#task-templates):
-
-- **Hooks**: The `on_ticket_done` / `on_event` Python hook mechanism has unclear
-  boundaries. Should hooks be replaced by event-driven templates? By a more
-  structured plugin system? The current mechanism works but feels like an escape
-  hatch rather than a design.
-- **Root template**: The `SYSTEM.yaml` → `boot_root_template` mechanism is a
-  special case that probably shouldn't be special. Why isn't the root template
-  just an `autostart` entry — the same mechanism used for all other automatic
-  task creation?
-- **Top-level entry points**: There's no clean external API for "start this
-  work." Today it requires calling `run_playbook` (code) or the server endpoints
-  (HTTP). The library API should make this a first-class operation.
-
-## Naming Migration
-
-The codebase uses legacy names (`ticket`, `playbook`, `playbook_id`) while the
-documentation uses the new names (`task`, `template`, `template_id`). This is a
-mechanical migration — well-suited for a codemod — but it needs to happen
-across Python source, TypeScript source, YAML config, REST endpoints, and SSE
-event types. The migration should be coordinated as a single change to avoid a
-prolonged mixed-terminology state.
-
-## Dead Code Removal
-
-The [DAG-based workflow model](./patterns.md#dag-based-workflows) left fossils
-in the codebase: `depends_on`, `blocked` status, `promote_blocked_tickets`,
-topological sort logic, and the old `GUIDE.md` playbook syntax. These should be
-removed once we're confident no downstream consumer depends on them.
+Speculative, ambitious, and less well-defined ideas live in
+[tea-leaves.md](./tea-leaves.md).

--- a/packages/bees/docs/package-split.md
+++ b/packages/bees/docs/package-split.md
@@ -1,0 +1,319 @@
+> [!NOTE] This is a directional concept, not a finalized design. It captures the
+> packaging architecture that emerged from the delegated sessions exploration
+> and the "run from GitHub" question.
+
+# Package Split
+
+The goal: `bees` becomes a zero-dependency orchestration library that owns both
+task lifecycle _and_ the function layer. Model-provider concerns live in a separate
+runner package. CLI and server applications are thin shells that wire the two
+together.
+
+## The dependency graph
+
+```
+opal_backend (standalone, owns Gemini session runtime)
+         ↑
+bees-gemini (depends on bees + opal_backend)
+  ├── runners/streaming.py  (wraps opal_backend Loop)
+  ├── runners/live.py       (Gemini Live API, future)
+  └── adapter.py            (bridges bees ↔ opal_backend FunctionGroup)
+  ↑              ↑
+ box             app
+  ↑              ↑
+bees (zero external deps)
+  ├── orchestration (scheduler, task store, coordination, mutations)
+  ├── functions (declarations + handlers)
+  └── protocols (FunctionGroup, FunctionFactory, SessionRunner)
+```
+
+Four packages, four responsibilities:
+
+| Package           | What it is                    | External deps                       |
+| ----------------- | ----------------------------- | ----------------------------------- |
+| **`bees`**        | Orchestration library + functions | None (stdlib only)                  |
+| **`bees-gemini`** | Gemini model provider         | `google-genai`, `httpx`             |
+| **`box`**         | Filesystem-driven CLI runner  | `bees`, `bees-gemini`, `watchfiles` |
+| **`app`**         | Reference web application     | `bees`, `bees-gemini`, `fastapi`    |
+
+## What each package owns
+
+### `bees` — the library
+
+**Owns**: Task lifecycle, scheduling, the agent tree, mutations, coordination,
+prompt assembly, the hive filesystem format, **and the function layer**.
+
+The functions in `bees/functions/` are framework capabilities:
+
+| Function module   | What it does               | Gemini-specific? |
+| ----------------- | -------------------------- | ---------------- |
+| `tasks.py`        | Create/manage tasks        | No               |
+| `events.py`       | Broadcast/subscribe events | No               |
+| `skills.py`       | Load skill instructions    | No               |
+| `chat.py`         | Conversation control       | No               |
+| `system.py`       | Workspace file operations  | No               |
+| `simple_files.py` | File I/O                   | No               |
+| `mcp_bridge.py`   | MCP server forwarding      | No               |
+| `sandbox.py`      | Sandboxed code execution   | No               |
+
+**Defines**: The `SessionRunner` protocol — a contract for "run this task's
+session and report back."
+
+**Dependencies**: None beyond stdlib. Pure `pathlib`, `json`, `asyncio`,
+`dataclasses`. This is what makes `pip install bees` lightweight and safe.
+
+### `bees-gemini` — the model provider
+
+**Owns**: The Gemini-specific session runners. Wraps `opal_backend`'s session
+runtime behind bees' `SessionRunner` protocol.
+
+```
+bees-gemini/
+  runners/
+    streaming.py     # Wraps opal_backend Loop + GenerateContent
+    live.py          # Gemini Live API WebSocket (future)
+  adapter.py         # bridges bees ↔ opal_backend FunctionGroup
+```
+
+**The adapter** bridges bees' function protocols to `opal_backend`'s types. Since
+the protocols are designed to mirror `opal_backend`'s shape, this is structural
+compatibility — no translation logic, just type-level bridging.
+
+**Auth lives here.** The runner's constructor takes credentials. Bees never sees
+API keys:
+
+```python
+runner = StreamingRunner(
+    api_key=load_gemini_key(),
+    http_client=httpx.AsyncClient(timeout=httpx.Timeout(300.0)),
+)
+
+bees = Bees(hive_dir, runner=runner)
+```
+
+### `opal_backend` — the session runtime
+
+`opal_backend` is a standalone package that owns the Gemini session runtime
+(Loop, streaming, GenerateContent, interaction stores). It's used in production
+by an older version of the system and has consumers outside the bees ecosystem.
+
+`bees-gemini` depends on `opal_backend` for its `StreamingRunner`
+implementation. `bees` itself never imports from `opal_backend` — the runner
+package is the only bridge.
+
+### `box` — the CLI runner
+
+**Owns**: The filesystem-driven development mode. Watches the hive directory,
+manages the box-active sentinel, classifies changes, handles the restart loop.
+
+**Is**: A thin shell that wires `bees` + `bees-gemini` + config together:
+
+```python
+runner = StreamingRunner(api_key=load_gemini_key(), ...)
+bees = Bees(hive_dir, runner=runner)
+manager = MutationManager(hive_dir, bees=bees)
+manager.activate()
+await bees.listen()
+async for changes in awatch(hive_dir):
+    ...
+```
+
+**The user experience**:
+
+```bash
+# From anywhere, without cloning the repo:
+uv run --from "git+https://github.com/.../box" \
+  bees-box --hive ~/my-hive
+```
+
+### `app` — the reference application
+
+**Owns**: The web server that demonstrates how to consume `bees` as a library.
+REST endpoints for task interaction, SSE for observation, tool dispatch for
+delegated sessions.
+
+**Demonstrates**: How a production application would integrate bees — auth,
+multi-user, HTTP API surface.
+
+**Is not**: The only way to use bees. It's a reference, not the framework.
+
+## The key boundary: SessionRunner
+
+From [delegated-sessions-2.md](./delegated-sessions-2.md):
+
+```python
+class SessionRunner(Protocol):
+    async def run(
+        self,
+        configuration: SessionConfiguration,
+        channel: ContextChannel,
+    ) -> SessionResult: ...
+```
+
+`bees` defines this protocol. `bees-gemini` implements it. `box` and `app`
+instantiate the implementation and hand it to `Bees`.
+
+## The function protocol bridge
+
+Today, every function module in `bees/functions/` imports `opal_backend`'s type
+system: `FunctionGroup`, `FunctionGroupFactory`, `SessionHooks`,
+`assemble_function_group`, `load_declarations`. The handler _logic_ is pure bees
+(task creation, event routing, file I/O), but the handler _shape_ comes from
+`opal_backend`.
+
+The split replaces these imports with bees-native protocols that mirror
+`opal_backend`'s types:
+
+```python
+# bees/protocols.py — framework-owned
+class FunctionGroup(Protocol): ...
+class FunctionFactory(Protocol): ...
+class FunctionHooks(Protocol): ...
+```
+
+Since these protocols match `opal_backend`'s existing types in shape, Python's
+structural subtyping means `opal_backend`'s `FunctionGroup` satisfies bees'
+`FunctionGroup` protocol _without any changes to `opal_backend`_. The adapter in
+`bees-gemini` doesn't need translation logic — it just passes through.
+
+This also opens a future path: if `opal_backend` eventually wants to drop its
+own types and implement bees' protocols directly, that's a non-breaking change.
+
+## Function declarations
+
+Function declarations use Gemini's `FunctionDeclaration` format directly. There's no
+need to invent a bees-native schema — Gemini's format is well-documented JSON
+Schema and serves as a practical lingua franca. If a future non-Gemini runner
+needs a different format, the adaptation happens on the runner's side.
+
+## What moves where
+
+### Out of `bees/` → into `bees-gemini`
+
+| Current location           | New home                           | Why                         |
+| -------------------------- | ---------------------------------- | --------------------------- |
+| `bees/session.py`          | `bees-gemini/runners/streaming.py` | Model connection, streaming |
+| `bees/disk_file_system.py` | `bees-gemini/` or `bees/`          | Depends on design of VFS    |
+| `opal_backend` imports     | `bees-gemini/` only                | Provider-specific types     |
+
+### Out of `bees/` → into `box`
+
+| Current location | New home     | Why                       |
+| ---------------- | ------------ | ------------------------- |
+| `bees/box.py`    | `box/box.py` | CLI + watchfiles + config |
+
+### Stays in `bees/`
+
+| Module            | What it does                               |
+| ----------------- | ------------------------------------------ |
+| `scheduler.py`    | Task orchestration, cycle logic            |
+| `task_runner.py`  | Metadata bookkeeping (delegates to runner) |
+| `task_node.py`    | Per-task state and lifecycle               |
+| `task_store.py`   | Task persistence                           |
+| `coordination.py` | Cross-task event routing                   |
+| `segments.py`     | System instruction assembly                |
+| `mutations.py`    | MutationManager                            |
+| `bees.py`         | High-level API                             |
+| `ticket.py`       | Wire format                                |
+| `functions/*.py`  | Function declarations and handlers         |
+
+## Relationship to delegated sessions
+
+This is the same architectural direction as
+[delegated-sessions-2.md](./delegated-sessions-2.md), stated as a packaging
+concern. Delegated sessions asks: "what if all sessions are delegated?" This
+document answers: "then bees has zero model-provider dependencies and is
+installable on its own."
+
+The key refinement over delegated-sessions-2 is that **functions stay in bees**.
+The earlier draft placed runners and functions together in `bees/runners/`. This
+split recognizes that functions are framework capabilities (task creation, event
+routing, file I/O) — they're orthogonal to the model provider. A Claude runner
+would use the same functions.
+
+## Implications
+
+**`bees` becomes trivially installable.** No C extensions, no heavy
+dependencies, no auth configuration. Any Python ≥ 3.11 can `pip install bees`.
+
+**Model providers are pluggable.** Write a `bees-claude`, a `bees-ollama`, a
+`bees-mock`. The framework doesn't privilege any provider. Each provider package
+contains a runner + an adapter for bees' function protocols.
+
+**Functions are shared.** The function layer is framework infrastructure, not
+provider-specific. `tasks_create_task` works the same whether the session is
+Gemini streaming, Gemini Live, or Claude.
+
+**`hivetool` is entirely decoupled.** It reads the hive filesystem and writes
+mutations. It works with any runner — or no runner at all (read-only observation
+of a hive populated by something else entirely).
+
+**Testing simplifies radically.** `bees` tests cover orchestration + function
+handlers with a `TestRunner` that returns scripted responses. No Gemini mocking,
+no network stubs, no API keys in CI.
+
+## Grounded in code: the import graph
+
+Tracing the actual `opal_backend` imports in `bees/` reveals three categories:
+
+### Clean today (moves to `bees-gemini` wholesale)
+
+`session.py` (940 lines) is where bees and `opal_backend` are deeply entangled.
+It imports `new_session`, `start_session`, `resume_session`, `Subscribers`,
+`InMemorySessionStore`, `InteractionState` — all `opal_backend` session
+internals. It also assembles all function groups and calls `opal_backend`'s
+session API directly. This entire file _is_ the `StreamingRunner`.
+
+### Clean today (trivial fix)
+
+`scheduler.py` imports `HttpBackendClient` only for type annotation. Replace
+with a protocol or `Any` and it's clean. `task_runner.py` already uses
+`backend: Any` — zero `opal_backend` imports.
+
+`box.py` imports `app.auth`, `app.config`, `HttpBackendClient`. All three
+become constructor parameters when it moves to its own package.
+
+### The friction: function modules
+
+All 8 function modules import `opal_backend.function_definition` for:
+- `FunctionGroup`, `FunctionGroupFactory`, `SessionHooks` (types)
+- `assemble_function_group`, `load_declarations` (assembly utilities)
+
+Additionally, `chat.py` and `simple_files.py` import `_make_handlers` from
+`opal_backend.functions.*` — these delegate to `opal_backend`'s built-in
+handlers for file I/O and chat.
+
+**Resolution**: The tool protocol bridge (above) addresses the type imports.
+The `_make_handlers` delegations and `load_declarations`/`assemble_function_group`
+utilities need bees-native equivalents or thin wrappers in the protocols module.
+Since these are pure data assembly (JSON schema loading + handler map → group),
+the extraction is mechanical.
+
+## Open questions
+
+**VFS layer.** `disk_file_system.py` depends on `opal_backend`'s
+`FileSystemProtocol`. Same protocol bridge approach applies — define a
+bees-native `FileSystem` protocol that mirrors the shape.
+
+**MCP lifecycle.** MCP connections are currently established per-session. Under
+the split, bees manages MCP connections as framework infrastructure (since
+`mcp_bridge.py` stays in bees). The runner doesn't need to know about MCP.
+
+**`_make_handlers` delegation.** `chat.py` and `simple_files.py` import handler
+factories from `opal_backend.functions.*`. These need to either move into bees
+(if the logic is framework-level) or be injected by the runner (if they're
+provider-specific). Needs investigation.
+
+## Gradual migration
+
+1. Define tool protocols in `bees/protocols.py` (mirror `opal_backend` shapes).
+2. Define `SessionRunner` protocol.
+3. Migrate `bees/functions/` to import from `bees/protocols.py`.
+4. Create `bees-gemini` with `StreamingRunner` (wraps `session.py` +
+   `opal_backend`).
+5. Move `box.py` into its own package.
+6. Remove `opal_backend` imports from `bees/`.
+7. Drop all external deps from `bees/pyproject.toml`.
+
+Each step is independently shippable — the existing code path continues to work
+throughout.

--- a/packages/bees/docs/tea-leaves.md
+++ b/packages/bees/docs/tea-leaves.md
@@ -1,0 +1,24 @@
+# Tea Leaves
+
+Speculative, ambitious, and less well-defined ideas. These are real pressures
+that will eventually need answers, but the design space is wide open.
+
+## Production Attachment
+
+The aspirational workflow: attach to a production instance and have task data
+stream to local disk for observation with hivetool. This is a sync protocol:
+the production store projects its state onto a local hive directory, and
+hivetool reads it as if it were a local run.
+
+Prerequisite: the storage backend protocol from [future.md](./future.md).
+
+## Multi-Hive Support
+
+A user should be able to run multiple hives simultaneously. Use cases: A/B
+testing different template configurations, running evaluations against a
+baseline, comparing swarm behavior across variants.
+
+**What's blocking**: The scheduler currently assumes a single hive. The hive
+path, template registry, and ticket store are effectively singletons. Supporting
+multiple hives means making these instance-scoped rather than module-scoped —
+which overlaps with the library extraction work.


### PR DESCRIPTION
## What
Restructured `packages/bees/docs/` into a navigable set of concept documents oriented around the library extraction and delegation themes.

## Why
The existing `future.md` was a flat list mixing concrete next steps with speculative ideas. Splitting it into focused documents makes each concern independently readable and reviewable, and gives the package split vision a grounded, code-traced home.

## Changes

### New docs
- **`package-split.md`** — Four-package architecture (`bees`, `bees-gemini`, `box`, `app`), grounded in the actual `opal_backend` import graph. Covers the function protocol bridge, `opal_backend` relationship, and gradual migration path.
- **`framework-improvements.md`** — Concrete, well-scoped gaps (event delivery, filesystem scoping, template questions, naming migration, dead code removal).
- **`tea-leaves.md`** — Speculative ideas (production attachment, multi-hive support).

### Restructured
- **`future.md`** — Now a trailhead linking to the delegation/packaging concept docs and summarizing the consumption API sub-problems.

## Testing
Documentation only — no code changes.
