### PR TITLE
[bees] Hivetool Surface Discovery (Project Surface Phase 4)

### DIFF
--- a/packages/bees/PROJECT_SURFACE.md
+++ b/packages/bees/PROJECT_SURFACE.md
@@ -50,9 +50,9 @@ application renders.
 - **Per-scope surfaces.** Each agent writes `{scope}/surface.json` within its
   writable area. The consumer walks the tree and aggregates. No cross-scope
   writing needed.
-- **Notification via `events_broadcast`.** The agent writes content files, writes
-  `surface.json`, then broadcasts `surface_updated`. No new function — reuses
-  existing infrastructure.
+- **Notification via `events_broadcast`.** The agent writes content files,
+  writes `surface.json`, then broadcasts `surface_updated`. No new function —
+  reuses existing infrastructure.
 - **Consumer event subscription.** A new extensibility point in the scheduler
   allows consumers (applications) to subscribe to broadcast events alongside
   agents. `surface_updated` is the first use case, but the mechanism is general.
@@ -83,7 +83,8 @@ registered callback, and can push it to the client via SSE.
 Surface format specified in [docs/surface-schema.md](docs/surface-schema.md).
 
 - [x] Snapshot `surface.json` — agent overwrites on every change, with a
-      monotonic `version` counter for change detection. Rollback is consumer-side.
+      monotonic `version` counter for change detection. Rollback is
+      consumer-side.
 - [x] Two flat entity types: **Sections** (declared groups with id, title,
       description) and **Items** (typed content leaves with id, title, path,
       description, render hint, role, section reference).
@@ -107,10 +108,10 @@ Teach agents to produce surfaces.
 
 - [x] Write a skill that teaches the agent how to write `surface.json`.
       [SKILL.md](hive/skills/surface/SKILL.md)
-- [x] The skill covers: writing content files, structuring the manifest, broadcasting
-      `surface_updated`. Includes the core loop (write content → write surface.json →
-      broadcast), full format reference, and a worked example showing incremental
-      updates across three versions.
+- [x] The skill covers: writing content files, structuring the manifest,
+      broadcasting `surface_updated`. Includes the core loop (write content →
+      write surface.json → broadcast), full format reference, and a worked
+      example showing incremental updates across three versions.
 - [x] Composable design: skill layers on top of any primary skill via
       `allowed-tools: [files.*, events.*]`. Any template can add `surface` to
       its `skills` list alongside existing skills.
@@ -121,33 +122,40 @@ consumer.
 
 ---
 
-## Phase 4 — Surface Aggregation
+## Phase 4 — Hivetool Surface Discovery
 
-When a root task has sub-agents each with their own surface, how does the
-consumer compose them?
+Minimal surface rendering in hivetool. New `<bees-surface-view>` component,
+root-scope `surface.json` only, plain text rendering.
 
-- [ ] Flat merge? Tree projection? Filtered by tags?
-- [ ] Per the MVC model, this is the consumer's decision — but the convention should
-      make aggregation natural.
-- [ ] Define how per-scope surfaces (`research/surface.json`, `app/surface.json`)
-      compose into a task-level view.
+- [x] Surface types in `hivetool/src/data/types.ts` (`SurfaceManifest`,
+      `SurfaceSection`, `SurfaceItem`).
+- [x] `readSurface(ticketId)` in `ticket-store.ts` — reads
+      `filesystem/surface.json` for a ticket.
+- [x] New `surface-view.ts` component — renders title, sections, items as plain
+      text cards. Status items as compact indicators.
+- [x] `ticket-detail.ts` — renders `<bees-surface-view>` above the file tree
+      when a surface exists. Re-reads on filesystem observer updates.
 
-🎯 A task with multiple sub-agents produces per-scope surfaces. A consumer can
-walk the tree and assemble a coherent composite view.
+🎯 In hivetool, selecting a task with a `surface.json` shows the surface content
+rendered as structured cards, and it updates in real time.
 
 ---
 
