### PR TITLE
[bees] Gemini Live API runner infrastructure

### DIFF
--- a/packages/bees/app/server.py
+++ b/packages/bees/app/server.py
@@ -168,7 +168,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     )
 
     runner = GeminiRunner(backend)
-    bees = Bees(hive_dir, runner)
+    runners = {"generate": runner}
+    bees = Bees(hive_dir, runners)
 
     bees.on(TaskAdded, _on_task_added)
     bees.on(CycleStarted, _on_cycle_start)

--- a/packages/bees/bees/bees.py
+++ b/packages/bees/bees/bees.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Awaitable, Callable, TypeVar
 
 from bees.protocols.events import SchedulerEvent
+from bees.protocols.session import SessionRunner
 from bees.task_store import TaskStore
 from bees.task_node import TaskNode
 from bees.scheduler import Scheduler
@@ -24,13 +25,13 @@ class Bees:
     Acts like the 'Document' in the DOM analogy.
     """
 
-    def __init__(self, hive_dir: Path, runner):
+    def __init__(self, hive_dir: Path, runners: dict[str, SessionRunner]):
         self._store = TaskStore(hive_dir)
         self._observers: dict[type[SchedulerEvent], list[EventCallback]] = defaultdict(list)
         self._loop_task = None
 
         self._scheduler = Scheduler(
-            runner=runner, emit=self._emit, store=self._store,
+            runners=runners, emit=self._emit, store=self._store,
         )
 
     async def _emit(self, event: SchedulerEvent) -> None:

--- a/packages/bees/bees/box.py
+++ b/packages/bees/bees/box.py
@@ -179,9 +179,10 @@ async def run(hive_dir: Path, backend: HttpBackendClient) -> None:
     startup_manager.activate()
 
     runner = GeminiRunner(backend)
+    runners = {"generate": runner}
 
     while True:
-        bees = Bees(hive_dir, runner)
+        bees = Bees(hive_dir, runners)
 
         bees.on(TaskAdded, _on_task_added)
         bees.on(CycleStarted, _on_cycle_start)

--- a/packages/bees/bees/playbook.py
+++ b/packages/bees/bees/playbook.py
@@ -150,6 +150,7 @@ def run_playbook(
         owning_task_id=owning_task_id,
         context=context,
         slug=slug,
+        runner=data.get("runner", "generate"),
     )
 
     # Autostart: stamp child tasks declared in the template.

--- a/packages/bees/bees/protocols/session.py
+++ b/packages/bees/bees/protocols/session.py
@@ -147,6 +147,12 @@ class SessionConfiguration:
     file_system: FileSystem
     """Disk-backed file system for the session's workspace."""
 
+    ticket_id: str | None = None
+    """Unique identifier for the task being executed."""
+
+    ticket_dir: Path | None = None
+    """Path to the task's directory on disk."""
+
     label: str = ""
     """Short label for log prefixes (usually ``ticket_id[:8]``)."""
 

