### PR TITLE
[bees] Reconcile bees docs with codebase

### DIFF
--- a/packages/bees/docs/README.md
+++ b/packages/bees/docs/README.md
@@ -5,6 +5,8 @@
 - [architecture.md](architecture.md) — The two-layer model (Session →
   Scheduler), function groups, task trees, scoped filesystems, and the hive
   directory. The primary reference for how bees is built.
+- [api.md](api.md) — Reference for the `Bees` and `TaskNode` classes — the
+  public consumption surface for applications.
 
 ## Layer deep dives
 
@@ -29,6 +31,8 @@
 
 - [box.md](box.md) — The filesystem-driven orchestrator. Watches the hive for
   changes and drives the scheduler without an HTTP server.
+- [mutations.md](mutations.md) — The mutation log: atomic filesystem commands
+  for multi-step operations (reset, respond, batch task creation).
 - [hivetool.md](hivetool.md) — The built-in developer workbench for inspecting
   and editing hive configuration.
 

--- a/packages/bees/docs/api.md
+++ b/packages/bees/docs/api.md
@@ -13,14 +13,12 @@ The `bees` library is a framework for building agent swarm systems.
 
 The main entry point for interacting with a hive of tasks.
 
-#### `__init__(self, hive_dir: Path, *, http: httpx.AsyncClient, backend: HttpBackendClient, hooks: SchedulerHooks | None = None)`
+#### `__init__(self, hive_dir: Path, runners: dict[str, SessionRunner])`
 
 Initializes a new `Bees` instance.
 
 - **`hive_dir`**: The root directory of the hive where tasks are stored.
-- **`http`**: An async HTTP client for external requests.
-- **`backend`**: A client for interacting with the backend service.
-- **`hooks`**: Optional scheduler hooks.
+- **`runners`**: A dictionary mapping runner types to `SessionRunner` implementations (e.g., `{"generate": GeminiRunner(...), "live": LiveRunner(...)}`).
 
 #### `children`
 
@@ -56,12 +54,17 @@ Creates a new root task in the hive.
 - **`**kwargs`**: Additional arguments for task creation (e.g., `tags`).
 - **Returns**: A `TaskNode` representing the newly created task.
 
-#### `on(self, event_name: str, handler: Callable)`
+#### `on(self, event_type: type[T], callback: Callable[[T], Any])`
 
-Registers an event handler for the specified event.
+Registers a typed event listener.
 
-- **`event_name`**: The name of the event. Supported events: `task_added`, `cycle_start`, `task_event`, `task_start`, `task_done`, `cycle_complete`.
-- **`handler`**: The callback function to run when the event fires.
+- **`event_type`**: The event class to listen for. Available types: `TaskAdded`, `CycleStarted`, `TaskEvent`, `TaskStarted`, `TaskDone`, `BroadcastReceived`, `CycleComplete`.
+- **`callback`**: The callback function, receiving the typed event instance.
+
+Example:
+```python
+bees.on(TaskDone, lambda e: print(f"Done: {e.task.id}"))
+```
 
 #### `listen(self)` (Async)
 

--- a/packages/bees/docs/architecture.md
+++ b/packages/bees/docs/architecture.md
@@ -113,13 +113,14 @@ There are three kinds of function groups:
 
 The built-in functions are:
 
