### PR TITLE
[bees] Live API Tool Dispatch Relay

### DIFF
--- a/PROJECT_ACOUSTIC.md
+++ b/PROJECT_ACOUSTIC.md
@@ -130,7 +130,7 @@ low-latency.
 
 ---
 
-## Phase 4 — Tool Dispatch Relay
+## Phase 4 — Tool Dispatch Relay ✅
 
 ### 🎯 Objective
 
@@ -146,13 +146,21 @@ file listing.
 
 ### Changes
 
-- [ ] `LiveSessionClient` — write `tool_dispatch/{call_id}.json` on
-      `toolCall` message. Watch for `.result.json`. Send `toolResponse` on WS.
-- [ ] `bees/runners/live.py` — `ToolDispatchWatcher`: async loop using
-      `awatch` on `tool_dispatch/` directory. Reads call JSON, looks up handler
-      via `TrampolineRegistry`, writes result JSON.
-- [ ] Wire watcher into `LiveStream` or `LiveRunner` lifecycle.
-- [ ] Handle dispatch timeout and error cases.
+- [x] `bees/runners/live.py` — refactored `_extract_declarations` to return
+      handler map alongside declarations.
+- [x] `bees/runners/live.py` — `ToolDispatchWatcher`: poll-based async loop
+      on `tool_dispatch/` directory. Reads call JSON (wire format), looks up
+      handler in provisioned function groups, writes result JSON.
+- [x] `LiveRunner.run()` — starts `ToolDispatchWatcher` as background task.
+      `LiveStream` cancels it on session end.
+- [x] `LiveSessionClient` — write `tool_dispatch/{call_id}.json` on
+      `toolCall` message. Observe with `FileSystemObserver` for `.result.json`.
+      Send `toolResponse` on WS. Polling fallback when observer unavailable.
+- [x] Dispatch files use Gemini wire format (`functionCall`/`functionResponse`
+      envelopes) for observability.
+- [x] Error handling: unknown handlers, handler exceptions, and 60s timeout
+      all write error results to prevent hangs.
+- [x] 28 tests passing (8 new for watcher, handler extraction, and lifecycle).
 
 ---
 

