### PR TITLE
[bees] Specify SessionRunner protocol

### DIFF
--- a/packages/bees/bees/protocols/__init__.py
+++ b/packages/bees/bees/protocols/__init__.py
@@ -57,6 +57,7 @@ from bees.protocols.session import (
     SessionConfiguration,
     SessionEvent,
     SessionResult,
+    SessionRunner,
     SessionStream,
 )
 
@@ -104,5 +105,6 @@ __all__ = [
     "SessionConfiguration",
     "SessionEvent",
     "SessionResult",
+    "SessionRunner",
     "SessionStream",
 ]

--- a/packages/bees/bees/protocols/session.py
+++ b/packages/bees/bees/protocols/session.py
@@ -1,7 +1,7 @@
 # Copyright 2026 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-"""Session types — observation, configuration, and stream protocols.
+"""Session types — observation, configuration, stream, and runner protocols.
 
 Defines the types that sit at the session boundary:
 
@@ -19,6 +19,10 @@ Defines the types that sit at the session boundary:
 **Stream** (runner return type):
 
 - ``SessionStream`` — async iterable of events with back-channel methods.
+
+**Runner** (execution contract):
+
+- ``SessionRunner`` — the contract between bees and a model provider.
 """
 
 from __future__ import annotations
@@ -37,6 +41,7 @@ __all__ = [
     "SessionConfiguration",
     "SessionEvent",
     "SessionResult",
+    "SessionRunner",
     "SessionStream",
 ]
 
@@ -218,5 +223,58 @@ class SessionStream(Protocol):
         opaque blob and hands it back on resume.  For the batch runner
         this is serialized ``opal_backend`` ``InteractionState``.  For
         the Live runner this would be a session resumption token.
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Session runner
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class SessionRunner(Protocol):
+    """Contract: execute a session and return an event stream.
+
+    The runner owns the model interaction — API calls, turn management,
+    function dispatch.  It receives a provisioned configuration (function
+    groups, file system, segments) and returns a stream of events.
+
+    The framework (bees) owns observation (``EvalCollector``), orchestration
+    (``Scheduler``), and persistence (resume state to disk).
+    """
+
+    async def run(
+        self,
+        config: SessionConfiguration,
+    ) -> SessionStream:
+        """Start a new session and return an event stream.
+
+        The stream yields events until the run ends (completion,
+        suspension, pause, or error).  After the stream exhausts,
+        ``stream.resume_state()`` provides the opaque blob needed
+        to resume (or ``None`` if the run completed).
+        """
+        ...
+
+    async def resume(
+        self,
+        config: SessionConfiguration,
+        *,
+        state: bytes,
+        response: dict[str, Any],
+        context_parts: list[dict[str, Any]] | None = None,
+    ) -> SessionStream:
+        """Resume a suspended session.
+
+        Args:
+            config: Same provisioned configuration as ``run()``.
+            state: Opaque resume state from a previous
+                ``stream.resume_state()`` call.
+            response: The user's response dict (text, structured data).
+            context_parts: Pre-formatted context parts to inject at
+                the start of the resumed session.  Assembled by bees
+                from ``response.context_updates`` and
+                ``pending_context_updates`` in task metadata.
         """
         ...

