### PR TITLE
[bees] Hivetool Live Session Client

### DIFF
--- a/PROJECT_ACOUSTIC.md
+++ b/PROJECT_ACOUSTIC.md
@@ -1,0 +1,231 @@
+# Project Acoustic — Gemini Live API Integration
+
+Bees is a batch orchestrator: accumulate context, call GenerateContent, dispatch
+tools, repeat. The Gemini Live API is fundamentally different — full-duplex
+WebSocket, continuous audio streams, server-managed context. Rather than
+fighting the grain of both APIs, Project Acoustic introduces a **delegated
+session** pattern: bees provisions tools and auth, then delegates the model
+connection to the browser while retaining orchestration, tool dispatch, and
+lifecycle management.
+
+## Architecture
+
+```
+┌──────────── Box (Python) ───────────┐    ┌────── Hivetool (Browser) ──────┐
+│                                     │    │                                │
+│  LiveRunner                         │    │  LiveSessionClient             │
+│  ├─ extract tool declarations       │    │  ├─ read live_session.json     │
+│  ├─ assemble system instruction     │    │  ├─ open WebSocket to Gemini   │
+│  ├─ get ephemeral auth token        │    │  ├─ send setup message         │
+│  ├─ write live_session.json ──────────────►  ├─ stream audio in/out       │
+│  └─ LiveStream (polls for result)   │    │  ├─ relay tool calls ──────────┤
+│                                     │    │  └─ write live_result.json     │
+│  Tool Dispatch                      │    │                                │
+│  ├─ watch tool_dispatch/*.json  ◄────────── write tool_dispatch/{id}.json │
+│  ├─ execute Python handler          │    │                                │
+│  └─ write {id}.result.json  ─────────────►  read result, relay to WS     │
+└─────────────────────────────────────┘    └────────────────────────────────┘
+```
+
+Two processes, one filesystem. The box writes the session bundle; hivetool
+runs the audio loop. Tool calls bounce through `tool_dispatch/` files. The
+LiveStream blocks until `live_result.json` appears, then the scheduler resumes
+normal task lifecycle processing.
+
+## Communication Protocol
+
+All communication between box and browser uses the task directory on the
+shared filesystem:
+
+| File                        | Writer   | Reader   | Purpose                                    |
+| --------------------------- | -------- | -------- | ------------------------------------------ |
+| `live_session.json`         | Box      | Hivetool | Session bundle (token, endpoint, setup)    |
+| `live_result.json`          | Hivetool | Box      | Session completion signal                  |
+| `tool_dispatch/{id}.json`   | Hivetool | Box      | Tool call request                          |
+| `tool_dispatch/{id}.result.json` | Box | Hivetool | Tool call response                         |
+| `context_updates/{ts}.json` | Box      | Hivetool | Context updates from subagent completions  |
+| `chat_log.json`             | Hivetool | Box      | Transcription log                          |
+
+---
+
+## Phase 1 — Runner Infrastructure ✅
+
+### 🎯 Objective
+
+A template with `runner: live` creates a task that is dispatched to a
+`LiveRunner` instead of the `GeminiRunner`. The runner extracts tool
+declarations, assembles the system instruction, acquires an ephemeral token,
+and writes `live_session.json` to the task directory. The `LiveStream` blocks
+until `live_result.json` appears.
+
+**Observable proof:** Create a task with `runner: live`. Observe
+`live_session.json` appear in the task directory containing the token, WebSocket
+endpoint, and setup message with system instruction and tool declarations.
+
+### Changes
+
+- [x] `ticket.py` — `RunnerType = Literal["generate", "live"]`, `runner` field
+      on `TicketMetadata`.
+- [x] `task_store.py`, `playbook.py` — wire `runner` through creation.
+- [x] `bees.py`, `scheduler.py`, `task_runner.py` — `runners: dict[str,
+      SessionRunner]` with `_runner_for(task)` dispatch.
+- [x] `box.py`, `server.py` — construct `{"generate": ..., "live": ...}`.
+- [x] `SessionConfiguration` — add `ticket_id`, `ticket_dir`.
+- [x] `bees/runners/live.py` — `LiveRunner`, `LiveStream`, declaration
+      extraction, system instruction assembly, bundle writing.
+- [x] 20 tests for LiveRunner/LiveStream, 414 total passing.
+
+---
+
+## Phase 2 — WebSocket Session Client ✅
+
+### 🎯 Objective
+
+Hivetool detects `live_session.json` in a task directory, opens a WebSocket to
+the Gemini Live API, and sends the setup message. On session end, it writes
+`live_result.json`. No audio yet — text-only proves the WebSocket lifecycle.
+
+**Observable proof:** Start a `runner: live` task. Hivetool reads the bundle,
+connects to the Live API, and logs "session connected" in the console.
+Disconnecting writes `live_result.json`, and the box's LiveStream unblocks.
+
+### Changes
+
+- [x] `common/types.ts` — add `runner?: string` to `TaskData`.
+- [x] `hivetool/src/data/live-session.ts` — **[NEW]** `LiveSessionClient`:
+      reads bundle, opens WebSocket, sends setup, handles messages, writes
+      result.
+- [x] `hivetool/src/data/ticket-store.ts` — on scan, check for
+      `live_session.json` and surface active live sessions via
+      `activeLiveSessions` signal.
+- [x] `hivetool/src/ui/ticket-detail.ts` — live session panel with
+      connect/disconnect, status indicator, and transcript display.
+
+---
+
+## Phase 3 — Audio I/O
+
+### 🎯 Objective
+
+Speak into the microphone, hear the agent respond. Audio streams bidirectionally
+over the Live API WebSocket.
+
+**Observable proof:** Start a live session. Click a mic button. Speak a
+greeting. Hear the agent respond with a voice. The conversation is natural and
+low-latency.
+
+### Changes
+
+- [ ] `hivetool/src/data/audio-handler.ts` — **[NEW]** `AudioInput` (mic →
+      PCM → base64 → WS) and `AudioOutput` (WS → PCM → AudioContext →
+      speakers).
+- [ ] `AudioInput` — `navigator.mediaDevices.getUserMedia()`, `AudioWorklet`
+      or `ScriptProcessorNode` for PCM capture at 16kHz mono.
+- [ ] `AudioOutput` — decode base64 PCM, queue into `AudioContext` playback
+      buffer, handle barge-in (stop playback when user speaks).
+- [ ] Wire audio handler into `LiveSessionClient` message loop.
+- [ ] Mic toggle button in ticket detail UI.
+
+---
+
+## Phase 4 — Tool Dispatch Relay
+
+### 🎯 Objective
+
+The Live API can call bees' Python tool handlers. Tool calls from the WebSocket
+bounce through the filesystem to the box, which executes the handler and returns
+the result.
+
+**Observable proof:** Start a live audio session with an agent that has file
+tools. Ask the agent to list files. The tool call appears in
+`tool_dispatch/`, the box executes `simple_files_list_files`, the result is
+written back, hivetool relays it to the WebSocket, and the agent reports the
+file listing.
+
+### Changes
+
+- [ ] `LiveSessionClient` — write `tool_dispatch/{call_id}.json` on
+      `toolCall` message. Watch for `.result.json`. Send `toolResponse` on WS.
+- [ ] `bees/runners/live.py` — `ToolDispatchWatcher`: async loop using
+      `awatch` on `tool_dispatch/` directory. Reads call JSON, looks up handler
+      via `TrampolineRegistry`, writes result JSON.
+- [ ] Wire watcher into `LiveStream` or `LiveRunner` lifecycle.
+- [ ] Handle dispatch timeout and error cases.
+
+---
+
+## Phase 5 — Context Updates & Transcription
+
+### 🎯 Objective
+
+Context updates from subagent completions reach the live session. The
+conversation is logged to `chat_log.json` for post-session review.
+
+**Observable proof:** During a live session, a subagent completes and its
+outcome is injected as a context update. The agent acknowledges the new
+information in its next response. After the session ends, `chat_log.json`
+contains the full conversation transcript.
+
+### Changes
+
+- [ ] `LiveSessionClient` — watch `context_updates/` directory. On new file,
+      read it and call `session.send(clientContent)` on the WebSocket.
+- [ ] `LiveSessionClient` — extract text transcriptions from server messages,
+      append to `chat_log.json`.
+- [ ] `LiveStream.send_context()` — already implemented (writes to
+      `context_updates/` on box side).
+
+---
+
+## Phase 6 — UI Polish
+
+### 🎯 Objective
+
+Live sessions have a dedicated UI panel in ticket detail: connection status,
+mic toggle, waveform visualizer, and live transcript.
+
+**Observable proof:** Select a live-running task in hivetool. See a "Live
+Session" panel with a glowing dot for connection status, a mic button, and a
+scrolling transcript of the conversation.
+
+### Changes
+
+- [ ] `ticket-detail.ts` — render live session panel when
+      `ticket.runner === "live"` and session is active.
+- [ ] Connection status indicator (connecting / connected / disconnected).
+- [ ] Mic toggle button with visual feedback.
+- [ ] Audio level waveform or VU meter.
+- [ ] Live transcript display (from server-side text events).
+
+---
+
+## Non-Goals
+
+- **Audio processing in Python.** Audio stays entirely in the browser.
+  The box never touches audio data.
+- **Live API resume.** The Live API doesn't support session resume the same
+  way batch does. A disconnected live session is a new session.
+- **Multi-user live sessions.** One browser tab per live session.
+- **Custom voice models.** Uses Gemini's built-in voice configuration.
+
+## File Map
+
+```
+packages/bees/
+  bees/
+    runners/
+      live.py                    ← LiveRunner, LiveStream (Phase 1 ✅)
+    ticket.py                    ← RunnerType, runner field (Phase 1 ✅)
+    task_runner.py               ← _runner_for() dispatch (Phase 1 ✅)
+  common/
+    types.ts                     ← runner field on TaskData (Phase 2)
+  hivetool/src/
+    data/
+      live-session.ts            ← [NEW] LiveSessionClient (Phase 2)
+      audio-handler.ts           ← [NEW] AudioInput, AudioOutput (Phase 3)
+      ticket-store.ts            ← live session detection (Phase 2)
+    ui/
+      ticket-detail.ts           ← live session panel (Phase 6)
+  tests/
+    test_live_runner.py          ← LiveRunner tests (Phase 1 ✅)
+```

