### PR TITLE
[bees] Live session event channel, logging fixes, and audio transcription

### DIFF
--- a/PROJECT_ACOUSTIC.md
+++ b/PROJECT_ACOUSTIC.md
@@ -28,9 +28,10 @@ lifecycle management.
 ```
 
 Two processes, one filesystem. The box writes the session bundle; hivetool
-runs the audio loop. Tool calls bounce through `tool_dispatch/` files. The
-LiveStream blocks until `live_result.json` appears, then the scheduler resumes
-normal task lifecycle processing.
+runs the audio loop. Tool calls bounce through `tool_dispatch/` files. Live
+events flow back through `live_events/` files, which `LiveStream` polls and
+translates into `EvalCollector`-compatible events for `drain_session`.
+The `live_result.json` file serves as a fallback termination signal.
 
 ## Communication Protocol
 
@@ -40,11 +41,12 @@ shared filesystem:
 | File                        | Writer   | Reader   | Purpose                                    |
 | --------------------------- | -------- | -------- | ------------------------------------------ |
 | `live_session.json`         | Box      | Hivetool | Session bundle (token, endpoint, setup)    |
-| `live_result.json`          | Hivetool | Box      | Session completion signal                  |
+| `live_result.json`          | Hivetool | Box      | Session completion signal (fallback)       |
 | `tool_dispatch/{id}.json`   | Hivetool | Box      | Tool call request                          |
 | `tool_dispatch/{id}.result.json` | Box | Hivetool | Tool call response                         |
 | `context_updates/{ts}.json` | Box      | Hivetool | Context updates from subagent completions  |
-| `chat_log.json`             | Hivetool | Box      | Transcription log                          |
+| `live_events/{seq}.json`    | Hivetool | Box      | Structured session events (turns, tools, usage, end) |
+| `chat_log.json`             | Box      | Hivetool | Transcription log (written by `drain_session`) |
 
 ---
 
@@ -164,7 +166,7 @@ file listing.
 
 ---
 
-## Phase 5 — Context Updates & Transcription
+## Phase 5 — Context Updates & Transcription ✅
 
 ### 🎯 Objective
 
@@ -178,16 +180,70 @@ contains the full conversation transcript.
 
 ### Changes
 
-- [ ] `LiveSessionClient` — watch `context_updates/` directory. On new file,
-      read it and call `session.send(clientContent)` on the WebSocket.
-- [ ] `LiveSessionClient` — extract text transcriptions from server messages,
-      append to `chat_log.json`.
-- [ ] `LiveStream.send_context()` — already implemented (writes to
+- [x] `LiveRunner.run()` — creates `context_updates/` eagerly so the
+      browser observer can start immediately.
+- [x] `LiveSessionClient` — `FileSystemObserver` on `context_updates/`
+      directory. On new file, reads parts and sends as `clientContent` on WS.
+      Polling fallback when observer unavailable.
+- [x] Transcript is turn-delimited (newline on `turnComplete`) with
+      `[Context update: ...]` markers for injected updates.
+- [x] `LiveStream.send_context()` — already implemented (writes to
       `context_updates/` on box side).
 
 ---
 
-## Phase 6 — UI Polish
+## Phase 6 — Live Session Logging ✅
+
+### 🎯 Objective
+
+Live sessions produce the same `*.log.json` files as batch sessions, appearing
+in the existing log viewer alongside them. The box is the sole writer.
+
+**Observable proof:** After a live session ends, open the log viewer → the
+session appears in the sidebar. Click it → timeline shows turns, tool calls,
+system instruction, and context updates. Token bars show data if the Live API
+reported `usageMetadata`.
+
+### Architecture: Event Channel
+
+The browser writes structured event files to `live_events/` (sequenced
+`{seq:06d}.json`). The box's `LiveStream` polls these files and translates
+each into `EvalCollector`-compatible events. `drain_session` processes them
+normally, producing log files and `chat_log.json` — same as batch sessions.
+
+| Event type       | When written                    | EvalCollector translation                  |
+| ---------------- | ------------------------------- | ----------------------------------------- |
+| `sessionStart`   | After `setupComplete`          | Sets config. First `sendRequest` body.     |
+| `turnComplete`   | On `serverContent.turnComplete` | `sendRequest` event (with context so far)  |
+| `toolCall`       | On `toolCall` message          | `functionCall` event(s)                   |
+| `toolResponse`   | After dispatch result relayed   | Context entry (`user` + `functionResponse`) |
+| `usageMetadata`  | On `usageMetadata` message      | `usageMetadata` event                     |
+| `contextUpdate`  | On context injection            | Context entry (`user` + text parts)        |
+| `sessionEnd`     | On WS close / disconnect        | `complete` event                          |
+
+### Changes
+
+- [x] `LiveStream` — rewritten from single-shot poll to event channel reader.
+      Polls `live_events/` by sequence number, maintains context accumulator,
+      translates events to `EvalCollector` format. Falls back to
+      `live_result.json` for crash recovery.
+- [x] `LiveRunner.run()` — creates `live_events/` eagerly, passes `setup`
+      config to `LiveStream` constructor.
+- [x] `_clean_stale_artifacts()` — also cleans stale `live_events/`.
+- [x] `LiveSessionClient` — removed all browser-side log accumulation
+      (`#logContext`, `#logTurns`, `#writeSessionLog()`, `#chatLog`,
+      `#persistChatLog()`, `#logsDir`).
+- [x] `LiveSessionClient` — added `#writeEvent(type, data)` helper and
+      event writing at all turn boundaries.
+- [x] `ticket-detail.ts` — removed `logsDir` resolution and passing.
+- [x] `ticket-store.ts` — removed `getLogsDir()`.
+- [x] `ChatLogEntry` type removed (unused).
+- [x] 10 new tests for event channel (9 event types + context accumulation
+      across turns), 2 fallback tests preserved.
+
+---
+
+## Phase 7 — UI Polish
 
 ### 🎯 Objective
 
@@ -235,7 +291,7 @@ packages/bees/
       audio-handler.ts           ← [NEW] AudioInput, AudioOutput (Phase 3)
       ticket-store.ts            ← live session detection (Phase 2)
     ui/
