### PR TITLE
[bees] Extract session observation types to bees.protocols

### DIFF
--- a/packages/bees/bees/protocols/__init__.py
+++ b/packages/bees/bees/protocols/__init__.py
@@ -8,7 +8,7 @@ Each module defines the types for one boundary:
 - ``functions`` — function declaration, assembly, and dispatch.
 - ``filesystem`` — FileSystem protocol and supporting types.
 - ``handler_types`` — suspend/resume, termination, and context injection.
-- (future) ``session`` — SessionRunner, SessionConfiguration, etc.
+- ``session`` — session observation types (result, event constants).
 """
 
 from bees.protocols.filesystem import (
@@ -51,6 +51,11 @@ from bees.protocols.handler_types import (
     WaitForChoiceEvent,
     WaitForInputEvent,
 )
+from bees.protocols.session import (
+    PAUSE_TYPES,
+    SUSPEND_TYPES,
+    SessionResult,
+)
 
 __all__ = [
     # filesystem
@@ -90,4 +95,8 @@ __all__ = [
     "SuspendEvent",
     "WaitForChoiceEvent",
     "WaitForInputEvent",
+    # session observation
+    "PAUSE_TYPES",
+    "SUSPEND_TYPES",
+    "SessionResult",
 ]

--- a/packages/bees/bees/protocols/session.py
+++ b/packages/bees/bees/protocols/session.py
@@ -1,0 +1,83 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Session observation types — the output contract of a session.
+
+Defines the types that the orchestration layer (``TaskRunner``,
+``Scheduler``, ``EvalCollector``) uses to interpret session output:
+
+- ``SessionResult`` — structured result of a completed or suspended session.
+- ``SUSPEND_TYPES`` — event type strings that signal session suspension.
+- ``PAUSE_TYPES`` — event type strings that signal transient pause.
+
+These types are the shared vocabulary between the runner (which produces
+events) and the orchestrator (which categorizes them).  They are
+prerequisites for the ``SessionRunner`` protocol.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+__all__ = [
+    "PAUSE_TYPES",
+    "SUSPEND_TYPES",
+    "SessionResult",
+]
+
+
+# ---------------------------------------------------------------------------
+# Event type constants
+# ---------------------------------------------------------------------------
+
+SUSPEND_TYPES: frozenset[str] = frozenset({
+    "waitForInput",
+    "waitForChoice",
+    "readGraph",
+    "inspectNode",
+    "applyEdits",
+    "queryConsent",
+})
+"""Event type strings that indicate the session has suspended.
+
+The event stream is a sequence of ``dict[str, Any]`` where each dict has a
+single key naming the event type.  If that key is in ``SUSPEND_TYPES``, the
+session is waiting for a client response before continuing.
+"""
+
+PAUSE_TYPES: frozenset[str] = frozenset({"paused"})
+"""Event type strings that indicate a transient infrastructure pause.
+
+The scheduler can retry the session later without user intervention.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Session result
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SessionResult:
+    """Result of a completed or suspended session.
+
+    Produced by the session runner and consumed by ``TaskRunner`` for
+    metadata bookkeeping and by ``Scheduler`` for orchestration decisions.
+    """
+
+    session_id: str
+    status: str
+    events: int
+    output: str
+    turns: int = 0
+    thoughts: int = 0
+    outcome: str | None = None
+    error: str | None = None
+    files: list[dict[str, str]] = field(default_factory=list)
+    intermediate: list[dict[str, Any]] | None = None
+    suspended: bool = False
+    suspend_event: dict[str, Any] | None = None
+    outcome_content: dict[str, Any] | None = None
+    paused: bool = False
+    paused_event: dict[str, Any] | None = None

--- a/packages/bees/bees/scheduler.py
+++ b/packages/bees/bees/scheduler.py
@@ -45,7 +45,7 @@ from typing import Any, Awaitable, Callable
 
 from bees.coordination import route_coordination_task
 from bees.playbook import run_task_done_hooks, load_system_config, run_playbook