--- a/packages/bees/app/server.py
+++ b/packages/bees/app/server.py
@@ -40,6 +40,7 @@ from bees.protocols.events import (
     TaskStarted,
 )
 from bees.runners.gemini import GeminiRunner
+from bees.runners.live import LiveRunner
 from opal_backend.local.backend_client_impl import HttpBackendClient
 
 logger = logging.getLogger(__name__)
@@ -168,7 +169,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     )
 
     runner = GeminiRunner(backend)
-    runners = {"generate": runner}
+    runners = {
+        "generate": runner,
+        "live": LiveRunner(api_key=gemini_key),
+    }
     bees = Bees(hive_dir, runners)
 
     bees.on(TaskAdded, _on_task_added)

--- a/packages/bees/bees/box.py
+++ b/packages/bees/bees/box.py
@@ -51,6 +51,7 @@ from bees.protocols.events import (
     TaskStarted,
 )
 from bees.runners.gemini import GeminiRunner
+from bees.runners.live import LiveRunner
 from bees.ticket import Ticket
 from opal_backend.local.backend_client_impl import HttpBackendClient
 
@@ -154,7 +155,9 @@ async def _on_cycle_complete(event: CycleComplete) -> None:
 # ---------------------------------------------------------------------------
 
 
-async def run(hive_dir: Path, backend: HttpBackendClient) -> None:
+async def run(
+    hive_dir: Path, backend: HttpBackendClient, *, gemini_key: str,
+) -> None:
     """Run the box — outer restart loop + inner file-watch loop.
 
     This function runs indefinitely until cancelled or interrupted.
@@ -179,7 +182,10 @@ async def run(hive_dir: Path, backend: HttpBackendClient) -> None:
     startup_manager.activate()
 
     runner = GeminiRunner(backend)
-    runners = {"generate": runner}
+    runners = {
+        "generate": runner,
+        "live": LiveRunner(api_key=gemini_key),
+    }
 
     while True:
         bees = Bees(hive_dir, runners)
@@ -286,7 +292,7 @@ def main() -> None:
 
     async def _run() -> None:
         try:
-            await run(hive_dir, backend)
+            await run(hive_dir, backend, gemini_key=gemini_key)
         finally:
             await http_client.aclose()
 

--- a/packages/bees/bees/runners/live.py
+++ b/packages/bees/bees/runners/live.py
@@ -46,10 +46,10 @@ RESULT_FILENAME = "live_result.json"
 LIVE_API_ENDPOINT = (
     "wss://generativelanguage.googleapis.com/ws/"
     "google.ai.generativelanguage.v1alpha."
-    "GenerativeService.BidiGenerateContent"
+    "GenerativeService.BidiGenerateContentConstrained"
 )
 
-DEFAULT_MODEL = "models/gemini-2.5-flash-preview-native-audio-dialog"
+DEFAULT_MODEL = "models/gemini-3.1-flash-live-preview"
 
 
 # ---------------------------------------------------------------------------
@@ -62,8 +62,13 @@ class _NullHooks:
 
     Bees' function group factories receive ``SessionHooks`` by signature
     but capture their real dependencies through closures.  This stub
-    satisfies the structural contract without providing real services.
+    satisfies the structural contract while forwarding the file system
+    from the provisioned config (some factories access it at
+    construction time).
     """
