### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/packages/visual-editor/src/a2/google-drive/unescape.ts
+++ b/packages/visual-editor/src/a2/google-drive/unescape.ts
@@ -12,6 +12,11 @@ const namedEntities: Record<string, string> = {
   // add more as needed
 };
 
+/**
+ * WARNING: This function decodes HTML entities including `<`, `>`, and `&`.
+ * The output must NEVER be inserted into the DOM via innerHTML without
+ * sanitization. Use textContent or a sanitization library like DOMPurify.
+ */
 function unescape(html: string): string {
   return html.replace(unescapeTest, (_, n) => {
     n = n.toLowerCase();

--- a/packages/visual-editor/src/utils/make-share-link-from-template.ts
+++ b/packages/visual-editor/src/utils/make-share-link-from-template.ts
@@ -17,8 +17,8 @@ export function makeShareLinkFromTemplate({
 }: MakeShareLinkFromTemplate): string {
   const url = new URL(
     urlTemplate
-      .replaceAll("{fileId}", fileId)
-      .replaceAll("{resourceKey}", resourceKey ?? "")
+      .replaceAll("{fileId}", encodeURIComponent(fileId))
+      .replaceAll("{resourceKey}", resourceKey ? encodeURIComponent(resourceKey) : "")
   );
   // Remove any empty parameters. A slightly hacky way to clean up resourceKey
   // parameters when there is no resourceKey.


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `Medium` | **File**: `packages/visual-editor/src/a2/google-drive/unescape.ts:L1`

The `unescape` function in `packages/visual-editor/src/a2/google-drive/unescape.ts` decodes HTML entities (including numeric and named entities). If this function is used to process untrusted user input (e.g., filenames or content from Google Drive) that is subsequently rendered to the DOM using `innerHTML` or similar methods without additional sanitization, it could lead to Cross-Site Scripting (XSS) attacks. The function reverses the encoding performed by `escapeHtml`, effectively bypassing XSS protections if used incorrectly.

## Solution

Ensure that the output of `unescape` is never inserted into the DOM without proper sanitization. Consider using a dedicated sanitization library like DOMPurify if the content needs to be rendered as HTML, or ensure the output is treated as text content only (e.g., using `textContent` instead of `innerHTML`).

## Changes

- `packages/visual-editor/src/a2/google-drive/unescape.ts` (modified)
- `packages/visual-editor/src/utils/make-share-link-from-template.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced