### PR TITLE
[bees] FileSystem protocol extraction

### DIFF
--- a/packages/bees/bees/disk_file_system.py
+++ b/packages/bees/bees/disk_file_system.py
@@ -4,9 +4,9 @@
 """
 Disk-backed file system for bees agent sessions.
 
-Satisfies the ``FileSystem`` protocol from ``opal_backend`` by reading
-and writing directly to a working directory on disk.  Paths are relative
-to ``work_dir`` — no ``/mnt/`` prefix.
+Satisfies the ``FileSystem`` protocol by reading and writing directly
+to a working directory on disk.  Paths are relative to ``work_dir`` —
+no ``/mnt/`` prefix.
 
 This replaces the in-memory ``AgentFileSystem`` + bidirectional sync
 hacks that previously bridged the virtual FS with the bash sandbox.
@@ -21,11 +21,10 @@ import mimetypes
 from pathlib import Path
 from typing import Any
 
-from opal_backend.file_system_protocol import (
+from bees.protocols.filesystem import (
     FileDescriptor,
     FileSystemSnapshot,
     SystemFileGetter,
-    file_descriptor_to_part,
     DEFAULT_EXTENSION,
     DEFAULT_MIME_TYPE,
     KNOWN_TYPES,

--- a/packages/bees/bees/protocols/__init__.py
+++ b/packages/bees/bees/protocols/__init__.py
@@ -6,10 +6,20 @@
 Each module defines the types for one boundary:
 
 - ``functions`` — function declaration, assembly, and dispatch.
+- ``filesystem`` — FileSystem protocol and supporting types.
 - (future) ``session`` — SessionRunner, SessionConfiguration, etc.
-- (future) ``filesystem`` — FileSystem protocol.
 """
 
