### PR TITLE
[bees] Surface / Detail tab layout in hivetool

### DIFF
--- a/packages/bees/PROJECT_SURFACE.md
+++ b/packages/bees/PROJECT_SURFACE.md
@@ -141,21 +141,74 @@ rendered as structured cards, and it updates in real time.
 
 ---
 
-## Phase 5 — Hivetool Full Surface View
+## Phase 5a — Surface / Detail Tab Layout
 
-Promote the surface to a full-pane view with rich rendering.
+Extract ticket detail into two panes behind a tab bar. New wrapper component
+`<bees-ticket-pane>` owns the header, tab bar, and view switching. The existing
+`<bees-ticket-detail>` becomes the "Detail" tab content (timeline only, header
+removed). A new `<bees-surface-pane>` component gets the full main area for
+the "Surface" tab.
 
-- [ ] Sub-tab layout in ticket detail: `Surface · Detail` tabs, surface as the
-      default when present. Each gets the full main pane area.
-- [ ] Markdown rendering for `.md` items (basic or library-backed).
-- [ ] Bundle rendering for `render: "bundle"` items (sandboxed iframe with blob
-      URLs from File System Access API reads).
-- [ ] Multi-scope surface discovery — walk the filesystem tree for all
-      `surface.json` files, scope selector when multiple exist.
-- [ ] File content preview for items with `path` (loaded on demand).
+- [x] New `ticket-pane.ts` — owns ticket header, status badge, identity chips,
+      and a `Surface · Detail` tab bar. Composes `<bees-surface-pane>` and
+      `<bees-ticket-detail>` as tab bodies.
+- [x] Refactor `ticket-detail.ts` — strip the header; render only the timeline
+      content (context, objective, chat, outcome, suspend, tags, files).
+- [x] New `surface-pane.ts` — full-pane surface view. Receives the ticket ID,
+      reads root `surface.json`, renders the existing `<bees-surface-view>`.
+- [x] `app.ts` — swap `<bees-ticket-detail>` for `<bees-ticket-pane>` in the
+      tickets tab main area.
+- [x] Default to Surface tab when a surface exists, Detail otherwise.
 
-🎯 The surface view is a full-pane peer to ticket detail, with rendered markdown,
-bundle iframes, and content previews.
+🎯 Selecting a task shows a `Surface · Detail` tab bar below the header. Surface
+is the default when present. Each tab gets the full main pane.
+
+---
+
+## Phase 5b — Bundle Rendering
+
+Surface items with `render: "bundle"` render in a sandboxed iframe.
+
+- [ ] `surface-pane.ts` — detect `render: "bundle"` items. Read the JS file
+      (and conventionally-discovered CSS by same stem) via
+      `TicketStore.readFileContent`. Construct blob URLs and render in a
+      sandboxed iframe (`sandbox="allow-scripts"`).
+- [ ] Revoke blob URLs on disconnect / item change.
+- [ ] Update `<bees-surface-view>` (or `surface-pane`) to render bundle items
+      as interactive iframes instead of static cards.
+
+🎯 A surface item with `render: "bundle"` displays as a live, sandboxed iframe
+in the surface pane.
+
+---
+
+## Phase 5c — Markdown Rendering and Content Preview
+
+Rich rendering for markdown items and on-demand content preview.
+
+- [ ] Add `markdown-it` dependency to `hivetool/package.json`.
+- [ ] Port the `markdown` Lit directive from `bees/web/src/directives/markdown.ts`
+      (or extract to a shared location).
+- [ ] Surface pane renders `.md` items as formatted markdown (not raw text).
+- [ ] Items with `path` show a content preview area, loaded on demand when the
+      item is expanded or selected.
+
+🎯 Markdown surface items render as formatted HTML. Items with file paths show
+on-demand content previews.
+
+---
+
+## Phase 5d — Multi-Scope Surface Discovery
+
+Walk the filesystem tree for all `surface.json` files, aggregate across scopes.
+
+- [ ] `TicketStore.readAllSurfaces(ticketId)` — recursively walk
+      `filesystem/` for all `surface.json` files, return keyed by scope path.
+- [ ] Surface pane shows a scope selector when multiple surfaces exist.
+- [ ] Default to root scope; sub-scope surfaces accessible via selector.
+
+🎯 When a task has sub-agent scopes with their own surfaces, all are
+discoverable and individually viewable in the surface pane.
 
 ---
 

--- a/packages/bees/hivetool/src/ui/app.ts
+++ b/packages/bees/hivetool/src/ui/app.ts
@@ -31,7 +31,7 @@ import "./template-detail.js";
 import "./skill-list.js";
 import "./skill-detail.js";
 import "./ticket-list.js";
-import "./ticket-detail.js";
+import "./ticket-pane.js";
 import "./event-list.js";
 import "./event-detail.js";
 import "./log-list.js";
