### PR TITLE
[bees] Bees-native function types

### DIFF
--- a/.agent/skills/spec-driven/SKILL.md
+++ b/.agent/skills/spec-driven/SKILL.md
@@ -40,7 +40,9 @@ Activities:
   the library because they're framework capabilities"), record it with its
   rationale.
 
-The outcome is a **spec doc**.
+The outcome is a **spec doc**. After producing each revision of the spec doc,
+stop and discuss it with the user. The idea is that the spec doc is the work
+order, and the user needs to approve it.
 
 ## The Spec Doc
 

--- a/packages/bees/bees/functions/chat.py
+++ b/packages/bees/bees/functions/chat.py
@@ -18,8 +18,9 @@ from pathlib import Path
 from typing import Any
 
 from opal_backend.function_caller import CONTEXT_PARTS_KEY
-from opal_backend.function_definition import (
+from bees.protocols.functions import (
     FunctionGroup,
+    FunctionGroupFactory,
     SessionHooks,
     assemble_function_group,
     load_declarations,
@@ -40,7 +41,7 @@ def get_chat_function_group_factory(
     on_chat_entry: "ChatEntryCallback" = None,
     workspace_root_id: str | None = None,
     scheduler: Any | None = None,
-) -> "FunctionGroupFactory":
+) -> FunctionGroupFactory:
     """Return a factory that builds the bees chat function group.
 
     The returned callable accepts ``SessionHooks`` and produces a
@@ -52,7 +53,6 @@ def get_chat_function_group_factory(
         on_chat_entry: Optional callback ``(role, content) -> None``
             invoked when the agent sends a user-facing message.
     """
-    from opal_backend.function_definition import FunctionGroupFactory
 
     def factory(hooks: SessionHooks) -> FunctionGroup:
         handlers = _make_handlers(

--- a/packages/bees/bees/functions/events.py
+++ b/packages/bees/bees/functions/events.py
@@ -16,12 +16,12 @@ from typing import Any, Callable
 
 from bees.subagent_scope import SubagentScope
 
-from opal_backend.function_definition import (
+from bees.protocols.functions import (
     FunctionGroup,
+    FunctionGroupFactory,
     SessionHooks,
     assemble_function_group,
     load_declarations,
-    FunctionGroupFactory,
 )
 
 from bees.ticket import Ticket

--- a/packages/bees/bees/functions/mcp_bridge.py
+++ b/packages/bees/bees/functions/mcp_bridge.py
@@ -32,10 +32,10 @@ from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
 from typing import Any
 
-from opal_backend.function_definition import (
+from bees.protocols.functions import (
+    FunctionDefinition,
     FunctionGroup,
     FunctionGroupFactory,
-    FunctionDefinition,
     SessionHooks,
 )
 

--- a/packages/bees/bees/functions/sandbox.py
+++ b/packages/bees/bees/functions/sandbox.py
@@ -28,7 +28,7 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
-from opal_backend.function_definition import (
+from bees.protocols.functions import (
     FunctionGroup,
     FunctionGroupFactory,
     SessionHooks,

--- a/packages/bees/bees/functions/simple_files.py
+++ b/packages/bees/bees/functions/simple_files.py
@@ -17,8 +17,9 @@ import json
 from pathlib import Path
 from typing import Any
 
-from opal_backend.function_definition import (
+from bees.protocols.functions import (
     FunctionGroup,
+    FunctionGroupFactory,
     SessionHooks,
     assemble_function_group,
     load_declarations,
@@ -96,7 +97,7 @@ def _make_list_dir_handler(work_dir: Path) -> Any:
     return system_list_dir
 
 
-def get_simple_files_function_group_factory(scope: SubagentScope | None = None) -> "FunctionGroupFactory":
+def get_simple_files_function_group_factory(scope: SubagentScope | None = None) -> FunctionGroupFactory:
     """Return a factory that builds the simple-files function group.
 
     The returned callable accepts ``SessionHooks`` and produces a
@@ -106,7 +107,6 @@ def get_simple_files_function_group_factory(scope: SubagentScope | None = None) 
     With ``DiskFileSystem``, paths are bare (relative to work_dir) —
     no path translation is needed.
     """
-    from opal_backend.function_definition import FunctionGroupFactory
 
     def factory(hooks: SessionHooks) -> FunctionGroup:
         handlers = _make_handlers(

--- a/packages/bees/bees/functions/skills.py
+++ b/packages/bees/bees/functions/skills.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from opal_backend.function_definition import (
+from bees.protocols.functions import (
     FunctionGroup,
     assemble_function_group,
     load_declarations,

--- a/packages/bees/bees/functions/system.py
+++ b/packages/bees/bees/functions/system.py
@@ -21,8 +21,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from opal_backend.function_definition import (
+from bees.protocols.functions import (
     FunctionGroup,
+    FunctionGroupFactory,
     SessionHooks,
     assemble_function_group,
     load_declarations,
@@ -37,7 +38,7 @@ _DECLARATIONS_DIR = Path(__file__).resolve().parent.parent / "declarations"
 _LOADED = load_declarations("system", declarations_dir=_DECLARATIONS_DIR)
 
 
-def get_system_function_group_factory() -> "FunctionGroupFactory":
+def get_system_function_group_factory() -> FunctionGroupFactory:
     """Return a factory that builds the bees system function group.
 
     The returned callable accepts ``SessionHooks`` and produces a
@@ -45,7 +46,6 @@ def get_system_function_group_factory() -> "FunctionGroupFactory":
     system group entirely. Only termination functions are included,
     but their implementations are identical to the built-in versions.
     """
-    from opal_backend.function_definition import FunctionGroupFactory
 
     def factory(hooks: SessionHooks) -> FunctionGroup:
         handlers = _make_handlers(

--- a/packages/bees/bees/functions/tasks.py
+++ b/packages/bees/bees/functions/tasks.py
@@ -11,12 +11,12 @@ from typing import Any
 
 from bees.subagent_scope import SubagentScope
 
-from opal_backend.function_definition import (
+from bees.protocols.functions import (
     FunctionGroup,
+    FunctionGroupFactory,
     SessionHooks,
     assemble_function_group,
     load_declarations,
-    FunctionGroupFactory,
 )
 
 __all__ = ["get_tasks_function_group_factory"]

--- a/packages/bees/bees/protocols/__init__.py
+++ b/packages/bees/bees/protocols/__init__.py
@@ -1,0 +1,47 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bees-native protocols and types.
+
+Each module defines the types for one boundary:
+
+- ``functions`` — function declaration, assembly, and dispatch.
+- (future) ``session`` — SessionRunner, SessionConfiguration, etc.
+- (future) ``filesystem`` — FileSystem protocol.
+"""
+
+from bees.protocols.functions import (
+    FunctionDeclaration,
+    FunctionDefinition,
+    FunctionGroup,
+    FunctionGroupFactory,
+    FunctionHandler,
+    LoadedDeclarations,
+    MappedDefinitions,
+    PreconditionHandler,
+    SessionHooks,
+    StatusUpdateCallback,
+    StatusUpdateOptions,
+    assemble_function_group,
+    empty_definitions,
+    load_declarations,
+    map_definitions,
+)
+
+__all__ = [
+    "FunctionDeclaration",
+    "FunctionDefinition",
+    "FunctionGroup",
+    "FunctionGroupFactory",
+    "FunctionHandler",
+    "LoadedDeclarations",
+    "MappedDefinitions",
+    "PreconditionHandler",
+    "SessionHooks",
+    "StatusUpdateCallback",
+    "StatusUpdateOptions",
+    "assemble_function_group",
+    "empty_definitions",
+    "load_declarations",
+    "map_definitions",
+]

--- a/packages/bees/bees/protocols/functions.py
+++ b/packages/bees/bees/protocols/functions.py
@@ -1,0 +1,278 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bees-native types for function declaration, assembly, and dispatch.
+
+These mirror the shapes in ``opal_backend.function_definition`` so that
+bees' function modules can import from here instead. Python's structural
+subtyping means opal_backend's concrete types satisfy these definitions
+without modification.
+
+See ``spec/function-types.md`` for design rationale.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Protocol, TypedDict, runtime_checkable
+
+# ---------------------------------------------------------------------------
+# Type aliases
+# ---------------------------------------------------------------------------
+
+FunctionDeclaration = dict[str, Any]
+"""A Gemini-format function declaration (JSON Schema)."""
+
+StatusUpdateCallback = Callable[[str | None, "StatusUpdateOptions | None"], None]
+"""Callback for function handlers to report status updates."""
+
+FunctionHandler = Callable[
+    [dict[str, Any], StatusUpdateCallback],
+    Awaitable[dict[str, Any]],
+]
+"""Async handler: receives parsed args + status callback, returns response."""
+
+PreconditionHandler = Callable[
+    [dict[str, Any]],
+    Awaitable[None],
+]
+"""Async precondition: receives args, raises on failure."""
+
+
+class StatusUpdateOptions(TypedDict, total=False):
+    """Options for status update callbacks."""
+
+    is_thought: bool
+    expected_duration_in_sec: int
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FunctionDefinition:
+    """A single function the agent can call.
+
+    Mirrors ``opal_backend.function_definition.FunctionDefinition``.
+    """
+
+    name: str
+    description: str
+    handler: FunctionHandler
+    precondition: PreconditionHandler | None = None
+    parameters_json_schema: dict[str, Any] | None = None
+    response_json_schema: dict[str, Any] | None = None
+    icon: str | None = None
+    title: str | None = None
+
+
+@dataclass
+class MappedDefinitions:
+    """Separated declarations and definitions for a set of functions.
+
+    - ``definitions``: list of (name, FunctionDefinition) for dispatch.
+    - ``declarations``: list of Gemini FunctionDeclaration dicts for the API.
+    """
+
+    definitions: list[tuple[str, FunctionDefinition]] = field(
+        default_factory=list,
+    )
+    declarations: list[FunctionDeclaration] = field(default_factory=list)
+
+
+@dataclass
+class FunctionGroup(MappedDefinitions):
+    """A group of related functions with an optional system instruction.
+
+    Mirrors ``opal_backend.function_definition.FunctionGroup``.
+    """
+
+    name: str | None = None
+    instruction: str | None = None
+
+
+@dataclass
+class LoadedDeclarations:
+    """Raw declarations, metadata, and instruction loaded from JSON/md."""
+
+    name: str
+    declarations: list[FunctionDeclaration]
+    metadata: list[dict[str, Any]]
+    instruction: str | None
+
+
+# ---------------------------------------------------------------------------
+# Protocols
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class SessionHooks(Protocol):
+    """Contract for session-internal objects exposed to function group factories.
+
+    Bees' function modules accept this in their factory signatures but
+    get their dependencies through closure — the hooks parameter is
+    structurally required but unused. Properties are typed as ``Any``
+    for decoupling; a richer ``FileSystem`` protocol is a separate spec.
+    """
+
+    @property
+    def controller(self) -> Any:
+        """The loop controller."""
+        ...
+
+    @property
+    def file_system(self) -> Any:
+        """The agent file system."""
+        ...
+
+    @property
+    def task_tree_manager(self) -> Any:
+        """The task tree manager."""
+        ...
+
+
+FunctionGroupFactory = Callable[[SessionHooks], FunctionGroup]
+"""A callable that receives session hooks and returns a FunctionGroup."""
+
+
+# ---------------------------------------------------------------------------
+# Declaration loading and assembly
+# ---------------------------------------------------------------------------
+
+
+def load_declarations(
+    group: str,
+    *,
+    declarations_dir: Path | None = None,
+) -> LoadedDeclarations:
+    """Load declarations, metadata, and instruction for a function group.
+
+    Reads ``<declarations_dir>/<group>.functions.json``,
+    ``<group>.metadata.json``, and ``<group>.instruction.md``.
+
+    Args:
+        group: The function group name (e.g. ``"events"``).
+        declarations_dir: Directory containing declaration files.
+            Required — there is no default directory in the bees package.
+    """
+    if declarations_dir is None:
+        raise ValueError(
+            "declarations_dir is required — bees does not have a default "
+            "declarations directory."
+        )
+
+    decls = json.loads(
+        (declarations_dir / f"{group}.functions.json").read_text(),
+    )
+    meta = json.loads(
+        (declarations_dir / f"{group}.metadata.json").read_text(),
+    )
+    instr_path = declarations_dir / f"{group}.instruction.md"
+    try:
+        instr = instr_path.read_text()
+    except FileNotFoundError:
+        instr = None
+
+    return LoadedDeclarations(
+        name=group,
+        declarations=decls,
+        metadata=meta,
+        instruction=instr,
+    )
+
+
+def assemble_function_group(
+    loaded: LoadedDeclarations,
+    handlers: dict[str, FunctionHandler],
+    *,
+    name: str | None = None,
+    instruction_override: str | None = None,
+    preconditions: dict[str, PreconditionHandler] | None = None,
+) -> FunctionGroup:
+    """Build a FunctionGroup from loaded declarations and a handler map.
+
+    Only declarations that have a matching handler are included. This allows
+    partial coverage — a module can implement a subset of the declared
+    functions.
+
+    Args:
+        loaded: Declarations loaded via ``load_declarations``.
+        handlers: Map of function name to async handler.
+        name: Group name for identification and filtering.
+            Defaults to ``loaded.name``.
+        instruction_override: Replaces the loaded instruction when the
+            instruction template needs runtime interpolation.
+        preconditions: Optional map of function name to precondition handler.
+    """
+    metadata_by_name: dict[str, dict[str, Any]] = {
+        entry["name"]: entry for entry in loaded.metadata
+    }
+    preconds = preconditions or {}
+
+    definitions: list[tuple[str, FunctionDefinition]] = []
+    declarations: list[FunctionDeclaration] = []
+
+    for decl in loaded.declarations:
+        fname = decl["name"]
+        handler = handlers.get(fname)
+        if handler is None:
+            continue
+
+        meta = metadata_by_name.get(fname, {})
+        func_def = FunctionDefinition(
+            name=fname,
+            description=decl.get("description", ""),
+            handler=handler,
+            precondition=preconds.get(fname),
+            parameters_json_schema=decl.get("parametersJsonSchema"),
+            response_json_schema=decl.get("responseJsonSchema"),
+            icon=meta.get("icon"),
+            title=meta.get("title"),
+        )
+        definitions.append((fname, func_def))
+        declarations.append(decl)
+
+    instruction = (
+        instruction_override
+        if instruction_override is not None
+        else loaded.instruction
+    )
+    group_name = name if name is not None else loaded.name
+
+    return FunctionGroup(
+        name=group_name,
+        definitions=definitions,
+        declarations=declarations,
+        instruction=instruction,
+    )
+
+
+def map_definitions(
+    functions: list[FunctionDefinition],
+) -> MappedDefinitions:
+    """Convert a list of FunctionDefinitions into MappedDefinitions."""
+    definitions: list[tuple[str, FunctionDefinition]] = [
+        (f.name, f) for f in functions
+    ]
+    declarations: list[FunctionDeclaration] = []
+    for f in functions:
+        decl: FunctionDeclaration = {
+            "name": f.name,
+            "description": f.description,
+        }
+        if f.parameters_json_schema:
+            decl["parametersJsonSchema"] = f.parameters_json_schema
+        if f.response_json_schema:
+            decl["responseJsonSchema"] = f.response_json_schema
+        declarations.append(decl)
+    return MappedDefinitions(definitions=definitions, declarations=declarations)
+
+
+def empty_definitions() -> MappedDefinitions:
+    """Return an empty MappedDefinitions."""
+    return MappedDefinitions()

--- a/packages/bees/spec/function-types.md
+++ b/packages/bees/spec/function-types.md
@@ -1,0 +1,147 @@
+# Function Types — Spec Doc
+
+**Goal**: Define bees-native types and utilities for function declaration,
+assembly, and dispatch — eliminating all `opal_backend.function_definition`
+imports from `bees/functions/`.
+
+## Design Decisions
+
+### Mirror, don't abstract
+
+The bees-native types are structural copies of `opal_backend.function_definition`
+types. Same field names, same shapes. This ensures:
+
+- Existing `opal_backend` types satisfy the bees types via structural subtyping.
+- The migration is a series of import rewrites, not logic changes.
+- `session.py` (which stays coupled to `opal_backend` for now) continues to work
+  because it consumes function groups by structure, not by identity.
+
+### Utilities move wholesale
+
+`load_declarations` and `assemble_function_group` are pure data assembly — they
+load JSON from disk and build dataclasses. They contain no model-provider logic.
+Every bees function module already passes `bees/declarations/` as the directory,
+bypassing opal's default. The bees copies are verbatim ports with one change:
+they return bees-native types.
+
+### `SessionHooks` is structurally minimal
+
+Bees' function modules accept `SessionHooks` in their factory signatures but
+never use it (dependencies come through closure). The bees-native `SessionHooks`
+mirrors opal's shape with `Any`-typed properties. A richer `FileSystem` protocol
+is a separate spec (see inventory).
+
+### `_make_handlers` delegation is out of scope
+
+`chat.py`, `simple_files.py`, and `system.py` import `_make_handlers` from
+`opal_backend.functions.*`. These are handler factories that delegate to
+opal-owned implementations (file I/O helpers, chat control). They're a separate
+concern — either the logic migrates into bees (if framework-level) or gets
+injected by the runner (if provider-specific). This spec covers only the type
+and assembly layer.
+
+### `CONTEXT_PARTS_KEY` is out of scope
+
+`chat.py` imports a string constant from `opal_backend.function_caller`. This
+is a single-use constant that can be inlined or moved in the migration step.
+Not worth a protocol.
+
+## Protocol Inventory
+
+| Protocol / Type       | Replaces                            | Specified | Tested  | Migrated |
+| --------------------- | ----------------------------------- | --------- | ------- | -------- |
+| `FunctionGroup`       | `opal_backend.FunctionGroup`        | ✅        | ✅      | ✅       |
+| `FunctionDefinition`  | `opal_backend.FunctionDefinition`   | ✅        | ✅      | ✅       |
+| `FunctionGroupFactory`| `opal_backend.FunctionGroupFactory` | ✅        | ✅      | ✅       |
+| `SessionHooks`        | `opal_backend.SessionHooks`         | ✅        | ✅      | ✅       |
+| `LoadedDeclarations`  | `opal_backend.LoadedDeclarations`   | ✅        | ✅      | ✅       |
+| `load_declarations`   | `opal_backend.load_declarations`    | ✅        | ✅      | ✅       |
+| `assemble_function_group` | `opal_backend.assemble_function_group` | ✅ | ✅  | ✅       |
+
+## Protocol Shapes
+
+### `FunctionGroup`
+
+Dataclass inheriting from `MappedDefinitions`:
+
+- `definitions: list[tuple[str, FunctionDefinition]]` — name + handler pairs
+- `declarations: list[dict[str, Any]]` — Gemini-format JSON schemas
+- `name: str | None` — group identifier for filtering
+- `instruction: str | None` — system instruction fragment
+
+### `FunctionDefinition`
+
+Dataclass:
+
+- `name: str`
+- `description: str`
+- `handler: FunctionHandler` — `async (args, status_cb) -> dict`
+- `precondition: PreconditionHandler | None`
+- `parameters_json_schema: dict | None`
+- `response_json_schema: dict | None`
+- `icon: str | None`
+- `title: str | None`
+
+### `SessionHooks`
+
+Protocol (runtime-checkable):
+
+- `controller -> Any`
+- `file_system -> Any`
+- `task_tree_manager -> Any`
+
+### `FunctionGroupFactory`
+
+Type alias: `Callable[[SessionHooks], FunctionGroup]`
+
+### `load_declarations(group, *, declarations_dir) -> LoadedDeclarations`
+
+Reads `{group}.functions.json`, `{group}.metadata.json`,
+`{group}.instruction.md` from the declarations directory.
+
+### `assemble_function_group(loaded, handlers, ...) -> FunctionGroup`
+
+Joins loaded declarations with handler map. Only declarations with matching
+handlers are included.
+
+## Migration Notes
+
+### Import rewrite
+
+Every function module replaces:
+
+```diff
+-from opal_backend.function_definition import (
+-    FunctionGroup,
+-    SessionHooks,
+-    assemble_function_group,
+-    load_declarations,
+-    FunctionGroupFactory,
+-)
++from bees.protocols.functions import (
++    FunctionGroup,
++    SessionHooks,
++    assemble_function_group,
++    load_declarations,
++    FunctionGroupFactory,
++)
+```
+
+### Remaining opal imports after migration
+
+After this migration, the following `opal_backend` imports will remain in
+`bees/functions/`:
+
+- `chat.py`: `CONTEXT_PARTS_KEY`, `_make_handlers`, `ChatEntryCallback`,
+  `SuspendError`
+- `simple_files.py`: `_make_handlers`
+- `system.py`: `_make_handlers`
+
+These are a separate migration covered by a future spec.
+
+### `session.py` compatibility
+
+`session.py` calls the factory functions and passes the returned groups to
+`opal_backend`'s session API. Since the bees `FunctionGroup` has the same
+fields as opal's `FunctionGroup`, and opal's session API reads groups by
+attribute (not `isinstance`), the migration is transparent.

--- a/packages/bees/tests/test_protocols/test_functions.py
+++ b/packages/bees/tests/test_protocols/test_functions.py
@@ -1,0 +1,374 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Conformance tests for bees.protocols.
+
+Verifies that:
+1. Bees-native types work end-to-end (load → assemble → use).
+2. opal_backend's concrete types structurally satisfy the bees-native shapes.
+3. Minimal mocks satisfy the SessionHooks protocol.
+
+See ``spec/function-types.md`` for context.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bees.protocols import (
+    FunctionDefinition,
+    FunctionGroup,
+    FunctionGroupFactory,
+    LoadedDeclarations,
+    MappedDefinitions,
+    SessionHooks,
+    assemble_function_group,
+    empty_definitions,
+    load_declarations,
+    map_definitions,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def declarations_dir(tmp_path: Path) -> Path:
+    """Create a minimal declarations directory on disk."""
+    decls = [
+        {
+            "name": "greet",
+            "description": "Say hello",
+            "parametersJsonSchema": {
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+            },
+        },
+        {
+            "name": "farewell",
+            "description": "Say goodbye",
+        },
+    ]
+    meta = [
+        {"name": "greet", "icon": "👋", "title": "Greet"},
+        {"name": "farewell", "icon": "🫡", "title": "Farewell"},
+    ]
+    (tmp_path / "test_group.functions.json").write_text(json.dumps(decls))
+    (tmp_path / "test_group.metadata.json").write_text(json.dumps(meta))
+    (tmp_path / "test_group.instruction.md").write_text(
+        "You are a friendly greeter."
+    )
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# 1. Bees-native types work end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestLoadDeclarations:
+    """Tests for ``load_declarations``."""
+
+    def test_loads_declarations_and_metadata(
+        self, declarations_dir: Path
+    ) -> None:
+        loaded = load_declarations(
+            "test_group", declarations_dir=declarations_dir
+        )
+        assert loaded.name == "test_group"
+        assert len(loaded.declarations) == 2
+        assert loaded.declarations[0]["name"] == "greet"
+        assert len(loaded.metadata) == 2
+        assert loaded.instruction == "You are a friendly greeter."
+
+    def test_missing_instruction_is_none(self, tmp_path: Path) -> None:
+        (tmp_path / "bare.functions.json").write_text("[]")
+        (tmp_path / "bare.metadata.json").write_text("[]")
+        loaded = load_declarations("bare", declarations_dir=tmp_path)
+        assert loaded.instruction is None
+
+    def test_requires_declarations_dir(self) -> None:
+        with pytest.raises(ValueError, match="declarations_dir is required"):
+            load_declarations("anything")
+
+
+class TestAssembleFunctionGroup:
+    """Tests for ``assemble_function_group``."""
+
+    @pytest.fixture
+    def loaded(self, declarations_dir: Path) -> LoadedDeclarations:
+        return load_declarations(
+            "test_group", declarations_dir=declarations_dir
+        )
+
+    def test_assembles_matching_handlers(
+        self, loaded: LoadedDeclarations
+    ) -> None:
+        async def greet_handler(
+            args: dict[str, Any], status_cb: Any
+        ) -> dict[str, Any]:
+            return {"message": f"Hello, {args.get('name', 'world')}!"}
+
+        group = assemble_function_group(
+            loaded, {"greet": greet_handler}
+        )
+
+        assert isinstance(group, FunctionGroup)
+        assert group.name == "test_group"
+        assert group.instruction == "You are a friendly greeter."
+        # Only the handler-matched declaration is included.
+        assert len(group.definitions) == 1
+        assert len(group.declarations) == 1
+        assert group.definitions[0][0] == "greet"
+        assert group.definitions[0][1].icon == "👋"
+
+    def test_skips_declarations_without_handlers(
+        self, loaded: LoadedDeclarations
+    ) -> None:
+        group = assemble_function_group(loaded, {})
+        assert len(group.definitions) == 0
+        assert len(group.declarations) == 0
+
+    def test_instruction_override(
+        self, loaded: LoadedDeclarations
+    ) -> None:
+        async def noop(args: Any, cb: Any) -> dict[str, Any]:
+            return {}
+
+        group = assemble_function_group(
+            loaded,
+            {"greet": noop},
+            instruction_override="Custom instruction",
+        )
+        assert group.instruction == "Custom instruction"
+
+    def test_name_override(self, loaded: LoadedDeclarations) -> None:
+        group = assemble_function_group(
+            loaded, {}, name="custom_name"
+        )
+        assert group.name == "custom_name"
+
+    def test_preconditions_attached(
+        self, loaded: LoadedDeclarations
+    ) -> None:
+        async def handler(args: Any, cb: Any) -> dict[str, Any]:
+            return {}
+
+        async def precond(args: Any) -> None:
+            pass
+
+        group = assemble_function_group(
+            loaded,
+            {"greet": handler},
+            preconditions={"greet": precond},
+        )
+        assert group.definitions[0][1].precondition is precond
+
+
+class TestMapDefinitions:
+    """Tests for ``map_definitions``."""
+
+    def test_maps_definitions_to_declarations(self) -> None:
+        async def handler(args: Any, cb: Any) -> dict[str, Any]:
+            return {}
+
+        func = FunctionDefinition(
+            name="test_func",
+            description="A test function",
+            handler=handler,
+            parameters_json_schema={"type": "object"},
+        )
+        mapped = map_definitions([func])
+        assert len(mapped.definitions) == 1
+        assert len(mapped.declarations) == 1
+        assert mapped.declarations[0]["name"] == "test_func"
+        assert "parametersJsonSchema" in mapped.declarations[0]
+
+    def test_empty_definitions(self) -> None:
+        mapped = empty_definitions()
+        assert mapped.definitions == []
+        assert mapped.declarations == []
+
+
+# ---------------------------------------------------------------------------
+# 2. opal_backend types structurally satisfy bees types
+# ---------------------------------------------------------------------------
+
+
+class TestOpalBackendConformance:
+    """Verifies that opal_backend's types have the same fields as bees' types.
+
+    This is the conformance gate: if these tests pass, migrating function
+    modules from ``opal_backend.function_definition`` to ``bees.protocols``
+    is a safe import rewrite.
+    """
+
+    def test_function_group_fields_match(self) -> None:
+        from opal_backend.function_definition import (
+            FunctionGroup as OpalFunctionGroup,
+        )
+
+        bees_fields = {f.name for f in FunctionGroup.__dataclass_fields__.values()}
+        opal_fields = {f.name for f in OpalFunctionGroup.__dataclass_fields__.values()}
+        assert bees_fields == opal_fields, (
+            f"Field mismatch — bees: {bees_fields - opal_fields}, "
+            f"opal: {opal_fields - bees_fields}"
+        )
+
+    def test_function_definition_fields_match(self) -> None:
+        from opal_backend.function_definition import (
+            FunctionDefinition as OpalFunctionDefinition,
+        )
+
+        bees_fields = {
+            f.name for f in FunctionDefinition.__dataclass_fields__.values()
+        }
+        opal_fields = {
+            f.name for f in OpalFunctionDefinition.__dataclass_fields__.values()
+        }
+        assert bees_fields == opal_fields, (
+            f"Field mismatch — bees: {bees_fields - opal_fields}, "
+            f"opal: {opal_fields - bees_fields}"
+        )
+
+    def test_loaded_declarations_fields_match(self) -> None:
+        from opal_backend.function_definition import (
+            LoadedDeclarations as OpalLoadedDeclarations,
+        )
+
+        bees_fields = {
+            f.name for f in LoadedDeclarations.__dataclass_fields__.values()
+        }
+        opal_fields = {
+            f.name for f in OpalLoadedDeclarations.__dataclass_fields__.values()
+        }
+        assert bees_fields == opal_fields, (
+            f"Field mismatch — bees: {bees_fields - opal_fields}, "
+            f"opal: {opal_fields - bees_fields}"
+        )
+
+    def test_mapped_definitions_fields_match(self) -> None:
+        from opal_backend.function_definition import (
+            MappedDefinitions as OpalMappedDefinitions,
+        )
+
+        bees_fields = {
+            f.name for f in MappedDefinitions.__dataclass_fields__.values()
+        }
+        opal_fields = {
+            f.name for f in OpalMappedDefinitions.__dataclass_fields__.values()
+        }
+        assert bees_fields == opal_fields, (
+            f"Field mismatch — bees: {bees_fields - opal_fields}, "
+            f"opal: {opal_fields - bees_fields}"
+        )
+
+    def test_session_hooks_is_protocol_compatible(self) -> None:
+        """opal_backend's SessionHooks satisfies bees' SessionHooks."""
+        from opal_backend.function_definition import (
+            SessionHooks as OpalSessionHooks,
+        )
+
+        # Both are runtime-checkable Protocols with the same property names.
+        bees_props = {"controller", "file_system", "task_tree_manager"}
+        opal_props = set()
+        for name in dir(OpalSessionHooks):
+            if not name.startswith("_"):
+                member = getattr(OpalSessionHooks, name, None)
+                if isinstance(member, property):
+                    opal_props.add(name)
+        # Allow opal to have extra properties — bees only requires these three.
+        assert bees_props <= opal_props, (
+            f"Missing in opal: {bees_props - opal_props}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. Minimal mocks satisfy the SessionHooks protocol
+# ---------------------------------------------------------------------------
+
+
+class TestSessionHooksMock:
+    """A minimal mock satisfies the ``SessionHooks`` protocol."""
+
+    def test_mock_satisfies_protocol(self) -> None:
+        class MockHooks:
+            @property
+            def controller(self) -> Any:
+                return None
+
+            @property
+            def file_system(self) -> Any:
+                return None
+
+            @property
+            def task_tree_manager(self) -> Any:
+                return None
+
+        assert isinstance(MockHooks(), SessionHooks)
+
+    def test_factory_type_is_callable(self) -> None:
+        """FunctionGroupFactory is a callable type alias."""
+
+        class MockHooks:
+            @property
+            def controller(self) -> Any:
+                return None
+
+            @property
+            def file_system(self) -> Any:
+                return None
+
+            @property
+            def task_tree_manager(self) -> Any:
+                return None
+
+        def my_factory(hooks: SessionHooks) -> FunctionGroup:
+            return FunctionGroup(name="test")
+
+        # The factory callable works with a mock hooks instance.
+        group = my_factory(MockHooks())
+        assert isinstance(group, FunctionGroup)
+        assert group.name == "test"
+
+
+# ---------------------------------------------------------------------------
+# 4. Real bees declarations work with bees-native assembly
+# ---------------------------------------------------------------------------
+
+
+class TestRealDeclarations:
+    """Load actual bees declarations through bees-native utilities.
+
+    This proves the bees-native code path produces valid groups from the
+    same declaration files the function modules use today.
+    """
+
+    @pytest.fixture
+    def bees_declarations_dir(self) -> Path:
+        return Path(__file__).resolve().parent.parent.parent / "bees" / "declarations"
+
+    @pytest.mark.parametrize(
+        "group_name",
+        ["events", "tasks", "skills", "sandbox", "chat", "system"],
+    )
+    def test_load_real_declarations(
+        self, bees_declarations_dir: Path, group_name: str
+    ) -> None:
+        """Each bees declaration group loads without error."""
+        try:
+            loaded = load_declarations(
+                group_name, declarations_dir=bees_declarations_dir
+            )
+        except FileNotFoundError:
+            pytest.skip(f"Declarations for {group_name} not found")
+            return
+        assert loaded.name == group_name
+        assert isinstance(loaded.declarations, list)
+        assert isinstance(loaded.metadata, list)


### PR DESCRIPTION
## What

Introduces `bees/protocols/functions.py` — bees-owned copies of the function types and assembly utilities from `opal_backend.function_definition` — and migrates all 8 function modules to import from it.

## Why

First step of the package split: decoupling `bees/functions/` from `opal_backend` so bees can become a zero-dependency orchestration library. Uses Spec-Driven Development: define types, prove conformance, then rewrite imports.

## Changes

### New files
- **`bees/protocols/functions.py`** — `FunctionGroup`, `FunctionDefinition`, `SessionHooks`, `load_declarations`, `assemble_function_group`, and related types. Mirrors opal_backend shapes for structural compatibility.
- **`bees/protocols/__init__.py`** — re-exports for convenience (both `bees.protocols` and `bees.protocols.functions` work).
- **`spec/function-types.md`** — spec doc with design decisions, protocol inventory, and migration notes.
- **`tests/test_protocols/test_functions.py`** — 23 conformance tests: end-to-end assembly, opal_backend field-level conformance, mock satisfaction, and real declaration loading.

### Migrated function modules (import rewrite only, no logic changes)
- `events.py`, `tasks.py`, `skills.py`, `sandbox.py`, `mcp_bridge.py` — fully decoupled from `opal_backend.function_definition`.
- `system.py`, `simple_files.py`, `chat.py` — types migrated; still import `_make_handlers` and other handler-level APIs from `opal_backend` (separate future spec).

## Testing

`pytest tests/` — 258 passed. Conformance tests verify bees and opal_backend types have identical field sets.
