### PR TITLE
[bees] Fix instruction-only group leak in live sessions

### DIFF
--- a/packages/bees/bees/runners/live.py
+++ b/packages/bees/bees/runners/live.py
@@ -181,14 +181,25 @@ def _extract_declarations(
                 handler_map[name] = handler
         all_declarations.extend(group_included)
 
-        # Include instructions only if: (a) the group is instruction-only
-        # (no declarations at all — e.g. skills, live), or (b) at least
-        # one declaration survived the filter.  This prevents unrelated
-        # groups from leaking their instructions into the system prompt.
+        # Include instructions only if at least one declaration survived
+        # the filter.  For instruction-only groups (no declarations at all,
+        # e.g. skills, live), check whether the group's *name* matches a
+        # filter pattern — this prevents unrelated instruction-only groups
+        # from leaking into the system prompt.
         if group.instruction:
-            is_instruction_only = len(group.declarations) == 0
-            if is_instruction_only or group_included:
-                instructions.append(group.instruction)
+            has_declarations = len(group.declarations) > 0
+            if has_declarations:
+                # Normal group: include instruction only if at least one
+                # declaration survived the filter.
+                if group_included:
+                    instructions.append(group.instruction)
+            else:
+                # Instruction-only group: include if no filter is set,
+                # or the group name matches a filter pattern.
+                if not function_filter or _group_matches_filter(
+                    group.name, function_filter,
+                ):
+                    instructions.append(group.instruction)
 
     return all_declarations, "\n\n".join(instructions), handler_map
 
@@ -206,6 +217,27 @@ def _matches_filter(name: str, patterns: list[str]) -> bool:
             if name.startswith(prefix + "_") or name == prefix:
                 return True
         elif name == pattern:
+            return True
+    return False
+
+
+def _group_matches_filter(
+    group_name: str | None,
+    patterns: list[str],
+) -> bool:
+    """Check whether an instruction-only group's name matches a filter pattern.
+
+    Group names are matched against the prefix of ``group.*`` patterns.
+    For example, group ``"skills"`` matches ``"skills.*"``.
+    """
+    if not group_name:
+        return False
+    for pattern in patterns:
+        if pattern.endswith(".*"):
+            prefix = pattern[:-2]
+            if group_name == prefix:
+                return True
+        elif group_name == pattern:
             return True
     return False
 

--- a/packages/bees/tests/test_live_runner.py
+++ b/packages/bees/tests/test_live_runner.py
@@ -234,8 +234,59 @@ def test_extract_declarations_filters_instructions():
     assert "Files instruction" not in instruction
 
 
-def test_extract_declarations_includes_instruction_only_groups():
-    """Instruction-only groups (no declarations) always include their instruction."""
+def test_extract_declarations_instruction_only_matches_filter():
+    """Instruction-only groups are included when their name matches the filter."""
+    live_group = FunctionGroup(
+        name="live",
+        declarations=[],
+        definitions=[],
+        instruction="Live instruction",
+    )
+    skills_group = FunctionGroup(
+        name="skills",
+        declarations=[],
+        definitions=[],
+        instruction="Skills instruction",
+    )
+
+    # Filter includes live.* but not skills.* — only live instruction appears.
+    _, instruction, _ = _extract_declarations(
+        [live_group, skills_group], ["live.*", "files.*"],
+    )
+
+    assert "Live instruction" in instruction
+    assert "Skills instruction" not in instruction
+
+
+def test_extract_declarations_instruction_only_no_filter():
+    """Without a filter, all instruction-only groups are included."""
+    live_group = FunctionGroup(
+        name="live",
+        declarations=[],
+        definitions=[],
+        instruction="Live instruction",
+    )
+    skills_group = FunctionGroup(
+        name="skills",
+        declarations=[],
+        definitions=[],
+        instruction="Skills instruction",
+    )
+
+    _, instruction, _ = _extract_declarations(
+        [live_group, skills_group], None,
+    )
+
+    assert "Live instruction" in instruction
+    assert "Skills instruction" in instruction
+
+
+def test_extract_declarations_skills_leak_regression():
+    """Skills instruction must not leak into live sessions (regression).
+
+    When the filter is [live.*, files.*], the skills group (instruction-only,
+    name='skills') should NOT have its instruction included.
+    """
     system_factory = _make_test_factory(
         "system",
         [{"name": "system_objective_fulfilled", "description": "done"}],
@@ -247,14 +298,23 @@ def test_extract_declarations_includes_instruction_only_groups():
         definitions=[],
         instruction="Live instruction",
     )
-
-    # Even with a filter, the live (instruction-only) group's instruction appears.
-    _, instruction, _ = _extract_declarations(
-        [system_factory, live_group], ["system.*"],
+    skills_group = FunctionGroup(
+        name="skills",
+        declarations=[],
+        definitions=[],
+        instruction="Skills instruction",
     )
 
-    assert "System instruction" in instruction
+    _, instruction, _ = _extract_declarations(
+        [system_factory, live_group, skills_group],
+        ["live.*", "files.*"],
+    )
+
     assert "Live instruction" in instruction
+    # system.* is not in the filter, so system instruction should be excluded.
+    assert "System instruction" not in instruction
+    # skills.* is not in the filter, so skills instruction should be excluded.
+    assert "Skills instruction" not in instruction
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Instruction-only function groups (like `skills`) were unconditionally included in the live session system prompt, regardless of the template's `functions` filter.

## Why

The filter logic had a carve-out: groups with zero declarations were treated as "always include." This was intended for groups like `live.*` that are pure instruction, but it also matched `skills` — which leaked a "Using Skills" instruction block into live sessions that didn't request `skills.*`. The model received irrelevant instructions about skill directories that don't exist in a live context.

## Changes

### `runners/live.py`
- `_extract_declarations` — instruction-only groups now check their **group name** against the filter (e.g. group `"skills"` only matches if `skills.*` is in the filter). Groups with declarations still use the existing per-function check.
- `_group_matches_filter` — **[NEW]** helper that matches a group name against `group.*` filter patterns.

### `tests/test_live_runner.py`
- Replaced `test_extract_declarations_includes_instruction_only_groups` (asserted wrong behavior) with:
  - `test_extract_declarations_instruction_only_matches_filter` — only matching groups included
  - `test_extract_declarations_instruction_only_no_filter` — all groups included when no filter
  - `test_extract_declarations_skills_leak_regression` — exact reproduction of the bug

## Testing

- `pytest tests/test_live_runner.py` — 50 tests pass
- Manual: live session system instruction no longer contains "Using Skills" block when template filter is `[live.*, files.*]`
