### PR TITLE
[bees] Reconcile bees docs with reality

### DIFF
--- a/packages/bees/README.md
+++ b/packages/bees/README.md
@@ -1,7 +1,7 @@
 # Bees
 
-Agent swarm orchestration framework. Uses the opal-backend agent loop to run
-sessions, coordinated by a scheduler that manages tasks as a tree.
+Agent swarm orchestration framework. Manages tasks as a tree, with pluggable
+session runners for different modalities (batch text, live voice).
 
 For the full documentation, see [docs/README.md](docs/README.md).
 
@@ -11,8 +11,8 @@ For the full documentation, see [docs/README.md](docs/README.md).
 npm run setup -w packages/bees
 ```
 
-This creates a `.venv` and installs opal-backend (with its local deps) plus
-bees.
+This creates a `.venv` and installs dependencies (including `opal-backend` for
+the batch runner).
 
 ## Configuration
 
@@ -28,40 +28,40 @@ runtime state (templates, skills, tasks, logs). Defaults to `hive`.
 
 ## Running
 
-### Server
+### Box (filesystem-driven)
 
 ```bash
-npm run dev:server -w packages/bees
+npm run dev:box -w packages/bees
 ```
 
-Starts the FastAPI server on port 3200. The server boots the scheduler, recovers
-any stuck tasks, and begins draining. The web shell is served alongside it.
+Watches the hive directory for changes and drives the scheduler through
+filesystem events. Use with [hivetool](#hivetool) for a browser-based developer
+workbench. See [docs/box.md](docs/box.md) for the full documentation.
 
-See [docs/reference-app.md](docs/reference-app.md) for the full server and web
-shell documentation.
-
-### Single session (CLI)
+### Hivetool
 
 ```bash
-npm run session:start -w packages/bees -- "Your prompt here"
+npm run dev:hivetool -w packages/bees
 ```
 
-Events stream to stderr. The final result prints as JSON to stdout.
+Browser-based developer workbench for inspecting and editing hive configuration,
+templates, skills, and task state. Reads and writes hive files directly via the
+File System Access API. See [docs/hivetool.md](docs/hivetool.md).
 
-### Tickets (CLI)
+Also hosted at: https://breadboard-ai.github.io/breadboard/hivetool/
+
+### Server (reference app)
 
 ```bash
-# Create tickets
-npm run ticket:add -w packages/bees -- "Tell me a joke"
-
-# Drain the queue (run all available tickets)
-npm run ticket:drain -w packages/bees
+npm run dev -w packages/bees
 ```
 
-Each ticket becomes a directory under `hive/tickets/{uuid}/` containing
-`objective.md` and `metadata.json`.
+Starts the FastAPI server on port 3200 alongside the web shell. The server boots
+the scheduler, recovers any stuck tasks, and begins draining. See
+[docs/reference-app.md](docs/reference-app.md) for the full documentation.
 
 ## Output
 
-Session log files land in `hive/logs/` in the eval viewer's `EvalFileData`
-format (`bees-session-{date}.log.json`).
+Session log files land in `hive/logs/` as structured JSON
+(`bees-{task-id}-{date}.log.json`). These can be inspected in hivetool's
+Sessions tab.

--- a/packages/bees/docs/README.md
+++ b/packages/bees/docs/README.md
@@ -39,10 +39,26 @@
   the template schema reference (appendix).
 - [flux.md](flux.md) — Stability map classifying each subsystem as solid,
   settling, or fluid.
+- [library-extraction.md](library-extraction.md) — Record of the completed
+  library extraction: specs, migration phases, and remaining `opal_backend`
+  imports.
 - [interview-log.md](interview-log.md) — Raw architect insights captured during
   the Phase 3 design interview. Primary source material for patterns.md.
 
+## Concept explorations
+
+Design docs that traced the path to the current architecture. Each has been
+realized (with divergences noted in their banners) and is kept as a historical
+record.
+
+- [delegated-sessions.md](delegated-sessions.md) — What if session execution is
+  owned by the browser? Shipped as Project Acoustic.
+- [delegated-sessions-2.md](delegated-sessions-2.md) — What if _all_ sessions
+  are delegated? Led to the `SessionRunner` protocol.
+- [package-split.md](package-split.md) — The delegated sessions insight as a
+  packaging concern. Remaining step in the library extraction.
+
 ## Forward arrow
 
-- [future.md](future.md) — Short- to medium-term work: the consumption API,
-  hive abstraction, multi-hive support, event delivery, and naming migration.
+- [future.md](future.md) — What's next: the package split, consumption API,
+  and hive abstraction.

--- a/packages/bees/docs/box.md
+++ b/packages/bees/docs/box.md
@@ -78,9 +78,16 @@ Changes to `logs/` and other directories outside `config/`, `skills/`, and
 ```python
 # Pseudocode — see bees/box.py for the real implementation.
 
-async def run(hive_dir, backend):
+async def run(hive_dir, *, gemini_key):
+    runners = {
+        "generate": GeminiRunner(backend),
+        "live": LiveRunner(api_key=gemini_key),
+    }
     while True:                          # Outer: cold restart loop
-        bees = Bees(hive_dir, backend)
+        bees = Bees(hive_dir, runners)
+        bees.on(TaskAdded, _on_task_added)
+        bees.on(TaskDone, _on_task_done)
+        # ...
         bees.listen()
 
         async for changes in awatch(hive_dir):   # Inner: file watch
@@ -131,8 +138,8 @@ locally without a server.
 
 ## Observability
 