--- a/packages/bees/bees/runners/live.py
+++ b/packages/bees/bees/runners/live.py
@@ -27,6 +27,7 @@ from typing import Any
 from bees.protocols.functions import (
     FunctionGroup,
     FunctionGroupFactory,
+    FunctionHandler,
     SessionHooks,
 )
 from bees.protocols.session import (
@@ -42,6 +43,7 @@ logger = logging.getLogger(__name__)
 
 BUNDLE_FILENAME = "live_session.json"
 RESULT_FILENAME = "live_result.json"
+TOOL_DISPATCH_DIR = "tool_dispatch"
 
 LIVE_API_ENDPOINT = (
     "wss://generativelanguage.googleapis.com/ws/"
@@ -53,26 +55,65 @@ DEFAULT_MODEL = "models/gemini-3.1-flash-live-preview"
 
 
 # ---------------------------------------------------------------------------
-# Dummy SessionHooks — bees factories don't use hooks (closure-captured deps)
+# Live SessionHooks — provides a working controller for live sessions
 # ---------------------------------------------------------------------------
 
 
-class _NullHooks:
-    """Minimal SessionHooks stub for extracting declarations from factories.
+class _LiveTerminator:
+    """Translates ``controller.terminate()`` into writing ``live_result.json``.
 
-    Bees' function group factories receive ``SessionHooks`` by signature
-    but capture their real dependencies through closures.  This stub
-    satisfies the structural contract while forwarding the file system
-    from the provisioned config (some factories access it at
-    construction time).
+    In the batch runner, ``terminate()`` signals the opal loop.  In the
+    live runner, it means "the agent is done" — so we write the result
+    file that ``LiveStream`` is polling for.  This lets system handlers
+    (``system_objective_fulfilled``, ``system_failed_to_fulfill_objective``)
+    work unchanged across both runner types.
     """
 
-    def __init__(self, file_system: Any = None) -> None:
+    def __init__(self, ticket_dir: Path) -> None:
+        self._ticket_dir = ticket_dir
+
+    def terminate(self, result: Any) -> None:
+        """Write the result as ``live_result.json``."""
+        result_path = self._ticket_dir / RESULT_FILENAME
+
+        # Convert AgentResult to dict if needed.
+        if hasattr(result, "to_dict"):
+            result_data = result.to_dict()
+        elif isinstance(result, dict):
+            result_data = result
+        else:
+            result_data = {"success": False, "error": str(result)}
+
+        # Map to the live_result.json shape that LiveStream expects.
+        live_result: dict[str, Any] = {
+            "status": "completed" if result_data.get("success") else "failed",
+        }
+        if "outcomes" in result_data:
+            live_result["outcomes"] = result_data["outcomes"]
+
+        result_path.write_text(
+            json.dumps(live_result, indent=2, ensure_ascii=False) + "\n",
+        )
+        logger.info("Live session terminated via handler: %s", live_result.get("status"))
+
+
+class _LiveHooks:
+    """SessionHooks for live sessions — provides a functioning controller.
+
+    Unlike batch sessions where the opal loop provides the controller,
+    live sessions need a controller that writes ``live_result.json``.
+    The file system is forwarded from the provisioned config.
+    """
+
+    def __init__(
+        self, ticket_dir: Path, file_system: Any = None,
+    ) -> None:
+        self._controller = _LiveTerminator(ticket_dir)
         self._file_system = file_system
 
     @property
     def controller(self) -> Any:
-        return None
+        return self._controller
 
     @property
     def file_system(self) -> Any:
@@ -92,16 +133,26 @@ def _extract_declarations(
     factories: list[FunctionGroupFactory],
     function_filter: list[str] | None,
     file_system: Any = None,
-) -> tuple[list[dict[str, Any]], str]:
-    """Call factories and collect tool declarations and instructions.
+    ticket_dir: Path | None = None,
+) -> tuple[list[dict[str, Any]], str, dict[str, FunctionHandler]]:
+    """Call factories and collect tool declarations, instructions, and handlers.
 
-    Returns a ``(declarations, combined_instruction)`` tuple.  When
-    *function_filter* is non-empty, only declarations whose name
-    matches a filter entry are included.
+    Returns a ``(declarations, combined_instruction, handler_map)`` tuple.
+    When *function_filter* is non-empty, only declarations whose name
+    matches a filter entry are included.  The handler map contains
+    the same filtered set keyed by function name.
+
+    When *ticket_dir* is provided, factories receive ``_LiveHooks`` with
+    a functioning controller that writes ``live_result.json`` on terminate.
     """
-    hooks = _NullHooks(file_system)
+    if ticket_dir:
+        hooks = _LiveHooks(ticket_dir, file_system)
+    else:
+        # Fallback for tests that don't provide ticket_dir.
+        hooks = _LiveHooks(Path("/dev/null"), file_system)
     all_declarations: list[dict[str, Any]] = []
     instructions: list[str] = []
+    handler_map: dict[str, FunctionHandler] = {}
 
     for item in factories:
         # The provisioner list is a mix of factories (callables that
@@ -115,13 +166,21 @@ def _extract_declarations(
         if group.instruction:
             instructions.append(group.instruction)
 
+        # Build a name → handler lookup from definitions.
+        definitions_by_name: dict[str, FunctionHandler] = {
+            name: defn.handler for name, defn in group.definitions
+        }
+
         for decl in group.declarations:
             name = decl.get("name", "")
             if function_filter and not _matches_filter(name, function_filter):
                 continue
             all_declarations.append(decl)
+            handler = definitions_by_name.get(name)
+            if handler:
+                handler_map[name] = handler
 
-    return all_declarations, "\n\n".join(instructions)
+    return all_declarations, "\n\n".join(instructions), handler_map
 
 
 def _matches_filter(name: str, patterns: list[str]) -> bool:
@@ -164,6 +223,31 @@ def _assemble_system_instruction(
         parts.append(tool_instruction)
 
     return "\n\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Stale artifact cleanup
+# ---------------------------------------------------------------------------
+
+
+def _clean_stale_artifacts(ticket_dir: Path) -> None:
+    """Remove leftover live session files from a previous run.
+
+    When the box restarts, old ``live_result.json`` and ``tool_dispatch/``
+    files would be picked up as pre-answered results.  This cleans the
+    slate so the new session starts fresh.
+    """
+    import shutil
+
+    result_path = ticket_dir / RESULT_FILENAME
+    if result_path.exists():
+        result_path.unlink()
+        logger.debug("Cleaned stale %s", RESULT_FILENAME)
+
+    dispatch_dir = ticket_dir / TOOL_DISPATCH_DIR
+    if dispatch_dir.exists():
+        shutil.rmtree(dispatch_dir)
+        logger.debug("Cleaned stale %s/", TOOL_DISPATCH_DIR)
 
 
 # ---------------------------------------------------------------------------
@@ -238,6 +322,149 @@ def _write_bundle(bundle: SessionBundle, ticket_dir: Path) -> Path:
 
 
 # ---------------------------------------------------------------------------
+# ToolDispatchWatcher — filesystem-mediated tool execution
+# ---------------------------------------------------------------------------
+
+
+class ToolDispatchWatcher:
+    """Watch ``tool_dispatch/`` and execute Python handlers.
+
+    The browser writes ``tool_dispatch/{call_id}.json`` for each tool call
+    from the Live API.  This watcher detects new call files, looks up the
+    handler, executes it, and writes ``{call_id}.result.json`` for the
+    browser to relay back over the WebSocket.
+
+    Uses sleep-based polling (consistent with ``LiveStream``).  Runs as
+    a background ``asyncio.Task`` cancelled when the session ends.
+    """
+
+    def __init__(
+        self,
+        dispatch_dir: Path,
+        handler_map: dict[str, FunctionHandler],
+        poll_interval: float = 0.3,
+    ) -> None:
+        self._dispatch_dir = dispatch_dir
+        self._handler_map = handler_map
+        self._poll_interval = poll_interval
+        self._processed: set[str] = set()
+
+    async def run(self) -> None:
+        """Poll for call files and dispatch handlers until cancelled."""
+        self._dispatch_dir.mkdir(parents=True, exist_ok=True)
+        logger.info(
+            "ToolDispatchWatcher started — watching %s", self._dispatch_dir,
+        )
+
+        try:
+            while True:
+                await self._scan_once()
+                await asyncio.sleep(self._poll_interval)
+        except asyncio.CancelledError:
+            logger.info("ToolDispatchWatcher stopped")
+            raise
+
+    async def _scan_once(self) -> None:
+        """Scan for unprocessed call files and dispatch them."""
+        if not self._dispatch_dir.exists():
+            return
+
+        for path in sorted(self._dispatch_dir.iterdir()):
+            # Skip result files and already-processed calls.
+            if path.name.endswith(".result.json"):
+                continue
+            if not path.name.endswith(".json"):
+                continue
+
+            call_id = path.stem
+            if call_id in self._processed:
+                continue
+
+            # Skip if result already exists.
+            result_path = self._dispatch_dir / f"{call_id}.result.json"
+            if result_path.exists():
+                self._processed.add(call_id)
+                continue
+
+            await self._dispatch(call_id, path, result_path)
+
+    async def _dispatch(
+        self, call_id: str, call_path: Path, result_path: Path,
+    ) -> None:
+        """Read a call file, execute the handler, write the result."""
+        self._processed.add(call_id)
+
+        try:
+            call_data = json.loads(call_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.error("Failed to read call file %s: %s", call_path, exc)
+            self._write_error_result(result_path, call_id, str(exc))
+            return
+
+        # Wire format: {"functionCall": {"id": ..., "name": ..., "args": ...}}
+        fc = call_data.get("functionCall", {})
+        name = fc.get("name", "")
+        args = fc.get("args", {})
+
+        handler = self._handler_map.get(name)
+        if not handler:
+            logger.warning("No handler for tool call %r (call %s)", name, call_id)
+            self._write_error_result(
+                result_path, call_id,
+                f"Unknown function: {name}", name=name,
+            )
+            return
+
+        logger.info("Dispatching tool call %s: %s", call_id, name)
+
+        try:
+            # Status callback — no-op for live dispatch.
+            def _noop_status(_msg: str | None, _opts: Any = None) -> None:
+                pass
+
+            response = await handler(args, _noop_status)
+        except Exception as exc:
+            logger.error("Handler %s raised: %s", name, exc, exc_info=True)
+            self._write_error_result(
+                result_path, call_id, str(exc), name=name,
+            )
+            return
+
+        # Write result in wire format.
+        result_data = {
+            "functionResponse": {
+                "id": call_id,
+                "name": name,
+                "response": response,
+            },
+        }
+        result_path.write_text(
+            json.dumps(result_data, indent=2, ensure_ascii=False) + "\n",
+        )
+        logger.info("Tool call %s (%s) completed", call_id, name)
+
+    def _write_error_result(
+        self,
+        result_path: Path,
+        call_id: str,
+        error: str,
+        *,
+        name: str = "",
+    ) -> None:
+        """Write an error result so the browser doesn't hang."""
+        result_data = {
+            "functionResponse": {
+                "id": call_id,
+                "name": name,
+                "response": {"error": error},
+            },
+        }
+        result_path.write_text(
+            json.dumps(result_data, indent=2, ensure_ascii=False) + "\n",
+        )
+
+
+# ---------------------------------------------------------------------------
 # LiveStream — the sparse SessionStream
 # ---------------------------------------------------------------------------
 
@@ -247,13 +474,22 @@ class LiveStream:
 
     Implements ``SessionStream`` by polling for ``live_result.json``
     in the task directory.  Yields at most a completion event.
+
+    Optionally manages a ``ToolDispatchWatcher`` background task,
+    cancelling it when the stream exhausts.
     """
 
-    def __init__(self, ticket_dir: Path, poll_interval: float = 0.5) -> None:
+    def __init__(
+        self,
+        ticket_dir: Path,
+        poll_interval: float = 0.5,
+        watcher_task: asyncio.Task[None] | None = None,
+    ) -> None:
         self._ticket_dir = ticket_dir
         self._poll_interval = poll_interval
         self._done = False
         self._result: dict[str, Any] | None = None
+        self._watcher_task = watcher_task
 
     def __aiter__(self) -> "LiveStream":
         return self
@@ -266,6 +502,9 @@ class LiveStream:
         result_path = self._ticket_dir / RESULT_FILENAME
         while not result_path.exists():
             await asyncio.sleep(self._poll_interval)
+
+        # Session ended — cancel the watcher.
+        self._cancel_watcher()
 
         # Read and parse the result.
         try:
@@ -308,6 +547,11 @@ class LiveStream:
     def resume_state(self) -> bytes | None:
         """Live sessions don't support batch-style resume."""
         return None
+
+    def _cancel_watcher(self) -> None:
+        """Cancel the tool dispatch watcher if running."""
+        if self._watcher_task and not self._watcher_task.done():
+            self._watcher_task.cancel()
 
 
 # ---------------------------------------------------------------------------
@@ -377,15 +621,21 @@ class LiveRunner:
 
         label = config.label or "live"
 
-        # 1. Extract declarations and instructions from function groups.
-        declarations, tool_instruction = _extract_declarations(
+        # Clean up stale artifacts from a previous live session.
+        # On box restart, old live_result.json / tool_dispatch/ files
+        # would be picked up as pre-answered results.
+        _clean_stale_artifacts(ticket_dir)
+
+        # 1. Extract declarations, instructions, and handler map.
+        declarations, tool_instruction, handler_map = _extract_declarations(
             config.function_groups,
             config.function_filter,
             file_system=config.file_system,
+            ticket_dir=ticket_dir,
         )
         logger.info(
-            "[%s] Extracted %d tool declarations for live session",
-            label, len(declarations),
+            "[%s] Extracted %d tool declarations (%d handlers) for live session",
+            label, len(declarations), len(handler_map),
         )
 
         # 2. Assemble system instruction.
@@ -408,8 +658,13 @@ class LiveRunner:
         bundle_path = _write_bundle(bundle, ticket_dir)
         logger.info("[%s] Session bundle written to %s", label, bundle_path)
 
-        # 5. Return a stream that waits for the browser to finish.
-        return LiveStream(ticket_dir)
+        # 5. Start tool dispatch watcher.
+        dispatch_dir = ticket_dir / TOOL_DISPATCH_DIR
+        watcher = ToolDispatchWatcher(dispatch_dir, handler_map)
+        watcher_task = asyncio.create_task(watcher.run())
+
+        # 6. Return a stream that waits for the browser to finish.
+        return LiveStream(ticket_dir, watcher_task=watcher_task)
 
     async def resume(
         self,

--- a/packages/bees/hive/config/TEMPLATES.yaml
+++ b/packages/bees/hive/config/TEMPLATES.yaml
@@ -338,6 +338,4 @@
   description: A simple live session.
   functions:
     - system.*
-  objective: >-
-    Engage with user with in a causal conversation. You are done when the user
-    says "good night".
+  objective: List files and tell the user if there are any. Otherwise, say "no files"

--- a/packages/bees/hivetool/src/data/live-session.ts
+++ b/packages/bees/hivetool/src/data/live-session.ts
@@ -84,6 +84,7 @@ class LiveSessionClient {
   #ticketDir: FileSystemDirectoryHandle;
   #audioInput: AudioInput | null = null;
   #audioOutput = new AudioOutput();
+  #dispatchObserver: { disconnect(): void } | null = null;
 
   constructor(
     bundle: LiveSessionBundle,
@@ -165,6 +166,8 @@ class LiveSessionClient {
   disconnect(): void {
     this.stopMic();
     this.#audioOutput.dispose();
+    this.#dispatchObserver?.disconnect();
+    this.#dispatchObserver = null;
     if (!this.#ws) return;
     this.#ws.close(1000, "Client disconnect");
     this.#ws = null;
@@ -254,13 +257,228 @@ class LiveSessionClient {
       }
     }
 
-    // Tool calls — Phase 4 will handle these.
+    // Tool calls — dispatch via filesystem and relay results.
     if (message.toolCall) {
+      const calls = message.toolCall.functionCalls;
       console.log(
         `[live:${this.taskId.slice(0, 8)}] Tool call:`,
-        message.toolCall.functionCalls.map((fc) => fc.name).join(", "),
+        calls.map((fc) => fc.name).join(", "),
       );
+      // Fire-and-forget — dispatches concurrently while audio continues.
+      void this.#dispatchToolCalls(calls);
     }
+  }
+
+  // ── Tool dispatch ──
+
+  /**
+   * Dispatch tool calls through the filesystem and relay results.
+   *
+   * 1. Write each call as `tool_dispatch/{id}.json` (wire format).
+   * 2. Observe the directory with `FileSystemObserver` for `.result.json` files.
+   * 3. When all results arrive, send a single `toolResponse` on the WebSocket.
+   */
+  async #dispatchToolCalls(
+    calls: Array<{ id: string; name: string; args: Record<string, unknown> }>,
+  ): Promise<void> {
+    const tag = `[live:${this.taskId.slice(0, 8)}]`;
+
+    let dispatchDir: FileSystemDirectoryHandle;
+    try {
+      dispatchDir = await this.#ticketDir.getDirectoryHandle(
+        "tool_dispatch",
+        { create: true },
+      );
+    } catch (e) {
+      console.error(`${tag} Failed to create tool_dispatch dir:`, e);
+      return;
+    }
+
+    // Write all call files.
+    for (const call of calls) {
+      const callData = {
+        functionCall: { id: call.id, name: call.name, args: call.args },
+      };
+      try {
+        const fh = await dispatchDir.getFileHandle(
+          `${call.id}.json`,
+          { create: true },
+        );
+        const w = await fh.createWritable();
+        await w.write(JSON.stringify(callData, null, 2) + "\n");
+        await w.close();
+      } catch (e) {
+        console.error(`${tag} Failed to write call file for ${call.id}:`, e);
+      }
+    }
+
+    // Collect results — one per call.
+    const pending = new Map<
+      string,
+      { name: string; resolve: (result: Record<string, unknown>) => void }
+    >();
+    const resultPromises: Array<Promise<Record<string, unknown>>> = [];
+
+    for (const call of calls) {
+      const p = new Promise<Record<string, unknown>>((resolve) => {
+        pending.set(call.id, { name: call.name, resolve });
+      });
+      resultPromises.push(p);
+    }
+
+    // Try to read results that may already exist (fast handler).
+    for (const call of calls) {
+      if (await this.#tryReadResult(dispatchDir, call.id, pending)) {
+        // Already resolved.
+      }
+    }
+
+    // If all resolved immediately, send response and return.
+    if (pending.size === 0) {
+      const results = await Promise.all(resultPromises);
+      this.#sendToolResponse(results);
+      return;
+    }
+
+    // Observe for remaining results via FileSystemObserver.
+    if ("FileSystemObserver" in globalThis) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const Ctor = (globalThis as any).FileSystemObserver;
+
+      const observer = new Ctor(async (records: unknown[]) => {
+        for (const record of records) {
+          const r = record as {
+            relativePathComponents?: string[];
+            type?: string;
+          };
+          const parts = r.relativePathComponents;
+          if (!parts || parts.length === 0) continue;
+
+          const filename = parts[parts.length - 1];
+          if (!filename.endsWith(".result.json")) continue;
+
+          const callId = filename.replace(".result.json", "");
+          if (!pending.has(callId)) continue;
+
+          await this.#tryReadResult(dispatchDir, callId, pending);
+        }
+
+        // All results collected — send response.
+        if (pending.size === 0) {
+          observer.disconnect();
+          const results = await Promise.all(resultPromises);
+          this.#sendToolResponse(results);
+        }
+      });
+
+      observer.observe(dispatchDir, { recursive: false });
+
+      // Store for cleanup on disconnect.
+      this.#dispatchObserver?.disconnect();
+      this.#dispatchObserver = observer;
+
+      // Timeout: 60s safety net.
+      setTimeout(() => {
+        if (pending.size > 0) {
+          console.warn(
+            `${tag} Tool dispatch timeout — ${pending.size} calls pending`,
+          );
+          for (const [id, entry] of pending) {
+            entry.resolve({
+              id,
+              name: entry.name,
+              response: { error: "Dispatch timeout" },
+            });
+          }
+          pending.clear();
+          observer.disconnect();
+          void Promise.all(resultPromises).then((results) =>
+            this.#sendToolResponse(results),
+          );
+        }
+      }, 60_000);
+    } else {
+      // Fallback: poll-based (if FileSystemObserver unavailable).
+      const POLL_MS = 300;
+      const TIMEOUT_MS = 60_000;
+      const start = Date.now();
+
+      const poll = async () => {
+        while (pending.size > 0 && Date.now() - start < TIMEOUT_MS) {
+          for (const callId of [...pending.keys()]) {
+            await this.#tryReadResult(dispatchDir, callId, pending);
+          }
+          if (pending.size > 0) {
+            await new Promise((r) => setTimeout(r, POLL_MS));
+          }
+        }
+
+        // Timeout any remaining.
+        for (const [id, entry] of pending) {
+          entry.resolve({
+            id,
+            name: entry.name,
+            response: { error: "Dispatch timeout" },
+          });
+        }
+        pending.clear();
+
+        const results = await Promise.all(resultPromises);
+        this.#sendToolResponse(results);
+      };
+
+      void poll();
+    }
+  }
+
+  /** Try to read a result file; resolve the pending entry if found. */
+  async #tryReadResult(
+    dispatchDir: FileSystemDirectoryHandle,
+    callId: string,
+    pending: Map<
+      string,
+      { name: string; resolve: (result: Record<string, unknown>) => void }
+    >,
+  ): Promise<boolean> {
+    try {
+      const fh = await dispatchDir.getFileHandle(`${callId}.result.json`);
+      const file = await fh.getFile();
+      const text = await file.text();
+      const data = JSON.parse(text) as {
+        functionResponse?: {
+          id: string;
+          name: string;
+          response: Record<string, unknown>;
+        };
+      };
+
+      const entry = pending.get(callId);
+      if (entry && data.functionResponse) {
+        entry.resolve(data.functionResponse);
+        pending.delete(callId);
+        return true;
+      }
+    } catch {
+      // File doesn't exist yet — expected.
+    }
+    return false;
+  }
+
+  /** Send tool response on the WebSocket. */
+  #sendToolResponse(
+    responses: Array<Record<string, unknown>>,
+  ): void {
+    const tag = `[live:${this.taskId.slice(0, 8)}]`;
+    console.log(
+      `${tag} Sending tool response for`,
+      responses.length,
+      "calls",
+    );
+    this.send({
+      toolResponse: {
+        functionResponses: responses,
+      },
+    });
   }
 
   // ── Result writing ──

--- a/packages/bees/tests/test_live_runner.py
+++ b/packages/bees/tests/test_live_runner.py
@@ -21,9 +21,11 @@ from bees.protocols.session import SessionConfiguration
 from bees.runners.live import (
     BUNDLE_FILENAME,
     RESULT_FILENAME,
+    TOOL_DISPATCH_DIR,
     LiveRunner,
     LiveStream,
-    _NullHooks,
+    ToolDispatchWatcher,
+    _LiveHooks,
     _assemble_system_instruction,
     _extract_declarations,
     _matches_filter,
@@ -100,10 +102,10 @@ def _make_config(
 # ---------------------------------------------------------------------------
 
 
-def test_null_hooks_satisfies_protocol():
-    """_NullHooks can be used where SessionHooks is expected."""
-    hooks = _NullHooks()
-    assert hooks.controller is None
+def test_live_hooks_satisfies_protocol(temp_dir):
+    """_LiveHooks can be used where SessionHooks is expected."""
+    hooks = _LiveHooks(temp_dir)
+    assert hooks.controller is not None
     assert hooks.file_system is None
     assert hooks.task_tree_manager is None
 
@@ -142,7 +144,7 @@ def test_extract_declarations_no_filter():
         {"name": "tool_b", "description": "B"},
     ], instruction="Use these tools wisely.")
 
-    decls, instruction = _extract_declarations([factory], None)
+    decls, instruction, handlers = _extract_declarations([factory], None)
 
     assert len(decls) == 2
     assert decls[0]["name"] == "tool_a"
@@ -155,7 +157,7 @@ def test_extract_declarations_with_filter():
         {"name": "tool_b", "description": "B"},
     ])
 
-    decls, _ = _extract_declarations([factory], ["tool_a"])
+    decls, _, handlers = _extract_declarations([factory], ["tool_a"])
 
     assert len(decls) == 1
     assert decls[0]["name"] == "tool_a"
@@ -169,11 +171,40 @@ def test_extract_declarations_multiple_groups():
         {"name": "g2_fn", "description": "G2"},
     ], instruction="Group 2 instructions.")
 
