### PR TITLE
fix: resolve #1940 — Add offline PWA support to breadboard Web

### DIFF
--- a/packages/breadboard-web/public/manifest.json
+++ b/packages/breadboard-web/public/manifest.json
@@ -1,0 +1,20 @@
+{
+  "short_name": "Breadboard",
+  "name": "Breadboard",
+  "icons": [
+    {
+      "src": "/icon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/icon-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
+  "start_url": "/",
+  "display": "standalone",
+  "theme_color": "#000000",
+  "background_color": "#ffffff"
+}

--- a/packages/breadboard-web/public/sw.js
+++ b/packages/breadboard-web/public/sw.js
@@ -1,0 +1,54 @@
+const CACHE_NAME = 'breadboard-cache-v1';
+const STATIC_ASSETS = [
+  '/',
+  '/index.html',
+  '/manifest.json'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => {
+      return cache.addAll(STATIC_ASSETS);
+    }).catch((err) => {
+      console.error('Failed to cache static assets:', err);
+    })
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((cacheNames) => {
+      return Promise.all(
+        cacheNames
+          .filter((name) => name !== CACHE_NAME)
+          .map((name) => caches.delete(name))
+      );
+    })
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then((response) => {
+      if (response) {
+        return response;
+      }
+      return fetch(event.request).then((fetchResponse) => {
+        if (!fetchResponse || fetchResponse.status !== 200 || fetchResponse.type !== 'basic') {
+          return fetchResponse;
+        }
+        const responseToCache = fetchResponse.clone();
+        caches.open(CACHE_NAME).then((cache) => {
+          cache.put(event.request, responseToCache);
+        });
+        return fetchResponse;
+      });
+    })
+  );
+});

--- a/packages/breadboard-web/src/register-service-worker.ts
+++ b/packages/breadboard-web/src/register-service-worker.ts
@@ -1,0 +1,13 @@
+export function registerServiceWorker(): void {
+  if ('serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+      navigator.serviceWorker.register('/sw.js')
+        .then((registration) => {
+          console.log('ServiceWorker registered:', registration.scope);
+        })
+        .catch((error) => {
+          console.error('ServiceWorker registration failed:', error);
+        });
+    });
+  }
+}


### PR DESCRIPTION
## Summary

fix: resolve #1940 — Add offline PWA support to breadboard Web

## Problem

**Severity**: `Low` | **File**: ``packages/breadboard-web/index.html` (or main web entry point)`

The application lacks the required Service Worker for offline asset caching and Web App Manifest for installability. To enable offline PWA support, the app needs: (1) A Service Worker to cache static assets (JS bundles, HTML, icons) and potentially API responses using a CacheFirst or StaleWhileRevalidate strategy, (2) A `manifest.json` file defining the app name, icons, theme colors, and display mode (standalone), and (3) Registration logic in the main entry point to install the Service Worker. This is an enhancement that improves UX in low-connectivity environments without breaking existing functionality.

## Solution



## Changes

- `packages/breadboard-web/public/manifest.json` (new)
- `packages/breadboard-web/public/sw.js` (new)
- `packages/breadboard-web/src/register-service-worker.ts` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced