### PR TITLE
[bees] Handler Types — Bees Library Extraction (SDD)

### DIFF
--- a/packages/bees/bees/functions/chat.py
+++ b/packages/bees/bees/functions/chat.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from opal_backend.function_caller import CONTEXT_PARTS_KEY
 from bees.protocols.functions import (
     FunctionGroup,
     FunctionGroupFactory,
@@ -25,8 +24,12 @@ from bees.protocols.functions import (
     assemble_function_group,
     load_declarations,
 )
+from bees.protocols.handler_types import (
+    ChatEntryCallback,
+    CONTEXT_PARTS_KEY,
+    SuspendError,
+)
 from opal_backend.functions.chat import _make_handlers
-from opal_backend.functions.chat import ChatEntryCallback
 from bees.context_updates import updates_to_context_parts
 
 __all__ = ["get_chat_function_group_factory"]
@@ -70,7 +73,7 @@ def get_chat_function_group_factory(
         async def chat_await_context_update(
             args: dict[str, Any], status_cb: Any,
         ) -> dict[str, Any]:
-            from opal_backend.functions.chat import SuspendError
+            # SuspendError imported at module level from bees.protocols.
 
             # Check for pending context updates first.
             # If updates are already buffered, return immediately

--- a/packages/bees/bees/protocols/__init__.py
+++ b/packages/bees/bees/protocols/__init__.py
@@ -7,6 +7,7 @@ Each module defines the types for one boundary:
 
 - ``functions`` — function declaration, assembly, and dispatch.
 - ``filesystem`` — FileSystem protocol and supporting types.
+- ``handler_types`` — suspend/resume, termination, and context injection.
 - (future) ``session`` — SessionRunner, SessionConfiguration, etc.
 """
 
@@ -37,6 +38,19 @@ from bees.protocols.functions import (
     load_declarations,
     map_definitions,
 )
+from bees.protocols.handler_types import (
+    AgentResult,
+    ChatEntryCallback,
+    ChoiceItem,
+    CONTEXT_PARTS_KEY,
+    FileData,
+    LLMContent,
+    SessionTerminator,
+    SuspendError,
+    SuspendEvent,
+    WaitForChoiceEvent,
+    WaitForInputEvent,
+)
 
 __all__ = [
     # filesystem
@@ -64,4 +78,16 @@ __all__ = [
     "empty_definitions",
     "load_declarations",
     "map_definitions",
+    # handler types
+    "AgentResult",
+    "ChatEntryCallback",
+    "ChoiceItem",
+    "CONTEXT_PARTS_KEY",
+    "FileData",
+    "LLMContent",
+    "SessionTerminator",
+    "SuspendError",
+    "SuspendEvent",
+    "WaitForChoiceEvent",
+    "WaitForInputEvent",
 ]

--- a/packages/bees/bees/protocols/handler_types.py
+++ b/packages/bees/bees/protocols/handler_types.py
@@ -1,0 +1,241 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bees-native handler types for suspend/resume and session termination.
+
+These are bees-native copies of types from ``opal_backend`` that function
+handlers use for:
+
+- **Suspend/resume**: ``SuspendError``, ``WaitForInputEvent``,
+  ``WaitForChoiceEvent``, ``ChoiceItem``
+- **Session termination**: ``SessionTerminator``, ``AgentResult``, ``FileData``
+- **Context injection**: ``CONTEXT_PARTS_KEY``
+- **Chat callbacks**: ``ChatEntryCallback``
+
+The shapes mirror ``opal_backend`` exactly — same field names, same defaults,
+same ``to_dict()`` output. Python's structural subtyping means opal's concrete
+types satisfy these definitions without changes.
+
+See ``spec/handler-types.md`` for design rationale.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Callable, Protocol, Union, runtime_checkable
+
+__all__ = [
+    "AgentResult",
+    "ChatEntryCallback",
+    "ChoiceItem",
+    "CONTEXT_PARTS_KEY",
+    "FileData",
+    "LLMContent",
+    "SessionTerminator",
+    "SuspendError",
+    "SuspendEvent",
+    "WaitForChoiceEvent",
+    "WaitForInputEvent",
+]
+
+# ---------------------------------------------------------------------------
+# Type aliases
+# ---------------------------------------------------------------------------
+
+LLMContent = dict[str, Any]
+"""Gemini content structure: ``{"parts": [...], "role": "..."}``.
+
+Mirrors ``opal_backend.events.LLMContent``.
+"""
+
+# Sentinel key in handler return dicts — signals "inject these parts into
+# the conversation context."  Mirrors ``opal_backend.function_caller``.
+CONTEXT_PARTS_KEY = "__context_parts__"
+
+# Type alias for the optional chat log entry callback.
+# Signature: (role: "agent" | "user", content: str) -> None
+ChatEntryCallback = Callable[[str, str], None] | None
+
+
+# ---------------------------------------------------------------------------
+# Wire-format data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FileData:
+    """A file from the agent file system, keyed by path.
+
+    Mirrors ``opal_backend.events.FileData``.
+    """
+
+    path: str
+    content: LLMContent
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"path": self.path, "content": self.content}
+
+
+@dataclass
+class AgentResult:
+    """Result of an agent loop run.
+
+    Mirrors ``opal_backend.events.AgentResult``.
+    """
+
+    success: bool
+    href: str = "/"
+    outcomes: LLMContent | None = None
+    intermediate: list[FileData] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {"success": self.success}
+        if self.href != "/":
+            d["href"] = self.href
+        if self.outcomes is not None:
+            d["outcomes"] = self.outcomes
+        if self.intermediate is not None:
+            d["intermediate"] = [f.to_dict() for f in self.intermediate]
+        return d
+
+
+# ---------------------------------------------------------------------------
+# SessionTerminator protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class SessionTerminator(Protocol):
+    """Contract: terminate the session with a result.
+
+    Bees-native protocol for the termination side of
+    ``opal_backend.loop.LoopController``. Function handlers call
+    ``terminate(result)`` to stop the loop.
+    """
+
+    def terminate(self, result: AgentResult | dict[str, Any]) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# Suspend event types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class WaitForInputEvent:
+    """Needs user text/file input.
+
+    Mirrors ``opal_backend.events.WaitForInputEvent``.
+    """
+
+    type: str = "waitForInput"
+    request_id: str = ""
+    prompt: LLMContent = field(default_factory=dict)
+    input_type: str = "text"
+    skip_label: str | None = None
+    interaction_id: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "requestId": self.request_id,
+            "prompt": self.prompt,
+            "inputType": self.input_type,
+        }
+        if self.skip_label is not None:
+            payload["skipLabel"] = self.skip_label
+        if self.interaction_id is not None:
+            payload["interactionId"] = self.interaction_id
+        return {"waitForInput": payload}
+
+
+@dataclass
+class ChoiceItem:
+    """A single choice in a WaitForChoiceEvent.
+
+    Mirrors ``opal_backend.events.ChoiceItem``.
+    """
+
+    id: str = ""
+    content: LLMContent = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"id": self.id, "content": self.content}
+
+
+@dataclass
+class WaitForChoiceEvent:
+    """Needs user choice selection.
+
+    Mirrors ``opal_backend.events.WaitForChoiceEvent``.
+    """
+
+    type: str = "waitForChoice"
+    request_id: str = ""
+    prompt: LLMContent = field(default_factory=dict)
+    choices: list[ChoiceItem] = field(default_factory=list)
+    selection_mode: str = "single"
+    layout: str | None = None
+    none_of_the_above_label: str | None = None
+    interaction_id: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "requestId": self.request_id,
+            "prompt": self.prompt,
+            "choices": [c.to_dict() for c in self.choices],
+            "selectionMode": self.selection_mode,
+        }
+        if self.layout is not None:
+            payload["layout"] = self.layout
+        if self.none_of_the_above_label is not None:
+            payload["noneOfTheAboveLabel"] = self.none_of_the_above_label
+        if self.interaction_id is not None:
+            payload["interactionId"] = self.interaction_id
+        return {"waitForChoice": payload}
+
+
+# Union of suspend event types that bees handlers construct.
+# Narrower than opal's SuspendEvent — graph-editing events belong in
+# bees-gemini.
+SuspendEvent = Union[WaitForInputEvent, WaitForChoiceEvent]
+
+
+# ---------------------------------------------------------------------------
+# SuspendError
+# ---------------------------------------------------------------------------
+
+
+class SuspendError(Exception):
+    """Raised by function handlers that need client input.
+
+    Mirrors ``opal_backend.suspend.SuspendError``.
+
+    The function handler constructs a suspend event (e.g.,
+    ``WaitForInputEvent``) and raises this exception. The loop catches it,
+    saves state, and returns a ``SuspendResult``.
+
+    Args:
+        event: The typed suspend event to send to the client.
+        function_call_part: The function call part that triggered this
+            suspend.
+        is_precondition_check: Whether this suspend is a precondition
+            check (skippable).
+    """
+
+    def __init__(
+        self,
+        event: SuspendEvent,
+        function_call_part: dict[str, Any] | None = None,
+        *,
+        is_precondition_check: bool = False,
+    ) -> None:
+        self.event = event
+        self.function_call_part = function_call_part or {}
+        self.is_precondition_check = is_precondition_check
+        # Assign a unique interaction ID for the reconnect protocol.
+        self.interaction_id = str(uuid.uuid4())
+        # Populated by FunctionCaller.get_results() with results from
+        # sibling function calls that completed before this suspend.
+        self.completed_responses: list = []
+        super().__init__(f"Suspend: {getattr(event, 'type', 'unknown')}")

--- a/packages/bees/docs/future.md
+++ b/packages/bees/docs/future.md
@@ -61,13 +61,21 @@ copies of `FileSystem`, `FileDescriptor`, `FileSystemSnapshot`,
 resolve pidgin markup (`<file>`, `<a>` tags) in agent output back to data parts
 from the file system. Prerequisite for inlining handler bodies.
 
+**Handler types** ([spec](../spec/handler-types.md)) — ✅ complete. Bees-native
+copies of `SuspendError`, `WaitForInputEvent`, `WaitForChoiceEvent`,
+`ChoiceItem`, `AgentResult`, `FileData`, `SessionTerminator` protocol,
+`CONTEXT_PARTS_KEY`, and `ChatEntryCallback` live in
+`bees/protocols/handler_types.py`. These are the types that function handlers use
+for suspend/resume, session termination, and context injection. Prerequisite for
+inlining handler bodies.
+
 **Remaining protocols** from the [package-split inventory](./package-split.md):
 
 | Protocol        | Status  |
 | --------------- | ------- |
 | `SessionRunner` | Pending |
 
-**Remaining `opal_backend` imports** in `bees/` after the three completed
+**Remaining `opal_backend` imports** in `bees/` after the four completed
 migrations:
 
 | Module             | Imports                                                    | Category           |
@@ -75,15 +83,14 @@ migrations:
 | `session.py`       | Session runtime (`new_session`, `start_session`, stores…)  | SessionRunner      |
 | `scheduler.py`     | `HttpBackendClient` (type annotation only)                 | SessionRunner      |
 | `box.py`           | `HttpBackendClient`, `app.auth`, `app.config`              | SessionRunner      |
-| `functions/chat.py`| `_make_handlers`, `CONTEXT_PARTS_KEY`, `ChatEntryCallback`, `SuspendError` | Handler delegation |
-| `functions/simple_files.py` | `_make_handlers`                                  | Handler delegation |
-| `functions/system.py`       | `_make_handlers`                                  | Handler delegation |
+| `functions/chat.py`| `_make_handlers`, `CONTEXT_PARTS_KEY`, `ChatEntryCallback`, `SuspendError` | Handler bodies |\
+| `functions/simple_files.py` | `_make_handlers`                                  | Handler bodies |
+| `functions/system.py`       | `_make_handlers`                                  | Handler bodies |
 
 The "SessionRunner" category disappears when `session.py` moves to
-`bees-gemini`. The "Handler delegation" category decomposes into two remaining
-specs: **handler types** (bees-native copies of `SuspendError`, suspend event
-types, `AgentResult`, `SessionTerminator` protocol, constants) and **handler
-bodies** (inlining `_make_handlers` using bees-native pidgin + handler types).
+`bees-gemini`. The "Handler bodies" category is the final spec: inlining
+`_make_handlers` using bees-native pidgin + handler types. All type dependencies
+are now satisfied — only the handler logic itself remains to be copied.
 
 ## The Consumption API
 

--- a/packages/bees/docs/package-split.md
+++ b/packages/bees/docs/package-split.md
@@ -318,12 +318,16 @@ with conformance tests, then migrate imports.
 | `FunctionGroup`   | `opal_backend.FunctionGroup`        | ✅        | ✅     | ✅       |
 | `FunctionFactory` | `opal_backend.FunctionGroupFactory` | ✅        | ✅     | ✅       |
 | `FunctionHooks`   | `opal_backend.SessionHooks`         | ✅        | ✅     | ✅       |
-| `SessionRunner`   | Implicit contract in `session.py`   | Pending   | —      | —        |
 | `FileSystem`      | `opal_backend.FileSystemProtocol`   | ✅        | ✅     | ✅       |
+| `SuspendError`    | `opal_backend.suspend.SuspendError` | ✅        | ✅     | ✅       |
+| `AgentResult`     | `opal_backend.events.AgentResult`   | ✅        | ✅     | ✅       |
+| `SessionTerminator` | `opal_backend.loop.LoopController`| ✅        | ✅     | ✅       |
+| `SessionRunner`   | Implicit contract in `session.py`   | Pending   | —      | —        |
 
 See [spec/function-types.md](../spec/function-types.md) for the function types
-spec and [spec/filesystem.md](../spec/filesystem.md) for the filesystem types
-spec and conformance tests.
+spec, [spec/filesystem.md](../spec/filesystem.md) for the filesystem types spec,
+and [spec/handler-types.md](../spec/handler-types.md) for the handler types spec
+and conformance tests.
 
 ### Migration steps
 

--- a/packages/bees/spec/handler-types.md
+++ b/packages/bees/spec/handler-types.md
@@ -1,0 +1,248 @@
+# Handler Types — Spec Doc
+
+**Goal**: Create bees-native copies of the types that function handlers import
+from `opal_backend` for suspend/resume, session termination, and context
+injection — so that handler bodies can eventually be inlined without any
+`opal_backend` dependency.
+
+## Context
+
+Three bees function modules (`chat.py`, `simple_files.py`, `system.py`) delegate
+to `opal_backend`'s `_make_handlers`. Those handler factories use internal types:
+`SuspendError`, suspend event dataclasses, `AgentResult`, `LoopController`,
+`CONTEXT_PARTS_KEY`, and `ChatEntryCallback`.
+
+Before the handler *bodies* can be inlined into bees (eliminating the
+`_make_handlers` imports), bees needs its own copies of these types. This spec
+extracts the types as an independent step. The handler inlining is a separate,
+later spec that builds on this one.
+
+## Design Decisions
+
+### Verbatim copies, different package
+
+The bees versions are verbatim copies of the opal versions. Same field names,
+same shapes, same `to_dict()` methods. The only difference is the import source.
+Python's structural subtyping means the opal and bees types are interchangeable.
+
+### `SessionTerminator` protocol instead of `LoopController` class
+
+Bees doesn't need the full `LoopController` class — only the `terminate(result)`
+method. The bees-native version defines a `SessionTerminator` protocol with a
+single method. `LoopController` satisfies it structurally.
+
+### Suspend event types are data, not wire protocol
+
+The suspend event dataclasses (`WaitForInputEvent`, `WaitForChoiceEvent`,
+`ChoiceItem`) are used by handlers to construct `SuspendError` payloads. They're
+data containers — the wire serialization (`to_dict()`) is preserved for
+compatibility, but bees handlers only need the constructor and field access.
+
+### `CONTEXT_PARTS_KEY` is a string constant
+
+`CONTEXT_PARTS_KEY = "__context_parts__"` is imported by `chat.py` from
+`opal_backend.function_caller`. It's a sentinel key in handler return dicts that
+signals "inject these parts into the conversation context." Trivial to copy.
+
+### `ChatEntryCallback` is a type alias
+
+`ChatEntryCallback = Callable[[str, str], None] | None` — used by the chat
+handler factory signature. Trivial to copy.
+
+### `FileData` and `AgentResult` come together
+
+`AgentResult` references `FileData` in its `intermediate` field. Both are
+dataclasses from `opal_backend.events`. They travel as a unit.
+
+### `LLMContent` alias comes along
+
+Several types use `LLMContent = dict[str, Any]` as a type alias. It's already
+defined in `opal_backend.events`. The bees copy goes in the same module for
+clarity.
+
+## Protocol Inventory
+
+| Type / Constant       | Replaces                                     | Specified | Tested | Migrated |
+| --------------------- | -------------------------------------------- | --------- | ------ | -------- |
+| `SuspendError`        | `opal_backend.suspend.SuspendError`          | ✅        | ✅     | ✅       |
+| `WaitForInputEvent`   | `opal_backend.events.WaitForInputEvent`      | ✅        | ✅     | ✅       |
+| `WaitForChoiceEvent`  | `opal_backend.events.WaitForChoiceEvent`     | ✅        | ✅     | ✅       |
+| `ChoiceItem`          | `opal_backend.events.ChoiceItem`             | ✅        | ✅     | ✅       |
+| `AgentResult`         | `opal_backend.events.AgentResult`            | ✅        | ✅     | ✅       |
+| `FileData`            | `opal_backend.events.FileData`               | ✅        | ✅     | ✅       |
+| `SessionTerminator`   | `opal_backend.loop.LoopController`           | ✅        | ✅     | ✅       |
+| `CONTEXT_PARTS_KEY`   | `opal_backend.function_caller.CONTEXT_PARTS_KEY` | ✅    | ✅     | ✅       |
+| `ChatEntryCallback`   | `opal_backend.functions.chat.ChatEntryCallback`  | ✅    | ✅     | ✅       |
+| `LLMContent`          | `opal_backend.events.LLMContent`             | ✅        | ✅     | ✅       |
+
+## Protocol Shapes
+
+### `SuspendError`
+
+```python
+class SuspendError(Exception):
+    """Raised by function handlers that need client input."""
+
+    def __init__(
+        self,
+        event: SuspendEvent,
+        function_call_part: dict[str, Any] | None = None,
+        *,
+        is_precondition_check: bool = False,
+    ) -> None: ...
+
+    event: SuspendEvent
+    function_call_part: dict[str, Any]
+    is_precondition_check: bool
+    interaction_id: str
+    completed_responses: list
+```
+
+Depends on: `SuspendEvent` (union of suspend event types).
+
+### `WaitForInputEvent`
+
+```python
+@dataclass
+class WaitForInputEvent:
+    type: str = "waitForInput"
+    request_id: str = ""
+    prompt: LLMContent = field(default_factory=dict)
+    input_type: str = "text"
+    skip_label: str | None = None
+    interaction_id: str | None = None
+
+    def to_dict(self) -> dict[str, Any]: ...
+```
+
+### `WaitForChoiceEvent`
+
+```python
+@dataclass
+class WaitForChoiceEvent:
+    type: str = "waitForChoice"
+    request_id: str = ""
+    prompt: LLMContent = field(default_factory=dict)
+    choices: list[ChoiceItem] = field(default_factory=list)
+    selection_mode: str = "single"
+    layout: str | None = None
+    none_of_the_above_label: str | None = None
+    interaction_id: str | None = None
+
+    def to_dict(self) -> dict[str, Any]: ...
+```
+
+### `ChoiceItem`
+
+```python
+@dataclass
+class ChoiceItem:
+    id: str = ""
+    content: LLMContent = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]: ...
+```
+
+### `SessionTerminator`
+
+```python
+@runtime_checkable
+class SessionTerminator(Protocol):
+    """Contract: terminate the session with a result."""
+
+    def terminate(self, result: AgentResult | dict[str, Any]) -> None: ...
+```
+
+### `AgentResult`
+
+```python
+@dataclass
+class AgentResult:
+    success: bool
+    href: str = "/"
+    outcomes: LLMContent | None = None
+    intermediate: list[FileData] | None = None
+
+    def to_dict(self) -> dict[str, Any]: ...
+```
+
+### `FileData`
+
+```python
+@dataclass
+class FileData:
+    path: str
+    content: LLMContent
+
+    def to_dict(self) -> dict[str, Any]: ...
+```
+
+### Constants and aliases
+
+```python
+LLMContent = dict[str, Any]
+CONTEXT_PARTS_KEY = "__context_parts__"
+ChatEntryCallback = Callable[[str, str], None] | None
+SuspendEvent = WaitForInputEvent | WaitForChoiceEvent
+```
+
+Note: `SuspendEvent` in bees is narrower than opal's — only the two types that
+bees handlers actually construct. The graph-editing events
+(`ReadGraphEvent`, `InspectNodeEvent`, etc.) are session-level concerns that
+belong in `bees-gemini`.
+
+## Migration Notes
+
+### Target file
+
+`bees/protocols/handler_types.py` — new module in the existing protocols
+package.
+
+### What this enables
+
+With handler types in place, the handler inlining spec can rewrite:
+
+```diff
+-from opal_backend.functions.chat import _make_handlers
+-from opal_backend.functions.chat import SuspendError
+-from opal_backend.functions.chat import ChatEntryCallback
+-from opal_backend.function_caller import CONTEXT_PARTS_KEY
++from bees.protocols.handler_types import (
++    SuspendError,
++    ChatEntryCallback,
++    CONTEXT_PARTS_KEY,
++    WaitForInputEvent,
++    WaitForChoiceEvent,
++    ChoiceItem,
++)
+```
+
+And then inline the handler bodies using these types + bees-native pidgin.
+
+### This spec does not change `_make_handlers` imports
+
+It migrates the type imports (`SuspendError`, `ChatEntryCallback`,
+`CONTEXT_PARTS_KEY`) to bees-native sources. The `_make_handlers` imports
+remain — they're the handler bodies spec.
+
+### Migrated files
+
+- `bees/functions/chat.py` — `CONTEXT_PARTS_KEY`, `ChatEntryCallback`,
+  `SuspendError` now import from `bees.protocols.handler_types`
+- `tests/test_chat.py` — `CONTEXT_PARTS_KEY` now imports from
+  `bees.protocols.handler_types`
+
+`WaitForInputEvent`, `WaitForChoiceEvent`, `ChoiceItem`, `AgentResult`,
+`FileData`, and `SessionTerminator` are not yet imported by any bees module —
+the handler bodies spec will use them when inlining `_make_handlers`.
+
+### Conformance testing strategy
+
+1. **Structural conformance**: verify bees' dataclasses have the same fields
+   and defaults as opal's.
+2. **`to_dict()` conformance**: verify identical wire serialization for the
+   same field values.
+3. **`SuspendError` behavior**: verify same exception properties and
+   `interaction_id` assignment.
+4. **`SessionTerminator` protocol**: verify `LoopController` satisfies it
+   structurally.

--- a/packages/bees/tests/test_chat.py
+++ b/packages/bees/tests/test_chat.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock
 from bees.functions.chat import get_chat_function_group_factory
 from bees.task_store import TaskStore
 from bees.context_updates import CONTEXT_UPDATE_TAG
-from opal_backend.function_caller import CONTEXT_PARTS_KEY
+from bees.protocols.handler_types import CONTEXT_PARTS_KEY
 
 
 @pytest.fixture

--- a/packages/bees/tests/test_protocols/test_handler_types.py
+++ b/packages/bees/tests/test_protocols/test_handler_types.py
@@ -1,0 +1,373 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Conformance tests for bees-native handler types.
+
+Verifies that ``bees.protocols.handler_types`` types have the same fields,
+defaults, and ``to_dict()`` output as their ``opal_backend`` counterparts.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import pytest
+
+from bees.protocols.handler_types import (
+    AgentResult,
+    ChatEntryCallback,
+    ChoiceItem,
+    CONTEXT_PARTS_KEY,
+    FileData,
+    LLMContent,
+    SessionTerminator,
+    SuspendError,
+    WaitForChoiceEvent,
+    WaitForInputEvent,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Constants and aliases
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    """Verify constants match opal_backend values."""
+
+    def test_context_parts_key_value(self) -> None:
+        from opal_backend.function_caller import (
+            CONTEXT_PARTS_KEY as opal_key,
+        )
+
+        assert CONTEXT_PARTS_KEY == opal_key
+
+    def test_chat_entry_callback_type(self) -> None:
+        """ChatEntryCallback is a type alias — verify shape matches."""
+        from opal_backend.functions.chat import (
+            ChatEntryCallback as OpalChatEntryCallback,
+        )
+
+        # Both should accept the same (role, content) -> None signature.
+        # Since these are type aliases, we verify they have the same
+        # runtime representation.
+        assert ChatEntryCallback == OpalChatEntryCallback
+
+
+# ---------------------------------------------------------------------------
+# 2. FileData
+# ---------------------------------------------------------------------------
+
+
+class TestFileData:
+    """Verify FileData matches opal_backend.events.FileData."""
+
+    def test_fields_match(self) -> None:
+        from opal_backend.events import FileData as OpalFileData
+
+        bees_fd = FileData(path="/test.txt", content={"parts": [{"text": "hi"}]})
+        opal_fd = OpalFileData(path="/test.txt", content={"parts": [{"text": "hi"}]})
+
+        assert bees_fd.path == opal_fd.path
+        assert bees_fd.content == opal_fd.content
+
+    def test_to_dict_matches(self) -> None:
+        from opal_backend.events import FileData as OpalFileData
+
+        content: LLMContent = {"parts": [{"text": "hello"}]}
+
+        bees_fd = FileData(path="/a.txt", content=content)
+        opal_fd = OpalFileData(path="/a.txt", content=content)
+
+        assert bees_fd.to_dict() == opal_fd.to_dict()
+
+
+# ---------------------------------------------------------------------------
+# 3. AgentResult
+# ---------------------------------------------------------------------------
+
+
+class TestAgentResult:
+    """Verify AgentResult matches opal_backend.events.AgentResult."""
+
+    def test_defaults_match(self) -> None:
+        from opal_backend.events import AgentResult as OpalAgentResult
+
+        bees_ar = AgentResult(success=True)
+        opal_ar = OpalAgentResult(success=True)
+
+        assert bees_ar.success == opal_ar.success
+        assert bees_ar.href == opal_ar.href
+        assert bees_ar.outcomes == opal_ar.outcomes
+        assert bees_ar.intermediate == opal_ar.intermediate
+
+    def test_to_dict_minimal(self) -> None:
+        from opal_backend.events import AgentResult as OpalAgentResult
+
+        bees_ar = AgentResult(success=True)
+        opal_ar = OpalAgentResult(success=True)
+
+        assert bees_ar.to_dict() == opal_ar.to_dict()
+
+    def test_to_dict_full(self) -> None:
+        from opal_backend.events import AgentResult as OpalAgentResult
+        from opal_backend.events import FileData as OpalFileData
+
+        bees_ar = AgentResult(
+            success=True,
+            href="/result",
+            outcomes={"parts": [{"text": "done"}]},
+            intermediate=[
+                FileData(path="/out.txt", content={"parts": [{"text": "data"}]}),
+            ],
+        )
+        opal_ar = OpalAgentResult(
+            success=True,
+            href="/result",
+            outcomes={"parts": [{"text": "done"}]},
+            intermediate=[
+                OpalFileData(path="/out.txt", content={"parts": [{"text": "data"}]}),
+            ],
+        )
+
+        assert bees_ar.to_dict() == opal_ar.to_dict()
+
+    def test_to_dict_default_href_omitted(self) -> None:
+        """Default href '/' is not included in to_dict() output."""
+        ar = AgentResult(success=False)
+        d = ar.to_dict()
+        assert "href" not in d
+
+    def test_to_dict_custom_href_included(self) -> None:
+        ar = AgentResult(success=True, href="/custom")
+        d = ar.to_dict()
+        assert d["href"] == "/custom"
+
+
+# ---------------------------------------------------------------------------
+# 4. WaitForInputEvent
+# ---------------------------------------------------------------------------
+
+
+class TestWaitForInputEvent:
+    """Verify WaitForInputEvent matches opal_backend.events."""
+
+    def test_defaults_match(self) -> None:
+        from opal_backend.events import (
+            WaitForInputEvent as OpalWaitForInputEvent,
+        )
+
+        bees_ev = WaitForInputEvent()
+        opal_ev = OpalWaitForInputEvent()
+
+        assert bees_ev.type == opal_ev.type
+        assert bees_ev.request_id == opal_ev.request_id
+        assert bees_ev.prompt == opal_ev.prompt
+        assert bees_ev.input_type == opal_ev.input_type
+        assert bees_ev.skip_label == opal_ev.skip_label
+        assert bees_ev.interaction_id == opal_ev.interaction_id
+
+    def test_to_dict_matches(self) -> None:
+        from opal_backend.events import (
+            WaitForInputEvent as OpalWaitForInputEvent,
+        )
+
+        kwargs: dict[str, Any] = {
+            "request_id": "req-1",
+            "prompt": {"parts": [{"text": "Enter your name"}], "role": "user"},
+            "input_type": "text",
+            "skip_label": "Skip",
+        }
+
+        bees_ev = WaitForInputEvent(**kwargs)
+        opal_ev = OpalWaitForInputEvent(**kwargs)
+
+        assert bees_ev.to_dict() == opal_ev.to_dict()
+
+    def test_to_dict_minimal(self) -> None:
+        """Minimal event without optional fields."""
+        ev = WaitForInputEvent(request_id="r1")
+        d = ev.to_dict()
+        assert d == {
+            "waitForInput": {
+                "requestId": "r1",
+                "prompt": {},
+                "inputType": "text",
+            },
+        }
+
+
+# ---------------------------------------------------------------------------
+# 5. ChoiceItem
+# ---------------------------------------------------------------------------
+
+
+class TestChoiceItem:
+    """Verify ChoiceItem matches opal_backend.events."""
+
+    def test_to_dict_matches(self) -> None:
+        from opal_backend.events import ChoiceItem as OpalChoiceItem
+
+        bees_ci = ChoiceItem(id="c1", content={"parts": [{"text": "Option A"}]})
+        opal_ci = OpalChoiceItem(id="c1", content={"parts": [{"text": "Option A"}]})
+
+        assert bees_ci.to_dict() == opal_ci.to_dict()
+
+
+# ---------------------------------------------------------------------------
+# 6. WaitForChoiceEvent
+# ---------------------------------------------------------------------------
+
+
+class TestWaitForChoiceEvent:
+    """Verify WaitForChoiceEvent matches opal_backend.events."""
+
+    def test_defaults_match(self) -> None:
+        from opal_backend.events import (
+            WaitForChoiceEvent as OpalWaitForChoiceEvent,
+        )
+
+        bees_ev = WaitForChoiceEvent()
+        opal_ev = OpalWaitForChoiceEvent()
+
+        assert bees_ev.type == opal_ev.type
+        assert bees_ev.selection_mode == opal_ev.selection_mode
+        assert bees_ev.layout == opal_ev.layout
+        assert bees_ev.none_of_the_above_label == opal_ev.none_of_the_above_label
+
+    def test_to_dict_matches(self) -> None:
+        from opal_backend.events import (
+            WaitForChoiceEvent as OpalWaitForChoiceEvent,
+            ChoiceItem as OpalChoiceItem,
+        )
+
+        bees_ev = WaitForChoiceEvent(
+            request_id="req-2",
+            prompt={"parts": [{"text": "Pick one"}]},
+            choices=[
+                ChoiceItem(id="a", content={"parts": [{"text": "A"}]}),
+                ChoiceItem(id="b", content={"parts": [{"text": "B"}]}),
+            ],
+            selection_mode="single",
+            layout="list",
+            none_of_the_above_label="None",
+        )
+        opal_ev = OpalWaitForChoiceEvent(
+            request_id="req-2",
+            prompt={"parts": [{"text": "Pick one"}]},
+            choices=[
+                OpalChoiceItem(id="a", content={"parts": [{"text": "A"}]}),
+                OpalChoiceItem(id="b", content={"parts": [{"text": "B"}]}),
+            ],
+            selection_mode="single",
+            layout="list",
+            none_of_the_above_label="None",
+        )
+
+        assert bees_ev.to_dict() == opal_ev.to_dict()
+
+    def test_to_dict_minimal(self) -> None:
+        ev = WaitForChoiceEvent(request_id="r1")
+        d = ev.to_dict()
+        assert d == {
+            "waitForChoice": {
+                "requestId": "r1",
+                "prompt": {},
+                "choices": [],
+                "selectionMode": "single",
+            },
+        }
+
+
+# ---------------------------------------------------------------------------
+# 7. SuspendError
+# ---------------------------------------------------------------------------
+
+
+class TestSuspendError:
+    """Verify SuspendError matches opal_backend.suspend.SuspendError."""
+
+    def test_is_exception(self) -> None:
+        ev = WaitForInputEvent(request_id="r1")
+        err = SuspendError(ev)
+        assert isinstance(err, Exception)
+
+    def test_properties_match(self) -> None:
+        from opal_backend.suspend import SuspendError as OpalSuspendError
+        from opal_backend.events import (
+            WaitForInputEvent as OpalWaitForInputEvent,
+        )
+
+        fc_part = {"functionCall": {"name": "chat_request_user_input", "args": {}}}
+
+        bees_ev = WaitForInputEvent(request_id="r1")
+        bees_err = SuspendError(bees_ev, fc_part, is_precondition_check=True)
+
+        opal_ev = OpalWaitForInputEvent(request_id="r1")
+        opal_err = OpalSuspendError(opal_ev, fc_part, is_precondition_check=True)
+
+        # Same properties (interaction_id will differ — both are random UUIDs)
+        assert bees_err.event.type == opal_err.event.type
+        assert bees_err.function_call_part == opal_err.function_call_part
+        assert bees_err.is_precondition_check == opal_err.is_precondition_check
+        assert bees_err.completed_responses == opal_err.completed_responses
+
+    def test_interaction_id_is_uuid(self) -> None:
+        ev = WaitForInputEvent()
+        err = SuspendError(ev)
+        # Should be a valid UUID string.
+        parsed = uuid.UUID(err.interaction_id)
+        assert str(parsed) == err.interaction_id
+
+    def test_default_function_call_part(self) -> None:
+        ev = WaitForInputEvent()
+        err = SuspendError(ev)
+        assert err.function_call_part == {}
+
+    def test_exception_message(self) -> None:
+        ev = WaitForInputEvent()
+        err = SuspendError(ev)
+        assert "waitForInput" in str(err)
+
+    def test_choice_event_message(self) -> None:
+        ev = WaitForChoiceEvent()
+        err = SuspendError(ev)
+        assert "waitForChoice" in str(err)
+
+
+# ---------------------------------------------------------------------------
+# 8. SessionTerminator protocol
+# ---------------------------------------------------------------------------
+
+
+class TestSessionTerminator:
+    """Verify LoopController satisfies the SessionTerminator protocol."""
+
+    def test_loop_controller_satisfies_protocol(self) -> None:
+        from opal_backend.loop import LoopController
+
+        assert isinstance(LoopController(), SessionTerminator)
+
+    def test_mock_satisfies_protocol(self) -> None:
+        class MockTerminator:
+            def __init__(self) -> None:
+                self.result: Any = None
+
+            def terminate(self, result: Any) -> None:
+                self.result = result
+
+        assert isinstance(MockTerminator(), SessionTerminator)
+
+    def test_mock_terminator_works(self) -> None:
+        class MockTerminator:
+            def __init__(self) -> None:
+                self.result: Any = None
+
+            def terminate(self, result: Any) -> None:
+                self.result = result
+
+        t = MockTerminator()
+        ar = AgentResult(success=True, outcomes={"parts": [{"text": "done"}]})
+        t.terminate(ar)
+        assert t.result is ar


### PR DESCRIPTION
Adds bees-native copies of the types that function handlers import from
`opal_backend` for suspend/resume, session termination, and context injection.
Migrates existing type imports to use the new bees-native source.

## What

New module `bees/protocols/handler_types.py` with verbatim copies of:

- **`SuspendError`** — exception raised by handlers to request user input
- **`WaitForInputEvent`**, **`WaitForChoiceEvent`**, **`ChoiceItem`** — suspend
  event dataclasses
- **`AgentResult`**, **`FileData`** — session result types
- **`SessionTerminator`** — protocol for the `terminate()` contract
  (`LoopController` satisfies it structurally)
- **`CONTEXT_PARTS_KEY`**, **`ChatEntryCallback`**, **`LLMContent`** — constants
  and type aliases

25 conformance tests verify identical fields, defaults, `to_dict()` output, and
structural protocol satisfaction against `opal_backend`.

Migrated imports in `chat.py` and `test_chat.py` — three fewer `opal_backend`
imports in `bees/functions/`.

## Why

This is the leaf prerequisite in the library extraction dependency graph. With
handler types + pidgin (already done) in place, the next spec can inline the
`_make_handlers` bodies — the final step to eliminating `opal_backend` imports
from `bees/functions/`.

## SDD Cycle

Following [Spec-Driven Development](packages/bees/spec/handler-types.md):

1. ✅ **Specify** — protocol shapes in `handler_types.py`
2. ✅ **Test** — 25 conformance tests (all pass)
3. ✅ **Migrate** — `chat.py`: `SuspendError`, `ChatEntryCallback`,
   `CONTEXT_PARTS_KEY`; `test_chat.py`: `CONTEXT_PARTS_KEY`
4. ✅ **Verify** — 323 tests pass

## Files

- `bees/protocols/handler_types.py` — new protocol module
- `bees/protocols/__init__.py` — exports new types
- `bees/functions/chat.py` — migrated 3 type imports to bees-native
- `tests/test_protocols/test_handler_types.py` — conformance tests
- `tests/test_chat.py` — migrated 1 import to bees-native
- `spec/handler-types.md` — spec doc
- `docs/future.md` — updated progress tracking
- `docs/package-split.md` — updated protocol inventory
