### PR TITLE
[bees] Bees-native pidgin resolution

### DIFF
--- a/.agent/skills/spec-driven/SKILL.md
+++ b/.agent/skills/spec-driven/SKILL.md
@@ -39,6 +39,10 @@ Activities:
 - **Name the decisions.** When a design question is resolved ("functions stay in
   the library because they're framework capabilities"), record it with its
   rationale.
+- **Separate "what to copy" from "what to change."** During brainstorm, you'll
+  spot things that could be improved. Record them, but don't mix them into the
+  spec. The spec should only contain copies of existing shapes. Improvements
+  belong in a follow-up spec after the abstraction boundary exists.
 
 The outcome is a **spec doc**. After producing each revision of the spec doc,
 stop and discuss it with the user. The idea is that the spec doc is the work
@@ -104,6 +108,19 @@ migration.
 
 At the start of each session, check the spec doc. Pick the next pending protocol
 from the inventory.
+
+### Scope Check
+
+Before starting the cycle, count the inventory items in your spec doc.
+
+- **≤ 8 items** → proceed.
+- **> 8 items** → you're probably combining multiple specs. Decompose first.
+  Draw the dependency graph of the types you want to extract. Start from the
+  leaves — types that depend only on things you've already extracted. Each leaf
+  cluster is a natural spec boundary.
+
+A spec that covers one source module is a good size. A spec that reaches across
+3+ source modules is almost certainly too big.
 
 ## The Cycle
 
@@ -198,7 +215,14 @@ requires changing logic, the protocol is wrong — go back to step 1.
 
 **Work bottom-up.** Start with protocols that have the most importers — they
 eliminate the most legacy coupling. Save the big structural protocols for last.
+Concretely: draw the dependency graph of the types you want to extract. Start
+from the leaves — types whose only dependencies are things already in your
+library. If a type depends on something you haven't extracted yet, extract that
+dependency first.
 
 **Mirror, then evolve.** First release: the protocol mirrors the existing type
 exactly. Second release (optional): evolve the protocol to a better shape now
-that the abstraction boundary exists. Don't try to do both at once.
+that the abstraction boundary exists. Don't try to do both at once. During
+brainstorm, you'll spot simplifications ("bees doesn't need pidgin" — wrong;
+"bees could use a simpler API for X" — maybe, but later). Record them as
+follow-up work, not spec items.

--- a/packages/bees/bees/pidgin.py
+++ b/packages/bees/bees/pidgin.py
@@ -1,0 +1,112 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bees-native pidgin resolution utilities.
+
+Pidgin is a micro-language (``<file src="..." />``, ``<a href="...">``,
+``<content>``, ``<asset>``) for passing files around in LLM context. The
+model writes pidgin markup in its outputs (e.g. referencing a file it
+created), and function handlers call ``from_pidgin_string`` to resolve
+those tags back to data parts from the file system.
+
+This is a bees-native copy of the resolution direction from
+``opal_backend.pidgin``. The only difference is the ``FileSystem`` import
+source — ``bees.protocols.filesystem`` instead of
+``opal_backend.file_system_protocol``.
+
+See ``spec/pidgin.md`` for design rationale.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, cast
+
+from bees.protocols.filesystem import FileSystem
+
+__all__ = ["from_pidgin_string", "merge_text_parts"]
+
+# ---------------------------------------------------------------------------
+# from_pidgin_string — pidgin text → LLMContent
+# ---------------------------------------------------------------------------
+
+# Regex patterns matching the TS SPLIT_REGEX, FILE_PARSE_REGEX, LINK_PARSE_REGEX
+_SPLIT_REGEX = re.compile(
+    r'(<file\s+src\s*=\s*"[^"]*"\s*/>|<a\s+href\s*=\s*"[^"]*"\s*>[^<]*</a>)'
+)
+_FILE_PARSE_REGEX = re.compile(r'<file\s+src\s*=\s*"([^"]*)"\s*/>')
+_LINK_PARSE_REGEX = re.compile(r'<a\s+href\s*=\s*"([^"]*)"\s*>\s*([^<]*)\s*</a>')
+
+
+async def from_pidgin_string(
+    content: str, file_system: FileSystem
+) -> dict[str, Any] | list[dict[str, Any]]:
+    """Resolve pidgin markup in a string to data parts.
+
+    Parses ``<file src="..." />`` tags, resolves them via the file
+    system, and returns an ``LLMContent``-like dict with merged text parts.
+    Also parses ``<a href="...">title</a>`` link tags, extracting just the
+    title text.
+
+    Args:
+        content: The pidgin string to parse.
+        file_system: The file system to resolve file references against.
+
+    Returns:
+        An ``LLMContent`` dict ``{"parts": [...], "role": "user"}`` on
+        success, or an error dict ``{"$error": "..."}`` on failure.
+    """
+    segments = _SPLIT_REGEX.split(content)
+    parts: list[dict[str, Any]] = []
+    errors: list[str] = []
+
+    for segment in segments:
+        # Check for <file src="..." />
+        file_match = _FILE_PARSE_REGEX.match(segment)
+        if file_match:
+            path = file_match.group(1)
+            result = await file_system.get(path)
+            if isinstance(result, dict) and "$error" in result:
+                errors.append(result["$error"])
+                continue
+            assert isinstance(result, list)
+            parts.extend(cast(list[dict[str, Any]], result))
+            continue
+
+        # Check for <a href="...">title</a>
+        link_match = _LINK_PARSE_REGEX.match(segment)
+        if link_match:
+            title = link_match.group(2).strip()
+            parts.append({"text": title})
+            continue
+
+        # Plain text
+        if segment:
+            parts.append({"text": segment})
+
+    if errors:
+        return {"$error": f"Agent unable to proceed: {','.join(errors)}"}
+
+    # Merge consecutive text parts
+    merged = merge_text_parts(parts)
+    return {"parts": merged, "role": "user"}
+
+
+def merge_text_parts(
+    parts: list[dict[str, Any]], separator: str = "\n"
+) -> list[dict[str, Any]]:
+    """Merge consecutive text parts into a single text part.
+
+    Non-text parts (inlineData, fileData, etc.) are left as-is.
+    """
+    merged: list[dict[str, Any]] = []
+    for part in parts:
+        if "text" in part and len(part) == 1:
+            # This is a pure text part
+            if merged and "text" in merged[-1] and len(merged[-1]) == 1:
+                merged[-1]["text"] += separator + part["text"]
+            else:
+                merged.append(dict(part))
+        else:
+            merged.append(part)
+    return merged

--- a/packages/bees/docs/future.md
+++ b/packages/bees/docs/future.md
@@ -56,11 +56,34 @@ copies of `FileSystem`, `FileDescriptor`, `FileSystemSnapshot`,
 `bees/protocols/filesystem.py`. `disk_file_system.py` now imports from
 `bees.protocols` instead of `opal_backend.file_system_protocol`.
 
+**Pidgin** ([spec](../spec/pidgin.md)) — ✅ complete. Bees-native copies of
+`from_pidgin_string` and `merge_text_parts` live in `bees/pidgin.py`. These
+resolve pidgin markup (`<file>`, `<a>` tags) in agent output back to data parts
+from the file system. Prerequisite for inlining handler bodies.
+
 **Remaining protocols** from the [package-split inventory](./package-split.md):
 
 | Protocol        | Status  |
 | --------------- | ------- |
 | `SessionRunner` | Pending |