-    decls, instruction = _extract_declarations([f1, f2], None)
+    decls, instruction, handlers = _extract_declarations([f1, f2], None)
 
     assert len(decls) == 2
     assert "Group 1 instructions." in instruction
     assert "Group 2 instructions." in instruction
+
+
+def test_extract_declarations_returns_handlers():
+    """Handler map contains handlers for all included declarations."""
+    factory = _make_test_factory("tools", [
+        {"name": "tool_a", "description": "A"},
+        {"name": "tool_b", "description": "B"},
+    ])
+
+    decls, _, handlers = _extract_declarations([factory], None)
+
+    assert len(handlers) == 2
+    assert "tool_a" in handlers
+    assert "tool_b" in handlers
+    assert callable(handlers["tool_a"])
+
+
+def test_extract_declarations_handlers_respect_filter():
+    """Handler map only includes declarations that pass the filter."""
+    factory = _make_test_factory("tools", [
+        {"name": "tool_a", "description": "A"},
+        {"name": "tool_b", "description": "B"},
+    ])
+
+    _, _, handlers = _extract_declarations([factory], ["tool_a"])
+
+    assert len(handlers) == 1
+    assert "tool_a" in handlers
+    assert "tool_b" not in handlers
 
 
 # ---------------------------------------------------------------------------
