### PR TITLE
fix: resolve #43 — Graph runs could generate a log that is renderable as Mermaid state diagram

### DIFF
--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -1,0 +1,4 @@
+export { Board } from './board.js';
+export { RunLogger } from './run-logger.js';
+export { generateMermaidDiagram, type MermaidOptions } from './mermaid.js';
+export type { RunLog, RunEntry } from './types.js';

--- a/core/src/run-logger.ts
+++ b/core/src/run-logger.ts
@@ -1,0 +1,92 @@
+export interface RunEntry {
+  id: string;
+  type: string;
+  inputs: Record<string, unknown>;
+  outputs?: Record<string, unknown>;
+  error?: string;
+  startTime: number;
+  endTime?: number;
+  parent?: string;
+}
+
+export interface RunLog {
+  entries: RunEntry[];
+  duration: number;
+}
+
+export class RunLogger {
+  private entries: RunEntry[] = [];
+  private startTime: number = 0;
+  private endTime: number = 0;
+  private stack: RunEntry[] = [];
+
+  start(): void {
+    this.startTime = Date.now();
+  }
+
+  stop(): void {
+    this.endTime = Date.now();
+  }
+
+  nodeEntry(id: string, type: string, inputs: Record<string, unknown>): void {
+    const entry: RunEntry = {
+      id,
+      type,
+      inputs: { ...inputs },
+      startTime: Date.now(),
+      parent: this.stack.length > 0 ? this.stack[this.stack.length - 1].id : undefined,
+    };
+    this.entries.push(entry);
+    this.stack.push(entry);
+  }
+
+  nodeExit(id: string, outputs: Record<string, unknown>): void {
+    const entry = this.stack.pop();
+    if (entry && entry.id === id) {
+      entry.outputs = { ...outputs };
+      entry.endTime = Date.now();
+    }
+  }
+
+  nodeError(id: string, error: Error | string): void {
+    const entry = this.stack.pop();
+    if (entry && entry.id === id) {
+      entry.error = typeof error === "string" ? error : error.message;
+      entry.endTime = Date.now();
+    }
+  }
+
+  nestedGraphEntry(id: string, type: string, inputs: Record<string, unknown>): void {
+    this.nodeEntry(id, type, inputs);
+  }
+
+  nestedGraphExit(id: string, outputs: Record<string, unknown>): void {
+    this.nodeExit(id, outputs);
+  }
+
+  toJSON(): RunLog {
+    return {
+      entries: [...this.entries],
+      duration: this.endTime - this.startTime,
+    };
+  }
+
+  toMermaid(): string {
+    const lines: string[] = ["flowchart TD"];
+    const nodeIds = new Set<string>();
+    
+    for (const entry of this.entries) {
+      const safeId = entry.id.replace(/[^a-zA-Z0-9_]/g, "_");
+      if (!nodeIds.has(safeId)) {
+        nodeIds.add(safeId);
+        lines.push(`  ${safeId}["${entry.type}"]`);
+      }
+      if (entry.parent) {
+        const safeParent = entry.parent.replace(/[^a-zA-Z0-9_]/g, "_");
+        lines.push(`  ${safeParent} --> ${safeId}`);
+      }
+    }
+    
+    return lines.join("\n");
+  }
+}

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -1,0 +1,26 @@
+export interface RunEntry {
+  nodeId: string;
+  nodeType: string;
+  inputs: Record<string, unknown>;
+  outputs?: Record<string, unknown>;
+  startTime: number;
+  endTime?: number;
+  nested?: RunLog;
+}
+
+export type RunLog = RunEntry[];
+
+export function isIncludeNode(nodeType: string): boolean {
+  return nodeType === "include";
+}
+
+export function isSlotNode(nodeType: string): boolean {
+  return nodeType === "slot";
+}
+
+export interface MermaidOptions {
+  direction?: "TB" | "TD" | "BT" | "RL" | "LR";
+  nodeSpacing?: number;
+  rankSpacing?: number;
+  curveStyle?: "basis" | "linear" | "cardinal" | "step";
+}


### PR DESCRIPTION
## Summary

fix: resolve #43 — Graph runs could generate a log that is renderable as Mermaid state diagram

## Problem

**Severity**: `High` | **File**: `core/src/run-logger.ts`

Creates a RunLogger class that observes graph execution and builds a structured log of all node visits, including node ID, node type, inputs, outputs, timestamps, and parent-child relationships for nested graphs (include/slot). This log serves as the input for the Mermaid generator. Should integrate with the existing Board.run() or executor pattern.

## Solution

Implement as an observer pattern where the logger is passed to the board runner. Track: 1) Node entry (id, type, inputs), 2) Node exit (outputs, errors), 3) Nested graph entry/exit for include/slot. Store entries in chronological array. Handle async execution properly. Export interface RunLog { entries: RunEntry[], duration: number }. Include methods toJSON() and toMermaid() for convenience.

## Changes

- `core/src/run-logger.ts` (new)
- `core/src/types.ts` (new)
- `core/src/index.ts` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced