### PR TITLE
[bees] Rename files group and coalesce transcripts

### DIFF
--- a/PROJECT_ACOUSTIC.md
+++ b/PROJECT_ACOUSTIC.md
@@ -27,26 +27,26 @@ lifecycle management.
 └─────────────────────────────────────┘    └────────────────────────────────┘
 ```
 
-Two processes, one filesystem. The box writes the session bundle; hivetool
-runs the audio loop. Tool calls bounce through `tool_dispatch/` files. Live
-events flow back through `live_events/` files, which `LiveStream` polls and
-translates into `EvalCollector`-compatible events for `drain_session`.
-The `live_result.json` file serves as a fallback termination signal.
+Two processes, one filesystem. The box writes the session bundle; hivetool runs
+the audio loop. Tool calls bounce through `tool_dispatch/` files. Live events
+flow back through `live_events/` files, which `LiveStream` polls and translates
+into `EvalCollector`-compatible events for `drain_session`. The
+`live_result.json` file serves as a fallback termination signal.
 
 ## Communication Protocol
 
-All communication between box and browser uses the task directory on the
-shared filesystem:
+All communication between box and browser uses the task directory on the shared
+filesystem:
 
-| File                        | Writer   | Reader   | Purpose                                    |
-| --------------------------- | -------- | -------- | ------------------------------------------ |
-| `live_session.json`         | Box      | Hivetool | Session bundle (token, endpoint, setup)    |
-| `live_result.json`          | Hivetool | Box      | Session completion signal (fallback)       |
-| `tool_dispatch/{id}.json`   | Hivetool | Box      | Tool call request                          |
-| `tool_dispatch/{id}.result.json` | Box | Hivetool | Tool call response                         |
-| `context_updates/{ts}.json` | Box      | Hivetool | Context updates from subagent completions  |
-| `live_events/{seq}.json`    | Hivetool | Box      | Structured session events (turns, tools, usage, end) |
-| `chat_log.json`             | Box      | Hivetool | Transcription log (written by `drain_session`) |
+| File                             | Writer   | Reader   | Purpose                                              |
+| -------------------------------- | -------- | -------- | ---------------------------------------------------- |
+| `live_session.json`              | Box      | Hivetool | Session bundle (token, endpoint, setup)              |
+| `live_result.json`               | Hivetool | Box      | Session completion signal (fallback)                 |
+| `tool_dispatch/{id}.json`        | Hivetool | Box      | Tool call request                                    |
+| `tool_dispatch/{id}.result.json` | Box      | Hivetool | Tool call response                                   |
+| `context_updates/{ts}.json`      | Box      | Hivetool | Context updates from subagent completions            |
+| `live_events/{seq}.json`         | Hivetool | Box      | Structured session events (turns, tools, usage, end) |
+| `chat_log.json`                  | Box      | Hivetool | Transcription log (written by `drain_session`)       |
 
 ---
 
@@ -56,9 +56,9 @@ shared filesystem:
 
 A template with `runner: live` creates a task that is dispatched to a
 `LiveRunner` instead of the `GeminiRunner`. The runner extracts tool
-declarations, assembles the system instruction, acquires an ephemeral token,
-and writes `live_session.json` to the task directory. The `LiveStream` blocks
-until `live_result.json` appears.
+declarations, assembles the system instruction, acquires an ephemeral token, and
+writes `live_session.json` to the task directory. The `LiveStream` blocks until
+`live_result.json` appears.
 
 **Observable proof:** Create a task with `runner: live`. Observe
 `live_session.json` appear in the task directory containing the token, WebSocket
@@ -69,8 +69,8 @@ endpoint, and setup message with system instruction and tool declarations.
 - [x] `ticket.py` — `RunnerType = Literal["generate", "live"]`, `runner` field
       on `TicketMetadata`.
 - [x] `task_store.py`, `playbook.py` — wire `runner` through creation.
-- [x] `bees.py`, `scheduler.py`, `task_runner.py` — `runners: dict[str,
-      SessionRunner]` with `_runner_for(task)` dispatch.
+- [x] `bees.py`, `scheduler.py`, `task_runner.py` —
+      `runners: dict[str,     SessionRunner]` with `_runner_for(task)` dispatch.
 - [x] `box.py`, `server.py` — construct `{"generate": ..., "live": ...}`.
 - [x] `SessionConfiguration` — add `ticket_id`, `ticket_dir`.
 - [x] `bees/runners/live.py` — `LiveRunner`, `LiveStream`, declaration
@@ -94,9 +94,8 @@ Disconnecting writes `live_result.json`, and the box's LiveStream unblocks.
 ### Changes
 
 - [x] `common/types.ts` — add `runner?: string` to `TaskData`.
-- [x] `hivetool/src/data/live-session.ts` — **[NEW]** `LiveSessionClient`:
-      reads bundle, opens WebSocket, sends setup, handles messages, writes
-      result.
+- [x] `hivetool/src/data/live-session.ts` — **[NEW]** `LiveSessionClient`: reads
+      bundle, opens WebSocket, sends setup, handles messages, writes result.
 - [x] `hivetool/src/data/ticket-store.ts` — on scan, check for
       `live_session.json` and surface active live sessions via
       `activeLiveSessions` signal.
@@ -118,17 +117,16 @@ low-latency.
 
 ### Changes
 
-- [x] `hivetool/src/data/audio-handler.ts` — **[NEW]** `AudioInput` (mic →
-      PCM → base64 → WS) and `AudioOutput` (WS → PCM → AudioContext →
-      speakers).
-- [x] `AudioInput` — `navigator.mediaDevices.getUserMedia()`, `AudioWorklet`
-      for PCM capture at 16kHz mono.
+- [x] `hivetool/src/data/audio-handler.ts` — **[NEW]** `AudioInput` (mic → PCM →
+      base64 → WS) and `AudioOutput` (WS → PCM → AudioContext → speakers).
+- [x] `AudioInput` — `navigator.mediaDevices.getUserMedia()`, `AudioWorklet` for
+      PCM capture at 16kHz mono.
 - [x] `AudioOutput` — decode base64 PCM, queue into `AudioContext` playback
       buffer.
 - [x] Wire audio handler into `LiveSessionClient` message loop.
 - [x] Mic toggle button in ticket detail UI.
-- [x] Fix binary Blob frame decoding (`#handleMessage`) — the Live API sends
-      all frames as binary, not text.
+- [x] Fix binary Blob frame decoding (`#handleMessage`) — the Live API sends all
+      frames as binary, not text.
 
 ---
 
@@ -141,27 +139,26 @@ bounce through the filesystem to the box, which executes the handler and returns
 the result.
 
 **Observable proof:** Start a live audio session with an agent that has file
-tools. Ask the agent to list files. The tool call appears in
-`tool_dispatch/`, the box executes `simple_files_list_files`, the result is
-written back, hivetool relays it to the WebSocket, and the agent reports the
-file listing.
+tools. Ask the agent to list files. The tool call appears in `tool_dispatch/`,
+the box executes `simple_files_list_files`, the result is written back, hivetool
+relays it to the WebSocket, and the agent reports the file listing.
 
 ### Changes
 
 - [x] `bees/runners/live.py` — refactored `_extract_declarations` to return
       handler map alongside declarations.
-- [x] `bees/runners/live.py` — `ToolDispatchWatcher`: poll-based async loop
-      on `tool_dispatch/` directory. Reads call JSON (wire format), looks up
+- [x] `bees/runners/live.py` — `ToolDispatchWatcher`: poll-based async loop on
+      `tool_dispatch/` directory. Reads call JSON (wire format), looks up
       handler in provisioned function groups, writes result JSON.
 - [x] `LiveRunner.run()` — starts `ToolDispatchWatcher` as background task.
       `LiveStream` cancels it on session end.
