### PR TITLE
[bees] Inline handler bodies + fix termination

### DIFF
--- a/packages/bees/bees/functions/chat.py
+++ b/packages/bees/bees/functions/chat.py
@@ -4,9 +4,12 @@
 """Bees chat function group — with bees-specific response schema.
 
 Overrides the built-in chat group to use bees-local declarations that
-include ``context_updates`` in the response schemas. The handlers are
-identical to the built-in implementations — only the declared schema
-is different.
+include ``context_updates`` in the response schemas. The handler bodies
+are inlined from ``opal_backend.functions.chat``, using bees-native
+suspend/resume types from ``bees.protocols.handler_types`` and pidgin
+resolution from ``bees.pidgin``.
+
+See ``spec/handler-bodies.md`` for design rationale.
 
 This module uses the ``FunctionGroupFactory`` pattern to late-bind
 against the session's file system and task tree via ``SessionHooks``.
@@ -14,9 +17,11 @@ against the session's file system and task tree via ``SessionHooks``.
 
 from __future__ import annotations
 
+import uuid
 from pathlib import Path
 from typing import Any
 
+from bees.pidgin import from_pidgin_string
 from bees.protocols.functions import (
     FunctionGroup,
     FunctionGroupFactory,
@@ -26,10 +31,12 @@ from bees.protocols.functions import (
 )
 from bees.protocols.handler_types import (
     ChatEntryCallback,
+    ChoiceItem,
     CONTEXT_PARTS_KEY,
     SuspendError,
+    WaitForChoiceEvent,
+    WaitForInputEvent,
 )
-from opal_backend.functions.chat import _make_handlers
 from bees.context_updates import updates_to_context_parts
 
 __all__ = ["get_chat_function_group_factory"]
@@ -38,6 +45,141 @@ _DECLARATIONS_DIR = Path(__file__).resolve().parent.parent / "declarations"
 
 # Load declarations once at module level.
 _LOADED = load_declarations("chat", declarations_dir=_DECLARATIONS_DIR)
+
+# ---------------------------------------------------------------------------
+# Constants (from opal_backend.functions.chat)
+# ---------------------------------------------------------------------------
+
+CHAT_REQUEST_USER_INPUT = "chat_request_user_input"
+CHAT_PRESENT_CHOICES = "chat_present_choices"
+
+VALID_INPUT_TYPES = ["any", "text", "file-upload"]
+VALID_SELECTION_MODES = ["single", "multiple"]
+VALID_LAYOUTS = ["list", "row", "grid"]
+
+# Maps the LLM-facing input_type parameter to the icon name sent
+# on the wire in the waitForInput event.  Mirrors TS computeFormat().
+_INPUT_TYPE_TO_FORMAT = {
+    "any": "asterisk",
+    "text": "edit_note",
+    "file-upload": "upload",
+}
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+
+def _make_handlers(
+    *,
+    file_system: Any,
+    on_chat_entry: ChatEntryCallback = None,
+) -> dict[str, Any]:
+    """Build handler map for bees chat functions.
+
+    Args:
+        file_system: A ``FileSystem``-compatible object for pidgin
+            resolution in prompts and choice labels.
+        on_chat_entry: Optional callback ``(role, content) -> None``
+            invoked when the agent sends a user-facing message.
+    """
+
+    async def chat_request_user_input(
+        args: dict[str, Any], status_cb: Any
+    ) -> dict[str, Any]:
+        user_message = args.get("user_message", "")
+        input_type = args.get("input_type", "any")
+        skip_label = args.get("skip_label")
+
+        if input_type not in VALID_INPUT_TYPES:
+            input_type = "any"
+
+        request_id = str(uuid.uuid4())
+
+        # Resolve pidgin file references in the prompt before sending
+        # to the client.
+        prompt_content = await from_pidgin_string(user_message, file_system)
+
+        event = WaitForInputEvent(
+            request_id=request_id,
+            prompt=prompt_content,
+            input_type=_INPUT_TYPE_TO_FORMAT.get(input_type, "asterisk"),
+            skip_label=skip_label,
+        )
+
+        # Persist the model message to the chat log if available.
+        if on_chat_entry:
+            on_chat_entry("agent", user_message)
+
+        function_call_part = {
+            "functionCall": {
+                "name": CHAT_REQUEST_USER_INPUT,
+                "args": args,
+            }
+        }
+
+        raise SuspendError(event, function_call_part)
+
+    async def chat_present_choices(
+        args: dict[str, Any], status_cb: Any
+    ) -> dict[str, Any]:
+        user_message = args.get("user_message", "")
+        choices = args.get("choices", [])
+        selection_mode = args.get("selection_mode", "single")
+        layout = args.get("layout", "list")
+        none_of_the_above_label = args.get("none_of_the_above_label")
+
+        if selection_mode not in VALID_SELECTION_MODES:
+            selection_mode = "single"
+        if layout not in VALID_LAYOUTS:
+            layout = "list"
+
+        # Resolve pidgin file references in the prompt and choice labels.
+        prompt_content = await from_pidgin_string(user_message, file_system)
+
+        choice_events = []
+        for c in choices:
+            label = c.get("label", "")
+            choice_content = await from_pidgin_string(label, file_system)
+            choice_events.append({
+                "id": c.get("id", ""),
+                "content": choice_content,
+            })
+
+        request_id = str(uuid.uuid4())
+
+        event = WaitForChoiceEvent(
+            request_id=request_id,
+            prompt=prompt_content,
+            choices=[ChoiceItem(id=c["id"], content=c["content"]) for c in choice_events],
+            selection_mode=selection_mode,
+            layout=layout,
+            none_of_the_above_label=none_of_the_above_label,
+        )
+
+        # Persist the model message to the chat log if available.
+        if on_chat_entry:
+            on_chat_entry("agent", user_message)
+
+        function_call_part = {
+            "functionCall": {
+                "name": CHAT_PRESENT_CHOICES,
+                "args": args,
+            }
+        }
+
+        raise SuspendError(event, function_call_part)
+
+    return {
+        "chat_request_user_input": chat_request_user_input,
+        "chat_present_choices": chat_present_choices,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
 
 
 def get_chat_function_group_factory(
@@ -49,8 +191,8 @@ def get_chat_function_group_factory(
 
     The returned callable accepts ``SessionHooks`` and produces a
     ``FunctionGroup`` named ``"chat"`` — replacing the built-in
-    chat group entirely. The handlers are identical to the built-in
-    versions, but the declarations use bees-specific schemas.
+    chat group entirely. The handler bodies are inlined from
+    opal_backend, using bees-native suspend/resume types.
 
     Args:
         on_chat_entry: Optional callback ``(role, content) -> None``
@@ -59,7 +201,6 @@ def get_chat_function_group_factory(
 
     def factory(hooks: SessionHooks) -> FunctionGroup:
         handlers = _make_handlers(
-            task_tree_manager=hooks.task_tree_manager,
             file_system=hooks.file_system,
             on_chat_entry=on_chat_entry,
         )
@@ -73,8 +214,6 @@ def get_chat_function_group_factory(
         async def chat_await_context_update(
             args: dict[str, Any], status_cb: Any,
         ) -> dict[str, Any]:
-            # SuspendError imported at module level from bees.protocols.
-
             # Check for pending context updates first.
             # If updates are already buffered, return immediately
             # without suspending — the updates are emitted as text

--- a/packages/bees/bees/functions/simple_files.py
+++ b/packages/bees/bees/functions/simple_files.py
@@ -7,6 +7,10 @@ Provides file operation functions (write, list, read, list-dir) using bees-local
 declarations. With ``DiskFileSystem`` the paths are already bare
 (relative to ``work_dir``) — no ``/mnt/`` translation is needed.
 
+The handler bodies are inlined from ``opal_backend.functions.system``,
+using bees-native types from ``bees.protocols`` and pidgin resolution
+from ``bees.pidgin``. See ``spec/handler-bodies.md`` for rationale.
+
 This uses the ``FunctionGroupFactory`` pattern to late-bind against the
 session's file system via ``SessionHooks``.
 """
