### PR TITLE
[bees] Bees Phase 2 — Runner Migration

### DIFF
--- a/packages/bees/app/server.py
+++ b/packages/bees/app/server.py
@@ -31,6 +31,7 @@ from sse_starlette.sse import EventSourceResponse
 from app.auth import load_gemini_key
 from app.config import load_hive_dir
 from bees import Task, Bees
+from bees.runners.gemini import GeminiRunner
 from opal_backend.local.backend_client_impl import HttpBackendClient
 
 logger = logging.getLogger(__name__)
@@ -158,7 +159,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         gemini_key=gemini_key,
     )
 
-    bees = Bees(hive_dir, backend)
+    runner = GeminiRunner(backend)
+    bees = Bees(hive_dir, runner)
 
     bees.on("task_added", _on_task_added)
     bees.on("cycle_start", _on_cycle_start)

--- a/packages/bees/bees/bees.py
+++ b/packages/bees/bees/bees.py
@@ -16,9 +16,8 @@ class Bees:
     Acts like the 'Document' in the DOM analogy.
     """
 
-    def __init__(self, hive_dir: Path, backend):
+    def __init__(self, hive_dir: Path, runner):
         self._store = TaskStore(hive_dir)
-        self._backend = backend
         self._events = defaultdict(list)
         self._loop_task = None
         
@@ -30,7 +29,7 @@ class Bees:
             on_task_done=lambda t: self._emit("task_done", t),
             on_cycle_complete=lambda c: self._emit("cycle_complete", c),
         )
-        self._scheduler = Scheduler(backend=backend, hooks=hooks, store=self._store)
+        self._scheduler = Scheduler(runner=runner, hooks=hooks, store=self._store)
 
     async def _emit(self, event_name: str, *args):
         for callback in self._events[event_name]:

--- a/packages/bees/bees/box.py
+++ b/packages/bees/bees/box.py
@@ -42,6 +42,7 @@ from watchfiles import awatch, Change
 from app.auth import load_gemini_key
 from app.config import load_hive_dir
 from bees import Bees
+from bees.runners.gemini import GeminiRunner
 from bees.ticket import Ticket
 from opal_backend.local.backend_client_impl import HttpBackendClient
 
@@ -166,8 +167,10 @@ async def run(hive_dir: Path, backend: HttpBackendClient) -> None:
     # Write sentinel so hivetool knows the box is listening.
     startup_manager.activate()
 
+    runner = GeminiRunner(backend)
+
     while True:
-        bees = Bees(hive_dir, backend)
+        bees = Bees(hive_dir, runner)
 
         bees.on("task_added", _on_task_added)
         bees.on("cycle_start", _on_cycle_start)

--- a/packages/bees/bees/runners/gemini.py
+++ b/packages/bees/bees/runners/gemini.py
@@ -100,16 +100,21 @@ class GeminiStream:
         if event is None:
             self._exhausted = True
             await self._task
-            await self._capture_resume_state()
             raise StopAsyncIteration
 
-        # Track suspend/pause events — needed for resume state capture.
+        # Track suspend/pause events and capture resume state eagerly.
+        # Track suspend/pause events and capture resume state eagerly.
+        # The interaction store's load() is destructive (pop semantics),
+        # so we must do exactly one load that serves both enrichment and
+        # resume state capture.
         if "paused" in event:
             self._suspend_event = event
+            await self._capture_resume_state()
         else:
             for suspend_type in SUSPEND_TYPES:
                 if suspend_type in event:
                     self._suspend_event = event
+                    await self._capture_resume_state()
                     break
 
         return event
@@ -138,18 +143,18 @@ class GeminiStream:
     # -- internal ----------------------------------------------------------
 
     async def _capture_resume_state(self) -> None:
-        """Extract resume state from opal stores after the stream exhausts.
+        """Extract resume state from the interaction store.
 
-        Mirrors the logic from ``session.py._save_session_state``: find
-        the interaction_id (from the suspend event or session store), load
-        the ``InteractionState``, and serialize to a JSON blob.
+        Called eagerly when a suspend/pause event is detected — the store
+        uses pop semantics (``load`` consumes the entry), so this is the
+        single point where the state is read.
 
-        The blob also includes ``function_name`` extracted from the
-        ``InteractionState.function_call_part`` — this lets the consumer
-        annotate suspend events without interpreting the interaction state.
+        Also enriches the suspend event with ``function_name`` extracted
+        from the interaction state, so bees can differentiate suspend
+        reasons without interpreting the opaque blob.
         """
         if self._suspend_event is None:
-            return  # Completed normally — no resume needed.
+            return
 
         # Extract interaction_id from the suspend/pause event.
         interaction_id: str | None = None
@@ -176,7 +181,7 @@ class GeminiStream:
         if not interaction_id:
             return
 
-        # Load interaction state saved by the opal session loop.
+        # Single load — load() is destructive (pops the entry).
         state = await self._interaction_store.load(interaction_id)
         if state is None:
             return
@@ -199,6 +204,12 @@ class GeminiStream:
         self._resume_blob = json.dumps(
             blob, ensure_ascii=False,
         ).encode("utf-8")
+
+        # Enrich the suspend event with function_name so bees can
+        # differentiate (e.g., await_context_update vs request_user_input)
+        # without parsing the resume blob.
+        if function_name:
+            self._suspend_event["function_name"] = function_name
 
 
 # ---------------------------------------------------------------------------

