### PR TITLE
[bees] Observation API — typed events replace SchedulerHooks

### DIFF
--- a/packages/bees/app/server.py
+++ b/packages/bees/app/server.py
@@ -31,6 +31,14 @@ from sse_starlette.sse import EventSourceResponse
 from app.auth import load_gemini_key
 from app.config import load_hive_dir
 from bees import Task, Bees
+from bees.protocols.events import (
+    CycleComplete,
+    CycleStarted,
+    TaskAdded,
+    TaskDone,
+    TaskEvent,
+    TaskStarted,
+)
 from bees.runners.gemini import GeminiRunner
 from opal_backend.local.backend_client_impl import HttpBackendClient
 
@@ -73,50 +81,50 @@ bees: Bees | None = None
 # ---------------------------------------------------------------------------
 
 
-async def _on_task_added(task: Task) -> None:
+async def _on_task_added(event: TaskAdded) -> None:
     """Broadcast a newly added agent."""
     await broadcaster.broadcast({
         "type": "agent:added",
-        "agent": _agent_to_dict(task),
+        "agent": _agent_to_dict(event.task),
     })
 
 
-async def _on_cycle_start(cycle: int, new: int, resumable: int) -> None:
+async def _on_cycle_start(event: CycleStarted) -> None:
     await broadcaster.broadcast({
         "type": "scheduler:started",
-        "wave": cycle,
-        "new": new,
-        "resumable": resumable,
+        "wave": event.cycle,
+        "new": event.available,
+        "resumable": event.resumable,
     })
 
 
-async def _on_task_event(task_id: str, event: dict[str, Any]) -> None:
+async def _on_task_event(event: TaskEvent) -> None:
     await broadcaster.broadcast({
         "type": "session:event",
-        "task_id": task_id,
-        "event": event,
+        "task_id": event.task_id,
+        "event": event.event,
     })
 
 
-async def _on_task_start(task: Task) -> None:
+async def _on_task_start(event: TaskStarted) -> None:
     """Broadcast when an agent transitions to running."""
     await broadcaster.broadcast({
         "type": "agent:updated",
-        "agent": _agent_to_dict(task),
+        "agent": _agent_to_dict(event.task),
     })
 
 
-async def _on_task_done(task: Task) -> None:
+async def _on_task_done(event: TaskDone) -> None:
     """Post-completion hook: broadcast updated agent state."""
     await broadcaster.broadcast({
         "type": "agent:updated",
-        "agent": _agent_to_dict(task),
+        "agent": _agent_to_dict(event.task),
     })
 
 
 
-async def _on_cycle_complete(cycles: int) -> None:
-    await broadcaster.broadcast({"type": "scheduler:stopped", "waves": cycles})
+async def _on_cycle_complete(event: CycleComplete) -> None:
+    await broadcaster.broadcast({"type": "scheduler:stopped", "waves": event.total_cycles})
 
 
 # ---------------------------------------------------------------------------
@@ -162,12 +170,12 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     runner = GeminiRunner(backend)
     bees = Bees(hive_dir, runner)
 
-    bees.on("task_added", _on_task_added)
-    bees.on("cycle_start", _on_cycle_start)
-    bees.on("task_event", _on_task_event)
-    bees.on("task_start", _on_task_start)
-    bees.on("task_done", _on_task_done)
-    bees.on("cycle_complete", _on_cycle_complete)
+    bees.on(TaskAdded, _on_task_added)
+    bees.on(CycleStarted, _on_cycle_start)
+    bees.on(TaskEvent, _on_task_event)
+    bees.on(TaskStarted, _on_task_start)
+    bees.on(TaskDone, _on_task_done)
+    bees.on(CycleComplete, _on_cycle_complete)
 
     await bees.listen()
 

--- a/packages/bees/bees/bees.py
+++ b/packages/bees/bees/bees.py
@@ -5,9 +5,17 @@ from __future__ import annotations
 import asyncio
 from collections import defaultdict
 from pathlib import Path
+from typing import Any, Awaitable, Callable, TypeVar
+
+from bees.protocols.events import SchedulerEvent
 from bees.task_store import TaskStore
 from bees.task_node import TaskNode
-from bees.scheduler import Scheduler, SchedulerHooks
+from bees.scheduler import Scheduler
+
+T = TypeVar("T", bound=SchedulerEvent)
+
+# Callback type for typed event listeners.
+EventCallback = Callable[..., Any]
 
 
 class Bees:
@@ -18,28 +26,29 @@ class Bees:
 
     def __init__(self, hive_dir: Path, runner):
         self._store = TaskStore(hive_dir)
-        self._events = defaultdict(list)
+        self._observers: dict[type[SchedulerEvent], list[EventCallback]] = defaultdict(list)
         self._loop_task = None
-        
-        hooks = SchedulerHooks(
-            on_task_added=lambda t: self._emit("task_added", t),
-            on_cycle_start=lambda c, a, r: self._emit("cycle_start", c, a, r),
-            on_task_event=lambda t, e: self._emit("task_event", t, e),
-            on_task_start=lambda t: self._emit("task_start", t),
-            on_task_done=lambda t: self._emit("task_done", t),
-            on_cycle_complete=lambda c: self._emit("cycle_complete", c),
-        )
-        self._scheduler = Scheduler(runner=runner, hooks=hooks, store=self._store)
 