+
+    def __init__(self, file_system: Any = None) -> None:
+        self._file_system = file_system
 
     @property
     def controller(self) -> Any:
@@ -71,14 +76,11 @@ class _NullHooks:
 
     @property
     def file_system(self) -> Any:
-        return None
+        return self._file_system
 
     @property
     def task_tree_manager(self) -> Any:
         return None
-
-
-_NULL_HOOKS = _NullHooks()
 
 
 # ---------------------------------------------------------------------------
@@ -89,6 +91,7 @@ _NULL_HOOKS = _NullHooks()
 def _extract_declarations(
     factories: list[FunctionGroupFactory],
     function_filter: list[str] | None,
+    file_system: Any = None,
 ) -> tuple[list[dict[str, Any]], str]:
     """Call factories and collect tool declarations and instructions.
 
@@ -96,11 +99,18 @@ def _extract_declarations(
     *function_filter* is non-empty, only declarations whose name
     matches a filter entry are included.
     """
+    hooks = _NullHooks(file_system)
     all_declarations: list[dict[str, Any]] = []
     instructions: list[str] = []
 
-    for factory in factories:
-        group: FunctionGroup = factory(_NULL_HOOKS)
+    for item in factories:
+        # The provisioner list is a mix of factories (callables that
+        # return FunctionGroup) and already-constructed FunctionGroup
+        # instances (e.g. skills).  Distinguish by checking callable.
+        if callable(item) and not isinstance(item, FunctionGroup):
+            group: FunctionGroup = item(hooks)
+        else:
+            group = item
 
         if group.instruction:
             instructions.append(group.instruction)
