### PR TITLE
[bees] Live session UX polish — push-to-talk, voice selection, and bug fixes

### DIFF
--- a/packages/bees/bees/playbook.py
+++ b/packages/bees/bees/playbook.py
@@ -151,6 +151,7 @@ def run_playbook(
         context=context,
         slug=slug,
         runner=data.get("runner", "generate"),
+        voice=data.get("voice"),
     )
 
     # Autostart: stamp child tasks declared in the template.

--- a/packages/bees/bees/protocols/session.py
+++ b/packages/bees/bees/protocols/session.py
@@ -170,6 +170,9 @@ class SessionConfiguration:
        ``ObservationConfig`` in a future spec.
     """
 
+    voice: str | None = None
+    """Prebuilt voice name for Live API audio output (e.g. ``'Kore'``)."""
+
 
 # ---------------------------------------------------------------------------
 # Session stream

--- a/packages/bees/bees/provisioner.py
+++ b/packages/bees/bees/provisioner.py
@@ -53,6 +53,7 @@ def provision_session(
     mcp_factories: list | None = None,
     on_chat_entry: Callable[[str, str], None] | None = None,
     seed_files: bool = True,
+    voice: str | None = None,
 ) -> SessionConfiguration:
     """Assemble everything a session runner needs from task parameters.
 
@@ -162,4 +163,5 @@ def provision_session(
         label=label,
         log_path=log_path,
         on_chat_entry=on_chat_entry,
+        voice=voice,
     )

--- a/packages/bees/bees/runners/live.py
+++ b/packages/bees/bees/runners/live.py
@@ -219,13 +219,25 @@ def _assemble_system_instruction(
     segments: list[dict[str, Any]],
     tool_instruction: str,
 ) -> str:
-    """Combine provisioned segments and tool instructions into one string."""
+    """Combine provisioned segments and tool instructions into one string.
+
+    Handles two segment formats:
+    - ``{"parts": [{"text": "..."}]}`` — the parts-based format.
+    - ``{"type": "text", "text": "..."}`` — from ``resolve_segments``.
+    """
     parts: list[str] = []
 
     for segment in segments:
+        # Parts-based format (e.g. from function groups).
         segment_parts = segment.get("parts", [])
         for part in segment_parts:
             text = part.get("text")
+            if text:
+                parts.append(text)
+
+        # Direct text format (from resolve_segments).
+        if not segment_parts:
+            text = segment.get("text")
             if text:
                 parts.append(text)
 