-| Group          | Filter prefix    | Purpose                                                                                                                                                          |
-| -------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `system`       | `system.*`       | Termination: `system_objective_fulfilled`, `system_failed_to_fulfill_objective`.                                                                                 |
-| `chat`         | `chat.*`         | Resume/suspend: `chat_request_user_input`, `chat_present_choices`, `chat_await_context_update`.                                                                  |
-| `files` | `files.*` | File I/O: `files_write_file`, `files_list_files`, `files_read_text_from_file`.                                                                        |
-| `sandbox`      | `sandbox.*`      | `execute_bash` - Sandboxed bash execution in the task's working directory                                                                                        |
-| `generate`     | `generate.*`     | Multimodal content generation and search grounding `generate_text`, `generate_images`, `generate_video`, `generate_speech_from_text`, `generate_music_from_text` |
+| Group          | Filter prefix    | Purpose                                                                                                                             |
+| -------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `system`       | `system.*`       | Termination: `system_objective_fulfilled`, `system_failed_to_fulfill_objective`.                                                     |
+| `chat`         | `chat.*`         | Resume/suspend: `chat_request_user_input`, `chat_present_choices`, `chat_await_context_update`.                                      |
+| `files`        | `files.*`        | File I/O: `files_write_file`, `files_list_files`, `files_read_text_from_file`, `files_list_dir`.                                     |
+| `sandbox`      | `sandbox.*`      | `execute_bash` — sandboxed bash execution in the task's working directory.                                                           |
+| `live`         | `live.*`         | Instruction-only: voice-native system instruction for `runner: live` sessions. No callable functions.                                |
+| `generate`     | `generate.*`     | _(Aspirational)_ Multimodal content generation. Currently provided by `opal_backend`, not bees. Will move into bees as a native group. |
 
 #### The file system
 
@@ -428,23 +429,35 @@ template if none exists.
 
 ## What sits on top
 
-The scheduler exposes methods (`trigger()`, `run_ticket()`,
-`recover_stuck_tickets()`) and hooks (`SchedulerHooks`) that applications wire
-into. An application can be anything that uses the scheduler layer: a CLI, or an
-entire web app, complete with backend and frontend.
+Applications interact with bees through the `Bees` class — the high-level entry
+point that wraps the scheduler and task store.
+
+```python
+bees = Bees(hive_dir, runners)
+bees.on(TaskDone, lambda e: print(f"Done: {e.task.id}"))
+await bees.listen()     # recover, boot root template, start scheduler loop
+bees.trigger()          # wake the scheduler to re-evaluate work
+await bees.shutdown()   # clean stop
+```
+
+`Bees` provides a typed event API (`bees.on(EventType, callback)`) for observing
+state changes, and query methods (`children`, `all`, `get_by_id`, `query`) for
+inspecting the task tree. The scheduler's internals are not part of the public
+API — applications interact exclusively through `Bees`.
 
 ### The reference application
 
 The current codebase includes a reference application:
 
 - **`app/server.py`** — A FastAPI server that projects scheduler state as REST
-  endpoints and SSE events. Every endpoint is a thin view: `GET /tickets`
-  queries the task list, `POST /tickets/{id}/respond` writes a response file and
-  triggers the scheduler.
+  endpoints and SSE events. Every endpoint is a thin view: queries the task
+  list, writes response files, and triggers the scheduler.
 - **`web/`** — A chat-based web shell that connects to the server via SSE.
   Renders agent conversations and iframe-hosted React apps.
 
-This reference application has been extracted from the core `bees` package into `app/`. Bees is designed to be an installable library; application authors will build their own frontends and backends on top of the scheduler.
+This reference application has been extracted from the core `bees` package into
+`app/`. Bees is designed to be an installable library; application authors build
+their own frontends and backends on top of the `Bees` API.
 
 ## Hivetool
 

--- a/packages/bees/docs/flux.md
+++ b/packages/bees/docs/flux.md
@@ -14,15 +14,16 @@ Stability runs from the core outward. The deeper into the framework you go, the
 more settled things are. The outermost layer — how applications consume bees —
 is where most future work lives.
 