-- [x] `LiveSessionClient` — write `tool_dispatch/{call_id}.json` on
-      `toolCall` message. Observe with `FileSystemObserver` for `.result.json`.
-      Send `toolResponse` on WS. Polling fallback when observer unavailable.
+- [x] `LiveSessionClient` — write `tool_dispatch/{call_id}.json` on `toolCall`
+      message. Observe with `FileSystemObserver` for `.result.json`. Send
+      `toolResponse` on WS. Polling fallback when observer unavailable.
 - [x] Dispatch files use Gemini wire format (`functionCall`/`functionResponse`
       envelopes) for observability.
-- [x] Error handling: unknown handlers, handler exceptions, and 60s timeout
-      all write error results to prevent hangs.
+- [x] Error handling: unknown handlers, handler exceptions, and 60s timeout all
+      write error results to prevent hangs.
 - [x] 28 tests passing (8 new for watcher, handler extraction, and lifecycle).
 
 ---
@@ -180,8 +177,8 @@ contains the full conversation transcript.
 
 ### Changes
 
-- [x] `LiveRunner.run()` — creates `context_updates/` eagerly so the
-      browser observer can start immediately.
+- [x] `LiveRunner.run()` — creates `context_updates/` eagerly so the browser
+      observer can start immediately.
 - [x] `LiveSessionClient` — `FileSystemObserver` on `context_updates/`
       directory. On new file, reads parts and sends as `clientContent` on WS.
       Polling fallback when observer unavailable.
@@ -207,19 +204,19 @@ reported `usageMetadata`.
 ### Architecture: Event Channel
 
 The browser writes structured event files to `live_events/` (sequenced
-`{seq:06d}.json`). The box's `LiveStream` polls these files and translates
-each into `EvalCollector`-compatible events. `drain_session` processes them
-normally, producing log files and `chat_log.json` — same as batch sessions.
+`{seq:06d}.json`). The box's `LiveStream` polls these files and translates each
+into `EvalCollector`-compatible events. `drain_session` processes them normally,
+producing log files and `chat_log.json` — same as batch sessions.
 
-| Event type       | When written                    | EvalCollector translation                  |
-| ---------------- | ------------------------------- | ----------------------------------------- |
-| `sessionStart`   | After `setupComplete`          | Sets config. First `sendRequest` body.     |
-| `turnComplete`   | On `serverContent.turnComplete` | `sendRequest` event (with context so far)  |
-| `toolCall`       | On `toolCall` message          | `functionCall` event(s)                   |
-| `toolResponse`   | After dispatch result relayed   | Context entry (`user` + `functionResponse`) |
-| `usageMetadata`  | On `usageMetadata` message      | `usageMetadata` event                     |
-| `contextUpdate`  | On context injection            | Context entry (`user` + text parts)        |
-| `sessionEnd`     | On WS close / disconnect        | `complete` event                          |
+| Event type      | When written                    | EvalCollector translation                   |
+| --------------- | ------------------------------- | ------------------------------------------- |
+| `sessionStart`  | After `setupComplete`           | Sets config. First `sendRequest` body.      |
+| `turnComplete`  | On `serverContent.turnComplete` | `sendRequest` event (with context so far)   |
+| `toolCall`      | On `toolCall` message           | `functionCall` event(s)                     |
+| `toolResponse`  | After dispatch result relayed   | Context entry (`user` + `functionResponse`) |
+| `usageMetadata` | On `usageMetadata` message      | `usageMetadata` event                       |
+| `contextUpdate` | On context injection            | Context entry (`user` + text parts)         |
+| `sessionEnd`    | On WS close / disconnect        | `complete` event                            |
 
 ### Changes
 
@@ -227,14 +224,14 @@ normally, producing log files and `chat_log.json` — same as batch sessions.
       Polls `live_events/` by sequence number, maintains context accumulator,
       translates events to `EvalCollector` format. Falls back to
       `live_result.json` for crash recovery.
-- [x] `LiveRunner.run()` — creates `live_events/` eagerly, passes `setup`
-      config to `LiveStream` constructor.
+- [x] `LiveRunner.run()` — creates `live_events/` eagerly, passes `setup` config
+      to `LiveStream` constructor.
 - [x] `_clean_stale_artifacts()` — also cleans stale `live_events/`.
 - [x] `LiveSessionClient` — removed all browser-side log accumulation
       (`#logContext`, `#logTurns`, `#writeSessionLog()`, `#chatLog`,
       `#persistChatLog()`, `#logsDir`).
-- [x] `LiveSessionClient` — added `#writeEvent(type, data)` helper and
-      event writing at all turn boundaries.
+- [x] `LiveSessionClient` — added `#writeEvent(type, data)` helper and event
+      writing at all turn boundaries.
 - [x] `ticket-detail.ts` — removed `logsDir` resolution and passing.
 - [x] `ticket-store.ts` — removed `getLogsDir()`.
 - [x] `ChatLogEntry` type removed (unused).
@@ -255,39 +252,41 @@ executor.
 **Observable proof:** Start a live session. The agent responds conversationally
 in a natural voice, uses tools when needed, and signals completion via
 `system_objective_fulfilled` — without the stilted Cynefin/meta-plan framing
-visible in its behavior. The system prompt in `log.json` shows only the
-`live.*` instruction, not `system.*`.
+visible in its behavior. The system prompt in `log.json` shows only the `live.*`
+instruction, not `system.*`.
 
 ### Bug Fix: Instruction Leak
 
-`provision_session()` constructs *all* function group factories (system,
-simple-files, skills, sandbox, events, tasks, chat) regardless of the
-template's `functions` filter. The filter only gates which *declarations* are
-sent to the API — every group's instruction text still gets concatenated into
-the system prompt. This means a `runner: live` template with
-`functions: [system.*]` still gets instructions for files, skills, sandbox,
-events, tasks, and chat.
+`provision_session()` constructs _all_ function group factories (system,
+simple-files, skills, sandbox, events, tasks, chat) regardless of the template's
+`functions` filter. The filter only gates which _declarations_ are sent to the
+API — every group's instruction text still gets concatenated into the system
+prompt. This means a `runner: live` template with `functions: [system.*]` still
+gets instructions for files, skills, sandbox, events, tasks, and chat.
 
 Fix: `_extract_declarations()` must skip instructions from groups whose
 declarations are entirely filtered out.
 
 ### Changes
 
-- [x] `bees/declarations/live.*` — **[NEW]** Instruction-only declaration
-      files: `live.instruction.md` (voice-native system prompt),
-      `live.functions.json` (empty `[]`), `live.metadata.json` (empty `{}`).
+- [x] `bees/declarations/live.*` — **[NEW]** Instruction-only declaration files:
+      `live.instruction.md` (voice-native system prompt), `live.functions.json`
+      (empty `[]`), `live.metadata.json` (empty `{}`).
 - [x] `bees/functions/live.py` — **[NEW]** `get_live_function_group()` —
       instruction-only `FunctionGroup` (same pattern as `skills.py`).
-- [x] `bees/provisioner.py` — add `get_live_function_group()` to the
-      function groups list.
+- [x] `bees/provisioner.py` — add `get_live_function_group()` to the function
+      groups list.
 - [x] `bees/runners/live.py` — fix `_extract_declarations()` to skip
       instructions from groups whose declarations are entirely filtered out.
 - [x] `TEMPLATES.yaml` — live-session template uses `live.*` instead of
       `system.*`.
 - [x] Tests for instruction filtering and live prompt assembly.