-    async def _emit(self, event_name: str, *args):
-        for callback in self._events[event_name]:
-            res = callback(*args)
+        self._scheduler = Scheduler(
+            runner=runner, emit=self._emit, store=self._store,
+        )
+
+    async def _emit(self, event: SchedulerEvent) -> None:
+        """Dispatch a typed event to all registered observers."""
+        # Dispatch to observers registered for this specific event type.
+        for callback in self._observers.get(type(event), []):
+            res = callback(event)
             if asyncio.iscoroutine(res):
                 await res
 
-    def on(self, event_name: str, callback):
-        """Registers an event listener."""
-        self._events[event_name].append(callback)
+    def on(self, event_type: type[T], callback: Callable[[T], Any]) -> None:
+        """Register a typed event listener.
+
+        Example::
+
+            bees.on(TaskDone, lambda e: print(f"Done: {e.task.id}"))
+        """
+        self._observers[event_type].append(callback)
 
     def pause_all(self) -> int:
         """Pause all non-terminal tasks.
@@ -112,4 +121,3 @@ class Bees:
         """Creates a root task."""
         task = await self._scheduler.create_task(objective, **kwargs)
         return TaskNode(task, self)
-

--- a/packages/bees/bees/box.py
+++ b/packages/bees/bees/box.py
@@ -42,6 +42,14 @@ from watchfiles import awatch, Change
 from app.auth import load_gemini_key
 from app.config import load_hive_dir
 from bees import Bees
+from bees.protocols.events import (
+    CycleComplete,
+    CycleStarted,
+    TaskAdded,
+    TaskDone,
+    TaskEvent,
+    TaskStarted,
+)
 from bees.runners.gemini import GeminiRunner
 from bees.ticket import Ticket
 from opal_backend.local.backend_client_impl import HttpBackendClient
@@ -103,29 +111,32 @@ def classify_change(path: Path, hive_dir: Path) -> ChangeKind:
 # ---------------------------------------------------------------------------
 
 
-async def _on_task_added(task: Ticket) -> None:
+async def _on_task_added(event: TaskAdded) -> None:
+    task = event.task
     logger.info("Agent added: %s (%s)", task.metadata.title or task.id[:8], task.id[:8])
 
 
-async def _on_cycle_start(cycle: int, new: int, resumable: int) -> None:
+async def _on_cycle_start(event: CycleStarted) -> None:
     logger.info(
         "Cycle %d: %d new + %d resumable",
-        cycle, new, resumable,
+        event.cycle, event.available, event.resumable,
     )
 
 
-async def _on_task_event(task_id: str, event: dict) -> None:
-    logger.debug("Event [%s]: %s", task_id[:8], event.get("type", "unknown"))
+async def _on_task_event(event: TaskEvent) -> None:
+    logger.debug("Event [%s]: %s", event.task_id[:8], event.event.get("type", "unknown"))
 
 
-async def _on_task_start(task: Ticket) -> None:
+async def _on_task_start(event: TaskStarted) -> None:
+    task = event.task
     logger.info(
         "Agent running: %s (%s)",
         task.metadata.title or task.id[:8], task.id[:8],
     )
 
 
-async def _on_task_done(task: Ticket) -> None:
+async def _on_task_done(event: TaskDone) -> None:
+    task = event.task
     logger.info(
         "Agent %s: %s (%s)",
         task.metadata.status,
@@ -134,8 +145,8 @@ async def _on_task_done(task: Ticket) -> None:
     )
 
 
-async def _on_cycle_complete(cycles: int) -> None:
-    logger.info("All cycles complete (%d total)", cycles)
+async def _on_cycle_complete(event: CycleComplete) -> None:
+    logger.info("All cycles complete (%d total)", event.total_cycles)
 
 
 # ---------------------------------------------------------------------------
@@ -172,12 +183,12 @@ async def run(hive_dir: Path, backend: HttpBackendClient) -> None:
     while True:
         bees = Bees(hive_dir, runner)
 
-        bees.on("task_added", _on_task_added)
-        bees.on("cycle_start", _on_cycle_start)
-        bees.on("task_event", _on_task_event)
-        bees.on("task_start", _on_task_start)
-        bees.on("task_done", _on_task_done)
-        bees.on("cycle_complete", _on_cycle_complete)
+        bees.on(TaskAdded, _on_task_added)
+        bees.on(CycleStarted, _on_cycle_start)
+        bees.on(TaskEvent, _on_task_event)
+        bees.on(TaskStarted, _on_task_start)
+        bees.on(TaskDone, _on_task_done)
+        bees.on(CycleComplete, _on_cycle_complete)
 
         await bees.listen()
         logger.info("Bees started — watching for changes")

--- a/packages/bees/bees/coordination.py
+++ b/packages/bees/bees/coordination.py
@@ -19,6 +19,7 @@ from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable
 
 from bees.playbook import run_event_hooks
+from bees.protocols.events import EventEmitter, TaskDone
 from bees.task_store import TaskStore
 from bees.ticket import Ticket
 
@@ -31,7 +32,7 @@ async def route_coordination_task(
     task: Ticket,
     store: TaskStore,
     running_tasks: set[str],
-    on_task_done: Callable[[Ticket], Awaitable[None]] | None = None,
+    emit: EventEmitter,
 ) -> None:
     """Route a coordination task's signal to matching subscribers.
 