-| Area               | Stability    | Summary                                           |
-| ------------------ | ------------ | ------------------------------------------------- |
-| Session layer      | **Solid**    | Contract settled. Internals may shift.            |
-| Scheduler core     | **Solid**    | Task lifecycle and cycle mechanics are permanent. |
-| Skills             | **Solid**    | Anchored to an external spec.                     |
-| Event delivery     | **Settling** | Shape is right, plumbing may change.              |
-| Filesystem sharing | **Settling** | Scoping model may evolve.                         |
-| Task templates     | **Settling** | Open questions around hooks, root, entry points.  |
-| Consumption API    | **Fluid**    | How apps build on bees is largely unanswered.     |
+| Area               | Stability    | Summary                                             |
+| ------------------ | ------------ | --------------------------------------------------- |
+| Session layer      | **Solid**    | Contract settled. Internals may shift.              |
+| Scheduler core     | **Solid**    | Task lifecycle and cycle mechanics are permanent.   |
+| Skills             | **Solid**    | Anchored to an external spec.                       |
+| Typed events       | **Solid**    | `Bees.on()` with `SchedulerEvent` subclasses.       |
+| Event delivery     | **Settling** | Shape is right, plumbing may change.                |
+| Filesystem sharing | **Settling** | Scoping model may evolve.                           |
+| Task templates     | **Settling** | Open questions around hooks, root, entry points.    |
+| Consumption API    | **Settling** | `Bees` class exists, but query surface is evolving. |
 
 ## Solid
 
@@ -33,11 +34,11 @@ care: changes here ripple outward.
 ### Session layer
 
 The session is the atom of bees: one LLM conversation with tools, suspend,
-resume, and pause. The contract — `run_session` / `resume_session` returning a
-`SessionResult` — is permanent. Internals will shift to better align with
-`architecture.md` (e.g. removing the `skills.*` function group workaround,
-cleaning up dot↔underscore naming), but the session concept and its consumer
-surface are not changing.
+resume, and pause. The contract — `SessionRunner.run()` / `.resume()` returning
+a `SessionStream`, consumed by `drain_session()` to produce a `SessionResult` —
+is permanent. Internals will shift (e.g. removing the `skills.*` function group
+workaround, cleaning up dot↔underscore naming), but the session concept and its
+consumer surface are not changing.
 
 ### Scheduler core
 