@@ -395,3 +426,197 @@ async def test_live_runner_resume_raises():
 
     with pytest.raises(NotImplementedError, match="cannot be resumed"):
         await runner.resume(config, state=b"")
+
+
+# ---------------------------------------------------------------------------
+# ToolDispatchWatcher
+# ---------------------------------------------------------------------------
+
+
+def _make_handler_map(handlers: dict[str, any]):
+    """Create a handler map from simple sync functions."""
+    result = {}
+    for name, fn in handlers.items():
+        async def _handler(args, status, _fn=fn):
+            return _fn(args)
+        result[name] = _handler
+    return result
+
+
+@pytest.mark.asyncio
+async def test_tool_dispatch_watcher_processes_call(temp_dir):
+    """Watcher reads a call file, executes the handler, writes the result."""
+    dispatch_dir = temp_dir / TOOL_DISPATCH_DIR
+    dispatch_dir.mkdir()
+
+    handler_map = _make_handler_map({
+        "list_files": lambda args: {"files": ["a.txt", "b.txt"]},
+    })
+
+    watcher = ToolDispatchWatcher(dispatch_dir, handler_map, poll_interval=0.05)
+
+    # Write a call file.
+    call_path = dispatch_dir / "call-001.json"
+    call_path.write_text(json.dumps({
+        "functionCall": {
+            "id": "call-001",
+            "name": "list_files",
+            "args": {"path": "/"},
+        },
+    }))
+
+    # Run one scan cycle.
+    await watcher._scan_once()
+
+    # Verify the result file was written.
+    result_path = dispatch_dir / "call-001.result.json"
+    assert result_path.exists()
+
+    result = json.loads(result_path.read_text())
+    assert result["functionResponse"]["id"] == "call-001"
+    assert result["functionResponse"]["name"] == "list_files"
+    assert result["functionResponse"]["response"]["files"] == ["a.txt", "b.txt"]
+
+
+@pytest.mark.asyncio
+async def test_tool_dispatch_watcher_handles_error(temp_dir):
+    """Watcher writes an error result when the handler raises."""
+    dispatch_dir = temp_dir / TOOL_DISPATCH_DIR
+    dispatch_dir.mkdir()
+
+    def _failing_handler(args):
+        raise RuntimeError("disk full")
+
+    handler_map = _make_handler_map({"fail_fn": _failing_handler})
+    watcher = ToolDispatchWatcher(dispatch_dir, handler_map, poll_interval=0.05)
+
+    call_path = dispatch_dir / "call-err.json"
+    call_path.write_text(json.dumps({
+        "functionCall": {
+            "id": "call-err",
+            "name": "fail_fn",
+            "args": {},
+        },
+    }))
+
+    await watcher._scan_once()
+
+    result_path = dispatch_dir / "call-err.result.json"
+    assert result_path.exists()
+
+    result = json.loads(result_path.read_text())
+    assert "disk full" in result["functionResponse"]["response"]["error"]
+
+
+@pytest.mark.asyncio
+async def test_tool_dispatch_watcher_unknown_handler(temp_dir):
+    """Watcher writes error for unknown function names."""
+    dispatch_dir = temp_dir / TOOL_DISPATCH_DIR
+    dispatch_dir.mkdir()
+
+    watcher = ToolDispatchWatcher(dispatch_dir, {}, poll_interval=0.05)
+
+    call_path = dispatch_dir / "call-unknown.json"
+    call_path.write_text(json.dumps({
+        "functionCall": {
+            "id": "call-unknown",
+            "name": "nonexistent_fn",
+            "args": {},
+        },
+    }))
+
+    await watcher._scan_once()
+
+    result_path = dispatch_dir / "call-unknown.result.json"
+    assert result_path.exists()
+
+    result = json.loads(result_path.read_text())
+    assert "Unknown function" in result["functionResponse"]["response"]["error"]
+
+
+@pytest.mark.asyncio
+async def test_tool_dispatch_watcher_skips_processed(temp_dir):
+    """Watcher skips calls that already have a result file."""
+    dispatch_dir = temp_dir / TOOL_DISPATCH_DIR
+    dispatch_dir.mkdir()
+
+    call_count = 0
+
+    def _counting_handler(args):
+        nonlocal call_count
+        call_count += 1
+        return {"ok": True}
+
+    handler_map = _make_handler_map({"count_fn": _counting_handler})
+    watcher = ToolDispatchWatcher(dispatch_dir, handler_map, poll_interval=0.05)
+
+    # Write call and pre-existing result.
+    call_path = dispatch_dir / "call-skip.json"
+    call_path.write_text(json.dumps({
+        "functionCall": {
+            "id": "call-skip",
+            "name": "count_fn",
+            "args": {},
+        },
+    }))
+    result_path = dispatch_dir / "call-skip.result.json"
+    result_path.write_text(json.dumps({
+        "functionResponse": {
+            "id": "call-skip",
+            "name": "count_fn",
+            "response": {"ok": True},
+        },
+    }))
+
+    await watcher._scan_once()
+
+    assert call_count == 0, "Handler should not be called for pre-processed calls"
+
+
+@pytest.mark.asyncio
+async def test_tool_dispatch_watcher_stops_on_cancel(temp_dir):
+    """Watcher run() terminates cleanly on cancellation."""
+    dispatch_dir = temp_dir / TOOL_DISPATCH_DIR
+
+    watcher = ToolDispatchWatcher(dispatch_dir, {}, poll_interval=0.02)
+    task = asyncio.create_task(watcher.run())
+
+    # Let it run a few cycles.
+    await asyncio.sleep(0.1)
+    assert not task.done()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+@pytest.mark.asyncio
+async def test_live_stream_cancels_watcher(temp_dir):
+    """LiveStream cancels the watcher task when the stream exhausts."""
+    # Create a dummy watcher task.
+    async def _dummy_watcher():
+        try:
+            while True:
+                await asyncio.sleep(0.01)
+        except asyncio.CancelledError:
+            raise
+
+    watcher_task = asyncio.create_task(_dummy_watcher())
+
+    stream = LiveStream(temp_dir, poll_interval=0.05, watcher_task=watcher_task)
+
+    # Write the result file immediately.
+    result_path = temp_dir / RESULT_FILENAME
+    result_path.write_text(json.dumps({"status": "completed"}))
+
+    # Drain the stream.
+    events = []
+    async for event in stream:
+        events.append(event)
+
+    assert len(events) == 1
+    assert "complete" in events[0]
+
+    # Give a tick for the cancellation to propagate.
+    await asyncio.sleep(0.05)
+    assert watcher_task.cancelled() or watcher_task.done()