@@ -915,13 +915,13 @@ class BeesApp extends SignalWatcher(LitElement) {
   private renderMain(flashTicketId: string | null) {
     switch (this.activeTab) {
       case "tickets":
-        return html`<bees-ticket-detail
+        return html`<bees-ticket-pane
           .ticketStore=${this.ticketStore}
           .mutationClient=${this.mutationClient}
           .templateStore=${this.templateStore}
           .skillStore=${this.skillStore}
           .flashTicketId=${flashTicketId}
-        ></bees-ticket-detail>`;
+        ></bees-ticket-pane>`;
       case "events":
         return html`<bees-event-detail
           .ticketStore=${this.ticketStore}

--- a/packages/bees/hivetool/src/ui/surface-pane.ts
+++ b/packages/bees/hivetool/src/ui/surface-pane.ts
@@ -1,0 +1,105 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Full-pane surface view — the "Surface" tab body.
+ *
+ * Receives a ticket ID, reads root `surface.json` via the ticket store,
+ * and renders the existing `<bees-surface-view>` in the full main area.
+ * Re-reads surface data when the ticket ID changes or the filesystem
+ * observer fires.
+ */
+
+import { SignalWatcher } from "@lit-labs/signals";
+import { LitElement, html, css, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+
+import type { TicketStore } from "../data/ticket-store.js";
+import type { SurfaceManifest } from "../data/types.js";
+import { sharedStyles } from "./shared-styles.js";
+import "./surface-view.js";
+
+export { BeesSurfacePane };
+
+@customElement("bees-surface-pane")
+class BeesSurfacePane extends SignalWatcher(LitElement) {
+  static styles = [
+    sharedStyles,
+    css`
+      :host {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        overflow-y: auto;
+      }
+
+      .surface-container {
+        padding: 24px 32px;
+        max-width: 960px;
+        margin: 0 auto;
+        width: 100%;
+      }
+
+      .empty-state {
+        flex: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: #64748b;
+        font-size: 0.9rem;
+      }
+    `,
+  ];
+
+  @property({ attribute: false })
+  accessor ticketStore: TicketStore | null = null;
+
+  @property({ type: String })
+  accessor ticketId: string | null = null;
+
+  @state() accessor surface: SurfaceManifest | null = null;
+
+  /** Track which ticket ID we last loaded for. */
+  #loadedFor: string | null = null;
+
+  render() {
+    if (!this.ticketStore || !this.ticketId) {
+      return html`<div class="empty-state">No surface available</div>`;
+    }
+
+    // Reload surface when ticket changes.
+    if (this.#loadedFor !== this.ticketId) {
+      this.surface = null;
+      this.#loadedFor = this.ticketId;
+      this.loadSurface();
+    }
+
+    if (!this.surface) return nothing;
+
+    return html`
+      <div class="surface-container">
+        <bees-surface-view .surface=${this.surface}></bees-surface-view>
+      </div>
+    `;
+  }
+
+  /** Reload the surface — called on ticket change and by the parent on fs updates. */
+  async loadSurface(): Promise<void> {
+    if (!this.ticketStore || !this.ticketId) return;
+    this.surface = await this.ticketStore.readSurface(this.ticketId);
+  }
+
+  /** Whether a surface is currently loaded. */
+  get hasSurface(): boolean {
+    return this.surface !== null;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "bees-surface-pane": BeesSurfacePane;
+  }
+}

--- a/packages/bees/hivetool/src/ui/ticket-detail.ts
+++ b/packages/bees/hivetool/src/ui/ticket-detail.ts
@@ -5,11 +5,12 @@
  */
 
 /**
- * Detail panel for a selected ticket.
+ * Timeline content for a selected ticket — the "Detail" tab body.
  *
- * Renders ticket metadata, identity chips, context, objective, chat
- * history, outcome, error, suspend event, tags, functions, watch events,
- * and the ticket's file tree.
+ * Renders context, objective, chat history, outcome, error, suspend
+ * event, tags, functions, watch events, and the ticket's file tree.
+ * The header, identity chips, and tab bar are owned by
+ * `<bees-ticket-pane>`.
  */
 
 import { SignalWatcher } from "@lit-labs/signals";
@@ -18,14 +19,10 @@ import { customElement, property, state } from "lit/decorators.js";
 
 import type { TicketStore, FileTreeNode } from "../data/ticket-store.js";
 import type { MutationClient } from "../data/mutation-client.js";
-import type { TemplateStore } from "../data/template-store.js";
-import type { SkillStore } from "../data/skill-store.js";
-import type { SurfaceManifest } from "../data/types.js";
 import { sharedStyles } from "./shared-styles.js";
 import { renderJson } from "./json-tree.js";
 import { jsonTreeStyles } from "./json-tree.styles.js";
 import "./truncated-text.js";
-import "./surface-view.js";
 
 export { BeesTicketDetail };
 
@@ -423,19 +420,12 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
   @property({ attribute: false })
   accessor mutationClient: MutationClient | null = null;
 
-  @property({ attribute: false })
-  accessor templateStore: TemplateStore | null = null;
-
-  @property({ attribute: false })
-  accessor skillStore: SkillStore | null = null;
-
   /** ID of a recently updated ticket (for flash animation). */
   @property({ attribute: false })
   accessor flashTicketId: string | null = null;
 
   @state() accessor fileTree: FileTreeNode[] = [];
   @state() accessor fileContents: Record<string, string | null> = {};
-  @state() accessor surface: SurfaceManifest | null = null;
 
   // ── Response state ──
   @state() accessor replyText = "";
@@ -456,83 +446,11 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
         Select a ticket to view details
       </div>`;
 
-    // Reset file tree and surface if ticket changed.
+    // Reset file tree if ticket changed.
     if (this.#treeLoadedFor !== ticket.id) {
       this.fileTree = [];
       this.fileContents = {};
-      this.surface = null;
       this.#treeLoadedFor = ticket.id;
-      this.loadSurface(ticket.id);
-    }
-
-    const suspendFn =
-      ticket.suspend_event?.function_name as string | undefined;
-    const statusLabel =
-      ticket.status === "suspended" &&
-      ticket.assignee === "user" &&
-      suspendFn !== "chat_await_context_update"
-        ? "waiting for user"
-        : ticket.status === "suspended"
-          ? "waiting for event"
-          : ticket.status;
-
-    // Collect identity chips.
-    const identityChips: Array<{
-      label: string;
-      value: string;
-      cls?: string;
-      onclick?: () => void;
-    }> = [];
-    if (ticket.model)
-      identityChips.push({
-        label: "model",
-        value: ticket.model,
-        cls: "model",
-      });
-    if (ticket.playbook_id) {
-      const templateNames = new Set(
-        (this.templateStore?.templates.get() ?? []).map((t) => t.name)
-      );
-      const exists = templateNames.has(ticket.playbook_id);
-      identityChips.push({
-        label: "template",
-        value: ticket.playbook_id,
-        cls: "playbook",
-        onclick: exists
-          ? () => this.navigate("templates", ticket.playbook_id!)
-          : undefined,
-      });
-    }
-    if (ticket.creator_ticket_id)
-      identityChips.push({
-        label: "parent",
-        value: ticket.creator_ticket_id.slice(0, 8),
-        onclick: () => this.navigate("tickets", ticket.creator_ticket_id!),
-      });
-    if (ticket.owning_task_id)
-      identityChips.push({
-        label: "fs owner",
-        value: ticket.owning_task_id.slice(0, 8),
-        onclick: () => this.navigate("tickets", ticket.owning_task_id!),
-      });
-    identityChips.push({
-      label: "session",
-      value: ticket.id.slice(0, 8),
-      onclick: () => this.navigate("logs", ticket.id),
-    });
-    if (ticket.skills && ticket.skills.length > 0) {
-      const skillDirs = new Set(
-        (this.skillStore?.skills.get() ?? []).map((sk) => sk.dirName)
-      );
-      for (const s of ticket.skills)
-        identityChips.push({
-          label: "skill",
-          value: s,
-          cls: "skill",
-          onclick: skillDirs.has(s)
-            ? () => this.navigate("skills", s)
-            : undefined,
-        });
     }
 
     const chatHistory = (ticket.chat_history ?? []).filter(
@@ -540,210 +458,136 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
     );
 
     return html`
-      <div
-        class="job-detail ${this.flashTicketId === ticket.id
-          ? "lightning-flash"
-          : ""}"
-      >
-        <div class="job-detail-header">
-          <div class="job-detail-header-top">
-            <h2 class="job-detail-title">${ticket.title || "Ticket"}</h2>
-            <div style="display:flex;align-items:center;gap:8px">
-              ${this.renderTaskControl(ticket.id, ticket.status)}
-              <div class="job-detail-badge ${ticket.status}">${statusLabel}</div>
-            </div>
-          </div>
-          <div class="job-detail-meta">
-            <span
-              >ID: <code class="mono">${ticket.id.slice(0, 13)}...</code></span
-            >
-            <span
-              >Created:
-              ${new Date(ticket.created_at ?? "").toLocaleString()}</span
-            >
-            ${ticket.completed_at
-              ? html`<span
-                  >Completed:
-                  ${new Date(ticket.completed_at).toLocaleString()}</span
-                >`
-              : nothing}
-            ${ticket.turns
-              ? html`<span>${ticket.turns} turns</span>`
-              : nothing}
-            ${ticket.thoughts
-              ? html`<span>${ticket.thoughts} thoughts</span>`
-              : nothing}
-          </div>
-        </div>
-
-        <div class="timeline">
-          ${identityChips.length > 0
-            ? html`
-                <div class="identity-row">
-                  ${identityChips.map(
-                    (c) => html`
-                      <span
-                        class="identity-chip ${c.cls ?? ""} ${c.onclick
-                          ? "linkable"
-                          : ""}"
-                        @click=${c.onclick ?? nothing}
+      <div class="timeline">
+        ${ticket.context
+          ? html`
+              <div class="context-card">
+                <div class="context-label">Context</div>
+                <bees-truncated-text
+                  threshold="300"
+                  max-height="150"
+                  fadeBg="#111827"
+                  >${ticket.context}</bees-truncated-text
+                >
+              </div>
+            `
+          : nothing}
+        ${ticket.objective &&
+        ticket.objective.trim() !== (ticket.context ?? "").trim()
+          ? html`
+              <div class="block">
+                <div class="block-header">Objective</div>
+                <div class="block-content">
+                  <bees-truncated-text
+                    threshold="500"
+                    max-height="200"
+                    fadeBg="#0f1115"
+                    >${ticket.objective}</bees-truncated-text
+                  >
+                </div>
+              </div>
+            `
+          : nothing}
+        ${chatHistory.length > 0
+          ? html`
+              <div class="block">
+                <div class="block-header">
+                  Chat (${chatHistory.length} messages)
+                </div>
+                <div class="chat-log">
+                  ${chatHistory.map(
+                    (m) => html`
+                      <div
+                        class="chat-turn ${m.role === "user"
+                          ? "user"
+                          : "agent"}"
                       >
-                        <span class="identity-label">${c.label}</span>
-                        ${c.value}
-                      </span>
+                        <div class="chat-role">${m.role}</div>
+                        <div class="chat-text">${m.text}</div>
+                      </div>
                     `
                   )}
-                  ${ticket.playbook_run_id
-                    ? html`<span class="identity-chip">
-                        <span class="identity-label">run</span>
-                        ${ticket.playbook_run_id.slice(0, 8)}
-                      </span>`
-                    : nothing}
                 </div>
-              `
-            : nothing}
-          ${ticket.context
-            ? html`
-                <div class="context-card">
-                  <div class="context-label">Context</div>
+              </div>
+            `
+          : nothing}
+        ${ticket.outcome
+          ? html`
+              <div class="block outcome">
+                <div class="block-header">Outcome</div>
+                <div class="block-content">
                   <bees-truncated-text
                     threshold="300"
                     max-height="150"
-                    fadeBg="#111827"
-                    >${ticket.context}</bees-truncated-text
+                    fadeBg="#0f1115"
+                    >${ticket.outcome}</bees-truncated-text
                   >
                 </div>
-              `
-            : nothing}
-          ${ticket.objective &&
-          ticket.objective.trim() !== (ticket.context ?? "").trim()
-            ? html`
-                <div class="block">
-                  <div class="block-header">Objective</div>
-                  <div class="block-content">
-                    <bees-truncated-text
-                      threshold="500"
-                      max-height="200"
-                      fadeBg="#0f1115"
-                      >${ticket.objective}</bees-truncated-text
-                    >
-                  </div>
+              </div>
+            `
+          : nothing}
+        ${ticket.error
+          ? html`
+              <div class="block error">
+                <div class="block-header">Error</div>
+                <div class="block-content">${ticket.error}</div>
+              </div>
+            `
+          : nothing}
+        ${ticket.runner === "live"
+          ? this.renderLiveSessionPanel(ticket.id)
+          : nothing}
+        ${ticket.status === "suspended" && ticket.suspend_event
+          ? this.renderSuspendedBlock(ticket.id, ticket.suspend_event, ticket.assignee)
+          : nothing}
+        ${ticket.tags && ticket.tags.length > 0
+          ? html`
+              <div class="block">
+                <div class="block-header">Tags</div>
+                <div class="block-content">
+                  ${ticket.tags.map(
+                    (tag) =>
+                      html`<span class="tool-badge" style="margin-right:6px"
+                        >${tag}</span
+                      >`
+                  )}
                 </div>
-              `
-            : nothing}
-          ${chatHistory.length > 0
-            ? html`
-                <div class="block">
-                  <div class="block-header">
-                    Chat (${chatHistory.length} messages)
-                  </div>
-                  <div class="chat-log">
-                    ${chatHistory.map(
-                      (m) => html`
-                        <div
-                          class="chat-turn ${m.role === "user"
-                            ? "user"
-                            : "agent"}"
-                        >
-                          <div class="chat-role">${m.role}</div>
-                          <div class="chat-text">${m.text}</div>
-                        </div>
-                      `
-                    )}
-                  </div>
+              </div>
+            `
+          : nothing}
+        ${ticket.functions && ticket.functions.length > 0
+          ? html`
+              <div class="block">
+                <div class="block-header">Functions</div>
+                <div class="block-content">
+                  ${ticket.functions.map(
+                    (fn) =>
+                      html`<span class="tool-badge" style="margin-right:6px"
+                        >${fn}</span
+                      >`
+                  )}
                 </div>
-              `
-            : nothing}
-          ${ticket.outcome
-            ? html`
-                <div class="block outcome">
-                  <div class="block-header">Outcome</div>
-                  <div class="block-content">
-                    <bees-truncated-text
-                      threshold="300"
-                      max-height="150"
-                      fadeBg="#0f1115"
-                      >${ticket.outcome}</bees-truncated-text
-                    >
-                  </div>
+              </div>
+            `
+          : nothing}
+        ${ticket.watch_events && ticket.watch_events.length > 0
+          ? html`
+              <div class="block">
+                <div class="block-header">Listening For</div>
+                <div class="block-content">
+                  ${ticket.watch_events.map(
+                    (ev) =>
+                      html`<span
+                        class="signal-chip"
+                        style="margin-right:6px"
+                        >${ev.type}</span
+                      >`
+                  )}
                 </div>
-              `
-            : nothing}
-          ${ticket.error
-            ? html`
-                <div class="block error">
-                  <div class="block-header">Error</div>
-                  <div class="block-content">${ticket.error}</div>
-                </div>
-              `
-            : nothing}
-          ${ticket.runner === "live"
-            ? this.renderLiveSessionPanel(ticket.id)
-            : nothing}
-          ${ticket.status === "suspended" && ticket.suspend_event
-            ? this.renderSuspendedBlock(ticket.id, ticket.suspend_event, ticket.assignee)
-            : nothing}
-          ${ticket.tags && ticket.tags.length > 0
-            ? html`
-                <div class="block">
-                  <div class="block-header">Tags</div>
-                  <div class="block-content">
-                    ${ticket.tags.map(
-                      (tag) =>
-                        html`<span class="tool-badge" style="margin-right:6px"
-                          >${tag}</span
-                        >`
-                    )}
-                  </div>
-                </div>
-              `
-            : nothing}
-          ${ticket.functions && ticket.functions.length > 0
-            ? html`
-                <div class="block">
-                  <div class="block-header">Functions</div>
-                  <div class="block-content">
-                    ${ticket.functions.map(
-                      (fn) =>
-                        html`<span class="tool-badge" style="margin-right:6px"
-                          >${fn}</span
-                        >`
-                    )}
-                  </div>
-                </div>
-              `
-            : nothing}
-          ${ticket.watch_events && ticket.watch_events.length > 0
-            ? html`
-                <div class="block">
-                  <div class="block-header">Listening For</div>
-                  <div class="block-content">
-                    ${ticket.watch_events.map(
-                      (ev) =>
-                        html`<span
-                          class="signal-chip"
-                          style="margin-right:6px"
-                          >${ev.type}</span
-                        >`
-                    )}
-                  </div>
-                </div>
-              `
-            : nothing}
-          ${this.surface
-            ? html`
-                <div class="block">
-                  <div class="block-header">Surface</div>
-                  <div class="block-content">
-                    <bees-surface-view
-                      .surface=${this.surface}
-                    ></bees-surface-view>
-                  </div>
-                </div>
-              `
-            : nothing}
-          ${this.renderFileTree(ticket.id)}
-        </div>
+              </div>
+            `
+          : nothing}
+        ${this.renderFileTree(ticket.id)}
       </div>
     `;
   }
@@ -843,14 +687,6 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
     if (!this.ticketStore) return;
     const tree = await this.ticketStore.readTree(ticketId);
     this.fileTree = tree;
-    // Also refresh the surface — the observer triggers tree reloads on
-    // any filesystem change, so this keeps the surface in sync.
-    this.loadSurface(ticketId);
-  }
-
-  private async loadSurface(ticketId: string) {
-    if (!this.ticketStore) return;
-    this.surface = await this.ticketStore.readSurface(ticketId);
   }
 
   private async loadFileContent(
@@ -864,72 +700,6 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
       ...this.fileContents,
       [pathKey]: content,
     };
-  }
-
-  private navigate(tab: string, id: string) {
-    this.dispatchEvent(
-      new CustomEvent("navigate", {
-        detail: { tab, id },
-        bubbles: true,
-      })
-    );
-  }
-
-  // ── Per-task pause / resume ──
-
-  private renderTaskControl(taskId: string, status: string) {
-    // Only show when the box is actively listening for mutations.
-    if (!this.mutationClient?.boxActive.get()) return nothing;
-
-    const ACTIVE = new Set(["running", "available", "suspended", "blocked"]);
-
-    if (ACTIVE.has(status)) {
-      return html`
-        <button
-          style="padding:3px 10px;font-size:0.65rem;font-weight:600;
-                 background:transparent;color:#f87171;border:1px solid #991b1b;
-                 border-radius:4px;cursor:pointer;font-family:inherit;
-                 transition:all 0.15s"
-          @click=${() => this.handlePauseTask(taskId)}
-        >
-          ⏸ Pause
-        </button>
-      `;
-    }
-
-    if (status === "paused") {
-      return html`
-        <button
-          style="padding:3px 10px;font-size:0.65rem;font-weight:600;
-                 background:transparent;color:#4ade80;border:1px solid #166534;
-                 border-radius:4px;cursor:pointer;font-family:inherit;
-                 transition:all 0.15s"
-          @click=${() => this.handleResumeTask(taskId)}
-        >
-          ▶ Resume
-        </button>
-      `;
-    }
-
-    return nothing;
-  }
-
-  private async handlePauseTask(taskId: string) {
-    if (!this.mutationClient) return;
-    try {
-      await this.mutationClient.pauseTask(taskId);
-    } catch (e) {
-      console.error("Failed to pause task:", e);
-    }
-  }
-
-  private async handleResumeTask(taskId: string) {
-    if (!this.mutationClient) return;
-    try {
-      await this.mutationClient.resumeTask(taskId);
-    } catch (e) {
-      console.error("Failed to resume task:", e);
-    }
   }
 
   // ── Suspend / Response ──

--- a/packages/bees/hivetool/src/ui/ticket-pane.ts
+++ b/packages/bees/hivetool/src/ui/ticket-pane.ts
@@ -1,0 +1,389 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Ticket pane — wrapper that owns the ticket header, tab bar, and view
+ * switching between the Surface and Detail tabs.
+ *
+ * The header (title, status badge, identity chips, task controls) is
+ * shared across both tabs. Below it sits a `Surface · Detail` tab bar.
+ * Each tab body gets the remaining vertical space.
+ *
+ * Defaults to the Surface tab when a surface exists for the selected
+ * ticket, and to the Detail tab otherwise.
+ */
+
+import { SignalWatcher } from "@lit-labs/signals";
+import { LitElement, html, css, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+
+import type { TicketStore } from "../data/ticket-store.js";
+import type { MutationClient } from "../data/mutation-client.js";
+import type { TemplateStore } from "../data/template-store.js";
+import type { SkillStore } from "../data/skill-store.js";
+import { sharedStyles } from "./shared-styles.js";
+import "./ticket-detail.js";
+import "./surface-pane.js";
+
+export { BeesTicketPane };
+
+type PaneTab = "surface" | "detail";
+
+@customElement("bees-ticket-pane")
+class BeesTicketPane extends SignalWatcher(LitElement) {
+  static styles = [
+    sharedStyles,
+    css`
+      :host {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        overflow: hidden;
+      }
+
+      /* ── Tab bar ── */
+      .pane-tabs {
+        display: flex;
+        padding: 0 32px;
+        border-bottom: 1px solid #1e293b;
+        background: #0f1115;
+        flex-shrink: 0;
+      }
+
+      .pane-tab {
+        padding: 8px 14px;
+        font-size: 0.75rem;
+        font-weight: 600;
+        color: #64748b;
+        cursor: pointer;
+        border-bottom: 2px solid transparent;
+        transition: color 0.15s;
+        user-select: none;
+      }
+
+      .pane-tab.active {
+        color: #f8fafc;
+        border-bottom-color: #3b82f6;
+      }
+
+      .pane-tab:hover:not(.active) {
+        color: #cbd5e1;
+      }
+
+      /* ── Tab body ── */
+      .tab-body {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+      }
+    `,
+  ];
+
+  @property({ attribute: false })
+  accessor ticketStore: TicketStore | null = null;
+
+  @property({ attribute: false })
+  accessor mutationClient: MutationClient | null = null;
+
+  @property({ attribute: false })
+  accessor templateStore: TemplateStore | null = null;
+
+  @property({ attribute: false })
+  accessor skillStore: SkillStore | null = null;
+
+  @property({ attribute: false })
+  accessor flashTicketId: string | null = null;
+
+  @state() accessor activePane: PaneTab = "detail";
+  @state() accessor hasSurface = false;
+
+  /**
+   * Track the ticket ID for which we last probed,
+   * so we only re-probe on ticket change, not on every render.
+   */
+  #probedFor: string | null = null;
+
+  render() {
+    if (!this.ticketStore) return nothing;
+    const ticket = this.ticketStore.selectedTicket.get();
+    if (!ticket)
+      return html`<div class="empty-state">
+        Select a ticket to view details
+      </div>`;
+
+    // Probe for surface on ticket change.
+    if (this.#probedFor !== ticket.id) {
+      this.#probedFor = ticket.id;
+      this.hasSurface = false;
+      this.activePane = "detail";
+      this.probeSurface(ticket.id);
+    }
+
+    const suspendFn =
+      ticket.suspend_event?.function_name as string | undefined;
+    const statusLabel =
+      ticket.status === "suspended" &&
+      ticket.assignee === "user" &&
+      suspendFn !== "chat_await_context_update"
+        ? "waiting for user"
+        : ticket.status === "suspended"
+          ? "waiting for event"
+          : ticket.status;
+
+    // Collect identity chips.
+    const identityChips: Array<{
+      label: string;
+      value: string;
+      cls?: string;
+      onclick?: () => void;
+    }> = [];
+    if (ticket.model)
+      identityChips.push({
+        label: "model",
+        value: ticket.model,
+        cls: "model",
+      });
+    if (ticket.playbook_id) {
+      const templateNames = new Set(
+        (this.templateStore?.templates.get() ?? []).map((t) => t.name)
+      );
+      const exists = templateNames.has(ticket.playbook_id);
+      identityChips.push({
+        label: "template",
+        value: ticket.playbook_id,
+        cls: "playbook",
+        onclick: exists
+          ? () => this.navigate("templates", ticket.playbook_id!)
+          : undefined,
+      });
+    }
+    if (ticket.creator_ticket_id)
+      identityChips.push({
+        label: "parent",
+        value: ticket.creator_ticket_id.slice(0, 8),
+        onclick: () => this.navigate("tickets", ticket.creator_ticket_id!),
+      });
+    if (ticket.owning_task_id)
+      identityChips.push({
+        label: "fs owner",
+        value: ticket.owning_task_id.slice(0, 8),
+        onclick: () => this.navigate("tickets", ticket.owning_task_id!),
+      });
+    identityChips.push({
+      label: "session",
+      value: ticket.id.slice(0, 8),
+      onclick: () => this.navigate("logs", ticket.id),
+    });
+    if (ticket.skills && ticket.skills.length > 0) {
+      const skillDirs = new Set(
+        (this.skillStore?.skills.get() ?? []).map((sk) => sk.dirName)
+      );
+      for (const s of ticket.skills)
+        identityChips.push({
+          label: "skill",
+          value: s,
+          cls: "skill",
+          onclick: skillDirs.has(s)
+            ? () => this.navigate("skills", s)
+            : undefined,
+        });
+    }
+
+    return html`
+      <div
+        class="job-detail ${this.flashTicketId === ticket.id
+          ? "lightning-flash"
+          : ""}"
+      >
+        <div class="job-detail-header">
+          <div class="job-detail-header-top">
+            <h2 class="job-detail-title">${ticket.title || "Ticket"}</h2>
+            <div style="display:flex;align-items:center;gap:8px">
+              ${this.renderTaskControl(ticket.id, ticket.status)}
+              <div class="job-detail-badge ${ticket.status}">${statusLabel}</div>
+            </div>
+          </div>
+          <div class="job-detail-meta">
+            <span
+              >ID: <code class="mono">${ticket.id.slice(0, 13)}...</code></span
+            >
+            <span
+              >Created:
+              ${new Date(ticket.created_at ?? "").toLocaleString()}</span
+            >
+            ${ticket.completed_at
+              ? html`<span
+                  >Completed:
+                  ${new Date(ticket.completed_at).toLocaleString()}</span
+                >`
+              : nothing}
+            ${ticket.turns
+              ? html`<span>${ticket.turns} turns</span>`
+              : nothing}
+            ${ticket.thoughts
+              ? html`<span>${ticket.thoughts} thoughts</span>`
+              : nothing}
+          </div>
+        </div>
+
+        ${identityChips.length > 0
+          ? html`
+              <div
+                class="identity-row"
+                style="padding: 8px 32px; border-bottom: 1px solid #1e293b"
+              >
+                ${identityChips.map(
+                  (c) => html`
+                    <span
+                      class="identity-chip ${c.cls ?? ""} ${c.onclick
+                        ? "linkable"
+                        : ""}"
+                      @click=${c.onclick ?? nothing}
+                    >
+                      <span class="identity-label">${c.label}</span>
+                      ${c.value}
+                    </span>
+                  `
+                )}
+                ${ticket.playbook_run_id
+                  ? html`<span class="identity-chip">
+                      <span class="identity-label">run</span>
+                      ${ticket.playbook_run_id.slice(0, 8)}
+                    </span>`
+                  : nothing}
+              </div>
+            `
+          : nothing}
+
+        ${this.hasSurface
+          ? html`
+              <div class="pane-tabs">
+                <div
+                  class="pane-tab ${this.activePane === "surface" ? "active" : ""}"
+                  @click=${() => { this.activePane = "surface"; }}
+                >
+                  Surface
+                </div>
+                <div
+                  class="pane-tab ${this.activePane === "detail" ? "active" : ""}"
+                  @click=${() => { this.activePane = "detail"; }}
+                >
+                  Detail
+                </div>
+              </div>
+
+              <div class="tab-body">
+                ${this.activePane === "surface"
+                  ? html`<bees-surface-pane
+                      .ticketStore=${this.ticketStore}
+                      .ticketId=${ticket.id}
+                    ></bees-surface-pane>`
+                  : html`<bees-ticket-detail
+                      .ticketStore=${this.ticketStore}
+                      .mutationClient=${this.mutationClient}
+                      .flashTicketId=${this.flashTicketId}
+                    ></bees-ticket-detail>`}
+              </div>
+            `
+          : html`
+              <div class="tab-body">
+                <bees-ticket-detail
+                  .ticketStore=${this.ticketStore}
+                  .mutationClient=${this.mutationClient}
+                  .flashTicketId=${this.flashTicketId}
+                ></bees-ticket-detail>
+              </div>
+            `}
+      </div>
+    `;
+  }
+
+  // ── Per-task pause / resume (lifted from ticket-detail) ──
+
+  private renderTaskControl(taskId: string, status: string) {
+    if (!this.mutationClient?.boxActive.get()) return nothing;
+
+    const ACTIVE = new Set(["running", "available", "suspended", "blocked"]);
+
+    if (ACTIVE.has(status)) {
+      return html`
+        <button
+          style="padding:3px 10px;font-size:0.65rem;font-weight:600;
+                 background:transparent;color:#f87171;border:1px solid #991b1b;
+                 border-radius:4px;cursor:pointer;font-family:inherit;
+                 transition:all 0.15s"
+          @click=${() => this.handlePauseTask(taskId)}
+        >
+          ⏸ Pause
+        </button>
+      `;
+    }
+
+    if (status === "paused") {
+      return html`
+        <button
+          style="padding:3px 10px;font-size:0.65rem;font-weight:600;
+                 background:transparent;color:#4ade80;border:1px solid #166534;
+                 border-radius:4px;cursor:pointer;font-family:inherit;
+                 transition:all 0.15s"
+          @click=${() => this.handleResumeTask(taskId)}
+        >
+          ▶ Resume
+        </button>
+      `;
+    }
+
+    return nothing;
+  }
+
+  private async handlePauseTask(taskId: string) {
+    if (!this.mutationClient) return;
+    try {
+      await this.mutationClient.pauseTask(taskId);
+    } catch (e) {
+      console.error("Failed to pause task:", e);
+    }
+  }
+
+  private async handleResumeTask(taskId: string) {
+    if (!this.mutationClient) return;
+    try {
+      await this.mutationClient.resumeTask(taskId);
+    } catch (e) {
+      console.error("Failed to resume task:", e);
+    }
+  }
+
+  // ── Surface probe ──
+
+  private async probeSurface(ticketId: string): Promise<void> {
+    if (!this.ticketStore) return;
+    const surface = await this.ticketStore.readSurface(ticketId);
+    // Only apply if we're still looking at the same ticket.
+    if (this.#probedFor === ticketId) {
+      this.hasSurface = surface !== null;
+      this.activePane = surface ? "surface" : "detail";
+    }
+  }
+
+  // ── Navigation ──
+
+  private navigate(tab: string, id: string) {
+    this.dispatchEvent(
+      new CustomEvent("navigate", {
+        detail: { tab, id },
+        bubbles: true,
+      })
+    );
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "bees-ticket-pane": BeesTicketPane;
+  }
+}


### PR DESCRIPTION
## What
Extract the hivetool ticket detail view into a tabbed `Surface · Detail` layout, so the agent's curated surface gets a dedicated full-pane view.

## Why
Phase 5a of Project Surface. The surface was previously embedded as a block inside the timeline. Giving it its own tab makes it the primary presentation and leaves the timeline as a secondary diagnostic view.

## Changes

### `hivetool/src/ui/`
- **[NEW] `ticket-pane.ts`** — wrapper component owning the ticket header (title, status badge, identity chips, task controls) and a `Surface · Detail` tab bar. Probes for `surface.json` on ticket change; hides tabs when no surface exists.
- **[NEW] `surface-pane.ts`** — full-pane "Surface" tab body. Owns surface loading and renders `<bees-surface-view>`.
- **[MODIFIED] `ticket-detail.ts`** — stripped header, identity chips, surface loading, and task controls. Now a pure timeline renderer.
- **[MODIFIED] `app.ts`** — swapped `<bees-ticket-detail>` for `<bees-ticket-pane>` in the tickets tab main area.

### `PROJECT_SURFACE.md`
- Phase 5a items checked off.

## Testing
1. Run `npm run dev:hivetool -w packages/bees`.
2. Select a ticket **without** a `surface.json` — no tab bar, detail view renders directly.
3. Select a ticket **with** a `surface.json` (e.g. `37eea4e3`) — `Surface · Detail` tabs appear, Surface is auto-selected.
4. Switch between tabs — each gets the full main pane.