--- a/packages/bees/bees/scheduler.py
+++ b/packages/bees/bees/scheduler.py
@@ -45,13 +45,12 @@ from typing import Any, Awaitable, Callable
 
 from bees.coordination import route_coordination_task
 from bees.playbook import run_task_done_hooks, load_system_config, run_playbook
-from bees.protocols.session import SessionResult
+from bees.protocols.session import SessionResult, SessionRunner, SessionStream
 from bees.task_runner import TaskRunner
 from bees.ticket import Ticket
 from bees.task_store import TaskStore
 from bees.functions.mcp_bridge import MCPRegistry
 from bees.context_updates import updates_to_context_parts
-from opal_backend.local.backend_client_impl import HttpBackendClient
 
 logger = logging.getLogger(__name__)
 
@@ -161,11 +160,10 @@ class Scheduler:
     def __init__(
         self,
         *,
-        backend: HttpBackendClient,
+        runner: SessionRunner,
         store: TaskStore,
         hooks: SchedulerHooks | None = None,
     ) -> None:
-        self._backend = backend
         self._hooks = hooks or SchedulerHooks()
         self.store = store
         self._trigger = asyncio.Event()
@@ -173,14 +171,14 @@ class Scheduler:
         self._running_tasks: set[str] = set()
         self._completion_events: dict[str, asyncio.Event] = {}
         self._active_tasks: dict[str, asyncio.Task] = {}
-        self._context_queues: dict[str, asyncio.Queue] = {}
+        self._active_streams: dict[str, SessionStream] = {}
         self._mcp_registry: MCPRegistry | None = None
 