--- a/packages/bees/bees/session.py
+++ b/packages/bees/bees/session.py
@@ -348,12 +348,137 @@ def extract_files(
 
 
 # ---------------------------------------------------------------------------
-# Shared auth setup
+# Session draining — the composition point
 # ---------------------------------------------------------------------------
 
 
+async def drain_session(
+    stream: "SessionStream",
+    *,
+    config: "SessionConfiguration",
+    ticket_id: str | None = None,
+    on_event: Any | None = None,
+) -> SessionResult:
+    """Drain a session stream into a ``SessionResult``.
+
+    Iterates the stream, collects events via :class:`EvalCollector`, writes
+    eval logs at turn boundaries, prints event summaries, and builds the
+    final ``SessionResult``.
+
+    The caller is responsible for:
+
+    - Mid-session context injection via ``stream.send_context()``.
+    - Persisting ``stream.resume_state()`` after this returns.
+
+    Args:
+        stream: A running session's event stream.
+        config: The provisioned session configuration (used for
+            label and log_path).
+        ticket_id: Task identifier for log tagging.
+        on_event: Optional async callback invoked for each event.
+    """
+    from bees.protocols.session import SessionConfiguration, SessionStream
+
+    prefix = f"[{config.label}] " if config.label else ""
+    log_path = config.log_path
+    collector = EvalCollector()
+    event_count = 0
+
+    try:
+        async for event in stream:
+            collector.collect(event)
+            event_count += 1
+            _print_event_summary(event, prefix=prefix)
+
+            # Write log at turn boundaries.
+            if log_path and (
+                "sendRequest" in event
+                or "usageMetadata" in event
+                or "complete" in event
+                or "error" in event
+                or "paused" in event
+                or any(k in event for k in SUSPEND_TYPES)
+            ):
+                _write_eval_log(
+                    log_path,
+                    collector.to_eval_file_data(ticket_id=ticket_id),
+                )
+
+            if on_event:
+                await on_event(event)
+    finally:
+        # Final log write — captures any events since the last boundary.
+        if log_path:
+            _write_eval_log(
+                log_path,
+                collector.to_eval_file_data(ticket_id=ticket_id),
+            )
+
+    # Derive status from collector state.
+    if collector.suspended:
+        status = "suspended"
+    elif collector.paused:
+        status = "paused"
+    elif collector.error:
+        status = "failed"
+    else:
+        status = "completed"
+
+    return SessionResult(
+        session_id=ticket_id or "",
+        status=status,
+        events=event_count,
+        output=str(log_path) if log_path else "",
+        turns=collector.turn_count,
+        thoughts=collector.total_thoughts,
+        outcome=collector.outcome_text(),
+        error=collector.error,
+        files=[],
+        intermediate=collector.intermediate,
+        suspended=collector.suspended,
+        suspend_event=collector.suspend_event,
+        outcome_content=collector.outcome_llm_content(),
+        paused=collector.paused,
+        paused_event=collector.paused_event,
+    )
 
 
+# ---------------------------------------------------------------------------
+# Resume state persistence
+# ---------------------------------------------------------------------------
+
+RESUME_STATE_FILENAME = "resume_state.bin"
+
+
+def save_resume_state(ticket_dir: Path, state: bytes) -> None:
+    """Persist opaque resume state to the ticket directory.
+
+    The state is written as raw bytes — bees does not interpret the
+    contents.  The runner deserializes its own state on resume.
+    """
+    state_path = ticket_dir / RESUME_STATE_FILENAME
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_bytes(state)
+
+
+def load_resume_state(ticket_dir: Path) -> bytes | None:
+    """Load saved resume state, or ``None`` if not found."""
+    state_path = ticket_dir / RESUME_STATE_FILENAME
+    if not state_path.exists():
+        return None
+    return state_path.read_bytes()
+
+
+def clear_resume_state(ticket_dir: Path) -> None:
+    """Remove saved resume state (after successful resume)."""
+    state_path = ticket_dir / RESUME_STATE_FILENAME
+    if state_path.exists():
+        state_path.unlink()
+
+
+# ---------------------------------------------------------------------------
+# Core session runner
+# ---------------------------------------------------------------------------
 
 
 # ---------------------------------------------------------------------------

--- a/packages/bees/docs/future.md
+++ b/packages/bees/docs/future.md
@@ -108,9 +108,16 @@ session API) — ready for the `SessionRunner` migration.
 
 **Remaining protocols** from the [package-split inventory](./package-split.md):
 
-| Protocol        | Status  |
-| --------------- | ------- |
-| `SessionRunner` | Pending |
+| Protocol        | Status    |
+| --------------- | --------- |
+| `SessionRunner` | Specified |
+
+**SessionRunner** ([spec](../spec/session-runner.md)) — specified + tested.
+`SessionRunner` protocol, `drain_session` composition function, and opaque
+resume state persistence (`save_resume_state` / `load_resume_state` /
+`clear_resume_state`) live in `bees/protocols/session.py` and `bees/session.py`.
+The migration (creating `GeminiRunner`, restructuring `task_runner.py`, removing
+`run_session` / `resume_session`) is the next spec.
 
 **Remaining `opal_backend` imports** in `bees/`:
 