@@ -286,6 +298,8 @@ def _build_bundle(
     """Assemble the session bundle from provisioned configuration."""
     model = config.model or DEFAULT_MODEL
 
+    voice = config.voice or "Kore"
+
     setup: dict[str, Any] = {
         "model": model,
         "generationConfig": {
@@ -293,7 +307,7 @@ def _build_bundle(
             "speechConfig": {
                 "voiceConfig": {
                     "prebuiltVoiceConfig": {
-                        "voiceName": "Kore",
+                        "voiceName": voice,
                     },
                 },
             },
@@ -307,6 +321,21 @@ def _build_bundle(
         # { text: string } payloads.
         "inputAudioTranscription": {},
         "outputAudioTranscription": {},
+        # VAD tuning for tool-calling sessions: lower sensitivity and
+        # longer silence threshold to avoid cutting off users mid-thought
+        # before a tool call.  The client sends audioStreamEnd when the
+        # user releases the Talk button.
+        "realtimeInputConfig": {
+            "automaticActivityDetection": {
+                "startOfSpeechSensitivity": "START_SENSITIVITY_LOW",
+                "endOfSpeechSensitivity": "END_SENSITIVITY_LOW",
+                "silenceDurationMs": 500,
+            },
+        },
+        # Proactive audio — model can choose to stay silent when input
+        # is not directed at it.  This is a standard BidiGenerateContentSetup
+        # field that requires v1alpha (which we already use).
+        "proactivity": {"proactiveAudio": True},
     }
 
     if declarations:

--- a/packages/bees/bees/task_runner.py
+++ b/packages/bees/bees/task_runner.py
@@ -113,6 +113,7 @@ class TaskRunner:
                 on_chat_entry=lambda role, text: append_chat_log(
                     task.dir, role, text,
                 ),
+                voice=task.metadata.voice,
             )
 
             stream = await self._runner_for(task).run(config)
@@ -236,6 +237,7 @@ class TaskRunner:
                     task.dir, role, text,
                 ),
                 seed_files=False,  # Files already on disk from previous run.
+                voice=task.metadata.voice,
             )
 
             stream = await self._runner_for(task).resume(

--- a/packages/bees/bees/task_store.py
+++ b/packages/bees/bees/task_store.py
@@ -126,6 +126,7 @@ class TaskStore:
         signal_type: str | None = None,
         slug: str | None = None,
         runner: RunnerType = "generate",
+        voice: str | None = None,
     ) -> Ticket:
         """Create a new task.
 
@@ -177,6 +178,7 @@ class TaskStore:
                 signal_type=signal_type,
                 slug=slug,
                 runner=runner,
+                voice=voice,
             ),
         )
         self.save(ticket)

--- a/packages/bees/bees/ticket.py
+++ b/packages/bees/bees/ticket.py
@@ -73,6 +73,9 @@ class TicketMetadata:
     runner: RunnerType = "generate"
     """Which session runner to use: ``generate`` (batch) or ``live`` (Gemini Live API)."""
 
+    voice: str | None = None
+    """Prebuilt voice name for Live API audio output (e.g. ``'Kore'``)."""
+
     def to_dict(self) -> dict[str, Any]:
         d = asdict(self)
         # Omit None fields for cleaner JSON.
@@ -115,6 +118,7 @@ class TicketMetadata:
             pending_context_updates=data.get("pending_context_updates"),
             paused_from=data.get("paused_from"),
             runner=data.get("runner", "generate"),
+            voice=data.get("voice"),
         )
 
 

--- a/packages/bees/common/types.ts
+++ b/packages/bees/common/types.ts
@@ -44,4 +44,5 @@ export interface TaskData {
   outcome_content?: Record<string, unknown>;
   files?: Array<{ path: string; mimeType: string; localPath: string }>;
   runner?: "generate" | "live";
+  voice?: string;
 }

--- a/packages/bees/hive/config/TEMPLATES.yaml
+++ b/packages/bees/hive/config/TEMPLATES.yaml
@@ -334,10 +334,14 @@
 
 - name: live-session
   runner: live
+  voice: Kore
   title: Live Session
   description: A simple live session.
   functions:
     - live.*
     - files.*
   objective:
-    List files and tell the user if there are any. Otherwise, say "no files"
+    Act as a translator. Detect the language from the first phrase the user
+    says. Then, when the user says something non-English, say it out loud in
+    English. When you hear the user say something in English, respond in the
+    detected language.

--- a/packages/bees/hivetool/src/data/audio-handler.ts
+++ b/packages/bees/hivetool/src/data/audio-handler.ts
@@ -49,19 +49,51 @@ function base64ToInt16(b64: string): Int16Array {
 /** Callback for each audio chunk ready to send over WebSocket. */
 type OnChunkCallback = (base64Pcm: string) => void;
 
+/** Called when the audio gate closes, signaling end of user speech. */
+type OnStreamEndCallback = () => void;
+
 class AudioInput {
   #context: AudioContext | null = null;
   #stream: MediaStream | null = null;
   #workletNode: AudioWorkletNode | null = null;
   #onChunk: OnChunkCallback;
+  #onStreamEnd: OnStreamEndCallback;
   #running = false;
 
-  constructor(onChunk: OnChunkCallback) {
+  /**
+   * When true (default), PCM chunks from the worklet are discarded.
+   * The mic capture stays running to avoid getUserMedia latency on
+   * each Talk press — we just gate whether chunks flow to the callback.
+   */
+  #gated = true;
+
+  constructor(onChunk: OnChunkCallback, onStreamEnd: OnStreamEndCallback) {
     this.#onChunk = onChunk;
+    this.#onStreamEnd = onStreamEnd;
   }
 
   get running(): boolean {
     return this.#running;
+  }
+
+  get gated(): boolean {
+    return this.#gated;
+  }
+
+  /** Open the gate — audio chunks start flowing to the callback. */
+  openGate(): void {
+    this.#gated = false;
+  }
+
+  /**
+   * Close the gate — audio chunks stop flowing.
+   * Fires the onStreamEnd callback so the caller can send audioStreamEnd.
+   */
+  closeGate(): void {
+    if (!this.#gated) {
+      this.#gated = true;
+      this.#onStreamEnd();
+    }
   }
 
   /** Start capturing microphone audio. */
@@ -97,6 +129,9 @@ class AudioInput {
     // Receive PCM chunks from the worklet thread.
     let chunkCount = 0;
     this.#workletNode.port.onmessage = (event: MessageEvent) => {
+      // Gate: discard chunks when the user isn't talking.
+      if (this.#gated) return;
+
       const pcm = event.data.pcm as Int16Array;
       if (pcm && pcm.length > 0) {
         chunkCount++;
@@ -127,6 +162,11 @@ class AudioInput {
   /** Stop capturing and release resources. */
   stop(): void {
     if (!this.#running) return;
+
+    // Close the gate if still open.
+    if (!this.#gated) {
+      this.#gated = true;
+    }
 
     this.#workletNode?.disconnect();
     this.#workletNode = null;

--- a/packages/bees/hivetool/src/data/live-session.ts
+++ b/packages/bees/hivetool/src/data/live-session.ts
@@ -52,6 +52,7 @@ interface ServerMessage {
       }>;
     };
     turnComplete?: boolean;
+    interrupted?: boolean;
   };
   toolCall?: {
     functionCalls: Array<{
@@ -59,6 +60,9 @@ interface ServerMessage {
       name: string;
       args: Record<string, unknown>;
     }>;
+  };
+  toolCallCancellation?: {
+    ids: string[];
   };
 }
 
@@ -74,7 +78,8 @@ class LiveSessionClient {
   readonly transcript = new Signal.State<string>("");
 
   /** Whether the microphone is currently active. */
-  readonly micActive = new Signal.State<boolean>(false);
+  /** Whether the user is currently holding the Talk button. */
+  readonly talking = new Signal.State<boolean>(false);
 
   /** The task ID this session belongs to. */
   readonly taskId: string;
@@ -191,7 +196,7 @@ class LiveSessionClient {
 
   /** Gracefully close the session. */
   disconnect(): void {
-    this.stopMic();
+    this.#stopMic();
     this.#audioOutput.dispose();
     this.#dispatchObserver?.disconnect();
     this.#dispatchObserver = null;
@@ -204,35 +209,65 @@ class LiveSessionClient {
     this.#ws = null;
   }
 
-  // ── Audio ──
+  // ── Push-to-Talk ──
 
-  /** Start capturing microphone audio and streaming to the Live API. */
-  async startMic(): Promise<void> {
-    if (this.#audioInput?.running) return;
+  /**
+   * Begin talking — opens the audio gate so mic chunks flow to the API.
+   *
+   * On first call, starts the mic capture (getUserMedia). The mic stays
+   * running across talk presses to avoid latency. Subsequent calls just
+   * open the gate.
+   */
+  async beginTalking(): Promise<void> {
     if (this.status.get() !== "connected") return;
 
-    this.#audioInput = new AudioInput((base64Pcm: string) => {
-      this.send({
-        realtimeInput: {
-          audio: {
-            data: base64Pcm,
-            mimeType: "audio/pcm;rate=16000",
-          },
+    // Lazily start the mic on the first Talk press.
+    if (!this.#audioInput) {
+      this.#audioInput = new AudioInput(
+        // onChunk — forward PCM to the WebSocket.
+        (base64Pcm: string) => {
+          this.send({
+            realtimeInput: {
+              audio: {
+                data: base64Pcm,
+                mimeType: "audio/pcm;rate=16000",
+              },
+            },
+          });
         },
-      });
-    });
+        // onStreamEnd — send audioStreamEnd when the gate closes.
+        () => {
+          this.send({ realtimeInput: { audioStreamEnd: true } });
+        },
+      );
+      await this.#audioInput.start();
+    }
 
-    await this.#audioInput.start();
-    this.micActive.set(true);
+    this.#audioInput.openGate();
+    this.talking.set(true);
   }
 
-  /** Stop microphone capture. */
-  stopMic(): void {
+  /**
+   * End talking — closes the audio gate.
+   *
+   * The mic stays running (no getUserMedia teardown). The audio gate
+   * close triggers an `audioStreamEnd` message to the API, flushing
+   * any cached audio in the server's VAD.
+   */
+  endTalking(): void {
+    if (this.#audioInput && !this.#audioInput.gated) {
+      this.#audioInput.closeGate();
+    }
+    this.talking.set(false);
+  }
+
+  /** Stop mic capture entirely and release the MediaStream. */
+  #stopMic(): void {
     if (this.#audioInput) {
       this.#audioInput.stop();
       this.#audioInput = null;
     }
-    this.micActive.set(false);
+    this.talking.set(false);
   }
 
   /** Send raw data over the WebSocket (for audio chunks, etc.). */
@@ -293,6 +328,16 @@ class LiveSessionClient {
           this.#audioOutput.play(part.inlineData.data);
         }
       }
+    }
+
+    // Interruption — the user spoke over the model.
+    // Flush the audio playback queue and discard the partial turn.
+    if (message.serverContent?.interrupted) {
+      console.log(
+        `[live:${this.taskId.slice(0, 8)}] Model interrupted`,
+      );
+      this.#audioOutput.flush();
+      this.#currentTurnParts = [];
     }
 
     // Turn complete — write event with accumulated model text parts.
@@ -357,6 +402,18 @@ class LiveSessionClient {
       });
       // Fire-and-forget — dispatches concurrently while audio continues.
       void this.#dispatchToolCalls(calls);
+    }
+
+    // Tool call cancellation — the server cancelled pending calls
+    // (typically because the user interrupted during tool execution).
+    if (message.toolCallCancellation) {
+      const ids = message.toolCallCancellation.ids;
+      console.log(
+        `[live:${this.taskId.slice(0, 8)}] Tool calls cancelled:`,
+        ids.join(", "),
+      );
+      // Already-dispatched calls may still complete on the Python side.
+      // We log the cancellation; best-effort is sufficient here.
     }
   }
 

--- a/packages/bees/hivetool/src/data/template-store.ts
+++ b/packages/bees/hivetool/src/data/template-store.ts
@@ -33,6 +33,7 @@ interface TemplateData {
   tasks?: string[];
   autostart?: string[];
   runner?: "generate" | "live";
+  voice?: string;
 }
 
 class TemplateStore {

--- a/packages/bees/hivetool/src/data/ticket-store.ts
+++ b/packages/bees/hivetool/src/data/ticket-store.ts
@@ -42,6 +42,15 @@ class TicketStore {
   /** Set of ticket IDs with active (unresolved) live session bundles. */
   readonly activeLiveSessions = new Signal.State<Set<string>>(new Set());
 
+  /**
+   * The single active live session connection.
+   *
+   * At most one WebSocket is open at a time.  The connection survives
+   * ticket selection changes — switching tickets in the sidebar does
+   * not tear it down.
+   */
+  readonly activeConnection = new Signal.State<LiveSessionClient | null>(null);
+
   #ticketsHandle: FileSystemDirectoryHandle | null = null;
   #observer: { disconnect(): void } | null = null;
   #activated = false;
@@ -118,6 +127,7 @@ class TicketStore {
     this.selectedTicketId.set(null);
     this.recentlyUpdatedTicket.set(null);
     this.activeLiveSessions.set(new Set());
+    this.disconnectLiveSession();
   }
 
   /** Clean up the observer. */
@@ -296,6 +306,57 @@ class TicketStore {
       return await this.#ticketsHandle.getDirectoryHandle(ticketId);
     } catch {
       return null;
+    }
+  }
+
+  // ── Live session connection management ──
+
+  /**
+   * Connect to a live session for the given ticket.
+   *
+   * Disconnects any existing session first (one connection at a time).
+   * Creates a `LiveSessionClient`, opens the WebSocket, and stores
+   * the client in `activeConnection`.
+   */
+  async connectLiveSession(ticketId: string): Promise<void> {
+    // Already connected to this ticket — nothing to do.
+    const current = this.activeConnection.get();
+    if (current?.taskId === ticketId) return;
+
+    // Disconnect any existing session.
+    if (current) {
+      current.disconnect();
+      this.activeConnection.set(null);
+    }
+
+    const dirHandle = await this.getTicketDirHandle(ticketId);
+    if (!dirHandle) {
+      console.error("Could not get directory handle for ticket", ticketId);
+      return;
+    }
+
+    const client = await LiveSessionClient.fromTicketDir(dirHandle);
+    if (!client) {
+      console.error("Could not create LiveSessionClient for", ticketId);
+      return;
+    }
+
+    this.activeConnection.set(client);
+
+    try {
+      await client.connect();
+    } catch (e) {
+      console.error("Live session connection failed:", e);
+      this.activeConnection.set(null);
+    }
+  }
+
+  /** Disconnect the active live session. */
+  disconnectLiveSession(): void {
+    const client = this.activeConnection.get();
+    if (client) {
+      client.disconnect();
+      this.activeConnection.set(null);
     }
   }
 

--- a/packages/bees/hivetool/src/ui/template-detail.ts
+++ b/packages/bees/hivetool/src/ui/template-detail.ts
@@ -29,6 +29,40 @@ import "./primitives/edit-controls.js";
 
 export { BeesTemplateDetail };
 
+/** Prebuilt voices available in the Gemini Live API. */
+const GEMINI_VOICES = [
+  "Kore",
+  "Puck",
+  "Charon",
+  "Aoede",
+  "Fenrir",
+  "Zephyr",
+  "Leda",
+  "Orus",
+  "Callirrhoe",
+  "Autonoe",
+  "Enceladus",
+  "Iapetus",
+  "Umbriel",
+  "Algieba",
+  "Despina",
+  "Erinome",
+  "Algenib",
+  "Rasalgethi",
+  "Laomedeia",
+  "Achernar",
+  "Alnilam",
+  "Schedar",
+  "Gacrux",
+  "Pulcherrima",
+  "Achird",
+  "Zubenelgenubi",
+  "Vindemiatrix",
+  "Sadachbia",
+  "Sadaltager",
+  "Sulafat",
+] as const;
+
 @customElement("bees-template-detail")
 class BeesTemplateDetail extends SignalWatcher(LitElement) {
   static styles = [
@@ -314,6 +348,8 @@ class BeesTemplateDetail extends SignalWatcher(LitElement) {
       chips.push({ label: "model", value: template.model, cls: "model" });
     if (template.runner && template.runner !== "generate")
       chips.push({ label: "runner", value: template.runner });
+    if (template.voice)
+      chips.push({ label: "voice", value: template.voice });
 
     const allTemplates = this.templateStore!.templates.get();
     const templateNames = new Set(allTemplates.map((t) => t.name));
@@ -588,6 +624,42 @@ class BeesTemplateDetail extends SignalWatcher(LitElement) {
                   })}
               ></bees-editable-field>
             </div>
+
+            ${draft.runner === "live"
+              ? html`
+                  <div class="edit-row">
+                    <div>
+                      <label
+                        style="display:block;font-size:0.7rem;color:#94a3b8;margin-bottom:4px"
+                        >Voice</label
+                      >
+                      <select
+                        style="
+                          width:100%;padding:6px 10px;background:#0b0c0f;
+                          border:1px solid #334155;border-radius:6px;
+                          color:#e2e8f0;font-family:inherit;font-size:0.85rem;
+                          outline:none;
+                        "
+                        @change=${(e: Event) => {
+                          const val = (e.target as HTMLSelectElement).value;
+                          this.updateDraft({ voice: val || undefined });
+                        }}
+                      >
+                        <option value="" ?selected=${!draft.voice}>
+                          Default (Kore)
+                        </option>
+                        ${GEMINI_VOICES.map(
+                          (v) => html`
+                            <option value=${v} ?selected=${draft.voice === v}>
+                              ${v}
+                            </option>
+                          `
+                        )}
+                      </select>
+                    </div>
+                  </div>
+                `
+              : nothing}
 
             <!-- Objective -->
             <bees-editable-textarea

--- a/packages/bees/hivetool/src/ui/ticket-detail.ts
+++ b/packages/bees/hivetool/src/ui/ticket-detail.ts
@@ -20,7 +20,6 @@ import type { TicketStore, FileTreeNode } from "../data/ticket-store.js";
 import type { MutationClient } from "../data/mutation-client.js";
 import type { TemplateStore } from "../data/template-store.js";
 import type { SkillStore } from "../data/skill-store.js";
-import { LiveSessionClient } from "../data/live-session.js";
 import { sharedStyles } from "./shared-styles.js";
 import { renderJson } from "./json-tree.js";
 import { jsonTreeStyles } from "./json-tree.styles.js";
@@ -440,8 +439,8 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
   @state() accessor selectedChoiceIds = new Set<string>();
   @state() accessor responding = false;
 
-  // ── Live session state ──
-  #liveClient: LiveSessionClient | null = null;
+  // Live session state is owned by TicketStore.activeConnection —
+  // no local client reference needed.
 
   /** Track the ticket ID we loaded the tree for. */
   #treeLoadedFor: string | null = null;
@@ -1126,42 +1125,47 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
       .get()
       .has(ticketId);
 
-    const status = this.#liveClient?.status.get() ?? "idle";
-    const transcript = this.#liveClient?.transcript.get() ?? "";
+    const client = this.ticketStore?.activeConnection.get();
+    const isThisTicket = client?.taskId === ticketId;
+    const status = isThisTicket ? (client!.status.get()) : "idle";
+    const transcript = isThisTicket ? (client!.transcript.get()) : "";
+    const isTalking = isThisTicket ? (client!.talking.get()) : false;
 
     if (!hasActive && status === "idle") return nothing;
 
     const isConnected =
       status === "connected" || status === "connecting";
 
+    // Another ticket is currently connected.
+    const otherConnected = client && !isThisTicket;
+
     return html`
       <div class="block live-panel">
         <div class="live-panel-header">
           <span class="live-status-dot ${status}"></span>
           <span class="live-status-label">Live Session — ${status}</span>
-          ${isConnected
+          ${isThisTicket && isConnected
             ? html`<button
                 class="live-btn disconnect"
                 @click=${() => this.handleLiveDisconnect()}
               >
                 Disconnect
               </button>`
-            : hasActive
-              ? html`<button
-                  class="live-btn connect"
-                  @click=${() => this.handleLiveConnect(ticketId)}
-                >
-                  Connect
-                </button>`
-              : nothing}
+            : nothing}
         </div>
-        ${status === "connected"
+        ${hasActive
           ? html`<div class="live-mic-bar">
               <button
-                class="live-btn mic ${this.#liveClient?.micActive.get() ? "active" : ""}"
-                @click=${() => this.handleMicToggle()}
+                class="live-btn talk ${isTalking ? "active" : ""}"
+                @pointerdown=${() => this.handleTalkStart(ticketId)}
+                @pointerup=${() => this.handleTalkEnd()}
+                @pointerleave=${() => this.handleTalkEnd()}
               >
-                ${this.#liveClient?.micActive.get() ? "🔇 Mute" : "🎤 Unmute"}
+                ${otherConnected
+                  ? "🎤 Talk to switch"
+                  : isTalking
+                    ? "🔊 Talking…"
+                    : "🎤 Talk"}
               </button>
             </div>`
           : nothing}
@@ -1178,50 +1182,43 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
     `;
   }
 
-  private async handleLiveConnect(ticketId: string): Promise<void> {
-    if (this.#liveClient) return;
+  /**
+   * Handle Talk button press.
+   *
+   * First press connects (if not already connected to this ticket),
+   * then opens the audio gate.
+   */
+  private async handleTalkStart(ticketId: string): Promise<void> {
     if (!this.ticketStore) return;
 
-    const dirHandle = await this.ticketStore.getTicketDirHandle(ticketId);
-    if (!dirHandle) {
-      console.error("Could not get directory handle for ticket", ticketId);
-      return;
+    const client = this.ticketStore.activeConnection.get();
+
+    // Not connected to this ticket — connect first.
+    if (!client || client.taskId !== ticketId) {
+      await this.ticketStore.connectLiveSession(ticketId);
     }
 
-    const client = await LiveSessionClient.fromTicketDir(dirHandle);
-    if (!client) {
-      console.error("Could not create LiveSessionClient for", ticketId);
-      return;
+    // Now begin talking (opens the audio gate).
+    const activeClient = this.ticketStore.activeConnection.get();
+    if (activeClient?.status.get() === "connected") {
+      try {
+        await activeClient.beginTalking();
+      } catch (e) {
+        console.error("Failed to start talking:", e);
+      }
     }
+  }
 
-    this.#liveClient = client;
-
-    try {
-      await client.connect();
-    } catch (e) {
-      console.error("Live session connection failed:", e);
-      this.#liveClient = null;
+  /** Handle Talk button release — close the audio gate. */
+  private handleTalkEnd(): void {
+    const client = this.ticketStore?.activeConnection.get();
+    if (client?.talking.get()) {
+      client.endTalking();
     }
   }
 
   private handleLiveDisconnect(): void {
-    if (!this.#liveClient) return;
-    this.#liveClient.disconnect();
-    this.#liveClient = null;
-  }
-
-  private async handleMicToggle(): Promise<void> {
-    if (!this.#liveClient) return;
-
-    if (this.#liveClient.micActive.get()) {
-      this.#liveClient.stopMic();
-    } else {
-      try {
-        await this.#liveClient.startMic();
-      } catch (e) {
-        console.error("Failed to start microphone:", e);
-      }
-    }
+    this.ticketStore?.disconnectLiveSession();
   }
 }
 

--- a/packages/bees/tests/test_live_runner.py
+++ b/packages/bees/tests/test_live_runner.py
@@ -83,6 +83,7 @@ def _make_config(
     factories: list | None = None,
     function_filter: list[str] | None = None,
     model: str | None = None,
+    voice: str | None = None,
 ) -> SessionConfiguration:
     """Create a minimal SessionConfiguration for testing."""
     fs = MagicMock()
@@ -95,6 +96,7 @@ def _make_config(
         ticket_id="test-task-id",
         ticket_dir=temp_dir,
         label="test",
+        voice=voice,
     )
 
 
@@ -279,6 +281,31 @@ def test_assemble_system_instruction_empty_tool_instruction():
     assert result == "Hello."
 
 
+def test_assemble_system_instruction_text_segments():
+    """Segments from resolve_segments use {"type": "text", "text": "..."} format."""
+    segments = [
+        {"type": "text", "text": "Act as a translator."},
+        {"type": "text", "text": "Be concise."},
+    ]
+    result = _assemble_system_instruction(segments, "Tool notes.")
+
+    assert "Act as a translator." in result
+    assert "Be concise." in result
+    assert "Tool notes." in result
+
+
+def test_assemble_system_instruction_mixed_formats():
+    """Both parts-based and direct text segments work together."""
+    segments = [
+        {"type": "text", "text": "Objective from resolve_segments."},
+        {"parts": [{"text": "Instruction from function group."}]},
+    ]
+    result = _assemble_system_instruction(segments, "")
+
+    assert "Objective from resolve_segments." in result
+    assert "Instruction from function group." in result
+
+
 # ---------------------------------------------------------------------------
 # _build_bundle
 # ---------------------------------------------------------------------------
@@ -310,6 +337,59 @@ def test_build_bundle_no_declarations(temp_dir):
         system_instruction="Hello.",
     )
     assert "tools" not in bundle.setup
+
+
+def test_build_bundle_includes_enhanced_capabilities(temp_dir):
+    """Setup includes VAD tuning, proactive audio, and affective dialog."""
+    config = _make_config(temp_dir)
+    bundle = _build_bundle(
+        config=config,
+        token="token",
+        declarations=[],
+        system_instruction="Hello.",
+    )
+    setup = bundle.setup
+
+    # VAD tuning.
+    vad = setup["realtimeInputConfig"]["automaticActivityDetection"]
+    assert vad["startOfSpeechSensitivity"] == "START_SENSITIVITY_LOW"
+    assert vad["endOfSpeechSensitivity"] == "END_SENSITIVITY_LOW"
+    assert vad["silenceDurationMs"] == 500
+
+    # Proactive audio (setup-level field).
+    assert setup["proactivity"]["proactiveAudio"] is True
+
+
+def test_build_bundle_voice_from_config(temp_dir):
+    """Voice name comes from SessionConfiguration.voice."""
+    config = _make_config(temp_dir, voice="Puck")
+    bundle = _build_bundle(
+        config=config,
+        token="token",
+        declarations=[],
+        system_instruction="Hello.",
+    )
+    voice_name = (
+        bundle.setup["generationConfig"]["speechConfig"]
+        ["voiceConfig"]["prebuiltVoiceConfig"]["voiceName"]
+    )
+    assert voice_name == "Puck"
+
+
+def test_build_bundle_voice_default(temp_dir):
+    """When no voice is set, defaults to Kore."""
+    config = _make_config(temp_dir)
+    bundle = _build_bundle(
+        config=config,
+        token="token",
+        declarations=[],
+        system_instruction="Hello.",
+    )
+    voice_name = (
+        bundle.setup["generationConfig"]["speechConfig"]
+        ["voiceConfig"]["prebuiltVoiceConfig"]["voiceName"]
+    )
+    assert voice_name == "Kore"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/bees/tests/test_protocols/test_session_configuration.py
+++ b/packages/bees/tests/test_protocols/test_session_configuration.py
@@ -87,6 +87,7 @@ class TestSessionConfigurationConformance(unittest.TestCase):
             "label",
             "log_path",
             "on_chat_entry",
+            "voice",
         }
         self.assertEqual(field_names, expected)
 


### PR DESCRIPTION
## What

Replaces the connect-then-toggle-mic interaction with a single push-to-talk button, adds configurable voice selection for live sessions, and fixes a bug where the template objective was silently dropped from the system instruction.

## Why

The previous live session UX required three steps (connect → unmute → speak) with the mic streaming continuously. Push-to-talk is more natural for voice interaction: hold to speak, release to stop. Audio gating also reduces noise sent to the API and lets the server flush its VAD buffer on release. Voice selection lets template authors pick from 30 Gemini prebuilt voices. The objective bug meant the model never saw the task's actual instructions.

## Changes

### Push-to-talk interaction (`hivetool`)
- `audio-handler.ts` — audio gate (`openGate`/`closeGate`) on `AudioInput`; mic stays warm, chunks only flow while talking
- `live-session.ts` — `beginTalking()`/`endTalking()` replace `startMic()`/`stopMic()`; sends `audioStreamEnd` on gate close; handles `interrupted` and `toolCallCancellation` server messages; flushes audio playback on interruption
- `ticket-detail.ts` — `pointerdown`/`pointerup` Talk button replaces Connect + Mute toggle; "Talk to switch" when another ticket is connected

### Store-owned connection (`hivetool`)
- `ticket-store.ts` — `activeConnection` signal (single live WebSocket); `connectLiveSession()`/`disconnectLiveSession()` manage lifecycle; connection survives ticket selection changes

### Voice selection (full stack)
- `TEMPLATES.yaml` — `voice: Kore` on `live-session` template
- `ticket.py` — `voice` field on `TicketMetadata` + `from_dict`
- `playbook.py` → `task_store.py` → `provisioner.py` → `task_runner.py` — thread `voice` through provisioning pipeline
- `protocols/session.py` — `voice` field on `SessionConfiguration`
- `runners/live.py` — `config.voice` in `_build_bundle` (default: `Kore`)
- `common/types.ts` — `voice` on `TaskData`
- `template-store.ts` — `voice` on `TemplateData`
- `template-detail.ts` — voice dropdown (30 Gemini voices) in edit mode, voice chip in view mode; only visible when `runner === "live"`

### API config fixes (`live.py`)
- VAD tuning — `realtimeInputConfig` with low sensitivity + 500ms silence threshold
- Proactive audio — `proactivity.proactiveAudio` at setup level
- Removed `enableAffectiveDialog` (causes `1011 Internal error` on Constrained endpoint)

### Bug fix: objective dropped from system instruction
- `_assemble_system_instruction` only handled `{"parts": [...]}` segments but `resolve_segments` produces `{"type": "text", "text": "..."}` — the objective text was silently ignored

## Testing

- `pytest tests/test_live_runner.py` — 48 tests pass (6 new: voice config, voice default, text segments, mixed formats, VAD tuning, proactive audio)
- `pytest tests/test_protocols/test_session_configuration.py` — conformance test updated for `voice` field
- `pytest tests/ --ignore=tests/test_box.py` — 422 tests pass
- Manual: push-to-talk tested with live Gemini session; translator objective now appears in system instruction