@@ -135,5 +136,4 @@ async def route_coordination_task(
     store.save_metadata(task)
 
     # Broadcast the updated coordination task to the UI.
-    if on_task_done:
-        await on_task_done(task)
+    await emit(TaskDone(task=task))

--- a/packages/bees/bees/protocols/events.py
+++ b/packages/bees/bees/protocols/events.py
@@ -1,0 +1,121 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Typed scheduler events for the Observation API.
+
+Each event is a ``@dataclass`` with named fields, replacing the positional
+callback signatures of the former ``SchedulerHooks``.  Events subclass
+``SchedulerEvent`` so consumers can subscribe to individual types or
+handle the base type uniformly.
+
+The ``EventEmitter`` type alias defines the callback signature threaded
+through ``Scheduler`` and ``TaskRunner``.
+
+See ``spec/observation.md`` for design rationale.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, fields
+from typing import Any, Awaitable, Callable, TypeVar
+
+from bees.ticket import Ticket
+
+__all__ = [
+    "CycleComplete",
+    "CycleStarted",
+    "EventEmitter",
+    "SchedulerEvent",
+    "TaskAdded",
+    "TaskDone",
+    "TaskEvent",
+    "TaskStarted",
+]
+
+
+# ---------------------------------------------------------------------------
+# Base event
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SchedulerEvent:
+    """Base for all scheduler-emitted events.
+
+    Every event carries a ``type`` discriminator for uniform logging,
+    serialization, and fan-out.
+    """
+
+    type: str = field(init=False, default="unknown")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a plain dict for JSON / SSE transport."""
+        result: dict[str, Any] = {}
+        for f in fields(self):
+            value = getattr(self, f.name)
+            result[f.name] = value.to_dict() if hasattr(value, "to_dict") else value
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Concrete events
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TaskAdded(SchedulerEvent):
+    """A new task was created or discovered."""
+
+    type: str = field(init=False, default="task_added")
+    task: Ticket = field(default=None)  # type: ignore[assignment]
+
+
+@dataclass
+class CycleStarted(SchedulerEvent):
+    """A new scheduling cycle is beginning."""
+
+    type: str = field(init=False, default="cycle_started")
+    cycle: int = 0
+    available: int = 0
+    resumable: int = 0
+
+
+@dataclass
+class TaskEvent(SchedulerEvent):
+    """A running session emitted a raw event."""
+
+    type: str = field(init=False, default="task_event")
+    task_id: str = ""
+    event: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class TaskStarted(SchedulerEvent):
+    """A task transitioned to running."""
+
+    type: str = field(init=False, default="task_started")
+    task: Ticket = field(default=None)  # type: ignore[assignment]
+
+
+@dataclass
+class TaskDone(SchedulerEvent):
+    """A task reached a resting state (completed/failed/suspended/paused)."""
+
+    type: str = field(init=False, default="task_done")
+    task: Ticket = field(default=None)  # type: ignore[assignment]
+
+
+@dataclass
+class CycleComplete(SchedulerEvent):
+    """All work is done — the scheduler is idle."""
+
+    type: str = field(init=False, default="cycle_complete")
+    total_cycles: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Emitter type
+# ---------------------------------------------------------------------------
+
+# The single callback signature used by Scheduler and TaskRunner.
+EventEmitter = Callable[[SchedulerEvent], Awaitable[None]]

--- a/packages/bees/bees/scheduler.py
+++ b/packages/bees/bees/scheduler.py
@@ -6,7 +6,7 @@ Scheduler — unified task lifecycle and orchestration.
 
 Owns the decisions of *what runs when* and the metadata bookkeeping
 around each task's execution.  Consumers (server, CLI) plug in
-behaviour via ``SchedulerHooks``.
+behaviour via typed ``SchedulerEvent`` callbacks (see ``bees.protocols.events``).
 
 The Concept of a Cycle
 ----------------------
@@ -40,11 +40,19 @@ from __future__ import annotations
 import asyncio
 import logging
 import sys
-from dataclasses import dataclass
 from typing import Any, Awaitable, Callable
 
 from bees.coordination import route_coordination_task
 from bees.playbook import run_task_done_hooks, load_system_config, run_playbook
+from bees.protocols.events import (
+    CycleComplete,
+    CycleStarted,
+    EventEmitter,
+    TaskAdded,
+    TaskDone,
+    TaskEvent,
+    TaskStarted,
+)
 from bees.protocols.session import SessionResult, SessionRunner, SessionStream
 from bees.task_runner import TaskRunner
 from bees.ticket import Ticket
@@ -56,44 +64,12 @@ logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# Lifecycle hooks
+# No-op emitter (default when no observer is registered)
 # ---------------------------------------------------------------------------
 
 
-@dataclass
-class SchedulerHooks:
-    """Optional callbacks that consumers register to react to scheduler events.
-    """
-
-    on_startup: Callable[[list[Ticket]], Awaitable[None]] | None = None
-    """Called once after recovery, with the full task list."""
-
-    on_task_added: Callable[[Ticket], Awaitable[None]] | None = None
-    """Called when a new task is created."""
-
-    on_cycle_start: Callable[[int, int, int], Awaitable[None]] | None = None
-    """Called at the start of each cycle.
-
-    Arguments passed to the callback:
-    - cycle_number: The sequence number of the current cycle (1-based).
-    - available_count: The number of new ('available') tasks being processed.
-    - resumable_count: The number of suspended tasks being resumed.
-    """
-
-    on_task_event: Callable[[str, dict], Awaitable[None]] | None = None
-    """Called when a running session emits an event (task_id, event_dict)."""
-
-    on_task_start: Callable[[Ticket], Awaitable[None]] | None = None
-    """Called when a task transitions to running (for UI updates)."""
-
-    on_task_done: Callable[[Ticket], Awaitable[None]] | None = None
-    """Called when a task reaches a resting state (completed/failed/suspended/paused)."""
-
-    on_events_broadcast: Callable[[Ticket], None] | None = None
-    """Called when an agent broadcasts an event mid-session."""
-
-    on_cycle_complete: Callable[[int], Awaitable[None]] | None = None
-    """Called when there is no more work (total_cycles)."""
+async def _noop_emit(event: Any) -> None:
+    """Default emitter that discards events."""
 
 
 # ---------------------------------------------------------------------------
@@ -162,9 +138,9 @@ class Scheduler:
         *,
         runner: SessionRunner,
         store: TaskStore,
-        hooks: SchedulerHooks | None = None,
+        emit: EventEmitter | None = None,
     ) -> None:
-        self._hooks = hooks or SchedulerHooks()
+        self._emit = emit or _noop_emit
         self.store = store
         self._trigger = asyncio.Event()
         self._running = False
@@ -185,8 +161,7 @@ class Scheduler:
             ),
             deliver_context_update=self._deliver_context_update,
             on_events_broadcast=self._on_events_broadcast_internal,
-            on_task_start=self._hooks.on_task_start,
-            on_task_event=self._hooks.on_task_event,
+            emit=self._emit,
         )
 
     # -- public API --------------------------------------------------------
@@ -196,7 +171,7 @@ class Scheduler:
         self._trigger.set()
 
     async def startup(self) -> Ticket | None:
-        """Recover stuck tasks, boot root template if needed, and fire startup hook."""
+        """Recover stuck tasks, boot root template if needed."""
         tasks = await self.recover_stuck_tasks()
 
         # Connect to MCP servers declared in SYSTEM.yaml.
@@ -209,10 +184,7 @@ class Scheduler:
         root_task = await self._boot_root_template(tasks)
         if root_task:
             tasks.append(root_task)
-            
-        if self._hooks.on_startup:
-            await self._hooks.on_startup(tasks)
-            
+
         return root_task
 
     async def shutdown(self) -> None:
@@ -222,12 +194,9 @@ class Scheduler:
             self._mcp_registry = None
 
     async def create_task(self, objective: str, **kwargs) -> Ticket:
-        """Create a new task and notify hooks."""
+        """Create a new task and emit TaskAdded."""
         task = self.store.create(objective, **kwargs)
-        
-        if self._hooks.on_task_added:
-            await self._hooks.on_task_added(task)
-            
+        await self._emit(TaskAdded(task=task))
         self.trigger()
         return task
 
@@ -246,10 +215,7 @@ class Scheduler:
 
         logger.info("Booting root template '%s'", root)
         task = run_playbook(root, store=self.store)
-        
-        if self._hooks.on_task_added:
-            await self._hooks.on_task_added(task)
-            
+        await self._emit(TaskAdded(task=task))
         return task
 
     async def wait_for_task(self, task_id: str, timeout_ms: float) -> str:
@@ -514,7 +480,7 @@ class Scheduler:
             for t in coordination:
                 await route_coordination_task(
                     t, self.store, self._running_tasks,
-                    self._hooks.on_task_done,
+                    self._emit,
                 )
 
             items = [
@@ -545,8 +511,9 @@ class Scheduler:
             cycle += 1
             total = len(items) + len(resumable)
 
-            if self._hooks.on_cycle_start:
-                await self._hooks.on_cycle_start(cycle, len(items), len(resumable))
+            await self._emit(CycleStarted(
+                cycle=cycle, available=len(items), resumable=len(resumable),
+            ))
 
             print(
                 f"Cycle {cycle}: {len(items)} new + {len(resumable)} "
@@ -579,18 +546,14 @@ class Scheduler:
                         "output": result.output,
                     })
 
-        if self._hooks.on_cycle_complete:
-            await self._hooks.on_cycle_complete(cycle)
+        await self._emit(CycleComplete(total_cycles=cycle))
 
         return all_summaries
 
     # -- internal ----------------------------------------------------------
 
     def _on_events_broadcast_internal(self, task: Ticket) -> None:
-        if self._hooks.on_events_broadcast:
-            self._hooks.on_events_broadcast(task)
-        if self._hooks.on_task_added:
-            asyncio.create_task(self._hooks.on_task_added(task))
+        asyncio.create_task(self._emit(TaskAdded(task=task)))
         self.trigger()
 
     async def _wrap_execution(
@@ -620,10 +583,9 @@ class Scheduler:
                 self._deliver_context_update(parent_id, update)
 
             enriched = self._enrich_parent_tags(updated)
-            if enriched and self._hooks.on_task_done:
-                await self._hooks.on_task_done(enriched)
-            if self._hooks.on_task_done:
-                await self._hooks.on_task_done(updated)
+            if enriched:
+                await self._emit(TaskDone(task=enriched))
+            await self._emit(TaskDone(task=updated))
 
             self.trigger()
 
@@ -648,7 +610,7 @@ class Scheduler:
             for t in coordination:
                 await route_coordination_task(
                     t, self.store, self._running_tasks,
-                    self._hooks.on_task_done,
+                    self._emit,
                 )
 
             items = [
@@ -665,10 +627,9 @@ class Scheduler:
 
             cycle += 1
 
-            if self._hooks.on_cycle_start:
-                await self._hooks.on_cycle_start(
-                    cycle, len(items), len(resumable),
-                )
+            await self._emit(CycleStarted(
+                cycle=cycle, available=len(items), resumable=len(resumable),
+            ))
 
             for item in items:
                 if item.id in self._running_tasks:
@@ -688,5 +649,4 @@ class Scheduler:
 
             await asyncio.sleep(1)
 
-        if self._hooks.on_cycle_complete:
-            await self._hooks.on_cycle_complete(cycle)
+        await self._emit(CycleComplete(total_cycles=cycle))

--- a/packages/bees/bees/task_runner.py
+++ b/packages/bees/bees/task_runner.py
@@ -19,6 +19,11 @@ from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable
 
 from bees.context_updates import updates_to_context_parts
+from bees.protocols.events import (
+    EventEmitter,
+    TaskEvent,
+    TaskStarted,
+)
 from bees.protocols.session import SessionResult, SessionRunner, SessionStream
 from bees.provisioner import provision_session
 from bees.segments import resolve_segments
@@ -57,8 +62,7 @@ class TaskRunner:
         get_mcp_factories: Callable[[], list | None],
         deliver_context_update: Callable[[str, dict[str, Any]], None],
         on_events_broadcast: Callable[[Ticket], None],
-        on_task_start: Callable[[Ticket], Awaitable[None]] | None = None,
-        on_task_event: Callable[[str, dict], Awaitable[None]] | None = None,
+        emit: EventEmitter,
     ) -> None:
         self._runner = runner
         self._store = store
@@ -67,8 +71,7 @@ class TaskRunner:
         self._get_mcp_factories = get_mcp_factories
         self._deliver_context_update = deliver_context_update
         self._on_events_broadcast = on_events_broadcast
-        self._on_task_start = on_task_start
-        self._on_task_event = on_task_event
+        self._emit = emit
 
     # -- public API --------------------------------------------------------
 
@@ -86,8 +89,7 @@ class TaskRunner:
 
         task.metadata.status = "running"
         self._store.save_metadata(task)
-        if self._on_task_start:
-            await self._on_task_start(task)
+        await self._emit(TaskStarted(task=task))
 
         label = task.id[:8]
         print(f"▶ [{label}] {task.objective!r}", file=sys.stderr)
@@ -195,8 +197,7 @@ class TaskRunner:
         task.metadata.status = "running"
         task.metadata.assignee = "agent"
         self._store.save_metadata(task)
-        if self._on_task_start:
-            await self._on_task_start(task)
+        await self._emit(TaskStarted(task=task))
 
         try:
             # Assemble context updates from both sources:
@@ -386,11 +387,10 @@ class TaskRunner:
         return deliver
 
     def _make_on_event(self, task_id: str):
-        """Create an event callback wired to the task-event hook."""
-        hook = self._on_task_event
+        """Create an event callback wired to the emit system."""
+        emit = self._emit
 
         async def on_event(event: dict[str, Any]):
-            if hook:
-                await hook(task_id, event)
+            await emit(TaskEvent(task_id=task_id, event=event))
 
         return on_event

--- a/packages/bees/docs/future.md
+++ b/packages/bees/docs/future.md
@@ -122,18 +122,27 @@ phase is independently shippable.
 | 1   | `gemini-runner`          | `GeminiRunner` + `GeminiStream` in `bees/runners/gemini.py`. Wraps opal session API.                                                     | ✅     |
 | 2   | `runner-migration`       | `TaskRunner` / `Scheduler` / `Bees` accept `SessionRunner`. `box.py` constructs `GeminiRunner`. Uses `runner.run()` + `drain_session()`. | ✅     |
 | 3   | `session-cleanup`        | Remove `run_session`, `resume_session`, legacy state, dead imports from `session.py`.                                                    | ✅     |
-| 4   | `gemini-runners-package` | Move runner to `gemini-runners` package. Zero `opal_backend` imports in `bees/`.                                                         | —      |
+| 4   | `gemini-runners-package` | Move runner to `gemini-runners` package. `box.py` moves to `box` package.                                                                | —      |
 
 **Phase 1** is pure additive code — nothing breaks. Phase 2 is the full
 substitution from construction (`box.py`) to consumption (`TaskRunner`). Phase 3
-is deletion. Phase 4 is the payoff.
+is deletion. Phase 4 is packaging.
 
 **Remaining `opal_backend` imports** in `bees/`:
 
-| Module             | Imports                                                   | Removed in |
-| ------------------ | --------------------------------------------------------- | ---------- |
-| `box.py`           | `HttpBackendClient`, `app.auth`, `app.config`             | Phase 4    |
-| `handler_types.py` | Transitional back-imports (`SuspendError`, `AgentResult`) | Phase 4    |
+| Module             | Imports                                                   | Removed in                |
+| ------------------ | --------------------------------------------------------- | ------------------------- |
+| `box.py`           | `HttpBackendClient`, `app.auth`, `app.config`             | Phase 4 (moves to `box`)  |
+| `handler_types.py` | Transitional back-imports (`SuspendError`, `AgentResult`) | Accepted — see note below |
+
+> **Transitional back-imports are accepted.** The opal session loop
+> (`opal_backend/run.py`) catches `SuspendError` and checks
+> `isinstance(result, AgentResult)` using opal's classes. Migrating the loop to
+> eliminate these two imports would risk losing battle-hardened retry logic,
+> exponential backoff, and other Chesterton's fences. The back-imports are
+> documented, harmless, and expire naturally when a new session path (e.g.,
+> Gemini Live API) replaces the opal loop. The cost — two type-level imports in
+> one file — is not worth the risk of rewriting the loop.
 
 ## The Consumption API
 
@@ -158,6 +167,10 @@ typed event stream rather than positional callbacks, and cleanly separate
 read-only observation from write-side interaction. The reference app's SSE
 `Broadcaster` is evidence of the pattern — it already fans out to multiple
 clients. The framework should do the same at the scheduler level.
+
+**Active spec**: [spec/observation.md](../spec/observation.md) — typed event
+dataclasses replacing `SchedulerHooks`, with `EventEmitter` callback threading
+through `Scheduler` → `TaskRunner`.
 
 ### Hive Abstraction
 

--- a/packages/bees/spec/observation.md
+++ b/packages/bees/spec/observation.md
@@ -1,0 +1,242 @@
+# Observation API — Spec Doc
+
+**Goal**: Replace `SchedulerHooks` with a typed event stream that supports
+multiple observers and makes event semantics explicit in the type system.
+
+## Context
+
+`SchedulerHooks` is a `@dataclass` with 7 optional callback fields. It was the
+right first step — simple, direct, and functional. But it has grown into a
+design smell:
+
+- **Stringly typed at the `Bees` level.** `bees.on("task_doen", cb)` silently
+  does nothing. No validation, no autocomplete.
+- **Untyped payloads.** `on_cycle_start` takes `(int, int, int)`. The semantics
+  live in docstrings, not code.
+- **No event objects.** Each hook has a different signature. You can't subscribe
+  to all events, filter, log, or relay them uniformly.
+- **`SchedulerHooks` is redundant.** `Bees.on()` wraps it with lambdas. The
+  dataclass adds no value — it's a pass-through layer.
+- **Mixed sync/async.** `on_events_broadcast` is sync; all others are async.
+  The contract is invisible.
+- **Leaked through constructor params.** `TaskRunner.__init__` receives
+  `on_task_start` and `on_task_event` as individual `Callable` params —
+  fragmented from the hooks bag.
+- **`on_startup` is dead.** Declared in `SchedulerHooks` but never wired by
+  `Bees.on()`. Neither consumer registers for it.
+
+### Consumers
+
+Two consumers exist today:
+
+| Consumer     | Events used | Purpose              |
+| ------------ | ----------- | -------------------- |
+| `box.py`     | 6 of 7      | Logging              |
+| `server.py`  | 6 of 7      | SSE broadcast to UI  |
+
+Both register the same 6 events (`task_added`, `cycle_start`, `task_event`,
+`task_start`, `task_done`, `cycle_complete`). Neither uses `on_startup`.
+
+### Internal wiring
+
+`Scheduler` also uses hooks internally in two places that break the abstraction:
+
+1. **`route_coordination_task`** receives `on_task_done` as a bare `Callable`
+   parameter instead of going through the hooks system.
+2. **`_on_events_broadcast_internal`** calls both `on_events_broadcast` *and*
+   `on_task_added` — overloaded semantics.
+
+## Design Decisions
+
+### Typed event dataclasses, not string keys
+
+Each event is a `@dataclass` with named fields. `Bees.on()` dispatches by type,
+not by string. This gives autocomplete, type checking, and exhaustiveness.
+
+### All events are async
+
+The one sync exception (`on_events_broadcast`) becomes async. The emit path
+already handles async via `_emit` — the inconsistency adds complexity for no
+benefit.
+
+### `SchedulerHooks` is deleted
+
+The dataclass disappears. The scheduler emits events directly. `TaskRunner`
+receives an emit callback, not individual hook params.
+
+### `on_startup` is dropped
+
+No consumer uses it. If a consumer needs the initial task list, `Bees.all`
+already provides it.
+
+### `on_events_broadcast` is split
+
+The current `_on_events_broadcast_internal` does three things:
+1. Calls `on_events_broadcast(task)`
+2. Calls `on_task_added(task)` (for newly created subtasks)
+3. Calls `trigger()` (to wake the scheduler)
+
+The first two are really a `TaskAdded` event. The scheduler trigger is internal
+plumbing. After migration, the function handler broadcasts emit `TaskAdded`
+events for each new task, and the scheduler's internal trigger stays internal.
+
+### Callback-based subscription (not async iterator)
+
+The async iterator pattern (`async for event in bees.events()`) is elegant but
+creates lifecycle complexity: who manages the iterator? When does it stop? What
+about back-pressure?
+
+Callbacks are simpler, match the current consumer pattern, and compose naturally
+with both logging (box) and fan-out (server's Broadcaster). An async iterator
+can be layered on top as a convenience wrapper later — the reverse is harder.
+
+## Protocol Inventory
+
+| Type              | Replaces                       | Specified | Tested | Migrated |
+| ----------------- | ------------------------------ | --------- | ------ | -------- |
+| `SchedulerEvent`  | (new — base type)              | ✅        | ✅     | ✅       |
+| `TaskAdded`       | `on_task_added(Ticket)`        | ✅        | ✅     | ✅       |
+| `CycleStarted`    | `on_cycle_start(int,int,int)`  | ✅        | ✅     | ✅       |
+| `TaskEvent`       | `on_task_event(str,dict)`      | ✅        | ✅     | ✅       |
+| `TaskStarted`     | `on_task_start(Ticket)`        | ✅        | ✅     | ✅       |
+| `TaskDone`        | `on_task_done(Ticket)`         | ✅        | ✅     | ✅       |
+| `CycleComplete`   | `on_cycle_complete(int)`       | ✅        | ✅     | ✅       |
+
+## Protocol Shapes
+
+### Event types
+
+```python
+from dataclasses import dataclass
+from typing import Any
+
+@dataclass
+class SchedulerEvent:
+    """Base for all scheduler-emitted events."""
+    type: str
+
+@dataclass
+class TaskAdded(SchedulerEvent):
+    """A new task was created or discovered."""
+    type: str = "task_added"
+    task: Ticket
+
+@dataclass
+class CycleStarted(SchedulerEvent):
+    """A new scheduling cycle is beginning."""
+    type: str = "cycle_started"
+    cycle: int
+    available: int
+    resumable: int
+
+@dataclass
+class TaskEvent(SchedulerEvent):
+    """A running session emitted a raw event."""
+    type: str = "task_event"
+    task_id: str
+    event: dict[str, Any]
+
+@dataclass
+class TaskStarted(SchedulerEvent):
+    """A task transitioned to running."""
+    type: str = "task_started"
+    task: Ticket
+
+@dataclass
+class TaskDone(SchedulerEvent):
+    """A task reached a resting state."""
+    type: str = "task_done"
+    task: Ticket
+
+@dataclass
+class CycleComplete(SchedulerEvent):
+    """All work is done — the scheduler is idle."""
+    type: str = "cycle_complete"
+    total_cycles: int
+```
+
+### Emit function
+
+The scheduler receives an emit callback instead of a hooks bag:
+
+```python
+# Type alias
+EventEmitter = Callable[[SchedulerEvent], Awaitable[None]]
+```
+
+`Scheduler.__init__` takes `emit: EventEmitter`. The `TaskRunner` receives the
+same `emit`. Internal emit sites become:
+
+```python
+# Before:
+if self._hooks.on_task_done:
+    await self._hooks.on_task_done(task)
+
+# After:
+await self._emit(TaskDone(task=task))
+```
+
+### `Bees` consumer API
+
+```python
+class Bees:
+    def on(self, event_type: type[T], callback: Callable[[T], Any]) -> None:
+        """Register a typed event listener."""
+        ...
+
+    # Private — wired as the emit callback to Scheduler
+    async def _emit(self, event: SchedulerEvent) -> None:
+        ...
+```
+
+Consumer code:
+
+```python
+# Before:
+bees.on("task_done", lambda t: logger.info("Done: %s", t.id))
+
+# After:
+bees.on(TaskDone, lambda e: logger.info("Done: %s", e.task.id))
+```
+
+## Migration Notes
+
+### `route_coordination_task` signature
+
+Currently takes `on_task_done: Callable` as a parameter. After migration, takes
+`emit: EventEmitter` and emits `TaskDone(task=task)` directly.
+
+### `TaskRunner` constructor simplification
+
+`on_task_start`, `on_task_event`, and `on_events_broadcast` collapse into a
+single `emit: EventEmitter`. The task runner calls `await emit(TaskStarted(...))`
+instead of `if self._on_task_start: await self._on_task_start(task)`.
+
+### `_on_events_broadcast_internal` decomposition
+
+This method currently:
+1. Calls `on_events_broadcast(task)` — becomes `emit(TaskAdded(task=task))`
+2. Calls `on_task_added(task)` on a `create_task` — same event, deduplicated
+3. Calls `trigger()` — stays as internal plumbing
+
+### Backward compatibility
+
+The migration is internal. `Bees.on()` changes signature from string-keyed to
+type-keyed. Both consumers (`box.py`, `server.py`) update in the same PR.
+No external API exists yet, so no backward compatibility concern.
+
+## Verification Plan
+
+### Automated
+
+1. `npm run build` — type-checks compilation.
+2. `npm run test -w packages/bees` — existing test suite passes.
+3. Conformance test: verify each event type is a dataclass with the expected
+   fields and satisfies `isinstance(event, SchedulerEvent)`.
+4. Integration test: mock emit, trigger scheduler operations, verify correct
+   events are emitted with correct payloads.
+
+### Manual
+
+1. Run `box` against a test hive — verify logging output is unchanged.
+2. Run `server` — verify SSE events are unchanged in the browser.

--- a/packages/bees/tests/test_protocols/test_events.py
+++ b/packages/bees/tests/test_protocols/test_events.py
@@ -1,0 +1,188 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Conformance tests for the Observation API event types.
+
+Verifies:
+1. Each event is a SchedulerEvent subclass with correct type discriminator.
+2. Each event has named fields (not positional).
+3. to_dict() produces a serializable dict.
+4. EventEmitter type is satisfiable by an async function.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from bees.protocols.events import (
+    CycleComplete,
+    CycleStarted,
+    EventEmitter,
+    SchedulerEvent,
+    TaskAdded,
+    TaskDone,
+    TaskEvent,
+    TaskStarted,
+)
+
+
+# ---------------------------------------------------------------------------
+# Subclass checks
+# ---------------------------------------------------------------------------
+
+
+def test_all_events_are_scheduler_events():
+    """Every concrete event is a SchedulerEvent."""
+    event_classes = [
+        TaskAdded, CycleStarted, TaskEvent,
+        TaskStarted, TaskDone, CycleComplete,
+    ]
+    for cls in event_classes:
+        # Use a mock for Ticket fields.
+        kwargs = _make_kwargs(cls)
+        instance = cls(**kwargs)
+        assert isinstance(instance, SchedulerEvent), (
+            f"{cls.__name__} is not a SchedulerEvent"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Type discriminators
+# ---------------------------------------------------------------------------
+
+
+def test_type_discriminators():
+    """Each event has a unique, non-init type field."""
+    expected = {
+        TaskAdded: "task_added",
+        CycleStarted: "cycle_started",
+        TaskEvent: "task_event",
+        TaskStarted: "task_started",
+        TaskDone: "task_done",
+        CycleComplete: "cycle_complete",
+    }
+    for cls, expected_type in expected.items():
+        kwargs = _make_kwargs(cls)
+        instance = cls(**kwargs)
+        assert instance.type == expected_type, (
+            f"{cls.__name__}.type is {instance.type!r}, "
+            f"expected {expected_type!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Named fields
+# ---------------------------------------------------------------------------
+
+
+def test_task_added_fields():
+    """TaskAdded has a task field."""
+    mock_task = MagicMock()
+    event = TaskAdded(task=mock_task)
+    assert event.task is mock_task
+
+
+def test_cycle_started_fields():
+    """CycleStarted has cycle, available, resumable fields."""
+    event = CycleStarted(cycle=3, available=5, resumable=2)
+    assert event.cycle == 3
+    assert event.available == 5
+    assert event.resumable == 2
+
+
+def test_task_event_fields():
+    """TaskEvent has task_id and event dict."""
+    event = TaskEvent(task_id="abc", event={"status": "ok"})
+    assert event.task_id == "abc"
+    assert event.event == {"status": "ok"}
+
+
+def test_task_started_fields():
+    """TaskStarted has a task field."""
+    mock_task = MagicMock()
+    event = TaskStarted(task=mock_task)
+    assert event.task is mock_task
+
+
+def test_task_done_fields():
+    """TaskDone has a task field."""
+    mock_task = MagicMock()
+    event = TaskDone(task=mock_task)
+    assert event.task is mock_task
+
+
+def test_cycle_complete_fields():
+    """CycleComplete has total_cycles."""
+    event = CycleComplete(total_cycles=7)
+    assert event.total_cycles == 7
+
+
+# ---------------------------------------------------------------------------
+# Serialization
+# ---------------------------------------------------------------------------
+
+
+def test_to_dict_includes_type():
+    """to_dict() includes the type discriminator."""
+    event = CycleStarted(cycle=1, available=2, resumable=0)
+    d = event.to_dict()
+    assert d["type"] == "cycle_started"
+    assert d["cycle"] == 1
+    assert d["available"] == 2
+    assert d["resumable"] == 0
+
+
+def test_to_dict_delegates_to_nested():
+    """to_dict() calls to_dict() on nested objects that have it."""
+    mock_task = MagicMock()
+    mock_task.to_dict.return_value = {"id": "t1"}
+    # Ensure hasattr check works on mock.
+    mock_task.__dict__["to_dict"] = mock_task.to_dict
+
+    event = TaskAdded(task=mock_task)
+    d = event.to_dict()
+    assert d["type"] == "task_added"
+
+
+# ---------------------------------------------------------------------------
+# EventEmitter type compatibility
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_async_function_satisfies_emitter():
+    """A plain async function satisfies EventEmitter."""
+    collected: list[SchedulerEvent] = []
+
+    async def emitter(event: SchedulerEvent) -> None:
+        collected.append(event)
+
+    # Type check: this assignment should be valid.
+    emit: EventEmitter = emitter
+
+    event = CycleStarted(cycle=1, available=0, resumable=0)
+    await emit(event)
+
+    assert len(collected) == 1
+    assert collected[0] is event
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_kwargs(cls: type) -> dict:
+    """Create minimal kwargs for a concrete event class."""
+    if cls in (TaskAdded, TaskStarted, TaskDone):
+        return {"task": MagicMock()}
+    if cls == CycleStarted:
+        return {"cycle": 1, "available": 0, "resumable": 0}
+    if cls == TaskEvent:
+        return {"task_id": "t1", "event": {}}
+    if cls == CycleComplete:
+        return {"total_cycles": 1}
+    return {}


### PR DESCRIPTION
## What

Replaces the `SchedulerHooks` callback bag with typed event dataclasses and a single `EventEmitter` callback pattern. Consumers now use `bees.on(TaskDone, handler)` instead of `bees.on("task_done", handler)`.

## Why

`SchedulerHooks` was a `@dataclass` with 7 optional callbacks using positional args and string-keyed dispatch at the `Bees` level. Silent typos, no autocomplete, untyped payloads, mixed sync/async, and a dead hook (`on_startup`) accumulated into a design smell. This replaces it with named-field event objects that compose cleanly with the existing consumer patterns (logging in `box.py`, SSE fan-out in `server.py`).

## Changes

### New files
- `bees/protocols/events.py` — 7 event dataclasses (`TaskAdded`, `CycleStarted`, `TaskEvent`, `TaskStarted`, `TaskDone`, `CycleComplete`) + `EventEmitter` type alias
- `spec/observation.md` — design spec with rationale and protocol inventory
- `tests/test_protocols/test_events.py` — 11 conformance tests

### Core migration
- **`scheduler.py`** — `SchedulerHooks` deleted; constructor takes `emit: EventEmitter`; all emit sites use typed events
- **`task_runner.py`** — `on_task_start` + `on_task_event` params collapsed into single `emit`
- **`coordination.py`** — `on_task_done: Callable` → `emit: EventEmitter`
- **`bees.py`** — `on()` is type-keyed; `_emit()` dispatches by event type

### Consumer updates
- **`box.py`** — handlers accept typed events with named fields
- **`server.py`** — same

### Docs
- **`docs/future.md`** — records back-imports decision (accepted), links Observation API spec

## Testing

`npm run test:python -w packages/bees` — 394 passed, 0 failed.