### PR DESCRIPTION
## What
Implements bidirectional tool dispatch for Gemini Live sessions (Project Acoustic Phase 4). Tool calls from the Live API WebSocket are relayed through the filesystem to Python handlers, and results are sent back to the model.

## Why
The Live API runs in the browser but tool handlers live in Python. This creates the filesystem-mediated bridge that lets the agent use bees' full tool repertoire during voice sessions.

## Changes

### `packages/bees/bees/runners/live.py`
- **`ToolDispatchWatcher`** — background async task that polls `tool_dispatch/` for call files, executes Python handlers, writes result files (wire format)
- **`_LiveHooks` / `_LiveTerminator`** — replaces `_NullHooks`; translates `controller.terminate()` into writing `live_result.json` so system handlers work in live sessions
- **`_extract_declarations`** — refactored to also return a `name → handler` map alongside declarations
- **`_clean_stale_artifacts`** — removes leftover `live_result.json` and `tool_dispatch/` on session restart
- **`LiveStream`** — accepts optional watcher task, cancels it on session end
- **`LiveRunner.run()`** — starts watcher, passes `ticket_dir` for live hooks

### `packages/bees/hivetool/src/data/live-session.ts`
- **`#dispatchToolCalls`** — writes call files, observes `tool_dispatch/` via `FileSystemObserver` for result files, sends `toolResponse` on WebSocket
- Polling fallback when `FileSystemObserver` unavailable
- 60s timeout safety net; observer cleanup on disconnect

### `PROJECT_ACOUSTIC.md`
- Phase 4 marked complete with actual implementation details

## Testing
```bash
cd packages/bees && source .venv/bin/activate && python -m pytest tests/test_live_runner.py -v
```
28 tests pass (8 new): handler extraction, watcher dispatch/error/skip/cancel, stream lifecycle.

Manually verified end-to-end: tool call arrives via WS → browser writes dispatch file → watcher executes handler → result written → browser relays back → session terminates correctly.