-        self._runner = TaskRunner(
-            backend=self._backend,
+        self._task_runner = TaskRunner(
+            runner=runner,
             store=self.store,
             scheduler_ref=self,
-            context_queues=self._context_queues,
+            active_streams=self._active_streams,
             get_mcp_factories=lambda: (
                 self._mcp_registry.get_factories()
                 if self._mcp_registry else None
@@ -382,11 +380,11 @@ class Scheduler:
            batch mode).  Append to ``pending_context_updates`` in
            metadata for later drain.
         """
-        # Path 1: mid-stream injection via live queue.
-        queue = self._context_queues.get(target_id)
-        if queue is not None:
+        # Path 1: mid-stream injection via live stream.
+        stream = self._active_streams.get(target_id)
+        if stream is not None:
             parts = updates_to_context_parts([update])
-            queue.put_nowait(parts)
+            asyncio.create_task(stream.send_context(parts))
             logger.info("Context update injected mid-stream for %s", target_id)
             return
 
@@ -557,10 +555,10 @@ class Scheduler:
             )
 
             coros = [
-                self._runner.run_task(item)
+                self._task_runner.run_task(item)
                 for item in items
             ] + [
-                self._runner.resume_task(item)
+                self._task_runner.resume_task(item)
                 for item in resumable
             ]
             results = await asyncio.gather(*coros, return_exceptions=True)
@@ -676,7 +674,7 @@ class Scheduler:
                 if item.id in self._running_tasks:
                     continue
                 self._running_tasks.add(item.id)
-                coro = self._runner.run_task(item)
+                coro = self._task_runner.run_task(item)
                 async_task = asyncio.create_task(self._wrap_execution(item, coro))
                 self._active_tasks[item.id] = async_task
 
@@ -684,7 +682,7 @@ class Scheduler:
                 if item.id in self._running_tasks:
                     continue
                 self._running_tasks.add(item.id)
-                coro = self._runner.resume_task(item)
+                coro = self._task_runner.resume_task(item)
                 async_task = asyncio.create_task(self._wrap_execution(item, coro))
                 self._active_tasks[item.id] = async_task
 

--- a/packages/bees/bees/session.py
+++ b/packages/bees/bees/session.py
@@ -447,7 +447,7 @@ async def drain_session(
 # Resume state persistence
 # ---------------------------------------------------------------------------
 
-RESUME_STATE_FILENAME = "resume_state.bin"
+RESUME_STATE_FILENAME = "session_state.json"
 
 
 def save_resume_state(ticket_dir: Path, state: bytes) -> None:

--- a/packages/bees/bees/task_runner.py
+++ b/packages/bees/bees/task_runner.py
@@ -18,15 +18,17 @@ import sys
 from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable
 
-from bees.protocols.session import SessionResult
+from bees.context_updates import updates_to_context_parts
+from bees.protocols.session import SessionResult, SessionRunner, SessionStream
+from bees.provisioner import provision_session
 from bees.segments import resolve_segments
 from bees.session import (
     append_chat_log,
-    clear_session_state,
+    clear_resume_state,
+    drain_session,
     extract_files,
-    load_session_state,
-    resume_session,
-    run_session,
+    load_resume_state,
+    save_resume_state,
 )
 from bees.subagent_scope import SubagentScope
 from bees.task_store import TaskStore
@@ -48,20 +50,20 @@ class TaskRunner:
     def __init__(
         self,
         *,
-        backend: Any,
+        runner: SessionRunner,
         store: TaskStore,
         scheduler_ref: Any,
-        context_queues: dict[str, asyncio.Queue],
+        active_streams: dict[str, SessionStream],
         get_mcp_factories: Callable[[], list | None],
         deliver_context_update: Callable[[str, dict[str, Any]], None],
         on_events_broadcast: Callable[[Ticket], None],
         on_task_start: Callable[[Ticket], Awaitable[None]] | None = None,
         on_task_event: Callable[[str, dict], Awaitable[None]] | None = None,
     ) -> None:
-        self._backend = backend
+        self._runner = runner
         self._store = store
         self._scheduler_ref = scheduler_ref
-        self._context_queues = context_queues
+        self._active_streams = active_streams
         self._get_mcp_factories = get_mcp_factories
         self._deliver_context_update = deliver_context_update
         self._on_events_broadcast = on_events_broadcast
@@ -91,18 +93,13 @@ class TaskRunner:
         print(f"▶ [{label}] {task.objective!r}", file=sys.stderr)
 
         try:
-            ctx_queue: asyncio.Queue = asyncio.Queue()
-            self._context_queues[task.id] = ctx_queue
             segments = resolve_segments(task, self._store)
             scope = SubagentScope.for_ticket(task)
-            result = await run_session(
+            config = provision_session(
                 segments=segments,
-                backend=self._backend,
-                label=label,
                 ticket_id=task.id,
                 ticket_dir=task.dir,
                 fs_dir=task.fs_dir,
-                on_event=self._make_on_event(task.id),
                 function_filter=task.metadata.functions,
                 allowed_skills=task.metadata.skills,
                 model=task.metadata.model,
@@ -110,9 +107,27 @@ class TaskRunner:
                 deliver_to_parent=self._make_deliver_to_parent(task),
                 scope=scope,
                 scheduler=self._scheduler_ref,
-                context_queue=ctx_queue,
                 mcp_factories=self._get_mcp_factories(),
+                on_chat_entry=lambda role, text: append_chat_log(
+                    task.dir, role, text,
+                ),
             )
+
+            stream = await self._runner.run(config)
+            self._active_streams[task.id] = stream
+            try:
+                result = await drain_session(
+                    stream,
+                    config=config,
+                    ticket_id=task.id,
+                    on_event=self._make_on_event(task.id),
+                )
+            finally:
+                self._active_streams.pop(task.id, None)
+
+            resume_state = stream.resume_state()
+            if resume_state:
+                save_resume_state(task.dir, resume_state)
         except Exception as exc:
             task.metadata.status = "failed"
             task.metadata.completed_at = datetime.now(timezone.utc).isoformat()
@@ -126,8 +141,6 @@ class TaskRunner:
                 output="",
                 error=str(exc),
             )
-        finally:
-            self._context_queues.pop(task.id, None)
 
         self._update_metadata(task, result)
         self._handle_suspend(task, result)
@@ -165,6 +178,20 @@ class TaskRunner:
         if user_text:
             append_chat_log(task.dir, "user", user_text)
 
+        # Load opaque resume state from previous suspend.
+        state = load_resume_state(task.dir)
+        if state is None:
+            task.metadata.status = "failed"
+            task.metadata.error = "No saved session state found"
+            self._store.save_metadata(task)
+            return SessionResult(
+                session_id="",
+                status="failed",
+                events=0,
+                output="",
+                error="No saved session state found",
+            )
+
         task.metadata.status = "running"
         task.metadata.assignee = "agent"
         self._store.save_metadata(task)
@@ -172,24 +199,68 @@ class TaskRunner:
             await self._on_task_start(task)
 
         try:
+            # Assemble context updates from both sources:
+            #   1. response.json may contain context_updates (from delivery)
+            #   2. ticket metadata may have pending_context_updates (buffered)
+            all_updates: list = []
+            response_updates = response.pop("context_updates", None)
+            if response_updates:
+                all_updates.extend(response_updates)
+
+            if task.metadata.pending_context_updates:
+                all_updates.extend(task.metadata.pending_context_updates)
+                task.metadata.pending_context_updates = []
+                self._store.save_metadata(task)
+
+            context_parts = (
+                updates_to_context_parts(all_updates)
+                if all_updates
+                else None
+            )
+
             scope = SubagentScope.for_ticket(task)
-            ctx_queue: asyncio.Queue = asyncio.Queue()
-            self._context_queues[task.id] = ctx_queue
-            result = await resume_session(
+            config = provision_session(
+                segments=[],  # Not used for resume.
                 ticket_id=task.id,
                 ticket_dir=task.dir,
                 fs_dir=task.fs_dir,
-                response=response,
-                backend=self._backend,
-                label=label,
-                on_event=self._make_on_event(task.id),
+                function_filter=task.metadata.functions,
+                allowed_skills=task.metadata.skills,
                 on_events_broadcast=self._on_events_broadcast,
                 deliver_to_parent=self._make_deliver_to_parent(task),
                 scope=scope,
                 scheduler=self._scheduler_ref,
-                context_queue=ctx_queue,
                 mcp_factories=self._get_mcp_factories(),
+                on_chat_entry=lambda role, text: append_chat_log(
+                    task.dir, role, text,
+                ),
+                seed_files=False,  # Files already on disk from previous run.
             )
+
+            stream = await self._runner.resume(
+                config,
+                state=state,
+                response=response,
+                context_parts=context_parts,
+            )
+            self._active_streams[task.id] = stream
+            try:
+                result = await drain_session(
+                    stream,
+                    config=config,
+                    ticket_id=task.id,
+                    on_event=self._make_on_event(task.id),
+                )
+            finally:
+                self._active_streams.pop(task.id, None)
+
+            resume_state = stream.resume_state()
+            if resume_state:
+                save_resume_state(task.dir, resume_state)
+            else:
+                clear_resume_state(task.dir)
+                # Clean up response file.
+                response_path.unlink(missing_ok=True)
         except Exception as exc:
             task.metadata.status = "failed"
             task.metadata.completed_at = datetime.now(timezone.utc).isoformat()
@@ -203,17 +274,10 @@ class TaskRunner:
                 output="",
                 error=str(exc),
             )
-        finally:
-            self._context_queues.pop(task.id, None)
 
         self._update_metadata(task, result, accumulate=True)
         self._handle_suspend(task, result)
         self._handle_pause(task, result)
-
-        if not result.suspended and not result.paused:
-            clear_session_state(task.dir)
-            # Clean up response file.
-            response_path.unlink(missing_ok=True)
 
         self._store.save_metadata(task)
         return result
@@ -278,16 +342,9 @@ class TaskRunner:
                 if fresh.metadata.title != task.metadata.title:
                     task.metadata.title = fresh.metadata.title
 
-            # Annotate suspend_event with the triggering function name
-            # so the UI can differentiate (e.g., await_context_update
-            # vs. request_user_input). Read from saved session state.
+            # function_name is already in suspend_event — enriched by
+            # the runner before yielding.
             suspend_event = dict(result.suspend_event) if result.suspend_event else {}
-            state = load_session_state(task.dir)
-            if state:
-                fcp = state.get("interaction_state", {}).get("function_call_part", {})
-                fn_name = fcp.get("functionCall", {}).get("name")
-                if fn_name:
-                    suspend_event["function_name"] = fn_name
 
             if getattr(task.metadata, "queued_updates", None):
                 update = task.metadata.queued_updates.pop(0)

--- a/packages/bees/docs/future.md
+++ b/packages/bees/docs/future.md
@@ -120,7 +120,7 @@ phase is independently shippable.
 | #   | Spec                     | What changes                                                                            | Status  |
 | --- | ------------------------ | --------------------------------------------------------------------------------------- | ------- |
 | 1   | `gemini-runner`          | `GeminiRunner` + `GeminiStream` in `bees/runners/gemini.py`. Wraps opal session API.    | ✅      |
-| 2   | `runner-migration`       | `TaskRunner` / `Scheduler` / `Bees` accept `SessionRunner`. `box.py` constructs `GeminiRunner`. Uses `runner.run()` + `drain_session()`. | Pending |
+| 2   | `runner-migration`       | `TaskRunner` / `Scheduler` / `Bees` accept `SessionRunner`. `box.py` constructs `GeminiRunner`. Uses `runner.run()` + `drain_session()`. | ✅      |
 | 3   | `session-cleanup`        | Remove `run_session`, `resume_session`, legacy state, transitional back-imports.         | —       |
 | 4   | `bees-gemini-package`    | Move runner to `bees-gemini` package. Zero `opal_backend` imports in `bees/`.            | —       |
 
@@ -133,8 +133,7 @@ Phase 3 is deletion. Phase 4 is the payoff.
 | Module             | Imports                                                    | Removed in |
 | ------------------ | ---------------------------------------------------------- | ---------- |
 | `session.py`       | Session runtime (`new_session`, `start_session`, stores…)  | Phase 3    |
-| `scheduler.py`     | `HttpBackendClient` (type annotation only)                 | Phase 2    |
-| `box.py`           | `HttpBackendClient`, `app.auth`, `app.config`              | Phase 2/4  |
+| `box.py`           | `HttpBackendClient`, `app.auth`, `app.config`              | Phase 4    |
 | `handler_types.py` | Transitional back-imports (`SuspendError`, `AgentResult`)  | Phase 3    |
 
 ## The Consumption API

--- a/packages/bees/spec/runner-migration.md
+++ b/packages/bees/spec/runner-migration.md
@@ -1,0 +1,277 @@
+# Runner Migration — Spec Doc
+
+**Goal**: Rewire the constructor-to-consumption chain so `TaskRunner` uses
+`runner.run()` + `drain_session()` instead of `run_session()` /
+`resume_session()`, and `box.py` constructs `GeminiRunner`.
+
+## Context
+
+Phase 1 shipped `GeminiRunner` + `GeminiStream` as a standalone
+`SessionRunner` implementation. `drain_session()`, `save_resume_state()`,
+and `load_resume_state()` also exist in `session.py`. Everything is additive
+— nothing uses the new code yet.
+
+Phase 2 substitutes the old call path with the new one across the full chain:
+
+```
+Before:  box.py → Bees(backend) → Scheduler(backend) → TaskRunner(backend) → run_session()
+After:   box.py → GeminiRunner(backend) → Bees(runner) → Scheduler(runner) → TaskRunner(runner)
+```
+
+Per the SDD principle *"every PR leaves the system working"*, the substitution
+must include the full path from construction (`box.py`) to consumption
+(`TaskRunner`). Implementing the adapter without wiring it leaves dead code;
+wiring without the adapter doesn't build.
+
+### Remaining `opal_backend` imports removed by this phase
+
+| Module         | Import removed                        |
+| -------------- | ------------------------------------- |
+| `scheduler.py` | `HttpBackendClient` (type annotation) |
+
+## Design Decisions
+
+### Constructor chain passes `SessionRunner`, not `HttpBackendClient`
+
+`Bees.__init__`, `Scheduler.__init__`, and `TaskRunner.__init__` all change
+their `backend` parameter to `runner: SessionRunner`. The `HttpBackendClient`
+construction stays in `box.py` — it's an application concern, not a framework
+concern. The runner is the boundary.
+
+### `TaskRunner.run_task()` becomes provision → run → drain → persist
+
+```python
+config = provision_session(...)
+stream = await self._runner.run(config)
+self._active_streams[task.id] = stream
+try:
+    result = await drain_session(stream, config=config, ...)
+finally:
+    del self._active_streams[task.id]
+
+resume_state = stream.resume_state()
+if resume_state:
+    save_resume_state(task.dir, resume_state)
+```
+
+Four clean steps replace the 15-parameter `run_session()` call.
+`function_name` is already in `result.suspend_event` — the runner enriched
+it before yielding (see below).
+
+### `TaskRunner.resume_task()` assembles context updates directly
+
+The context update assembly logic currently buried inside
+`resume_session()` (lines 746–763) moves to `TaskRunner.resume_task()`.
+This is simpler because the task runner already has the task and store:
+
+```python
+all_updates = []
+response_updates = response.pop("context_updates", None)
+if response_updates:
+    all_updates.extend(response_updates)
+
+if task.metadata.pending_context_updates:
+    all_updates.extend(task.metadata.pending_context_updates)
+    task.metadata.pending_context_updates = []
+    self._store.save_metadata(task)
+
+context_parts = updates_to_context_parts(all_updates) if all_updates else None
+
+state = load_resume_state(task.dir)
+stream = await self._runner.resume(config, state=state, response=response,
+                                    context_parts=context_parts)
+result = await drain_session(stream, ...)
+```
+
+No more `scheduler.store.get(ticket_id)` fallback — the task runner has the
+task object and store directly.
+
+### Context delivery uses streams, not raw queues
+
+`Scheduler._context_queues: dict[str, asyncio.Queue]` becomes
+`_active_streams: dict[str, SessionStream]`. The mid-stream injection path
+changes from `queue.put_nowait(parts)` to
+`asyncio.create_task(stream.send_context(parts))`.
+
+`create_task` is correct because: (a) we're always inside the event loop,
+(b) `GeminiStream.send_context` just does `put_nowait` internally — no real
+I/O, the task completes instantly, and (c) `_deliver_context_update` must stay
+sync (called from sync function handler closures via `deliver_to_parent`).
+
+The `_context_queues` dict and the `context_queues` parameter throughout the
+`TaskRunner` constructor are removed.
+
+### The runner enriches suspend events, bees observes them
+
+Currently `_handle_suspend` reads `load_session_state(task.dir)` to extract
+`function_name` from the persisted `InteractionState.function_call_part`.
+This reaches across the abstraction boundary — bees interprets
+runner-internal state.
+
+After migration, `GeminiStream` enriches suspend events with
+`function_name` before yielding them. The function name is the runner's
+domain knowledge (it knows about `InteractionState` and
+`function_call_part`). Bees just reads it from `result.suspend_event`:
+
+```python
+# In GeminiStream.__anext__, when a suspend event is detected:
+for suspend_type in SUSPEND_TYPES:
+    if suspend_type in event:
+        iid = event[suspend_type].get("interactionId")
+        if iid:
+            state = await self._interaction_store.load(iid)
+            if state:
+                fcp = state.to_dict().get("function_call_part", {})
+                fn = fcp.get("functionCall", {}).get("name")
+                if fn:
+                    event["function_name"] = fn
+        break
+```
+
+The enriched event flows through `drain_session` → `EvalCollector` →
+`SessionResult.suspend_event`. `_handle_suspend` reads
+`result.suspend_event.get("function_name")` — no blob parsing, no disk
+reads, no reaching into runner internals.
+
+The resume state blob stays truly opaque. Bees never interprets it.
+
+### Same file, new writer
+
+The new persistence functions (`save_resume_state` / `load_resume_state` /
+`clear_resume_state`) use the same `session_state.json` filename as the
+legacy functions. The opacity boundary is the `bytes` API, not the filename.
+This means tasks suspended before the migration resume after the migration
+with zero issues — no backward compatibility concern.
+
+## Module Changes
+
+### `task_runner.py`
+
+**Imports**:
+- Remove: `run_session`, `resume_session`, `load_session_state`,
+  `clear_session_state` from `bees.session`
+- Add: `drain_session`, `save_resume_state`, `load_resume_state`,
+  `clear_resume_state` from `bees.session`
+- Add: `SessionRunner` from `bees.protocols.session`
+- Add: `provision_session` from `bees.provisioner`
+- Add: `updates_to_context_parts` from `bees.context_updates`
+
+**Constructor**:
+- `backend: Any` → `runner: SessionRunner`
+- Remove `context_queues` parameter — streams tracked internally
+- Add `_active_streams: dict[str, SessionStream]` (private)
+
+**`run_task()`**: Provision → `runner.run()` → `drain_session()` → persist.
+Pass `on_events_broadcast`, `deliver_to_parent`, `scope`, `scheduler` to
+`provision_session`. The stream goes into `_active_streams` for mid-session
+context delivery.
+
+**`resume_task()`**: `load_resume_state()` → provision → assemble
+`context_parts` → `runner.resume()` → `drain_session()` → persist or clear.
+
+**`_handle_suspend(task, result)`**: Drop `load_session_state` call. Read
+`function_name` from `result.suspend_event.get("function_name")` instead.
+
+### `scheduler.py`
+
+**Imports**:
+- Remove: `from opal_backend.local.backend_client_impl import HttpBackendClient`
+- Add: `from bees.protocols.session import SessionRunner`
+
+**Constructor**:
+- `backend: HttpBackendClient` → `runner: SessionRunner`
+- Remove `_context_queues` dict
+- Add `_active_streams: dict[str, SessionStream]` (shared with TaskRunner
+  via constructor injection, same pattern as `_context_queues` today)
+
+**`_deliver_context_update` Path 1**:
+```python
+stream = self._active_streams.get(target_id)
+if stream is not None:
+    parts = updates_to_context_parts([update])
+    asyncio.create_task(stream.send_context(parts))
+    return
+```
+
+**TaskRunner construction**: Pass `runner` instead of `backend`. Remove
+`context_queues` parameter.
+
+### `bees.py`
+
+**Constructor**: `backend` → `runner`. Passes `runner=runner` to
+`Scheduler(...)`. Remove `_backend` field.
+
+### `box.py`
+
+**Imports**: Add `from bees.runners.gemini import GeminiRunner`
+
+**`run()`**:
+```python
+runner = GeminiRunner(backend)
+bees = Bees(hive_dir, runner)
+```
+
+**`main()`**: Unchanged — still creates `HttpBackendClient` the same way.
+
+## Friction
+
+### `on_chat_entry` wiring for resume
+
+Currently `resume_session` creates its own `_make_chat_log_writer`. After
+migration, `TaskRunner.resume_task()` passes it via `provision_session`
+(same as `run_task` does today). `task_runner.py` imports
+`_make_chat_log_writer` from `session.py` — or uses its public wrapper
+`append_chat_log` plus the `provision_session` parameter.
+
+Resolution: `provision_session` already accepts `on_chat_entry`. Pass
+`_make_chat_log_writer(task.dir)` from the task runner. Import the private
+function or make it public.
+
+### `_active_streams` ownership
+
+Today `_context_queues` is owned by the Scheduler and passed to TaskRunner
+via constructor injection. The same pattern applies to `_active_streams`:
+Scheduler owns the dict, TaskRunner adds/removes entries, Scheduler reads
+for `_deliver_context_update`.
+
+### `SubagentScope` and `scheduler_ref`
+
+`provision_session` accepts `scope` and `scheduler`. TaskRunner already has
+both (`SubagentScope.for_ticket(task)` and `self._scheduler_ref`). No change
+needed — the parameters already flow correctly in `run_task`.
+
+### `hive_dir` inference
+
+`run_session` and `resume_session` infer `hive_dir` from `ticket_dir`. After
+migration, `provision_session` does the same inference internally (lines
+83–89 of `provisioner.py`). No change needed.
+
+## Not in scope
+
+- **Removing `run_session` / `resume_session`** — Phase 3 (session-cleanup).
+- **Removing transitional back-imports** (`SuspendError`, `AgentResult`) —
+  Phase 3.
+- **Moving runner to `bees-gemini` package** — Phase 4.
+- **Other `run_session` callers** (if any CLI scripts call it directly) —
+  they continue working until Phase 3.
+
+## Verification Plan
+
+### Automated
+
+1. `npm run build` — type-checks compilation.
+2. `npm run test -w packages/bees` — existing test suite passes.
+3. Manually inspect remaining `opal_backend` imports in `bees/` — should be
+   reduced by one (`scheduler.py`'s `HttpBackendClient`).
+
+### Manual
+
+1. Run `box` against a test hive. Create a task, watch it execute through
+   the new path.
+2. Trigger a task suspension (via `request_user_input`). Verify
+   `session_state.json` is written, `function_name` appears in metadata's
+   `suspend_event`.
+3. Resume the suspended task. Verify it picks up from `session_state.json`
+   and clears it on completion.
+4. Test mid-session context delivery (subagent completes while parent is
+   running). Verify `stream.send_context()` path works.

--- a/packages/bees/spec/session-runner.md
+++ b/packages/bees/spec/session-runner.md
@@ -230,9 +230,9 @@ def load_resume_state(ticket_dir: Path) -> bytes | None:
 ```
 
 These replace the existing `save_session_state` / `load_session_state` pair.
-The file format changes from structured JSON (`session_state.json`) to an
-opaque blob (`resume_state.bin`).  `clear_session_state` becomes
-`clear_resume_state` for symmetry.
+The API changes from structured `dict` to opaque `bytes`, but the file
+remains `session_state.json` — no filename change, no backward compatibility
+concern.  `clear_session_state` becomes `clear_resume_state` for symmetry.
 
 ## Migration Notes
 

--- a/packages/bees/tests/test_scheduler.py
+++ b/packages/bees/tests/test_scheduler.py
@@ -52,7 +52,7 @@ def write_template(tmp_path):
 @pytest.mark.asyncio
 async def test_wait_for_task_already_completed(mock_clients):
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
     
     ticket = GLOBAL_STORE.create("Objective")
     ticket.metadata.status = "completed"
@@ -65,7 +65,7 @@ async def test_wait_for_task_already_completed(mock_clients):
 @pytest.mark.asyncio
 async def test_wait_for_task_blocks_and_completes(mock_clients):
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
     
     ticket = GLOBAL_STORE.create("Objective")
     
@@ -86,7 +86,7 @@ async def test_wait_for_task_blocks_and_completes(mock_clients):
 @pytest.mark.asyncio
 async def test_wait_for_task_timeout(mock_clients):
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
     
     ticket = GLOBAL_STORE.create("Objective")
     ticket.metadata.status = "running"
@@ -99,7 +99,7 @@ async def test_wait_for_task_timeout(mock_clients):
 @pytest.mark.asyncio
 async def test_wait_for_task_returns_early_on_suspend(mock_clients):
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
     
     ticket = GLOBAL_STORE.create("Objective")
     ticket.metadata.status = "running"
@@ -121,7 +121,7 @@ async def test_wait_for_task_returns_early_on_suspend(mock_clients):
 @pytest.mark.asyncio
 async def test_wait_for_task_returns_early_on_fail(mock_clients):
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
     
     ticket = GLOBAL_STORE.create("Objective")
     ticket.metadata.status = "running"
@@ -143,7 +143,7 @@ async def test_wait_for_task_returns_early_on_fail(mock_clients):
 @pytest.mark.asyncio
 async def test_deliver_context_update_immediate(mock_clients):
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
     
     creator = GLOBAL_STORE.create("Parent Objective")
     creator.metadata.status = "suspended"
@@ -174,7 +174,7 @@ async def test_deliver_context_update_immediate(mock_clients):
 async def test_enrich_parent_tags_merges(mock_clients):
     """Child tags are merged (union) into the parent's existing tags."""
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
 
     parent = GLOBAL_STORE.create("Parent", tags=["b", "c"])
     child = GLOBAL_STORE.create("Child", tags=["a", "b"])
@@ -193,7 +193,7 @@ async def test_enrich_parent_tags_merges(mock_clients):
 async def test_enrich_parent_tags_no_parent(mock_clients):
     """No crash when parent_task_id points to a nonexistent task."""
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
 
     child = GLOBAL_STORE.create("Child", tags=["a"])
     child.metadata.parent_task_id = "nonexistent-id"
@@ -207,7 +207,7 @@ async def test_enrich_parent_tags_no_parent(mock_clients):
 async def test_enrich_parent_tags_no_tags(mock_clients):
     """Parent is unchanged when the child has no tags."""
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
 
     parent = GLOBAL_STORE.create("Parent", tags=["x"])
     child = GLOBAL_STORE.create("Child")  # No tags.
@@ -224,7 +224,7 @@ async def test_enrich_parent_tags_no_tags(mock_clients):
 async def test_enrich_parent_tags_parent_has_no_tags(mock_clients):
     """Parent with None tags receives the child's tags."""
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
 
     parent = GLOBAL_STORE.create("Parent")  # tags=None
     child = GLOBAL_STORE.create("Child", tags=["a"])
@@ -264,7 +264,7 @@ def test_update_metadata_paused(mock_clients):
     from bees.protocols.session import SessionResult
 
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
 
     ticket = GLOBAL_STORE.create("Objective")
     result = SessionResult(
@@ -276,7 +276,7 @@ def test_update_metadata_paused(mock_clients):
         error="503 Service Unavailable",
     )
 
-    scheduler._runner._update_metadata(ticket, result)
+    scheduler._task_runner._update_metadata(ticket, result)
 
     # _update_metadata sets completed_at, but for paused it should be None.
     assert ticket.metadata.completed_at is None
@@ -290,7 +290,7 @@ def test_handle_pause_sets_status(mock_clients):
     from bees.protocols.session import SessionResult
 
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
 
     ticket = GLOBAL_STORE.create("Objective")
     ticket.metadata.status = "running"
@@ -305,7 +305,7 @@ def test_handle_pause_sets_status(mock_clients):
         error="503 Service Unavailable",
     )
 
-    scheduler._runner._handle_pause(ticket, result)
+    scheduler._task_runner._handle_pause(ticket, result)
 
     assert ticket.metadata.status == "paused"
     assert ticket.metadata.assignee is None
@@ -340,7 +340,7 @@ async def test_boots_when_no_root_ticket_exists(mock_clients, write_template, tm
     system_path.write_text(yaml.dump({"root": "opie"}))
 
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
 
     ticket = await scheduler._boot_root_template([])
 
@@ -358,7 +358,7 @@ async def test_skips_when_root_already_booted(mock_clients, write_template, tmp_
     existing = run_playbook("opie", store=GLOBAL_STORE)
     
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
 
     ticket = await scheduler._boot_root_template([existing])
 
@@ -372,7 +372,7 @@ async def test_returns_none_when_no_root_configured(mock_clients, tmp_path, monk
     system_path.write_text(yaml.dump({"title": "My Hive"}))
 
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
 
     ticket = await scheduler._boot_root_template([])
     assert ticket is None
@@ -382,7 +382,7 @@ async def test_returns_none_when_no_root_configured(mock_clients, tmp_path, monk
 async def test_returns_none_when_no_system_yaml(mock_clients, tmp_path):
     
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, backend=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
 
     ticket = await scheduler._boot_root_template([])
     assert ticket is None

--- a/packages/bees/tests/test_tree.py
+++ b/packages/bees/tests/test_tree.py
@@ -16,7 +16,7 @@ def temp_hive():
 
 
 def test_tree_traversal(temp_hive):
-    bees = Bees(temp_hive, backend=Mock())
+    bees = Bees(temp_hive, runner=Mock())
     store = bees._store
 
     # Create a tree structure
@@ -70,13 +70,13 @@ def test_tree_traversal(temp_hive):
 
 
 def test_empty_store(temp_hive):
-    bees = Bees(temp_hive, backend=Mock())
+    bees = Bees(temp_hive, runner=Mock())
     assert len(bees.children) == 0
     assert bees.get_by_id("non-existent") is None
 
 
 def test_query_by_tags(temp_hive):
-    bees = Bees(temp_hive, backend=Mock())
+    bees = Bees(temp_hive, runner=Mock())
     store = bees._store
 
     # Create tasks with tags
@@ -109,7 +109,7 @@ def test_query_by_tags(temp_hive):
 
 @pytest.mark.asyncio
 async def test_bees_create_child(temp_hive):
-    bees = Bees(temp_hive, backend=Mock())
+    bees = Bees(temp_hive, runner=Mock())
     bees._scheduler = Mock()
     
     mock_ticket = Mock()
@@ -126,7 +126,7 @@ async def test_bees_create_child(temp_hive):
 
 @pytest.mark.asyncio
 async def test_task_node_create_child(temp_hive):
-    bees = Bees(temp_hive, backend=Mock())
+    bees = Bees(temp_hive, runner=Mock())
     bees._scheduler = Mock()
     
     mock_ticket = Mock()
@@ -149,7 +149,7 @@ async def test_task_node_create_child(temp_hive):
 
 
 def test_task_node_respond(temp_hive):
-    bees = Bees(temp_hive, backend=Mock())
+    bees = Bees(temp_hive, runner=Mock())
     store_mock = Mock()
     bees._store = store_mock
     
@@ -163,7 +163,7 @@ def test_task_node_respond(temp_hive):
 
 
 def test_task_node_respond_with_text_kwarg(temp_hive):
-    bees = Bees(temp_hive, backend=Mock())
+    bees = Bees(temp_hive, runner=Mock())
     store_mock = Mock()
     bees._store = store_mock
     
@@ -177,7 +177,7 @@ def test_task_node_respond_with_text_kwarg(temp_hive):
 
 
 def test_task_node_respond_with_selected_ids_kwarg(temp_hive):
-    bees = Bees(temp_hive, backend=Mock())
+    bees = Bees(temp_hive, runner=Mock())
     store_mock = Mock()
     bees._store = store_mock
     
@@ -191,7 +191,7 @@ def test_task_node_respond_with_selected_ids_kwarg(temp_hive):
 
 
 def test_task_node_respond_mutually_exclusive_kwargs(temp_hive):
-    bees = Bees(temp_hive, backend=Mock())
+    bees = Bees(temp_hive, runner=Mock())
     ticket = Mock()
     ticket.id = "task1"
     node = TaskNode(ticket, bees)
@@ -201,7 +201,7 @@ def test_task_node_respond_mutually_exclusive_kwargs(temp_hive):
 
 
 def test_task_node_respond_missing_kwargs(temp_hive):
-    bees = Bees(temp_hive, backend=Mock())
+    bees = Bees(temp_hive, runner=Mock())
     ticket = Mock()
     ticket.id = "task1"
     node = TaskNode(ticket, bees)
@@ -211,7 +211,7 @@ def test_task_node_respond_missing_kwargs(temp_hive):
 
 
 def test_task_node_respond_dict_and_kwargs_conflict(temp_hive):
-    bees = Bees(temp_hive, backend=Mock())
+    bees = Bees(temp_hive, runner=Mock())
     ticket = Mock()
     ticket.id = "task1"
     node = TaskNode(ticket, bees)
@@ -221,7 +221,7 @@ def test_task_node_respond_dict_and_kwargs_conflict(temp_hive):
 
 
 def test_task_node_awaiting_response(temp_hive):
-    bees = Bees(temp_hive, backend=Mock())
+    bees = Bees(temp_hive, runner=Mock())
     
     ticket = Mock()
     ticket.metadata = Mock()
@@ -250,7 +250,7 @@ def test_task_node_awaiting_response(temp_hive):
 
 
 def test_bees_all(temp_hive):
-    bees = Bees(temp_hive, backend=Mock())
+    bees = Bees(temp_hive, runner=Mock())
     store_mock = Mock()
     bees._store = store_mock
     


### PR DESCRIPTION
## What
Rewires the full `box → Bees → Scheduler → TaskRunner` chain to use the `SessionRunner` protocol instead of passing `HttpBackendClient` directly. `TaskRunner` now follows a `provision → runner.run() → drain_session() → persist` pattern.

## Why
Phase 2 of the library extraction roadmap. Decouples the scheduling/orchestration layer from the Gemini-specific session API. `scheduler.py` no longer imports from `opal_backend`. Moves the framework one step closer to zero provider dependencies.

## Changes

**Core rewiring**
- `task_runner.py` — rewritten to use `SessionRunner.run()` / `.resume()` + `drain_session()` instead of `run_session()` / `resume_session()`. Resume state persisted via opaque `save_resume_state` / `load_resume_state` API. `_handle_suspend` reads `function_name` from the enriched event instead of parsing the state blob from disk.
- `scheduler.py` — accepts `runner: SessionRunner` instead of `backend: HttpBackendClient`. `_context_queues` replaced with `_active_streams`; mid-stream delivery uses `stream.send_context()`. `_runner` renamed to `_task_runner`.
- `bees.py` — constructor accepts `runner` instead of `backend`.
- `box.py`, `app/server.py` — construct `GeminiRunner(backend)` at the app boundary and pass `runner` to `Bees`.

**Runner fix**
- `gemini.py` — merged `_enrich_function_name` into `_capture_resume_state`. `InMemoryInteractionStore.load()` uses pop semantics (destructive read); having two methods each call `load()` meant the first consumed the state and the second found nothing. Now a single `load()` serves both resume blob capture and function_name enrichment.

**Housekeeping**
- `session.py` — `RESUME_STATE_FILENAME` set to `session_state.json` (same file as legacy, zero backward compat risk).
- `docs/future.md` — Phase 2 marked ✅, remaining imports table updated.
- `spec/runner-migration.md` — new spec documenting the migration work order.

## Testing
- 383 unit tests pass.
- Live box run verified: suspend, resume, multi-task orchestration all working end-to-end.
