### PR TITLE
[bees] Fix reset mutation deleting box-active sentinel

### DIFF
--- a/packages/bees/bees/mutations.py
+++ b/packages/bees/bees/mutations.py
@@ -324,6 +324,11 @@ class MutationManager:
                 continue
 
             for child in subdir.iterdir():
+                # Preserve the box-active sentinel — the box is still
+                # running, and removing it would signal hivetool that
+                # the box has stopped.
+                if child.name == BOX_ACTIVE_SENTINEL:
+                    continue
                 if child.is_dir():
                     shutil.rmtree(child)
                 else:


### PR DESCRIPTION
## What
The `reset` mutation handler was deleting the `.box-active` sentinel file when clearing the `mutations/` directory, causing hivetool to think the box had stopped.

## Why
After a reset, hivetool checks for the sentinel to decide whether the box is listening. Since `_handle_reset` iterates all children of `mutations/` and deletes them unconditionally, the sentinel was removed — even though the box was still running and about to restart.

## Changes
- **`packages/bees/bees/mutations.py`**: Skip `BOX_ACTIVE_SENTINEL` when clearing `mutations/` during reset.

## Testing
Trigger a `reset` mutation while the box is running and verify the `.box-active` sentinel persists in `mutations/` throughout the restart cycle.