-## Phase 5 — Hivetool Surface Rendering
+## Phase 5 — Hivetool Full Surface View
 
-Hivetool discovers and renders surface files from the task's filesystem.
+Promote the surface to a full-pane view with rich rendering.
 
-- [ ] On `surface_updated` (or filesystem change), scan for `surface.json` files in
-      the task's filesystem tree.
-- [ ] Render the surface based on the manifest: markdown, images, structured panels.
-- [ ] Update live as the agent works.
+- [ ] Sub-tab layout in ticket detail: `Surface · Detail` tabs, surface as the
+      default when present. Each gets the full main pane area.
+- [ ] Markdown rendering for `.md` items (basic or library-backed).
+- [ ] Bundle rendering for `render: "bundle"` items (sandboxed iframe with blob
+      URLs from File System Access API reads).
+- [ ] Multi-scope surface discovery — walk the filesystem tree for all
+      `surface.json` files, scope selector when multiple exist.
+- [ ] File content preview for items with `path` (loaded on demand).
 
-🎯 In hivetool, selecting a task shows its surface — rendered from the agent's
-`surface.json` — and it updates in real time as the agent writes.
+🎯 The surface view is a full-pane peer to ticket detail, with rendered markdown,
+bundle iframes, and content previews.
 
 ---
 
@@ -164,16 +172,19 @@ conversation and updates live.
 
 ---
 
-## Phase 7 — Clean Workspace Boundary
+## Phase 7 — Reverse Side-Channel
 
-`skills/` currently gets seeded into `filesystem/`. These are system files
-leaked into the content store — wrong separation. Surface makes this more
-visible.
+Structured event dispatch from box → hivetool via a `notifications/` directory,
+mirroring the mutation path (hivetool → box via `mutations/`).
 
-- [ ] Move skill seeding out of the agent workspace (or into a hidden/system
-      namespace the agent can read but the consumer ignores).
-- [ ] Ensure the workspace contains only agent-produced content.
+- [ ] Box subscribes to `BroadcastReceived` and writes notification files to
+      `hive/notifications/{uuid}.json`.
+- [ ] Hivetool watches `notifications/` with `FileSystemObserver`, dispatches to
+      signal-backed handlers.
+- [ ] `surface_updated` is the first consumer, but the mechanism is general.
 
-🎯 A task's `filesystem/` directory contains only files the agent wrote —
-no system-seeded files pollute the surface or the file tree.
+🎯 Hivetool receives structured, typed events from the box through the filesystem
+side-channel, enabling targeted reactions (e.g., re-read only the affected
+surface) instead of coarse filesystem rescans.
 
+---

--- a/packages/bees/hivetool/src/data/ticket-store.ts
+++ b/packages/bees/hivetool/src/data/ticket-store.ts
@@ -14,7 +14,7 @@
 
 import { Signal } from "signal-polyfill";
 import type { StateAccess } from "./state-access.js";
-import type { TicketData } from "./types.js";
+import type { TicketData, SurfaceManifest } from "./types.js";
 import { LiveSessionClient } from "./live-session.js";
 
 export { TicketStore };