--- a/packages/bees/bees/provisioner.py
+++ b/packages/bees/bees/provisioner.py
@@ -155,6 +155,8 @@ def provision_session(
         function_filter=function_filter,
         model=model,
         file_system=disk_fs,
+        ticket_id=ticket_id,
+        ticket_dir=ticket_dir,
         label=label,
         log_path=log_path,
         on_chat_entry=on_chat_entry,

--- a/packages/bees/bees/runners/live.py
+++ b/packages/bees/bees/runners/live.py
@@ -1,0 +1,413 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Live runner — delegated session via the Gemini Live API.
+
+Implements :class:`SessionRunner` by provisioning a session bundle
+(system instruction, tool declarations, ephemeral auth token) and
+writing it to the task directory.  The actual WebSocket connection to
+the Gemini Live API is established and owned by the browser (hivetool).
+
+The :class:`LiveStream` blocks until the browser signals completion
+by writing ``live_result.json`` to the task directory.
+"""
+
+from __future__ import annotations
+
+__all__ = ["LiveRunner"]
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from typing import Any
+
+from bees.protocols.functions import (
+    FunctionGroup,
+    FunctionGroupFactory,
+    SessionHooks,
+)
+from bees.protocols.session import (
+    SessionConfiguration,
+    SessionStream,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+BUNDLE_FILENAME = "live_session.json"
+RESULT_FILENAME = "live_result.json"
+
+LIVE_API_ENDPOINT = (
+    "wss://generativelanguage.googleapis.com/ws/"
+    "google.ai.generativelanguage.v1alpha."
+    "GenerativeService.BidiGenerateContent"
+)
+
+DEFAULT_MODEL = "models/gemini-2.5-flash-preview-native-audio-dialog"
+
+
+# ---------------------------------------------------------------------------
+# Dummy SessionHooks — bees factories don't use hooks (closure-captured deps)
+# ---------------------------------------------------------------------------
+
+
+class _NullHooks:
+    """Minimal SessionHooks stub for extracting declarations from factories.
+
+    Bees' function group factories receive ``SessionHooks`` by signature
+    but capture their real dependencies through closures.  This stub
+    satisfies the structural contract without providing real services.
+    """
+
+    @property
+    def controller(self) -> Any:
+        return None
+
+    @property
+    def file_system(self) -> Any:
+        return None
+
+    @property
+    def task_tree_manager(self) -> Any:
+        return None
+
+
+_NULL_HOOKS = _NullHooks()
+
+
+# ---------------------------------------------------------------------------
+# Declaration extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_declarations(
+    factories: list[FunctionGroupFactory],
+    function_filter: list[str] | None,
+) -> tuple[list[dict[str, Any]], str]:
+    """Call factories and collect tool declarations and instructions.
+
+    Returns a ``(declarations, combined_instruction)`` tuple.  When
+    *function_filter* is non-empty, only declarations whose name
+    matches a filter entry are included.
+    """
+    all_declarations: list[dict[str, Any]] = []
+    instructions: list[str] = []
+
+    for factory in factories:
+        group: FunctionGroup = factory(_NULL_HOOKS)
+
+        if group.instruction:
+            instructions.append(group.instruction)
+
+        for decl in group.declarations:
+            name = decl.get("name", "")
+            if function_filter and not _matches_filter(name, function_filter):
+                continue
+            all_declarations.append(decl)
+
+    return all_declarations, "\n\n".join(instructions)
+
+
+def _matches_filter(name: str, patterns: list[str]) -> bool:
+    """Check whether a function name matches one of the filter patterns.
+
+    Patterns can be exact names (``tasks_create_task``) or glob-style
+    group prefixes (``tasks.*``).
+    """
+    for pattern in patterns:
+        if pattern.endswith(".*"):
+            prefix = pattern[:-2]
+            # Convention: function names are ``group_functionname``.
+            if name.startswith(prefix + "_") or name == prefix:
+                return True
+        elif name == pattern:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# System instruction assembly
+# ---------------------------------------------------------------------------
+
+
+def _assemble_system_instruction(
+    segments: list[dict[str, Any]],
+    tool_instruction: str,
+) -> str:
+    """Combine provisioned segments and tool instructions into one string."""
+    parts: list[str] = []
+
+    for segment in segments:
+        segment_parts = segment.get("parts", [])
+        for part in segment_parts:
+            text = part.get("text")
+            if text:
+                parts.append(text)
+
+    if tool_instruction:
+        parts.append(tool_instruction)
+
+    return "\n\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Session bundle
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SessionBundle:
+    """Everything the browser needs to establish a Live API session."""
+
+    token: str
+    endpoint: str
+    setup: dict[str, Any]
+    task_id: str
+
+
+def _build_bundle(
+    *,
+    config: SessionConfiguration,
+    token: str,
+    declarations: list[dict[str, Any]],
+    system_instruction: str,
+) -> SessionBundle:
+    """Assemble the session bundle from provisioned configuration."""
+    model = config.model or DEFAULT_MODEL
+
+    setup: dict[str, Any] = {
+        "model": model,
+        "generationConfig": {
+            "responseModalities": ["AUDIO"],
+            "speechConfig": {
+                "voiceConfig": {
+                    "prebuiltVoiceConfig": {
+                        "voiceName": "Kore",
+                    },
+                },
+            },
+        },
+        "systemInstruction": {
+            "parts": [{"text": system_instruction}],
+        },
+    }
+
+    if declarations:
+        setup["tools"] = [{"functionDeclarations": declarations}]
+
+    return SessionBundle(
+        token=token,
+        endpoint=LIVE_API_ENDPOINT,
+        setup=setup,
+        task_id=config.ticket_id or "",
+    )
+
+
+def _write_bundle(bundle: SessionBundle, ticket_dir: Path) -> Path:
+    """Write the session bundle to the task directory."""
+    bundle_path = ticket_dir / BUNDLE_FILENAME
+    bundle_path.parent.mkdir(parents=True, exist_ok=True)
+
+    data = {
+        "token": bundle.token,
+        "endpoint": bundle.endpoint,
+        "setup": bundle.setup,
+        "task_id": bundle.task_id,
+    }
+
+    bundle_path.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False) + "\n",
+    )
+    return bundle_path
+
+
+# ---------------------------------------------------------------------------
+# LiveStream — the sparse SessionStream
+# ---------------------------------------------------------------------------
+
+
+class LiveStream:
+    """A session stream that blocks until the browser reports completion.
+
+    Implements ``SessionStream`` by polling for ``live_result.json``
+    in the task directory.  Yields at most a completion event.
+    """
+
+    def __init__(self, ticket_dir: Path, poll_interval: float = 0.5) -> None:
+        self._ticket_dir = ticket_dir
+        self._poll_interval = poll_interval
+        self._done = False
+        self._result: dict[str, Any] | None = None
+
+    def __aiter__(self) -> "LiveStream":
+        return self
+
+    async def __anext__(self) -> dict[str, Any]:
+        if self._done:
+            raise StopAsyncIteration
+
+        # Poll for the result file.
+        result_path = self._ticket_dir / RESULT_FILENAME
+        while not result_path.exists():
+            await asyncio.sleep(self._poll_interval)
+
+        # Read and parse the result.
+        try:
+            self._result = json.loads(result_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            self._done = True
+            return {"error": {"message": f"Failed to read live result: {exc}"}}
+
+        self._done = True
+
+        # Translate the browser's result into a completion event.
+        status = self._result.get("status", "completed")
+        if status == "failed":
+            return {"error": {
+                "message": self._result.get("error", "Live session failed"),
+            }}
+
+        return {"complete": {
+            "result": {
+                "success": status == "completed",
+                "outcomes": self._result.get("outcomes", {}),
+            },
+        }}
+
+    async def send_context(self, parts: list[dict[str, Any]]) -> None:
+        """Write context update for the browser to pick up.
+
+        The browser watches for these files and calls
+        ``session.send_client_content()`` on the Live API WebSocket.
+        """
+        updates_dir = self._ticket_dir / "context_updates"
+        updates_dir.mkdir(parents=True, exist_ok=True)
+
+        timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S-%f")
+        update_path = updates_dir / f"{timestamp}.json"
+        update_path.write_text(
+            json.dumps({"parts": parts}, indent=2, ensure_ascii=False) + "\n",
+        )
+
+    def resume_state(self) -> bytes | None:
+        """Live sessions don't support batch-style resume."""
+        return None
+
+
+# ---------------------------------------------------------------------------
+# LiveRunner — the SessionRunner implementation
+# ---------------------------------------------------------------------------
+
+
+class LiveRunner:
+    """Session runner for the Gemini Live API.
+
+    Provisions all the session configuration (system instruction, tool
+    declarations, ephemeral auth token) and writes a session bundle
+    to the task directory.  The browser establishes the actual WebSocket
+    connection and reports completion by writing a result file.
+
+    Implements the ``SessionRunner`` protocol.
+    """
+
+    def __init__(self, api_key: str) -> None:
+        self._api_key = api_key
+
+    async def _get_ephemeral_token(self) -> str:
+        """Request a short-lived ephemeral token from the Gemini API.
+
+        Uses ``google-genai`` SDK to create a single-use token
+        that expires after 30 minutes.
+        """
+        from google import genai
+
+        client = genai.Client(api_key=self._api_key)
+        expire_time = (
+            datetime.now(timezone.utc) + timedelta(minutes=30)
+        ).isoformat()
+
+        token_response = await asyncio.to_thread(
+            client.auth_tokens.create,
+            config={
+                "uses": 1,
+                "expire_time": expire_time,
+            },
+        )
+
+        return token_response.name
+
+    async def run(
+        self, config: SessionConfiguration,
+    ) -> LiveStream:
+        """Provision the session and write the bundle for the browser.
+
+        1. Extract tool declarations from function group factories.
+        2. Assemble the system instruction from segments.
+        3. Request an ephemeral auth token.
+        4. Write the session bundle to the task directory.
+        5. Return a ``LiveStream`` that blocks until the browser reports
+           completion.
+        """
+        ticket_dir = config.ticket_dir
+        if not ticket_dir:
+            raise ValueError(
+                "LiveRunner requires ticket_dir in SessionConfiguration"
+            )
+
+        label = config.label or "live"
+
+        # 1. Extract declarations and instructions from function groups.
+        declarations, tool_instruction = _extract_declarations(
+            config.function_groups,
+            config.function_filter,
+        )
+        logger.info(
+            "[%s] Extracted %d tool declarations for live session",
+            label, len(declarations),
+        )
+
+        # 2. Assemble system instruction.
+        system_instruction = _assemble_system_instruction(
+            config.segments, tool_instruction,
+        )
+
+        # 3. Get ephemeral token.
+        logger.info("[%s] Requesting ephemeral token...", label)
+        token = await self._get_ephemeral_token()
+        logger.info("[%s] Ephemeral token acquired", label)
+
+        # 4. Build and write the session bundle.
+        bundle = _build_bundle(
+            config=config,
+            token=token,
+            declarations=declarations,
+            system_instruction=system_instruction,
+        )
+        bundle_path = _write_bundle(bundle, ticket_dir)
+        logger.info("[%s] Session bundle written to %s", label, bundle_path)
+
+        # 5. Return a stream that waits for the browser to finish.
+        return LiveStream(ticket_dir)
+
+    async def resume(
+        self,
+        config: SessionConfiguration,
+        *,
+        state: bytes,
+        response: dict[str, Any] | None = None,
+    ) -> LiveStream:
+        """Live sessions don't support batch-style resume.
+
+        Raises ``NotImplementedError`` — a live session that ends
+        must be re-provisioned from scratch.
+        """
+        raise NotImplementedError(
+            "Live sessions cannot be resumed. "
+            "Start a new session instead."
+        )

--- a/packages/bees/bees/scheduler.py
+++ b/packages/bees/bees/scheduler.py
@@ -136,7 +136,7 @@ class Scheduler:
     def __init__(
         self,
         *,
-        runner: SessionRunner,
+        runners: dict[str, SessionRunner],
         store: TaskStore,
         emit: EventEmitter | None = None,
     ) -> None:
@@ -151,7 +151,7 @@ class Scheduler:
         self._mcp_registry: MCPRegistry | None = None
 
         self._task_runner = TaskRunner(
-            runner=runner,
+            runners=runners,
             store=self.store,
             scheduler_ref=self,
             active_streams=self._active_streams,

--- a/packages/bees/bees/task_runner.py
+++ b/packages/bees/bees/task_runner.py
@@ -55,7 +55,7 @@ class TaskRunner:
     def __init__(
         self,
         *,
-        runner: SessionRunner,
+        runners: dict[str, SessionRunner],
         store: TaskStore,
         scheduler_ref: Any,
         active_streams: dict[str, SessionStream],
@@ -64,7 +64,7 @@ class TaskRunner:
         on_events_broadcast: Callable[[Ticket], None],
         emit: EventEmitter,
     ) -> None:
-        self._runner = runner
+        self._runners = runners
         self._store = store
         self._scheduler_ref = scheduler_ref
         self._active_streams = active_streams
@@ -115,7 +115,7 @@ class TaskRunner:
                 ),
             )
 
