### PR TITLE
[bees] Consumer Event Subscription (Project Surface Phase 1)

### DIFF
--- a/packages/bees/PROJECT_SURFACE.md
+++ b/packages/bees/PROJECT_SURFACE.md
@@ -1,0 +1,165 @@
+# Project Surface
+
+## Orientation
+
+Key directories and files for this project:
+
+- [docs/future.md](docs/future.md) — original vision for Agent Artifacts and
+  Shared Directories
+- [docs/architecture.md](docs/architecture.md) — framework architecture overview
+- [docs/patterns.md](docs/patterns.md) — design philosophy (MVC, hive as
+  interchange)
+- [bees/functions/files.py](bees/functions/files.py) — file I/O function group
+  (how agents write files)
+- [bees/disk_file_system.py](bees/disk_file_system.py) — filesystem
+  implementation (content store)
+- [bees/subagent_scope.py](bees/subagent_scope.py) — write-fencing for
+  sub-agents (per-scope boundaries)
+- [bees/task_runner.py](bees/task_runner.py) — session wiring, metadata
+  bookkeeping, `extract_files`
+- [bees/protocols/events.py](bees/protocols/events.py) — typed event system
+  (`EventEmitter`, `TaskEvent`)
+- [bees/functions/events.py](bees/functions/events.py) — `events_broadcast`
+  function group
+- [hive/config/TEMPLATES.yaml](hive/config/TEMPLATES.yaml) — task templates
+  (`watch_events`, `tags`, `functions`)
+- [hivetool/src/data/ticket-store.ts](hivetool/src/data/ticket-store.ts) —
+  hivetool's filesystem-based store (FileSystemObserver, `scan()`)
+- [common/types.ts](common/types.ts) — shared `TaskData` type (the "database
+  row")
+
+## Summary
+
+Agents need a way to present curated output to the user — not just text in the
+chat log, but structured, persistent, updatable artifacts that the consumer
+application renders.
+
+**Surface** is the name for this concept. A surface is:
+
+- A `surface.json` file in the agent's scope within the shared filesystem
+- A structured manifest describing what the agent wants to present (sections,
+  panels, references to content files)
+- Updated mid-session, visible as the agent works
+- Discovered by consumers through event subscription
+
+## Key design decisions
+
+- **The filesystem is the artifact.** The ticket directory above `filesystem/`
+  is a database table (system metadata). `filesystem/` is the content store.
+  Surface lives here.
+- **Per-scope surfaces.** Each agent writes `{scope}/surface.json` within its
+  writable area. The consumer walks the tree and aggregates. No cross-scope
+  writing needed.
+- **Notification via `events_broadcast`.** The agent writes content files, writes
+  `surface.json`, then broadcasts `surface_updated`. No new function — reuses
+  existing infrastructure.
+- **Consumer event subscription.** A new extensibility point in the scheduler
+  allows consumers (applications) to subscribe to broadcast events alongside
+  agents. `surface_updated` is the first use case, but the mechanism is general.
+
+---
+
+## Phase 1 — Consumer Event Subscription ✅
+
+Extend the scheduler's event routing so that applications (not just agents) can
+subscribe to broadcast event types.
+
+- [x] `bees/protocols/events.py` — `BroadcastReceived(SchedulerEvent)` with
+      `signal_type`, `message`, `source_task_id`.
+- [x] `bees/coordination.py` — emit `BroadcastReceived` during
+      `route_coordination_task`, after agent delivery, before `TaskDone`.
+- [x] `app/server.py` — subscribe via `bees.on(BroadcastReceived, ...)`, push
+      `broadcast:received` to SSE clients.
+- [x] `tests/test_coordination.py` — **[NEW]** 4 tests (emission, ordering,
+      empty fields, coexistence with agent delivery).
+
+🎯 The reference app's server receives an `events_broadcast` event through a
+registered callback, and can push it to the client via SSE.
+
+---
+
+## Phase 2 — Surface Schema
+
+Define what goes in `surface.json`. Start minimal and let it evolve.
+
+- [ ] Sections with titles and content references? Flat list of items? Typed panels
+      (markdown, image, bundle)?
+- [ ] How does the schema handle updates — full replacement or incremental patches?
+- [ ] What metadata does each entry carry (name, type, path, timestamp)?
+
+🎯 A written schema spec that an agent can follow and a consumer can render,
+validated by hand-writing a few example `surface.json` files.
+
+---
+
+## Phase 3 — Surface Skill
+
+Teach agents to produce surfaces.
+
+- [ ] Write a skill that teaches the agent how to write `surface.json`.
+- [ ] The skill covers: writing content files, structuring the manifest, broadcasting
+      `surface_updated`.
+- [ ] Agent writes content files + `surface.json` + broadcasts `surface_updated`.
+
+🎯 An agent with the surface skill writes a `surface.json` in its scope
+directory and broadcasts `surface_updated`. The event reaches a subscribed
+consumer.
+
+---
+
+## Phase 4 — Surface Aggregation
+
+When a root task has sub-agents each with their own surface, how does the
+consumer compose them?
+
+- [ ] Flat merge? Tree projection? Filtered by tags?
+- [ ] Per the MVC model, this is the consumer's decision — but the convention should
+      make aggregation natural.
+- [ ] Define how per-scope surfaces (`research/surface.json`, `app/surface.json`)
+      compose into a task-level view.
+
+🎯 A task with multiple sub-agents produces per-scope surfaces. A consumer can
+walk the tree and assemble a coherent composite view.
+
+---
+
+## Phase 5 — Hivetool Surface Rendering
+
+Hivetool discovers and renders surface files from the task's filesystem.
+
+- [ ] On `surface_updated` (or filesystem change), scan for `surface.json` files in
+      the task's filesystem tree.
+- [ ] Render the surface based on the manifest: markdown, images, structured panels.
+- [ ] Update live as the agent works.
+
+🎯 In hivetool, selecting a task shows its surface — rendered from the agent's
+`surface.json` — and it updates in real time as the agent writes.
+
+---
+
+## Phase 6 — Reference App Surface Rendering
+
+The reference web app renders surfaces for chat-tagged tasks.
+
+- [ ] Server exposes surface data via REST endpoint.
+- [ ] Client renders the surface alongside the chat view.
+- [ ] SSE pushes `surface_updated` events to trigger client refresh.
+
+🎯 In the reference web app, a chat task's surface appears alongside the
+conversation and updates live.
+
+---
+
+## Phase 7 — Clean Workspace Boundary
+
+`skills/` currently gets seeded into `filesystem/`. These are system files
+leaked into the content store — wrong separation. Surface makes this more
+visible.
+
+- [ ] Move skill seeding out of the agent workspace (or into a hidden/system
+      namespace the agent can read but the consumer ignores).
+- [ ] Ensure the workspace contains only agent-produced content.
+
+🎯 A task's `filesystem/` directory contains only files the agent wrote —
+no system-seeded files pollute the surface or the file tree.
+

--- a/packages/bees/app/server.py
+++ b/packages/bees/app/server.py
@@ -32,6 +32,7 @@ from app.auth import load_gemini_key
 from app.config import load_hive_dir
 from bees import Task, Bees
 from bees.protocols.events import (
+    BroadcastReceived,
     CycleComplete,
     CycleStarted,
     TaskAdded,
@@ -128,6 +129,16 @@ async def _on_cycle_complete(event: CycleComplete) -> None:
     await broadcaster.broadcast({"type": "scheduler:stopped", "waves": event.total_cycles})
 
 
+async def _on_broadcast(event: BroadcastReceived) -> None:
+    """Push agent broadcast events to SSE clients."""
+    await broadcaster.broadcast({
+        "type": "broadcast:received",
+        "signal_type": event.signal_type,
+        "message": event.message,
+        "source_task_id": event.source_task_id,
+    })
+
+
 # ---------------------------------------------------------------------------
 # Request/response models
 # ---------------------------------------------------------------------------
@@ -181,6 +192,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     bees.on(TaskStarted, _on_task_start)
     bees.on(TaskDone, _on_task_done)
     bees.on(CycleComplete, _on_cycle_complete)
+    bees.on(BroadcastReceived, _on_broadcast)
 
     await bees.listen()
 

--- a/packages/bees/bees/coordination.py
+++ b/packages/bees/bees/coordination.py
@@ -19,7 +19,7 @@ from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable
 
 from bees.playbook import run_event_hooks
-from bees.protocols.events import EventEmitter, TaskDone
+from bees.protocols.events import BroadcastReceived, EventEmitter, TaskDone
 from bees.task_store import TaskStore
 from bees.ticket import Ticket
 
@@ -134,6 +134,13 @@ async def route_coordination_task(
         )
 
     store.save_metadata(task)
+
+    # Notify application consumers about the broadcast.
+    await emit(BroadcastReceived(
+        signal_type=signal_type,
+        message=payload,
+        source_task_id=task.id,
+    ))
 
     # Broadcast the updated coordination task to the UI.
     await emit(TaskDone(task=task))

--- a/packages/bees/bees/protocols/events.py
+++ b/packages/bees/bees/protocols/events.py
@@ -22,6 +22,7 @@ from typing import Any, Awaitable, Callable, TypeVar
 from bees.ticket import Ticket
 
 __all__ = [
+    "BroadcastReceived",
     "CycleComplete",
     "CycleStarted",
     "EventEmitter",
@@ -111,6 +112,21 @@ class CycleComplete(SchedulerEvent):
 
     type: str = field(init=False, default="cycle_complete")
     total_cycles: int = 0
+
+
+@dataclass
+class BroadcastReceived(SchedulerEvent):
+    """An agent broadcast event was received during coordination routing.
+
+    Bridges agent-level broadcasts (``events_broadcast``) into the
+    framework's typed event pipeline so application consumers can
+    subscribe via ``bees.on(BroadcastReceived, ...)``.
+    """
+
+    type: str = field(init=False, default="broadcast_received")
+    signal_type: str = ""
+    message: str = ""
+    source_task_id: str = ""
 
 
 # ---------------------------------------------------------------------------

--- a/packages/bees/tests/test_coordination.py
+++ b/packages/bees/tests/test_coordination.py
@@ -1,0 +1,132 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for coordination event routing.
+
+Covers the Phase 1 objective: applications receive agent-level broadcast
+events via the BroadcastReceived scheduler event.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from bees.coordination import route_coordination_task
+from bees.protocols.events import BroadcastReceived, TaskDone
+from bees.task_store import TaskStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    return TaskStore(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# BroadcastReceived emission
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_broadcast_received_emitted(store):
+    """route_coordination_task emits a BroadcastReceived event."""
+    coord = store.create(
+        "",
+        kind="coordination",
+        signal_type="surface_updated",
+        context="new content available",
+    )
+
+    emitted = []
+
+    async def capture(event):
+        emitted.append(event)
+
+    await route_coordination_task(coord, store, set(), capture)
+
+    broadcasts = [e for e in emitted if isinstance(e, BroadcastReceived)]
+    assert len(broadcasts) == 1
+
+    event = broadcasts[0]
+    assert event.signal_type == "surface_updated"
+    assert event.message == "new content available"
+    assert event.source_task_id == coord.id
+
+
+@pytest.mark.asyncio
+async def test_broadcast_received_before_task_done(store):
+    """BroadcastReceived fires before TaskDone in emission order."""
+    coord = store.create(
+        "",
+        kind="coordination",
+        signal_type="test_signal",
+        context="payload",
+    )
+
+    order = []
+
+    async def capture(event):
+        order.append(type(event).__name__)
+
+    await route_coordination_task(coord, store, set(), capture)
+
+    assert order == ["BroadcastReceived", "TaskDone"]
+
+
+@pytest.mark.asyncio
+async def test_broadcast_received_carries_empty_fields(store):
+    """BroadcastReceived handles missing context gracefully."""
+    coord = store.create(
+        "",
+        kind="coordination",
+        signal_type="ping",
+    )
+
+    emitted = []
+
+    async def capture(event):
+        emitted.append(event)
+
+    await route_coordination_task(coord, store, set(), capture)
+
+    broadcasts = [e for e in emitted if isinstance(e, BroadcastReceived)]
+    assert len(broadcasts) == 1
+    assert broadcasts[0].message == ""
+    assert broadcasts[0].signal_type == "ping"
+
+
+@pytest.mark.asyncio
+async def test_broadcast_received_with_subscriber_delivery(store):
+    """BroadcastReceived fires even when agent subscribers exist."""
+    # Create a subscriber that watches for the signal type.
+    subscriber = store.create(
+        "watcher",
+        watch_events=[{"type": "data_ready"}],
+    )
+    # Suspend it so it can receive delivery.
+    subscriber.metadata.status = "suspended"
+    subscriber.metadata.assignee = "user"
+    store.save_metadata(subscriber)
+
+    # Create the coordination task.
+    coord = store.create(
+        "",
+        kind="coordination",
+        signal_type="data_ready",
+        context="here it comes",
+    )
+
+    emitted = []
+
+    async def capture(event):
+        emitted.append(event)
+
+    await route_coordination_task(coord, store, set(), capture)
+
+    # Both agent delivery AND consumer notification happened.
+    broadcasts = [e for e in emitted if isinstance(e, BroadcastReceived)]
+    assert len(broadcasts) == 1
+    assert broadcasts[0].signal_type == "data_ready"
+
+    # The subscriber was delivered to.
+    updated = store.get(subscriber.id)
+    assert updated.metadata.assignee == "agent"


### PR DESCRIPTION
## What

Bridges agent-level broadcast events into the framework's typed event pipeline so application consumers (server, hivetool) can subscribe to them via `bees.on()`.

## Why

`events_broadcast` currently only reaches agent subscribers via `watch_events`. Applications have no way to receive these signals — blocking the upcoming Surface feature where the server and UI need to react to `surface_updated` broadcasts.

## Changes

### `bees/protocols/events.py`
- New `BroadcastReceived(SchedulerEvent)` dataclass with `signal_type`, `message`, `source_task_id`.

### `bees/coordination.py`
- Emit `BroadcastReceived` during `route_coordination_task`, after agent delivery and before the existing `TaskDone` emission.

### `app/server.py`
- Subscribe `bees.on(BroadcastReceived, _on_broadcast)`.
- Push `broadcast:received` events to SSE clients.

### `tests/test_coordination.py` [NEW]
- 4 tests: emission, ordering (before TaskDone), empty fields, coexistence with agent delivery.

### `PROJECT_SURFACE.md` [NEW]
- Project plan with Phase 1 marked complete; Phases 2–7 outlined with checkboxes.

## Testing

```bash
cd packages/bees
.venv/bin/python -m pytest tests/test_coordination.py tests/test_events.py tests/test_scheduler.py -v
```

27 tests pass, no regressions.