@@ -236,6 +236,28 @@ class TicketStore {
       const fileHandle = await dir.getFileHandle(filename);
       const file = await fileHandle.getFile();
       return await file.text();
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Read the root `surface.json` from a ticket's filesystem.
+   *
+   * Returns the parsed manifest, or `null` if no surface exists.
+   */
+  async readSurface(ticketId: string): Promise<SurfaceManifest | null> {
+    if (!this.#ticketsHandle) return null;
+    try {
+      const ticketDir = await this.#ticketsHandle.getDirectoryHandle(ticketId);
+      const fsDir = await ticketDir.getDirectoryHandle("filesystem");
+      const fileHandle = await fsDir.getFileHandle("surface.json");
+      const file = await fileHandle.getFile();
+      const text = await file.text();
+      const parsed = JSON.parse(text);
+      // Basic validation: must have items array.
+      if (!parsed || !Array.isArray(parsed.items)) return null;
+      return parsed as SurfaceManifest;
     } catch {
       return null;
     }

--- a/packages/bees/hivetool/src/data/types.ts
+++ b/packages/bees/hivetool/src/data/types.ts
@@ -140,3 +140,34 @@ export interface MergedSessionView {
   totalFunctionCalls: number;
   totalTokens: number;
 }
+
+// ---------------------------------------------------------------------------
+// Surface schema types (from docs/surface-schema.md)
+// ---------------------------------------------------------------------------
+
+/** A named group within a surface manifest. */
+export interface SurfaceSection {
+  id: string;
+  title: string;
+  description?: string;
+}
+
+/** A content leaf in a surface manifest. */
+export interface SurfaceItem {
+  id: string;
+  title: string;
+  path?: string;
+  description?: string;
+  render?: string;
+  role?: string;
+  section?: string;
+}
+
+/** Parsed surface.json — the agent's curated presentation manifest. */
+export interface SurfaceManifest {
+  version: number;
+  title?: string;
+  sections?: SurfaceSection[];
+  items: SurfaceItem[];
+}
+

--- a/packages/bees/hivetool/src/ui/surface-view.ts
+++ b/packages/bees/hivetool/src/ui/surface-view.ts
@@ -1,0 +1,280 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Surface view — renders an agent's curated presentation manifest.
+ *
+ * Displays the structured content from `surface.json`: title, sections
+ * as labeled groups, items as cards with title and description text.
+ * Status items render as compact inline indicators.
+ */
+
+import { LitElement, html, css, nothing } from "lit";
+import { customElement, property } from "lit/decorators.js";
+
+import type { SurfaceManifest, SurfaceItem } from "../data/types.js";
+
+export { BeesSurfaceView };
+
+@customElement("bees-surface-view")
+class BeesSurfaceView extends LitElement {
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    .surface-header {
+      display: flex;
+      align-items: baseline;
+      gap: 10px;
+      margin-bottom: 8px;
+    }
+
+    .surface-title {
+      font-size: 0.85rem;
+      font-weight: 600;
+      color: #f8fafc;
+    }
+
+    .surface-version {
+      font-size: 0.65rem;
+      color: #64748b;
+      font-family: "Google Mono", "Roboto Mono", monospace;
+    }
+
+    .section-group {
+      margin-bottom: 12px;
+    }
+
+    .section-heading {
+      font-size: 0.7rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #94a3b8;
+      margin-bottom: 6px;
+      padding-bottom: 4px;
+      border-bottom: 1px solid #1e293b;
+    }
+
+    .section-description {
+      font-size: 0.7rem;
+      color: #64748b;
+      margin-bottom: 6px;
+    }
+
+    .items {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .item-card {
+      padding: 8px 12px;
+      background: #111827;
+      border: 1px solid #1e293b;
+      border-radius: 6px;
+      transition: border-color 0.15s;
+    }
+
+    .item-card:hover {
+      border-color: #334155;
+    }
+
+    .item-card.primary {
+      border-left: 3px solid #3b82f6;
+    }
+
+    .item-title {
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: #e2e8f0;
+      margin-bottom: 2px;
+    }
+
+    .item-description {
+      font-size: 0.75rem;
+      color: #94a3b8;
+      line-height: 1.4;
+    }
+
+    .item-path {
+      font-size: 0.65rem;
+      color: #64748b;
+      font-family: "Google Mono", "Roboto Mono", monospace;
+      margin-top: 4px;
+    }
+
+    .item-badges {
+      display: flex;
+      gap: 6px;
+      margin-top: 4px;
+    }
+
+    .badge {
+      font-size: 0.6rem;
+      font-weight: 600;
+      padding: 1px 6px;
+      border-radius: 3px;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+
+    .badge.bundle {
+      background: #312e81;
+      color: #a5b4fc;
+    }
+
+    .badge.supporting {
+      background: #1e293b;
+      color: #94a3b8;
+    }
+
+    /* Status items render inline, not as cards. */
+    .status-item {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 10px;
+      background: #0f172a;
+      border: 1px solid #1e293b;
+      border-radius: 12px;
+      font-size: 0.7rem;
+      color: #94a3b8;
+      margin-right: 6px;
+      margin-bottom: 4px;
+    }
+
+    .status-dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: #22c55e;
+      flex-shrink: 0;
+    }
+  `;
+
+  @property({ attribute: false })
+  accessor surface: SurfaceManifest | null = null;
+
+  render() {
+    if (!this.surface) return nothing;
+    const { title, version, sections, items } = this.surface;
+
+    // Group items by section.
+    const sectionMap = new Map<string | undefined, SurfaceItem[]>();
+    for (const item of items) {
+      const key = item.section;
+      const group = sectionMap.get(key) ?? [];
+      group.push(item);
+      sectionMap.set(key, group);
+    }
+
+    // Separate status items from content items.
+    const statusItems = items.filter((i) => i.role === "status");
+    const contentSections = sections ?? [];
+
+    return html`
+      <div class="surface-header">
+        ${title
+          ? html`<span class="surface-title">${title}</span>`
+          : nothing}
+        <span class="surface-version">v${version}</span>
+      </div>
+
+      ${statusItems.length > 0
+        ? html`<div style="margin-bottom: 10px">
+            ${statusItems.map(
+              (item) => html`
+                <span class="status-item">
+                  <span class="status-dot"></span>
+                  ${item.description ?? item.title}
+                </span>
+              `
+            )}
+          </div>`
+        : nothing}
+
+      ${contentSections.map((section) => {
+        const sectionItems = (sectionMap.get(section.id) ?? []).filter(
+          (i) => i.role !== "status"
+        );
+        if (sectionItems.length === 0) return nothing;
+        return html`
+          <div class="section-group">
+            <div class="section-heading">${section.title}</div>
+            ${section.description
+              ? html`<div class="section-description">
+                  ${section.description}
+                </div>`
+              : nothing}
+            <div class="items">
+              ${sectionItems.map((item) => this.renderItem(item))}
+            </div>
+          </div>
+        `;
+      })}
+
+      ${this.renderDefaultSection(sectionMap, contentSections)}
+    `;
+  }
+
+  /** Render items that have no section (the default/ungrouped section). */
+  private renderDefaultSection(
+    sectionMap: Map<string | undefined, SurfaceItem[]>,
+    declaredSections: { id: string }[]
+  ) {
+    const declaredIds = new Set(declaredSections.map((s) => s.id));
+    // Collect items with no section or a section not in the declared list.
+    const defaultItems = [...(sectionMap.get(undefined) ?? [])];
+    for (const [key, items] of sectionMap) {
+      if (key !== undefined && !declaredIds.has(key)) {
+        defaultItems.push(...items);
+      }
+    }
+    // Exclude status items — already rendered above.
+    const contentItems = defaultItems.filter((i) => i.role !== "status");
+    if (contentItems.length === 0) return nothing;
+
+    return html`
+      <div class="items" style="margin-top: 6px">
+        ${contentItems.map((item) => this.renderItem(item))}
+      </div>
+    `;
+  }
+
+  private renderItem(item: SurfaceItem) {
+    const roleClass = item.role === "primary" ? "primary" : "";
+
+    return html`
+      <div class="item-card ${roleClass}">
+        <div class="item-title">${item.title}</div>
+        ${item.description
+          ? html`<div class="item-description">${item.description}</div>`
+          : nothing}
+        ${item.path
+          ? html`<div class="item-path">📄 ${item.path}</div>`
+          : nothing}
+        ${item.render || item.role === "supporting"
+          ? html`<div class="item-badges">
+              ${item.render
+                ? html`<span class="badge bundle">${item.render}</span>`
+                : nothing}
+              ${item.role === "supporting"
+                ? html`<span class="badge supporting">supporting</span>`
+                : nothing}
+            </div>`
+          : nothing}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "bees-surface-view": BeesSurfaceView;
+  }
+}

--- a/packages/bees/hivetool/src/ui/ticket-detail.ts
+++ b/packages/bees/hivetool/src/ui/ticket-detail.ts
@@ -20,10 +20,12 @@ import type { TicketStore, FileTreeNode } from "../data/ticket-store.js";
 import type { MutationClient } from "../data/mutation-client.js";
 import type { TemplateStore } from "../data/template-store.js";
 import type { SkillStore } from "../data/skill-store.js";
+import type { SurfaceManifest } from "../data/types.js";
 import { sharedStyles } from "./shared-styles.js";
 import { renderJson } from "./json-tree.js";
 import { jsonTreeStyles } from "./json-tree.styles.js";
 import "./truncated-text.js";
+import "./surface-view.js";
 
 export { BeesTicketDetail };
 
@@ -433,6 +435,7 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
 
   @state() accessor fileTree: FileTreeNode[] = [];
   @state() accessor fileContents: Record<string, string | null> = {};
+  @state() accessor surface: SurfaceManifest | null = null;
 
   // ── Response state ──
   @state() accessor replyText = "";
@@ -453,11 +456,13 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
         Select a ticket to view details
       </div>`;
 
-    // Reset file tree if ticket changed.
+    // Reset file tree and surface if ticket changed.
     if (this.#treeLoadedFor !== ticket.id) {
       this.fileTree = [];
       this.fileContents = {};
+      this.surface = null;
       this.#treeLoadedFor = ticket.id;
+      this.loadSurface(ticket.id);
     }
 
     const suspendFn =
@@ -725,6 +730,18 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
                 </div>
               `
             : nothing}
+          ${this.surface
+            ? html`
+                <div class="block">
+                  <div class="block-header">Surface</div>
+                  <div class="block-content">
+                    <bees-surface-view
+                      .surface=${this.surface}
+                    ></bees-surface-view>
+                  </div>
+                </div>
+              `
+            : nothing}
           ${this.renderFileTree(ticket.id)}
         </div>
       </div>
@@ -826,6 +843,14 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
     if (!this.ticketStore) return;
     const tree = await this.ticketStore.readTree(ticketId);
     this.fileTree = tree;
+    // Also refresh the surface — the observer triggers tree reloads on
+    // any filesystem change, so this keeps the surface in sync.
+    this.loadSurface(ticketId);
+  }
+
+  private async loadSurface(ticketId: string) {
+    if (!this.ticketStore) return;
+    this.surface = await this.ticketStore.readSurface(ticketId);
   }
 
   private async loadFileContent(


### PR DESCRIPTION
## What

Hivetool can now discover and render `surface.json` manifests from a task's
filesystem, showing the agent's curated presentation as structured cards.

## Why

Surface is the agent-to-user presentation layer — agents write structured
manifests that describe their work products. This is the first consumer-side
rendering, completing Phase 4 of Project Surface.

## Changes

### Data layer (`hivetool/src/data/`)
- **types.ts** — Added `SurfaceManifest`, `SurfaceSection`, `SurfaceItem` types
  matching the surface schema spec.
- **ticket-store.ts** — Added `readSurface(ticketId)` to read and parse
  `filesystem/surface.json` for a given ticket.

### UI layer (`hivetool/src/ui/`)
- **surface-view.ts** (new) — `<bees-surface-view>` component that renders a
  surface manifest: title + version, status items as compact chips, sections as
  labeled groups, items as cards with title/description/path/badges.
- **ticket-detail.ts** — Renders the surface view above the file tree when a
  surface exists. Re-reads on filesystem observer updates for live refresh.

### Project plan
- **PROJECT_SURFACE.md** — Expanded Phases 4–5 into four phases: Phase 4
  (discovery, done), Phase 5 (full surface view), Phase 6 (reference app),
  Phase 7 (reverse side-channel).

## Testing

1. Drop a `surface.json` into any ticket's `filesystem/` directory
2. Open hivetool, select the ticket
3. A "Surface" block appears above the file tree with rendered content
4. Edit `surface.json` → view updates automatically