-            stream = await self._runner.run(config)
+            stream = await self._runner_for(task).run(config)
             self._active_streams[task.id] = stream
             try:
                 result = await drain_session(
@@ -238,7 +238,7 @@ class TaskRunner:
                 seed_files=False,  # Files already on disk from previous run.
             )
 
-            stream = await self._runner.resume(
+            stream = await self._runner_for(task).resume(
                 config,
                 state=state,
                 response=response,
@@ -394,3 +394,15 @@ class TaskRunner:
             await emit(TaskEvent(task_id=task_id, event=event))
 
         return on_event
+
+    def _runner_for(self, task: Ticket) -> SessionRunner:
+        """Select the session runner for a task based on its metadata."""
+        runner_type = task.metadata.runner
+        runner = self._runners.get(runner_type)
+        if runner is None:
+            available = ", ".join(sorted(self._runners.keys()))
+            raise ValueError(
+                f"No runner registered for type {runner_type!r} "
+                f"(available: {available})"
+            )
+        return runner

--- a/packages/bees/bees/task_store.py
+++ b/packages/bees/bees/task_store.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from bees.ticket import Ticket, TicketMetadata, TicketStatus, TicketKind
+from bees.ticket import Ticket, TicketMetadata, TicketStatus, TicketKind, RunnerType
 
 
 # Matches {{ticket-id-prefix}} references in objectives.
@@ -125,6 +125,7 @@ class TaskStore:
         kind: TicketKind = "work",
         signal_type: str | None = None,
         slug: str | None = None,
+        runner: RunnerType = "generate",
     ) -> Ticket:
         """Create a new task.
 
@@ -175,6 +176,7 @@ class TaskStore:
                 kind=kind,
                 signal_type=signal_type,
                 slug=slug,
+                runner=runner,
             ),
         )
         self.save(ticket)

--- a/packages/bees/bees/ticket.py
+++ b/packages/bees/bees/ticket.py
@@ -28,6 +28,8 @@ TicketStatus = Literal[
 
 TicketKind = Literal["work", "coordination"]
 
+RunnerType = Literal["generate", "live"]
+
 
 
 
@@ -67,6 +69,9 @@ class TicketMetadata:
     pending_context_updates: list[dict[str, Any]] | None = None
     paused_from: str | None = None
     """The status this task had before it was paused (set by pause-all / pause-task)."""
+
+    runner: RunnerType = "generate"
+    """Which session runner to use: ``generate`` (batch) or ``live`` (Gemini Live API)."""
 
     def to_dict(self) -> dict[str, Any]:
         d = asdict(self)
@@ -109,6 +114,7 @@ class TicketMetadata:
             slug=data.get("slug"),
             pending_context_updates=data.get("pending_context_updates"),
             paused_from=data.get("paused_from"),
+            runner=data.get("runner", "generate"),
         )
 
 

--- a/packages/bees/tests/test_live_runner.py
+++ b/packages/bees/tests/test_live_runner.py
@@ -1,0 +1,397 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the LiveRunner and LiveStream."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bees.protocols.functions import (
+    FunctionGroup,
+    FunctionDefinition,
+)
+from bees.protocols.session import SessionConfiguration
+from bees.runners.live import (
+    BUNDLE_FILENAME,
+    RESULT_FILENAME,
+    LiveRunner,
+    LiveStream,
+    _NullHooks,
+    _assemble_system_instruction,
+    _extract_declarations,
+    _matches_filter,
+    _build_bundle,
+    _write_bundle,
+    SessionBundle,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def temp_dir():
+    with tempfile.TemporaryDirectory() as d:
+        yield Path(d)
+
+
+def _make_test_factory(
+    name: str,
+    declarations: list[dict],
+    instruction: str | None = None,
+):
+    """Create a test function group factory."""
+    async def _handler(args, status):
+        return {}
+
+    defs = [
+        (decl["name"], FunctionDefinition(
+            name=decl["name"],
+            description=decl.get("description", ""),
+            handler=_handler,
+        ))
+        for decl in declarations
+    ]
+
+    def factory(hooks):
+        return FunctionGroup(
+            name=name,
+            definitions=defs,
+            declarations=declarations,
+            instruction=instruction,
+        )
+
+    return factory
+
+
+def _make_config(
+    temp_dir: Path,
+    *,
+    segments: list | None = None,
+    factories: list | None = None,
+    function_filter: list[str] | None = None,
+    model: str | None = None,
+) -> SessionConfiguration:
+    """Create a minimal SessionConfiguration for testing."""
+    fs = MagicMock()
+    return SessionConfiguration(
+        segments=segments or [],
+        function_groups=factories or [],
+        function_filter=function_filter,
+        model=model,
+        file_system=fs,
+        ticket_id="test-task-id",
+        ticket_dir=temp_dir,
+        label="test",
+    )
+
+
+# ---------------------------------------------------------------------------
+# _NullHooks
+# ---------------------------------------------------------------------------
+
+
+def test_null_hooks_satisfies_protocol():
+    """_NullHooks can be used where SessionHooks is expected."""
+    hooks = _NullHooks()
+    assert hooks.controller is None
+    assert hooks.file_system is None
+    assert hooks.task_tree_manager is None
+
+
+# ---------------------------------------------------------------------------
+# _matches_filter
+# ---------------------------------------------------------------------------
+
+
+def test_matches_filter_exact():
+    assert _matches_filter("tasks_create_task", ["tasks_create_task"])
+
+
+def test_matches_filter_glob():
+    assert _matches_filter("tasks_create_task", ["tasks.*"])
+    assert _matches_filter("tasks_list", ["tasks.*"])
+
+
+def test_matches_filter_miss():
+    assert not _matches_filter("files_read", ["tasks.*"])
+    assert not _matches_filter("other_fn", ["tasks_create_task"])
+
+
+def test_matches_filter_multiple_patterns():
+    assert _matches_filter("files_read", ["tasks.*", "files.*"])
+
+
+# ---------------------------------------------------------------------------
+# _extract_declarations
+# ---------------------------------------------------------------------------
+
+
+def test_extract_declarations_no_filter():
+    factory = _make_test_factory("tools", [
+        {"name": "tool_a", "description": "A"},
+        {"name": "tool_b", "description": "B"},
+    ], instruction="Use these tools wisely.")
+
+    decls, instruction = _extract_declarations([factory], None)
+
+    assert len(decls) == 2
+    assert decls[0]["name"] == "tool_a"
+    assert "Use these tools wisely." in instruction
+
+
+def test_extract_declarations_with_filter():
+    factory = _make_test_factory("tools", [
+        {"name": "tool_a", "description": "A"},
+        {"name": "tool_b", "description": "B"},
+    ])
+
+    decls, _ = _extract_declarations([factory], ["tool_a"])
+
+    assert len(decls) == 1
+    assert decls[0]["name"] == "tool_a"
+
+
+def test_extract_declarations_multiple_groups():
+    f1 = _make_test_factory("group1", [
+        {"name": "g1_fn", "description": "G1"},
+    ], instruction="Group 1 instructions.")
+    f2 = _make_test_factory("group2", [
+        {"name": "g2_fn", "description": "G2"},
+    ], instruction="Group 2 instructions.")
+
+    decls, instruction = _extract_declarations([f1, f2], None)
+
+    assert len(decls) == 2
+    assert "Group 1 instructions." in instruction
+    assert "Group 2 instructions." in instruction
+
+
+# ---------------------------------------------------------------------------
+# _assemble_system_instruction
+# ---------------------------------------------------------------------------
+
+
+def test_assemble_system_instruction():
+    segments = [
+        {"parts": [{"text": "You are Opie."}]},
+        {"parts": [{"text": "Be helpful."}]},
+    ]
+    result = _assemble_system_instruction(segments, "Tool usage notes.")
+
+    assert "You are Opie." in result
+    assert "Be helpful." in result
+    assert "Tool usage notes." in result
+
+
+def test_assemble_system_instruction_empty_tool_instruction():
+    segments = [{"parts": [{"text": "Hello."}]}]
+    result = _assemble_system_instruction(segments, "")
+
+    assert result == "Hello."
+
+
+# ---------------------------------------------------------------------------
+# _build_bundle
+# ---------------------------------------------------------------------------
+
+
+def test_build_bundle(temp_dir):
+    config = _make_config(temp_dir, model="models/gemini-test")
+
+    bundle = _build_bundle(
+        config=config,
+        token="ephemeral-token",
+        declarations=[{"name": "fn1", "description": "Test"}],
+        system_instruction="You are a test agent.",
+    )
+
+    assert bundle.token == "ephemeral-token"
+    assert bundle.task_id == "test-task-id"
+    assert bundle.setup["model"] == "models/gemini-test"
+    assert bundle.setup["systemInstruction"]["parts"][0]["text"] == "You are a test agent."
+    assert len(bundle.setup["tools"][0]["functionDeclarations"]) == 1
+
+
+def test_build_bundle_no_declarations(temp_dir):
+    config = _make_config(temp_dir)
+    bundle = _build_bundle(
+        config=config,
+        token="token",
+        declarations=[],
+        system_instruction="Hello.",
+    )
+    assert "tools" not in bundle.setup
+
+
+# ---------------------------------------------------------------------------
+# _write_bundle
+# ---------------------------------------------------------------------------
+
+
+def test_write_bundle(temp_dir):
+    bundle = SessionBundle(
+        token="test-token",
+        endpoint="wss://example.com",
+        setup={"model": "test-model"},
+        task_id="task-123",
+    )
+
+    path = _write_bundle(bundle, temp_dir)
+
+    assert path == temp_dir / BUNDLE_FILENAME
+    assert path.exists()
+
+    data = json.loads(path.read_text())
+    assert data["token"] == "test-token"
+    assert data["task_id"] == "task-123"
+
+
+# ---------------------------------------------------------------------------
+# LiveStream
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_live_stream_completes_on_result(temp_dir):
+    """LiveStream yields completion when live_result.json appears."""
+    stream = LiveStream(temp_dir, poll_interval=0.05)
+
+    # Write the result file after a short delay.
+    async def write_result():
+        await asyncio.sleep(0.1)
+        result_path = temp_dir / RESULT_FILENAME
+        result_path.write_text(json.dumps({
+            "status": "completed",
+            "outcomes": {"parts": [{"text": "Done."}]},
+        }))
+
+    asyncio.create_task(write_result())
+
+    events = []
+    async for event in stream:
+        events.append(event)
+
+    assert len(events) == 1
+    assert "complete" in events[0]
+    assert events[0]["complete"]["result"]["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_live_stream_handles_failure(temp_dir):
+    """LiveStream yields error event when result reports failure."""
+    stream = LiveStream(temp_dir, poll_interval=0.05)
+
+    result_path = temp_dir / RESULT_FILENAME
+    result_path.write_text(json.dumps({
+        "status": "failed",
+        "error": "WebSocket disconnected",
+    }))
+
+    events = []
+    async for event in stream:
+        events.append(event)
+
+    assert len(events) == 1
+    assert "error" in events[0]
+    assert "WebSocket disconnected" in events[0]["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_live_stream_send_context(temp_dir):
+    """send_context writes a context update file."""
+    stream = LiveStream(temp_dir)
+
+    await stream.send_context([{"text": "Update from subagent."}])
+
+    updates_dir = temp_dir / "context_updates"
+    assert updates_dir.exists()
+
+    files = list(updates_dir.iterdir())
+    assert len(files) == 1
+
+    data = json.loads(files[0].read_text())
+    assert data["parts"][0]["text"] == "Update from subagent."
+
+
+@pytest.mark.asyncio
+async def test_live_stream_resume_state_is_none(temp_dir):
+    """resume_state returns None for live sessions."""
+    stream = LiveStream(temp_dir)
+    assert stream.resume_state() is None
+
+
+# ---------------------------------------------------------------------------
+# LiveRunner
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_live_runner_requires_ticket_dir():
+    """LiveRunner.run() raises if ticket_dir is missing."""
+    runner = LiveRunner(api_key="test-key")
+    config = SessionConfiguration(
+        segments=[],
+        function_groups=[],
+        function_filter=None,
+        model=None,
+        file_system=MagicMock(),
+        # ticket_dir intentionally omitted (defaults to None)
+    )
+
+    with pytest.raises(ValueError, match="ticket_dir"):
+        await runner.run(config)
+
+
+@pytest.mark.asyncio
+async def test_live_runner_writes_bundle(temp_dir):
+    """LiveRunner.run() provisions and writes the session bundle."""
+    runner = LiveRunner(api_key="test-key")
+
+    factory = _make_test_factory("test", [
+        {"name": "test_fn", "description": "A test function"},
+    ], instruction="Test tool instructions.")
+
+    config = _make_config(
+        temp_dir,
+        segments=[{"parts": [{"text": "You are a test agent."}]}],
+        factories=[factory],
+        model="models/test-model",
+    )
+
+    # Mock the ephemeral token request.
+    with patch.object(runner, "_get_ephemeral_token", return_value="mock-token"):
+        stream = await runner.run(config)
+
+    # Verify the bundle was written.
+    bundle_path = temp_dir / BUNDLE_FILENAME
+    assert bundle_path.exists()
+
+    data = json.loads(bundle_path.read_text())
+    assert data["token"] == "mock-token"
+    assert data["task_id"] == "test-task-id"
+    assert data["setup"]["model"] == "models/test-model"
+    assert "test_fn" in json.dumps(data["setup"]["tools"])
+    assert "You are a test agent." in data["setup"]["systemInstruction"]["parts"][0]["text"]
+
+    # Verify the stream is a LiveStream.
+    assert isinstance(stream, LiveStream)
+
+
+@pytest.mark.asyncio
+async def test_live_runner_resume_raises():
+    """LiveRunner.resume() raises NotImplementedError."""
+    runner = LiveRunner(api_key="test-key")
+    config = _make_config(Path("/tmp/fake"))
+
+    with pytest.raises(NotImplementedError, match="cannot be resumed"):
+        await runner.resume(config, state=b"")

--- a/packages/bees/tests/test_protocols/test_session_configuration.py
+++ b/packages/bees/tests/test_protocols/test_session_configuration.py
@@ -82,6 +82,8 @@ class TestSessionConfigurationConformance(unittest.TestCase):
             "function_filter",
             "model",
             "file_system",
+            "ticket_id",
+            "ticket_dir",
             "label",
             "log_path",
             "on_chat_entry",

--- a/packages/bees/tests/test_scheduler.py
+++ b/packages/bees/tests/test_scheduler.py
@@ -52,7 +52,7 @@ def write_template(tmp_path):
 @pytest.mark.asyncio
 async def test_wait_for_task_already_completed(mock_clients):
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runners={"generate": backend})
     
     ticket = GLOBAL_STORE.create("Objective")
     ticket.metadata.status = "completed"
@@ -65,7 +65,7 @@ async def test_wait_for_task_already_completed(mock_clients):
 @pytest.mark.asyncio
 async def test_wait_for_task_blocks_and_completes(mock_clients):
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runners={"generate": backend})
     
     ticket = GLOBAL_STORE.create("Objective")
     
@@ -86,7 +86,7 @@ async def test_wait_for_task_blocks_and_completes(mock_clients):
 @pytest.mark.asyncio
 async def test_wait_for_task_timeout(mock_clients):
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runners={"generate": backend})
     
     ticket = GLOBAL_STORE.create("Objective")
     ticket.metadata.status = "running"
@@ -99,7 +99,7 @@ async def test_wait_for_task_timeout(mock_clients):
 @pytest.mark.asyncio
 async def test_wait_for_task_returns_early_on_suspend(mock_clients):
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runners={"generate": backend})
     
     ticket = GLOBAL_STORE.create("Objective")
     ticket.metadata.status = "running"
@@ -121,7 +121,7 @@ async def test_wait_for_task_returns_early_on_suspend(mock_clients):
 @pytest.mark.asyncio
 async def test_wait_for_task_returns_early_on_fail(mock_clients):
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runners={"generate": backend})
     
     ticket = GLOBAL_STORE.create("Objective")
     ticket.metadata.status = "running"
@@ -143,7 +143,7 @@ async def test_wait_for_task_returns_early_on_fail(mock_clients):
 @pytest.mark.asyncio
 async def test_deliver_context_update_immediate(mock_clients):
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runners={"generate": backend})
     
     creator = GLOBAL_STORE.create("Parent Objective")
     creator.metadata.status = "suspended"
@@ -174,7 +174,7 @@ async def test_deliver_context_update_immediate(mock_clients):
 async def test_enrich_parent_tags_merges(mock_clients):
     """Child tags are merged (union) into the parent's existing tags."""
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runners={"generate": backend})
 
     parent = GLOBAL_STORE.create("Parent", tags=["b", "c"])
     child = GLOBAL_STORE.create("Child", tags=["a", "b"])