+
+**Remaining `opal_backend` imports** in `bees/` after the three completed
+migrations:
+
+| Module             | Imports                                                    | Category           |
+| ------------------ | ---------------------------------------------------------- | ------------------ |
+| `session.py`       | Session runtime (`new_session`, `start_session`, stores…)  | SessionRunner      |
+| `scheduler.py`     | `HttpBackendClient` (type annotation only)                 | SessionRunner      |
+| `box.py`           | `HttpBackendClient`, `app.auth`, `app.config`              | SessionRunner      |
+| `functions/chat.py`| `_make_handlers`, `CONTEXT_PARTS_KEY`, `ChatEntryCallback`, `SuspendError` | Handler delegation |
+| `functions/simple_files.py` | `_make_handlers`                                  | Handler delegation |
+| `functions/system.py`       | `_make_handlers`                                  | Handler delegation |
+
+The "SessionRunner" category disappears when `session.py` moves to
+`bees-gemini`. The "Handler delegation" category decomposes into two remaining
+specs: **handler types** (bees-native copies of `SuspendError`, suspend event
+types, `AgentResult`, `SessionTerminator` protocol, constants) and **handler
+bodies** (inlining `_make_handlers` using bees-native pidgin + handler types).
 
 ## The Consumption API
 

--- a/packages/bees/spec/pidgin.md
+++ b/packages/bees/spec/pidgin.md
@@ -1,0 +1,150 @@
+# Pidgin — Spec Doc
+
+**Goal**: Create a bees-native copy of the pidgin resolution utilities —
+`from_pidgin_string` and `merge_text_parts` — so that bees' function handlers
+can resolve pidgin markup without importing from `opal_backend`. The opal
+originals are untouched.
+
+## Context
+
+Pidgin is a micro-language (`<file src="..." />`, `<a href="...">`,
+`<content>`, `<asset>`) for passing files around in LLM context. The model
+writes pidgin markup in its outputs (e.g. referencing a file it created), and
+function handlers call `from_pidgin_string` to resolve those tags back to data
+parts from the file system.
+
+Today, three bees function modules (`chat.py`, `system.py`, `simple_files.py`)
+delegate to `opal_backend`'s `_make_handlers`, which internally calls
+`from_pidgin_string`. To eventually inline those handler bodies into bees
+(eliminating the `_make_handlers` imports), bees needs its own pidgin
+resolution.
+
+**This spec extracts pidgin as an independent step.** The handler inlining is a
+separate, later spec that builds on this one.
+
+## Design Decisions
+
+### Only `from_pidgin_string` direction
+
+The opal pidgin module has two directions:
+
+- `to_pidgin` — segments → pidgin text (used during prompt assembly)
+- `from_pidgin_string` — pidgin text → data parts (used by handlers)
+
+Bees only needs `from_pidgin_string` for now. The `to_pidgin` direction is used
+during session setup in `session.py`, which is in the `SessionRunner` category
+and will move to `bees-gemini`. No need to copy it.
+
+### Verbatim copy, different import
+
+The bees version is a verbatim copy of the opal version with one change: it
+imports `FileSystem` from `bees.protocols.filesystem` instead of
+`opal_backend.file_system_protocol`. The logic (regex patterns, tag parsing,
+text merging) is identical.
+
+### `merge_text_parts` comes along
+
+`merge_text_parts` is a pure helper called by `from_pidgin_string`. It has no
+external dependencies — it just merges consecutive text parts in a list. It
+belongs in the same module.
+
+### No new concepts
+
+Both functions already exist in `opal_backend.pidgin`. The bees copies mirror
+them exactly. Python's structural subtyping means bees' `FileSystem` protocol
+is satisfied by both `DiskFileSystem` and opal's `AgentFileSystem` — the
+same function works with either.
+
+## Protocol Inventory
+
+| Function / Constant  | Replaces                                 | Specified | Tested | Migrated |
+| -------------------- | ---------------------------------------- | --------- | ------ | -------- |
+| `from_pidgin_string` | `opal_backend.pidgin.from_pidgin_string` | ✅        | ✅     | ✅       |
+| `merge_text_parts`   | `opal_backend.pidgin.merge_text_parts`   | ✅        | ✅     | ✅       |
+
+## Protocol Shapes
+
+### `from_pidgin_string`
+
+```python
+async def from_pidgin_string(
+    content: str, file_system: FileSystem,
+) -> dict[str, Any]:
+    """Resolve pidgin markup in a string to data parts.
+
+    Parses ``<file src="..." />`` tags, resolves them via the file
+    system, and returns an LLMContent dict with merged text parts.
+    Also parses ``<a href="...">title</a>`` link tags, extracting
+    just the title text.
+
+    Returns:
+        ``{"parts": [...], "role": "user"}`` on success,
+        or ``{"$error": "..."}`` on failure.
+    """
+```
+
+Depends on:
+- `FileSystem` protocol (from `bees.protocols.filesystem`) — for `get()` calls
+  to resolve file references
+
+Internal constants (copied verbatim):
+- `_SPLIT_REGEX` — splits pidgin text into segments
+- `_FILE_PARSE_REGEX` — matches `<file src="..." />`
+- `_LINK_PARSE_REGEX` — matches `<a href="...">title</a>`
+
+### `merge_text_parts`
+
+```python
+def merge_text_parts(
+    parts: list[dict[str, Any]], separator: str = "\n",
+) -> list[dict[str, Any]]:
+    """Merge consecutive text parts into a single text part.
+
+    Non-text parts (inlineData, fileData, etc.) are left as-is.
+    """
+```
+
+Pure function. No dependencies.
+
+## Migration Notes
+
+### Target file
+
+`bees/pidgin.py` — new module, alongside the existing `bees/protocols/`
+package.
+
+### Import change (for future handler inlining)
+
+When handlers are later inlined into bees, they'll import:
+
+```diff
+-from opal_backend.pidgin import from_pidgin_string
++from bees.pidgin import from_pidgin_string
+```
+
+This spec doesn't change any existing imports — it just creates the module.
+The handler inlining spec will do the import rewrite.
+
+### Conformance testing strategy
+
+1. **Behavioral conformance**: verify bees' `from_pidgin_string` produces the
+   same output as opal's for identical inputs — plain text, `<file>` tags,
+   `<a>` tags, mixed content, error cases.
+2. **`merge_text_parts` conformance**: verify identical merging behavior —
+   consecutive text parts merged, non-text parts preserved, separator applied.
+3. **Regex conformance**: verify the split/parse patterns match the same
+   strings as opal's.
+
+### What this enables
+
+With `bees/pidgin.py` in place, the handler delegation work decomposes into
+two remaining specs:
+
+1. **Handler types** — bees-native copies of `SuspendError`, suspend event
+   types (`WaitForInputEvent`, `WaitForChoiceEvent`, `ChoiceItem`),
+   `AgentResult`, `FileData`, `SessionTerminator` protocol, `CONTEXT_PARTS_KEY`,
+   `ChatEntryCallback`.
+2. **Handler bodies** — inline `_make_handlers` from
+   `opal_backend.functions.chat` and `opal_backend.functions.system` into bees,
+   using bees-native pidgin + handler types. This is the step that actually
+   eliminates the `opal_backend` imports from `bees/functions/`.

