### PR TITLE
[bees] Fix chat_log.json written for all tasks

### DIFF
--- a/packages/bees/bees/protocols/session.py
+++ b/packages/bees/bees/protocols/session.py
@@ -170,6 +170,16 @@ class SessionConfiguration:
        ``ObservationConfig`` in a future spec.
     """
 
+    extract_chat_from_context: bool = False
+    """Extract chat log entries from ``sendRequest`` context.
+
+    When ``True``, ``drain_session`` scans each ``sendRequest`` event for
+    new user/model text turns and writes them to the chat log via
+    ``on_chat_entry``.  Used by live sessions, which lack function-level
+    chat handlers.  Batch sessions leave this ``False`` — their chat
+    function handlers write log entries directly.
+    """
+
     voice: str | None = None
     """Prebuilt voice name for Live API audio output (e.g. ``'Kore'``)."""
 

--- a/packages/bees/bees/session.py
+++ b/packages/bees/bees/session.py
@@ -390,7 +390,13 @@ async def drain_session(
             # For live sessions, sendRequest events carry the accumulated
             # context (including model and user turns).  We scan for new
             # entries since the last sendRequest and log their text.
-            if "sendRequest" in event and chat_entry:
+            # Batch sessions skip this — their chat function handlers
+            # write log entries directly.
+            if (
+                "sendRequest" in event
+                and chat_entry
+                and config.extract_chat_from_context
+            ):
                 contents = (
                     event["sendRequest"]
                     .get("body", {})

--- a/packages/bees/bees/task_runner.py
+++ b/packages/bees/bees/task_runner.py
@@ -116,6 +116,11 @@ class TaskRunner:
                 voice=task.metadata.voice,
             )
 
+            # Live sessions need context-level chat extraction because
+            # they lack function-level chat handlers.
+            if task.metadata.runner == "live":
+                config.extract_chat_from_context = True
+
             stream = await self._runner_for(task).run(config)
             self._active_streams[task.id] = stream
             try:
@@ -239,6 +244,11 @@ class TaskRunner:
                 seed_files=False,  # Files already on disk from previous run.
                 voice=task.metadata.voice,
             )
+
+            # Live sessions need context-level chat extraction because
+            # they lack function-level chat handlers.
+            if task.metadata.runner == "live":
+                config.extract_chat_from_context = True
 
             stream = await self._runner_for(task).resume(
                 config,

--- a/packages/bees/tests/test_protocols/test_session_configuration.py
+++ b/packages/bees/tests/test_protocols/test_session_configuration.py
@@ -57,6 +57,7 @@ class TestSessionConfigurationConformance(unittest.TestCase):
         self.assertEqual(config.label, "")
         self.assertIsNone(config.log_path)
         self.assertIsNone(config.on_chat_entry)
+        self.assertFalse(config.extract_chat_from_context)
 
     def test_all_fields_settable(self):
         """All fields can be set explicitly."""
@@ -87,6 +88,7 @@ class TestSessionConfigurationConformance(unittest.TestCase):
             "label",
             "log_path",
             "on_chat_entry",
+            "extract_chat_from_context",
             "voice",
         }
         self.assertEqual(field_names, expected)


### PR DESCRIPTION
## What
Gates the context-level chat log extraction in `drain_session` behind a new
`extract_chat_from_context` flag on `SessionConfiguration`, so only live
sessions extract chat entries from `sendRequest` context.

## Why
PR #8441 added chat log extraction inside `drain_session` for live sessions
(which lack function-level chat handlers), but the code ran unconditionally
for all tasks. This caused `chat_log.json` to be written for every task —
not just those with `chat.*` functions enabled — and double-wrote entries
for batch sessions that already log via chat function handlers.

## Changes

### `bees/protocols/session.py`
- Add `extract_chat_from_context: bool = False` field to `SessionConfiguration`

### `bees/session.py`
- Gate the `sendRequest` chat extraction block on `config.extract_chat_from_context`

### `bees/task_runner.py`
- Set `config.extract_chat_from_context = True` for live runner tasks
  (in both `run_task` and `resume_task`)

### `tests/test_protocols/test_session_configuration.py`
- Add new field to expected field names set
- Assert default value is `False`

## Testing
- 12/12 session configuration conformance tests passing
- 50/50 live runner tests passing
