### PR TITLE
[bees] Audio I/O for Live Sessions

### DIFF
--- a/PROJECT_ACOUSTIC.md
+++ b/PROJECT_ACOUSTIC.md
@@ -103,7 +103,7 @@ Disconnecting writes `live_result.json`, and the box's LiveStream unblocks.
 
 ---
 
-## Phase 3 — Audio I/O
+## Phase 3 — Audio I/O ✅
 
 ### 🎯 Objective
 
@@ -116,15 +116,17 @@ low-latency.
 
 ### Changes
 
-- [ ] `hivetool/src/data/audio-handler.ts` — **[NEW]** `AudioInput` (mic →
+- [x] `hivetool/src/data/audio-handler.ts` — **[NEW]** `AudioInput` (mic →
       PCM → base64 → WS) and `AudioOutput` (WS → PCM → AudioContext →
       speakers).
-- [ ] `AudioInput` — `navigator.mediaDevices.getUserMedia()`, `AudioWorklet`
-      or `ScriptProcessorNode` for PCM capture at 16kHz mono.
-- [ ] `AudioOutput` — decode base64 PCM, queue into `AudioContext` playback
-      buffer, handle barge-in (stop playback when user speaks).
-- [ ] Wire audio handler into `LiveSessionClient` message loop.
-- [ ] Mic toggle button in ticket detail UI.
+- [x] `AudioInput` — `navigator.mediaDevices.getUserMedia()`, `AudioWorklet`
+      for PCM capture at 16kHz mono.
+- [x] `AudioOutput` — decode base64 PCM, queue into `AudioContext` playback
+      buffer.
+- [x] Wire audio handler into `LiveSessionClient` message loop.
+- [x] Mic toggle button in ticket detail UI.
+- [x] Fix binary Blob frame decoding (`#handleMessage`) — the Live API sends
+      all frames as binary, not text.
 
 ---
 

--- a/packages/bees/hive/config/TEMPLATES.yaml
+++ b/packages/bees/hive/config/TEMPLATES.yaml
@@ -336,3 +336,8 @@
   runner: live
   title: Live Session
   description: A simple live session.
+  functions:
+    - system.*
+  objective: >-
+    Engage with user with in a causal conversation. You are done when the user
+    says "good night".

--- a/packages/bees/hivetool/src/data/audio-handler.ts
+++ b/packages/bees/hivetool/src/data/audio-handler.ts
@@ -1,0 +1,216 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Audio I/O for Gemini Live API sessions.
+ *
+ * **AudioInput** captures microphone audio via an AudioWorklet, downsamples
+ * to 16kHz 16-bit PCM, base64-encodes each chunk, and delivers it via a
+ * callback for streaming to the Live API WebSocket.
+ *
+ * **AudioOutput** receives base64-encoded 24kHz 16-bit PCM from the Live
+ * API, decodes it, and plays it through an AudioContext with seamless
+ * buffer stitching.
+ */
+
+export { AudioInput, AudioOutput };
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Encode an Int16Array to a base64 string. */
+function int16ToBase64(pcm: Int16Array): string {
+  const bytes = new Uint8Array(pcm.buffer, pcm.byteOffset, pcm.byteLength);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+/** Decode a base64 string to an Int16Array. */
+function base64ToInt16(b64: string): Int16Array {
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new Int16Array(bytes.buffer);
+}
+
+// ---------------------------------------------------------------------------
+// AudioInput — mic → PCM → base64
+// ---------------------------------------------------------------------------
+
+/** Callback for each audio chunk ready to send over WebSocket. */
+type OnChunkCallback = (base64Pcm: string) => void;
+
+class AudioInput {
+  #context: AudioContext | null = null;
+  #stream: MediaStream | null = null;
+  #workletNode: AudioWorkletNode | null = null;
+  #onChunk: OnChunkCallback;
+  #running = false;
+
+  constructor(onChunk: OnChunkCallback) {
+    this.#onChunk = onChunk;
+  }
+
+  get running(): boolean {
+    return this.#running;
+  }
+
+  /** Start capturing microphone audio. */
+  async start(): Promise<void> {
+    if (this.#running) return;
+
+    // Request mic access.
+    this.#stream = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        channelCount: 1,
+        sampleRate: { ideal: 48000 },
+        echoCancellation: true,
+        noiseSuppression: true,
+      },
+    });
+
+    // Create AudioContext and load the worklet processor.
+    this.#context = new AudioContext({ sampleRate: 48000 });
+
+    const workletUrl = new URL(
+      "./pcm-capture-processor.js",
+      import.meta.url,
+    );
+    await this.#context.audioWorklet.addModule(workletUrl);
+
+    // Wire: mic → worklet.
+    const source = this.#context.createMediaStreamSource(this.#stream);
+    this.#workletNode = new AudioWorkletNode(
+      this.#context,
+      "pcm-capture-processor",
+    );
+
+    // Receive PCM chunks from the worklet thread.
+    let chunkCount = 0;
+    this.#workletNode.port.onmessage = (event: MessageEvent) => {
+      const pcm = event.data.pcm as Int16Array;
+      if (pcm && pcm.length > 0) {
+        chunkCount++;
+        // Log amplitude every ~1 second (10 chunks × 100ms).
+        if (chunkCount % 10 === 0) {
+          let maxAmp = 0;
+          for (let i = 0; i < pcm.length; i++) {
+            const abs = Math.abs(pcm[i]);
+            if (abs > maxAmp) maxAmp = abs;
+          }
+          console.log(
+            `[audio-input] chunk #${chunkCount}: ${pcm.length} samples, peak=${maxAmp}`,
+          );
+        }
+        this.#onChunk(int16ToBase64(pcm));
+      }
+    };
+
+    source.connect(this.#workletNode);
+    // The worklet doesn't produce audio output — connect to a dummy
+    // destination to keep the graph alive.
+    this.#workletNode.connect(this.#context.destination);
+
+    this.#running = true;
+    console.log("[audio-input] Mic capture started");
+  }
+
+  /** Stop capturing and release resources. */
+  stop(): void {
+    if (!this.#running) return;
+
+    this.#workletNode?.disconnect();
+    this.#workletNode = null;
+
+    if (this.#stream) {
+      for (const track of this.#stream.getTracks()) {
+        track.stop();
+      }
+      this.#stream = null;
+    }
+
+    if (this.#context) {
+      void this.#context.close();
+      this.#context = null;
+    }
+
+    this.#running = false;
+    console.log("[audio-input] Mic capture stopped");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// AudioOutput — base64 PCM → speakers
+// ---------------------------------------------------------------------------
+
+/** Sample rate of audio received from the Live API. */
+const OUTPUT_SAMPLE_RATE = 24000;
+
+class AudioOutput {
+  #context: AudioContext | null = null;
+  /** Scheduled end time of the last queued buffer. */
+  #nextStartTime = 0;
+
+  /** Ensure the AudioContext is ready. */
+  #ensureContext(): AudioContext {
+    if (!this.#context) {
+      this.#context = new AudioContext({ sampleRate: OUTPUT_SAMPLE_RATE });
+      this.#nextStartTime = 0;
+    }
+    return this.#context;
+  }
+
+  /**
+   * Enqueue a base64-encoded PCM chunk for playback.
+   *
+   * Chunks are stitched seamlessly — each new buffer is scheduled to
+   * start exactly when the previous one ends.
+   */
+  play(base64Pcm: string): void {
+    const ctx = this.#ensureContext();
+
+    // Decode base64 → Int16 → Float32.
+    const int16 = base64ToInt16(base64Pcm);
+    const float32 = new Float32Array(int16.length);
+    for (let i = 0; i < int16.length; i++) {
+      float32[i] = int16[i] / (int16[i] < 0 ? 0x8000 : 0x7fff);
+    }
+
+    // Create an AudioBuffer.
+    const buffer = ctx.createBuffer(1, float32.length, OUTPUT_SAMPLE_RATE);
+    buffer.getChannelData(0).set(float32);
+
+    // Schedule playback.
+    const source = ctx.createBufferSource();
+    source.buffer = buffer;
+    source.connect(ctx.destination);
+
+    const now = ctx.currentTime;
+    const startTime = Math.max(now, this.#nextStartTime);
+    source.start(startTime);
+    this.#nextStartTime = startTime + buffer.duration;
+  }
+
+  /** Stop all playback and flush the queue. */
+  flush(): void {
+    if (this.#context) {
+      void this.#context.close();
+      this.#context = null;
+      this.#nextStartTime = 0;
+    }
+  }
+
+  /** Release resources. */
+  dispose(): void {
+    this.flush();
+  }
+}

--- a/packages/bees/hivetool/src/data/live-session.ts
+++ b/packages/bees/hivetool/src/data/live-session.ts
@@ -12,11 +12,12 @@
  * and manages the session lifecycle.  On completion or error, writes
  * `live_result.json` for the box's `LiveStream` to pick up.
  *
- * This module handles WebSocket messaging only — audio I/O and tool
- * dispatch are separate concerns added in later phases.
+ * This module handles WebSocket messaging and audio I/O. Tool
+ * dispatch is a separate concern added in Phase 4.
  */
 
 import { Signal } from "signal-polyfill";
+import { AudioInput, AudioOutput } from "./audio-handler.js";
 
 export { LiveSessionClient };
 export type { LiveSessionBundle, SessionStatus };
@@ -72,12 +73,17 @@ class LiveSessionClient {
   /** Reactive transcript — appended as text arrives from the model. */
   readonly transcript = new Signal.State<string>("");
 
+  /** Whether the microphone is currently active. */
+  readonly micActive = new Signal.State<boolean>(false);
+
   /** The task ID this session belongs to. */
   readonly taskId: string;
 
   #ws: WebSocket | null = null;
   #bundle: LiveSessionBundle;
   #ticketDir: FileSystemDirectoryHandle;
+  #audioInput: AudioInput | null = null;
+  #audioOutput = new AudioOutput();
 
   constructor(
     bundle: LiveSessionBundle,
@@ -157,9 +163,42 @@ class LiveSessionClient {
 
   /** Gracefully close the session. */
   disconnect(): void {
+    this.stopMic();
+    this.#audioOutput.dispose();
     if (!this.#ws) return;
     this.#ws.close(1000, "Client disconnect");
     this.#ws = null;
+  }
+
+  // ── Audio ──
+
+  /** Start capturing microphone audio and streaming to the Live API. */
+  async startMic(): Promise<void> {
+    if (this.#audioInput?.running) return;
+    if (this.status.get() !== "connected") return;
+
+    this.#audioInput = new AudioInput((base64Pcm: string) => {
+      this.send({
+        realtimeInput: {
+          audio: {
+            data: base64Pcm,
+            mimeType: "audio/pcm;rate=16000",
+          },
+        },
+      });
+    });
+
+    await this.#audioInput.start();
+    this.micActive.set(true);
+  }
+
+  /** Stop microphone capture. */
+  stopMic(): void {
+    if (this.#audioInput) {
+      this.#audioInput.stop();
+      this.#audioInput = null;
+    }
+    this.micActive.set(false);
   }
 
   /** Send raw data over the WebSocket (for audio chunks, etc.). */
@@ -170,17 +209,26 @@ class LiveSessionClient {
 
   // ── Message handling ──
 
-  #handleMessage(data: string | Blob | ArrayBuffer): void {
-    // Binary frames are audio data — Phase 3 will handle these.
-    if (typeof data !== "string") return;
+  async #handleMessage(data: string | Blob | ArrayBuffer): Promise<void> {
+    // The Live API sends all frames as binary. Decode to text first.
+    let text: string;
+    if (typeof data === "string") {
+      text = data;
+    } else if (data instanceof Blob) {
+      text = await data.text();
+    } else if (data instanceof ArrayBuffer) {
+      text = new TextDecoder().decode(data);
+    } else {
+      return;
+    }
 
     let message: ServerMessage;
     try {
-      message = JSON.parse(data) as ServerMessage;
+      message = JSON.parse(text) as ServerMessage;
     } catch {
       console.warn(
         `[live:${this.taskId.slice(0, 8)}] Unparseable message:`,
-        data.slice(0, 100),
+        text.slice(0, 100),
       );
       return;
     }
@@ -194,13 +242,15 @@ class LiveSessionClient {
       return;
     }
 
-    // Model text output — append to transcript.
+    // Model content — text goes to transcript, audio goes to speakers.
     if (message.serverContent?.modelTurn?.parts) {
       for (const part of message.serverContent.modelTurn.parts) {
         if (part.text) {
           this.transcript.set(this.transcript.get() + part.text);
         }
-        // Audio parts (inlineData) will be handled by AudioHandler in Phase 3.
+        if (part.inlineData?.data) {
+          this.#audioOutput.play(part.inlineData.data);
+        }
       }
     }
 

--- a/packages/bees/hivetool/src/data/pcm-capture-processor.js
+++ b/packages/bees/hivetool/src/data/pcm-capture-processor.js
@@ -1,0 +1,83 @@
+/**
+ * AudioWorklet processor for PCM capture.
+ *
+ * Runs on the audio rendering thread. Collects float32 samples from
+ * the microphone, downsamples to 16kHz, converts to 16-bit integers,
+ * and posts chunks (~100ms) to the main thread.
+ */
+
+class PCMCaptureProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    /** @type {Float32Array[]} */
+    this._buffer = [];
+    this._samplesBuffered = 0;
+    this._targetRate = 16000;
+    // Chunk size: ~100ms at 16kHz = 1600 samples.
+    this._chunkSize = 1600;
+  }
+
+  /**
+   * @param {Float32Array[][]} inputs
+   * @returns {boolean}
+   */
+  process(inputs) {
+    const input = inputs[0];
+    if (!input || input.length === 0) return true;
+
+    // Take mono channel (first channel).
+    const samples = input[0];
+    if (!samples || samples.length === 0) return true;
+
+    // Downsample: sampleRate → 16kHz using linear interpolation.
+    const ratio = sampleRate / this._targetRate;
+    const outputLength = Math.floor(samples.length / ratio);
+    const resampled = new Float32Array(outputLength);
+
+    for (let i = 0; i < outputLength; i++) {
+      const srcIndex = i * ratio;
+      const low = Math.floor(srcIndex);
+      const high = Math.min(low + 1, samples.length - 1);
+      const frac = srcIndex - low;
+      resampled[i] = samples[low] * (1 - frac) + samples[high] * frac;
+    }
+
+    this._buffer.push(resampled);
+    this._samplesBuffered += resampled.length;
+
+    // Flush when we have enough for a chunk.
+    if (this._samplesBuffered >= this._chunkSize) {
+      this._flush();
+    }
+
+    return true;
+  }
+
+  _flush() {
+    // Concatenate buffered samples.
+    const merged = new Float32Array(this._samplesBuffered);
+    let offset = 0;
+    for (const buf of this._buffer) {
+      merged.set(buf, offset);
+      offset += buf.length;
+    }
+
+    // Convert float32 [-1, 1] → int16.
+    const int16 = new Int16Array(merged.length);
+    for (let i = 0; i < merged.length; i++) {
+      const clamped = Math.max(-1, Math.min(1, merged[i]));
+      int16[i] = clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff;
+    }
+
+    // Post to main thread (transfer the buffer for zero-copy).
+    this.port.postMessage(
+      { pcm: int16 },
+      [int16.buffer],
+    );
+
+    this._buffer = [];
+    this._samplesBuffered = 0;
+  }
+}
+
+registerProcessor("pcm-capture-processor", PCMCaptureProcessor);

--- a/packages/bees/hivetool/src/ui/ticket-detail.ts
+++ b/packages/bees/hivetool/src/ui/ticket-detail.ts
@@ -376,6 +376,27 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
       }
       .live-btn.disconnect:hover { background: #1c1917; }
 
+      .live-btn.mic {
+        background: transparent;
+        color: #94a3b8;
+        border-color: #334155;
+      }
+      .live-btn.mic:hover { background: #1e293b; color: #e2e8f0; }
+      .live-btn.mic.active {
+        background: #065f4633;
+        color: #34d399;
+        border-color: #10b981;
+      }
+      .live-btn.mic.active:hover { background: #065f4666; }
+
+      .live-mic-bar {
+        padding: 8px 14px;
+        display: flex;
+        gap: 8px;
+        align-items: center;
+        border-top: 1px solid #1e293b;
+      }
+
       .live-transcript {
         padding: 10px 14px;
         max-height: 200px;
@@ -1134,6 +1155,16 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
                 </button>`
               : nothing}
         </div>
+        ${status === "connected"
+          ? html`<div class="live-mic-bar">
+              <button
+                class="live-btn mic ${this.#liveClient?.micActive.get() ? "active" : ""}"
+                @click=${() => this.handleMicToggle()}
+              >
+                ${this.#liveClient?.micActive.get() ? "🔇 Mute" : "🎤 Unmute"}
+              </button>
+            </div>`
+          : nothing}
         ${transcript
           ? html`<div class="live-transcript">${transcript}</div>`
           : isConnected
@@ -1177,6 +1208,20 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
     if (!this.#liveClient) return;
     this.#liveClient.disconnect();
     this.#liveClient = null;
+  }
+
+  private async handleMicToggle(): Promise<void> {
+    if (!this.#liveClient) return;
+
+    if (this.#liveClient.micActive.get()) {
+      this.#liveClient.stopMic();
+    } else {
+      try {
+        await this.#liveClient.startMic();
+      } catch (e) {
+        console.error("Failed to start microphone:", e);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## What
Adds bidirectional audio streaming to the Gemini Live API session client: mic capture → PCM → WebSocket input, and WebSocket output → PCM → speakers.

## Why
Phase 3 of Project Acoustic. The WebSocket lifecycle (Phase 2) proved the connection works; this phase adds the audio hardware integration so users can speak to and hear from the agent.

## Changes

### Audio capture (`hivetool/src/data/pcm-capture-processor.js`) [NEW]
AudioWorklet processor running on the audio rendering thread. Downsamples from native rate (48kHz) to 16kHz, converts float32 → int16, and posts ~100ms chunks to the main thread. Runs off the main thread to avoid jank.

### Audio handler (`hivetool/src/data/audio-handler.ts`) [NEW]
- **`AudioInput`**: `getUserMedia()` → AudioWorklet → base64 PCM chunks via callback.
- **`AudioOutput`**: decodes base64 24kHz PCM → `AudioContext` playback with seamless buffer stitching.

### LiveSessionClient (`hivetool/src/data/live-session.ts`)
- `startMic()` / `stopMic()` — wire `AudioInput` to send `realtimeInput.audio` messages.
- `#handleMessage()` — decode binary Blob frames (the Live API sends all messages as binary, not text), route `inlineData` audio parts to `AudioOutput.play()`.
- `micActive` signal for reactive UI binding.

### UI (`hivetool/src/ui/ticket-detail.ts`)
- Mic toggle button (🎤 Unmute / 🔇 Mute) appears when session is connected.
- CSS for mic bar and active/inactive states.

### Key bug fix
The Live API sends **all** WebSocket frames as binary Blobs, including JSON control messages like `setupComplete`. The Phase 2 handler silently dropped non-string data, which prevented the session from ever reaching "connected" status. Fixed by decoding `Blob` → text before JSON parsing.

## Testing
- Verified end-to-end: mic audio captured → sent to Live API → model receives and processes speech → responds with tool calls.
- Audio output path is wired and ready for when the model generates audio responses (pending template configuration tuning for voice-appropriate function groups).

## Next Steps
- Configure voice-appropriate function groups in `TEMPLATES.yaml` so the system instruction and tools are conversational rather than batch-oriented.
- Phase 4: Tool dispatch relay (bounce tool calls through filesystem to box).