@@ -52,6 +53,14 @@ Skills are anchored to an external specification
 ([Agent Skills](https://agentskills.io)). The contract is small and clear: a
 `SKILL.md` with YAML frontmatter, an `allowed-tools` list, and directory
 mounting into the agent's file system. This is unlikely to change.
+
+### Typed events
+
+The observation API — `bees.on(EventType, callback)` with `SchedulerEvent`
+subclasses (`TaskAdded`, `TaskDone`, `CycleStarted`, etc.) — is settled. This
+replaced the earlier `SchedulerHooks` callback bag. The event types themselves
+may grow (new events for new scheduler capabilities), but the dispatch mechanism
+and the `Bees.on()` surface are permanent.
 
 ## Settling
 
@@ -81,34 +90,32 @@ The template concept is solid (a blueprint for a task, defined in
 `functions`, `skills`, `tasks`, `autostart`, `watch_events`). But several open
 questions remain:
 
-- **Hooks** — the `on_run_playbook` / `on_ticket_done` / `on_event` contract is
+- **Hooks** — the `on_run_playbook` / `on_task_done` / `on_event` contract is
   not well-defined. It's unclear whether hooks are the right abstraction or
   whether they should be replaced by something else entirely.
 - **Root template** — the `SYSTEM.yaml` → `boot_root_template` mechanism is
   awkward. Why isn't this just `autostart`? The root template bootstrapping
   feels like a special case that shouldn't be special.
 - **Top-level task creation** — there's no clean way to create a task from the
-  top (outside the framework). The entry points are `run_playbook` (code) and
-  the server endpoints, but neither is a crisp API for "start this work."
+  top (outside the framework). The `Bees.create_child()` method exists but
+  isn't well-tested or documented.
 
 The overall shape feels right. The details are in motion.
 
-## Fluid
-
-These areas are under active construction. Expect breaking changes, missing
-abstractions, and incomplete contracts.
-
 ### Consumption API
 
-This is the biggest open question in bees: **how do applications build on this
-framework?**
+The `Bees` class is the entry point: `Bees(hive_dir, runners)` wraps the
+scheduler and task store, provides typed event observation via `bees.on()`, and
+exposes query methods (`children`, `all`, `get_by_id`, `query`).
 
-Today, the answer is ad-hoc. `app/server.py` wires `SchedulerHooks` to SSE
-broadcasting and exposes REST endpoints. The web shell consumes those endpoints.
-But this isn't a designed API — it's the first thing that worked. The boundary
-between "bees the library" and "the application built on bees" is blurry:
+This is a significant improvement over the earlier ad-hoc wiring — applications
+no longer need to touch scheduler internals directly. But the query surface is
+still evolving: the `TaskNode` wrapper, tag-based queries, and `create_child()`
+are young. The box (`bees.box`) and reference application (`app/server.py`) are
+the two consumption patterns, and both work, but neither has been designed as a
+reusable pattern.
 
-- `SchedulerHooks` is the closest thing to a plugin API, but it's a bag of
-  callbacks with no lifecycle contract.
-- The server is tightly coupled to one application pattern (SSE + REST). There's
-  no way to build a different kind of application without forking the server.
+The boundary between "bees the library" and "the application built on bees" is
+much clearer than before but not yet crisp. The interaction model (how users
+respond to suspended agents) is still handled by direct file edits or the
+mutation system rather than a framework-provided interaction surface.

--- a/packages/bees/docs/patterns.md
+++ b/packages/bees/docs/patterns.md
@@ -24,8 +24,8 @@ discovers what work needs to be done as it executes. The model that replaced it
 program calling subroutines. The workflow emerges at runtime, not at declaration
 time.
 
-Code fossils remain (`depends_on`, `blocked` status, `promote_blocked_tickets`,
-topological sort). These are mostly dead code, retained for now.
+Code fossils remain (`depends_on`, `blocked` status, topological sort). These
+are mostly dead code, retained for now.
 
 ### Isolated file systems
 
@@ -184,12 +184,12 @@ Today, the consumer has to edit the task directly — write `response.json`, fli
 `assignee`. This is reaching into the model's internals. A proper interaction
 surface is the main thing needed for the consumption API to mature.
 
-### SchedulerHooks (exploratory)
+### Typed Events
 
-`SchedulerHooks` is the closest thing to a plugin API for consumers, but it's
-undercooked and invasive. It's not clear this is the right abstraction. This
-area needs careful pattern examination before committing to a design — it's
-exploratory territory, not something to stabilize prematurely.
+Applications observe the scheduler through typed events via the `Bees` class
+(`bees.on(TaskDone, callback)`). Each event is a `@dataclass` subclassing
+`SchedulerEvent`. This replaced the earlier `SchedulerHooks` callback bag and
+is now settled — see [flux.md](./flux.md) for stability classification.
 
 ## The Hive
 
@@ -243,6 +243,9 @@ agent to fulfill, persisted as a directory on disk.
 | `watch_events` | object[] | no       | Subscribe to inter-agent coordination events. Each entry has a `type` field (e.g., `{type: "digest_ready"}`).                                                                 |
 | `tasks`        | string[] | no       | Allowlist of template names this agent can delegate to via `tasks_create_task`.                                                                                               |
 | `autostart`    | string[] | no       | Template names to stamp as child tasks automatically when this template is run. Each entry creates a subagent task linked to the parent.                                      |
+| `runner`       | string   | no       | Which session runner to use: `"generate"` (batch text, default) or `"live"` (Gemini Live API for voice sessions).                                                             |
+| `voice`        | string   | no       | Prebuilt voice name for Live API audio output (e.g., `"Kore"`). Only used with `runner: live`.                                                                                |
+| `assignee`     | string   | no       | Initial assignee: `"user"` (start suspended, waiting for input) or `"agent"` (start immediately). Default is `"agent"`.                                                        |
 
 ### Interpolation
 

--- a/packages/bees/docs/scheduler.md
+++ b/packages/bees/docs/scheduler.md
@@ -2,7 +2,7 @@
 
 The scheduler coordinates sessions into a swarm. It owns the decisions of _what
 runs when_ and the bookkeeping around each task's execution. Applications plug
-in behavior via `SchedulerHooks`.
+in behavior via typed events on the `Bees` class.
 
 This document traces how the scheduler actually works in the code.
 
@@ -75,69 +75,53 @@ for retry).
 
 The scheduler operates in waves. A cycle is one sweep through the work queue:
 
-1. **Promote** — `promote_blocked_tickets()` checks all `blocked` tasks. If all
-   dependencies are `completed`, promote to `available`. If any dependency
-   `failed`, fail the task.
+1. **Promote** — Check all `blocked` tasks. If all dependencies are
+   `completed`, promote to `available`. If any dependency `failed`, fail the
+   task.
 2. **Route** — Process `coordination` kind tasks (events). These carry no work,
    only event payloads. Route them to matching subscribers.
 3. **Collect** — Gather runnable work: new `available` tasks plus `suspended`
    tasks that have `assignee == "agent"` (responded to).
-4. **Execute** — Fire all collected tasks concurrently. In server mode, each
-   task is its own `asyncio.Task`. In batch mode (`run_all_waves`),
-   `asyncio.gather` runs them simultaneously.
+4. **Execute** — Fire all collected tasks concurrently. Each task runs as its
+   own `asyncio.Task`.
 5. **Settle** — Sessions run until they reach a resting state.
 6. **Trigger** — When any task settles, the scheduler wakes for the next cycle.
    If no work remains, it goes idle (server) or exits (CLI).
 
-### Server vs. batch mode
+### Observation
 
-The `Scheduler` class supports two execution modes:
+Applications observe the scheduler through typed events via the `Bees` class:
 
-- **`start_loop()`** — Background loop for server mode. Uses an `asyncio.Event`
-  trigger. Each ticket runs in its own task, enabling concurrent execution. The
-  loop sleeps between cycles and re-evaluates when triggered.
-- **`run_all_waves()`** — Synchronous batch mode for the CLI. Runs cycles
-  sequentially via `asyncio.gather`, collecting summaries until no work remains.
+```python
+bees.on(TaskAdded, callback)       # A new task was created or discovered.
+bees.on(CycleStarted, callback)    # A scheduling cycle is beginning.
+bees.on(TaskEvent, callback)       # A running session emitted a raw event.
+bees.on(TaskStarted, callback)     # A task transitioned to running.
+bees.on(TaskDone, callback)        # A task reached a resting state.
+bees.on(BroadcastReceived, callback) # An agent broadcast event was routed.
+bees.on(CycleComplete, callback)   # The scheduler has no more work.
+```
 
-### Hooks
-
-Applications wire into the scheduler via `SchedulerHooks`:
-
-| Hook                  | When it fires                                                |
-| --------------------- | ------------------------------------------------------------ |
-| `on_startup`          | After recovery, with the full task list.                     |
-| `on_cycle_start`      | Start of each cycle (cycle number, new count, resume count). |
-| `on_ticket_event`     | Running session emits an event.                              |
-| `on_ticket_start`     | Task transitions to `running`.                               |
-| `on_ticket_done`      | Task reaches a resting state.                                |
-| `on_events_broadcast` | Agent broadcasts an event mid-session.                       |
-| `on_cycle_complete`   | No more work (total cycles count).                           |
-
-The reference application (`app/server.py`) wires these hooks to SSE
-broadcasting.
+Each event is a `@dataclass` subclassing `SchedulerEvent` (defined in
+`bees/protocols/events.py`). The reference application wires these events to
+SSE broadcasting.
 
 ## Context delivery
 
 When events or updates need to reach a running or suspended agent, the scheduler
 uses three delivery paths (tried in order):
 
-1. **Mid-stream injection** — Guard: the target ticket has a live context queue
-   in `_context_queues`. This means the agent is inside a turn, waiting on a
-   model response. Push pre-formatted parts into the queue; the session layer
-   injects them at the next turn boundary. This is the scheduler's use of the
-   session layer's **dynamic steering** capability.
-2. **Immediate resume** — Guard: path 1 failed (no live queue) AND
-   `status == "suspended"` AND `assignee == "user"` AND
-   `target_id not in _running_tickets`. This means the agent is idle —
-   suspended, not being processed. Write `response.json` with `context_updates`
-   and flip `assignee` to `"agent"`. The scheduler picks it up on the next
-   cycle.
-3. **Buffer** — Guard: both path 1 and path 2 failed. This catches every other
-   case: the agent is running but between turns (no queue registered yet), or
-   the agent is suspended but currently being resumed (still in
-   `_running_tickets`), or the agent is in any non-suspended state. Append to
-   `pending_context_updates` in metadata. These drain on the next suspend →
-   resume transition.
+1. **Mid-stream injection** — If the target agent has a live session stream,
+   push pre-formatted parts into its context channel. The session layer injects
+   them at the next turn boundary. This is the scheduler's use of the session
+   layer's **dynamic steering** capability.
+2. **Immediate resume** — If the agent is idle (suspended, waiting for input,
+   and not currently being processed), write `response.json` with
+   `context_updates` and flip `assignee` to `"agent"`. The scheduler picks it
+   up on the next cycle.
+3. **Buffer** — If neither path works (agent is running between turns, being
+   resumed, or in a non-suspended state), append to `pending_context_updates`
+   in metadata. These drain on the next suspend → resume transition.
 
 This three-path model ensures updates are never lost, regardless of the target
 agent's state.
@@ -189,10 +173,10 @@ Read access is unrestricted — every agent can read the entire workspace.
 
 ### Directory creation
 
-When `stamp_child_ticket` creates a child task, it:
+When a child task is created (via `stamp_child_task`), it:
 
 1. Derives a `child_scope` from the parent scope + slug.
-2. Creates the task via `run_playbook`.
+2. Creates the task from the template.
 3. Creates the writable directory on the physical filesystem.
 4. Injects `<sandbox_environment>` instructions into the child's objective,
    telling it where it can write.
@@ -257,22 +241,22 @@ carry event payloads instead of work.
 ### Parent-child events
 
 `events_send_to_parent` and `tasks_send_event` use a different mechanism — they
-call `_deliver_context_update` directly, bypassing coordination tickets. This
-uses the three-path context delivery model described above.
+deliver context updates directly, bypassing coordination tickets. This uses the
+three-path context delivery model described above.
 
 ## Resilience
 
 ### Recovery
 
-On startup, `recover_stuck_tickets()` flips any `running` or `paused` tasks back
-to `available`. Since all session state is persisted on disk, the scheduler can
+On startup, the scheduler flips any `running` or `paused` tasks back to
+`available`. Since all session state is persisted on disk, the scheduler can
 safely restart and resume from the last checkpoint.
 
 ### Sub-agent completion notification
 
-When a child task completes or fails, the `wrap_run`/`wrap_resume` cleanup
-delivers a context update to the creator task with the status and outcome. This
-wakes the parent agent with:
+When a child task completes or fails, the scheduler delivers a context update
+to the creator task with the status and outcome. This wakes the parent agent
+with:
 
 ```
 <context_update>Task abc12345 completed: [outcome text]</context_update>
@@ -294,7 +278,7 @@ wakes the parent agent with:
 ## Gaps
 
 Code changes needed to reconcile the scheduler layer with the aspirational
-architecture in `docs/architecture/index.md`.
+architecture in `docs/architecture.md`.
 
 ### Coordination tickets should be replaced
 
@@ -310,9 +294,9 @@ creating database records that look like tasks.
 
 ### Tag enrichment: remove or design intentionally
 
-When a child task completes, `_enrich_creator_tags` merges the child's tags into
-the creator's tags. This was added as a convenience for UI routing but has no
-clear design rationale — it's an emergent side effect that may surprise users.
+When a child task completes, the scheduler merges the child's tags into the
+creator's tags. This was added as a convenience for UI routing but has no clear
+design rationale — it's an emergent side effect that may surprise users.
 
 **Gap**: Consider removing tag enrichment entirely. If it serves a real purpose,
 design it intentionally and document it. If not, delete the code.

--- a/packages/bees/docs/session.md
+++ b/packages/bees/docs/session.md
@@ -101,12 +101,13 @@ using bees-native protocols from `bees/protocols/`:
 | Group          | Filter prefix    | Purpose                                                                                                                  |
 | -------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `system`       | `system.*`       | Termination: `system_objective_fulfilled`, `system_failed_to_fulfill_objective`.                                         |
-| `files` | `files.*` | File I/O: `files_write_file`, `files_list_files`, `files_read_text_from_file`.                                        |
+| `files`        | `files.*`        | File I/O: `files_write_file`, `files_list_files`, `files_read_text_from_file`, `files_list_dir`.                         |
 | `sandbox`      | `sandbox.*`      | Sandboxed bash execution in the task's working directory.                                                                |
 | `chat`         | `chat.*`         | User interaction: `chat_request_user_input`, `chat_present_choices`, `chat_await_context_update`.                        |
 | `events`       | `events.*`       | Cross-agent communication: `events_broadcast`, `events_send_to_parent`.                                                  |
 | `tasks`        | `tasks.*`        | Task management: `tasks_list_types`, `tasks_create_task`, `tasks_check_status`, `tasks_cancel_task`, `tasks_send_event`. |
 | `skills`       | `skills.*`       | Instruction-only: injects a system instruction listing available skills. No callable functions.                          |
+| `live`         | `live.*`         | Instruction-only: voice-native system instruction for `runner: live` sessions. No callable functions.                    |
 
 ### The function filter
 


### PR DESCRIPTION
## What

Audit and update all 7 prescriptive docs in `packages/bees/docs/` to match the
current implementation, fixing stale references, missing features, and
outdated API descriptions.

## Why

The docs had accumulated drift: the `SchedulerHooks` callback bag was replaced
by typed events months ago, function group tables were incomplete, and the
`Bees` class — the actual public API — wasn't documented anywhere. This
reconciliation ensures the docs are a reliable source of truth for contributors.

## Changes

### `SchedulerHooks` → typed events
- **scheduler.md**: Replaced hooks table with `bees.on()` typed event API
- **patterns.md**: Updated "SchedulerHooks (exploratory)" → "Typed Events" (settled)
- **api.md**: Fixed `Bees.__init__` signature (removed stale `hooks`/`http`/`backend` params, added `runners`); fixed `on()` from string names to typed event classes
- **architecture.md**: Replaced internal scheduler method list with `Bees` class API + usage example

### Function group tables
- **architecture.md**, **session.md**: Added missing `files_list_dir`, added `live` group, marked `generate` as aspirational (provided by opal_backend, not bees)
- **patterns.md**: Added `runner`, `voice`, `assignee` to template field table

### Scheduler.md high-level rewrite
- Removed all internal variable/method names (`_context_queues`, `_running_tickets`, `promote_blocked_tickets`, `stamp_child_ticket`, `wrap_run`, etc.)
- Kept conceptual descriptions of cycle mechanics, context delivery, and coordination routing

### flux.md holistic update
- Added "Typed events" as **Solid**
- Fixed session contract description (`SessionRunner.run()` not `run_session()`)
- Promoted "Consumption API" from Fluid → **Settling** (the `Bees` class exists)

### Index
- **README.md**: Added `api.md` and `mutations.md` to docs index

## Testing

Documentation-only change — no code modified. Verify by reading the updated
docs and cross-referencing with source files linked in the reconciliation report.