-- [ ] `live.*` should carry termination declarations + handlers so
-      `system.*` is not needed in the template. Currently blocked by
-      `simple-files` naming (all functions prefixed `system_`).
+- [x] Rename `simple-files` group to `files` and rename all `system_*` file
+      functions to `files_*` prefix, so `files.*` filter pattern matches
+      correctly in live sessions.
+- [x] Coalesce same-role transcript fragments in `LiveStream` before writing to
+      context (the Live API sends `outputTranscription` word-by-word, producing
+      ~80 context entries for a few sentences).
 
 ---
 
@@ -295,8 +294,8 @@ declarations are entirely filtered out.
 
 ### 🎯 Objective
 
-Live sessions have a dedicated UI panel in ticket detail: connection status,
-mic toggle, waveform visualizer, and live transcript.
+Live sessions have a dedicated UI panel in ticket detail: connection status, mic
+toggle, waveform visualizer, and live transcript.
 
 **Observable proof:** Select a live-running task in hivetool. See a "Live
 Session" panel with a glowing dot for connection status, a mic button, and a
@@ -310,18 +309,15 @@ scrolling transcript of the conversation.
 - [ ] Mic toggle button with visual feedback.
 - [ ] Audio level waveform or VU meter.
 - [ ] Live transcript display (from server-side text events).
-- [ ] Coalesce same-role transcript fragments in `LiveStream` before
-      writing to context (the Live API sends `outputTranscription`
-      word-by-word, producing ~80 context entries for a few sentences).
 
 ---
 
 ## Non-Goals
 
-- **Audio processing in Python.** Audio stays entirely in the browser.
-  The box never touches audio data.
-- **Live API resume.** The Live API doesn't support session resume the same
-  way batch does. A disconnected live session is a new session.
+- **Audio processing in Python.** Audio stays entirely in the browser. The box
+  never touches audio data.
+- **Live API resume.** The Live API doesn't support session resume the same way
+  batch does. A disconnected live session is a new session.
 - **Multi-user live sessions.** One browser tab per live session.
 - **Custom voice models.** Uses Gemini's built-in voice configuration.
 