--- a/packages/bees/spec/session-runner.md
+++ b/packages/bees/spec/session-runner.md
@@ -1,0 +1,318 @@
+# SessionRunner — Spec Doc
+
+**Goal**: Define the `SessionRunner` protocol — the contract between bees
+(orchestration) and a model provider (session execution) — and extract the
+common event-draining pattern into a reusable `drain_session` function. This is
+the final protocol in the library extraction.
+
+## Context
+
+With the previous seven specs complete, `session.py` has been separated into:
+
+- **Provisioning** (`provisioner.py`) — assembles `SessionConfiguration`, zero
+  opal deps. ✅
+- **Observation types** (`protocols/session.py`) — `SessionResult`,
+  `SUSPEND_TYPES`, `PAUSE_TYPES`, `SessionConfiguration`, `SessionStream`,
+  `SessionEvent`. ✅
+- **Event collection** (`session.py`) — `EvalCollector`,
+  `_print_event_summary`. Opal-free. ✅
+- **Execution** (`session.py`) — `run_session()`, `resume_session()`. Deep opal
+  deps. ← **this spec**
+
+The `SessionRunner` protocol formalizes the execution boundary. Everything above
+(provisioning, observation, task orchestration) stays in `bees`. Everything
+below (model API calls, event generation) moves to the runner.
+
+### Remaining `opal_backend` imports after this spec
+
+| Module             | Current imports                                        | After this spec        |
+| ------------------ | ------------------------------------------------------ | ---------------------- |
+| `session.py`       | `HttpBackendClient`, `InMemoryInteractionStore`, `InteractionState`, `new_session`, `start_session`, `resume_session`, `Subscribers`, `InMemorySessionStore`, `register_task` | Same (migration is next spec) |
+| `scheduler.py`     | `HttpBackendClient` (type annotation)                  | Same                   |
+| `box.py`           | `HttpBackendClient`, `app.auth`, `app.config`          | Same                   |
+| `handler_types.py` | Transitional back-imports (`SuspendError`, `AgentResult`) | Same                 |
+
+This spec **specifies and tests** the boundary. The migration (restructuring
+`task_runner.py`, creating `GeminiRunner`, removing opal imports) is the
+follow-up spec.
+
+## Design Decisions
+
+### Two methods: `run` and `resume`
+
+A session runner has two entry points:
+
+- `run(config)` — start a new session from segments
+- `resume(config, state, response)` — continue a suspended session
+
+Both return a `SessionStream` (already defined). The distinction matters because
+resume requires opaque state from the previous run plus the user's response.
+
+### Both methods are async
+
+`run` and `resume` are `async def` — they may perform async setup (creating
+stores, calling API initialization) before returning the stream.
+Initialization errors raise directly from `run()`/`resume()`. Execution
+errors come through the event stream as `{"error": {...}}` events.
+
+### Resume state is opaque bytes
+
+`stream.resume_state()` returns `bytes | None`. Bees persists it to disk
+without interpretation. On resume, bees reads the blob and passes it to
+`runner.resume()`.
+
+For the batch `GeminiRunner`, this blob is serialized JSON containing
+`session_id`, `interaction_id`, and `InteractionState`. For a future Live
+runner, it could be a session resumption token.
+
+### Context injection: two paths, one protocol
+
+1. **On resume** — accumulated context updates from the response and from
+   `pending_context_updates` in task metadata → pre-processed by bees into
+   context parts → passed as `context_parts` to `runner.resume()`.
+2. **Mid-session** — new updates arriving while running → caller invokes
+   `stream.send_context(parts)`.
+
+Both paths are already accounted for in `SessionStream`. The `context_queue`
+parameter threading through `run_session` → `new_session` disappears — the
+runner manages its own internal queue.
+
+### Suspend events include the triggering function name
+
+Currently `task_runner._handle_suspend` peeks into persisted `InteractionState`
+to extract `function_call_part.functionCall.name`. With opaque resume state, the
+runner must include `function_name` in the suspend event dict before yielding it.
+This is metadata enrichment — the runner knows which function triggered the
+suspend because it processed the function call.
+
+> **Mirror, then evolve.** The initial `GeminiRunner` can either (a) include
+> `function_name` in suspend events, or (b) expose it via a structured
+> `resume_state()` that bees parses. Option (a) is cleaner because it keeps
+> resume state truly opaque. Noted as a migration detail, not a spec concern.
+
+### `drain_session` is the composition point
+
+A new function encapsulates the bees-side event loop — the duplicated pattern
+in both `run_session()` and `resume_session()`:
+
+```
+subscribe → create collector → drain events → write logs → build SessionResult
+```
+
+After migration, `task_runner.run_task()` becomes:
+
+```python
+config = provision_session(...)
+stream = await runner.run(config)
+self._active_streams[task.id] = stream    # for mid-session context injection
+try:
+    result = await drain_session(stream, config=config, ...)
+finally:
+    del self._active_streams[task.id]
+
+resume_state = stream.resume_state()
+if resume_state:
+    save_resume_state(ticket_dir, resume_state)
+```
+
+The 15-parameter `run_session()` call becomes four clean steps: provision, run,
+observe, persist.
+
+### `HttpBackendClient` disappears from bees
+
+Currently `Bees.__init__`, `Scheduler.__init__`, and `TaskRunner.__init__` all
+accept/pass `backend: HttpBackendClient`. After migration, they accept
+`runner: SessionRunner`. The `HttpBackendClient` lives entirely inside
+`bees-gemini`, constructed by the application layer (`box.py` or the web app).
+
+### `drain_session` lives in `session.py`
+
+`session.py` already holds `EvalCollector`, `_print_event_summary`, and
+`_write_eval_log` — all observation concerns. `drain_session` composes them. After
+migration, `run_session()` and `resume_session()` are removed and `session.py`
+becomes purely the observation module.
+
+## Protocol Inventory
+
+| Type / Function         | Status             | Category |
+| ----------------------- | ------------------ | -------- |
+| `SessionRunner`         | ✅ Spec'd + Tested | Specify  |
+| `drain_session`         | ✅ Implemented     | Specify  |
+| `save_resume_state`     | ✅ Implemented     | Specify  |
+| `load_resume_state`     | ✅ Implemented     | Specify  |
+
+## Protocol Shapes
+
+### `SessionRunner`
+
+```python
+@runtime_checkable
+class SessionRunner(Protocol):
+    """Contract: execute a session and return an event stream.
+
+    The runner owns the model interaction — API calls, turn management,
+    function dispatch.  It receives a provisioned configuration (function
+    groups, file system, segments) and returns a stream of events.
+
+    The framework (bees) owns observation (EvalCollector), orchestration
+    (Scheduler), and persistence (resume state to disk).
+    """
+
+    async def run(
+        self,
+        config: SessionConfiguration,
+    ) -> SessionStream:
+        """Start a new session and return an event stream.
+
+        The stream yields events until the run ends (completion,
+        suspension, pause, or error).  After the stream exhausts,
+        ``stream.resume_state()`` provides the opaque blob needed
+        to resume (or ``None`` if the run completed).
+        """
+        ...
+
+    async def resume(
+        self,
+        config: SessionConfiguration,
+        *,
+        state: bytes,
+        response: dict[str, Any],
+        context_parts: list[dict[str, Any]] | None = None,
+    ) -> SessionStream:
+        """Resume a suspended session.
+
+        Args:
+            config: Same provisioned configuration as ``run()``.
+            state: Opaque resume state from a previous
+                ``stream.resume_state()`` call.
+            response: The user's response dict (text, structured data).
+            context_parts: Pre-formatted context parts to inject at
+                the start of the resumed session.  Assembled by bees
+                from ``response.context_updates`` and
+                ``pending_context_updates`` in task metadata.
+        """
+        ...
+```
+
+### `drain_session`
+
+```python
+async def drain_session(
+    stream: SessionStream,
+    *,
+    config: SessionConfiguration,
+    ticket_id: str | None = None,
+    on_event: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
+) -> SessionResult:
+    """Drain a session stream into a SessionResult.
+
+    Iterates the stream, collects events via ``EvalCollector``, writes
+    eval logs at turn boundaries, prints event summaries, and builds
+    the final ``SessionResult``.
+
+    The caller is responsible for:
+    - Mid-session context injection via ``stream.send_context()``.
+    - Persisting ``stream.resume_state()`` after this returns.
+    """
+    ...
+```
+
+### Resume state persistence
+
+```python
+def save_resume_state(ticket_dir: Path, state: bytes) -> None:
+    """Persist opaque resume state to the ticket directory."""
+    ...
+
+def load_resume_state(ticket_dir: Path) -> bytes | None:
+    """Load saved resume state, or None if not found."""
+    ...
+```
+
+These replace the existing `save_session_state` / `load_session_state` pair.
+The file format changes from structured JSON (`session_state.json`) to an
+opaque blob (`resume_state.bin`).  `clear_session_state` becomes
+`clear_resume_state` for symmetry.
+
+## Migration Notes
+
+### This spec (Phase 1: Specify + Test)
+
+1. Add `SessionRunner` protocol to `bees/protocols/session.py`.
+2. Implement `drain_session` in `bees/session.py`.
+3. Implement `save_resume_state` / `load_resume_state` in `bees/session.py`.
+4. Write conformance tests.
+5. Update `bees/protocols/__init__.py` exports.
+6. Update `docs/future.md` progress.
+
+### Next spec (Phase 2: Migrate)
+
+1. Create `GeminiRunner` in `bees-gemini` wrapping opal's session API.
+2. Restructure `task_runner.py` to use
+   `runner.run(config)` + `drain_session()`.
+3. Change `Scheduler.__init__` / `Bees.__init__` to accept `SessionRunner`
+   instead of `HttpBackendClient`.
+4. Change `box.py` to construct `GeminiRunner` and pass to `Bees`.
+5. Remove `run_session()` / `resume_session()` from `session.py`.
+6. Remove transitional back-imports in `handler_types.py`.
+
+### Friction: `task_runner._handle_suspend` peeks into InteractionState
+
+Lines 281–290 of `task_runner.py` read
+`interaction_state.function_call_part.functionCall.name` from persisted session
+state to annotate suspend events with the triggering function's name. With
+opaque resume state, this information must come from elsewhere.
+
+**Resolution (deferred to Phase 2):** The `GeminiRunner` includes
+`function_name` in suspend event dicts before yielding them.  This is a
+one-line enrichment inside the runner, and it keeps resume state truly opaque.
+
+### Friction: `_save_session_state` extracts interaction_id from suspend events
+
+The current `_save_session_state` (lines 759–802) does complex extraction:
+finding `interaction_id` from the suspend event, falling back to the session
+store, then loading the InteractionState.  With the runner protocol, all of
+this is replaced by `stream.resume_state()` — the runner knows its own
+resumption needs.
+
+### Friction: `box.py` imports `app.auth` and `app.config`
+
+These are application concerns (loading the Gemini key, resolving hive dir from
+environment). They stay in `box` — the CLI runner package, not the `bees`
+library. After Phase 2, box constructs a `GeminiRunner` with the loaded
+credentials and passes it to `Bees`.
+
+## Conformance Testing Strategy
+
+1. **`SessionRunner` protocol satisfaction**: a minimal mock with `run()` and
+   `resume()` satisfies the protocol via `isinstance`.
+
+2. **`drain_session` with mock stream**: create a `MockStream` that yields a
+   predetermined event sequence (thought → functionCall → usageMetadata →
+   complete). Verify `drain_session` produces a correct `SessionResult` with
+   expected `turns`, `thoughts`, `outcome`, etc.
+
+3. **`drain_session` with suspend**: mock stream yields a `waitForInput` event
+   then exhausts.  Verify `result.suspended` is `True` and
+   `result.suspend_event` contains the event.
+
+4. **`drain_session` with pause**: mock stream yields a `paused` event.
+   Verify `result.paused` is `True` and `result.error` is set.
+
+5. **Resume state round-trip**: `save_resume_state` / `load_resume_state`
+   correctly persist and recover arbitrary bytes.
+
+6. **Accessibility**: `SessionRunner` is accessible from `bees.protocols`.
+
+## Dependencies
+
+All dependencies are already extracted:
+
+- `SessionConfiguration` — `bees/protocols/session.py` ✅
+- `SessionStream` — `bees/protocols/session.py` ✅
+- `SessionResult` — `bees/protocols/session.py` ✅
+- `SessionEvent` — `bees/protocols/session.py` ✅
+- `SUSPEND_TYPES` / `PAUSE_TYPES` — `bees/protocols/session.py` ✅
+- `EvalCollector` — `bees/session.py` (opal-free) ✅
+
+This spec is a leaf.

