### PR TITLE
[agent] Spec-driven development skill

### DIFF
--- a/.agent/README.md
+++ b/.agent/README.md
@@ -12,6 +12,7 @@ humans and agents work together in this codebase.
 | **Codemods**         | Mechanical, multi-file, type-aware refactors via `ts-morph`. See `codemods/README.md`.                                     | `codemod/`          |
 | **Idiomatic TS+Lit** | Living reference for idiomatic TypeScript and Lit — type safety, import hygiene, component design, signal patterns.        | `idiomatic-ts-lit/` |
 | **Port Fidelity**    | Audit, diff, and port changes between TypeScript and Python codebases to keep them in sync during the migration.           | `port-fidelity/`    |
+| **Spec-Driven**      | Write protocols and conformance tests first, then migrate code to satisfy them. For any Python boundary extraction.        | `spec-driven/`      |
 
 ## Workflows
 

--- a/.agent/skills/spec-driven/SKILL.md
+++ b/.agent/skills/spec-driven/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: spec-driven
+description:
+  Spec-driven development for Python projects. Write protocols and conformance
+  tests first, then migrate code to satisfy them. The spec is the source of
+  truth across conversation sessions.
+---
+
+# 📐 Spec-Driven Development
+
+Write the target interface first, prove it with a conformance test, then migrate
+existing code to satisfy the spec. Each step is independently shippable.
+
+## When to use
+
+- Extracting a library from entangled code
+- Defining boundaries between packages or modules
+- Replacing concrete dependencies with abstract contracts
+- Any refactor where "what should the boundary look like?" is the hard question
+
+## Why
+
+Reduce risk of breaking the running system while refactoring entangled code.
+
+## Step 0: Brainstorm
+
+Before writing code, brainstorm the protocol shape with the user. This is an
+interactive design session — the agent does code archaeology, the user provides
+architectural vision.
+
+Activities:
+
+- **Trace the import graph.** Find every place the concrete type is used. Map
+  which modules would be freed by the protocol.
+- **Identify friction.** Where does the current code resist the proposed
+  boundary? Surface these explicitly — they're design inputs, not obstacles.
+- **Discuss the boundary.** Explore the questions of where things belong. The
+  best protocols emerge from "should X go here or there?" conversations.
+- **Name the decisions.** When a design question is resolved ("functions stay in
+  the library because they're framework capabilities"), record it with its
+  rationale.
+
+The outcome is a **spec doc**.
+
+## The Spec Doc
+
+The spec doc lives at `packages/{name}/spec/{topic}.md`. It's the work order for
+the cycle — everything a future session needs to pick up the work without
+re-brainstorming.
+
+Contents:
+
+### Goal
+
+One sentence: what boundary is being created and why.
+
+### Design Decisions
+
+Each decision that shaped the protocol, with rationale. These are the "why" that
+a future session shouldn't re-debate.
+
+```markdown
+### Functions stay in the library
+
+The function layer (task creation, event routing, file I/O) is framework
+infrastructure, not model-provider-specific. A different model provider would
+use the same functions. Only the _handler shape_ (types like FunctionGroup)
+comes from the external dependency.
+```
+
+### Protocol Inventory
+
+The tracking table — what's been specified, tested, and migrated:
+
+```markdown
+| Protocol        | Replaces               | Specified | Tested  | Migrated |
+| --------------- | ---------------------- | --------- | ------- | -------- |
+| `SessionRunner` | `session.py` implicit  | ✅        | ✅      | Pending  |
+| `FunctionGroup` | `opal.FunctionGroup`   | ✅        | Pending | Pending  |
+| `FileSystem`    | `opal.FileSystemProto` | Pending   | —       | —        |
+```
+
+### Protocol Shapes
+
+For each protocol, the sketched signature — enough detail that a future session
+can write the `Protocol` class without re-reading all the source:
+
+```markdown
+#### `SessionRunner`
+
+- `async run(configuration, channel) -> SessionResult`
+- Configuration includes: segments, function groups, model, file system
+- Channel provides: context queue for mid-session updates
+- Result includes: status, turns, outcome, suspend/pause state
+```
+
+### Migration Notes
+
+Known friction, import delegation patterns, utility functions that need
+bees-native equivalents. Anything that would surprise someone executing the
+migration.
+
+At the start of each session, check the spec doc. Pick the next pending protocol
+from the inventory.
+
+## The Cycle
+
+### 1. Specify
+
+Write a Python `Protocol` class that defines the boundary.
+
+Rules:
+
+- **Mirror existing shapes.** Design the protocol to be structurally compatible
+  with the current implementation. Python's structural subtyping means existing
+  code can satisfy the protocol without changes.
+- **No new concepts.** If you can't express the boundary with concepts already
+  in the codebase, the boundary is wrong.
+- **Document the contract.** Each protocol method gets a docstring that states
+  what it promises, not what it does internally.
+
+```python
+from typing import Protocol, runtime_checkable
+
+@runtime_checkable
+class SessionRunner(Protocol):
+    """Contract: run a task's session and report back."""
+
+    async def run(
+        self,
+        configuration: SessionConfiguration,
+        channel: ContextChannel,
+    ) -> SessionResult: ...
+```
+
+### 2. Test
+
+Write a conformance test that:
+
+1. **Verifies the spec is satisfiable** — a minimal mock implementation
+   satisfies the protocol.
+2. **Verifies existing types conform** — the concrete class you're abstracting
+   from satisfies the new protocol (structural check via `isinstance` or
+   `issubclass`).
+3. **Documents edge cases** — what happens on failure? Empty inputs? Timeouts?
+
+```python
+def test_mock_satisfies_protocol():
+    """A minimal mock satisfies the protocol."""
+    class MockRunner:
+        async def run(self, configuration, channel):
+            return SessionResult(...)
+
+    assert isinstance(MockRunner(), SessionRunner)
+
+def test_existing_impl_satisfies_protocol():
+    """The concrete class we're abstracting from still works."""
+    from legacy_module import ConcreteRunner
+    assert isinstance(ConcreteRunner(...), SessionRunner)
+```
+
+### 3. Migrate
+
+Rewrite imports to use the protocol instead of the concrete type. This is
+mechanical:
+
+```diff
+-from legacy_module import ConcreteRunner
++from mylib.protocols import SessionRunner
+```
+
+After migration:
+
+- The module works exactly as before (structural compatibility).
+- The module no longer imports the concrete dependency.
+- The conformance test proves the migration is safe.
+
+### 4. Verify
+
+Run the full test suite. If it passes, the migration is complete for that
+protocol. Update the spec doc's inventory.
+
+## Principles
+
+**The spec is the artifact, not the PR.** A session that produces a protocol +
+conformance test has shipped something valuable, even if the migration hasn't
+started.
+
+**Each session is independently valuable.** Don't plan multi-session arcs that
+only pay off at the end. Each session should ship: a protocol, a migration, or a
+conformance test.
+
+**Don't break the running system.** Protocols coexist with legacy imports. The
+migration is a series of import rewrites, not a rewrite of logic. If a migration
+requires changing logic, the protocol is wrong — go back to step 1.
+
+**Work bottom-up.** Start with protocols that have the most importers — they
+eliminate the most legacy coupling. Save the big structural protocols for last.
+
+**Mirror, then evolve.** First release: the protocol mirrors the existing type
+exactly. Second release (optional): evolve the protocol to a better shape now
+that the abstraction boundary exists. Don't try to do both at once.

--- a/packages/bees/docs/package-split.md
+++ b/packages/bees/docs/package-split.md
@@ -5,9 +5,9 @@
 # Package Split
 
 The goal: `bees` becomes a zero-dependency orchestration library that owns both
-task lifecycle _and_ the function layer. Model-provider concerns live in a separate
-runner package. CLI and server applications are thin shells that wire the two
-together.
+task lifecycle _and_ the function layer. Model-provider concerns live in a
+separate runner package. CLI and server applications are thin shells that wire
+the two together.
 
 ## The dependency graph
 
@@ -29,12 +29,12 @@ bees (zero external deps)
 
 Four packages, four responsibilities:
 
-| Package           | What it is                    | External deps                       |
-| ----------------- | ----------------------------- | ----------------------------------- |
+| Package           | What it is                        | External deps                       |
+| ----------------- | --------------------------------- | ----------------------------------- |
 | **`bees`**        | Orchestration library + functions | None (stdlib only)                  |
-| **`bees-gemini`** | Gemini model provider         | `google-genai`, `httpx`             |
-| **`box`**         | Filesystem-driven CLI runner  | `bees`, `bees-gemini`, `watchfiles` |
-| **`app`**         | Reference web application     | `bees`, `bees-gemini`, `fastapi`    |
+| **`bees-gemini`** | Gemini model provider             | `google-genai`, `httpx`             |
+| **`box`**         | Filesystem-driven CLI runner      | `bees`, `bees-gemini`, `watchfiles` |
+| **`app`**         | Reference web application         | `bees`, `bees-gemini`, `fastapi`    |
 
 ## What each package owns
 
@@ -75,9 +75,9 @@ bees-gemini/
   adapter.py         # bridges bees ↔ opal_backend FunctionGroup
 ```
 
-**The adapter** bridges bees' function protocols to `opal_backend`'s types. Since
-the protocols are designed to mirror `opal_backend`'s shape, this is structural
-compatibility — no translation logic, just type-level bridging.
+**The adapter** bridges bees' function protocols to `opal_backend`'s types.
+Since the protocols are designed to mirror `opal_backend`'s shape, this is
+structural compatibility — no translation logic, just type-level bridging.
 
 **Auth lives here.** The runner's constructor takes credentials. Bees never sees
 API keys:
@@ -181,10 +181,11 @@ own types and implement bees' protocols directly, that's a non-breaking change.
 
 ## Function declarations
 
-Function declarations use Gemini's `FunctionDeclaration` format directly. There's no
-need to invent a bees-native schema — Gemini's format is well-documented JSON
-Schema and serves as a practical lingua franca. If a future non-Gemini runner
-needs a different format, the adaptation happens on the runner's side.
+Function declarations use Gemini's `FunctionDeclaration` format directly.
+There's no need to invent a bees-native schema — Gemini's format is
+well-documented JSON Schema and serves as a practical lingua franca. If a future
+non-Gemini runner needs a different format, the adaptation happens on the
+runner's side.
 
 ## What moves where
 
@@ -270,12 +271,13 @@ session API directly. This entire file _is_ the `StreamingRunner`.
 with a protocol or `Any` and it's clean. `task_runner.py` already uses
 `backend: Any` — zero `opal_backend` imports.
 
-`box.py` imports `app.auth`, `app.config`, `HttpBackendClient`. All three
-become constructor parameters when it moves to its own package.
+`box.py` imports `app.auth`, `app.config`, `HttpBackendClient`. All three become
+constructor parameters when it moves to its own package.
 
 ### The friction: function modules
 
 All 8 function modules import `opal_backend.function_definition` for:
+
 - `FunctionGroup`, `FunctionGroupFactory`, `SessionHooks` (types)
 - `assemble_function_group`, `load_declarations` (assembly utilities)
 
@@ -283,8 +285,8 @@ Additionally, `chat.py` and `simple_files.py` import `_make_handlers` from
 `opal_backend.functions.*` — these delegate to `opal_backend`'s built-in
 handlers for file I/O and chat.
 
-**Resolution**: The tool protocol bridge (above) addresses the type imports.
-The `_make_handlers` delegations and `load_declarations`/`assemble_function_group`
+**Resolution**: The tool protocol bridge (above) addresses the type imports. The
+`_make_handlers` delegations and `load_declarations`/`assemble_function_group`
 utilities need bees-native equivalents or thin wrappers in the protocols module.
 Since these are pure data assembly (JSON schema loading + handler map → group),
 the extraction is mechanical.
@@ -306,7 +308,23 @@ provider-specific). Needs investigation.
 
 ## Gradual migration
 
-1. Define tool protocols in `bees/protocols.py` (mirror `opal_backend` shapes).
+This split follows Spec-Driven Development. Write protocols first, prove them
+with conformance tests, then migrate imports.
+
+### Protocol inventory
+
+| Protocol          | Replaces                            | Specified | Tested | Migrated |
+| ----------------- | ----------------------------------- | --------- | ------ | -------- |
+| `FunctionGroup`   | `opal_backend.FunctionGroup`        | Pending   | —      | —        |
+| `FunctionFactory` | `opal_backend.FunctionGroupFactory` | Pending   | —      | —        |
+| `FunctionHooks`   | `opal_backend.SessionHooks`         | Pending   | —      | —        |
+| `SessionRunner`   | Implicit contract in `session.py`   | Pending   | —      | —        |
+| `FileSystem`      | `opal_backend.FileSystemProtocol`   | Pending   | —      | —        |
+
+### Migration steps
+
+1. Define function protocols in `bees/protocols.py` (mirror `opal_backend`
+   shapes).
 2. Define `SessionRunner` protocol.
 3. Migrate `bees/functions/` to import from `bees/protocols.py`.
 4. Create `bees-gemini` with `StreamingRunner` (wraps `session.py` +


### PR DESCRIPTION
## What
New agent skill for spec-driven development (SDD) — a methodology for Python boundary extraction via protocols and conformance tests.

## Why
The bees package split requires extracting clean boundaries from entangled code. SDD provides a repeatable, session-independent methodology: brainstorm the boundary with the user, capture decisions in a spec doc, then execute the Specify → Test → Migrate → Verify cycle.

## Changes

### New
- **`.agent/skills/spec-driven/SKILL.md`** — Generic SDD skill. Covers the brainstorm phase (interactive design), spec doc format (work order with protocol inventory), and the execution cycle.

### Modified
- **`.agent/README.md`** — Registered the spec-driven skill in the practices table.
- **`packages/bees/docs/package-split.md`** — Added protocol inventory table and SDD reference to the gradual migration section.

## Testing
Documentation only — no code changes.