@@ -193,7 +193,7 @@ async def test_enrich_parent_tags_merges(mock_clients):
 async def test_enrich_parent_tags_no_parent(mock_clients):
     """No crash when parent_task_id points to a nonexistent task."""
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runners={"generate": backend})
 
     child = GLOBAL_STORE.create("Child", tags=["a"])
     child.metadata.parent_task_id = "nonexistent-id"
@@ -207,7 +207,7 @@ async def test_enrich_parent_tags_no_parent(mock_clients):
 async def test_enrich_parent_tags_no_tags(mock_clients):
     """Parent is unchanged when the child has no tags."""
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runners={"generate": backend})
 
     parent = GLOBAL_STORE.create("Parent", tags=["x"])
     child = GLOBAL_STORE.create("Child")  # No tags.
@@ -224,7 +224,7 @@ async def test_enrich_parent_tags_no_tags(mock_clients):
 async def test_enrich_parent_tags_parent_has_no_tags(mock_clients):
     """Parent with None tags receives the child's tags."""
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runners={"generate": backend})
 
     parent = GLOBAL_STORE.create("Parent")  # tags=None
     child = GLOBAL_STORE.create("Child", tags=["a"])
@@ -264,7 +264,7 @@ def test_update_metadata_paused(mock_clients):
     from bees.protocols.session import SessionResult
 
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runners={"generate": backend})
 
     ticket = GLOBAL_STORE.create("Objective")
     result = SessionResult(
@@ -290,7 +290,7 @@ def test_handle_pause_sets_status(mock_clients):
     from bees.protocols.session import SessionResult
 
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runners={"generate": backend})
 
     ticket = GLOBAL_STORE.create("Objective")
     ticket.metadata.status = "running"