--- a/packages/bees/bees/declarations/files.functions.json
+++ b/packages/bees/bees/declarations/files.functions.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "system_list_files",
+    "name": "files_list_files",
     "description": "Lists all files",
     "parametersJsonSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -32,7 +32,7 @@
     }
   },
   {
-    "name": "system_write_file",
+    "name": "files_write_file",
     "description": "Writes the provided text to a file",
     "parametersJsonSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -70,7 +70,7 @@
     }
   },
   {
-    "name": "system_read_text_from_file",
+    "name": "files_read_text_from_file",
     "description": "Reads text from a file and return text as string. If the file does not contain text or is not supported, an error will be returned. Google Drive files may contain images and other non-textual content. Please use \"generate_text\" to read them at full fidelity.",
     "parametersJsonSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -103,7 +103,7 @@
     }
   },
   {
-    "name": "system_list_dir",
+    "name": "files_list_dir",
     "description": "Lists the contents of a directory, showing files and subdirectories with their sizes. Text files also include a line count.",
     "parametersJsonSchema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/packages/bees/bees/declarations/files.instruction.md
+++ b/packages/bees/bees/declarations/files.instruction.md
@@ -6,7 +6,7 @@ no path prefix is needed. Use snake_case. Examples: `robot_poem.txt`,
 
 You can embed files in your output using the `<file src="filename.ext" />` syntax.
 
-Only reference files that you know to exist. Call `system_list_files`
+Only reference files that you know to exist. Call `files_list_files`
 to confirm their existence. Do NOT make hypothetical file tags — they
 will cause processing errors.
 

--- a/packages/bees/bees/declarations/files.metadata.json
+++ b/packages/bees/bees/declarations/files.metadata.json
@@ -1,20 +1,20 @@
 [
   {
-    "name": "system_list_files",
+    "name": "files_list_files",
     "icon": "folder"
   },
   {
-    "name": "system_write_file",
+    "name": "files_write_file",
     "icon": "edit",
     "title": "Writing to file"
   },
   {
-    "name": "system_read_text_from_file",
+    "name": "files_read_text_from_file",
     "icon": "description",
     "title": "Reading from file"
   },
   {
-    "name": "system_list_dir",
+    "name": "files_list_dir",
     "icon": "folder_open",
     "title": "Listing directory"
   }

--- a/packages/bees/bees/declarations/sandbox.instruction.md
+++ b/packages/bees/bees/declarations/sandbox.instruction.md
@@ -7,8 +7,8 @@ a sandbox.
 Read `$HOME` to read the location of your working directory. Do not assume its
 location.
 
-Files you create or read with the file tools (`system_write_file`,
-`system_list_files`) and files you create in bash share the same working
+Files you create or read with the file tools (`files_write_file`,
+`files_list_files`) and files you create in bash share the same working
 directory — use bare filenames in both contexts. For example, a file saved as
-`robot_poem.txt` via `system_write_file` is immediately available in bash as
+`robot_poem.txt` via `files_write_file` is immediately available in bash as
 `cat robot_poem.txt`, and vice versa.

--- a/packages/bees/bees/functions/files.py
+++ b/packages/bees/bees/functions/files.py
@@ -1,7 +1,7 @@
 # Copyright 2026 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-"""Simple-files function group for Bees.
+"""Files function group for Bees.
 
 Provides file operation functions (write, list, read, list-dir) using bees-local
 declarations. With ``DiskFileSystem`` the paths are already bare
@@ -32,12 +32,12 @@ from bees.protocols.functions import (
 
 from bees.subagent_scope import SubagentScope
 
-__all__ = ["get_simple_files_function_group_factory"]
+__all__ = ["get_files_function_group_factory"]
 
 _DECLARATIONS_DIR = Path(__file__).resolve().parent.parent / "declarations"
 
 # Load declarations once at module level.
-_LOADED = load_declarations("simple-files", declarations_dir=_DECLARATIONS_DIR)
+_LOADED = load_declarations("files", declarations_dir=_DECLARATIONS_DIR)
 
 # Binary detection & line-counting limits.
 _BINARY_SNIFF_BYTES = 8 * 1024
@@ -63,7 +63,7 @@ def _make_file_handlers(
         file_system: A ``FileSystem``-compatible object.
     """
 
-    async def system_list_files(
+    async def files_list_files(
         args: dict[str, Any], status_cb: Any
     ) -> dict[str, Any]:
         status_update = args.get("status_update")
@@ -73,7 +73,7 @@ def _make_file_handlers(
             status_cb("Getting a list of files")
         return {"list": await file_system.list_files()}
 
-    async def system_write_file(
+    async def files_write_file(
         args: dict[str, Any], status_cb: Any
     ) -> dict[str, Any]:
         file_name = args.get("file_name", "")
@@ -95,7 +95,7 @@ def _make_file_handlers(
         file_path = file_system.write(file_name, resolved_content)
         return {"file_path": file_path}
 
-    async def system_read_text_from_file(
+    async def files_read_text_from_file(
         args: dict[str, Any], status_cb: Any
     ) -> dict[str, Any]:
         file_path = args.get("file_path", "")
@@ -105,16 +105,16 @@ def _make_file_handlers(
         return {"text": text}
 
     return {
-        "system_list_files": system_list_files,
-        "system_write_file": system_write_file,
-        "system_read_text_from_file": system_read_text_from_file,
+        "files_list_files": files_list_files,
+        "files_write_file": files_write_file,
+        "files_read_text_from_file": files_read_text_from_file,
     }
 
 
 def _make_list_dir_handler(work_dir: Path) -> Any:
-    """Build a ``system_list_dir`` handler bound to *work_dir*."""
+    """Build a ``files_list_dir`` handler bound to *work_dir*."""
 
-    async def system_list_dir(
+    async def files_list_dir(
         args: dict[str, Any], status_cb: Any,
     ) -> dict[str, Any]:
         dir_rel = args.get("dir", ".")
@@ -164,7 +164,7 @@ def _make_list_dir_handler(work_dir: Path) -> Any:
 
         return {"entries": json.dumps(entries)}
 
-    return system_list_dir
+    return files_list_dir
 
 
 # ---------------------------------------------------------------------------
@@ -172,11 +172,11 @@ def _make_list_dir_handler(work_dir: Path) -> Any:
 # ---------------------------------------------------------------------------
 
 
-def get_simple_files_function_group_factory(scope: SubagentScope | None = None) -> FunctionGroupFactory:
-    """Return a factory that builds the simple-files function group.
+def get_files_function_group_factory(scope: SubagentScope | None = None) -> FunctionGroupFactory:
+    """Return a factory that builds the files function group.
 
     The returned callable accepts ``SessionHooks`` and produces a
-    ``FunctionGroup`` named ``"simple-files"`` with file operation
+    ``FunctionGroup`` named ``"files"`` with file operation
     functions. Handler bodies are inlined from opal_backend.
 
     With ``DiskFileSystem``, paths are bare (relative to work_dir) —
@@ -189,11 +189,11 @@ def get_simple_files_function_group_factory(scope: SubagentScope | None = None) 
         )
 
         # Add bees-local handlers.
-        handlers["system_list_dir"] = _make_list_dir_handler(hooks.file_system._work_dir)
+        handlers["files_list_dir"] = _make_list_dir_handler(hooks.file_system._work_dir)
 
         
         if scope and scope.slug_path:
-            original_write = handlers["system_write_file"]
+            original_write = handlers["files_write_file"]
             
             async def restricted_write_file(args: dict[str, Any], status_cb: Any) -> dict[str, Any]:
                 file_name = args.get("file_name", "")
@@ -201,7 +201,7 @@ def get_simple_files_function_group_factory(scope: SubagentScope | None = None) 
                     return {"error": f"You can only write files in the directory: {scope.slug_path}"}
                 return await original_write(args, status_cb)
                 
-            handlers["system_write_file"] = restricted_write_file
+            handlers["files_write_file"] = restricted_write_file
             
         return assemble_function_group(_LOADED, handlers)
 

--- a/packages/bees/bees/functions/mcp_bridge.py
+++ b/packages/bees/bees/functions/mcp_bridge.py
@@ -42,7 +42,7 @@ from bees.protocols.functions import (
 logger = logging.getLogger(__name__)
 
 _BUILTIN_GROUP_NAMES = frozenset({
-    "system", "chat", "simple-files", "sandbox",
+    "system", "chat", "files", "sandbox",
     "events", "tasks", "skills", "generate",
 })
 

--- a/packages/bees/bees/functions/sandbox.py
+++ b/packages/bees/bees/functions/sandbox.py
@@ -12,7 +12,7 @@ File visibility
 ---------------
 When a ``DiskFileSystem`` is in use, the file system and bash share
 the same ``work_dir`` directory.  Files written by the agent via
-``system_write_file`` are immediately visible to bash, and files
+``files_write_file`` are immediately visible to bash, and files
 created by bash are immediately visible to the agent — no sync
 needed.
 """

--- a/packages/bees/bees/provisioner.py
+++ b/packages/bees/bees/provisioner.py
@@ -27,7 +27,7 @@ from bees.functions.chat import get_chat_function_group_factory
 from bees.functions.events import get_events_function_group_factory
 from bees.functions.live import get_live_function_group
 from bees.functions.sandbox import get_sandbox_function_group_factory
-from bees.functions.simple_files import get_simple_files_function_group_factory
+from bees.functions.files import get_files_function_group_factory
 from bees.functions.skills import get_skills_function_group
 from bees.functions.system import get_system_function_group_factory
 from bees.functions.tasks import get_tasks_function_group_factory
@@ -116,7 +116,7 @@ def provision_session(
     function_groups = [
         get_system_function_group_factory(),
         get_live_function_group(),
-        get_simple_files_function_group_factory(scope=scope),
+        get_files_function_group_factory(scope=scope),
         get_skills_function_group(available_skills=session_listing),
         get_sandbox_function_group_factory(
             work_dir=work_dir,

--- a/packages/bees/bees/runners/live.py
+++ b/packages/bees/bees/runners/live.py
@@ -696,19 +696,15 @@ class LiveStream:
             # User's speech transcribed by the Live API.
             text = data.get("text", "")
             if text:
-                self._context.append({
-                    "role": "user",
-                    "parts": [{"text": text}],
-                })
+                self._coalesce_transcript("user", text)
 
         elif event_type == "outputTranscript":
             # Model's audio output transcribed by the Live API.
+            # The Live API sends these word-by-word; coalescing
+            # prevents ~80 context entries per sentence.
             text = data.get("text", "")
             if text:
-                self._context.append({
-                    "role": "model",
-                    "parts": [{"text": text}],
-                })
+                self._coalesce_transcript("model", text)
 
         elif event_type == "sessionEnd":
             # Session complete — flush remaining context, cancel
@@ -730,6 +726,21 @@ class LiveStream:
                     },
                 }})
             self._done = True
+
+    def _coalesce_transcript(self, role: str, text: str) -> None:
+        """Append transcript text, merging with the last same-role entry.
+
+        The Live API sends ``outputTranscription`` (and sometimes
+        ``inputTranscription``) word-by-word.  Without coalescing,
+        a single sentence produces ~80 separate context entries.
+        This merges consecutive same-role fragments into one entry.
+        """
+        if self._context and self._context[-1].get("role") == role:
+            last_parts = self._context[-1].get("parts", [])
+            if last_parts and "text" in last_parts[-1]:
+                last_parts[-1]["text"] += text
+                return
+        self._context.append({"role": role, "parts": [{"text": text}]})
 
     def _flush_final_context(self) -> None:
         """Emit a final sendRequest to capture any pending context.

--- a/packages/bees/bees/subagent_scope.py
+++ b/packages/bees/bees/subagent_scope.py
@@ -101,7 +101,7 @@ class SubagentScope:
             "Your current working directory is the root of the workspace.\n"
             f"You are assigned to work in the subdirectory: ./{self.slug_path}\n"
             f"CRITICAL: You must prefix all file paths with {self.slug_path}/ "
-            "when creating or writing files (e.g., using system_write_file or "
+            "when creating or writing files (e.g., using files_write_file or "
             "redirection in bash). Writes to the root directory or other "
             "directories will fail.\n"
             "You can read files from anywhere in the workspace.\n"

--- a/packages/bees/docs/architecture.md
+++ b/packages/bees/docs/architecture.md
@@ -117,13 +117,13 @@ The built-in functions are:
 | -------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `system`       | `system.*`       | Termination: `system_objective_fulfilled`, `system_failed_to_fulfill_objective`.                                                                                 |
 | `chat`         | `chat.*`         | Resume/suspend: `chat_request_user_input`, `chat_present_choices`, `chat_await_context_update`.                                                                  |
-| `simple-files` | `simple-files.*` | File I/O: `system_write_text_to_file`, `system_list_files`, `system_read_text_from_file`.                                                                        |
+| `files` | `files.*` | File I/O: `files_write_file`, `files_list_files`, `files_read_text_from_file`.                                                                        |
 | `sandbox`      | `sandbox.*`      | `execute_bash` - Sandboxed bash execution in the task's working directory                                                                                        |
 | `generate`     | `generate.*`     | Multimodal content generation and search grounding `generate_text`, `generate_images`, `generate_video`, `generate_speech_from_text`, `generate_music_from_text` |
 
 #### The file system
 
-Each session has its own file system. The `simple-files.*` functions allow the
+Each session has its own file system. The `files.*` functions allow the
 agent to read and write files in the session's working directory. It is
 implemented as a VFS (Virtual File System) that can be backed by different
 storage mechanisms. Currently, the file system is backed by the disk, but it can
@@ -153,9 +153,9 @@ expected to run to completion without human intervention.
 | Configuration                                 | Example                                                                                             |
 | --------------------------------------------- | --------------------------------------------------------------------------------------------------- |
 | `chat.*`                                      | A typical conversational chat bot with no additional capabilities                                   |
-| `system.*`, `simple-files.*`                  | Context window compaction subagent: reads current context logs then summarizes them                 |
-| `system.*`, `generate.text`, `simple-files.*` | A researcher that uses search grounding capabilities of `generate_text` functions to write a report |
-| `chat.*`, `sandbox.*`, `simple-files.*`       | A conversational coding agent                                                                       |
+| `system.*`, `files.*`                  | Context window compaction subagent: reads current context logs then summarizes them                 |
+| `system.*`, `generate.text`, `files.*` | A researcher that uses search grounding capabilities of `generate_text` functions to write a report |
+| `chat.*`, `sandbox.*`, `files.*`       | A conversational coding agent                                                                       |
 
 ---
 
@@ -272,13 +272,13 @@ Here's the full table of all templates:
 
 | Template             | Skills           | Functions                                             | Can create                                                             | Effect                                                                                                                                                                                                                |
 | -------------------- | ---------------- | ----------------------------------------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `assistant`          | `persona`        | `simple-files.*`, `tasks.*`, `chat.*`                 | `journey-manager`, `knowledge`                                         | A conversational executive assistant. Chats with users, delegates all real work to the `journey-manager` sub-agent. Never does complex work itself to keep the conversation open. Auto-starts a `knowledge` gatherer. |
-| `journey-manager`    | `interview-user` | `simple-files.*`, `tasks.*`, `chat.*`                 | `researcher`, `ui-generator`, `journey-designer`, `digest-tile-writer` | A project manager. Interviews the user, then orchestrates a pipeline of research → design → build → iterate. Uses the same "delegate to keep the conversation open" pattern as `assistant`.                           |
-| `researcher`         | —                | `system.*`, `simple-files.*`, `generate.text`         | —                                                                      | A headless worker. Uses search grounding to research a topic, writes findings to files, terminates.                                                                                                                   |
+| `assistant`          | `persona`        | `files.*`, `tasks.*`, `chat.*`                 | `journey-manager`, `knowledge`                                         | A conversational executive assistant. Chats with users, delegates all real work to the `journey-manager` sub-agent. Never does complex work itself to keep the conversation open. Auto-starts a `knowledge` gatherer. |
+| `journey-manager`    | `interview-user` | `files.*`, `tasks.*`, `chat.*`                 | `researcher`, `ui-generator`, `journey-designer`, `digest-tile-writer` | A project manager. Interviews the user, then orchestrates a pipeline of research → design → build → iterate. Uses the same "delegate to keep the conversation open" pattern as `assistant`.                           |
+| `researcher`         | —                | `system.*`, `files.*`, `generate.text`         | —                                                                      | A headless worker. Uses search grounding to research a topic, writes findings to files, terminates.                                                                                                                   |
 | `journey-designer`   | `app-architect`  | `system.*`                                            | —                                                                      | A headless worker. Reads a skill for the spec, produces a `journey.json` blueprint, terminates. No file I/O beyond what the skill provides.                                                                           |
-| `ui-generator`       | `ui-generator`   | `sandbox.*`, `simple-files.*`, `events.*`, `system.*` | —                                                                      | A headless worker. Reads journey specs, generates React components, runs a bundler via sandbox, broadcasts an `app_update` event when done.                                                                           |
-| `knowledge`          | —                | `chat.await_context_update`, `simple-files.*`         | —                                                                      | An infinite observer. Watches for `digest_ready` events, reads the shared filesystem, synthesizes knowledge files. Never terminates — `chat.await_context_update` without `system.*`.                                 |
-| `digest-tile-writer` | —                | `system.*`, `events.*`, `simple-files.*`              | —                                                                      | Fire-and-forget headless worker. Writes a digest JSON, broadcasts `digest_ready`, terminates.                                                                                                                         |
+| `ui-generator`       | `ui-generator`   | `sandbox.*`, `files.*`, `events.*`, `system.*` | —                                                                      | A headless worker. Reads journey specs, generates React components, runs a bundler via sandbox, broadcasts an `app_update` event when done.                                                                           |
+| `knowledge`          | —                | `chat.await_context_update`, `files.*`         | —                                                                      | An infinite observer. Watches for `digest_ready` events, reads the shared filesystem, synthesizes knowledge files. Never terminates — `chat.await_context_update` without `system.*`.                                 |
+| `digest-tile-writer` | —                | `system.*`, `events.*`, `files.*`              | —                                                                      | Fire-and-forget headless worker. Writes a digest JSON, broadcasts `digest_ready`, terminates.                                                                                                                         |
 
 ### Scheduler built-in functions
 

--- a/packages/bees/docs/delegated-sessions.md
+++ b/packages/bees/docs/delegated-sessions.md
@@ -60,7 +60,7 @@ A template opts into delegated execution via `session_type`:
   skills:
     - persona
   functions:
-    - simple-files.*
+    - files.*
     - tasks.*
 ```
 

--- a/packages/bees/docs/future.md
+++ b/packages/bees/docs/future.md
@@ -47,7 +47,7 @@ Bees-native copies of `FunctionGroup`, `FunctionDefinition`, `SessionHooks`,
 `load_declarations`, and `assemble_function_group` live in
 `bees/protocols/functions.py`. All 8 function modules now import from
 `bees.protocols` instead of `opal_backend.function_definition`. Remaining
-`opal_backend` imports in `chat.py`, `simple_files.py`, and `system.py` are
+`opal_backend` imports in `chat.py`, `files.py`, and `system.py` are
 handler-level (`_make_handlers`) — a separate spec.
 
 **FileSystem types** ([spec](../spec/filesystem.md)) — ✅ complete. Bees-native
@@ -70,7 +70,7 @@ use for suspend/resume, session termination, and context injection.
 
 **Handler bodies** ([spec](../spec/handler-bodies.md)) — ✅ complete. Handler
 logic from `opal_backend.functions.{chat,system}._make_handlers` is inlined into
-bees' three function modules (`system.py`, `chat.py`, `simple_files.py`). All
+bees' three function modules (`system.py`, `chat.py`, `files.py`). All
 imports come from `bees.protocols` and `bees.pidgin`. Task tree management
 (`TaskTreeManager`, `set_in_progress` calls) stays in opal_backend — it's not a
 bees concern. The `bees/functions/` directory has **zero** `opal_backend`

--- a/packages/bees/docs/package-split.md
+++ b/packages/bees/docs/package-split.md
@@ -52,7 +52,7 @@ The functions in `bees/functions/` are framework capabilities:
 | `skills.py`       | Load skill instructions    | No               |
 | `chat.py`         | Conversation control       | No               |
 | `system.py`       | Workspace file operations  | No               |
-| `simple_files.py` | File I/O                   | No               |
+| `files.py` | File I/O                   | No               |
 | `mcp_bridge.py`   | MCP server forwarding      | No               |
 | `sandbox.py`      | Sandboxed code execution   | No               |
 
@@ -281,7 +281,7 @@ All 8 function modules import `opal_backend.function_definition` for:
 - `FunctionGroup`, `FunctionGroupFactory`, `SessionHooks` (types)
 - `assemble_function_group`, `load_declarations` (assembly utilities)
 
-Additionally, `chat.py` and `simple_files.py` import `_make_handlers` from
+Additionally, `chat.py` and `files.py` import `_make_handlers` from
 `opal_backend.functions.*` — these delegate to `opal_backend`'s built-in
 handlers for file I/O and chat.
 
@@ -301,7 +301,7 @@ bees-native `FileSystem` protocol that mirrors the shape.
 the split, bees manages MCP connections as framework infrastructure (since
 `mcp_bridge.py` stays in bees). The runner doesn't need to know about MCP.
 
-**`_make_handlers` delegation.** `chat.py` and `simple_files.py` import handler
+**`_make_handlers` delegation.** `chat.py` and `files.py` import handler
 factories from `opal_backend.functions.*`. These need to either move into bees
 (if the logic is framework-level) or be injected by the runner (if they're
 provider-specific). Needs investigation.

--- a/packages/bees/docs/patterns.md
+++ b/packages/bees/docs/patterns.md
@@ -236,7 +236,7 @@ agent to fulfill, persisted as a directory on disk.
 | `title`        | string   | no       | Human-readable title shown in UI and task type listings.                                                                                                                      |
 | `description`  | string   | no       | Short summary shown in task type listings.                                                                                                                                    |
 | `objective`    | string   | no       | The agent's instructions (natural-language prompt). Supports `{{system.context}}` and `{{system.ticket_id}}` interpolation.                                                   |
-| `functions`    | string[] | no       | Function filter globs controlling which tools the agent can use. Empty/omitted = all functions available. Examples: `"simple-files.*"`, `"tasks.*"`, `"system.*"`.            |
+| `functions`    | string[] | no       | Function filter globs controlling which tools the agent can use. Empty/omitted = all functions available. Examples: `"files.*"`, `"tasks.*"`, `"system.*"`.            |
 | `skills`       | string[] | no       | Names of skill directories to load into the session. Each name must match a subdirectory of `hive/skills/`.                                                                   |
 | `tags`         | string[] | no       | Metadata tags for UI routing, lifecycle hooks, and filtering. Special tags: `"chat"` enables persistent chat history; `"bundle"` marks templates that produce bundled output. |
 | `model`        | string   | no       | Override the default model (e.g., `"gemini-3.1-pro-preview"`).                                                                                                                |
@@ -256,7 +256,7 @@ Template objectives support placeholder interpolation:
 
 The `functions` field uses glob patterns to filter which tools are available:
 
-- `"simple-files.*"` — all functions in the `simple-files` group.
+- `"files.*"` — all functions in the `files` group.
 - `"system.*"` — all system functions (terminate, context access).
 - `"tasks.*"` — task delegation functions.
 - `"chat.*"` — chat functions (request user input, await context updates).
@@ -281,5 +281,5 @@ Omitting `functions` entirely grants access to all available functions.
     research-data.json or research-notes.md.
 
     Return the relative path of the file with research.
-  functions: ["system.*", "sandbox.*", "simple-files.*", "generate.text"]
+  functions: ["system.*", "sandbox.*", "files.*", "generate.text"]
 ```

--- a/packages/bees/docs/session.md
+++ b/packages/bees/docs/session.md
@@ -103,7 +103,7 @@ The bees function groups:
 | Group          | Filter prefix    | Purpose                                                                                                                  |
 | -------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `system`       | `system.*`       | Termination: `system_objective_fulfilled`, `system_failed_to_fulfill_objective`.                                         |
-| `simple-files` | `simple-files.*` | File I/O: `system_write_file`, `system_list_files`, `system_read_text_from_file`.                                        |
+| `files` | `files.*` | File I/O: `files_write_file`, `files_list_files`, `files_read_text_from_file`.                                        |
 | `sandbox`      | `sandbox.*`      | Sandboxed bash execution in the task's working directory.                                                                |
 | `chat`         | `chat.*`         | User interaction: `chat_request_user_input`, `chat_present_choices`, `chat_await_context_update`.                        |
 | `events`       | `events.*`       | Cross-agent communication: `events_broadcast`, `events_send_to_parent`.                                                  |
@@ -114,7 +114,7 @@ The bees function groups:
 
 Template authors control what an agent can do by specifying `functions` globs on
 the template and `allowed-tools` in skill frontmatter. Both are lists of filter
-prefixes (e.g. `["system.*", "simple-files.*"]`). The session merges them at
+prefixes (e.g. `["system.*", "files.*"]`). The session merges them at
 construction time:
 
 ```python
@@ -143,7 +143,7 @@ Key characteristics:
 - **Binary support**: images and other binary files are base64-encoded for the
   model and written as raw bytes to disk.
 - **Skill seeding**: skill directories are written to the file system at session
-  start so the agent can read them via `system_read_text_from_file`.
+  start so the agent can read them via `files_read_text_from_file`.
 
 ## Context window
 

--- a/packages/bees/hive/config/TEMPLATES.yaml
+++ b/packages/bees/hive/config/TEMPLATES.yaml
@@ -19,7 +19,7 @@
     - opie
     - chat
   functions:
-    - simple-files.*
+    - files.*
     - tasks.*
   tasks:
     - journey-manager
@@ -94,7 +94,7 @@
     - Each subagent working on a task gets a clean LLM context. Be explicit in
     your task assignments. They know nothing about prior conversation.
   functions:
-    - simple-files.*
+    - files.*
     - tasks.*
   skills:
     - interview-user
@@ -209,7 +209,7 @@
     - type: digest_ready
   functions:
     - chat.await_context_update
-    - simple-files.*
+    - files.*
 
 - name: researcher
   title: Researcher
@@ -231,7 +231,7 @@
   functions:
     - system.*
     - sandbox.*
-    - simple-files.*
+    - files.*
     - generate.text
   tags:
     - worker
@@ -330,7 +330,7 @@
   functions:
     - system.*
     - events.*
-    - simple-files.*
+    - files.*
 
 - name: live-session
   runner: live
@@ -338,6 +338,6 @@
   description: A simple live session.
   functions:
     - live.*
-    - simple-files.*
+    - files.*
   objective:
     List files and tell the user if there are any. Otherwise, say "no files"

--- a/packages/bees/hive/skills/app-architect/SKILL.md
+++ b/packages/bees/hive/skills/app-architect/SKILL.md
@@ -6,7 +6,7 @@ description:
   mini-app. Segments are separated by LLM decision points where the orchestrator
   decides what comes next.
 allowed-tools:
-  - simple-files.*
+  - files.*
 ---
 
 # App Architect

--- a/packages/bees/hive/skills/ui-generator/SKILL.md
+++ b/packages/bees/hive/skills/ui-generator/SKILL.md
@@ -6,7 +6,7 @@ description:
   language descriptions.
 allowed-tools:
   - sandbox.*
-  - simple-files.*
+  - files.*
   - events.*
   - system.*
 ---
@@ -77,7 +77,7 @@ pipeline.
 
 You MUST save all generated files to the real filesystem in your working
 directory (`$HOME`) by using the `execute_bash` tool. **Do NOT use
-`system_write_file`**, because it writes to a virtual filesystem that the
+`files_write_file`**, because it writes to a virtual filesystem that the
 bundler cannot access.
 
 **CRITICAL STYLING RULES: NO TAILWIND!**
@@ -125,7 +125,7 @@ previous runs. Each subdirectory is a previous run, containing its `App.jsx` and
 
 **Reuse workflow:**
 
-1. Use `system_read_text_from_file` to list `library/` and browse available
+1. Use `files_read_text_from_file` to list `library/` and browse available
    components.
 2. If a component matches what you need (e.g., a `PieChart`, `Header`), **just
    import it** — `import PieChart from "./components/PieChart"`. You do NOT need
@@ -409,7 +409,7 @@ export default function SelectModels({ data = {}, onTransition }) {
   optimized `bundle.js` and `bundle.css` in your working directory, ready for
   the iframe to render.
 - Do NOT use hallucinated tools like `generate_and_execute_code` or
-  `system_write_file`. Ensure all operations happen on the real filesystem via
+  `files_write_file`. Ensure all operations happen on the real filesystem via
   `execute_bash`.
 
 ## Available Globals

--- a/packages/bees/spec/filesystem.md
+++ b/packages/bees/spec/filesystem.md
@@ -165,7 +165,7 @@ The broader `opal_backend` import inventory in `bees/` becomes:
 - `box.py` — `HttpBackendClient` + app config
 - `functions/chat.py` — `_make_handlers`, `CONTEXT_PARTS_KEY`,
   `ChatEntryCallback`, `SuspendError`
-- `functions/simple_files.py` — `_make_handlers`
+- `functions/files.py` — `_make_handlers`
 - `functions/system.py` — `_make_handlers`
 
 ### Follow-up: tighten `SessionHooks.file_system`

--- a/packages/bees/spec/function-types.md
+++ b/packages/bees/spec/function-types.md
@@ -33,7 +33,7 @@ is a separate spec (see inventory).
 
 ### `_make_handlers` delegation is out of scope
 
-`chat.py`, `simple_files.py`, and `system.py` import `_make_handlers` from
+`chat.py`, `files.py`, and `system.py` import `_make_handlers` from
 `opal_backend.functions.*`. These are handler factories that delegate to
 opal-owned implementations (file I/O helpers, chat control). They're a separate
 concern — either the logic migrates into bees (if framework-level) or gets
@@ -134,7 +134,7 @@ After this migration, the following `opal_backend` imports will remain in
 
 - `chat.py`: `CONTEXT_PARTS_KEY`, `_make_handlers`, `ChatEntryCallback`,
   `SuspendError`
-- `simple_files.py`: `_make_handlers`
+- `files.py`: `_make_handlers`
 - `system.py`: `_make_handlers`
 
 These are a separate migration covered by a future spec.

--- a/packages/bees/spec/handler-bodies.md
+++ b/packages/bees/spec/handler-bodies.md
@@ -9,7 +9,7 @@ the function layer.
 Three bees function modules delegate handler construction to opal_backend:
 
 ```python
-# system.py, simple_files.py
+# system.py, files.py
 from opal_backend.functions.system import _make_handlers
 
 # chat.py
@@ -35,11 +35,11 @@ opal_backend concern. Bees does not need it. Concretely:
 - `SessionHooks.task_tree_manager` remains in the protocol for now (opal still
   passes it), but no bees handler references it.
 
-### File operations come from the system module, not simple_files
+### File operations come from the system module, not files
 
-The upstream `simple_files.py` calls the _system_ module's `_make_handlers` for
-its file operation handlers (`system_write_file`, `system_read_text_from_file`,
-`system_list_files`). Bees inlines these directly — no intermediate delegation.
+The upstream `files.py` calls the _system_ module's `_make_handlers` for
+its file operation handlers (`files_write_file`, `files_read_text_from_file`,
+`files_list_files`). Bees inlines these directly — no intermediate delegation.
 
 ### Handler signatures are preserved
 
@@ -64,7 +64,7 @@ private implementation details, not protocol types.
 | ------------------ | ----------------- | ---------------------------------------------------------------------- | ----------- |
 | System termination | `system.py`       | `system_objective_fulfilled`, `system_failed_to_fulfill_objective`     | ✅ Complete |
 | Chat suspend       | `chat.py`         | `chat_request_user_input`, `chat_present_choices`                      | ✅ Complete |
-| File operations    | `simple_files.py` | `system_write_file`, `system_read_text_from_file`, `system_list_files` | ✅ Complete |
+| File operations    | `files.py` | `files_write_file`, `files_read_text_from_file`, `files_list_files` | ✅ Complete |
 
 ## Handler Sketches
 
@@ -132,7 +132,7 @@ Constants to copy:
 - `VALID_INPUT_TYPES`, `VALID_SELECTION_MODES`, `VALID_LAYOUTS`
 - `_INPUT_TYPE_TO_FORMAT` (input type → icon mapping)
 
-### File operation handlers (`simple_files.py`)
+### File operation handlers (`files.py`)
 
 Source: `opal_backend/functions/system.py` L154–197 (the file subset).
 
@@ -141,21 +141,21 @@ Dependencies (all bees-native):
 - `bees.protocols.filesystem.FileSystem` (via `hooks.file_system`)
 - `bees.pidgin.from_pidgin_string`
 
-`system_list_files`:
+`files_list_files`:
 
 - Calls `file_system.list_files()`
 
-`system_write_file`:
+`files_write_file`:
 
 - Resolves pidgin in content via `from_pidgin_string`
 - Extracts text parts from resolved content
 - Calls `file_system.write(file_name, resolved_content)`
 
-`system_read_text_from_file`:
+`files_read_text_from_file`:
 
 - Calls `file_system.read_text(file_path)`
 
-Note: bees already has a local `_make_list_dir_handler` in `simple_files.py`.
+Note: bees already has a local `_make_list_dir_handler` in `files.py`.
 This is additive — the inlined opal handlers sit alongside it.
 
 ## Migration Notes
@@ -163,7 +163,7 @@ This is additive — the inlined opal handlers sit alongside it.
 ### Execution order
 
 Start with `system.py` — fewest handlers, simplest logic, proves the pattern.
-Then `chat.py` — adds suspend/resume complexity. Then `simple_files.py` — the
+Then `chat.py` — adds suspend/resume complexity. Then `files.py` — the
 file operations.
 
 ### What changes in each file

--- a/packages/bees/spec/handler-types.md
+++ b/packages/bees/spec/handler-types.md
@@ -7,7 +7,7 @@ injection — so that handler bodies can eventually be inlined without any
 
 ## Context
 
-Three bees function modules (`chat.py`, `simple_files.py`, `system.py`) delegate
+Three bees function modules (`chat.py`, `files.py`, `system.py`) delegate
 to `opal_backend`'s `_make_handlers`. Those handler factories use internal
 types: `SuspendError`, suspend event dataclasses, `AgentResult`,
 `LoopController`, `CONTEXT_PARTS_KEY`, and `ChatEntryCallback`.

--- a/packages/bees/spec/pidgin.md
+++ b/packages/bees/spec/pidgin.md
@@ -13,7 +13,7 @@ markup in its outputs (e.g. referencing a file it created), and function
 handlers call `from_pidgin_string` to resolve those tags back to data parts from
 the file system.
 
-Today, three bees function modules (`chat.py`, `system.py`, `simple_files.py`)
+Today, three bees function modules (`chat.py`, `system.py`, `files.py`)
 delegate to `opal_backend`'s `_make_handlers`, which internally calls
 `from_pidgin_string`. To eventually inline those handler bodies into bees
 (eliminating the `_make_handlers` imports), bees needs its own pidgin

--- a/packages/bees/spec/session-configuration.md
+++ b/packages/bees/spec/session-configuration.md
@@ -30,7 +30,7 @@ Tracing `run_session()`, the provisioning steps are:
    `merge_function_filter`).
 3. Create `DiskFileSystem` backed by `fs_dir` or `ticket_dir/filesystem`.
 4. Seed skill files into the file system.
-5. Assemble function group factories (system, simple_files, skills, sandbox,
+5. Assemble function group factories (system, files, skills, sandbox,
    events, tasks, chat) plus MCP factories.
 6. Resolve the model name and log path.
 

--- a/packages/bees/tests/test_files.py
+++ b/packages/bees/tests/test_files.py
@@ -1,7 +1,7 @@
 # Copyright 2026 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for system_list_dir in the simple-files function group."""
+"""Tests for files_list_dir in the files function group."""
 
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from bees.functions.simple_files import _make_list_dir_handler
+from bees.functions.files import _make_list_dir_handler
 
 
 @pytest.fixture

--- a/packages/bees/tests/test_live_runner.py
+++ b/packages/bees/tests/test_live_runner.py
@@ -216,7 +216,7 @@ def test_extract_declarations_filters_instructions():
         instruction="System instruction",
     )
     files_factory = _make_test_factory(
-        "simple-files",
+        "files",
         [{"name": "files_list", "description": "list"}],
         instruction="Files instruction",
     )
@@ -670,6 +670,56 @@ async def test_live_stream_output_transcript(temp_dir):
     assert len(body["contents"]) == 1
     assert body["contents"][0]["role"] == "model"
     assert body["contents"][0]["parts"][0]["text"] == "You have zero files."
+
+
+@pytest.mark.asyncio
+async def test_live_stream_coalesces_output_transcript(temp_dir):
+    """Consecutive outputTranscript fragments merge into one context entry."""
+    events_dir = temp_dir / LIVE_EVENTS_DIR
+    events_dir.mkdir()
+
+    # Simulate word-by-word transcription from the Live API.
+    _write_event(events_dir, 0, {"type": "outputTranscript", "text": "You "})
+    _write_event(events_dir, 1, {"type": "outputTranscript", "text": "have "})
+    _write_event(events_dir, 2, {"type": "outputTranscript", "text": "zero "})
+    _write_event(events_dir, 3, {"type": "outputTranscript", "text": "files."})
+    _write_event(events_dir, 4, {"type": "sessionEnd", "status": "completed"})
+
+    stream = LiveStream(temp_dir, poll_interval=0.05)
+    events = []
+    async for event in stream:
+        events.append(event)
+
+    body = events[0]["sendRequest"]["body"]
+    # All four fragments coalesce into a single model entry.
+    assert len(body["contents"]) == 1
+    assert body["contents"][0]["role"] == "model"
+    assert body["contents"][0]["parts"][0]["text"] == "You have zero files."
+
+
+@pytest.mark.asyncio
+async def test_live_stream_coalesces_input_transcript(temp_dir):
+    """Consecutive inputTranscript fragments merge into one context entry."""
+    events_dir = temp_dir / LIVE_EVENTS_DIR
+    events_dir.mkdir()
+
+    _write_event(events_dir, 0, {"type": "inputTranscript", "text": "List "})
+    _write_event(events_dir, 1, {"type": "inputTranscript", "text": "my files."})
+    _write_event(events_dir, 2, {"type": "outputTranscript", "text": "Sure!"})
+    _write_event(events_dir, 3, {"type": "sessionEnd", "status": "completed"})
+
+    stream = LiveStream(temp_dir, poll_interval=0.05)
+    events = []
+    async for event in stream:
+        events.append(event)
+
+    body = events[0]["sendRequest"]["body"]
+    # Input fragments coalesce, then a new entry for the model role.
+    assert len(body["contents"]) == 2
+    assert body["contents"][0]["role"] == "user"
+    assert body["contents"][0]["parts"][0]["text"] == "List my files."
+    assert body["contents"][1]["role"] == "model"
+    assert body["contents"][1]["parts"][0]["text"] == "Sure!"
 
 
 @pytest.mark.asyncio

--- a/packages/bees/tests/test_sandbox.py
+++ b/packages/bees/tests/test_sandbox.py
@@ -57,13 +57,13 @@ async def test_sandbox_restricts_writes_to_slug(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_simple_files_restricts_writes_to_slug():
-    from bees.functions.simple_files import get_simple_files_function_group_factory
+async def test_files_restricts_writes_to_slug():
+    from bees.functions.files import get_files_function_group_factory
     from unittest.mock import MagicMock
     
     slug = "my-slug"
     scope = SubagentScope(workspace_root_id="r", slug_path=slug)
-    factory = get_simple_files_function_group_factory(scope=scope)
+    factory = get_files_function_group_factory(scope=scope)
     
     mock_hooks = MagicMock()
     mock_hooks.file_system = MagicMock()
@@ -71,10 +71,10 @@ async def test_simple_files_restricts_writes_to_slug():
     
     fg = factory(mock_hooks)
     
-    # Find system_write_file handler
+    # Find files_write_file handler
     write_handler = None
     for name, defn in fg.definitions:
-        if name == "system_write_file":
+        if name == "files_write_file":
             write_handler = defn.handler
             break
             

--- a/packages/bees/tests/test_session_filter.py
+++ b/packages/bees/tests/test_session_filter.py
@@ -13,12 +13,12 @@ class TestMergeFunctionFilter:
     def test_template_filter_plus_skill_tools(self):
         """Template functions + skill allowed-tools → union of both."""
         result = merge_function_filter(
-            function_filter=["simple-files.*", "tasks.*"],
+            function_filter=["files.*", "tasks.*"],
             skill_tools=["sandbox.*", "events.*"],
             allowed_skills=["ui-generator"],
         )
         assert result == [
-            "simple-files.*", "tasks.*", "sandbox.*", "events.*", "skills.*",
+            "files.*", "tasks.*", "sandbox.*", "events.*", "skills.*",
         ]
 
     def test_no_template_filter_with_skill_tools(self):
@@ -29,13 +29,13 @@ class TestMergeFunctionFilter:
         """
         result = merge_function_filter(
             function_filter=None,
-            skill_tools=["sandbox.*", "simple-files.*", "events.*", "system.*"],
+            skill_tools=["sandbox.*", "files.*", "events.*", "system.*"],
             allowed_skills=["ui-generator"],
         )
         assert result is not None, "Must not be None — would allow all functions"
         assert "skills.*" in result
         assert "sandbox.*" in result
-        assert "simple-files.*" in result
+        assert "files.*" in result
 
     def test_no_skills_no_filter_stays_none(self):
         """No skills, no filter → None (allow everything)."""


### PR DESCRIPTION
## What

Renames the `simple-files` function group to `files` (with `system_*` → `files_*` function names) and adds transcript fragment coalescing to `LiveStream`.

## Why

Two remaining Phase 7 items. The `simple-files.*` filter pattern couldn't match file functions because they were prefixed `system_` — renaming to `files_*` aligns the function prefix with the group name, making `files.*` work naturally. Separately, the Live API sends `outputTranscription` word-by-word, inflating context with ~80 entries per sentence — coalescing merges consecutive same-role fragments into one entry.

## Changes

### Rename `simple-files` → `files` (`system_*` → `files_*`)
- **Declarations:** renamed `simple-files.{functions,instruction,metadata}.json` → `files.*`, updated all function names
- **Module:** renamed `simple_files.py` → `files.py`, `test_simple_files.py` → `test_files.py`
- **Factory:** `get_simple_files_function_group_factory` → `get_files_function_group_factory`
- **Cross-cutting:** updated provisioner, mcp_bridge, subagent_scope, sandbox instruction, TEMPLATES.yaml (6 globs), skill frontmatter (ui-generator, app-architect)
- **Tests:** updated test_sandbox, test_session_filter, test_live_runner
- **Docs/specs:** updated 11 doc/spec files

### Transcript coalescing
- Added `LiveStream._coalesce_transcript()` — merges consecutive same-role `inputTranscript`/`outputTranscript` events into a single context entry
- Added tests for output coalescing (4 fragments → 1 entry) and input coalescing with role boundary

## Testing

```bash
cd packages/bees && .venv/bin/python -m pytest tests/ -x -q
```

62 tests pass. Manually verified live session with `files.*` filter — file tools dispatch correctly with new names.