-The box wires `SchedulerHooks` to Python's `logging` module. All lifecycle
-events appear on stderr:
+The box subscribes to typed scheduler events via `bees.on()` and logs them to
+stderr via Python's `logging` module:
 
 ```
 18:25:01 [INFO] bees.box: Box starting — watching /path/to/hive

--- a/packages/bees/docs/delegated-sessions-2.md
+++ b/packages/bees/docs/delegated-sessions-2.md
@@ -1,6 +1,12 @@
-> [!NOTE] This is a conceptual exploration, not documentation of current
-> capabilities. Nothing described here is implemented yet. This builds on the
-> ideas in `delegated-sessions.md` and takes them to their logical conclusion.
+> [!NOTE]
+> The central thesis of this doc — bees as a pure orchestration and tooling
+> framework — is now reality. The `SessionRunner` protocol lives in
+> `bees/protocols/session.py`, with `GeminiRunner` and `LiveRunner` as concrete
+> implementations. Key differences from this proposal: `ContextChannel` was
+> absorbed into `SessionStream.send_context()`, and `dispatch.py` / `channel.py`
+> were never created as separate modules. See
+> [library-extraction.md](./library-extraction.md) for the current state and
+> [PROJECT_ACOUSTIC.md](../../PROJECT_ACOUSTIC.md) for the Live API integration.
 
 # Delegated Sessions — The General Case
 

--- a/packages/bees/docs/delegated-sessions.md
+++ b/packages/bees/docs/delegated-sessions.md
@@ -1,6 +1,10 @@
 > [!NOTE]
-> This is a conceptual exploration, not documentation of current capabilities.
-> Nothing described here is implemented yet.
+> This concept shipped as **Project Acoustic**
+> ([PROJECT_ACOUSTIC.md](../../PROJECT_ACOUSTIC.md)). The architecture diverged
+> from what's described here: the filesystem interchange pattern replaced the
+> REST APIs (`/session-bundle`, `/tool-dispatch`, `/session-status`), and
+> `session_type: delegated` became `runner: live`. The doc remains as a record
+> of the original design exploration.
 
 # Delegated Sessions
 

--- a/packages/bees/docs/future.md
+++ b/packages/bees/docs/future.md
@@ -1,31 +1,17 @@
 # Future Direction
 
 Short- to medium-term work needed to close gaps in the framework and bring about
-the vision described in [architecture.md](./architecture.md). Each concept doc
-explores a specific axis of the design space.
+the vision described in [architecture.md](./architecture.md).
 
-## The Library Extraction
+## Zero-Dependency `bees`
 
-The central architectural question: how does bees become a clean, installable
-library that applications `import` rather than fork?
+**Goal:** `pip install bees` works with no transitive dependencies. The
+framework owns orchestration and tools; model providers are pluggable packages
+that bring their own auth and API clients.
 
-Three concept docs trace the path:
-
-### [Delegated Sessions](./delegated-sessions.md)
-
-What if session execution is owned by an external party rather than the
-scheduler? The motivating use case is the Gemini Live API, but the insight
-generalizes.
-
-### [Delegated Sessions — The General Case](./delegated-sessions-2.md)
-
-What if _all_ sessions are delegated? Bees becomes a pure orchestration and
-tooling framework. Auth drops out of the core. Testing simplifies. The
-`SessionRunner` protocol emerges as the key abstraction.
-
-### [Package Split](./package-split.md)
-
-The delegated sessions insight, stated as a packaging concern. Four packages:
+The [library extraction](./library-extraction.md) decoupled bees from
+`opal_backend` at the protocol level. What remains is the physical split — four
+packages, four responsibilities:
 
 | Package              | What it is                    | External deps                          |
 | -------------------- | ----------------------------- | -------------------------------------- |
@@ -34,119 +20,11 @@ The delegated sessions insight, stated as a packaging concern. Four packages:
 | **`box`**            | Filesystem-driven CLI runner  | `bees`, `gemini-runners`, `watchfiles` |
 | **`app`**            | Reference web application     | `bees`, `gemini-runners`, `fastapi`    |
 
-The key refinement: functions (tool declarations + handlers) stay in `bees` as
-framework capabilities. They're orthogonal to the model provider.
-
-### Progress
-
-The library extraction follows [Spec-Driven Development](../spec/). Each
-protocol is specified, tested for conformance, then migrated.
-
-**Function types** ([spec](../spec/function-types.md)) — ✅ complete.
-Bees-native copies of `FunctionGroup`, `FunctionDefinition`, `SessionHooks`,
-`load_declarations`, and `assemble_function_group` live in
-`bees/protocols/functions.py`. All 8 function modules now import from
-`bees.protocols` instead of `opal_backend.function_definition`. Remaining
-`opal_backend` imports in `chat.py`, `files.py`, and `system.py` are
-handler-level (`_make_handlers`) — a separate spec.
-
-**FileSystem types** ([spec](../spec/filesystem.md)) — ✅ complete. Bees-native
-copies of `FileSystem`, `FileDescriptor`, `FileSystemSnapshot`,
-`SystemFileGetter`, `file_descriptor_to_part`, and constants live in
-`bees/protocols/filesystem.py`. `disk_file_system.py` now imports from
-`bees.protocols` instead of `opal_backend.file_system_protocol`.
-
-**Pidgin** ([spec](../spec/pidgin.md)) — ✅ complete. Bees-native copies of
-`from_pidgin_string` and `merge_text_parts` live in `bees/pidgin.py`. These
-resolve pidgin markup (`<file>`, `<a>` tags) in agent output back to data parts
-from the file system. Prerequisite for inlining handler bodies.
-
-**Handler types** ([spec](../spec/handler-types.md)) — ✅ complete. Bees-native
-copies of `SuspendError`, `WaitForInputEvent`, `WaitForChoiceEvent`,
-`ChoiceItem`, `AgentResult`, `FileData`, `SessionTerminator` protocol,
-`CONTEXT_PARTS_KEY`, and `ChatEntryCallback` live in
-`bees/protocols/handler_types.py`. These are the types that function handlers
-use for suspend/resume, session termination, and context injection.
-
-**Handler bodies** ([spec](../spec/handler-bodies.md)) — ✅ complete. Handler
-logic from `opal_backend.functions.{chat,system}._make_handlers` is inlined into
-bees' three function modules (`system.py`, `chat.py`, `files.py`). All
-imports come from `bees.protocols` and `bees.pidgin`. Task tree management
-(`TaskTreeManager`, `set_in_progress` calls) stays in opal_backend — it's not a
-bees concern. The `bees/functions/` directory has **zero** `opal_backend`
-imports.
-
-> **Transitional back-imports.** Two types in `bees/protocols/handler_types.py`
-> subclass their `opal_backend` counterparts:
->
-> | Bees type      | Inherits from                       | Why                                  |
-> | -------------- | ----------------------------------- | ------------------------------------ |
-> | `SuspendError` | `opal_backend.suspend.SuspendError` | Session loop catches via `except`    |
-> | `AgentResult`  | `opal_backend.events.AgentResult`   | Session loop checks via `isinstance` |
->
-> The session loop (`opal_backend/run.py`) uses `except SuspendError` and
-> `isinstance(result, AgentResult)` with opal's classes. Until the loop moves to
-> `gemini-runners`, bees' versions must inherit so these checks pass. Both
-> imports are removed when the session loop migrates.
-
-**Session observation types** ([spec](../spec/session-observation.md)) — ✅
-complete. Bees-native copies of `SUSPEND_TYPES` and `PAUSE_TYPES` live in
-`bees/protocols/session.py`. `SessionResult` relocated from `session.py` to
-`bees/protocols/session.py`. `session.py` re-exports `SessionResult` for
-backward compatibility. `task_runner.py`, `scheduler.py`, and tests now import
-`SessionResult` from `bees.protocols.session`. `EvalCollector` and
-`_print_event_summary` are now fully opal-free.
-
-**Session configuration** ([spec](../spec/session-configuration.md)) — ✅
-complete. `SessionConfiguration` (provisioning output), `SessionStream` (async
-iterable event stream with back-channel), and `SessionEvent` (type alias) are
-specified and tested in `bees/protocols/session.py`. The `provision_session`
-function in `bees/provisioner.py` extracts provisioning logic from
-`run_session()` and `resume_session()`, both of which now delegate to it.
-`session.py`'s remaining imports are purely execution (opal_backend session API)
-— ready for the `SessionRunner` migration.
-
-**SessionRunner** ([spec](../spec/session-runner.md)) — ✅ specified + tested.
-`SessionRunner` protocol, `drain_session` composition function, and opaque
-resume state persistence (`save_resume_state` / `load_resume_state` /
-`clear_resume_state`) live in `bees/protocols/session.py` and `bees/session.py`.
-
-### Migration phases
-
-With all protocols specified, the remaining work is the **migration** — creating
-the concrete `GeminiRunner`, rewiring consumers, and removing dead code. Each
-phase is independently shippable.
-
-| #   | Spec                     | What changes                                                                                                                             | Status |
-| --- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- | ------ |
-| 1   | `gemini-runner`          | `GeminiRunner` + `GeminiStream` in `bees/runners/gemini.py`. Wraps opal session API.                                                     | ✅     |
-| 2   | `runner-migration`       | `TaskRunner` / `Scheduler` / `Bees` accept `SessionRunner`. `box.py` constructs `GeminiRunner`. Uses `runner.run()` + `drain_session()`. | ✅     |
-| 3   | `session-cleanup`        | Remove `run_session`, `resume_session`, legacy state, dead imports from `session.py`.                                                    | ✅     |
-| 4   | `gemini-runners-package` | Move runner to `gemini-runners` package. `box.py` moves to `box` package.                                                                | —      |
-
-**Phase 1** is pure additive code — nothing breaks. Phase 2 is the full
-substitution from construction (`box.py`) to consumption (`TaskRunner`). Phase 3
-is deletion. Phase 4 is packaging.
-
-**Remaining `opal_backend` imports** in `bees/`:
-
-| Module             | Imports                                                   | Removed in                |
-| ------------------ | --------------------------------------------------------- | ------------------------- |
-| `box.py`           | `HttpBackendClient`, `app.auth`, `app.config`             | Phase 4 (moves to `box`)  |
-| `handler_types.py` | Transitional back-imports (`SuspendError`, `AgentResult`) | Accepted — see note below |
-
-> **Transitional back-imports are accepted.** The opal session loop
-> (`opal_backend/run.py`) catches `SuspendError` and checks
-> `isinstance(result, AgentResult)` using opal's classes. Migrating the loop to
-> eliminate these two imports would risk losing battle-hardened retry logic,
-> exponential backoff, and other Chesterton's fences. The back-imports are
-> documented, harmless, and expire naturally when a new session path (e.g.,
-> Gemini Live API) replaces the opal loop. The cost — two type-level imports in
-> one file — is not worth the risk of rewriting the loop.
+See [package-split.md](./package-split.md) for the full design.
 
 ## The Consumption API
 
-With the library extraction as the goal, three sub-problems need to crystallize.
+With the library extraction as the goal, two sub-problems need to crystallize.
 
 ### The Interaction Surface
 
@@ -155,22 +33,6 @@ The controller side of the MVC model (see
 [mutations system](./mutations.md) provides an atomic interaction model for the
 filesystem-based hive. The library API should make responding to suspended tasks
 and creating task groups first-class operations on `Bees` or `TaskNode`.
-
-### The Observation API
-
-`SchedulerHooks` is a bag of callbacks with no lifecycle contract. It's invasive
-— the hooks reach deep into the scheduler's internals — and it only supports one
-consumer.
-
-**Direction**: The observation API should support multiple observers, provide a
-typed event stream rather than positional callbacks, and cleanly separate
-read-only observation from write-side interaction. The reference app's SSE
-`Broadcaster` is evidence of the pattern — it already fans out to multiple
-clients. The framework should do the same at the scheduler level.
-
-**Active spec**: [spec/observation.md](../spec/observation.md) — typed event
-dataclasses replacing `SchedulerHooks`, with `EventEmitter` callback threading
-through `Scheduler` → `TaskRunner`.
 
 ### Hive Abstraction
 
@@ -185,6 +47,103 @@ a protocol with at least two implementations:
 
 The configuration surface (templates, skills, system config) can remain
 file-based — it's the task runtime state that needs to scale.
+
+## Multi-Modal Sessions
+
+A task currently maps to a single session type. But a conversational task
+naturally switches modalities: the user pushes to talk (live session), then
+types a follow-up (text session). The task is the same — the session mode
+changes.
+
+This implies a task can have **multiple sequential sessions** of different
+types. The scheduler already handles suspend/resume across sessions, but the
+concept of switching runner type mid-task is new. Key questions:
+
+- **Session continuity.** When switching from live → text, does the text session
+  inherit the live session's context? The live session produces a transcript via
+  `chat_log.json` and `live_events/` — could these seed the text session's
+  initial context?
+- **Runner selection.** Currently `runner` is a static field on `TicketMetadata`
+  set at task creation. Multi-modal tasks need the runner to be chosen per
+  interaction — push-to-talk → `live`, text input → `generate`.
+- **UI affordance.** The Talk button and text input already coexist in hivetool.
+  The question is whether they target the same task or create separate sessions.
+
+## Agent Artifacts
+
+Agents need a common framework for presenting artifacts to the user — things the
+agent creates and wants to display, not just text output in the chat log.
+
+### What an agent can present
+
+Not an exhaustive list, but a starting point:
+
+- **Image** — generated or retrieved, displayed inline.
+- **Markdown** — structured text with formatting (reports, summaries, plans).
+- **Bundle** — a richer format, possibly HTML, for interactive or composed
+  artifacts.
+
+### Requirements
+
+- **Declarative.** The agent signals "show this to the user" through a function
+  call or file convention — not by encoding display logic.
+- **Persistent.** Artifacts survive the session. The app can load the current
+  set of artifacts for a task without replaying the session.
+- **Addressable.** Each artifact has an identity so the agent can update or
+  replace it.
+
+### Open design space
+
+This could be:
+
+- **A function group** (`artifacts.*`) — `artifacts_present_image`,
+  `artifacts_present_markdown`, etc. Explicit and discoverable, but adds
+  functions to every agent's toolbox.
+- **A convention conveyed through skills** — the skill instruction teaches the
+  agent to write files to a known directory (`artifacts/`) with metadata. No
+  special function group needed, but the convention is implicit.
+- **A hybrid** — a thin function group for signaling intent, backed by files on
+  disk for persistence.
+
+The persistence requirement points toward the filesystem — artifacts as files in
+the task directory, with a manifest that the app reads on load.
+
+## Shared Directories
+
+Templates could designate certain directories as shared across sibling agent
+sessions. A task tree often has multiple agents that need to coordinate through
+shared resources:
+
+- **Shared components** — a design system or code library that multiple agents
+  contribute to and consume.
+- **Accumulated state** — a research corpus, a knowledge base, or a running log
+  that grows across sessions.
+
+### The stomping problem
+
+Concurrent writers to the same files is a race condition. Possible mitigations:
+
+- **Append-only** — shared directories are append-only. Each agent writes new
+  files; no agent modifies another agent's files.
+- **Lock-free partitioning** — each agent gets a subdirectory within the shared
+  space. A merge step (manual or automated) reconciles.
+- **Explicit coordination** — agents use `events_send_to_sibling` to negotiate
+  writes. The shared directory is the _result_ of coordination, not the
+  _mechanism_.
+
+### Template surface
+
+```yaml
+- name: design-team
+  shared_directories:
+    - path: components/
+      mode: append-only
+    - path: design-tokens/
+      mode: partitioned
+```
+
+Not sure yet whether this belongs in the template schema, the task tree
+configuration, or the file system protocol.
 
 ## Further out
 

--- a/packages/bees/docs/library-extraction.md
+++ b/packages/bees/docs/library-extraction.md
@@ -1,0 +1,129 @@
+# The Library Extraction
+
+The central architectural question: how does bees become a clean, installable
+library that applications `import` rather than fork?
+
+Three concept docs trace the path:
+
+### [Delegated Sessions](./delegated-sessions.md)
+
+What if session execution is owned by an external party rather than the
+scheduler? The motivating use case is the Gemini Live API, but the insight
+generalizes.
+
+### [Delegated Sessions — The General Case](./delegated-sessions-2.md)
+
+What if _all_ sessions are delegated? Bees becomes a pure orchestration and
+tooling framework. Auth drops out of the core. Testing simplifies. The
+`SessionRunner` protocol emerges as the key abstraction.
+
+### [Package Split](./package-split.md)
+
+The delegated sessions insight, stated as a packaging concern. Four packages:
+
+| Package              | What it is                    | External deps                          |
+| -------------------- | ----------------------------- | -------------------------------------- |
+| **`bees`**           | Orchestration library + tools | None (stdlib only)                     |
+| **`gemini-runners`** | Gemini model provider         | `google-genai`, `httpx`                |
+| **`box`**            | Filesystem-driven CLI runner  | `bees`, `gemini-runners`, `watchfiles` |
+| **`app`**            | Reference web application     | `bees`, `gemini-runners`, `fastapi`    |
+
+The key refinement: functions (tool declarations + handlers) stay in `bees` as
+framework capabilities. They're orthogonal to the model provider.
+
+## Completed Specs
+
+The library extraction follows [Spec-Driven Development](../spec/). Each
+protocol is specified, tested for conformance, then migrated.
+
+**Function types** ([spec](../spec/function-types.md)) — ✅ complete.
+Bees-native copies of `FunctionGroup`, `FunctionDefinition`, `SessionHooks`,
+`load_declarations`, and `assemble_function_group` live in
+`bees/protocols/functions.py`. All function modules now import from
+`bees.protocols` instead of `opal_backend.function_definition`. The
+`bees/functions/` directory has **zero** `opal_backend` imports.
+
+**FileSystem types** ([spec](../spec/filesystem.md)) — ✅ complete. Bees-native
+copies of `FileSystem`, `FileDescriptor`, `FileSystemSnapshot`,
+`SystemFileGetter`, `file_descriptor_to_part`, and constants live in
+`bees/protocols/filesystem.py`. `disk_file_system.py` now imports from
+`bees.protocols` instead of `opal_backend.file_system_protocol`.
+
+**Pidgin** ([spec](../spec/pidgin.md)) — ✅ complete. Bees-native copies of
+`from_pidgin_string` and `merge_text_parts` live in `bees/pidgin.py`. These
+resolve pidgin markup (`<file>`, `<a>` tags) in agent output back to data parts
+from the file system. Prerequisite for inlining handler bodies.
+
+**Handler types** ([spec](../spec/handler-types.md)) — ✅ complete. Bees-native
+copies of `SuspendError`, `WaitForInputEvent`, `WaitForChoiceEvent`,
+`ChoiceItem`, `AgentResult`, `FileData`, `SessionTerminator` protocol,
+`CONTEXT_PARTS_KEY`, and `ChatEntryCallback` live in
+`bees/protocols/handler_types.py`. These are the types that function handlers
+use for suspend/resume, session termination, and context injection.
+
+**Handler bodies** ([spec](../spec/handler-bodies.md)) — ✅ complete. Handler
+logic from `opal_backend.functions.{chat,system}._make_handlers` is inlined into
+bees' three function modules (`system.py`, `chat.py`, `files.py`). All
+imports come from `bees.protocols` and `bees.pidgin`. Task tree management
+(`TaskTreeManager`, `set_in_progress` calls) stays in opal_backend — it's not a
+bees concern. The `bees/functions/` directory has **zero** `opal_backend`
+imports.
+
+**Session observation types** ([spec](../spec/session-observation.md)) — ✅
+complete. Bees-native copies of `SUSPEND_TYPES` and `PAUSE_TYPES` live in
+`bees/protocols/session.py`. `SessionResult` relocated from `session.py` to
+`bees/protocols/session.py`. `task_runner.py`, `scheduler.py`, and tests now
+import `SessionResult` from `bees.protocols.session`. `EvalCollector` and
+`_print_event_summary` are fully opal-free.
+
+**Session configuration** ([spec](../spec/session-configuration.md)) — ✅
+complete. `SessionConfiguration` (provisioning output), `SessionStream` (async
+iterable event stream with back-channel), and `SessionEvent` (type alias) are
+specified and tested in `bees/protocols/session.py`. The `provision_session`
+function in `bees/provisioner.py` extracts provisioning logic into a standalone
+function with zero `opal_backend` dependencies.
+
+**SessionRunner** ([spec](../spec/session-runner.md)) — ✅ specified + tested.
+`SessionRunner` protocol, `drain_session` composition function, and opaque
+resume state persistence (`save_resume_state` / `load_resume_state` /
+`clear_resume_state`) live in `bees/protocols/session.py` and `bees/session.py`.
+
+**Observation API** ([spec](../spec/observation.md)) — ✅ complete. Typed event
+dataclasses (`TaskAdded`, `CycleStarted`, `TaskEvent`, `TaskStarted`,
+`TaskDone`, `CycleComplete`) replaced `SchedulerHooks`. `EventEmitter` callback
+threading through `Scheduler` → `TaskRunner`. `SchedulerHooks` deleted. Both
+consumers (`box.py`, `server.py`) use typed event subscription via `Bees.on()`.
+
+## Completed Migration Phases
+
+| #   | Phase                    | What changed                                                                                                                             |
+| --- | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `gemini-runner`          | `GeminiRunner` + `GeminiStream` in `bees/runners/gemini.py`. Wraps opal session API.                                                     |
+| 2   | `runner-migration`       | `TaskRunner` / `Scheduler` / `Bees` accept `SessionRunner`. `box.py` constructs `GeminiRunner`. Uses `runner.run()` + `drain_session()`. |
+| 3   | `session-cleanup`        | Removed `run_session`, `resume_session`, legacy state, dead imports from `session.py`.                                                   |
+
+> **Transitional back-imports.** Two types in `bees/protocols/handler_types.py`
+> subclass their `opal_backend` counterparts:
+>
+> | Bees type      | Inherits from                       | Why                                  |
+> | -------------- | ----------------------------------- | ------------------------------------ |
+> | `SuspendError` | `opal_backend.suspend.SuspendError` | Session loop catches via `except`    |
+> | `AgentResult`  | `opal_backend.events.AgentResult`   | Session loop checks via `isinstance` |
+>
+> The session loop (`opal_backend/run.py`) uses `except SuspendError` and
+> `isinstance(result, AgentResult)` with opal's classes. Until the loop moves to
+> `gemini-runners`, bees' versions must inherit so these checks pass. Both
+> imports are removed when the session loop migrates.
+>
+> These back-imports are accepted. The cost — two type-level imports in one file
+> — is not worth the risk of rewriting the opal session loop's battle-hardened
+> retry logic and exponential backoff.
+
+## Remaining `opal_backend` imports in `bees/`
+
+| Module             | Imports                                                   | Removed in                 |
+| ------------------ | --------------------------------------------------------- | -------------------------- |
+| `box.py`           | `HttpBackendClient`, `app.auth`, `app.config`             | Phase 4 (moves to `box`)   |
+| `runners/gemini.py`| `HttpBackendClient`, `InMemoryInteractionStore`,          | Phase 4 (moves to          |
+|                    | `InteractionState`, sessions API, `InMemorySessionStore`  | `gemini-runners`)          |
+| `handler_types.py` | Transitional back-imports (`SuspendError`, `AgentResult`) | Accepted — see note above  |

--- a/packages/bees/docs/package-split.md
+++ b/packages/bees/docs/package-split.md
@@ -1,6 +1,9 @@
-> [!NOTE] This is a directional concept, not a finalized design. It captures the
-> packaging architecture that emerged from the delegated sessions exploration
-> and the "run from GitHub" question.
+> [!NOTE]
+> This is the remaining step in the library extraction. All protocols have been
+> specified, tested, and migrated. The `SessionRunner` protocol is implemented
+> with two concrete runners (`GeminiRunner`, `LiveRunner`). What remains is the
+> physical package split described below. See
+> [library-extraction.md](./library-extraction.md) for what's already done.
 
 # Package Split
 
@@ -253,97 +256,44 @@ of a hive populated by something else entirely).
 handlers with a `TestRunner` that returns scripted responses. No Gemini mocking,
 no network stubs, no API keys in CI.
 
-## Grounded in code: the import graph
+## Current import graph
 
-Tracing the actual `opal_backend` imports in `bees/` reveals three categories:
+The library extraction is complete at the protocol level. The remaining
+`opal_backend` imports are isolated to three modules:
 
-### Clean today (moves to `gemini-runners` wholesale)
+| Module             | Imports                                                   | Moves to             |
+| ------------------ | --------------------------------------------------------- | -------------------- |
+| `box.py`           | `HttpBackendClient`, `app.auth`, `app.config`             | `box` package        |
+| `runners/gemini.py`| `HttpBackendClient`, `InMemoryInteractionStore`,          | `gemini-runners`     |
+|                    | `InteractionState`, sessions API, `InMemorySessionStore`  | package              |
+| `handler_types.py` | Transitional back-imports (`SuspendError`, `AgentResult`) | Accepted (see below) |
 
-`session.py` (940 lines) is where bees and `opal_backend` are deeply entangled.
-It imports `new_session`, `start_session`, `resume_session`, `Subscribers`,
-`InMemorySessionStore`, `InteractionState` — all `opal_backend` session
-internals. It also assembles all function groups and calls `opal_backend`'s
-session API directly. This entire file _is_ the `StreamingRunner`.
+**Everything else is clean.** `session.py` (549 lines) contains only
+`drain_session`, `EvalCollector`, resume state persistence, and file extraction
+— pure framework code with zero `opal_backend` imports. All 10 function modules
+import exclusively from `bees.protocols`. `scheduler.py`, `task_runner.py`, and
+`provisioner.py` have zero `opal_backend` imports.
 
-### Clean today (trivial fix)
-
-`scheduler.py` imports `HttpBackendClient` only for type annotation. Replace
-with a protocol or `Any` and it's clean. `task_runner.py` already uses
-`backend: Any` — zero `opal_backend` imports.
-
-`box.py` imports `app.auth`, `app.config`, `HttpBackendClient`. All three become
-constructor parameters when it moves to its own package.
-
-### The friction: function modules
-
-All 8 function modules import `opal_backend.function_definition` for:
-
-- `FunctionGroup`, `FunctionGroupFactory`, `SessionHooks` (types)
-- `assemble_function_group`, `load_declarations` (assembly utilities)
-
-Additionally, `chat.py` and `files.py` import `_make_handlers` from
-`opal_backend.functions.*` — these delegate to `opal_backend`'s built-in
-handlers for file I/O and chat.
-
-**Resolution**: The tool protocol bridge (above) addresses the type imports. The
-`_make_handlers` delegations and `load_declarations`/`assemble_function_group`
-utilities need bees-native equivalents or thin wrappers in the protocols module.
-Since these are pure data assembly (JSON schema loading + handler map → group),
-the extraction is mechanical.
+> **Transitional back-imports** in `handler_types.py` are accepted. `SuspendError`
+> and `AgentResult` subclass their `opal_backend` counterparts so the opal session
+> loop's `except` / `isinstance` checks pass. The cost (two type-level imports in
+> one file) is not worth rewriting the loop's battle-hardened retry logic.
 
 ## Open questions
-
-**VFS layer.** `disk_file_system.py` depends on `opal_backend`'s
-`FileSystemProtocol`. Same protocol bridge approach applies — define a
-bees-native `FileSystem` protocol that mirrors the shape.
 
 **MCP lifecycle.** MCP connections are currently established per-session. Under
 the split, bees manages MCP connections as framework infrastructure (since
 `mcp_bridge.py` stays in bees). The runner doesn't need to know about MCP.
 
-**`_make_handlers` delegation.** `chat.py` and `files.py` import handler
-factories from `opal_backend.functions.*`. These need to either move into bees
-(if the logic is framework-level) or be injected by the runner (if they're
-provider-specific). Needs investigation.
+## What remains
 
-## Gradual migration
+All protocols are specified, tested, and migrated (see
+[library-extraction.md](./library-extraction.md) for the full inventory). The
+remaining work is the physical package split:
 
-This split follows Spec-Driven Development. Write protocols first, prove them
-with conformance tests, then migrate imports.
+1. Create `gemini-runners` package with `GeminiRunner` (wraps `bees/runners/gemini.py`).
+2. Move `box.py` into its own package.
+3. Remove remaining `opal_backend` imports from `bees/`.
+4. Drop all external deps from `bees/pyproject.toml`.
 
-### Protocol inventory
-
-| Protocol            | Replaces                            | Specified | Tested | Migrated |
-| ------------------- | ----------------------------------- | --------- | ------ | -------- |
-| `FunctionGroup`     | `opal_backend.FunctionGroup`        | ✅        | ✅     | ✅       |
-| `FunctionFactory`   | `opal_backend.FunctionGroupFactory` | ✅        | ✅     | ✅       |
-| `FunctionHooks`     | `opal_backend.SessionHooks`         | ✅        | ✅     | ✅       |
-| `FileSystem`        | `opal_backend.FileSystemProtocol`   | ✅        | ✅     | ✅       |
-| `SuspendError`      | `opal_backend.suspend.SuspendError` | ✅        | ✅     | ✅       |
-| `AgentResult`       | `opal_backend.events.AgentResult`   | ✅        | ✅     | ✅       |
-| `SessionTerminator` | `opal_backend.loop.LoopController`  | ✅        | ✅     | ✅       |
-| `SUSPEND_TYPES`     | `opal_backend.events.SUSPEND_TYPES` | ✅        | ✅     | ✅       |
-| `PAUSE_TYPES`       | `opal_backend.events.PAUSE_TYPES`   | ✅        | ✅     | ✅       |
-| `SessionResult`     | (relocation to protocols)           | ✅        | ✅     | ✅       |
-| `SessionRunner`     | Implicit contract in `session.py`   | Pending   | —      | —        |
-
-See [spec/function-types.md](../spec/function-types.md) for the function types
-spec, [spec/filesystem.md](../spec/filesystem.md) for the filesystem types spec,
-[spec/handler-types.md](../spec/handler-types.md) for the handler types spec,
-and [spec/session-observation.md](../spec/session-observation.md) for the
-session observation types spec and conformance tests.
-
-### Migration steps
-
-1. Define function protocols in `bees/protocols.py` (mirror `opal_backend`
-   shapes).
-2. Define `SessionRunner` protocol.
-3. Migrate `bees/functions/` to import from `bees/protocols.py`.
-4. Create `gemini-runners` with `StreamingRunner` (wraps `session.py` +
-   `opal_backend`).
-5. Move `box.py` into its own package.
-6. Remove `opal_backend` imports from `bees/`.
-7. Drop all external deps from `bees/pyproject.toml`.
-
-Each step is independently shippable — the existing code path continues to work
-throughout.
+Each step is independently shippable.

--- a/packages/bees/docs/reference-app.md
+++ b/packages/bees/docs/reference-app.md
@@ -34,8 +34,8 @@ The server has three responsibilities:
 
 ### 1. Boot the system
 
-On startup, the server creates a `Bees` instance with an `HttpBackendClient`
-and calls `bees.listen()`, which recovers stuck tasks, boots the root template
+On startup, the server creates a `Bees` instance with session runners and
+calls `bees.listen()`, which recovers stuck tasks, boots the root template
 from `SYSTEM.yaml`, and starts the scheduler loop.
 
 ### 2. Project the model as REST
@@ -77,16 +77,16 @@ parameter scopes the search to a subagent's subdirectory.
 The server uses a `Broadcaster` (fan-out queue) to deliver real-time state
 changes to all connected clients via Server-Sent Events.
 
-The wiring: each `Bees` event callback maps to an SSE event type.
+The wiring: each typed event maps to an SSE event type via `bees.on()`.
 
-| Bees hook             | SSE event type      | What happened                    |
+| Bees event type       | SSE event type      | What happened                    |
 | --------------------- | ------------------- | -------------------------------- |
-| `ticket_added`        | `agent:added`       | A new agent was created          |
-| `ticket_start`        | `agent:updated`     | Agent transitioned to running    |
-| `ticket_done`         | `agent:updated`     | Agent reached a resting state    |
-| `ticket_event`        | `session:event`     | Running session emitted an event |
-| `cycle_start`         | `scheduler:started` | Scheduler cycle beginning        |
-| `cycle_complete`      | `scheduler:stopped` | Scheduler has no more work       |
+| `TaskAdded`           | `agent:added`       | A new agent was created          |
+| `TaskStarted`         | `agent:updated`     | Agent transitioned to running    |
+| `TaskDone`            | `agent:updated`     | Agent reached a resting state    |
+| `TaskEvent`           | `session:event`     | Running session emitted an event |
+| `CycleStarted`        | `scheduler:started` | Scheduler cycle beginning        |
+| `CycleComplete`       | `scheduler:stopped` | Scheduler has no more work       |
 
 On initial connection, the SSE stream sends an `init` event with the full task
 list. After that, clients receive incremental updates. There is no REST endpoint
@@ -185,13 +185,12 @@ concretely here:
 
 ## What Would Change
 
-When the consumption API matures (see [flux.md](./flux.md)), the reference app
-would:
+When the consumption API matures (see [future.md](./future.md)), the reference
+app would:
 
 1. Stop editing task files directly in `/reply` and `/choose` — use a
    framework-provided interaction surface instead.
-2. Replace `Bees` event callbacks with a more principled observation API.
-3. Potentially extract into its own package, consuming bees as a library.
+2. Potentially extract into its own package, consuming bees as a library.
 
 The current implementation works but is tightly coupled to the framework's
 internals. The reference app is as much a test of the consumption API's limits

--- a/packages/bees/docs/session.md
+++ b/packages/bees/docs/session.md
@@ -33,43 +33,48 @@ creating a new run.
 
 ## Implementation split
 
-The session implementation lives in two places:
+The session implementation is layered across three concerns:
 
-| Module                         | Responsibility                                                                                                                                                                       |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `opal_backend/sessions/api.py` | The agent loop itself: `new_session`, `start_session`, `resume_session`. Handles turn-by-turn model invocation, function dispatch, state persistence.                                |
-| `bees/session.py`              | Bees' wrapper. Assembles function groups, wires up the disk-backed file system, manages eval logging, and translates between bees' task model and `opal_backend`'s session protocol. |
+| Module                     | Responsibility                                                                                                                              |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `bees/provisioner.py`      | Assembles a `SessionConfiguration` from task parameters: filters skills, creates the file system, wires function groups. Pure bees logic.  |
+| `bees/runners/*.py`        | Concrete `SessionRunner` implementations. `GeminiRunner` (batch text), `LiveRunner` (delegated live/voice).                                |
+| `bees/session.py`          | `drain_session` — consumes the event stream from a runner, writes eval logs, extracts files, and returns a `SessionResult`.                |
 
-From the session layer's perspective, `opal_backend` is an implementation
-detail. Consumers of the session layer see a unified surface: call `run_session`
-or `resume_session`, get back a `SessionResult`.
+The `SessionRunner` protocol (`bees/protocols/session.py`) defines the boundary:
 
-### `run_session`
+```python
+class SessionRunner(Protocol):
+    async def run(self, configuration: SessionConfiguration) -> SessionStream: ...
+    async def resume(self, configuration: SessionConfiguration) -> SessionStream: ...
+```
 
-The main entry point. It:
+`TaskRunner` orchestrates the full sequence:
 
-1. Filters skills and merges `allowed-tools` into the function filter.
-2. Creates a `DiskFileSystem` backed by the task's working directory.
-3. Seeds skill files into the file system.
-4. Calls `new_session()` with all function groups and config.
-5. Starts the agent loop (`start_session`) and collects events via a subscriber
-   queue.
-6. Writes structured eval logs at turn boundaries.
-7. On suspend or pause, persists session state to `session_state.json`.
-8. Returns a `SessionResult` with status, metrics, outcome, and file manifest.
+1. Calls `provision_session()` to assemble a `SessionConfiguration`.
+2. Calls `runner.run(config)` or `runner.resume(config)` to get a `SessionStream`.
+3. Calls `drain_session(stream, config)` to consume events and produce a `SessionResult`.
 
-### `resume_session`
+### Provisioning
 
-Picks up where a suspended or paused session left off:
+`provision_session()` is the pure-bees half. It:
 
-1. Loads saved state from `session_state.json`.
-2. Reconstructs all function groups (file system is already on disk — no seeding
-   needed).
-3. Restores the interaction state and sets the session to "suspended".
-4. Collects any pending context updates (from both `response.json` and
-   metadata).
-5. Calls `api_resume_session()` with the response and context parts.
-6. Event loop and logging proceed identically to `run_session`.
+1. Resolves the hive directory.
+2. Filters skills and merges `allowed-tools` into the function filter.
+3. Creates a `DiskFileSystem` backed by the task's working directory.
+4. Seeds skill files into the file system.
+5. Assembles all function group factories.
+6. Returns a `SessionConfiguration` with everything a runner needs.
+
+### Draining
+
+`drain_session()` consumes a `SessionStream` (an async iterable of events). It:
+
+1. Writes structured eval logs at turn boundaries.
+2. Tracks token usage, function calls, and thoughts.
+3. On suspend or pause, persists session state via `save_resume_state()`.
+4. Extracts files from the workspace on completion.
+5. Returns a `SessionResult` with status, metrics, outcome, and file manifest.
 
 ## Function Groups
 
@@ -88,17 +93,10 @@ group contains:
    construction time. This is how stateless declarations get wired to stateful
    runtime context (the file system, the scheduler, the scope).
 
-### Two kinds of function groups
+### Bees function groups
 
-- **opal_backend built-ins** — provided by the underlying platform. These
-  include `generate.*` (search-grounded text generation, image/video/audio
-  generation) and others. Bees passes these through to the session — template
-  authors can filter them in or out, but bees doesn't redeclare them.
-- **Bees function groups** — defined in `bees/functions/` and
-  `bees/declarations/`. Some override opal_backend groups (e.g. `system` and
-  `chat` provide bees-specific behavior while keeping the same group name).
-
-The bees function groups:
+All function groups are defined in `bees/functions/` and `bees/declarations/`,
+using bees-native protocols from `bees/protocols/`:
 
 | Group          | Filter prefix    | Purpose                                                                                                                  |
 | -------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------ |
@@ -131,7 +129,8 @@ filter means all function groups are available.
 
 Each session has a disk-backed file system (`DiskFileSystem` in
 `bees/disk_file_system.py`). It satisfies the `FileSystem` protocol from
-`opal_backend` by reading and writing directly to a working directory on disk.
+`bees/protocols/filesystem.py` by reading and writing directly to a working
+directory on disk.
 
 Key characteristics:
 
@@ -215,8 +214,12 @@ Logs are written to `{hive}/logs/` at turn boundaries and on completion. A
 
 | File                       | Responsibility                                   |
 | -------------------------- | ------------------------------------------------ |
-| `bees/session.py`          | Session assembly, run/resume, eval collection    |
-| `bees/functions/`          | All bees-specific function group implementations |
+| `bees/provisioner.py`      | Session provisioning (pure bees logic)           |
+| `bees/session.py`          | `drain_session`, eval collection, resume state   |
+| `bees/runners/gemini.py`   | Batch text runner (wraps opal session API)        |
+| `bees/runners/live.py`     | Live voice runner (delegated to browser)          |
+| `bees/protocols/session.py`| `SessionRunner` protocol, `SessionConfiguration` |
+| `bees/functions/`          | All function group implementations               |
 | `bees/declarations/`       | Function schemas and instructions                |
 | `bees/disk_file_system.py` | Disk-backed VFS adapter                          |
 | `bees/context_updates.py`  | Event → context parts formatting                 |
@@ -224,9 +227,6 @@ Logs are written to `{hive}/logs/` at turn boundaries and on completion. A
 ---
 
 ## Gaps
-
-Code changes needed to reconcile the session layer with the aspirational
-architecture in `docs/architecture/index.md`.
 
 ### `skills.*` group exists only as a workaround
 
@@ -238,20 +238,3 @@ function group wrapper.
 **Gap**: The session layer needs a mechanism to inject system instruction
 fragments independently of function groups. Once that exists, the `skills.*`
 group can be removed.
-
-### Function naming: dots vs. underscores
-
-The architecture doc uses dot notation (`system.objective_fulfilled`) for both
-filter prefixes and function names. In practice, filter prefixes use dots
-(`system.*`) but actual function names use underscores
-(`system_objective_fulfilled`) because the Gemini API does not support dots in
-function names.
-
-This substitution is currently visible to users — template authors write
-`system.*` in filters but see `system_objective_fulfilled` in logs and
-responses.
-
-**Gap**: The dot↔underscore substitution should be invisible to the user.
-Function names displayed in the architecture doc should be the names users see
-everywhere. This likely requires a transparent translation layer at the
-declaration/dispatch boundary.


### PR DESCRIPTION
## What
Reconciled the bees documentation suite with the current codebase state after the library extraction and Project Acoustic shipped. Created a new `library-extraction.md` doc, trimmed `future.md` to forward-looking content only, and updated stale references across 9 files.

## Why
Several docs still described deleted code (`run_session`, `resume_session`, `SchedulerHooks`), referenced non-existent CLI commands, used old string-keyed hook names, and labeled completed work as "not implemented yet." The docs needed to catch up with the architecture.

## Changes

### New
- **`docs/library-extraction.md`** — Record of completed library extraction work (specs, migration phases, remaining `opal_backend` imports). Extracted from `future.md` so that doc stays forward-looking only.

### Updated
- **`README.md`** — Rewrote to reflect `SessionRunner` architecture. Removed ghost CLI commands (`session:start`, `ticket:add`, `ticket:drain`). Added `dev:box` and `dev:hivetool` entry points.
- **`docs/future.md`** — Trimmed to forward-looking only. Renamed "Phase 4" → "Zero-Dependency `bees`". Added three new sections: Multi-Modal Sessions, Agent Artifacts, Shared Directories.
- **`docs/session.md`** — Rewrote implementation split to reflect provisioner → runner → drain_session architecture. Removed deleted `run_session`/`resume_session` docs. Updated function groups to "all bees-native." Removed stale dot↔underscore gap.
- **`docs/box.md`** — Fixed `SchedulerHooks` → typed event subscription. Updated pseudocode to show runners dict.
- **`docs/reference-app.md`** — Fixed SSE event table to use typed event names (`TaskAdded`, not `ticket_added`). Removed completed observation API from "What Would Change."
- **`docs/delegated-sessions.md`** — Replaced "nothing is implemented" banner with pointer to Project Acoustic and architectural divergences.
- **`docs/delegated-sessions-2.md`** — Replaced "nothing is implemented" banner with note that the thesis is reality.
- **`docs/package-split.md`** — Updated import graph (clean `session.py`, zero function module imports). Fixed `SessionRunner` protocol status. Removed solved open questions.
- **`docs/README.md`** — Added `library-extraction.md`, new "Concept explorations" section, updated `future.md` description.

## Testing
Documentation-only change. Read the updated docs for accuracy.