--- a/packages/bees/tests/test_protocols/test_pidgin.py
+++ b/packages/bees/tests/test_protocols/test_pidgin.py
@@ -1,0 +1,310 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Conformance tests for bees-native pidgin utilities.
+
+Verifies that ``bees.pidgin`` produces identical results to
+``opal_backend.pidgin`` for the same inputs.
+"""
+
+from __future__ import annotations
+
+import pytest
+from typing import Any
+
+from bees.pidgin import from_pidgin_string, merge_text_parts
+
+
+# ---------------------------------------------------------------------------
+# 1. merge_text_parts — pure function tests
+# ---------------------------------------------------------------------------
+
+
+class TestMergeTextParts:
+    """Verify merge_text_parts behavior matches opal_backend.pidgin."""
+
+    def test_empty_list(self) -> None:
+        assert merge_text_parts([]) == []
+
+    def test_single_text_part(self) -> None:
+        parts = [{"text": "hello"}]
+        assert merge_text_parts(parts) == [{"text": "hello"}]
+
+    def test_consecutive_text_parts_merged(self) -> None:
+        parts = [{"text": "hello"}, {"text": "world"}]
+        result = merge_text_parts(parts)
+        assert result == [{"text": "hello\nworld"}]
+
+    def test_three_consecutive_text_parts(self) -> None:
+        parts = [{"text": "a"}, {"text": "b"}, {"text": "c"}]
+        result = merge_text_parts(parts)
+        assert result == [{"text": "a\nb\nc"}]
+
+    def test_non_text_parts_preserved(self) -> None:
+        parts = [
+            {"text": "hello"},
+            {"inlineData": {"data": "abc", "mimeType": "image/png"}},
+            {"text": "world"},
+        ]
+        result = merge_text_parts(parts)
+        assert len(result) == 3
+        assert result[0] == {"text": "hello"}
+        assert result[1] == {"inlineData": {"data": "abc", "mimeType": "image/png"}}
+        assert result[2] == {"text": "world"}
+
+    def test_mixed_text_parts_not_merged(self) -> None:
+        """Text parts with extra keys (e.g. 'thought') are not merged."""
+        parts = [{"text": "hello", "thought": True}, {"text": "world"}]
+        result = merge_text_parts(parts)
+        assert len(result) == 2
+
+    def test_custom_separator(self) -> None:
+        parts = [{"text": "a"}, {"text": "b"}]
+        result = merge_text_parts(parts, separator=" ")
+        assert result == [{"text": "a b"}]
+
+    def test_does_not_mutate_input(self) -> None:
+        parts = [{"text": "hello"}, {"text": "world"}]
+        original = [dict(p) for p in parts]
+        merge_text_parts(parts)
+        assert parts == original
+
+
+# ---------------------------------------------------------------------------
+# 2. from_pidgin_string — async resolution tests
+# ---------------------------------------------------------------------------
+
+
+class MockFileSystem:
+    """Minimal mock satisfying FileSystem.get() for pidgin resolution."""
+
+    def __init__(self, files: dict[str, list[dict[str, Any]]] | None = None) -> None:
+        self._files = files or {}
+
+    async def get(self, path: str) -> list[dict[str, Any]] | dict[str, str]:
+        if path in self._files:
+            return self._files[path]
+        return {"$error": f"File not found: {path}"}
+
+
+class TestFromPidginString:
+    """Verify from_pidgin_string behavior matches opal_backend.pidgin."""
+
+    @pytest.mark.asyncio
+    async def test_plain_text(self) -> None:
+        fs = MockFileSystem()
+        result = await from_pidgin_string("hello world", fs)
+        assert result == {"parts": [{"text": "hello world"}], "role": "user"}
+
+    @pytest.mark.asyncio
+    async def test_empty_string(self) -> None:
+        fs = MockFileSystem()
+        result = await from_pidgin_string("", fs)
+        assert result == {"parts": [], "role": "user"}
+
+    @pytest.mark.asyncio
+    async def test_file_tag_resolved(self) -> None:
+        fs = MockFileSystem(
+            files={"photo.png": [{"inlineData": {"data": "abc", "mimeType": "image/png"}}]}
+        )
+        result = await from_pidgin_string('<file src="photo.png" />', fs)
+        assert result == {
+            "parts": [{"inlineData": {"data": "abc", "mimeType": "image/png"}}],
+            "role": "user",
+        }
+
+    @pytest.mark.asyncio
+    async def test_file_tag_with_surrounding_text(self) -> None:
+        fs = MockFileSystem(
+            files={"img.png": [{"inlineData": {"data": "x", "mimeType": "image/png"}}]}
+        )
+        result = await from_pidgin_string(
+            'Here is the image: <file src="img.png" /> and some text after.',
+            fs,
+        )
+        assert isinstance(result, dict)
+        assert "parts" in result
+        parts = result["parts"]
+        # Text before, inline data, text after
+        assert len(parts) == 3
+        assert parts[0] == {"text": "Here is the image: "}
+        assert parts[1] == {"inlineData": {"data": "x", "mimeType": "image/png"}}
+        assert parts[2] == {"text": " and some text after."}
+
+    @pytest.mark.asyncio
+    async def test_link_tag_extracts_title(self) -> None:
+        fs = MockFileSystem()
+        result = await from_pidgin_string(
+            'Click <a href="/route-0">My Link</a> here.',
+            fs,
+        )
+        assert isinstance(result, dict)
+        parts = result["parts"]
+        # "Click " + "My Link" + " here." — consecutive text parts merged
+        assert len(parts) == 1
+        assert "Click" in parts[0]["text"]
+        assert "My Link" in parts[0]["text"]
+        assert "here." in parts[0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_file_not_found_returns_error(self) -> None:
+        fs = MockFileSystem()  # No files registered
+        result = await from_pidgin_string('<file src="missing.png" />', fs)
+        assert isinstance(result, dict)
+        assert "$error" in result
+
+    @pytest.mark.asyncio
+    async def test_multiple_file_tags(self) -> None:
+        fs = MockFileSystem(
+            files={
+                "a.txt": [{"text": "content-a"}],
+                "b.txt": [{"text": "content-b"}],
+            }
+        )
+        result = await from_pidgin_string(
+            '<file src="a.txt" /> and <file src="b.txt" />',
+            fs,
+        )
+        assert isinstance(result, dict)
+        parts = result["parts"]
+        # "content-a" + " and " + "content-b" — consecutive text merged
+        assert len(parts) == 1
+        assert "content-a" in parts[0]["text"]
+        assert "content-b" in parts[0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_mixed_content(self) -> None:
+        """File tags interleaved with non-text parts prevent merging."""
+        fs = MockFileSystem(
+            files={
+                "img.png": [
+                    {"inlineData": {"data": "abc", "mimeType": "image/png"}},
+                ],
+            }
+        )
+        result = await from_pidgin_string(
+            'Before <file src="img.png" /> after',
+            fs,
+        )
+        assert isinstance(result, dict)
+        parts = result["parts"]
+        assert len(parts) == 3
+        assert parts[0]["text"] == "Before "
+        assert "inlineData" in parts[1]
+        assert parts[2]["text"] == " after"
+
+
+# ---------------------------------------------------------------------------
+# 3. Conformance: bees' output matches opal_backend's output
+# ---------------------------------------------------------------------------
+
+
+class TestOpalConformance:
+    """Verify bees.pidgin produces identical output to opal_backend.pidgin."""
+
+    @pytest.mark.asyncio
+    async def test_from_pidgin_string_matches_opal(self) -> None:
+        """Both implementations produce the same output for identical inputs."""
+        from opal_backend.pidgin import (
+            from_pidgin_string as opal_from_pidgin_string,
+        )
+
+        fs = MockFileSystem(
+            files={
+                "photo.png": [
+                    {"inlineData": {"data": "abc", "mimeType": "image/png"}},
+                ],
+                "doc.txt": [{"text": "document content"}],
+            }
+        )
+
+        cases = [
+            "plain text",
+            '<file src="photo.png" />',
+            '<file src="doc.txt" />',
+            'Before <file src="photo.png" /> after',
+            '<a href="/route-0">My Link</a>',
+            'Text with <a href="/r">link</a> and <file src="doc.txt" /> mixed.',
+            '<file src="nonexistent.png" />',
+        ]
+
+        for content in cases:
+            bees_result = await from_pidgin_string(content, fs)
+            opal_result = await opal_from_pidgin_string(content, fs)
+            assert bees_result == opal_result, (
+                f"Mismatch for input: {content!r}\n"
+                f"  bees: {bees_result}\n"
+                f"  opal: {opal_result}"
+            )
+
+    def test_merge_text_parts_matches_opal(self) -> None:
+        """Both merge implementations produce identical output."""
+        from opal_backend.pidgin import (
+            merge_text_parts as opal_merge_text_parts,
+        )
+
+        cases = [
+            [],
+            [{"text": "hello"}],
+            [{"text": "a"}, {"text": "b"}, {"text": "c"}],
+            [{"text": "a"}, {"inlineData": {"data": "x"}}, {"text": "b"}],
+            [{"text": "a", "thought": True}, {"text": "b"}],
+        ]
+
+        for parts in cases:
+            bees_result = merge_text_parts(parts)
+            opal_result = opal_merge_text_parts(parts)
+            assert bees_result == opal_result, (
+                f"Mismatch for input: {parts!r}"
+            )
+
+    def test_regex_patterns_match_opal(self) -> None:
+        """Bees' regex patterns produce the same splits as opal's."""
+        from bees.pidgin import _SPLIT_REGEX, _FILE_PARSE_REGEX, _LINK_PARSE_REGEX
+        from opal_backend.pidgin import (
+            _SPLIT_REGEX as opal_SPLIT,
+            _FILE_PARSE_REGEX as opal_FILE,
+            _LINK_PARSE_REGEX as opal_LINK,
+        )
+
+        test_strings = [
+            'plain text',
+            '<file src="test.png" />',
+            '<a href="/route">title</a>',
+            'mixed <file src="a.png" /> text <a href="/b">link</a> end',
+            '<file  src = "spaced.png"  />',
+        ]
+
+        for s in test_strings:
+            assert _SPLIT_REGEX.split(s) == opal_SPLIT.split(s), (
+                f"SPLIT mismatch for: {s!r}"
+            )
+
+        file_strings = [
+            '<file src="test.png" />',
+            '<file  src = "spaced.png"  />',
+            'not a file tag',
+        ]
+        for s in file_strings:
+            bees_m = _FILE_PARSE_REGEX.match(s)
+            opal_m = opal_FILE.match(s)
+            assert (bees_m is not None) == (opal_m is not None), (
+                f"FILE match mismatch for: {s!r}"
+            )
+            if bees_m and opal_m:
+                assert bees_m.group(1) == opal_m.group(1)
+
+        link_strings = [
+            '<a href="/route">title</a>',
+            '<a  href = "/r"  > spaced </a>',
+            'not a link',
+        ]
+        for s in link_strings:
+            bees_m = _LINK_PARSE_REGEX.match(s)
+            opal_m = opal_LINK.match(s)
+            assert (bees_m is not None) == (opal_m is not None), (
+                f"LINK match mismatch for: {s!r}"
+            )
+            if bees_m and opal_m:
+                assert bees_m.group(1) == opal_m.group(1)
+                assert bees_m.group(2).strip() == opal_m.group(2).strip()


### PR DESCRIPTION
## What
Creates a bees-native copy of pidgin resolution utilities (`from_pidgin_string`, `merge_text_parts`) so that bees' function handlers can resolve pidgin markup without importing from `opal_backend`. Also improves the SDD skill based on field experience.

## Why
Continuing the library extraction of bees from `opal_backend`. Pidgin is the leaf dependency needed before handler bodies can be inlined — it depends only on `FileSystem` (already extracted). This is the third protocol extraction following function-types and filesystem.

## Changes

### `packages/bees/`
- **[NEW] `bees/pidgin.py`** — bees-native `from_pidgin_string` and `merge_text_parts`, importing `FileSystem` from `bees.protocols.filesystem` instead of `opal_backend`
- **[NEW] `spec/pidgin.md`** — spec doc following SDD methodology
- **[NEW] `tests/test_protocols/test_pidgin.py`** — 19 tests: behavioral tests for both functions + conformance tests verifying identical output against `opal_backend.pidgin`
- **[MOD] `docs/future.md`** — updated progress section with pidgin completion and decomposed handler delegation roadmap

### `.agent/`
- **[MOD] `skills/spec-driven/SKILL.md`** — three improvements from field use: scope check (≤8 items per spec), "separate what to copy from what to change" in brainstorm, concrete dependency-graph guidance for bottom-up principle

## Testing
```bash
cd packages/bees && .venv/bin/python -m pytest tests/test_protocols/test_pidgin.py -v
```
All 19 tests pass, including 3 conformance tests against `opal_backend.pidgin`. Full suite (298 tests) green.