+from bees.protocols.filesystem import (
+    DEFAULT_EXTENSION,
+    DEFAULT_MIME_TYPE,
+    KNOWN_TYPES,
+    FileDescriptor,
+    FileSystem,
+    FileSystemSnapshot,
+    SystemFileGetter,
+    file_descriptor_to_part,
+)
 from bees.protocols.functions import (
     FunctionDeclaration,
     FunctionDefinition,
@@ -29,6 +39,16 @@ from bees.protocols.functions import (
 )
 
 __all__ = [
+    # filesystem
+    "DEFAULT_EXTENSION",
+    "DEFAULT_MIME_TYPE",
+    "FileDescriptor",
+    "FileSystem",
+    "FileSystemSnapshot",
+    "KNOWN_TYPES",
+    "SystemFileGetter",
+    "file_descriptor_to_part",
+    # functions
     "FunctionDeclaration",
     "FunctionDefinition",
     "FunctionGroup",

--- a/packages/bees/bees/protocols/filesystem.py
+++ b/packages/bees/bees/protocols/filesystem.py
@@ -1,0 +1,210 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bees-native FileSystem protocol and supporting types.
+
+These mirror the shapes in ``opal_backend.file_system_protocol`` so that
+``DiskFileSystem`` can import from here instead. Python's structural
+subtyping means opal_backend's concrete types satisfy these definitions
+without modification.
+
+See ``spec/filesystem.md`` for design rationale.
+"""
+
+from __future__ import annotations
+
+import mimetypes
+from dataclasses import dataclass
+from typing import Any, Callable, Protocol, runtime_checkable
+
+# ---------------------------------------------------------------------------
+# MIME type registration
+# ---------------------------------------------------------------------------
+
+# Ensure common MIME types are registered — mirrors the side effect in
+# opal_backend.file_system_protocol.
+mimetypes.add_type("text/markdown", ".md")
+mimetypes.add_type("text/csv", ".csv")
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+KNOWN_TYPES = ["audio", "video", "image", "text"]
+DEFAULT_EXTENSION = "txt"
+DEFAULT_MIME_TYPE = "text/plain"
+
+# ---------------------------------------------------------------------------
+# Type aliases
+# ---------------------------------------------------------------------------
+
+SystemFileGetter = Callable[[], str | dict[str, str]]
+"""A callable that returns file content or an error dict."""
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FileDescriptor:
+    """Describes a file stored in an agent file system."""
+
+    data: str
+    mime_type: str
+    type: str  # "text", "inlineData", "fileData", "storedData"
+    title: str | None = None
+    resource_key: str | None = None
+
+
+@dataclass
+class FileSystemSnapshot:
+    """Serializable snapshot of file system state.
+
+    Contains everything needed to reconstruct a file system from
+    persisted state. For disk-backed implementations this is a
+    point-in-time capture of what's on disk.
+
+    Transient state (system file getters) is re-attached by the caller
+    after reconstruction.
+    """
+
+    files: dict[str, FileDescriptor]
+    routes: dict[str, str]
+    file_count: int
+
+
+# ---------------------------------------------------------------------------
+# Utility functions
+# ---------------------------------------------------------------------------
+
+
+def file_descriptor_to_part(file: FileDescriptor) -> dict[str, Any]:
+    """Convert a FileDescriptor to a Gemini data part dict.
+
+    Handles ``fileData``, ``inlineData``, ``storedData``, and text types.
+    """
+    if file.type == "fileData":
+        return {
+            "fileData": {
+                "fileUri": file.data,
+                "mimeType": file.mime_type,
+                **(
+                    {"resourceKey": file.resource_key}
+                    if file.resource_key
+                    else {}
+                ),
+            }
+        }
+    if file.type == "inlineData":
+        return {
+            "inlineData": {
+                "data": file.data,
+                "mimeType": file.mime_type,
+                **({"title": file.title} if file.title else {}),
+            }
+        }
+    if file.type == "storedData":
+        return {
+            "storedData": {
+                "handle": file.data,
+                "mimeType": file.mime_type,
+                **(
+                    {"resourceKey": file.resource_key}
+                    if file.resource_key
+                    else {}
+                ),
+            }
+        }
+    # Default: text
+    return {"text": file.data}
+
+
+# ---------------------------------------------------------------------------
+# Protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class FileSystem(Protocol):
+    """Protocol for agent file systems — in-memory or disk-backed.
+
+    Consumers should depend on this protocol, not on a concrete class.
+    """
+
+    def add_system_file(self, path: str, getter: SystemFileGetter) -> None:
+        """Register a virtual system file backed by a getter function."""
+        ...
+
+    def overwrite(self, name: str, data: str) -> str:
+        """Write (or overwrite) a named text file. Returns the path."""
+        ...
+
+    def write(self, name: str, data: str) -> str:
+        """Write a named file. Returns the path."""
+        ...
+
+    def append(self, path: str, data: str) -> dict[str, str] | None:
+        """Append data to an existing text file, or create it.
+
+        Returns ``None`` on success, or an error dict on failure.
+        """
+        ...
+
+    async def read_text(self, path: str) -> str | dict[str, str]:
+        """Read the text content of a file.
+
+        Returns the text string, or an error dict if not found / not text.
+        """
+        ...
+
+    async def get(self, path: str) -> list[dict[str, Any]] | dict[str, str]:
+        """Get the data parts for a file path.
+
+        Returns a list of Gemini data parts, or an error dict.
+        """
+        ...
+
+    async def get_many(
+        self, paths: list[str],
+    ) -> list[dict[str, Any]] | dict[str, str]:
+        """Get data parts for multiple file paths.
+
+        Returns all parts, or an error dict with joined errors.
+        """
+        ...
+
+    async def list_files(self) -> str:
+        """List all files as newline-separated paths."""
+        ...
+
+    def get_file_url(self, maybe_path: str) -> str | None:
+        """Get the URL for a file path, if it has a displayable URL.
+
+        Returns ``None`` for text files or unknown paths.
+        """
+        ...
+
+    def add_part(
+        self, part: dict[str, Any], file_name: str | None = None,
+    ) -> str | dict[str, str]:
+        """Add a data part to the file system. Returns the path or error dict."""
+        ...
+
+    def add_route(self, original_route: str) -> str:
+        """Register a route and return its pidgin name."""
+        ...
+
+    def get_original_route(self, route_name: str) -> str | dict[str, str]:
+        """Look up the original route for a pidgin route name."""
+        ...
+
+    @property
+    def files(self) -> dict[str, FileDescriptor]:
+        """Read-only access to all stored files."""
+        ...
+
+    @property
+    def snapshot(self) -> FileSystemSnapshot:
+        """Capture serializable state."""
+        ...

--- a/packages/bees/docs/future.md
+++ b/packages/bees/docs/future.md
@@ -37,6 +37,31 @@ The delegated sessions insight, stated as a packaging concern. Four packages:
 The key refinement: functions (tool declarations + handlers) stay in `bees` as
 framework capabilities. They're orthogonal to the model provider.
 
+### Progress
+
+The library extraction follows [Spec-Driven Development](../spec/). Each
+protocol is specified, tested for conformance, then migrated.
+
+**Function types** ([spec](../spec/function-types.md)) — ✅ complete. Bees-native
+copies of `FunctionGroup`, `FunctionDefinition`, `SessionHooks`,
+`load_declarations`, and `assemble_function_group` live in
+`bees/protocols/functions.py`. All 8 function modules now import from
+`bees.protocols` instead of `opal_backend.function_definition`. Remaining
+`opal_backend` imports in `chat.py`, `simple_files.py`, and `system.py` are
+handler-level (`_make_handlers`) — a separate spec.
+
+**FileSystem types** ([spec](../spec/filesystem.md)) — ✅ complete. Bees-native
+copies of `FileSystem`, `FileDescriptor`, `FileSystemSnapshot`,
+`SystemFileGetter`, `file_descriptor_to_part`, and constants live in
+`bees/protocols/filesystem.py`. `disk_file_system.py` now imports from
+`bees.protocols` instead of `opal_backend.file_system_protocol`.
+
+**Remaining protocols** from the [package-split inventory](./package-split.md):
+
+| Protocol        | Status  |
+| --------------- | ------- |
+| `SessionRunner` | Pending |
+
 ## The Consumption API
 
 With the library extraction as the goal, three sub-problems need to

--- a/packages/bees/docs/package-split.md
+++ b/packages/bees/docs/package-split.md
@@ -315,11 +315,15 @@ with conformance tests, then migrate imports.
 
 | Protocol          | Replaces                            | Specified | Tested | Migrated |
 | ----------------- | ----------------------------------- | --------- | ------ | -------- |
-| `FunctionGroup`   | `opal_backend.FunctionGroup`        | Pending   | —      | —        |
-| `FunctionFactory` | `opal_backend.FunctionGroupFactory` | Pending   | —      | —        |
-| `FunctionHooks`   | `opal_backend.SessionHooks`         | Pending   | —      | —        |
+| `FunctionGroup`   | `opal_backend.FunctionGroup`        | ✅        | ✅     | ✅       |
+| `FunctionFactory` | `opal_backend.FunctionGroupFactory` | ✅        | ✅     | ✅       |
+| `FunctionHooks`   | `opal_backend.SessionHooks`         | ✅        | ✅     | ✅       |
 | `SessionRunner`   | Implicit contract in `session.py`   | Pending   | —      | —        |
-| `FileSystem`      | `opal_backend.FileSystemProtocol`   | Pending   | —      | —        |
+| `FileSystem`      | `opal_backend.FileSystemProtocol`   | ✅        | ✅     | ✅       |
+
+See [spec/function-types.md](../spec/function-types.md) for the function types
+spec and [spec/filesystem.md](../spec/filesystem.md) for the filesystem types
+spec and conformance tests.
 
 ### Migration steps
 

--- a/packages/bees/spec/filesystem.md
+++ b/packages/bees/spec/filesystem.md
@@ -1,0 +1,176 @@
+# FileSystem Types — Spec Doc
+
+**Goal**: Define bees-native copies of the `FileSystem` protocol and its
+supporting types — eliminating the `opal_backend.file_system_protocol` import
+from `bees/disk_file_system.py`.
+
+## Design Decisions
+
+### Mirror the full opal shape
+
+The bees-native `FileSystem` protocol mirrors every method on
+`opal_backend.file_system_protocol.FileSystem` — including `add_route`,
+`get_original_route`, `get_file_url`, and `snapshot`, even though
+`DiskFileSystem` stubs some of them. This preserves structural compatibility
+with opal's `AgentFileSystem` and follows the "mirror, then evolve" principle.
+A future pass can slim the protocol once the import boundary exists.
+
+### Supporting types move wholesale
+
+`FileDescriptor`, `FileSystemSnapshot`, `SystemFileGetter`, and
+`file_descriptor_to_part` are pure data / pure functions with no
+model-provider logic. They're used directly by `DiskFileSystem` for file
+serialization, snapshot capture, and system file registration. The bees copies
+are verbatim ports.
+
+### Constants move too
+
+`KNOWN_TYPES`, `DEFAULT_EXTENSION`, and `DEFAULT_MIME_TYPE` are used by
+`DiskFileSystem` for filename generation and MIME type fallbacks. They're
+string constants with no external coupling.
+
+### `file_descriptor_to_part` is unused in `disk_file_system.py`
+
+`disk_file_system.py` imports `file_descriptor_to_part` but never calls it.
+The migration should drop this dead import rather than carry it forward. The
+function still belongs in the bees protocol module (it operates on
+`FileDescriptor`, which bees now owns), but the import is dead code.
+
+### Tightens `SessionHooks.file_system` typing
+
+The function types spec left `SessionHooks.file_system` typed as `Any`
+because the `FileSystem` protocol didn't exist in bees yet. This migration
+enables tightening that to `FileSystem` — connecting the two protocol
+boundaries. This is a follow-up step, not part of the core migration.
+
+### MIME type registration is infrastructure
+
+The opal module calls `mimetypes.add_type()` at module level to register
+`.md` and `.csv`. This side effect moves into the bees protocol module
+since `DiskFileSystem` depends on these registrations.
+
+## Protocol Inventory
+
+| Type / Function         | Replaces                                    | Specified | Tested | Migrated |
+| ----------------------- | ------------------------------------------- | --------- | ------ | -------- |
+| `FileSystem`            | `opal_backend.file_system_protocol.FileSystem` | ✅      | ✅     | ✅       |
+| `FileDescriptor`        | `opal_backend.file_system_protocol.FileDescriptor` | ✅  | ✅     | ✅       |
+| `FileSystemSnapshot`    | `opal_backend.file_system_protocol.FileSystemSnapshot` | ✅ | ✅  | ✅       |
+| `SystemFileGetter`      | `opal_backend.file_system_protocol.SystemFileGetter` | ✅ | ✅    | ✅       |
+| `file_descriptor_to_part` | `opal_backend.file_system_protocol.file_descriptor_to_part` | ✅ | ✅ | ✅  |
+| `DEFAULT_EXTENSION`     | `opal_backend.file_system_protocol.DEFAULT_EXTENSION` | ✅ | ✅    | ✅       |
+| `DEFAULT_MIME_TYPE`     | `opal_backend.file_system_protocol.DEFAULT_MIME_TYPE` | ✅ | ✅    | ✅       |
+| `KNOWN_TYPES`           | `opal_backend.file_system_protocol.KNOWN_TYPES` | ✅     | ✅     | ✅       |
+
+## Protocol Shapes
+
+### `FileSystem`
+
+Runtime-checkable protocol with these methods:
+
+- `add_system_file(path: str, getter: SystemFileGetter) -> None`
+- `overwrite(name: str, data: str) -> str`
+- `write(name: str, data: str) -> str`
+- `append(path: str, data: str) -> dict[str, str] | None`
+- `async read_text(path: str) -> str | dict[str, str]`
+- `async get(path: str) -> list[dict[str, Any]] | dict[str, str]`
+- `async get_many(paths: list[str]) -> list[dict[str, Any]] | dict[str, str]`
+- `async list_files() -> str`
+- `get_file_url(maybe_path: str) -> str | None`
+- `add_part(part: dict[str, Any], file_name: str | None = None) -> str | dict[str, str]`
+- `add_route(original_route: str) -> str`
+- `get_original_route(route_name: str) -> str | dict[str, str]`
+- `files -> dict[str, FileDescriptor]` (property)
+- `snapshot -> FileSystemSnapshot` (property)
+
+### `FileDescriptor`
+
+Dataclass:
+
+- `data: str`
+- `mime_type: str`
+- `type: str` — one of `"text"`, `"inlineData"`, `"fileData"`, `"storedData"`
+- `title: str | None = None`
+- `resource_key: str | None = None`
+
+### `FileSystemSnapshot`
+
+Dataclass:
+
+- `files: dict[str, FileDescriptor]`
+- `routes: dict[str, str]`
+- `file_count: int`
+
+### `SystemFileGetter`
+
+Type alias: `Callable[[], str | dict[str, str]]`
+
+### `file_descriptor_to_part(file: FileDescriptor) -> dict[str, Any]`
+
+Pure function. Converts a `FileDescriptor` to a Gemini data part dict.
+Handles `fileData`, `inlineData`, `storedData`, and text types.
+
+### Constants
+
+- `KNOWN_TYPES = ["audio", "video", "image", "text"]`
+- `DEFAULT_EXTENSION = "txt"`
+- `DEFAULT_MIME_TYPE = "text/plain"`
+
+## Migration Notes
+
+### Import rewrite
+
+`disk_file_system.py` replaces:
+
+```diff
+-from opal_backend.file_system_protocol import (
+-    FileDescriptor,
+-    FileSystemSnapshot,
+-    SystemFileGetter,
+-    file_descriptor_to_part,
+-    DEFAULT_EXTENSION,
+-    DEFAULT_MIME_TYPE,
+-    KNOWN_TYPES,
+-)
++from bees.protocols.filesystem import (
++    FileDescriptor,
++    FileSystemSnapshot,
++    SystemFileGetter,
++    DEFAULT_EXTENSION,
++    DEFAULT_MIME_TYPE,
++    KNOWN_TYPES,
++)
+```
+
+Note: `file_descriptor_to_part` is dropped — it's imported but never used in
+`disk_file_system.py`.
+
+### `session.py` compatibility
+
+`session.py` passes `DiskFileSystem` instances to `opal_backend`'s
+`new_session()` as the `file_system` parameter. Since `DiskFileSystem`
+satisfies both opal's `FileSystem` protocol and bees' `FileSystem` protocol
+structurally, this continues to work — the migration only changes where
+`DiskFileSystem` gets its supporting types, not its shape.
+
+### Remaining `opal_backend` imports after migration
+
+After this migration, `disk_file_system.py` will have zero `opal_backend`
+imports. The docstring reference to opal should be updated.
+
+The broader `opal_backend` import inventory in `bees/` becomes:
+
+- `session.py` — session runtime (out of scope, covered by `SessionRunner`)
+- `scheduler.py` — `HttpBackendClient` type annotation only
+- `box.py` — `HttpBackendClient` + app config
+- `functions/chat.py` — `_make_handlers`, `CONTEXT_PARTS_KEY`,
+  `ChatEntryCallback`, `SuspendError`
+- `functions/simple_files.py` — `_make_handlers`
+- `functions/system.py` — `_make_handlers`
+
+### Follow-up: tighten `SessionHooks.file_system`
+
+Once `FileSystem` lives in `bees.protocols`, `SessionHooks.file_system` can
+be tightened from `Any` to `FileSystem`. This is a one-line change in
+`bees/protocols/functions.py` with a new import. It's a natural follow-up
+but intentionally separate — the core migration should land first.

--- a/packages/bees/tests/test_disk_file_system.py
+++ b/packages/bees/tests/test_disk_file_system.py
@@ -15,7 +15,7 @@ import base64
 import pytest
 
 from bees.disk_file_system import DiskFileSystem
-from opal_backend.file_system_protocol import FileDescriptor
+from bees.protocols.filesystem import FileDescriptor
 
 
 # ---------------------------------------------------------------------------

--- a/packages/bees/tests/test_protocols/test_filesystem.py
+++ b/packages/bees/tests/test_protocols/test_filesystem.py
@@ -1,0 +1,359 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Conformance tests for bees.protocols.filesystem.
+
+Verifies that:
+1. Bees-native types work correctly (FileDescriptor, FileSystemSnapshot).
+2. ``file_descriptor_to_part`` converts all descriptor types.
+3. ``DiskFileSystem`` satisfies the bees ``FileSystem`` protocol.
+4. opal_backend's concrete types structurally match the bees-native shapes.
+5. Minimal mocks satisfy the ``FileSystem`` protocol.
+
+See ``spec/filesystem.md`` for context.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from bees.protocols.filesystem import (
+    DEFAULT_EXTENSION,
+    DEFAULT_MIME_TYPE,
+    KNOWN_TYPES,
+    FileDescriptor,
+    FileSystem,
+    FileSystemSnapshot,
+    SystemFileGetter,
+    file_descriptor_to_part,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Bees-native types work correctly
+# ---------------------------------------------------------------------------
+
+
+class TestFileDescriptor:
+    """FileDescriptor dataclass works as expected."""
+
+    def test_text_descriptor(self) -> None:
+        fd = FileDescriptor(data="hello", mime_type="text/plain", type="text")
+        assert fd.data == "hello"
+        assert fd.mime_type == "text/plain"
+        assert fd.type == "text"
+        assert fd.title is None
+        assert fd.resource_key is None
+
+    def test_inline_data_descriptor(self) -> None:
+        fd = FileDescriptor(
+            data="base64data",
+            mime_type="image/png",
+            type="inlineData",
+            title="screenshot.png",
+        )
+        assert fd.title == "screenshot.png"
+
+    def test_file_data_descriptor_with_resource_key(self) -> None:
+        fd = FileDescriptor(
+            data="gs://bucket/file",
+            mime_type="application/pdf",
+            type="fileData",
+            resource_key="abc123",
+        )
+        assert fd.resource_key == "abc123"
+
+
+class TestFileSystemSnapshot:
+    """FileSystemSnapshot dataclass works as expected."""
+
+    def test_snapshot_construction(self) -> None:
+        fd = FileDescriptor(data="x", mime_type="text/plain", type="text")
+        snap = FileSystemSnapshot(
+            files={"test.txt": fd},
+            routes={"": "", "/": "/"},
+            file_count=1,
+        )
+        assert len(snap.files) == 1
+        assert snap.file_count == 1
+        assert snap.routes == {"": "", "/": "/"}
+
+
+class TestConstants:
+    """Constants have the expected values."""
+
+    def test_known_types(self) -> None:
+        assert KNOWN_TYPES == ["audio", "video", "image", "text"]
+
+    def test_default_extension(self) -> None:
+        assert DEFAULT_EXTENSION == "txt"
+
+    def test_default_mime_type(self) -> None:
+        assert DEFAULT_MIME_TYPE == "text/plain"
+
+
+# ---------------------------------------------------------------------------
+# 2. file_descriptor_to_part converts all descriptor types
+# ---------------------------------------------------------------------------
+
+
+class TestFileDescriptorToPart:
+    """``file_descriptor_to_part`` produces correct Gemini data parts."""
+
+    def test_text_part(self) -> None:
+        fd = FileDescriptor(data="hello world", mime_type="text/plain", type="text")
+        part = file_descriptor_to_part(fd)
+        assert part == {"text": "hello world"}
+
+    def test_inline_data_part(self) -> None:
+        fd = FileDescriptor(
+            data="base64==", mime_type="image/png", type="inlineData",
+        )
+        part = file_descriptor_to_part(fd)
+        assert part == {
+            "inlineData": {"data": "base64==", "mimeType": "image/png"},
+        }
+
+    def test_inline_data_with_title(self) -> None:
+        fd = FileDescriptor(
+            data="base64==",
+            mime_type="image/png",
+            type="inlineData",
+            title="photo.png",
+        )
+        part = file_descriptor_to_part(fd)
+        assert part["inlineData"]["title"] == "photo.png"
+
+    def test_file_data_part(self) -> None:
+        fd = FileDescriptor(
+            data="gs://bucket/file.pdf",
+            mime_type="application/pdf",
+            type="fileData",
+        )
+        part = file_descriptor_to_part(fd)
+        assert part == {
+            "fileData": {
+                "fileUri": "gs://bucket/file.pdf",
+                "mimeType": "application/pdf",
+            },
+        }
+
+    def test_file_data_with_resource_key(self) -> None:
+        fd = FileDescriptor(
+            data="gs://bucket/file.pdf",
+            mime_type="application/pdf",
+            type="fileData",
+            resource_key="key123",
+        )
+        part = file_descriptor_to_part(fd)
+        assert part["fileData"]["resourceKey"] == "key123"
+
+    def test_stored_data_part(self) -> None:
+        fd = FileDescriptor(
+            data="handle-abc",
+            mime_type="video/mp4",
+            type="storedData",
+        )
+        part = file_descriptor_to_part(fd)
+        assert part == {
+            "storedData": {
+                "handle": "handle-abc",
+                "mimeType": "video/mp4",
+            },
+        }
+
+    def test_stored_data_with_resource_key(self) -> None:
+        fd = FileDescriptor(
+            data="handle-abc",
+            mime_type="video/mp4",
+            type="storedData",
+            resource_key="rk456",
+        )
+        part = file_descriptor_to_part(fd)
+        assert part["storedData"]["resourceKey"] == "rk456"
+
+
+# ---------------------------------------------------------------------------
+# 3. DiskFileSystem satisfies the bees FileSystem protocol
+# ---------------------------------------------------------------------------
+
+
+class TestDiskFileSystemConformance:
+    """DiskFileSystem structurally satisfies bees' FileSystem protocol."""
+
+    def test_isinstance_check(self, tmp_path: Path) -> None:
+        from bees.disk_file_system import DiskFileSystem
+
+        fs = DiskFileSystem(tmp_path)
+        assert isinstance(fs, FileSystem)
+
+
+# ---------------------------------------------------------------------------
+# 4. opal_backend types structurally match bees-native shapes
+# ---------------------------------------------------------------------------
+
+
+class TestOpalBackendConformance:
+    """Verifies that opal_backend's types have the same fields as bees' types.
+
+    This is the conformance gate: if these tests pass, migrating
+    ``disk_file_system.py`` from ``opal_backend.file_system_protocol``
+    to ``bees.protocols.filesystem`` is a safe import rewrite.
+    """
+
+    def test_file_descriptor_fields_match(self) -> None:
+        from opal_backend.file_system_protocol import (
+            FileDescriptor as OpalFileDescriptor,
+        )
+
+        bees_fields = {
+            f.name for f in FileDescriptor.__dataclass_fields__.values()
+        }
+        opal_fields = {
+            f.name for f in OpalFileDescriptor.__dataclass_fields__.values()
+        }
+        assert bees_fields == opal_fields, (
+            f"Field mismatch — bees: {bees_fields - opal_fields}, "
+            f"opal: {opal_fields - bees_fields}"
+        )
+
+    def test_file_system_snapshot_fields_match(self) -> None:
+        from opal_backend.file_system_protocol import (
+            FileSystemSnapshot as OpalFileSystemSnapshot,
+        )
+
+        bees_fields = {
+            f.name
+            for f in FileSystemSnapshot.__dataclass_fields__.values()
+        }
+        opal_fields = {
+            f.name
+            for f in OpalFileSystemSnapshot.__dataclass_fields__.values()
+        }
+        assert bees_fields == opal_fields, (
+            f"Field mismatch — bees: {bees_fields - opal_fields}, "
+            f"opal: {opal_fields - bees_fields}"
+        )
+
+    def test_file_system_protocol_methods_match(self) -> None:
+        """Bees' FileSystem protocol has the same methods as opal's."""
+        from opal_backend.file_system_protocol import (
+            FileSystem as OpalFileSystem,
+        )
+
+        def _protocol_members(cls: type) -> set[str]:
+            return {
+                name
+                for name in dir(cls)
+                if not name.startswith("_")
+                and name not in ("register",)  # Protocol internals
+            }
+
+        bees_members = _protocol_members(FileSystem)
+        opal_members = _protocol_members(OpalFileSystem)
+        assert bees_members == opal_members, (
+            f"Method mismatch — bees only: {bees_members - opal_members}, "
+            f"opal only: {opal_members - bees_members}"
+        )
+
+    def test_constants_match(self) -> None:
+        from opal_backend.file_system_protocol import (
+            DEFAULT_EXTENSION as OPAL_DEFAULT_EXTENSION,
+            DEFAULT_MIME_TYPE as OPAL_DEFAULT_MIME_TYPE,
+            KNOWN_TYPES as OPAL_KNOWN_TYPES,
+        )
+
+        assert KNOWN_TYPES == OPAL_KNOWN_TYPES
+        assert DEFAULT_EXTENSION == OPAL_DEFAULT_EXTENSION
+        assert DEFAULT_MIME_TYPE == OPAL_DEFAULT_MIME_TYPE
+
+    def test_file_descriptor_to_part_matches(self) -> None:
+        """Both implementations produce the same output for the same input."""
+        from opal_backend.file_system_protocol import (
+            FileDescriptor as OpalFileDescriptor,
+            file_descriptor_to_part as opal_file_descriptor_to_part,
+        )
+
+        cases = [
+            ("hello", "text/plain", "text", None, None),
+            ("base64==", "image/png", "inlineData", "photo.png", None),
+            ("gs://b/f", "application/pdf", "fileData", None, "key1"),
+            ("handle", "video/mp4", "storedData", None, "rk2"),
+        ]
+
+        for data, mime, ftype, title, rkey in cases:
+            bees_fd = FileDescriptor(
+                data=data, mime_type=mime, type=ftype,
+                title=title, resource_key=rkey,
+            )
+            opal_fd = OpalFileDescriptor(
+                data=data, mime_type=mime, type=ftype,
+                title=title, resource_key=rkey,
+            )
+            assert file_descriptor_to_part(bees_fd) == opal_file_descriptor_to_part(opal_fd), (
+                f"Output mismatch for type={ftype}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# 5. Minimal mocks satisfy the FileSystem protocol
+# ---------------------------------------------------------------------------
+
+
+class TestFileSystemMock:
+    """A minimal mock satisfies the ``FileSystem`` protocol."""
+
+    def test_mock_satisfies_protocol(self) -> None:
+        class MockFileSystem:
+            def add_system_file(self, path: str, getter: SystemFileGetter) -> None:
+                pass
+
+            def overwrite(self, name: str, data: str) -> str:
+                return name
+
+            def write(self, name: str, data: str) -> str:
+                return name
+
+            def append(self, path: str, data: str) -> dict[str, str] | None:
+                return None
+
+            async def read_text(self, path: str) -> str | dict[str, str]:
+                return ""
+
+            async def get(self, path: str) -> list[dict[str, Any]] | dict[str, str]:
+                return [{"text": ""}]
+
+            async def get_many(
+                self, paths: list[str],
+            ) -> list[dict[str, Any]] | dict[str, str]:
+                return []
+
+            async def list_files(self) -> str:
+                return ""
+
+            def get_file_url(self, maybe_path: str) -> str | None:
+                return None
+
+            def add_part(
+                self, part: dict[str, Any], file_name: str | None = None,
+            ) -> str | dict[str, str]:
+                return "file.txt"
+
+            def add_route(self, original_route: str) -> str:
+                return "/route-0"
+
+            def get_original_route(self, route_name: str) -> str | dict[str, str]:
+                return ""
+
+            @property
+            def files(self) -> dict[str, FileDescriptor]:
+                return {}
+
+            @property
+            def snapshot(self) -> FileSystemSnapshot:
+                return FileSystemSnapshot(files={}, routes={}, file_count=0)
+
+        assert isinstance(MockFileSystem(), FileSystem)


### PR DESCRIPTION
## What

Defines bees-native copies of the `FileSystem` protocol and all supporting types from `opal_backend.file_system_protocol`, then migrates `disk_file_system.py` to import exclusively from `bees.protocols.filesystem`.

## Why

Second step in the [library extraction roadmap](packages/bees/docs/future.md). After function types (completed earlier), this eliminates the last `opal_backend` import from `disk_file_system.py`, moving bees closer to a zero-external-dependency orchestration library. Only `SessionRunner` remains in the protocol inventory.

## Changes

### New files
- **`bees/protocols/filesystem.py`** — `FileSystem` protocol, `FileDescriptor`, `FileSystemSnapshot`, `SystemFileGetter`, `file_descriptor_to_part`, and constants. Full mirror of the opal shapes.
- **`spec/filesystem.md`** — Spec doc following SDD conventions: design decisions, protocol inventory, migration notes.
- **`tests/test_protocols/test_filesystem.py`** — 21 conformance tests: native types, `DiskFileSystem` isinstance check, opal field/method/constant parity, `file_descriptor_to_part` output equivalence, mock satisfiability.

### Modified files
- **`bees/disk_file_system.py`** — Import rewrite from `opal_backend` → `bees.protocols.filesystem`. Dropped unused `file_descriptor_to_part` import (dead code). Updated docstring.
- **`bees/protocols/__init__.py`** — Exports all filesystem types. Updated module docstring.
- **`tests/test_disk_file_system.py`** — `FileDescriptor` import updated to match.
- **`docs/future.md`** — Progress section updated; `FileSystem` marked complete.
- **`docs/package-split.md`** — Protocol inventory updated; spec link added.

## Testing

`npm run test:python -w packages/bees` — 279 passed.