-      ticket-detail.ts           ← live session panel (Phase 6)
+      ticket-detail.ts           ← live session panel (Phase 7)
   tests/
     test_live_runner.py          ← LiveRunner tests (Phase 1 ✅)
 ```

--- a/packages/bees/bees/runners/live.py
+++ b/packages/bees/bees/runners/live.py
@@ -44,6 +44,7 @@ logger = logging.getLogger(__name__)
 BUNDLE_FILENAME = "live_session.json"
 RESULT_FILENAME = "live_result.json"
 TOOL_DISPATCH_DIR = "tool_dispatch"
+LIVE_EVENTS_DIR = "live_events"
 
 LIVE_API_ENDPOINT = (
     "wss://generativelanguage.googleapis.com/ws/"
@@ -233,9 +234,9 @@ def _assemble_system_instruction(
 def _clean_stale_artifacts(ticket_dir: Path) -> None:
     """Remove leftover live session files from a previous run.
 
-    When the box restarts, old ``live_result.json`` and ``tool_dispatch/``
-    files would be picked up as pre-answered results.  This cleans the
-    slate so the new session starts fresh.
+    When the box restarts, old ``live_result.json``, ``tool_dispatch/``,
+    and ``live_events/`` files would be picked up as stale data.  This
+    cleans the slate so the new session starts fresh.
     """
     import shutil
 
@@ -244,10 +245,11 @@ def _clean_stale_artifacts(ticket_dir: Path) -> None:
         result_path.unlink()
         logger.debug("Cleaned stale %s", RESULT_FILENAME)
 
-    dispatch_dir = ticket_dir / TOOL_DISPATCH_DIR
-    if dispatch_dir.exists():
-        shutil.rmtree(dispatch_dir)
-        logger.debug("Cleaned stale %s/", TOOL_DISPATCH_DIR)
+    for subdir in (TOOL_DISPATCH_DIR, LIVE_EVENTS_DIR):
+        dirpath = ticket_dir / subdir
+        if dirpath.exists():
+            shutil.rmtree(dirpath)
+            logger.debug("Cleaned stale %s/", subdir)
 
 
 # ---------------------------------------------------------------------------
@@ -290,6 +292,12 @@ def _build_bundle(
         "systemInstruction": {
             "parts": [{"text": system_instruction}],
         },
+        # Enable server-side transcription of both user audio input
+        # and model audio output.  The API sends
+        # inputTranscription / outputTranscription messages with
+        # { text: string } payloads.
+        "inputAudioTranscription": {},
+        "outputAudioTranscription": {},
     }
 
     if declarations:
@@ -465,15 +473,20 @@ class ToolDispatchWatcher:
 
 
 # ---------------------------------------------------------------------------
-# LiveStream — the sparse SessionStream
+# LiveStream — event-driven SessionStream
 # ---------------------------------------------------------------------------
 
 
 class LiveStream:
-    """A session stream that blocks until the browser reports completion.
+    """Session stream that reads live events from the filesystem.
 
-    Implements ``SessionStream`` by polling for ``live_result.json``
-    in the task directory.  Yields at most a completion event.
+    The browser writes structured event files to ``live_events/``
+    in the ticket directory.  This stream polls for new files,
+    translates each event into ``EvalCollector``-compatible event
+    dicts, and yields them to ``drain_session``.
+
+    Falls back to ``live_result.json`` for crash recovery (if the
+    browser dies without writing a ``sessionEnd`` event).
 
     Optionally manages a ``ToolDispatchWatcher`` background task,
     cancelling it when the stream exhausts.
@@ -482,52 +495,274 @@ class LiveStream:
     def __init__(
         self,
         ticket_dir: Path,
+        *,
+        setup: dict[str, Any] | None = None,
         poll_interval: float = 0.5,
         watcher_task: asyncio.Task[None] | None = None,
     ) -> None:
         self._ticket_dir = ticket_dir
         self._poll_interval = poll_interval
         self._done = False
-        self._result: dict[str, Any] | None = None
         self._watcher_task = watcher_task
+        self._events_dir = ticket_dir / LIVE_EVENTS_DIR
+
+        # Read cursor: last processed sequence number.
+        self._cursor = -1
+
+        # Queue of translated events ready to yield.
+        self._pending: list[dict[str, Any]] = []
+
+        # Context accumulator — same shape as batch ``contents``.
+        self._context: list[dict[str, Any]] = []
+        self._config: dict[str, Any] | None = None
+
+        # Whether a sendRequest has been emitted for the current turn.
+        # The Live API may send toolCall without a preceding
+        # turnComplete; this flag lets us synthesize a turn boundary
+        # before the first functionCall event.
+        self._turn_emitted = False
+
+        # Build initial config from setup message (if available).
+        if setup:
+            self._config = {}
+            if setup.get("generationConfig"):
+                self._config["generationConfig"] = setup["generationConfig"]
+            if setup.get("tools"):
+                self._config["tools"] = setup["tools"]
+            if setup.get("systemInstruction"):
+                self._config["systemInstruction"] = setup["systemInstruction"]
+            else:
+                self._config["systemInstruction"] = {"parts": [{"text": ""}]}
 
     def __aiter__(self) -> "LiveStream":
         return self
 
     async def __anext__(self) -> dict[str, Any]:
+        # Drain pending events first.
+        if self._pending:
+            return self._pending.pop(0)
+
         if self._done:
             raise StopAsyncIteration
 
-        # Poll for the result file.
-        result_path = self._ticket_dir / RESULT_FILENAME
-        while not result_path.exists():
+        # Poll for new events or fallback result.
+        while not self._pending and not self._done:
+            self._scan_events()
+            if self._pending:
+                return self._pending.pop(0)
+
+            # Fallback: check for live_result.json (crash recovery).
+            # The result file is written by _LiveTerminator on the
+            # Python side, which runs *before* the browser has relayed
+            # the tool response and written the corresponding event
+            # file.  Wait one poll interval and re-scan to drain any
+            # in-flight events before processing the fallback.
+            result_path = self._ticket_dir / RESULT_FILENAME
+            if result_path.exists():
+                await asyncio.sleep(self._poll_interval)
+                self._scan_events()
+                if self._pending:
+                    return self._pending.pop(0)
+                self._handle_fallback_result(result_path)
+                if self._pending:
+                    return self._pending.pop(0)
+
             await asyncio.sleep(self._poll_interval)
 
-        # Session ended — cancel the watcher.
-        self._cancel_watcher()
+        if self._pending:
+            return self._pending.pop(0)
 
-        # Read and parse the result.
-        try:
-            self._result = json.loads(result_path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError) as exc:
+        raise StopAsyncIteration
+
+    def _scan_events(self) -> None:
+        """Scan ``live_events/`` for new event files past the cursor."""
+        if not self._events_dir.exists():
+            return
+
+        candidates: list[tuple[int, Path]] = []
+        for path in self._events_dir.iterdir():
+            if not path.name.endswith(".json"):
+                continue
+            try:
+                seq = int(path.stem)
+            except ValueError:
+                continue
+            if seq > self._cursor:
+                candidates.append((seq, path))
+
+        if not candidates:
+            return
+
+        # Process in sequence order.
+        for seq, path in sorted(candidates):
+            self._cursor = seq
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError) as exc:
+                logger.warning("Failed to read live event %s: %s", path, exc)
+                continue
+            self._translate_event(data)
+
+    def _translate_event(self, data: dict[str, Any]) -> None:
+        """Translate a browser event into EvalCollector-compatible events."""
+        event_type = data.get("type")
+
+        if event_type == "sessionStart":
+            # Browser confirmed setup — capture config.
+            config = data.get("config", {})
+            if config:
+                self._config = config
+                self._config.setdefault(
+                    "systemInstruction", {"parts": [{"text": ""}]},
+                )
+            # Emit initial sendRequest so EvalCollector captures the
+            # config (systemInstruction, tools, generationConfig) and
+            # starts the first turn.
+            body: dict[str, Any] = {"contents": list(self._context)}
+            if self._config:
+                body.update(self._config)
+            self._pending.append({"sendRequest": {"body": body}})
+            self._turn_emitted = True
+
+        elif event_type == "turnComplete":
+            # Flush accumulated model parts into context.
+            model_parts = data.get("parts", [])
+            if model_parts:
+                self._context.append({
+                    "role": "model",
+                    "parts": model_parts,
+                })
+
+            # Emit a synthetic sendRequest — this is how
+            # EvalCollector tracks turn boundaries.
+            body = {
+                "contents": list(self._context),
+            }
+            if self._config:
+                body.update(self._config)
+            self._pending.append({"sendRequest": {"body": body}})
+            self._turn_emitted = True
+
+        elif event_type == "toolCall":
+            # If the model called tools without a preceding
+            # turnComplete (common in the Live API), emit a
+            # synthetic sendRequest first so EvalCollector has
+            # a turn boundary before the functionCall events.
+            if not self._turn_emitted:
+                body = {"contents": list(self._context)}
+                if self._config:
+                    body.update(self._config)
+                self._pending.append({"sendRequest": {"body": body}})
+                self._turn_emitted = True
+
+            # Emit functionCall events.
+            for fc in data.get("functionCalls", []):
+                self._pending.append({"functionCall": fc})
+
+        elif event_type == "toolResponse":
+            # Add tool responses to context and reset the turn flag
+            # so the next tool call or turnComplete emits a new
+            # sendRequest (= new turn boundary).
+            responses = data.get("functionResponses", [])
+            if responses:
+                self._context.append({
+                    "role": "user",
+                    "parts": [
+                        {"functionResponse": r} for r in responses
+                    ],
+                })
+            self._turn_emitted = False
+
+        elif event_type == "usageMetadata":
+            metadata = data.get("metadata", {})
+            self._pending.append({"usageMetadata": {"metadata": metadata}})
+
+        elif event_type == "contextUpdate":
+            # Context injected from subagent completion.
+            parts = data.get("parts", [])
+            if parts:
+                self._context.append({"role": "user", "parts": parts})
+
+        elif event_type == "inputTranscript":
+            # User's speech transcribed by the Live API.
+            text = data.get("text", "")
+            if text:
+                self._context.append({
+                    "role": "user",
+                    "parts": [{"text": text}],
+                })
+
+        elif event_type == "outputTranscript":
+            # Model's audio output transcribed by the Live API.
+            text = data.get("text", "")
+            if text:
+                self._context.append({
+                    "role": "model",
+                    "parts": [{"text": text}],
+                })
+
+        elif event_type == "sessionEnd":
+            # Session complete — flush remaining context, cancel
+            # watcher, and emit the terminal event.
+            self._flush_final_context()
+            self._cancel_watcher()
+            status = data.get("status", "completed")
+            outcomes = data.get("outcomes", {})
+            if status == "failed":
+                error_msg = data.get("error", "Live session failed")
+                self._pending.append(
+                    {"error": {"message": error_msg}},
+                )
+            else:
+                self._pending.append({"complete": {
+                    "result": {
+                        "success": status == "completed",
+                        "outcomes": outcomes,
+                    },
+                }})
             self._done = True
-            return {"error": {"message": f"Failed to read live result: {exc}"}}
 
-        self._done = True
+    def _flush_final_context(self) -> None:
+        """Emit a final sendRequest to capture any pending context.
 
-        # Translate the browser's result into a completion event.
-        status = self._result.get("status", "completed")
+        After the last toolResponse there is no turn boundary event,
+        so EvalCollector would miss the final context entries.  This
+        emits one more sendRequest so the log includes the complete
+        conversation.
+        """
+        if not self._turn_emitted:
+            body: dict[str, Any] = {"contents": list(self._context)}
+            if self._config:
+                body.update(self._config)
+            self._pending.append({"sendRequest": {"body": body}})
+            self._turn_emitted = True
+
+    def _handle_fallback_result(self, result_path: Path) -> None:
+        """Handle crash-recovery via ``live_result.json``."""
+        self._flush_final_context()
+        self._cancel_watcher()
+        try:
+            result = json.loads(result_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            self._pending.append(
+                {"error": {"message": f"Failed to read live result: {exc}"}},
+            )
+            self._done = True
+            return
+
+        status = result.get("status", "completed")
         if status == "failed":
-            return {"error": {
-                "message": self._result.get("error", "Live session failed"),
-            }}
-
-        return {"complete": {
-            "result": {
-                "success": status == "completed",
-                "outcomes": self._result.get("outcomes", {}),
-            },
-        }}
+            self._pending.append({"error": {
+                "message": result.get("error", "Live session failed"),
+            }})
+        else:
+            self._pending.append({"complete": {
+                "result": {
+                    "success": status == "completed",
+                    "outcomes": result.get("outcomes", {}),
+                },
+            }})
+        self._done = True
 
     async def send_context(self, parts: list[dict[str, Any]]) -> None:
         """Write context update for the browser to pick up.
@@ -663,8 +898,17 @@ class LiveRunner:
         watcher = ToolDispatchWatcher(dispatch_dir, handler_map)
         watcher_task = asyncio.create_task(watcher.run())
 
-        # 6. Return a stream that waits for the browser to finish.
-        return LiveStream(ticket_dir, watcher_task=watcher_task)
+        # 6. Create directories eagerly so browser observers
+        #    can start watching immediately.
+        (ticket_dir / "context_updates").mkdir(parents=True, exist_ok=True)
+        (ticket_dir / LIVE_EVENTS_DIR).mkdir(parents=True, exist_ok=True)
+
+        # 7. Return a stream that reads events from the browser.
+        return LiveStream(
+            ticket_dir,
+            setup=bundle.setup,
+            watcher_task=watcher_task,
+        )
 
     async def resume(
         self,

--- a/packages/bees/bees/session.py
+++ b/packages/bees/bees/session.py
@@ -363,6 +363,9 @@ async def drain_session(
     collector = EvalCollector()
     event_count = 0
 
+    chat_entry = config.on_chat_entry if config else None
+    prev_context_len = 0
+
     try:
         async for event in stream:
             collector.collect(event)
@@ -382,6 +385,34 @@ async def drain_session(
                     log_path,
                     collector.to_eval_file_data(ticket_id=ticket_id),
                 )
+
+            # Extract conversation text for the chat log.
+            # For live sessions, sendRequest events carry the accumulated
+            # context (including model and user turns).  We scan for new
+            # entries since the last sendRequest and log their text.
+            if "sendRequest" in event and chat_entry:
+                contents = (
+                    event["sendRequest"]
+                    .get("body", {})
+                    .get("contents", [])
+                )
+                for entry in contents[prev_context_len:]:
+                    role = entry.get("role")
+                    parts = entry.get("parts", [])
+                    # Skip entries that are only tool responses.
+                    if all("functionResponse" in p for p in parts):
+                        continue
+                    text_parts = [
+                        p.get("text", "")
+                        for p in parts
+                        if "text" in p
+                    ]
+                    text = "".join(text_parts).strip()
+                    if text and role == "model":
+                        chat_entry("agent", text)
+                    elif text and role == "user":
+                        chat_entry("user", text)
+                prev_context_len = len(contents)
 
             if on_event:
                 await on_event(event)

--- a/packages/bees/hive/config/SYSTEM.yaml
+++ b/packages/bees/hive/config/SYSTEM.yaml
@@ -5,7 +5,6 @@
 # root        — Template name to auto-boot at startup. The system creates a
 #               ticket from this template if none with a matching playbook_id
 #               exists yet.
-
 title: Opal
 description: Personal assistant
-root: opie
+root: live-session

--- a/packages/bees/hivetool/src/data/live-session.ts
+++ b/packages/bees/hivetool/src/data/live-session.ts
@@ -85,6 +85,15 @@ class LiveSessionClient {
   #audioInput: AudioInput | null = null;
   #audioOutput = new AudioOutput();
   #dispatchObserver: { disconnect(): void } | null = null;
+  #contextObserver: { disconnect(): void } | null = null;
+
+  // Transcript state (for real-time UI display only).
+  #currentTurnParts: Array<{ text?: string }> = [];
+  #processedContextFiles = new Set<string>();
+
+  // Event channel state.
+  #eventSeq = 0;
+  #liveEventsDir: FileSystemDirectoryHandle | null = null;
 
   constructor(
     bundle: LiveSessionBundle,
@@ -107,6 +116,19 @@ class LiveSessionClient {
     if (this.#ws) return;
 
     this.status.set("connecting");
+
+    // Resolve the live_events/ directory for event writing.
+    try {
+      this.#liveEventsDir = await this.#ticketDir.getDirectoryHandle(
+        "live_events",
+        { create: true },
+      );
+    } catch (e) {
+      console.error(
+        `[live:${this.taskId.slice(0, 8)}] Failed to resolve live_events dir:`,
+        e,
+      );
+    }
 
     // Build the authenticated WebSocket URL.
     // Ephemeral tokens use access_token, not key.
@@ -141,6 +163,7 @@ class LiveSessionClient {
           reject(new Error(`WebSocket closed during setup: ${event.reason}`));
         } else {
           this.status.set("disconnected");
+          void this.#writeEvent("sessionEnd", { status: "completed" });
           this.#writeResult("completed");
         }
       });
@@ -154,6 +177,10 @@ class LiveSessionClient {
           reject(new Error("WebSocket connection failed"));
         } else {
           this.status.set("error");
+          void this.#writeEvent("sessionEnd", {
+            status: "failed",
+            error: "WebSocket error",
+          });
           this.#writeResult("failed", "WebSocket error");
         }
       });
@@ -168,6 +195,10 @@ class LiveSessionClient {
     this.#audioOutput.dispose();
     this.#dispatchObserver?.disconnect();
     this.#dispatchObserver = null;
+    this.#contextObserver?.disconnect();
+    this.#contextObserver = null;
+    // Write sessionEnd event for the box.
+    void this.#writeEvent("sessionEnd", { status: "completed" });
     if (!this.#ws) return;
     this.#ws.close(1000, "Client disconnect");
     this.#ws = null;
@@ -242,6 +273,12 @@ class LiveSessionClient {
         `[live:${this.taskId.slice(0, 8)}] Setup complete`,
       );
       this.status.set("connected");
+      // Write sessionStart event with the config.
+      void this.#writeEvent("sessionStart", {
+        config: this.#bundle.setup,
+      });
+      // Start watching for context updates from the box.
+      void this.#startContextObserver();
       return;
     }
 
@@ -250,11 +287,57 @@ class LiveSessionClient {
       for (const part of message.serverContent.modelTurn.parts) {
         if (part.text) {
           this.transcript.set(this.transcript.get() + part.text);
+          this.#currentTurnParts.push({ text: part.text });
         }
         if (part.inlineData?.data) {
           this.#audioOutput.play(part.inlineData.data);
         }
       }
+    }
+
+    // Turn complete — write event with accumulated model text parts.
+    if (message.serverContent?.turnComplete) {
+      const modelParts = this.#currentTurnParts
+        .filter((p) => p.text)
+        .map((p) => ({ text: p.text }));
+      void this.#writeEvent("turnComplete", { parts: modelParts });
+      this.#currentTurnParts = [];
+      // Add a newline separator between turns in the transcript.
+      const current = this.transcript.get();
+      if (current && !current.endsWith("\n")) {
+        this.transcript.set(current + "\n");
+      }
+    }
+
+    // Audio transcription — the API nests these inside serverContent
+    // when inputAudioTranscription / outputAudioTranscription are
+    // enabled in the setup config.
+    const serverContent = message.serverContent as
+      | (Record<string, unknown> & typeof message.serverContent)
+      | undefined;
+    if (serverContent?.inputTranscription) {
+      const { text } = serverContent.inputTranscription as { text?: string };
+      if (text) {
+        // Show user speech in the UI transcript.
+        this.transcript.set(this.transcript.get() + `\n> ${text}\n`);
+        void this.#writeEvent("inputTranscript", { text });
+      }
+    }
+    if (serverContent?.outputTranscription) {
+      const { text } = serverContent.outputTranscription as { text?: string };
+      if (text) {
+        void this.#writeEvent("outputTranscript", { text });
+      }
+    }
+
+    // Usage metadata — forward to event channel.
+    // The Live API can send usageMetadata alongside other fields
+    // on the BidiGenerateContentServerMessage.
+    const rawMessage = message as Record<string, unknown>;
+    if (rawMessage.usageMetadata) {
+      void this.#writeEvent("usageMetadata", {
+        metadata: rawMessage.usageMetadata,
+      });
     }
 
     // Tool calls — dispatch via filesystem and relay results.
@@ -264,6 +347,14 @@ class LiveSessionClient {
         `[live:${this.taskId.slice(0, 8)}] Tool call:`,
         calls.map((fc) => fc.name).join(", "),
       );
+      // Write toolCall event.
+      void this.#writeEvent("toolCall", {
+        functionCalls: calls.map((fc) => ({
+          name: fc.name,
+          args: fc.args,
+          id: fc.id,
+        })),
+      });
       // Fire-and-forget — dispatches concurrently while audio continues.
       void this.#dispatchToolCalls(calls);
     }
@@ -479,6 +570,172 @@ class LiveSessionClient {
         functionResponses: responses,
       },
     });
+
+    // Write toolResponse event for the box.
+    void this.#writeEvent("toolResponse", {
+      functionResponses: responses,
+    });
+  }
+
+  // ── Context update observer ──
+
+  /**
+   * Watch `context_updates/` for files written by `LiveStream.send_context()`.
+   *
+   * When a new `.json` file appears, reads it and injects the parts as
+   * `clientContent` on the WebSocket so the model receives context updates
+   * from subagent completions.
+   */
+  async #startContextObserver(): Promise<void> {
+    const tag = `[live:${this.taskId.slice(0, 8)}]`;
+
+    let contextDir: FileSystemDirectoryHandle;
+    try {
+      contextDir = await this.#ticketDir.getDirectoryHandle(
+        "context_updates",
+      );
+    } catch {
+      console.log(`${tag} No context_updates/ directory — skipping observer`);
+      return;
+    }
+
+    if ("FileSystemObserver" in globalThis) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const Ctor = (globalThis as any).FileSystemObserver;
+
+      const observer = new Ctor(async (records: unknown[]) => {
+        for (const record of records) {
+          const r = record as {
+            relativePathComponents?: string[];
+            type?: string;
+          };
+          const parts = r.relativePathComponents;
+          if (!parts || parts.length === 0) continue;
+
+          const filename = parts[parts.length - 1];
+          if (!filename.endsWith(".json")) continue;
+          if (this.#processedContextFiles.has(filename)) continue;
+
+          await this.#injectContextUpdate(contextDir, filename);
+        }
+      });
+
+      observer.observe(contextDir, { recursive: false });
+      this.#contextObserver = observer;
+      console.log(`${tag} Context update observer started`);
+    } else {
+      // Fallback: poll-based.
+      console.log(
+        `${tag} FileSystemObserver unavailable — polling context_updates/`,
+      );
+      this.#pollContextUpdates(contextDir);
+    }
+  }
+
+  /** Read and inject a single context update file. */
+  async #injectContextUpdate(
+    contextDir: FileSystemDirectoryHandle,
+    filename: string,
+  ): Promise<void> {
+    if (this.#processedContextFiles.has(filename)) return;
+    this.#processedContextFiles.add(filename);
+
+    const tag = `[live:${this.taskId.slice(0, 8)}]`;
+
+    try {
+      const fh = await contextDir.getFileHandle(filename);
+      const file = await fh.getFile();
+      const text = await file.text();
+      const data = JSON.parse(text) as { parts?: Array<{ text?: string }> };
+
+      if (!data.parts || data.parts.length === 0) return;
+
+      // Inject into the WebSocket as client content.
+      this.send({
+        clientContent: {
+          turns: [{ role: "user", parts: data.parts }],
+          turnComplete: true,
+        },
+      });
+
+      // Add context marker to transcript.
+      const summary = data.parts
+        .map((p) => p.text || "")
+        .join(" ")
+        .slice(0, 100);
+      this.transcript.set(
+        this.transcript.get() + `\n[Context update: ${summary}]\n`,
+      );
+
+      // Write contextUpdate event for the box.
+      void this.#writeEvent("contextUpdate", { parts: data.parts });
+
+      console.log(`${tag} Context update injected: ${filename}`);
+    } catch (e) {
+      console.error(`${tag} Failed to read context update ${filename}:`, e);
+    }
+  }
+
+  /** Poll-based fallback for context updates. */
+  #pollContextUpdates(
+    contextDir: FileSystemDirectoryHandle,
+  ): void {
+    const POLL_MS = 1000;
+
+    const poll = async () => {
+      while (this.status.get() === "connected") {
+        try {
+          for await (const [name] of contextDir.entries()) {
+            if (!name.endsWith(".json")) continue;
+            if (this.#processedContextFiles.has(name)) continue;
+            await this.#injectContextUpdate(contextDir, name);
+          }
+        } catch {
+          // Directory iteration error — ignore.
+        }
+        await new Promise((r) => setTimeout(r, POLL_MS));
+      }
+    };
+
+    void poll();
+  }
+
+  // ── Event channel writing ──
+
+  /**
+   * Write a structured event file to `live_events/` for the box to read.
+   *
+   * Files are named `{seq:06d}.json` with an incrementing sequence number.
+   * The box's `LiveStream` polls this directory and translates events
+   * into `EvalCollector`-compatible event dicts.
+   */
+  async #writeEvent(
+    type: string,
+    data: Record<string, unknown>,
+  ): Promise<void> {
+    if (!this.#liveEventsDir) return;
+
+    const seq = this.#eventSeq++;
+    const filename = `${String(seq).padStart(6, "0")}.json`;
+    const event = {
+      type,
+      ...data,
+      timestamp: new Date().toISOString(),
+    };
+
+    try {
+      const fh = await this.#liveEventsDir.getFileHandle(filename, {
+        create: true,
+      });
+      const w = await fh.createWritable();
+      await w.write(JSON.stringify(event, null, 2) + "\n");
+      await w.close();
+    } catch (e) {
+      console.error(
+        `[live:${this.taskId.slice(0, 8)}] Failed to write event ${filename}:`,
+        e,
+      );
+    }
   }
 
   // ── Result writing ──

--- a/packages/bees/hivetool/src/data/state-access.ts
+++ b/packages/bees/hivetool/src/data/state-access.ts
@@ -89,11 +89,12 @@ class StateAccess {
 
   /** Resolve a subdirectory from the hive handle. */
   async getSubdirectory(
-    name: string
+    name: string,
+    options?: { create?: boolean },
   ): Promise<FileSystemDirectoryHandle | null> {
     if (!this.#handle) return null;
     try {
-      return await this.#handle.getDirectoryHandle(name);
+      return await this.#handle.getDirectoryHandle(name, options);
     } catch {
       return null;
     }

--- a/packages/bees/hivetool/src/data/ticket-store.ts
+++ b/packages/bees/hivetool/src/data/ticket-store.ts
@@ -299,6 +299,9 @@ class TicketStore {
     }
   }
 
+
+
+
   // ── Live session detection ──
 
   async #detectLiveSessions(tickets: TicketData[]): Promise<void> {

--- a/packages/bees/tests/test_live_runner.py
+++ b/packages/bees/tests/test_live_runner.py
@@ -20,6 +20,7 @@ from bees.protocols.functions import (
 from bees.protocols.session import SessionConfiguration
 from bees.runners.live import (
     BUNDLE_FILENAME,
+    LIVE_EVENTS_DIR,
     RESULT_FILENAME,
     TOOL_DISPATCH_DIR,
     LiveRunner,
@@ -288,13 +289,407 @@ def test_write_bundle(temp_dir):
 
 
 # ---------------------------------------------------------------------------
-# LiveStream
+# LiveStream — event channel
+# ---------------------------------------------------------------------------
+
+
+def _write_event(events_dir: Path, seq: int, data: dict) -> None:
+    """Write an event file to the live_events directory."""
+    filename = f"{seq:06d}.json"
+    (events_dir / filename).write_text(json.dumps(data))
+
+
+@pytest.mark.asyncio
+async def test_live_stream_session_start(temp_dir):
+    """sessionStart event emits initial sendRequest with config."""
+    events_dir = temp_dir / LIVE_EVENTS_DIR
+    events_dir.mkdir()
+
+    stream = LiveStream(temp_dir, poll_interval=0.05)
+
+    _write_event(events_dir, 0, {
+        "type": "sessionStart",
+        "config": {
+            "model": "test-model",
+            "systemInstruction": {"parts": [{"text": "Be helpful."}]},
+        },
+    })
+    _write_event(events_dir, 1, {
+        "type": "sessionEnd",
+        "status": "completed",
+    })
+
+    events = []
+    async for event in stream:
+        events.append(event)
+
+    # sessionStart yields an initial sendRequest + sessionEnd yields complete.
+    assert len(events) == 2
+    assert "sendRequest" in events[0]
+    body = events[0]["sendRequest"]["body"]
+    assert body["systemInstruction"]["parts"][0]["text"] == "Be helpful."
+    assert "complete" in events[1]
+
+
+@pytest.mark.asyncio
+async def test_live_stream_tool_call_without_turn_complete(temp_dir):
+    """toolCall without preceding turnComplete synthesizes a sendRequest."""
+    events_dir = temp_dir / LIVE_EVENTS_DIR
+    events_dir.mkdir()
+
+    _write_event(events_dir, 0, {
+        "type": "sessionStart",
+        "config": {
+            "systemInstruction": {"parts": [{"text": "Test."}]},
+        },
+    })
+    # Model goes straight to tool call — no turnComplete.
+    _write_event(events_dir, 1, {
+        "type": "toolCall",
+        "functionCalls": [
+            {"name": "list_files", "args": {}, "id": "c1"},
+        ],
+    })
+    _write_event(events_dir, 2, {
+        "type": "toolResponse",
+        "functionResponses": [
+            {"name": "list_files", "id": "c1", "response": {"files": []}},
+        ],
+    })
+    # Second tool call after tool response.
+    _write_event(events_dir, 3, {
+        "type": "toolCall",
+        "functionCalls": [
+            {"name": "done", "args": {"result": "ok"}, "id": "c2"},
+        ],
+    })
+    _write_event(events_dir, 4, {
+        "type": "toolResponse",
+        "functionResponses": [
+            {"name": "done", "id": "c2", "response": {}},
+        ],
+    })
+    _write_event(events_dir, 5, {
+        "type": "sessionEnd",
+        "status": "completed",
+    })
+
+    stream = LiveStream(temp_dir, poll_interval=0.05)
+    events = []
+    async for event in stream:
+        events.append(event)
+
+    # Expected: sendRequest(sessionStart) + functionCall(list_files)
+    #         + sendRequest(after toolResponse resets flag) + functionCall(done)
+    #         + sendRequest(final flush from sessionEnd) + complete
+    types = [list(e.keys())[0] for e in events]
+    assert types == [
+        "sendRequest",    # from sessionStart
+        "functionCall",   # list_files (no extra sendRequest — turn already emitted)
+        "sendRequest",    # synthesized because toolResponse reset the flag
+        "functionCall",   # done
+        "sendRequest",    # final flush — captures done's toolResponse
+        "complete",
+    ]
+    # Final sendRequest should have both tool responses in context.
+    final_body = events[4]["sendRequest"]["body"]
+    fn_response_count = sum(
+        1 for entry in final_body["contents"]
+        for p in entry.get("parts", [])
+        if "functionResponse" in p
+    )
+    assert fn_response_count == 2  # list_files + done
+
+
+@pytest.mark.asyncio
+async def test_live_stream_turn_complete(temp_dir):
+    """turnComplete yields a synthetic sendRequest event."""
+    events_dir = temp_dir / LIVE_EVENTS_DIR
+    events_dir.mkdir()
+
+    stream = LiveStream(temp_dir, poll_interval=0.05)
+
+    _write_event(events_dir, 0, {
+        "type": "turnComplete",
+        "parts": [{"text": "Hello, I can help!"}],
+    })
+    _write_event(events_dir, 1, {
+        "type": "sessionEnd",
+        "status": "completed",
+    })
+
+    events = []
+    async for event in stream:
+        events.append(event)
+
+    assert len(events) == 2  # sendRequest + complete
+    assert "sendRequest" in events[0]
+    body = events[0]["sendRequest"]["body"]
+    # Context should contain the model turn.
+    assert len(body["contents"]) == 1
+    assert body["contents"][0]["role"] == "model"
+    assert body["contents"][0]["parts"][0]["text"] == "Hello, I can help!"
+
+
+@pytest.mark.asyncio
+async def test_live_stream_tool_call(temp_dir):
+    """toolCall yields functionCall events."""
+    events_dir = temp_dir / LIVE_EVENTS_DIR
+    events_dir.mkdir()
+
+    _write_event(events_dir, 0, {
+        "type": "toolCall",
+        "functionCalls": [
+            {"name": "list_files", "args": {"path": "/"}, "id": "c1"},
+        ],
+    })
+    _write_event(events_dir, 1, {
+        "type": "sessionEnd",
+        "status": "completed",
+    })
+
+    stream = LiveStream(temp_dir, poll_interval=0.05)
+    events = []
+    async for event in stream:
+        events.append(event)
+
+    # sendRequest (synthesized for missing turn) + functionCall + complete
+    assert len(events) == 3
+    assert "sendRequest" in events[0]
+    assert "functionCall" in events[1]
+    assert events[1]["functionCall"]["name"] == "list_files"
+
+
+@pytest.mark.asyncio
+async def test_live_stream_tool_response_adds_context(temp_dir):
+    """toolResponse adds to context, visible in next turnComplete."""
+    events_dir = temp_dir / LIVE_EVENTS_DIR
+    events_dir.mkdir()
+
+    # Turn 1: model speaks, tool is called, tool responds.
+    _write_event(events_dir, 0, {
+        "type": "turnComplete",
+        "parts": [{"text": "Let me check."}],
+    })
+    _write_event(events_dir, 1, {
+        "type": "toolResponse",
+        "functionResponses": [
+            {"name": "list_files", "id": "c1", "response": {"files": ["a.txt"]}},
+        ],
+    })
+    # Turn 2: model responds after seeing tool output.
+    _write_event(events_dir, 2, {
+        "type": "turnComplete",
+        "parts": [{"text": "Found a.txt!"}],
+    })
+    _write_event(events_dir, 3, {
+        "type": "sessionEnd",
+        "status": "completed",
+    })
+
+    stream = LiveStream(temp_dir, poll_interval=0.05)
+    events = []
+    async for event in stream:
+        events.append(event)
+
+    # sendRequest(turn1) + sendRequest(turn2) + complete
+    assert len(events) == 3
+    # Second sendRequest should have tool response in context.
+    body2 = events[1]["sendRequest"]["body"]
+    assert len(body2["contents"]) == 3  # model, user(toolResponse), model
+    assert body2["contents"][1]["role"] == "user"
+    assert "functionResponse" in body2["contents"][1]["parts"][0]
+
+
+@pytest.mark.asyncio
+async def test_live_stream_usage_metadata(temp_dir):
+    """usageMetadata yields a usageMetadata event."""
+    events_dir = temp_dir / LIVE_EVENTS_DIR
+    events_dir.mkdir()
+
+    _write_event(events_dir, 0, {
+        "type": "usageMetadata",
+        "metadata": {
+            "promptTokenCount": 100,
+            "candidatesTokenCount": 50,
+            "totalTokenCount": 150,
+        },
+    })
+    _write_event(events_dir, 1, {
+        "type": "sessionEnd",
+        "status": "completed",
+    })
+
+    stream = LiveStream(temp_dir, poll_interval=0.05)
+    events = []
+    async for event in stream:
+        events.append(event)
+
+    assert len(events) == 3  # usageMetadata + sendRequest (flush) + complete
+    assert "usageMetadata" in events[0]
+    assert events[0]["usageMetadata"]["metadata"]["totalTokenCount"] == 150
+
+
+@pytest.mark.asyncio
+async def test_live_stream_context_update(temp_dir):
+    """contextUpdate adds to context, visible in next turnComplete."""
+    events_dir = temp_dir / LIVE_EVENTS_DIR
+    events_dir.mkdir()
+
+    _write_event(events_dir, 0, {
+        "type": "contextUpdate",
+        "parts": [{"text": "Subagent completed: report ready."}],
+    })
+    _write_event(events_dir, 1, {
+        "type": "turnComplete",
+        "parts": [{"text": "I see the report."}],
+    })
+    _write_event(events_dir, 2, {
+        "type": "sessionEnd",
+        "status": "completed",
+    })
+
+    stream = LiveStream(temp_dir, poll_interval=0.05)
+    events = []
+    async for event in stream:
+        events.append(event)
+
+    # sendRequest + complete
+    assert len(events) == 2
+    body = events[0]["sendRequest"]["body"]
+    # Context: user(contextUpdate) + model(turnComplete)
+    assert len(body["contents"]) == 2
+    assert body["contents"][0]["role"] == "user"
+    assert body["contents"][0]["parts"][0]["text"] == "Subagent completed: report ready."
+
+
+@pytest.mark.asyncio
+async def test_live_stream_input_transcript(temp_dir):
+    """inputTranscript adds user speech to context."""
+    events_dir = temp_dir / LIVE_EVENTS_DIR
+    events_dir.mkdir()
+
+    _write_event(events_dir, 0, {
+        "type": "inputTranscript",
+        "text": "How many files do I have?",
+    })
+    _write_event(events_dir, 1, {
+        "type": "turnComplete",
+        "parts": [{"text": "Let me check."}],
+    })
+    _write_event(events_dir, 2, {
+        "type": "sessionEnd",
+        "status": "completed",
+    })
+
+    stream = LiveStream(temp_dir, poll_interval=0.05)
+    events = []
+    async for event in stream:
+        events.append(event)
+
+    # sendRequest (from turnComplete) + complete
+    assert len(events) == 2
+    body = events[0]["sendRequest"]["body"]
+    # Context: user(transcript) + model(turnComplete)
+    assert len(body["contents"]) == 2
+    assert body["contents"][0]["role"] == "user"
+    assert body["contents"][0]["parts"][0]["text"] == "How many files do I have?"
+    assert body["contents"][1]["role"] == "model"
+
+
+@pytest.mark.asyncio
+async def test_live_stream_output_transcript(temp_dir):
+    """outputTranscript adds model speech to context."""
+    events_dir = temp_dir / LIVE_EVENTS_DIR
+    events_dir.mkdir()
+
+    _write_event(events_dir, 0, {
+        "type": "outputTranscript",
+        "text": "You have zero files.",
+    })
+    _write_event(events_dir, 1, {
+        "type": "sessionEnd",
+        "status": "completed",
+    })
+
+    stream = LiveStream(temp_dir, poll_interval=0.05)
+    events = []
+    async for event in stream:
+        events.append(event)
+
+    # sendRequest (flush) + complete
+    assert len(events) == 2
+    body = events[0]["sendRequest"]["body"]
+    assert len(body["contents"]) == 1
+    assert body["contents"][0]["role"] == "model"
+    assert body["contents"][0]["parts"][0]["text"] == "You have zero files."
+
+
+@pytest.mark.asyncio
+async def test_live_stream_session_end_failure(temp_dir):
+    """sessionEnd with failed status yields error event."""
+    events_dir = temp_dir / LIVE_EVENTS_DIR
+    events_dir.mkdir()
+
+    _write_event(events_dir, 0, {
+        "type": "sessionEnd",
+        "status": "failed",
+        "error": "Connection lost",
+    })
+
+    stream = LiveStream(temp_dir, poll_interval=0.05)
+    events = []
+    async for event in stream:
+        events.append(event)
+
+    # sendRequest (final flush) + error
+    assert len(events) == 2
+    assert "sendRequest" in events[0]
+    assert "error" in events[1]
+    assert "Connection lost" in events[1]["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_live_stream_config_from_setup(temp_dir):
+    """LiveStream can receive initial config via constructor."""
+    events_dir = temp_dir / LIVE_EVENTS_DIR
+    events_dir.mkdir()
+
+    setup = {
+        "model": "models/gemini-test",
+        "systemInstruction": {"parts": [{"text": "You are helpful."}]},
+        "generationConfig": {"temperature": 0.7},
+    }
+
+    stream = LiveStream(temp_dir, setup=setup, poll_interval=0.05)
+
+    _write_event(events_dir, 0, {
+        "type": "turnComplete",
+        "parts": [{"text": "Hi there."}],
+    })
+    _write_event(events_dir, 1, {
+        "type": "sessionEnd",
+        "status": "completed",
+    })
+
+    events = []
+    async for event in stream:
+        events.append(event)
+
+    # sendRequest should include config from setup.
+    body = events[0]["sendRequest"]["body"]
+    assert body["systemInstruction"]["parts"][0]["text"] == "You are helpful."
+    assert body["generationConfig"]["temperature"] == 0.7
+
+
+# ---------------------------------------------------------------------------
+# LiveStream — fallback (crash recovery)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_live_stream_completes_on_result(temp_dir):
-    """LiveStream yields completion when live_result.json appears."""
+async def test_live_stream_fallback_completes_on_result(temp_dir):
+    """LiveStream yields completion via live_result.json fallback."""
     stream = LiveStream(temp_dir, poll_interval=0.05)
 
     # Write the result file after a short delay.
@@ -312,14 +707,15 @@ async def test_live_stream_completes_on_result(temp_dir):
     async for event in stream:
         events.append(event)
 
-    assert len(events) == 1
-    assert "complete" in events[0]
-    assert events[0]["complete"]["result"]["success"] is True
+    assert len(events) == 2  # sendRequest (flush) + complete
+    assert "sendRequest" in events[0]
+    assert "complete" in events[1]
+    assert events[1]["complete"]["result"]["success"] is True
 
 
 @pytest.mark.asyncio
-async def test_live_stream_handles_failure(temp_dir):
-    """LiveStream yields error event when result reports failure."""
+async def test_live_stream_fallback_handles_failure(temp_dir):
+    """LiveStream yields error event via live_result.json fallback."""
     stream = LiveStream(temp_dir, poll_interval=0.05)
 
     result_path = temp_dir / RESULT_FILENAME
@@ -332,9 +728,10 @@ async def test_live_stream_handles_failure(temp_dir):
     async for event in stream:
         events.append(event)
 
-    assert len(events) == 1
-    assert "error" in events[0]
-    assert "WebSocket disconnected" in events[0]["error"]["message"]
+    assert len(events) == 2  # sendRequest (flush) + error
+    assert "sendRequest" in events[0]
+    assert "error" in events[1]
+    assert "WebSocket disconnected" in events[1]["error"]["message"]
 
 
 @pytest.mark.asyncio
@@ -603,19 +1000,25 @@ async def test_live_stream_cancels_watcher(temp_dir):
 
     watcher_task = asyncio.create_task(_dummy_watcher())
 
+    events_dir = temp_dir / LIVE_EVENTS_DIR
+    events_dir.mkdir()
+
     stream = LiveStream(temp_dir, poll_interval=0.05, watcher_task=watcher_task)
 
-    # Write the result file immediately.
-    result_path = temp_dir / RESULT_FILENAME
-    result_path.write_text(json.dumps({"status": "completed"}))
+    # Write a sessionEnd event.
+    _write_event(events_dir, 0, {
+        "type": "sessionEnd",
+        "status": "completed",
+    })
 
     # Drain the stream.
     events = []
     async for event in stream:
         events.append(event)
 
-    assert len(events) == 1
-    assert "complete" in events[0]
+    assert len(events) == 2  # sendRequest (flush) + complete
+    assert "sendRequest" in events[0]
+    assert "complete" in events[1]
 
     # Give a tick for the cancellation to propagate.
     await asyncio.sleep(0.05)


### PR DESCRIPTION
## What
Implements the event channel architecture for live sessions (browser → box via `live_events/` files), fixes three logging bugs that caused incomplete logs, adds server-side audio transcription, and wires chat log persistence for live sessions.

## Why
Live session logs were empty because there was no mechanism for session events (turns, tool calls, usage metadata) to flow from the browser back to the box for log writing. The box is the single authoritative writer for `*.log.json` and `chat_log.json`, matching the batch session pattern. Once the event channel was in place, three additional bugs surfaced: the Live API omits `turnComplete` for tool-only turns, the final tool response in a terminal tool call was never flushed, and `live_result.json` raced with in-flight events.

## Changes

### Event Channel (`live_events/`)
- **`live-session.ts`**: Browser writes structured JSON events (sessionStart, turnComplete, toolCall, toolResponse, usageMetadata, inputTranscript, outputTranscript, sessionEnd) as sequenced files to `live_events/`
- **`live.py` (`LiveStream`)**: Polls `live_events/`, translates events into `EvalCollector`-compatible format, yields to `drain_session`
- **`state-access.ts` / `ticket-store.ts`**: Expose `live_events/` directory handle to the session client

### Logging Bug Fixes (`LiveStream._translate_event`)
- **Turn boundary synthesis**: `sessionStart` emits initial `sendRequest`; `toolCall` synthesizes one if the Live API skipped `turnComplete`; `toolResponse` resets the flag
- **Final context flush**: `_flush_final_context()` emits a closing `sendRequest` before terminal events to capture the last tool response
- **Race condition**: When `live_result.json` is detected, waits one poll interval and re-scans for late-arriving browser events

### Audio Transcription
- **`live.py`**: Adds `inputAudioTranscription` / `outputAudioTranscription` to session setup config; translates transcript events into user/model context entries
- **`live-session.ts`**: Extracts `inputTranscription` / `outputTranscription` from `serverContent` (not top-level — API docs are misleading), writes as `inputTranscript` / `outputTranscript` events
- **`session.py`**: `drain_session` writes both user and agent text to `chat_log.json`

### Context Updates
- **`live-session.ts`**: Observes `context_updates/` directory for box-written context injections, relays to Live API via `session.send(clientContent)`

### Tests & Docs
- **`test_live_runner.py`**: +435 lines — tests for turn synthesis, transcript events, final flush, tool-only turns, race condition fallback, context updates, watcher lifecycle
- **`PROJECT_ACOUSTIC.md`**: Updated architecture diagrams and communication protocol table; marked Phase 5 & 6 complete

## Testing
- 39/39 tests passing in `test_live_runner.py`
- Verified end-to-end: log.json contains config, full context with user transcripts, all tool calls including terminal ones, and correct turn counts