@@ -323,11 +333,15 @@ class LiveRunner:
         """Request a short-lived ephemeral token from the Gemini API.
 
         Uses ``google-genai`` SDK to create a single-use token
-        that expires after 30 minutes.
+        that expires after 30 minutes.  The auth_tokens API is only
+        available on the ``v1alpha`` endpoint.
         """
         from google import genai
 
-        client = genai.Client(api_key=self._api_key)
+        client = genai.Client(
+            api_key=self._api_key,
+            http_options={"api_version": "v1alpha"},
+        )
         expire_time = (
             datetime.now(timezone.utc) + timedelta(minutes=30)
         ).isoformat()
@@ -337,6 +351,7 @@ class LiveRunner:
             config={
                 "uses": 1,
                 "expire_time": expire_time,
+                "http_options": {"api_version": "v1alpha"},
             },
         )
 
@@ -366,6 +381,7 @@ class LiveRunner:
         declarations, tool_instruction = _extract_declarations(
             config.function_groups,
             config.function_filter,
+            file_system=config.file_system,
         )
         logger.info(
             "[%s] Extracted %d tool declarations for live session",

--- a/packages/bees/common/types.ts
+++ b/packages/bees/common/types.ts
@@ -43,4 +43,5 @@ export interface TaskData {
   watch_events?: Array<{ type: string }>;
   outcome_content?: Record<string, unknown>;
   files?: Array<{ path: string; mimeType: string; localPath: string }>;
+  runner?: "generate" | "live";
 }

--- a/packages/bees/hive/config/TEMPLATES.yaml
+++ b/packages/bees/hive/config/TEMPLATES.yaml
@@ -331,3 +331,8 @@
     - system.*
     - events.*
     - simple-files.*
+
+- name: live-session
+  runner: live
+  title: Live Session
+  description: A simple live session.

--- a/packages/bees/hivetool/src/data/live-session.ts
+++ b/packages/bees/hivetool/src/data/live-session.ts
@@ -1,0 +1,297 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Client for Gemini Live API sessions.
+ *
+ * Reads a session bundle (`live_session.json`) from a task directory,
+ * opens a WebSocket to the Gemini Live API, sends the setup message,
+ * and manages the session lifecycle.  On completion or error, writes
+ * `live_result.json` for the box's `LiveStream` to pick up.
+ *
+ * This module handles WebSocket messaging only — audio I/O and tool
+ * dispatch are separate concerns added in later phases.
+ */
+
+import { Signal } from "signal-polyfill";
+
+export { LiveSessionClient };
+export type { LiveSessionBundle, SessionStatus };
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** The session bundle written by `LiveRunner` on the Python side. */
+interface LiveSessionBundle {
+  token: string;
+  endpoint: string;
+  setup: Record<string, unknown>;
+  task_id: string;
+}
+
+type SessionStatus =
+  | "idle"
+  | "connecting"
+  | "connected"
+  | "disconnected"
+  | "error";
+
+/** A message received from the Live API WebSocket. */
+interface ServerMessage {
+  setupComplete?: Record<string, unknown>;
+  serverContent?: {
+    modelTurn?: {
+      parts?: Array<{
+        text?: string;
+        inlineData?: { mimeType: string; data: string };
+      }>;
+    };
+    turnComplete?: boolean;
+  };
+  toolCall?: {
+    functionCalls: Array<{
+      id: string;
+      name: string;
+      args: Record<string, unknown>;
+    }>;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// LiveSessionClient
+// ---------------------------------------------------------------------------
+
+class LiveSessionClient {
+  /** Reactive session status for UI binding. */
+  readonly status = new Signal.State<SessionStatus>("idle");
+
+  /** Reactive transcript — appended as text arrives from the model. */
+  readonly transcript = new Signal.State<string>("");
+
+  /** The task ID this session belongs to. */
+  readonly taskId: string;
+
+  #ws: WebSocket | null = null;
+  #bundle: LiveSessionBundle;
+  #ticketDir: FileSystemDirectoryHandle;
+
+  constructor(
+    bundle: LiveSessionBundle,
+    ticketDir: FileSystemDirectoryHandle,
+  ) {
+    this.#bundle = bundle;
+    this.#ticketDir = ticketDir;
+    this.taskId = bundle.task_id;
+  }
+
+  // ── Lifecycle ──
+
+  /**
+   * Open the WebSocket connection and send the setup message.
+   *
+   * Resolves when the connection is established (or rejects on immediate
+   * failure).  Session events arrive asynchronously via the WebSocket.
+   */
+  async connect(): Promise<void> {
+    if (this.#ws) return;
+
+    this.status.set("connecting");
+
+    // Build the authenticated WebSocket URL.
+    // Ephemeral tokens use access_token, not key.
+    const url = `${this.#bundle.endpoint}?access_token=${this.#bundle.token}`;
+
+    return new Promise<void>((resolve, reject) => {
+      const ws = new WebSocket(url);
+
+      ws.addEventListener("open", () => {
+        console.log(
+          `[live:${this.taskId.slice(0, 8)}] WebSocket connected`,
+        );
+
+        // Send the setup message immediately.
+        ws.send(JSON.stringify({ setup: this.#bundle.setup }));
+      });
+
+      ws.addEventListener("message", (event: MessageEvent) => {
+        this.#handleMessage(event.data);
+      });
+
+      ws.addEventListener("close", (event: CloseEvent) => {
+        console.log(
+          `[live:${this.taskId.slice(0, 8)}] WebSocket closed:`,
+          event.code,
+          event.reason,
+        );
+        this.#ws = null;
+
+        if (this.status.get() === "connecting") {
+          this.status.set("error");
+          reject(new Error(`WebSocket closed during setup: ${event.reason}`));
+        } else {
+          this.status.set("disconnected");
+          this.#writeResult("completed");
+        }
+      });
+
+      ws.addEventListener("error", () => {
+        console.error(
+          `[live:${this.taskId.slice(0, 8)}] WebSocket error`,
+        );
+        if (this.status.get() === "connecting") {
+          this.status.set("error");
+          reject(new Error("WebSocket connection failed"));
+        } else {
+          this.status.set("error");
+          this.#writeResult("failed", "WebSocket error");
+        }
+      });
+
+      this.#ws = ws;
+    });
+  }
+
+  /** Gracefully close the session. */
+  disconnect(): void {
+    if (!this.#ws) return;
+    this.#ws.close(1000, "Client disconnect");
+    this.#ws = null;
+  }
+
+  /** Send raw data over the WebSocket (for audio chunks, etc.). */
+  send(message: Record<string, unknown>): void {
+    if (!this.#ws || this.#ws.readyState !== WebSocket.OPEN) return;
+    this.#ws.send(JSON.stringify(message));
+  }
+
+  // ── Message handling ──
+
+  #handleMessage(data: string | Blob | ArrayBuffer): void {
+    // Binary frames are audio data — Phase 3 will handle these.
+    if (typeof data !== "string") return;
+
+    let message: ServerMessage;
+    try {
+      message = JSON.parse(data) as ServerMessage;
+    } catch {
+      console.warn(
+        `[live:${this.taskId.slice(0, 8)}] Unparseable message:`,
+        data.slice(0, 100),
+      );
+      return;
+    }
+
+    // Setup complete — transition to connected.
+    if (message.setupComplete) {
+      console.log(
+        `[live:${this.taskId.slice(0, 8)}] Setup complete`,
+      );
+      this.status.set("connected");
+      return;
+    }
+
+    // Model text output — append to transcript.
+    if (message.serverContent?.modelTurn?.parts) {
+      for (const part of message.serverContent.modelTurn.parts) {
+        if (part.text) {
+          this.transcript.set(this.transcript.get() + part.text);
+        }
+        // Audio parts (inlineData) will be handled by AudioHandler in Phase 3.
+      }
+    }
+
+    // Tool calls — Phase 4 will handle these.
+    if (message.toolCall) {
+      console.log(
+        `[live:${this.taskId.slice(0, 8)}] Tool call:`,
+        message.toolCall.functionCalls.map((fc) => fc.name).join(", "),
+      );
+    }
+  }
+
+  // ── Result writing ──
+
+  async #writeResult(
+    status: "completed" | "failed",
+    error?: string,
+  ): Promise<void> {
+    try {
+      const result: Record<string, unknown> = { status };
+      if (error) result.error = error;
+      result.timestamp = new Date().toISOString();
+
+      const fileHandle = await this.#ticketDir.getFileHandle(
+        "live_result.json",
+        { create: true },
+      );
+      const writable = await fileHandle.createWritable();
+      await writable.write(JSON.stringify(result, null, 2) + "\n");
+      await writable.close();
+
+      console.log(
+        `[live:${this.taskId.slice(0, 8)}] Result written: ${status}`,
+      );
+    } catch (e) {
+      console.error(
+        `[live:${this.taskId.slice(0, 8)}] Failed to write result:`,
+        e,
+      );
+    }
+  }
+
+  // ── Static factory ──
+
+  /**
+   * Read a session bundle from a ticket directory.
+   *
+   * Returns `null` if `live_session.json` doesn't exist or isn't readable.
+   */
+  static async fromTicketDir(
+    ticketDir: FileSystemDirectoryHandle,
+  ): Promise<LiveSessionClient | null> {
+    try {
+      const fileHandle = await ticketDir.getFileHandle(
+        "live_session.json",
+      );
+      const file = await fileHandle.getFile();
+      const text = await file.text();
+      const bundle = JSON.parse(text) as LiveSessionBundle;
+
+      if (!bundle.token || !bundle.endpoint || !bundle.setup) {
+        console.warn("Invalid live_session.json — missing required fields");
+        return null;
+      }
+
+      return new LiveSessionClient(bundle, ticketDir);
+    } catch {
+      // File doesn't exist or isn't readable — not a live session.
+      return null;
+    }
+  }
+
+  /**
+   * Check whether a ticket directory has an active live session bundle
+   * (i.e., `live_session.json` exists but `live_result.json` does not).
+   */
+  static async hasActiveSession(
+    ticketDir: FileSystemDirectoryHandle,
+  ): Promise<boolean> {
+    try {
+      await ticketDir.getFileHandle("live_session.json");
+    } catch {
+      return false;
+    }
+
+    // If result already exists, the session is done.
+    try {
+      await ticketDir.getFileHandle("live_result.json");
+      return false;
+    } catch {
+      return true;
+    }
+  }
+}

--- a/packages/bees/hivetool/src/data/template-store.ts
+++ b/packages/bees/hivetool/src/data/template-store.ts
@@ -32,6 +32,7 @@ interface TemplateData {
   watch_events?: Array<{ type: string }>;
   tasks?: string[];
   autostart?: string[];
+  runner?: "generate" | "live";
 }
 
 class TemplateStore {

--- a/packages/bees/hivetool/src/data/ticket-store.ts
+++ b/packages/bees/hivetool/src/data/ticket-store.ts
@@ -15,6 +15,7 @@
 import { Signal } from "signal-polyfill";
 import type { StateAccess } from "./state-access.js";
 import type { TicketData } from "./types.js";
+import { LiveSessionClient } from "./live-session.js";
 
 export { TicketStore };
 export type { FileTreeNode };
@@ -37,6 +38,9 @@ class TicketStore {
     if (!id) return null;
     return this.tickets.get().find((t) => t.id === id) ?? null;
   });
+
+  /** Set of ticket IDs with active (unresolved) live session bundles. */
+  readonly activeLiveSessions = new Signal.State<Set<string>>(new Set());
 
   #ticketsHandle: FileSystemDirectoryHandle | null = null;
   #observer: { disconnect(): void } | null = null;
@@ -95,6 +99,9 @@ class TicketStore {
     });
 
     this.tickets.set(entries);
+
+    // Detect active live sessions.
+    await this.#detectLiveSessions(entries);
   }
 
   selectTicket(id: string): void {
@@ -110,6 +117,7 @@ class TicketStore {
     this.tickets.set([]);
     this.selectedTicketId.set(null);
     this.recentlyUpdatedTicket.set(null);
+    this.activeLiveSessions.set(new Set());
   }
 
   /** Clean up the observer. */
@@ -136,6 +144,7 @@ class TicketStore {
     tags?: string[];
     tasks?: string[];
     model?: string;
+    runner?: "generate" | "live";
     context?: string;
     watch_events?: Array<{ type: string }>;
   }): Promise<string> {
@@ -168,6 +177,7 @@ class TicketStore {
     if (opts.tags?.length) metadata.tags = opts.tags;
     if (opts.tasks?.length) metadata.tasks = opts.tasks;
     if (opts.model) metadata.model = opts.model;
+    if (opts.runner) metadata.runner = opts.runner;
     if (opts.context) metadata.context = opts.context;
     if (opts.watch_events?.length) metadata.watch_events = opts.watch_events;
 
@@ -270,6 +280,59 @@ class TicketStore {
       return await file.text();
     } catch {
       return null;
+    }
+  }
+
+  /**
+   * Get the `FileSystemDirectoryHandle` for a ticket.
+   *
+   * Used by `LiveSessionClient.fromTicketDir()` to read the session bundle.
+   */
+  async getTicketDirHandle(
+    ticketId: string,
+  ): Promise<FileSystemDirectoryHandle | null> {
+    if (!this.#ticketsHandle) return null;
+    try {
+      return await this.#ticketsHandle.getDirectoryHandle(ticketId);
+    } catch {
+      return null;
+    }
+  }
+
+  // ── Live session detection ──
+
+  async #detectLiveSessions(tickets: TicketData[]): Promise<void> {
+    if (!this.#ticketsHandle) return;
+
+    const liveTickets = tickets.filter((t) => t.runner === "live");
+    if (liveTickets.length === 0) {
+      if (this.activeLiveSessions.get().size > 0) {
+        this.activeLiveSessions.set(new Set());
+      }
+      return;
+    }
+
+    const activeIds = new Set<string>();
+    for (const ticket of liveTickets) {
+      try {
+        const ticketDir = await this.#ticketsHandle.getDirectoryHandle(
+          ticket.id,
+        );
+        if (await LiveSessionClient.hasActiveSession(ticketDir)) {
+          activeIds.add(ticket.id);
+        }
+      } catch {
+        // Directory not accessible — skip.
+      }
+    }
+
+    // Only update signal if the set changed.
+    const current = this.activeLiveSessions.get();
+    if (
+      activeIds.size !== current.size ||
+      ![...activeIds].every((id) => current.has(id))
+    ) {
+      this.activeLiveSessions.set(activeIds);
     }
   }
 

--- a/packages/bees/hivetool/src/ui/template-detail.ts
+++ b/packages/bees/hivetool/src/ui/template-detail.ts
@@ -312,6 +312,8 @@ class BeesTemplateDetail extends SignalWatcher(LitElement) {
     chips.push({ label: "name", value: template.name, cls: "playbook" });
     if (template.model)
       chips.push({ label: "model", value: template.model, cls: "model" });
+    if (template.runner && template.runner !== "generate")
+      chips.push({ label: "runner", value: template.runner });
 
     const allTemplates = this.templateStore!.templates.get();
     const templateNames = new Set(allTemplates.map((t) => t.name));
@@ -574,6 +576,16 @@ class BeesTemplateDetail extends SignalWatcher(LitElement) {
                 placeholder="e.g. gemini-3.1-pro-preview"
                 @change=${(e: CustomEvent) =>
                   this.updateDraft({ model: e.detail.value })}
+              ></bees-editable-field>
+              <bees-editable-field
+                label="Runner"
+                .value=${draft.runner ?? "generate"}
+                editing
+                placeholder="generate"
+                @change=${(e: CustomEvent) =>
+                  this.updateDraft({
+                    runner: e.detail.value === "live" ? "live" : "generate",
+                  })}
               ></bees-editable-field>
             </div>
 
@@ -909,6 +921,7 @@ class BeesTemplateDetail extends SignalWatcher(LitElement) {
         tags: template.tags,
         tasks: template.tasks,
         model: template.model,
+        runner: template.runner,
         context,
         watch_events: template.watch_events,
       });

--- a/packages/bees/hivetool/src/ui/ticket-detail.ts
+++ b/packages/bees/hivetool/src/ui/ticket-detail.ts
@@ -20,6 +20,7 @@ import type { TicketStore, FileTreeNode } from "../data/ticket-store.js";
 import type { MutationClient } from "../data/mutation-client.js";
 import type { TemplateStore } from "../data/template-store.js";
 import type { SkillStore } from "../data/skill-store.js";
+import { LiveSessionClient } from "../data/live-session.js";
 import { sharedStyles } from "./shared-styles.js";
 import { renderJson } from "./json-tree.js";
 import { jsonTreeStyles } from "./json-tree.styles.js";
@@ -304,6 +305,93 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
         flex: 1;
         line-height: 1.4;
       }
+
+      /* ── Live session panel ── */
+
+      .live-panel {
+        border: 1px solid #1e3a5f;
+        border-radius: 8px;
+        overflow: hidden;
+      }
+
+      .live-panel-header {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 10px 14px;
+        background: #0c1929;
+        border-bottom: 1px solid #1e3a5f;
+      }
+
+      .live-status-dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        flex-shrink: 0;
+        transition: background 0.3s;
+      }
+
+      .live-status-dot.idle { background: #475569; }
+      .live-status-dot.connecting { background: #f59e0b; animation: pulse 1s infinite; }
+      .live-status-dot.connected { background: #22c55e; animation: pulse 2s infinite; }
+      .live-status-dot.disconnected { background: #64748b; }
+      .live-status-dot.error { background: #ef4444; }
+
+      @keyframes pulse {
+        0%, 100% { opacity: 1; }
+        50% { opacity: 0.4; }
+      }
+
+      .live-status-label {
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: #94a3b8;
+        flex: 1;
+      }
+
+      .live-btn {
+        padding: 4px 12px;
+        font-size: 0.7rem;
+        font-weight: 600;
+        border-radius: 4px;
+        cursor: pointer;
+        font-family: inherit;
+        transition: all 0.15s;
+        border: 1px solid;
+      }
+
+      .live-btn.connect {
+        background: #1d4ed8;
+        color: #dbeafe;
+        border-color: #2563eb;
+      }
+      .live-btn.connect:hover { background: #2563eb; }
+
+      .live-btn.disconnect {
+        background: transparent;
+        color: #f87171;
+        border-color: #991b1b;
+      }
+      .live-btn.disconnect:hover { background: #1c1917; }
+
+      .live-transcript {
+        padding: 10px 14px;
+        max-height: 200px;
+        overflow-y: auto;
+        font-size: 0.8rem;
+        line-height: 1.5;
+        color: #cbd5e1;
+        white-space: pre-wrap;
+        word-break: break-word;
+        background: #0a0f1a;
+      }
+
+      .live-transcript-empty {
+        color: #475569;
+        font-style: italic;
+      }
     `,
   ];
 
@@ -330,6 +418,9 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
   @state() accessor replyText = "";
   @state() accessor selectedChoiceIds = new Set<string>();
   @state() accessor responding = false;
+
+  // ── Live session state ──
+  #liveClient: LiveSessionClient | null = null;
 
   /** Track the ticket ID we loaded the tree for. */
   #treeLoadedFor: string | null = null;
@@ -560,6 +651,9 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
                   <div class="block-content">${ticket.error}</div>
                 </div>
               `
+            : nothing}
+          ${ticket.runner === "live"
+            ? this.renderLiveSessionPanel(ticket.id)
             : nothing}
           ${ticket.status === "suspended" && ticket.suspend_event
             ? this.renderSuspendedBlock(ticket.id, ticket.suspend_event, ticket.assignee)
@@ -1002,6 +1096,87 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
     } finally {
       this.responding = false;
     }
+  }
+
+  // ── Live session ──
+
+  private renderLiveSessionPanel(ticketId: string) {
+    const hasActive = this.ticketStore?.activeLiveSessions
+      .get()
+      .has(ticketId);
+
+    const status = this.#liveClient?.status.get() ?? "idle";
+    const transcript = this.#liveClient?.transcript.get() ?? "";
+
+    if (!hasActive && status === "idle") return nothing;
+
+    const isConnected =
+      status === "connected" || status === "connecting";
+
+    return html`
+      <div class="block live-panel">
+        <div class="live-panel-header">
+          <span class="live-status-dot ${status}"></span>
+          <span class="live-status-label">Live Session — ${status}</span>
+          ${isConnected
+            ? html`<button
+                class="live-btn disconnect"
+                @click=${() => this.handleLiveDisconnect()}
+              >
+                Disconnect
+              </button>`
+            : hasActive
+              ? html`<button
+                  class="live-btn connect"
+                  @click=${() => this.handleLiveConnect(ticketId)}
+                >
+                  Connect
+                </button>`
+              : nothing}
+        </div>
+        ${transcript
+          ? html`<div class="live-transcript">${transcript}</div>`
+          : isConnected
+            ? html`<div class="live-transcript">
+                <span class="live-transcript-empty"
+                  >Waiting for agent response…</span
+                >
+              </div>`
+            : nothing}
+      </div>
+    `;
+  }
+
+  private async handleLiveConnect(ticketId: string): Promise<void> {
+    if (this.#liveClient) return;
+    if (!this.ticketStore) return;
+
+    const dirHandle = await this.ticketStore.getTicketDirHandle(ticketId);
+    if (!dirHandle) {
+      console.error("Could not get directory handle for ticket", ticketId);
+      return;
+    }
+
+    const client = await LiveSessionClient.fromTicketDir(dirHandle);
+    if (!client) {
+      console.error("Could not create LiveSessionClient for", ticketId);
+      return;
+    }
+
+    this.#liveClient = client;
+
+    try {
+      await client.connect();
+    } catch (e) {
+      console.error("Live session connection failed:", e);
+      this.#liveClient = null;
+    }
+  }
+
+  private handleLiveDisconnect(): void {
+    if (!this.#liveClient) return;
+    this.#liveClient.disconnect();
+    this.#liveClient = null;
   }
 }
 

--- a/packages/bees/pyproject.toml
+++ b/packages/bees/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Bees — agent swarm orchestration framework"
 requires-python = ">=3.11"
 dependencies = [
+    "google-genai>=1.0.0",
     "httpx>=0.27.0",
     "mcp>=1.0.0",
     "python-dotenv>=1.0.0",


### PR DESCRIPTION
## What
Adds a browser-side WebSocket client for Gemini Live API sessions, completing the delegated session pattern where the box provisions the session and the browser owns the connection.

## Why
Phase 2 of Project Acoustic: the browser must establish the Live API WebSocket because it owns the audio hardware. The box writes a session bundle (ephemeral token, tool declarations, system instruction) and blocks until the browser signals completion.

## Changes

### Runner fixes (`bees/runners/live.py`)
- Fix `_NullHooks` to forward `file_system` from config (factories like `simple_files` access `_work_dir` at construction time)
- Handle mixed `function_groups` list (factories + already-constructed `FunctionGroup` instances)
- Use `v1alpha` API version for ephemeral token creation
- Use `BidiGenerateContentConstrained` endpoint (required for ephemeral tokens)
- Correct model name to `gemini-3.1-flash-live-preview`

### Hivetool session client (`hivetool/src/data/live-session.ts`)
- `LiveSessionClient`: WebSocket lifecycle, setup message delivery, JSON/binary message dispatch
- Reactive `status` and `transcript` signals for UI binding
- Factory method reads `live_session.json` from task directory
- Writes `live_result.json` on session end for the box's `LiveStream` to pick up

### Hivetool UI integration
- `TicketStore`: detects active live sessions during scan, exposes `activeLiveSessions` signal, adds `getTicketDirHandle()`
- `ticket-detail.ts`: live session panel with connect/disconnect controls, status indicator, transcript — all signal-driven (no polling)
- `template-detail.ts`: `runner` field in view mode (identity chip) and edit mode

### Data model
- `TemplateData`: add `runner?: "generate" | "live"`
- `TicketStore.createTask()`: accept and write `runner` to metadata
- `pyproject.toml`: add `google-genai` dependency

## Testing
- 20 LiveRunner unit tests passing
- TypeScript compiles cleanly
- Manual E2E: create template with `runner: live` → run → box writes bundle → hivetool connects WebSocket → setup completes → audio frames flowing