-from bees.session import SessionResult
+from bees.protocols.session import SessionResult
 from bees.task_runner import TaskRunner
 from bees.ticket import Ticket
 from bees.task_store import TaskStore

--- a/packages/bees/bees/session.py
+++ b/packages/bees/bees/session.py
@@ -27,7 +27,7 @@ import httpx
 
 from opal_backend.local.backend_client_impl import HttpBackendClient
 from opal_backend.local.interaction_store_impl import InMemoryInteractionStore
-from opal_backend.events import PAUSE_TYPES, SUSPEND_TYPES
+from bees.protocols.session import PAUSE_TYPES, SUSPEND_TYPES, SessionResult
 from opal_backend.interaction_store import InteractionState
 from opal_backend.sessions.api import (
     Subscribers,
@@ -97,30 +97,9 @@ def append_chat_log(ticket_dir: Path, role: str, text: str) -> None:
     _make_chat_log_writer(ticket_dir)(role, text)
 
 
-# ---------------------------------------------------------------------------
-# Session result
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class SessionResult:
-    """Result of a completed or suspended session."""
-
-    session_id: str
-    status: str
-    events: int
-    output: str
-    turns: int = 0
-    thoughts: int = 0
-    outcome: str | None = None
-    error: str | None = None
-    files: list[dict[str, str]] = field(default_factory=list)
-    intermediate: list[dict[str, Any]] | None = None
-    suspended: bool = False
-    suspend_event: dict[str, Any] | None = None
-    outcome_content: dict[str, Any] | None = None
-    paused: bool = False
-    paused_event: dict[str, Any] | None = None
+# SessionResult is defined in bees.protocols.session and re-exported here
+# for backward compatibility.
+__all__ = ["SessionResult"]
 
 
 # ---------------------------------------------------------------------------

--- a/packages/bees/bees/task_runner.py
+++ b/packages/bees/bees/task_runner.py
@@ -18,9 +18,9 @@ import sys
 from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable
 
+from bees.protocols.session import SessionResult
 from bees.segments import resolve_segments
 from bees.session import (
-    SessionResult,
     append_chat_log,
     clear_session_state,
     extract_files,

--- a/packages/bees/docs/future.md
+++ b/packages/bees/docs/future.md
@@ -89,6 +89,14 @@ imports.
 > to `bees-gemini`, bees' versions must inherit so these checks pass. Both
 > imports are removed when the session loop migrates.
 
+**Session observation types** ([spec](../spec/session-observation.md)) — ✅
+complete. Bees-native copies of `SUSPEND_TYPES` and `PAUSE_TYPES` live in
+`bees/protocols/session.py`. `SessionResult` relocated from `session.py` to
+`bees/protocols/session.py`. `session.py` re-exports `SessionResult` for
+backward compatibility. `task_runner.py`, `scheduler.py`, and tests now import
+`SessionResult` from `bees.protocols.session`. `EvalCollector` and
+`_print_event_summary` are now fully opal-free.
+
 **Remaining protocols** from the [package-split inventory](./package-split.md):
 
 | Protocol        | Status  |
@@ -105,6 +113,73 @@ imports.
 
 The "SessionRunner" category disappears when `session.py` moves to
 `bees-gemini`.
+
+### Anatomy of `session.py`
+
+`session.py` (≈940 lines) conflates three concerns that need to be separated
+before the `SessionRunner` protocol can be defined:
+
+| Concern              | ~Lines | opal deps?                              | Stays in bees? |
+| -------------------- | ------ | --------------------------------------- | -------------- |
+| **Observation types** | 25    | `SUSPEND_TYPES`, `PAUSE_TYPES` (constants) | Yes — protocols |
+| **Task utilities**    | 80    | None                                    | Yes            |
+| **Event collection**  | 200   | `SUSPEND_TYPES` only                    | Yes            |
+| **Session execution** | 400   | Deep (5 opal imports: stores, session API) | No — becomes runner |
+
+**Observation types** — `SessionResult` (already bees-native dataclass),
+`SUSPEND_TYPES`, `PAUSE_TYPES`. These define the output contract: what the
+orchestrator learns from a session. `SessionResult` is used by `task_runner.py`,
+`scheduler.py`, and tests. The event constants are the shared vocabulary between
+runner (produces events) and orchestrator (categorizes them).
+
+**Task utilities** — `extract_files`, `append_chat_log`,
+`load_session_state`, `clear_session_state`. Pure filesystem operations for
+task bookkeeping. No opal deps. Used by `task_runner.py`. These stay in bees
+regardless of where session execution lives.
+
+**Event collection** — `EvalCollector`, `_print_event_summary`,
+`_write_eval_log`. Process the event stream into structured logs and metrics.
+`EvalCollector`'s only opal dependency is `SUSPEND_TYPES` (string constants).
+Once the observation types are extracted, these components become fully
+opal-free.
+
+**Session execution** — `run_session()`, `resume_session()`,
+`_save_session_state()`. The actual model interaction: assembling function
+groups, calling `opal_backend`'s session API (`new_session`, `start_session`),
+draining the event queue. This is the `SessionRunner` implementation. It also
+does **provisioning** (assembling everything the session needs from the task) —
+that provisioning logic stays in bees when the execution moves to the runner.
+
+### What `task_runner.py` imports from `session.py`
+
+```python
+from bees.session import (
+    SessionResult,        # observation type — no opal deps
+    append_chat_log,      # task utility — no opal deps
+    clear_session_state,  # task utility — no opal deps
+    extract_files,        # task utility — no opal deps
+    load_session_state,   # task utility — no opal deps
+    resume_session,       # session execution — deep opal
+    run_session,          # session execution — deep opal
+)
+```
+
+5 of 7 imports are pure orchestration utilities. Only the last two are the
+actual session execution that becomes the `SessionRunner` protocol.
+
+### Incremental path
+
+The `SessionRunner` protocol decomposes into two specs:
+
+1. **Session observation types** ([spec](../spec/session-observation.md)) —
+   extract `SUSPEND_TYPES`, `PAUSE_TYPES`, and `SessionResult` into
+   `bees/protocols/session.py`. This is the leaf: no dependencies on other
+   unextracted types. Makes `EvalCollector` fully opal-free and establishes the
+   output contract before defining the runner protocol.
+
+2. **SessionRunner protocol** — define the `run(configuration, channel) →
+   SessionResult` contract, separating provisioning (stays in bees) from
+   execution (moves to runner). Depends on step 1 for the `SessionResult` type.
 
 ## The Consumption API
 

--- a/packages/bees/docs/package-split.md
+++ b/packages/bees/docs/package-split.md
@@ -322,12 +322,16 @@ with conformance tests, then migrate imports.
 | `SuspendError`    | `opal_backend.suspend.SuspendError` | ✅        | ✅     | ✅       |
 | `AgentResult`     | `opal_backend.events.AgentResult`   | ✅        | ✅     | ✅       |
 | `SessionTerminator` | `opal_backend.loop.LoopController`| ✅        | ✅     | ✅       |
+| `SUSPEND_TYPES`   | `opal_backend.events.SUSPEND_TYPES` | ✅        | ✅     | ✅       |
+| `PAUSE_TYPES`     | `opal_backend.events.PAUSE_TYPES`   | ✅        | ✅     | ✅       |
+| `SessionResult`   | (relocation to protocols)           | ✅        | ✅     | ✅       |
 | `SessionRunner`   | Implicit contract in `session.py`   | Pending   | —      | —        |
 
 See [spec/function-types.md](../spec/function-types.md) for the function types
 spec, [spec/filesystem.md](../spec/filesystem.md) for the filesystem types spec,
-and [spec/handler-types.md](../spec/handler-types.md) for the handler types spec
-and conformance tests.
+[spec/handler-types.md](../spec/handler-types.md) for the handler types spec,
+and [spec/session-observation.md](../spec/session-observation.md) for the
+session observation types spec and conformance tests.
 
 ### Migration steps
 

--- a/packages/bees/spec/session-observation.md
+++ b/packages/bees/spec/session-observation.md
@@ -1,0 +1,181 @@
+# Session Observation Types — Spec Doc
+
+**Goal**: Extract the types that the orchestration layer (`TaskRunner`,
+`Scheduler`, `EvalCollector`) uses to interpret session output — event type
+constants and the structured result — into `bees/protocols/`, so that the
+observation side of the session boundary is cleanly bees-native before the
+`SessionRunner` protocol is specified.
+
+## Context
+
+`session.py` currently conflates session execution (calling `opal_backend`'s
+session API) with session observation (interpreting events, producing results).
+When the `SessionRunner` protocol is defined, `session.py`'s execution code
+moves to `bees-gemini`. The observation types stay in bees — they're the output
+contract that any runner must satisfy.
+
+Three items cross this boundary today:
+
+1. **`SUSPEND_TYPES`** — imported from `opal_backend.events`. Used by
+   `EvalCollector.collect()` and `_print_event_summary()` to detect suspend
+   events in the event stream.
+2. **`PAUSE_TYPES`** — imported from `opal_backend.events`. Used by
+   `_print_event_summary()` (and implicitly by `EvalCollector` via the
+   `"paused"` key check).
+3. **`SessionResult`** — a bees-native dataclass already, but lives in
+   `session.py`. Used by `task_runner.py`, `scheduler.py`, and tests. When
+   `session.py` becomes the runner, this type needs to stay behind.
+
+All three are leaves: zero dependencies on other unextracted types.
+
+## Design Decisions
+
+### Verbatim copies of the constants
+
+`SUSPEND_TYPES` and `PAUSE_TYPES` are `frozenset[str]` — event type strings
+that match dict keys in the event stream. The bees copies are identical values.
+Conformance test verifies they match the opal originals.
+
+### `SessionResult` stays a concrete dataclass
+
+`SessionResult` is already bees-native (no opal imports). It doesn't need to
+become a Protocol — it's a value type, not an abstraction boundary. The move is
+a relocation to the protocols module so that consumers (`task_runner.py`,
+`scheduler.py`) don't import it from the future runner module.
+
+### Event constants are the shared vocabulary
+
+The event stream is a sequence of `dict[str, Any]` where each dict has a single
+key naming the event type (e.g. `{"waitForInput": {...}}`, `{"complete": {...}}`).
+`SUSPEND_TYPES` and `PAUSE_TYPES` define which keys signal suspension and pause
+respectively. This vocabulary is shared between the runner (which produces
+events) and the orchestrator (which categorizes them). Making it bees-native
+establishes it as part of the framework contract.
+
+### No changes to `EvalCollector` in this spec
+
+`EvalCollector` becomes opal-free as a side effect (its only opal import was
+`SUSPEND_TYPES`). But restructuring `EvalCollector` itself (e.g. moving it to
+its own module) is a separate concern — this spec only extracts the types it
+depends on.
+
+## Protocol Inventory
+
+| Type / Constant  | Replaces                          | Specified | Tested  | Migrated |
+| ---------------- | --------------------------------- | --------- | ------- | -------- |
+| `SUSPEND_TYPES`  | `opal_backend.events.SUSPEND_TYPES` | ✅      | ✅      | ✅       |
+| `PAUSE_TYPES`    | `opal_backend.events.PAUSE_TYPES`   | ✅      | ✅      | ✅       |
+| `SessionResult`  | (already bees-native, relocation)   | ✅      | ✅      | ✅       |
+
+## Protocol Shapes
+
+### `SUSPEND_TYPES`
+
+```python
+SUSPEND_TYPES: frozenset[str] = frozenset({
+    "waitForInput",
+    "waitForChoice",
+    "readGraph",
+    "inspectNode",
+    "applyEdits",
+    "queryConsent",
+})
+```
+
+All six suspend event type strings from
+`opal_backend.events`. The orchestrator uses these to detect when a session has
+suspended (the event stream contains a dict with one of these keys).
+
+### `PAUSE_TYPES`
+
+```python
+PAUSE_TYPES: frozenset[str] = frozenset({"paused"})
+```
+
+Single pause event type. Used to detect transient infrastructure failures that
+the scheduler can retry.
+
+### `SessionResult`
+
+```python
+@dataclass
+class SessionResult:
+    """Result of a completed or suspended session."""
+
+    session_id: str
+    status: str
+    events: int
+    output: str
+    turns: int = 0
+    thoughts: int = 0
+    outcome: str | None = None
+    error: str | None = None
+    files: list[dict[str, str]] = field(default_factory=list)
+    intermediate: list[dict[str, Any]] | None = None
+    suspended: bool = False
+    suspend_event: dict[str, Any] | None = None
+    outcome_content: dict[str, Any] | None = None
+    paused: bool = False
+    paused_event: dict[str, Any] | None = None
+```
+
+Identical to the existing dataclass in `session.py`. No changes to fields or
+semantics.
+
+## Migration Notes
+
+### Target file
+
+`bees/protocols/session.py` — new module in the existing protocols package.
+
+### What this enables
+
+After this spec, `session.py`'s remaining opal imports are purely session
+execution concerns (stores, session API). This creates a clean cut line for the
+`SessionRunner` protocol: everything above the line (observation types) is
+bees-native; everything below (execution) moves to the runner.
+
+Concretely, `session.py`'s opal imports reduce from:
+
+```python
+from opal_backend.local.backend_client_impl import HttpBackendClient
+from opal_backend.local.interaction_store_impl import InMemoryInteractionStore
+from opal_backend.events import PAUSE_TYPES, SUSPEND_TYPES          # ← removed
+from opal_backend.interaction_store import InteractionState
+from opal_backend.sessions.api import (...)
+from opal_backend.sessions.in_memory_store import InMemorySessionStore
+```
+
+to 5 imports, all deep session runtime.
+
+### Import migration
+
+```diff
+# session.py
+-from opal_backend.events import PAUSE_TYPES, SUSPEND_TYPES
++from bees.protocols.session import PAUSE_TYPES, SUSPEND_TYPES
+
+# task_runner.py
+-from bees.session import (
+-    SessionResult,
++from bees.protocols.session import SessionResult
++from bees.session import (
+     append_chat_log,
+     ...
+ )
+
+# scheduler.py
+-from bees.session import SessionResult
++from bees.protocols.session import SessionResult
+```
+
+### Conformance testing strategy
+
+1. **Constant conformance**: verify `bees.protocols.session.SUSPEND_TYPES` and
+   `PAUSE_TYPES` are identical to `opal_backend.events.SUSPEND_TYPES` and
+   `PAUSE_TYPES`.
+2. **`SessionResult` structural check**: verify the dataclass has the expected
+   fields and defaults (snapshot test against the current definition).
+3. **Re-export from `session.py`**: during transition, `session.py` can
+   re-export `SessionResult` from the new location so that any external
+   consumers continue to work.

--- a/packages/bees/tests/test_protocols/test_session.py
+++ b/packages/bees/tests/test_protocols/test_session.py
@@ -1,0 +1,180 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Conformance tests for bees.protocols.session.
+
+Verifies that:
+1. SUSPEND_TYPES and PAUSE_TYPES match the opal_backend originals.
+2. SessionResult has the expected fields, defaults, and structure.
+"""
+
+from __future__ import annotations
+
+import unittest
+from dataclasses import fields
+
+
+class TestSuspendTypesConformance(unittest.TestCase):
+    """SUSPEND_TYPES matches opal_backend.events.SUSPEND_TYPES."""
+
+    def test_identical_to_opal(self):
+        """Bees SUSPEND_TYPES is identical to the opal original."""
+        from bees.protocols.session import SUSPEND_TYPES
+        from opal_backend.events import SUSPEND_TYPES as OpalSuspendTypes
+
+        self.assertEqual(SUSPEND_TYPES, OpalSuspendTypes)
+
+    def test_is_frozenset(self):
+        """SUSPEND_TYPES is a frozenset (immutable)."""
+        from bees.protocols.session import SUSPEND_TYPES
+
+        self.assertIsInstance(SUSPEND_TYPES, frozenset)
+
+    def test_contains_known_types(self):
+        """SUSPEND_TYPES contains all known suspend event types."""
+        from bees.protocols.session import SUSPEND_TYPES
+
+        expected = {
+            "waitForInput",
+            "waitForChoice",
+            "readGraph",
+            "inspectNode",
+            "applyEdits",
+            "queryConsent",
+        }
+        self.assertEqual(SUSPEND_TYPES, expected)
+
+
+class TestPauseTypesConformance(unittest.TestCase):
+    """PAUSE_TYPES matches opal_backend.events.PAUSE_TYPES."""
+
+    def test_identical_to_opal(self):
+        """Bees PAUSE_TYPES is identical to the opal original."""
+        from bees.protocols.session import PAUSE_TYPES
+        from opal_backend.events import PAUSE_TYPES as OpalPauseTypes
+
+        self.assertEqual(PAUSE_TYPES, OpalPauseTypes)
+
+    def test_is_frozenset(self):
+        """PAUSE_TYPES is a frozenset (immutable)."""
+        from bees.protocols.session import PAUSE_TYPES
+
+        self.assertIsInstance(PAUSE_TYPES, frozenset)
+
+    def test_contains_paused(self):
+        """PAUSE_TYPES contains exactly 'paused'."""
+        from bees.protocols.session import PAUSE_TYPES
+
+        self.assertEqual(PAUSE_TYPES, frozenset({"paused"}))
+
+
+class TestSessionResultConformance(unittest.TestCase):
+    """SessionResult has the expected fields and defaults."""
+
+    def test_required_fields(self):
+        """SessionResult requires session_id, status, events, output."""
+        from bees.protocols.session import SessionResult
+
+        result = SessionResult(
+            session_id="test-123",
+            status="completed",
+            events=5,
+            output="/path/to/log.json",
+        )
+        self.assertEqual(result.session_id, "test-123")
+        self.assertEqual(result.status, "completed")
+        self.assertEqual(result.events, 5)
+        self.assertEqual(result.output, "/path/to/log.json")
+
+    def test_default_values(self):
+        """Optional fields have correct defaults."""
+        from bees.protocols.session import SessionResult
+
+        result = SessionResult(
+            session_id="test",
+            status="completed",
+            events=0,
+            output="",
+        )
+        self.assertEqual(result.turns, 0)
+        self.assertEqual(result.thoughts, 0)
+        self.assertIsNone(result.outcome)
+        self.assertIsNone(result.error)
+        self.assertEqual(result.files, [])
+        self.assertIsNone(result.intermediate)
+        self.assertFalse(result.suspended)
+        self.assertIsNone(result.suspend_event)
+        self.assertIsNone(result.outcome_content)
+        self.assertFalse(result.paused)
+        self.assertIsNone(result.paused_event)
+
+    def test_field_names_match_original(self):
+        """Field names and count match the original in session.py."""
+        from bees.protocols.session import SessionResult
+
+        field_names = {f.name for f in fields(SessionResult)}
+        expected = {
+            "session_id",
+            "status",
+            "events",
+            "output",
+            "turns",
+            "thoughts",
+            "outcome",
+            "error",
+            "files",
+            "intermediate",
+            "suspended",
+            "suspend_event",
+            "outcome_content",
+            "paused",
+            "paused_event",
+        }
+        self.assertEqual(field_names, expected)
+
+    def test_suspended_result(self):
+        """SessionResult can represent a suspended session."""
+        from bees.protocols.session import SessionResult
+
+        result = SessionResult(
+            session_id="s-1",
+            status="suspended",
+            events=3,
+            output="/log.json",
+            suspended=True,
+            suspend_event={"waitForInput": {"prompt": {"parts": []}}},
+        )
+        self.assertTrue(result.suspended)
+        self.assertIn("waitForInput", result.suspend_event)
+
+    def test_paused_result(self):
+        """SessionResult can represent a paused session."""
+        from bees.protocols.session import SessionResult
+
+        result = SessionResult(
+            session_id="s-2",
+            status="paused",
+            events=2,
+            output="/log.json",
+            paused=True,
+            paused_event={"paused": {"message": "503"}},
+            error="503",
+        )
+        self.assertTrue(result.paused)
+        self.assertEqual(result.error, "503")
+
+    def test_accessible_from_protocols_package(self):
+        """SessionResult is accessible via bees.protocols."""
+        from bees.protocols import SessionResult
+
+        result = SessionResult(
+            session_id="pkg-test",
+            status="completed",
+            events=0,
+            output="",
+        )
+        self.assertEqual(result.session_id, "pkg-test")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/bees/tests/test_scheduler.py
+++ b/packages/bees/tests/test_scheduler.py
@@ -261,7 +261,7 @@ def test_eval_collector_detects_paused():
 
 def test_update_metadata_paused(mock_clients):
     """Paused result → task status 'paused', completed_at is None."""
-    from bees.session import SessionResult
+    from bees.protocols.session import SessionResult
 
     _, backend = mock_clients
     scheduler = Scheduler(store=GLOBAL_STORE, backend=backend)
@@ -287,7 +287,7 @@ def test_update_metadata_paused(mock_clients):
 
 def test_handle_pause_sets_status(mock_clients):
     """_handle_pause sets task status to 'paused', assignee to None."""
-    from bees.session import SessionResult
+    from bees.protocols.session import SessionResult
 
     _, backend = mock_clients
     scheduler = Scheduler(store=GLOBAL_STORE, backend=backend)


### PR DESCRIPTION
## What

Extracts `SessionResult`, `SUSPEND_TYPES`, and `PAUSE_TYPES` into
`bees/protocols/session.py` — the types the orchestration layer uses to
interpret session output. Migrates all consumers to the new canonical location.

## Why

Prerequisite for the `SessionRunner` protocol. `session.py` currently conflates
session execution (opal_backend-entangled) with session observation (pure bees).
This separates the observation side so it's cleanly bees-native before the
runner protocol is defined. After this change, `EvalCollector` and
`_print_event_summary` have zero opal_backend dependencies.

## Changes

### New files
- `bees/protocols/session.py` — `SUSPEND_TYPES`, `PAUSE_TYPES` (copied from
  opal_backend.events), `SessionResult` (relocated from session.py)
- `tests/test_protocols/test_session.py` — 12 conformance tests verifying
  constants match opal originals and SessionResult has correct fields/defaults
- `spec/session-observation.md` — SDD spec doc

### Import migrations
- `bees/session.py` — constants now from `bees.protocols.session`; local
  `SessionResult` class replaced with re-export for backward compat
- `bees/task_runner.py` — `SessionResult` from `bees.protocols.session`
- `bees/scheduler.py` — `SessionResult` from `bees.protocols.session`
- `bees/protocols/__init__.py` — exports the three new symbols
- `tests/test_scheduler.py` — inline imports migrated

### Documentation
- `docs/future.md` — anatomy of `session.py` (four-concern breakdown),
  annotated import map, incremental path toward SessionRunner
- `docs/package-split.md` — protocol inventory updated with 3 new rows

## Testing

- `pytest tests/test_protocols/test_session.py` — 12/12 pass
- `pytest tests/test_scheduler.py` — 18/18 pass (existing tests, migrated imports)
- `npm run dev:box` — full end-to-end box run completed successfully