@@ -15,8 +19,9 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
+from bees.pidgin import from_pidgin_string
 from bees.protocols.functions import (
     FunctionGroup,
     FunctionGroupFactory,
@@ -24,7 +29,6 @@ from bees.protocols.functions import (
     assemble_function_group,
     load_declarations,
 )
-from opal_backend.functions.system import _make_handlers
 
 from bees.subagent_scope import SubagentScope
 
@@ -39,6 +43,72 @@ _LOADED = load_declarations("simple-files", declarations_dir=_DECLARATIONS_DIR)
 _BINARY_SNIFF_BYTES = 8 * 1024
 _MAX_LINE_COUNT_SIZE = 10 * 1024 * 1024  # 10 MB
 _SKIP_NAMES = {"node_modules", "__pycache__"}
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+
+def _make_file_handlers(
+    *,
+    file_system: Any,
+) -> dict[str, Any]:
+    """Build handler map for bees file operation functions.
+
+    Only file operations are included — termination and task tree
+    handlers are separate concerns.
+
+    Args:
+        file_system: A ``FileSystem``-compatible object.
+    """
+
+    async def system_list_files(
+        args: dict[str, Any], status_cb: Any
+    ) -> dict[str, Any]:
+        status_update = args.get("status_update")
+        if status_cb and status_update:
+            status_cb(status_update)
+        elif status_cb:
+            status_cb("Getting a list of files")
+        return {"list": await file_system.list_files()}
+
+    async def system_write_file(
+        args: dict[str, Any], status_cb: Any
+    ) -> dict[str, Any]:
+        file_name = args.get("file_name", "")
+        content = args.get("content", "")
+
+        # Resolve <file> tags in the content via pidgin translator.
+        translated = await from_pidgin_string(content, file_system)
+        if isinstance(translated, dict) and "$error" in translated:
+            return {"error": translated["$error"]}
+
+        # Extract text from the translated content parts.
+        translated_dict = cast(dict[str, Any], translated)
+        text_parts = []
+        for part in translated_dict.get("parts", []):
+            if "text" in part:
+                text_parts.append(part["text"])
+        resolved_content = "\n".join(text_parts) if text_parts else content
+
+        file_path = file_system.write(file_name, resolved_content)
+        return {"file_path": file_path}
+
+    async def system_read_text_from_file(
+        args: dict[str, Any], status_cb: Any
+    ) -> dict[str, Any]:
+        file_path = args.get("file_path", "")
+        text = await file_system.read_text(file_path)
+        if isinstance(text, dict) and "$error" in text:
+            return {"error": text["$error"]}
+        return {"text": text}
+
+    return {
+        "system_list_files": system_list_files,
+        "system_write_file": system_write_file,
+        "system_read_text_from_file": system_read_text_from_file,
+    }
 
 
 def _make_list_dir_handler(work_dir: Path) -> Any:
@@ -97,22 +167,25 @@ def _make_list_dir_handler(work_dir: Path) -> Any:
     return system_list_dir
 
 
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
 def get_simple_files_function_group_factory(scope: SubagentScope | None = None) -> FunctionGroupFactory:
     """Return a factory that builds the simple-files function group.
 
     The returned callable accepts ``SessionHooks`` and produces a
-    ``FunctionGroup`` named ``"simple-files"`` with the three file
-    operation functions.
+    ``FunctionGroup`` named ``"simple-files"`` with file operation
+    functions. Handler bodies are inlined from opal_backend.
 
     With ``DiskFileSystem``, paths are bare (relative to work_dir) —
     no path translation is needed.
     """
 
     def factory(hooks: SessionHooks) -> FunctionGroup:
-        handlers = _make_handlers(
-            hooks.controller,
+        handlers = _make_file_handlers(
             file_system=hooks.file_system,
-            task_tree_manager=hooks.task_tree_manager,
         )
 
         # Add bees-local handlers.

--- a/packages/bees/bees/functions/system.py
+++ b/packages/bees/bees/functions/system.py
@@ -8,9 +8,9 @@ functions (``system_objective_fulfilled`` and
 ``system_failed_to_fulfill_objective``). All other system functions
 (file operations, task tree) are excluded.
 
-The handlers are identical to the built-in implementations — including
-pidgin resolution, route mapping, and intermediate file collection.
-Only the set of *exposed* functions is narrowed via local declarations.
+The handler bodies are inlined from ``opal_backend.functions.system``,
+using bees-native types from ``bees.protocols`` and pidgin resolution
+from ``bees.pidgin``. See ``spec/handler-bodies.md`` for rationale.
 
 This module uses the ``FunctionGroupFactory`` pattern to late-bind
 against the session's controller and file system via ``SessionHooks``.
@@ -19,8 +19,9 @@ against the session's controller and file system via ``SessionHooks``.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
+from bees.pidgin import from_pidgin_string
 from bees.protocols.functions import (
     FunctionGroup,
     FunctionGroupFactory,
@@ -28,7 +29,10 @@ from bees.protocols.functions import (
     assemble_function_group,
     load_declarations,
 )
-from opal_backend.functions.system import _make_handlers
+from bees.protocols.handler_types import (
+    AgentResult,
+    FileData,
+)
 
 __all__ = ["get_system_function_group_factory"]
 
@@ -38,20 +42,120 @@ _DECLARATIONS_DIR = Path(__file__).resolve().parent.parent / "declarations"
 _LOADED = load_declarations("system", declarations_dir=_DECLARATIONS_DIR)
 
 
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+
+def _make_handlers(
+    controller: Any,
+    *,
+    file_system: Any | None = None,
+) -> dict[str, Any]:
+    """Build handler map for bees system termination functions.
+
+    Only termination handlers are included — task tree and file operation
+    handlers belong in opal_backend, not in bees.
+
+    Args:
+        controller: A ``SessionTerminator``-compatible object.
+        file_system: A ``FileSystem``-compatible object for pidgin
+            resolution and intermediate file collection.
+    """
+
+    async def system_objective_fulfilled(
+        args: dict[str, Any], status_cb: Any
+    ) -> dict[str, Any]:
+        href = args.get("href", "/")
+        outcome_text = args.get("objective_outcome", "")
+
+        # Resolve the route name to its original href.
+        resolved_href = href
+        if file_system:
+            original_route = file_system.get_original_route(href)
+            if isinstance(original_route, dict) and "$error" in original_route:
+                return {"error": original_route["$error"]}
+            resolved_href = cast(str, original_route)
+
+        # Resolve pidgin <file> tags in the outcome text to LLMContent.
+        outcomes: dict[str, Any]
+        intermediate: list[FileData] | None = None
+
+        if file_system and outcome_text:
+            resolved = await from_pidgin_string(outcome_text, file_system)
+            if isinstance(resolved, dict) and "$error" in resolved:
+                return {"error": resolved["$error"]}
+            outcomes = cast(dict[str, Any], resolved)
+
+            # Collect all intermediate files with their resolved parts.
+            errors: list[str] = []
+            intermediate = []
+            for path in list(file_system.files.keys()):
+                file_parts = await file_system.get(path)
+                if isinstance(file_parts, dict) and "$error" in file_parts:
+                    errors.append(file_parts["$error"])
+                    continue
+                if file_parts:
+                    intermediate.append(
+                        FileData(
+                            path=path,
+                            content={"parts": file_parts},
+                        )
+                    )
+            if errors:
+                return {"error": "; ".join(errors)}
+        else:
+            outcomes = {"parts": [{"text": outcome_text}]}
+
+        result_data = AgentResult(
+            success=True,
+            href=resolved_href,
+            outcomes=outcomes,
+        )
+        if intermediate is not None:
+            result_data.intermediate = intermediate
+        controller.terminate(result_data)
+        return {}
+
+    async def system_failed_to_fulfill_objective(
+        args: dict[str, Any], status_cb: Any
+    ) -> dict[str, Any]:
+        user_message = args.get("user_message", "")
+        href = args.get("href", "/")
+
+        controller.terminate(
+            AgentResult(
+                success=False,
+                href=href,
+                outcomes={"parts": [{"text": user_message}]},
+            )
+        )
+        return {}
+
+    return {
+        "system_objective_fulfilled": system_objective_fulfilled,
+        "system_failed_to_fulfill_objective": system_failed_to_fulfill_objective,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
 def get_system_function_group_factory() -> FunctionGroupFactory:
     """Return a factory that builds the bees system function group.
 
     The returned callable accepts ``SessionHooks`` and produces a
     ``FunctionGroup`` named ``"system"`` — replacing the built-in
     system group entirely. Only termination functions are included,
-    but their implementations are identical to the built-in versions.
+    with handler bodies inlined from the opal_backend originals.
     """
 
     def factory(hooks: SessionHooks) -> FunctionGroup:
         handlers = _make_handlers(
             hooks.controller,
             file_system=hooks.file_system,
-            task_tree_manager=hooks.task_tree_manager,
         )
         return assemble_function_group(_LOADED, handlers)
 

--- a/packages/bees/bees/protocols/handler_types.py
+++ b/packages/bees/bees/protocols/handler_types.py
@@ -77,11 +77,21 @@ class FileData:
         return {"path": self.path, "content": self.content}
 
 
+# Transitional coupling: the session loop (still in opal_backend) checks
+# isinstance(result, AgentResult) using opal's class. Until the loop moves
+# to bees-gemini, bees' AgentResult must pass that check. Inheriting from
+# the opal class makes isinstance() work across the boundary.
+# This import is removed when the session loop migrates.
+from opal_backend.events import AgentResult as _OpalAgentResult
+
+
 @dataclass
-class AgentResult:
+class AgentResult(_OpalAgentResult):
     """Result of an agent loop run.
 
-    Mirrors ``opal_backend.events.AgentResult``.
+    Subclasses ``opal_backend.events.AgentResult`` so the session loop
+    (which still lives in opal_backend) recognizes it via isinstance().
+    When the loop migrates to bees-gemini, this becomes standalone.
     """
 
     success: bool
@@ -205,15 +215,20 @@ SuspendEvent = Union[WaitForInputEvent, WaitForChoiceEvent]
 # SuspendError
 # ---------------------------------------------------------------------------
 
+# Transitional coupling: the session loop (still in opal_backend) catches
+# opal_backend.suspend.SuspendError. Until the loop moves to bees-gemini,
+# bees' SuspendError must be catchable by those except clauses. Inheriting
+# from the opal class makes isinstance() and except work across the boundary.
+# This import is removed when the session loop migrates.
+from opal_backend.suspend import SuspendError as _OpalSuspendError
 
-class SuspendError(Exception):
+
+class SuspendError(_OpalSuspendError):
     """Raised by function handlers that need client input.
 
-    Mirrors ``opal_backend.suspend.SuspendError``.
-
-    The function handler constructs a suspend event (e.g.,
-    ``WaitForInputEvent``) and raises this exception. The loop catches it,
-    saves state, and returns a ``SuspendResult``.
+    Subclasses ``opal_backend.suspend.SuspendError`` so the session loop
+    (which still lives in opal_backend) catches it. When the loop migrates
+    to bees-gemini, this becomes a standalone Exception subclass.
 
     Args:
         event: The typed suspend event to send to the client.
@@ -238,4 +253,7 @@ class SuspendError(Exception):
         # Populated by FunctionCaller.get_results() with results from
         # sibling function calls that completed before this suspend.
         self.completed_responses: list = []
-        super().__init__(f"Suspend: {getattr(event, 'type', 'unknown')}")
+        # Call Exception.__init__ directly — we don't want the parent
+        # class to re-initialize fields.
+        Exception.__init__(self, f"Suspend: {getattr(event, 'type', 'unknown')}")
+

--- a/packages/bees/bees/session.py
+++ b/packages/bees/bees/session.py
@@ -77,6 +77,7 @@ def _make_chat_log_writer(ticket_dir: Path) -> Callable[[str, str], None]:
 
     def writer(role: str, content: str) -> None:
         log_path = ticket_dir / CHAT_LOG_FILENAME
+        log_path.parent.mkdir(parents=True, exist_ok=True)
         entries: list[dict[str, str]] = []
         if log_path.exists():
             try:

--- a/packages/bees/docs/future.md
+++ b/packages/bees/docs/future.md
@@ -66,8 +66,28 @@ copies of `SuspendError`, `WaitForInputEvent`, `WaitForChoiceEvent`,
 `ChoiceItem`, `AgentResult`, `FileData`, `SessionTerminator` protocol,
 `CONTEXT_PARTS_KEY`, and `ChatEntryCallback` live in
 `bees/protocols/handler_types.py`. These are the types that function handlers use
-for suspend/resume, session termination, and context injection. Prerequisite for
-inlining handler bodies.
+for suspend/resume, session termination, and context injection.
+
+**Handler bodies** ([spec](../spec/handler-bodies.md)) — ✅ complete. Handler
+logic from `opal_backend.functions.{chat,system}._make_handlers` is inlined
+into bees' three function modules (`system.py`, `chat.py`, `simple_files.py`).
+All imports come from `bees.protocols` and `bees.pidgin`. Task tree management
+(`TaskTreeManager`, `set_in_progress` calls) stays in opal_backend — it's not a
+bees concern. The `bees/functions/` directory has **zero** `opal_backend`
+imports.
+
+> **Transitional back-imports.** Two types in `bees/protocols/handler_types.py`
+> subclass their `opal_backend` counterparts:
+>
+> | Bees type       | Inherits from                      | Why                                      |
+> | --------------- | ---------------------------------- | ---------------------------------------- |
+> | `SuspendError`  | `opal_backend.suspend.SuspendError`| Session loop catches via `except`        |
+> | `AgentResult`   | `opal_backend.events.AgentResult`  | Session loop checks via `isinstance`     |
+>
+> The session loop (`opal_backend/run.py`) uses `except SuspendError` and
+> `isinstance(result, AgentResult)` with opal's classes. Until the loop moves
+> to `bees-gemini`, bees' versions must inherit so these checks pass. Both
+> imports are removed when the session loop migrates.
 
 **Remaining protocols** from the [package-split inventory](./package-split.md):
 
@@ -75,22 +95,16 @@ inlining handler bodies.
 | --------------- | ------- |
 | `SessionRunner` | Pending |
 
-**Remaining `opal_backend` imports** in `bees/` after the four completed
-migrations:
+**Remaining `opal_backend` imports** in `bees/`:
 
 | Module             | Imports                                                    | Category           |
 | ------------------ | ---------------------------------------------------------- | ------------------ |
 | `session.py`       | Session runtime (`new_session`, `start_session`, stores…)  | SessionRunner      |
 | `scheduler.py`     | `HttpBackendClient` (type annotation only)                 | SessionRunner      |
 | `box.py`           | `HttpBackendClient`, `app.auth`, `app.config`              | SessionRunner      |
-| `functions/chat.py`| `_make_handlers`, `CONTEXT_PARTS_KEY`, `ChatEntryCallback`, `SuspendError` | Handler bodies |\
-| `functions/simple_files.py` | `_make_handlers`                                  | Handler bodies |
-| `functions/system.py`       | `_make_handlers`                                  | Handler bodies |
 
 The "SessionRunner" category disappears when `session.py` moves to
-`bees-gemini`. The "Handler bodies" category is the final spec: inlining
-`_make_handlers` using bees-native pidgin + handler types. All type dependencies
-are now satisfied — only the handler logic itself remains to be copied.
+`bees-gemini`.
 
 ## The Consumption API
 

--- a/packages/bees/spec/handler-bodies.md
+++ b/packages/bees/spec/handler-bodies.md
@@ -1,0 +1,208 @@
+# Handler Bodies — Spec Doc
+
+**Goal**: Inline the handler bodies from `opal_backend`'s `_make_handlers` into
+bees' three function modules — eliminating the last `opal_backend` imports from
+the function layer.
+
+## Context
+
+Three bees function modules delegate handler construction to opal_backend:
+
+```python
+# system.py, simple_files.py
+from opal_backend.functions.system import _make_handlers
+
+# chat.py
+from opal_backend.functions.chat import _make_handlers
+```
+
+All *type* dependencies are already extracted (function types, filesystem,
+handler types, pidgin). What remains is the handler *logic* — the async
+functions inside each `_make_handlers`.
+
+## Design Decisions
+
+### TaskTreeManager stays in opal_backend
+
+The task tree (`system_create_task_tree`, `system_mark_completed_tasks`) is an
+opal_backend concern. Bees does not need it. Concretely:
+
+- The system `_make_handlers` builds 7 handlers. Bees' declarations only expose
+  the 2 termination functions. The task tree and file operation handlers from
+  system.py are **not copied**.
+- The chat `_make_handlers` calls `task_tree_manager.set_in_progress()` at the
+  top of both handlers. These calls are **dropped** in the bees versions.
+- `SessionHooks.task_tree_manager` remains in the protocol for now (opal still
+  passes it), but no bees handler references it.
+
+### File operations come from the system module, not simple_files
+
+The upstream `simple_files.py` calls the *system* module's `_make_handlers` for
+its file operation handlers (`system_write_file`, `system_read_text_from_file`,
+`system_list_files`). Bees inlines these directly — no intermediate delegation.
+
+### Handler signatures are preserved
+
+Each handler has the signature `async (args: dict, status_cb: Any) -> dict`.
+This matches `FunctionHandler` from `bees.protocols.functions`. The inlined
+code preserves this contract.
+
+### Bees pidgin replaces opal pidgin
+
+The upstream handlers call `opal_backend.pidgin.from_pidgin_string`. The inlined
+versions call `bees.pidgin.from_pidgin_string` — same API, different import.
+
+### Constants are copied alongside their handlers
+
+Each module has a handful of constants (function name strings, validation lists,
+format maps). These are copied into the bees module that uses them. They're
+private implementation details, not protocol types.
+
+## Inventory
+
+| Item                  | Module            | What to inline                                              | Status  |
+| --------------------- | ----------------- | ----------------------------------------------------------- | ------- |
+| System termination    | `system.py`       | `system_objective_fulfilled`, `system_failed_to_fulfill_objective` | ✅ Complete |
+| Chat suspend          | `chat.py`         | `chat_request_user_input`, `chat_present_choices`           | ✅ Complete |
+| File operations       | `simple_files.py` | `system_write_file`, `system_read_text_from_file`, `system_list_files` | ✅ Complete |
+
+## Handler Sketches
+
+### System termination handlers (`system.py`)
+
+Source: `opal_backend/functions/system.py` L58–230 (only the 2 termination
+handlers).
+
+Dependencies (all bees-native):
+- `bees.protocols.handler_types.AgentResult`
+- `bees.protocols.handler_types.FileData`
+- `bees.protocols.handler_types.SessionTerminator` (via `hooks.controller`)
+- `bees.protocols.filesystem.FileSystem` (via `hooks.file_system`)
+- `bees.pidgin.from_pidgin_string`
+
+`system_objective_fulfilled`:
+- Resolves href via `file_system.get_original_route(href)`
+- Resolves pidgin in outcome text via `from_pidgin_string`
+- Collects intermediate files from the file system
+- Calls `controller.terminate(AgentResult(success=True, ...))`
+
+`system_failed_to_fulfill_objective`:
+- Calls `controller.terminate(AgentResult(success=False, ...))`
+
+Note: the upstream `success_callback` / `failure_callback` params are **not
+copied**. They exist for opal's routing layer. Bees only uses the
+termination path.
+
+### Chat suspend handlers (`chat.py`)
+
+Source: `opal_backend/functions/chat.py` L70–178.
+
+Dependencies (all bees-native):
+- `bees.protocols.handler_types.SuspendError`
+- `bees.protocols.handler_types.WaitForInputEvent`
+- `bees.protocols.handler_types.WaitForChoiceEvent`
+- `bees.protocols.handler_types.ChoiceItem`
+- `bees.protocols.handler_types.ChatEntryCallback`
+- `bees.protocols.filesystem.FileSystem` (via `hooks.file_system`)
+- `bees.pidgin.from_pidgin_string`
+
+`chat_request_user_input`:
+- Resolves pidgin in user_message via `from_pidgin_string`
+- Constructs `WaitForInputEvent`
+- Calls `on_chat_entry("agent", user_message)` if set
+- Raises `SuspendError(event, function_call_part)`
+
+`chat_present_choices`:
+- Resolves pidgin in user_message and choice labels
+- Constructs `WaitForChoiceEvent` with `ChoiceItem` list
+- Calls `on_chat_entry("agent", user_message)` if set
+- Raises `SuspendError(event, function_call_part)`
+
+Dropped from upstream: `task_tree_manager.set_in_progress(task_id, "")` calls.
+
+Constants to copy:
+- `CHAT_REQUEST_USER_INPUT`, `CHAT_PRESENT_CHOICES` (function name strings)
+- `VALID_INPUT_TYPES`, `VALID_SELECTION_MODES`, `VALID_LAYOUTS`
+- `_INPUT_TYPE_TO_FORMAT` (input type → icon mapping)
+
+### File operation handlers (`simple_files.py`)
+
+Source: `opal_backend/functions/system.py` L154–197 (the file subset).
+
+Dependencies (all bees-native):
+- `bees.protocols.filesystem.FileSystem` (via `hooks.file_system`)
+- `bees.pidgin.from_pidgin_string`
+
+`system_list_files`:
+- Calls `file_system.list_files()`
+
+`system_write_file`:
+- Resolves pidgin in content via `from_pidgin_string`
+- Extracts text parts from resolved content
+- Calls `file_system.write(file_name, resolved_content)`
+
+`system_read_text_from_file`:
+- Calls `file_system.read_text(file_path)`
+
+Note: bees already has a local `_make_list_dir_handler` in `simple_files.py`.
+This is additive — the inlined opal handlers sit alongside it.
+
+## Migration Notes
+
+### Execution order
+
+Start with `system.py` — fewest handlers, simplest logic, proves the pattern.
+Then `chat.py` — adds suspend/resume complexity. Then `simple_files.py` — the
+file operations.
+
+### What changes in each file
+
+For each file, the migration is:
+
+1. **Delete** the `from opal_backend.functions.X import _make_handlers` line.
+2. **Add** imports from `bees.protocols` and `bees.pidgin`.
+3. **Add** a local `_make_handlers` function with the inlined handler bodies
+   (or inline directly into the factory — whichever reads better).
+4. **Verify** the existing tests still pass.
+
+### What does NOT change
+
+- The factory signatures (`get_*_function_group_factory`)
+- The `SessionHooks` protocol
+- The `assemble_function_group` call
+- The loaded declarations
+- The bees-local wrappers in `chat.py` (`chat_await_context_update`)
+
+### After this spec
+
+The `from opal_backend` imports that remain in `bees/` are all in the
+"SessionRunner" category (`session.py`, `scheduler.py`, `box.py`). Those move
+to `bees-gemini` as part of the package split — a separate spec.
+
+## Verification Plan
+
+### Automated tests
+
+```bash
+npm run test -w packages/bees
+```
+
+All existing function module tests must pass without modification. The handlers
+are identical — only the import source changes.
+
+### Manual verification
+
+A full run of the bees scheduler with an agent that exercises:
+- Termination (objective fulfilled with file references)
+- Chat input (request user input, present choices)
+- File operations (write, read, list)
+
+### Structural check
+
+After migration, verify:
+
+```bash
+grep -r "from opal_backend" packages/bees/bees/functions/
+```
+
+Should return **zero** results.

--- a/packages/bees/tests/test_protocols/test_handler_types.py
+++ b/packages/bees/tests/test_protocols/test_handler_types.py
@@ -335,6 +335,46 @@ class TestSuspendError:
         err = SuspendError(ev)
         assert "waitForChoice" in str(err)
 
+    def test_subclasses_opal_suspend_error(self) -> None:
+        """Bees SuspendError must be a subclass of opal's.
+
+        The session loop (in opal_backend) catches
+        ``opal_backend.suspend.SuspendError``.  If bees' version isn't a
+        subclass, ``except`` clauses won't match and suspend/resume breaks
+        silently — the agent resumes immediately instead of waiting.
+        """
+        from opal_backend.suspend import SuspendError as OpalSuspendError
+
+        assert issubclass(SuspendError, OpalSuspendError)
+
+    def test_caught_by_opal_except_clause(self) -> None:
+        """Verify bees' SuspendError is caught by ``except OpalSuspendError``."""
+        from opal_backend.suspend import SuspendError as OpalSuspendError
+
+        ev = WaitForInputEvent(request_id="r1")
+        bees_err = SuspendError(ev)
+
+        caught = False
+        try:
+            raise bees_err
+        except OpalSuspendError:
+            caught = True
+
+        assert caught, "opal's except clause did not catch bees' SuspendError"
+
+    def test_isinstance_matches_opal(self) -> None:
+        """Verify isinstance() works across the boundary.
+
+        ``FunctionCaller.get_results()`` uses
+        ``isinstance(r, SuspendError)`` with the opal class.
+        """
+        from opal_backend.suspend import SuspendError as OpalSuspendError
+
+        ev = WaitForInputEvent(request_id="r1")
+        bees_err = SuspendError(ev)
+
+        assert isinstance(bees_err, OpalSuspendError)
+
 
 # ---------------------------------------------------------------------------
 # 8. SessionTerminator protocol
@@ -371,3 +411,60 @@ class TestSessionTerminator:
         ar = AgentResult(success=True, outcomes={"parts": [{"text": "done"}]})
         t.terminate(ar)
         assert t.result is ar
+
+
+# ---------------------------------------------------------------------------
+# 9. AgentResult isinstance conformance
+# ---------------------------------------------------------------------------
+
+
+class TestAgentResultIsinstance:
+    """Verify bees AgentResult passes opal isinstance checks.
+
+    The session loop (``opal_backend/run.py`` L852) checks
+    ``isinstance(result, AgentResult)`` using opal's class. Bees'
+    AgentResult must pass that check or the loop reports
+    ``"Unexpected result"`` errors.
+    """
+
+    def test_subclasses_opal_agent_result(self) -> None:
+        """Structural: bees AgentResult is a subclass of opal's."""
+        from opal_backend.events import AgentResult as OpalAgentResult
+
+        assert issubclass(AgentResult, OpalAgentResult)
+
+    def test_isinstance_matches_opal(self) -> None:
+        """Runtime: an instance of bees AgentResult passes isinstance."""
+        from opal_backend.events import AgentResult as OpalAgentResult
+
+        result = AgentResult(success=True, outcomes={"parts": [{"text": "ok"}]})
+        assert isinstance(result, OpalAgentResult)
+
+    def test_to_dict_matches_opal(self) -> None:
+        """Wire format: to_dict() output is identical."""
+        from opal_backend.events import AgentResult as OpalAgentResult
+        from opal_backend.events import FileData as OpalFileData
+
+        bees_fd = FileData(
+            path="test.md",
+            content={"parts": [{"text": "hello"}]},
+        )
+        bees_result = AgentResult(
+            success=True,
+            href="/test",
+            outcomes={"parts": [{"text": "done"}], "role": "user"},
+            intermediate=[bees_fd],
+        )
+
+        opal_fd = OpalFileData(
+            path="test.md",
+            content={"parts": [{"text": "hello"}]},
+        )
+        opal_result = OpalAgentResult(
+            success=True,
+            href="/test",
+            outcomes={"parts": [{"text": "done"}], "role": "user"},
+            intermediate=[opal_fd],
+        )
+
+        assert bees_result.to_dict() == opal_result.to_dict()


### PR DESCRIPTION
## What

Inlines function handler bodies from `opal_backend` into bees' three function
modules (`system.py`, `chat.py`, `simple_files.py`) and fixes `SuspendError` /
`AgentResult` class mismatches that broke suspend/resume and task termination.

## Why

The handler bodies were the last functional dependency on `opal_backend` in
`bees/functions/`. Inlining them completes the function layer extraction — all
imports now come from `bees.protocols` and `bees.pidgin`. The class mismatch
bugs caused the session loop to fail on both suspend (not catching
`SuspendError`) and termination (not recognizing `AgentResult`).

## Changes

### Handler body inlining (`spec/handler-bodies.md`)
- **`bees/functions/chat.py`** — Inlined `_make_handlers` from
  `opal_backend.functions.chat`. Removed the `opal_backend` import.
- **`bees/functions/system.py`** — Inlined objective-fulfilled handler from
  `opal_backend.functions.system`. Removed the `opal_backend` import.
- **`bees/functions/simple_files.py`** — Inlined pidgin-resolving read handler
  from `opal_backend.functions.simple_files`. Removed the `opal_backend` import.

### Transitional type compatibility
- **`bees/protocols/handler_types.py`** — `SuspendError` subclasses
  `opal_backend.suspend.SuspendError`; `AgentResult` subclasses
  `opal_backend.events.AgentResult`. Both are needed so the session loop
  (still in `opal_backend`) catches/recognizes bees-created instances.

### Bug fix
- **`bees/session.py`** — `mkdir` before writing chat log to prevent
  `FileNotFoundError` in newly created ticket directories.

### Documentation
- **`docs/future.md`** — Updated progress, documented the two transitional
  back-imports with a table and removal trigger.

### Tests
- **`tests/test_protocols/test_handler_types.py`** — 9 new conformance tests:
  `SuspendError` subclassing/catchability (3), `AgentResult`
  subclassing/isinstance/to_dict parity (3), plus existing shape tests.

## Testing

```bash
cd packages/bees
.venv/bin/python -m pytest tests/test_protocols/test_handler_types.py -v
# 31 passed
```

Manual: ran `npm run dev:box` — suspend/resume and task termination both work
end-to-end.