--- a/packages/bees/tests/test_protocols/test_session_runner.py
+++ b/packages/bees/tests/test_protocols/test_session_runner.py
@@ -1,0 +1,432 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Conformance tests for SessionRunner protocol, drain_session, and resume state.
+
+Verifies that:
+1. SessionRunner protocol can be satisfied by a minimal mock.
+2. drain_session correctly drains a mock stream into a SessionResult.
+3. drain_session handles suspend, pause, and error scenarios.
+4. save_resume_state / load_resume_state / clear_resume_state round-trip.
+5. SessionRunner is accessible via the protocols package.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import unittest
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+import tempfile
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class MockStream:
+    """A minimal SessionStream backed by a list of events."""
+
+    def __init__(
+        self,
+        events: list[dict[str, Any]],
+        *,
+        resume: bytes | None = None,
+    ) -> None:
+        self._events = events
+        self._index = 0
+        self._resume = resume
+        self.tool_responses: list[list[dict[str, Any]]] = []
+        self.context_parts: list[list[dict[str, Any]]] = []
+
+    def __aiter__(self) -> AsyncIterator[dict[str, Any]]:
+        return self
+
+    async def __anext__(self) -> dict[str, Any]:
+        if self._index >= len(self._events):
+            raise StopAsyncIteration
+        event = self._events[self._index]
+        self._index += 1
+        return event
+
+    async def send_tool_response(
+        self, responses: list[dict[str, Any]],
+    ) -> None:
+        self.tool_responses.append(responses)
+
+    async def send_context(
+        self, parts: list[dict[str, Any]],
+    ) -> None:
+        self.context_parts.append(parts)
+
+    def resume_state(self) -> bytes | None:
+        return self._resume
+
+
+class MockRunner:
+    """A minimal SessionRunner backed by MockStream."""
+
+    def __init__(
+        self,
+        events: list[dict[str, Any]] | None = None,
+        *,
+        resume_blob: bytes | None = None,
+    ) -> None:
+        self._events = events or []
+        self._resume_blob = resume_blob
+        self.run_calls: list[Any] = []
+        self.resume_calls: list[dict[str, Any]] = []
+
+    async def run(self, config: Any) -> MockStream:
+        self.run_calls.append(config)
+        return MockStream(self._events, resume=self._resume_blob)
+
+    async def resume(
+        self,
+        config: Any,
+        *,
+        state: bytes,
+        response: dict[str, Any],
+        context_parts: list[dict[str, Any]] | None = None,
+    ) -> MockStream:
+        self.resume_calls.append({
+            "config": config,
+            "state": state,
+            "response": response,
+            "context_parts": context_parts,
+        })
+        return MockStream(self._events, resume=self._resume_blob)
+
+
+def _make_config(**overrides: Any):
+    """Create a SessionConfiguration with test defaults."""
+    from bees.protocols.session import SessionConfiguration
+
+    fs = MagicMock()
+    defaults = dict(
+        segments=[{"type": "text", "text": "hello"}],
+        function_groups=[],
+        function_filter=None,
+        model="gemini-2.5-flash",
+        file_system=fs,
+        label="test",
+    )
+    defaults.update(overrides)
+    return SessionConfiguration(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# SessionRunner protocol conformance
+# ---------------------------------------------------------------------------
+
+
+class TestSessionRunnerConformance(unittest.TestCase):
+    """SessionRunner protocol can be satisfied by a minimal mock."""
+
+    def test_mock_satisfies_protocol(self):
+        """A minimal mock with run() and resume() satisfies SessionRunner."""
+        from bees.protocols.session import SessionRunner
+
+        runner = MockRunner()
+        self.assertIsInstance(runner, SessionRunner)
+
+    def test_run_returns_stream(self):
+        """run() returns a SessionStream."""
+        from bees.protocols.session import SessionRunner, SessionStream
+
+        runner = MockRunner(events=[{"complete": {"result": {}}}])
+
+        async def check():
+            config = _make_config()
+            stream = await runner.run(config)
+            self.assertIsInstance(stream, SessionStream)
+            self.assertEqual(len(runner.run_calls), 1)
+
+        asyncio.get_event_loop().run_until_complete(check())
+
+    def test_resume_returns_stream(self):
+        """resume() returns a SessionStream."""
+        from bees.protocols.session import SessionRunner, SessionStream
+
+        runner = MockRunner(events=[{"complete": {"result": {}}}])
+
+        async def check():
+            config = _make_config()
+            stream = await runner.resume(
+                config,
+                state=b"saved-state",
+                response={"text": "hello"},
+                context_parts=[{"text": "update"}],
+            )
+            self.assertIsInstance(stream, SessionStream)
+            self.assertEqual(len(runner.resume_calls), 1)
+            call = runner.resume_calls[0]
+            self.assertEqual(call["state"], b"saved-state")
+            self.assertEqual(call["response"], {"text": "hello"})
+            self.assertEqual(call["context_parts"], [{"text": "update"}])
+
+        asyncio.get_event_loop().run_until_complete(check())
+
+    def test_accessible_from_protocols_package(self):
+        """SessionRunner is accessible via bees.protocols."""
+        from bees.protocols import SessionRunner
+
+        runner = MockRunner()
+        self.assertIsInstance(runner, SessionRunner)
+
+
+# ---------------------------------------------------------------------------
+# drain_session conformance
+# ---------------------------------------------------------------------------
+
+
+class TestDrainSessionComplete(unittest.TestCase):
+    """drain_session correctly drains a complete session."""
+
+    def test_basic_complete_session(self):
+        """A session with thought → functionCall → usageMetadata → complete
+        produces a correct SessionResult."""
+        from bees.session import drain_session
+
+        events = [
+            {"thought": {"text": "thinking..."}},
+            {"functionCall": {"name": "test_fn", "args": {}}},
+            {"usageMetadata": {"metadata": {
+                "promptTokenCount": 100,
+                "candidatesTokenCount": 50,
+            }}},
+            {"sendRequest": {"body": {"contents": [{"parts": []}]}}},
+            {"complete": {"result": {
+                "success": True,
+                "outcomes": {"parts": [{"text": "done"}]},
+            }}},
+        ]
+        stream = MockStream(events)
+        config = _make_config()
+
+        async def check():
+            result = await drain_session(
+                stream, config=config, ticket_id="test-123",
+            )
+            self.assertEqual(result.status, "completed")
+            self.assertEqual(result.events, 5)
+            self.assertEqual(result.turns, 1)
+            self.assertEqual(result.thoughts, 1)
+            self.assertEqual(result.outcome, "done")
+            self.assertFalse(result.suspended)
+            self.assertFalse(result.paused)
+            self.assertIsNone(result.error)
+            self.assertEqual(result.session_id, "test-123")
+
+        asyncio.get_event_loop().run_until_complete(check())
+
+    def test_empty_stream(self):
+        """An empty stream produces a completed result with zero events."""
+        from bees.session import drain_session
+
+        stream = MockStream([])
+        config = _make_config()
+
+        async def check():
+            result = await drain_session(stream, config=config)
+            self.assertEqual(result.status, "completed")
+            self.assertEqual(result.events, 0)
+            self.assertEqual(result.turns, 0)
+
+        asyncio.get_event_loop().run_until_complete(check())
+
+    def test_on_event_callback(self):
+        """on_event is called for each event."""
+        from bees.session import drain_session
+
+        events = [
+            {"thought": {"text": "a"}},
+            {"complete": {"result": {}}},
+        ]
+        stream = MockStream(events)
+        config = _make_config()
+        received: list[dict] = []
+
+        async def on_event(event):
+            received.append(event)
+
+        async def check():
+            await drain_session(
+                stream, config=config, on_event=on_event,
+            )
+            self.assertEqual(len(received), 2)
+            self.assertEqual(received[0], events[0])
+            self.assertEqual(received[1], events[1])
+
+        asyncio.get_event_loop().run_until_complete(check())
+
+
+class TestDrainSessionSuspend(unittest.TestCase):
+    """drain_session correctly handles session suspension."""
+
+    def test_suspend_via_wait_for_input(self):
+        """A waitForInput event produces a suspended result."""
+        from bees.session import drain_session
+
+        events = [
+            {"thought": {"text": "need input"}},
+            {"waitForInput": {
+                "interactionId": "i-1",
+                "prompt": "What next?",
+            }},
+        ]
+        stream = MockStream(events)
+        config = _make_config()
+
+        async def check():
+            result = await drain_session(stream, config=config)
+            self.assertEqual(result.status, "suspended")
+            self.assertTrue(result.suspended)
+            self.assertIsNotNone(result.suspend_event)
+            self.assertIn("waitForInput", result.suspend_event)
+
+        asyncio.get_event_loop().run_until_complete(check())
+
+    def test_suspend_via_wait_for_choice(self):
+        """A waitForChoice event produces a suspended result."""
+        from bees.session import drain_session
+
+        events = [
+            {"waitForChoice": {
+                "interactionId": "i-2",
+                "choices": [],
+            }},
+        ]
+        stream = MockStream(events)
+        config = _make_config()
+
+        async def check():
+            result = await drain_session(stream, config=config)
+            self.assertTrue(result.suspended)
+            self.assertEqual(result.status, "suspended")
+
+        asyncio.get_event_loop().run_until_complete(check())
+
+
+class TestDrainSessionPause(unittest.TestCase):
+    """drain_session correctly handles transient pause."""
+
+    def test_paused_event(self):
+        """A paused event produces a paused result with error."""
+        from bees.session import drain_session
+
+        events = [
+            {"paused": {
+                "message": "Rate limit exceeded",
+                "interactionId": "i-3",
+            }},
+        ]
+        stream = MockStream(events)
+        config = _make_config()
+
+        async def check():
+            result = await drain_session(stream, config=config)
+            self.assertEqual(result.status, "paused")
+            self.assertTrue(result.paused)
+            self.assertEqual(result.error, "Rate limit exceeded")
+
+        asyncio.get_event_loop().run_until_complete(check())
+
+
+class TestDrainSessionError(unittest.TestCase):
+    """drain_session correctly handles error events."""
+
+    def test_error_event(self):
+        """An error event produces a failed result."""
+        from bees.session import drain_session
+
+        events = [
+            {"error": {"message": "Model unavailable"}},
+        ]
+        stream = MockStream(events)
+        config = _make_config()
+
+        async def check():
+            result = await drain_session(stream, config=config)
+            self.assertEqual(result.status, "failed")
+            self.assertEqual(result.error, "Model unavailable")
+
+        asyncio.get_event_loop().run_until_complete(check())
+
+
+# ---------------------------------------------------------------------------
+# Resume state persistence
+# ---------------------------------------------------------------------------
+
+
+class TestResumeStatePersistence(unittest.TestCase):
+    """save_resume_state / load_resume_state / clear_resume_state round-trip."""
+
+    def test_round_trip(self):
+        """Saved bytes can be loaded back identically."""
+        from bees.session import (
+            save_resume_state,
+            load_resume_state,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            ticket_dir = Path(tmp)
+            state = b'{"session_id": "s-1", "interaction_id": "i-1"}'
+            save_resume_state(ticket_dir, state)
+            loaded = load_resume_state(ticket_dir)
+            self.assertEqual(loaded, state)
+
+    def test_load_missing_returns_none(self):
+        """Loading from a dir with no saved state returns None."""
+        from bees.session import load_resume_state
+
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(load_resume_state(Path(tmp)))
+
+    def test_clear_removes_file(self):
+        """clear_resume_state removes the file."""
+        from bees.session import (
+            save_resume_state,
+            load_resume_state,
+            clear_resume_state,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            ticket_dir = Path(tmp)
+            save_resume_state(ticket_dir, b"data")
+            clear_resume_state(ticket_dir)
+            self.assertIsNone(load_resume_state(ticket_dir))
+
+    def test_clear_noop_when_missing(self):
+        """clear_resume_state does nothing if no file exists."""
+        from bees.session import clear_resume_state
+
+        with tempfile.TemporaryDirectory() as tmp:
+            # Should not raise.
+            clear_resume_state(Path(tmp))
+
+    def test_binary_data_preserved(self):
+        """Arbitrary binary data survives round-trip."""
+        from bees.session import save_resume_state, load_resume_state
+
+        with tempfile.TemporaryDirectory() as tmp:
+            ticket_dir = Path(tmp)
+            state = bytes(range(256))
+            save_resume_state(ticket_dir, state)
+            self.assertEqual(load_resume_state(ticket_dir), state)
+
+    def test_creates_parent_dirs(self):
+        """save_resume_state creates parent directories."""
+        from bees.session import save_resume_state, load_resume_state
+
+        with tempfile.TemporaryDirectory() as tmp:
+            ticket_dir = Path(tmp) / "nested" / "deep"
+            save_resume_state(ticket_dir, b"hello")
+            self.assertEqual(load_resume_state(ticket_dir), b"hello")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What
Defines the `SessionRunner` protocol — the final protocol in the bees library extraction — along with the `drain_session` composition function and opaque resume state persistence.

## Why
This is the specify + test phase (Phase 1) of the last remaining protocol boundary between `bees` (orchestration) and the model provider (session execution). With this protocol defined, the next step can mechanically migrate `session.py`'s execution logic into a `GeminiRunner` in `bees-gemini`.

## Changes

### `bees/protocols/session.py`
- Add `SessionRunner` protocol with `run(config) → SessionStream` and `resume(config, state, response) → SessionStream`
- Export from `__all__` and `bees.protocols` package

### `bees/session.py`
- Add `drain_session()` — encapsulates the duplicated event-draining pattern from `run_session()` and `resume_session()` (iterate stream → collect via EvalCollector → write logs → build SessionResult)
- Add `save_resume_state()` / `load_resume_state()` / `clear_resume_state()` — opaque bytes persistence replacing the structured `session_state.json` pattern

### `docs/future.md`
- Update SessionRunner status from Pending → Specified

### New files
- `spec/session-runner.md` — full spec doc with design decisions, protocol shapes, migration plan
- `tests/test_protocols/test_session_runner.py` — 17 conformance tests

## Testing
```bash
cd packages/bees && .venv/bin/python -m pytest tests/test_protocols/ -v
# 135 passed
```