@@ -340,7 +340,7 @@ async def test_boots_when_no_root_ticket_exists(mock_clients, write_template, tm
     system_path.write_text(yaml.dump({"root": "opie"}))
 
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runners={"generate": backend})
 
     ticket = await scheduler._boot_root_template([])
 
@@ -358,7 +358,7 @@ async def test_skips_when_root_already_booted(mock_clients, write_template, tmp_
     existing = run_playbook("opie", store=GLOBAL_STORE)
     
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runners={"generate": backend})
 
     ticket = await scheduler._boot_root_template([existing])
 
@@ -372,7 +372,7 @@ async def test_returns_none_when_no_root_configured(mock_clients, tmp_path, monk
     system_path.write_text(yaml.dump({"title": "My Hive"}))
 
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runners={"generate": backend})
 
     ticket = await scheduler._boot_root_template([])
     assert ticket is None
@@ -382,7 +382,7 @@ async def test_returns_none_when_no_root_configured(mock_clients, tmp_path, monk
 async def test_returns_none_when_no_system_yaml(mock_clients, tmp_path):
     
     _, backend = mock_clients
-    scheduler = Scheduler(store=GLOBAL_STORE, runner=backend)
+    scheduler = Scheduler(store=GLOBAL_STORE, runners={"generate": backend})
 
     ticket = await scheduler._boot_root_template([])
     assert ticket is None

--- a/packages/bees/tests/test_tree.py
+++ b/packages/bees/tests/test_tree.py
@@ -16,7 +16,7 @@ def temp_hive():
 
 
 def test_tree_traversal(temp_hive):
-    bees = Bees(temp_hive, runner=Mock())
+    bees = Bees(temp_hive, runners={"generate": Mock()})
     store = bees._store
 
     # Create a tree structure
@@ -70,13 +70,13 @@ def test_tree_traversal(temp_hive):
 
 
 def test_empty_store(temp_hive):
-    bees = Bees(temp_hive, runner=Mock())
+    bees = Bees(temp_hive, runners={"generate": Mock()})
     assert len(bees.children) == 0
     assert bees.get_by_id("non-existent") is None
 
 
 def test_query_by_tags(temp_hive):
-    bees = Bees(temp_hive, runner=Mock())
+    bees = Bees(temp_hive, runners={"generate": Mock()})
     store = bees._store
 
     # Create tasks with tags
@@ -109,7 +109,7 @@ def test_query_by_tags(temp_hive):
 
 @pytest.mark.asyncio
 async def test_bees_create_child(temp_hive):
-    bees = Bees(temp_hive, runner=Mock())
+    bees = Bees(temp_hive, runners={"generate": Mock()})
     bees._scheduler = Mock()
     
     mock_ticket = Mock()
@@ -126,7 +126,7 @@ async def test_bees_create_child(temp_hive):
 
 @pytest.mark.asyncio
 async def test_task_node_create_child(temp_hive):
-    bees = Bees(temp_hive, runner=Mock())
+    bees = Bees(temp_hive, runners={"generate": Mock()})
     bees._scheduler = Mock()
     
     mock_ticket = Mock()
@@ -149,7 +149,7 @@ async def test_task_node_create_child(temp_hive):
 
 
 def test_task_node_respond(temp_hive):
-    bees = Bees(temp_hive, runner=Mock())
+    bees = Bees(temp_hive, runners={"generate": Mock()})
     store_mock = Mock()
     bees._store = store_mock
     
@@ -163,7 +163,7 @@ def test_task_node_respond(temp_hive):
 
 
 def test_task_node_respond_with_text_kwarg(temp_hive):
-    bees = Bees(temp_hive, runner=Mock())
+    bees = Bees(temp_hive, runners={"generate": Mock()})
     store_mock = Mock()
     bees._store = store_mock
     
@@ -177,7 +177,7 @@ def test_task_node_respond_with_text_kwarg(temp_hive):
 
 
 def test_task_node_respond_with_selected_ids_kwarg(temp_hive):
-    bees = Bees(temp_hive, runner=Mock())
+    bees = Bees(temp_hive, runners={"generate": Mock()})
     store_mock = Mock()
     bees._store = store_mock
     
@@ -191,7 +191,7 @@ def test_task_node_respond_with_selected_ids_kwarg(temp_hive):
 
 
 def test_task_node_respond_mutually_exclusive_kwargs(temp_hive):
-    bees = Bees(temp_hive, runner=Mock())
+    bees = Bees(temp_hive, runners={"generate": Mock()})
     ticket = Mock()
     ticket.id = "task1"
     node = TaskNode(ticket, bees)
@@ -201,7 +201,7 @@ def test_task_node_respond_mutually_exclusive_kwargs(temp_hive):
 
 
 def test_task_node_respond_missing_kwargs(temp_hive):
-    bees = Bees(temp_hive, runner=Mock())
+    bees = Bees(temp_hive, runners={"generate": Mock()})
     ticket = Mock()
     ticket.id = "task1"
     node = TaskNode(ticket, bees)
@@ -211,7 +211,7 @@ def test_task_node_respond_missing_kwargs(temp_hive):
 
 
 def test_task_node_respond_dict_and_kwargs_conflict(temp_hive):
-    bees = Bees(temp_hive, runner=Mock())
+    bees = Bees(temp_hive, runners={"generate": Mock()})
     ticket = Mock()
     ticket.id = "task1"
     node = TaskNode(ticket, bees)
@@ -221,7 +221,7 @@ def test_task_node_respond_dict_and_kwargs_conflict(temp_hive):
 
 
 def test_task_node_awaiting_response(temp_hive):
-    bees = Bees(temp_hive, runner=Mock())
+    bees = Bees(temp_hive, runners={"generate": Mock()})
     
     ticket = Mock()
     ticket.metadata = Mock()
@@ -250,7 +250,7 @@ def test_task_node_awaiting_response(temp_hive):
 
 
 def test_bees_all(temp_hive):
-    bees = Bees(temp_hive, runner=Mock())
+    bees = Bees(temp_hive, runners={"generate": Mock()})
     store_mock = Mock()
     bees._store = store_mock
     


### PR DESCRIPTION
## What
Adds runner selection infrastructure and a new `LiveRunner` that provisions Gemini Live API sessions for browser-based execution. The framework can now route tasks to different session runners based on a `runner` field on task metadata.

## Why
The Gemini Live API requires a persistent WebSocket with audio I/O — something only the browser can own. This PR establishes the "delegated session" pattern: bees provisions tools and auth, writes a session bundle, and the browser (hivetool) establishes the actual connection. This is the server-side half of that architecture.

## Changes

### Runner selection (Phase 0)
- `ticket.py`: Added `RunnerType = Literal["generate", "live"]` and `runner` field on `TicketMetadata`
- `task_store.py`, `playbook.py`: Wire `runner` through task creation and template YAML
- `bees.py`, `scheduler.py`, `task_runner.py`: Evolved constructors from single `runner` to `runners: dict[str, SessionRunner]`
- `task_runner.py`: New `_runner_for(task)` dispatches to the correct runner based on `task.metadata.runner`
- `box.py`, `server.py`: Construct `{"generate": GeminiRunner(backend)}`

### LiveRunner (Phase 1)
- **New** `bees/runners/live.py`: `LiveRunner` implements `SessionRunner` — extracts tool declarations from function group factories, assembles system instruction, acquires ephemeral Gemini API token, writes `live_session.json` bundle to task directory
- **New** `LiveStream` implements `SessionStream` — polls for `live_result.json`, yields completion event, supports `send_context()` via filesystem
- `protocols/session.py`: Added `ticket_id` and `ticket_dir` fields to `SessionConfiguration`
- `provisioner.py`: Forwards ticket fields to config

### Tests
- **New** `tests/test_live_runner.py`: 20 tests covering declaration extraction, filter matching, bundle building, LiveStream polling, context updates, LiveRunner provisioning flow
- Updated `test_tree.py`, `test_scheduler.py`, `test_session_configuration.py` for new constructor signatures and fields

## Testing
```bash
cd packages/bees
.venv/bin/python -m pytest -x -q   # 414 passed
```
