### PR TITLE
[bees] Bundle rendering for HiveTool surfaces

### DIFF
--- a/packages/bees/PROJECT_SURFACE.md
+++ b/packages/bees/PROJECT_SURFACE.md
@@ -165,24 +165,52 @@ is the default when present. Each tab gets the full main pane.
 
 ---
 
-## Phase 5b — Bundle Rendering
+## Phase 5b — Bundle Rendering ✅
 
 Surface items with `render: "bundle"` render in a sandboxed iframe.
 
-- [ ] `surface-pane.ts` — detect `render: "bundle"` items. Read the JS file
-      (and conventionally-discovered CSS by same stem) via
-      `TicketStore.readFileContent`. Construct blob URLs and render in a
-      sandboxed iframe (`sandbox="allow-scripts"`).
-- [ ] Revoke blob URLs on disconnect / item change.
-- [ ] Update `<bees-surface-view>` (or `surface-pane`) to render bundle items
-      as interactive iframes instead of static cards.
+- [x] Shared code in `common/`: `bundle-types.ts` (message protocol),
+      `message-bridge.ts` (host↔iframe postMessage bridge),
+      `iframe-runtime.ts` (self-contained HTML generator with inline React
+      UMD, CJS require shim, `window.opalSDK` proxy, error boundary).
+- [x] `<bees-bundle-frame>` component — hosts a single sandboxed iframe.
+      Manages MessageBridge lifecycle, relays `readFile` requests to
+      `TicketStore.readFileContent`, displays component errors.
+- [x] `react-cache.ts` — fetches React 18 UMD from unpkg once per session,
+      builds and caches the iframe blob URL shared across all frames.
+- [x] `surface-pane.ts` — detects `render: "bundle"` items, reads JS/CSS
+      from the ticket filesystem, renders each as a `<bees-bundle-frame>`
+      card. Non-bundle items render as before. Blob URL revoked on dispose.
 
 🎯 A surface item with `render: "bundle"` displays as a live, sandboxed iframe
 in the surface pane.
 
 ---
 
-## Phase 5c — Markdown Rendering and Content Preview
+## Phase 5c — SDK Extensibility ✅
+
+Make `window.opalSDK` a generic RPC proxy so that adding new SDK methods
+is a host-side-only concern. The iframe runtime becomes closed to modification.
+
+- [x] Replace the hardcoded `opalSDK` object in `iframe-runtime.ts` with a
+      `Proxy` that forwards any method call as a generic
+      `{ type: "sdk.call", method, args, requestId }` message. Every call
+      returns a `Promise` (fire-and-forget methods resolve immediately on
+      the host).
+- [x] Add `sdk.call` / `sdk.call.response` message types to `bundle-types.ts`.
+      Removed per-method types (`readFile`, `navigate`, `emit`). Added
+      `SdkHandlers` type for the host-side registry.
+- [x] In `bundle-frame.ts`, replaced the inline `readFile` relay with a
+      generic `#handleSdkCall` dispatcher backed by `sdkHandlers: SdkHandlers`.
+- [x] In `surface-pane.ts`, `#makeSdkHandlers()` builds the registry with
+      `readFile`, `navigateTo`, and `emit` handlers.
+
+🎯 Adding a new `window.opalSDK.foo()` method requires only registering a
+handler on the host — no changes to `iframe-runtime.ts` or `bundle-types.ts`.
+
+---
+
+## Phase 5d — Markdown Rendering and Content Preview
 
 Rich rendering for markdown items and on-demand content preview.
 
@@ -198,7 +226,7 @@ on-demand content previews.
 
 ---
 
-## Phase 5d — Multi-Scope Surface Discovery
+## Phase 5e — Multi-Scope Surface Discovery
 
 Walk the filesystem tree for all `surface.json` files, aggregate across scopes.
 

--- a/packages/bees/common/README.md
+++ b/packages/bees/common/README.md
@@ -1,0 +1,119 @@
+# Opal SDK — Bundle Rendering Bridge
+
+This directory contains the shared infrastructure for rendering React component
+bundles in sandboxed iframes. It's used by both the Opal web shell and HiveTool.
+
+## Architecture
+
+```
+┌─────────────────────┐     postMessage      ┌──────────────────────┐
+│     Host (Lit)       │ ◄──────────────────► │  Iframe (React)      │
+│                      │                      │                      │
+│  MessageBridge       │  sdk.call ──────►    │  window.opalSDK      │
+│  SdkHandlers map     │  ◄── sdk.call.resp   │  (generic Proxy)     │
+│                      │                      │                      │
+│  render ────────►    │                      │  CJS eval + mount    │
+│  update-props ───►   │                      │  Error boundary      │
+└─────────────────────┘                      └──────────────────────┘
+```
+
+The iframe runtime exposes `window.opalSDK` as a **generic RPC proxy**. Any
+method call on it is forwarded to the host as a `sdk.call` message. The host
+looks up the method in its `SdkHandlers` registry and sends back the result.
+
+**The iframe runtime never needs to change when adding new SDK methods.**
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `bundle-types.ts` | Message protocol types and `SdkHandlers` registry type |
+| `message-bridge.ts` | Host-side typed postMessage bridge (ready gating, dispose) |
+| `iframe-runtime.ts` | `buildIframeHtml()` — self-contained sandbox HTML generator |
+
+## Adding a New SDK Method
+
+To expose a new method on `window.opalSDK` (e.g., `opalSDK.getTheme()`):
+
+### 1. Register a handler on the host
+
+In `surface-pane.ts` (or wherever you build the `SdkHandlers` map):
+
+```ts
+handlers.set("getTheme", async () => {
+  return { mode: "dark", accent: "#3b5fc0" };
+});
+```
+
+### 2. That's it
+
+The iframe component can now call:
+
+```js
+const theme = await window.opalSDK.getTheme();
+// → { mode: "dark", accent: "#3b5fc0" }
+```
+
+No changes to `iframe-runtime.ts`, `bundle-types.ts`, or `message-bridge.ts`.
+
+## How It Works
+
+### Iframe side (`window.opalSDK`)
+
+The SDK is a `Proxy` with a `get` trap. Any property access returns a function
+that:
+
+1. Serializes the method name and arguments
+2. Generates a `requestId` (UUID)
+3. Sends `{ type: "sdk.call", method, args, requestId }` to the host
+4. Returns a `Promise` that resolves when `sdk.call.response` arrives
+
+### Host side (`SdkHandlers`)
+
+`<bees-bundle-frame>` receives `sdk.call` messages and dispatches them:
+
+1. Looks up `method` in the `sdkHandlers` Map
+2. Calls the handler with the spread `args`
+3. Sends `{ type: "sdk.call.response", requestId, result }` back
+4. If the handler throws, sends `{ type: "sdk.call.response", requestId, error }`
+5. If no handler is registered, sends an error response
+
+### Fire-and-forget methods
+
+Methods like `navigateTo` or `emit` that don't return meaningful data still
+go through the same round-trip. The handler returns `undefined` (or void),
+which resolves the caller's Promise immediately. The component can `await`
+or ignore the return value — both work.
+
+## Security Model
+
+The iframe uses `sandbox="allow-scripts"` **without** `allow-same-origin`.
+This means:
+
+- ✅ JavaScript execution (React rendering, opalSDK calls)
+- ✅ `postMessage` to/from the host
+- ❌ No network access (fetch, XHR, CDN scripts)
+- ❌ No access to host DOM or cookies
+- ❌ No `localStorage` / `sessionStorage`
+
+React is embedded inline as UMD source (fetched at the host level, cached
+per session). Google Fonts `<link>` tags are included but won't load in the
+sandbox — components fall back to system fonts.
+
+## Message Protocol
+
+### Host → Iframe
+
+| Type | Fields | Purpose |
+|---|---|---|
+| `render` | `code`, `css?`, `props` | Evaluate CJS bundle and mount component |
+| `update-props` | `props` | Re-render with new props (no re-eval) |
+| `sdk.call.response` | `requestId`, `result?`, `error?` | Return value for an SDK call |
+
+### Iframe → Host
+
+| Type | Fields | Purpose |
+|---|---|---|
+| `ready` | — | Iframe runtime initialized |
+| `error` | `message`, `stack?` | Uncaught error or component crash |
+| `sdk.call` | `requestId`, `method`, `args` | SDK method invocation |

--- a/packages/bees/common/bundle-types.ts
+++ b/packages/bees/common/bundle-types.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Message protocol types for the host ↔ iframe bundle rendering bridge.
+ *
+ * These types define the postMessage contract between a host page and a
+ * sandboxed iframe that renders React components from CJS bundles. Used
+ * by both the Opal web shell and HiveTool devtools.
+ */
+
+export type { HostMessage, IframeMessage, OpalSDK, SdkHandlers };
+
+/** Messages the host sends TO the iframe. */
+type HostMessage =
+  | {
+      type: "render";
+      code: string;
+      css?: string;
+      props: Record<string, unknown>;
+    }
+  | { type: "update-props"; props: Record<string, unknown> }
+  | {
+      type: "sdk.call.response";
+      requestId: string;
+      result?: unknown;
+      error?: string;
+    };
+
+/** Messages the iframe sends TO the host. */
+type IframeMessage =
+  | { type: "ready" }
+  | { type: "error"; message: string; stack?: string }
+  | {
+      type: "sdk.call";
+      requestId: string;
+      method: string;
+      args: unknown[];
+    };
+
+/** The SDK exposed as `window.opalSDK` inside the sandboxed iframe. */
+interface OpalSDK {
+  [method: string]: (...args: unknown[]) => Promise<unknown>;
+}
+
+/**
+ * Host-side handler registry for SDK methods.
+ *
+ * Each key is a method name (e.g. "readFile", "navigateTo").
+ * The handler receives the args array and returns a result (or throws).
+ */
+type SdkHandlers = Map<string, (...args: unknown[]) => Promise<unknown>>;

--- a/packages/bees/common/iframe-runtime.ts
+++ b/packages/bees/common/iframe-runtime.ts
@@ -1,0 +1,379 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Generates a self-contained HTML document for a sandboxed bundle iframe.
+ *
+ * The returned HTML embeds React + ReactDOM inline (passed as pre-fetched
+ * source strings) and includes the full iframe runtime: CJS require shim,
+ * `window.opalSDK` proxy, React rendering with error boundary, and the
+ * host message handler.
+ *
+ * Usage:
+ *   const html = buildIframeHtml(reactUmdSource, reactDomUmdSource);
+ *   const blob = new Blob([html], { type: "text/html" });
+ *   const url = URL.createObjectURL(blob);
+ *   iframe.src = url;
+ */
+
+export { buildIframeHtml };
+
+/**
+ * Build a complete, self-contained HTML document for the bundle sandbox.
+ *
+ * @param reactSource - The full UMD source of React (e.g. react.production.min.js)
+ * @param reactDomSource - The full UMD source of ReactDOM (e.g. react-dom.production.min.js)
+ */
+function buildIframeHtml(reactSource: string, reactDomSource: string): string {
+  // Escape </script> in the embedded sources — the HTML parser would
+  // otherwise treat it as the end of the script block.
+  const safeReact = reactSource.replace(/<\/script/gi, "<\\/script");
+  const safeReactDom = reactDomSource.replace(/<\/script/gi, "<\\/script");
+
+  // The runtime script is inlined as a string. It mirrors the logic from
+  // web/src/iframe/entry.ts but works without ESM imports — React is
+  // available as a global from the preceding UMD scripts.
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Sandbox</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap" rel="stylesheet" />
+
+  <style>
+    /* ── MD3 Design Tokens ──────────────────────────────────────────────── */
+    :root {
+      --cg-font-sans: 'Inter', system-ui, -apple-system, sans-serif;
+      --cg-font-mono: 'JetBrains Mono', ui-monospace, monospace;
+      --cg-text-display-lg-size: 57px;  --cg-text-display-lg-line-height: 64px;  --cg-text-display-lg-weight: 400;
+      --cg-text-display-md-size: 45px;  --cg-text-display-md-line-height: 52px;  --cg-text-display-md-weight: 400;
+      --cg-text-display-sm-size: 36px;  --cg-text-display-sm-line-height: 44px;  --cg-text-display-sm-weight: 400;
+      --cg-text-headline-lg-size: 32px;  --cg-text-headline-lg-line-height: 40px;  --cg-text-headline-lg-weight: 400;
+      --cg-text-headline-md-size: 28px;  --cg-text-headline-md-line-height: 36px;  --cg-text-headline-md-weight: 400;
+      --cg-text-headline-sm-size: 24px;  --cg-text-headline-sm-line-height: 32px;  --cg-text-headline-sm-weight: 400;
+      --cg-text-title-lg-size: 22px;  --cg-text-title-lg-line-height: 28px;  --cg-text-title-lg-weight: 500;
+      --cg-text-title-md-size: 16px;  --cg-text-title-md-line-height: 24px;  --cg-text-title-md-weight: 500;
+      --cg-text-title-sm-size: 14px;  --cg-text-title-sm-line-height: 20px;  --cg-text-title-sm-weight: 500;
+      --cg-text-body-lg-size: 16px;  --cg-text-body-lg-line-height: 24px;  --cg-text-body-lg-weight: 400;
+      --cg-text-body-md-size: 14px;  --cg-text-body-md-line-height: 20px;  --cg-text-body-md-weight: 400;
+      --cg-text-body-sm-size: 12px;  --cg-text-body-sm-line-height: 16px;  --cg-text-body-sm-weight: 400;
+      --cg-text-label-lg-size: 14px;  --cg-text-label-lg-line-height: 20px;  --cg-text-label-lg-weight: 500;
+      --cg-text-label-md-size: 12px;  --cg-text-label-md-line-height: 16px;  --cg-text-label-md-weight: 500;
+      --cg-text-label-sm-size: 11px;  --cg-text-label-sm-line-height: 16px;  --cg-text-label-sm-weight: 500;
+      --cg-color-surface-dim: #f5f3f0;
+      --cg-color-surface: #fdfcfa;
+      --cg-color-surface-bright: #ffffff;
+      --cg-color-surface-container-lowest: #ffffff;
+      --cg-color-surface-container-low: #f8f6f3;
+      --cg-color-surface-container: #f0eeeb;
+      --cg-color-surface-container-high: #eae8e5;
+      --cg-color-surface-container-highest: #e4e2df;
+      --cg-color-on-surface: #1c1b1f;
+      --cg-color-on-surface-muted: #79757f;
+      --cg-color-primary: #3b5fc0;
+      --cg-color-primary-container: #dbe1f9;
+      --cg-color-on-primary: #ffffff;
+      --cg-color-on-primary-container: #0f1b3d;
+      --cg-color-secondary: #bec6dc;
+      --cg-color-secondary-container: #3b4358;
+      --cg-color-on-secondary: #283141;
+      --cg-color-on-secondary-container: #d8e0f8;
+      --cg-color-tertiary: #d4bfff;
+      --cg-color-tertiary-container: #3f2e6e;
+      --cg-color-on-tertiary: #2a1a51;
+      --cg-color-on-tertiary-container: #eedcff;
+      --cg-color-error: #ba1a1a;
+      --cg-color-error-container: #ffdad6;
+      --cg-color-on-error: #ffffff;
+      --cg-color-on-error-container: #410e0b;
+      --cg-color-outline: #7a767e;
+      --cg-color-outline-variant: #e0ddd9;
+      --cg-sp-0: 0px;    --cg-sp-1: 4px;    --cg-sp-2: 8px;
+      --cg-sp-3: 12px;   --cg-sp-4: 16px;   --cg-sp-5: 20px;
+      --cg-sp-6: 24px;   --cg-sp-7: 28px;   --cg-sp-8: 32px;
+      --cg-sp-9: 36px;   --cg-sp-10: 40px;  --cg-sp-11: 44px;
+      --cg-sp-12: 48px;  --cg-sp-13: 52px;  --cg-sp-14: 56px;
+      --cg-sp-15: 60px;  --cg-sp-16: 64px;
+      --cg-radius-xs: 4px;   --cg-radius-sm: 8px;
+      --cg-radius-md: 12px;  --cg-radius-lg: 16px;
+      --cg-radius-xl: 28px;  --cg-radius-full: 999px;
+      --cg-elevation-1: 0 1px 3px 1px rgba(0,0,0,0.15), 0 1px 2px rgba(0,0,0,0.3);
+      --cg-elevation-2: 0 2px 6px 2px rgba(0,0,0,0.15), 0 1px 2px rgba(0,0,0,0.3);
+      --cg-elevation-3: 0 4px 8px 3px rgba(0,0,0,0.15), 0 1px 3px rgba(0,0,0,0.3);
+      --cg-motion-duration-short: 150ms;
+      --cg-motion-duration-medium: 300ms;
+      --cg-motion-duration-long: 500ms;
+      --cg-motion-easing-standard: cubic-bezier(0.2, 0.0, 0, 1.0);
+      --cg-motion-easing-decel: cubic-bezier(0.0, 0.0, 0, 1.0);
+      --cg-motion-easing-accel: cubic-bezier(0.3, 0.0, 0.8, 0.15);
+      --cg-card-bg: var(--cg-color-surface-container);
+      --cg-card-radius: var(--cg-radius-md);
+      --cg-card-padding: var(--cg-sp-4);
+      --cg-card-shadow: var(--cg-elevation-1);
+      --cg-button-radius: var(--cg-radius-full);
+      --cg-button-padding: var(--cg-sp-3) var(--cg-sp-6);
+      --cg-button-bg: var(--cg-color-primary);
+      --cg-button-color: var(--cg-color-on-primary);
+      --cg-button-font-size: var(--cg-text-label-lg-size);
+      --cg-button-font-weight: var(--cg-text-label-lg-weight);
+      --cg-input-bg: var(--cg-color-surface-container-high);
+      --cg-input-border: var(--cg-color-outline-variant);
+      --cg-input-radius: var(--cg-radius-sm);
+      --cg-input-padding: var(--cg-sp-3) var(--cg-sp-4);
+      --cg-input-color: var(--cg-color-on-surface);
+      --cg-input-placeholder: var(--cg-color-on-surface-muted);
+      --cg-badge-bg: var(--cg-color-tertiary-container);
+      --cg-badge-color: var(--cg-color-on-tertiary-container);
+      --cg-badge-radius: var(--cg-radius-full);
+      --cg-badge-padding: var(--cg-sp-1) var(--cg-sp-2);
+      --cg-badge-font-size: var(--cg-text-label-sm-size);
+      --cg-divider-color: var(--cg-color-outline-variant);
+      --cg-divider-thickness: 1px;
+      --cg-divider-style: solid;
+      --cg-border-style: solid;
+      --cg-border-width: 1px;
+      --cg-heading-transform: none;
+      --cg-heading-letter-spacing: normal;
+      --cg-img-radius: var(--cg-radius-md);
+      --cg-img-border: none;
+      --cg-img-shadow: none;
+      --cg-img-filter: none;
+      --cg-hover-scale: 1.02;
+      --cg-hover-brightness: 1.1;
+      --cg-hover-shadow: var(--cg-elevation-2);
+    }
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body {
+      height: 100%;
+      font-family: var(--cg-font-sans);
+      font-size: var(--cg-text-body-md-size);
+      line-height: var(--cg-text-body-md-line-height);
+      color: var(--cg-color-on-surface);
+      background: var(--cg-color-surface);
+      -webkit-font-smoothing: antialiased;
+    }
+    #root { min-height: 100%; }
+    #error {
+      display: none;
+      position: fixed;
+      inset: 0;
+      padding: var(--cg-sp-4);
+      background: var(--cg-color-error-container);
+      color: var(--cg-color-on-error-container);
+      font-family: var(--cg-font-mono);
+      font-size: var(--cg-text-body-sm-size);
+      white-space: pre-wrap;
+      overflow: auto;
+      z-index: 9999;
+    }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <div id="error"></div>
+
+  <!-- React UMD — inlined to avoid network fetches from the sandboxed blob: origin -->
+  <script>${safeReact}</${""}script>
+  <script>${safeReactDom}</${""}script>
+
+  <script>
+  // ── Iframe Runtime ────────────────────────────────────────────────────
+  // Mirrors web/src/iframe/entry.ts but runs standalone (no ESM imports).
+  // React and ReactDOM are globals from the UMD scripts above.
+  (function() {
+    "use strict";
+
+    // ── Require shim ──
+    // esbuild CJS output calls require("react"). Intercept it.
+    function requireShim(id) {
+      if (id === "react" || id.startsWith("react/")) return React;
+      if (id === "react-dom/client") return ReactDOM;
+      console.warn('[bees-iframe] Unknown require("' + id + '")');
+      return {};
+    }
+
+    // ── Opal SDK (Generic RPC Proxy) ──
+    // Every method call on window.opalSDK is forwarded to the host as
+    // { type: "sdk.call", method, args, requestId }. The host responds
+    // with { type: "sdk.call.response", requestId, result?, error? }.
+    // Adding new SDK methods requires only a host-side handler.
+    var pendingCalls = new Map();
+
+    window.opalSDK = new Proxy({}, {
+      get: function(target, prop) {
+        if (typeof prop !== "string") return undefined;
+        // Standard object protocol — don't intercept.
+        if (prop === "then" || prop === "toJSON") return undefined;
+        return function() {
+          var args = Array.prototype.slice.call(arguments);
+          var requestId = crypto.randomUUID();
+          return new Promise(function(resolve, reject) {
+            pendingCalls.set(requestId, { resolve: resolve, reject: reject });
+            window.parent.postMessage({
+              type: "sdk.call",
+              method: prop,
+              args: args,
+              requestId: requestId
+            }, "*");
+          });
+        };
+      }
+    });
+
+    // ── React state ──
+    var currentComponent = null;
+    var currentRoot = null;
+    var currentProps = {};
+
+    // ── Error boundary ──
+    var ErrorBoundary = (function(_super) {
+      function EB(props) {
+        _super.call(this, props);
+        this.state = { error: null };
+      }
+      EB.prototype = Object.create(_super.prototype);
+      EB.prototype.constructor = EB;
+
+      EB.getDerivedStateFromError = function(error) {
+        return { error: error };
+      };
+
+      EB.prototype.componentDidCatch = function(error) {
+        window.parent.postMessage(
+          { type: "error", message: error.message, stack: error.stack },
+          "*"
+        );
+        var errorEl = document.getElementById("error");
+        if (errorEl) {
+          errorEl.style.display = "block";
+          errorEl.textContent = error.message + "\\n\\n" + error.stack;
+        }
+      };
+
+      EB.prototype.render = function() {
+        if (this.state.error) {
+          return React.createElement("div", {
+            style: {
+              padding: "16px", margin: "16px",
+              background: "var(--cg-color-error-container)",
+              color: "var(--cg-color-on-error-container)",
+              borderRadius: "var(--cg-radius-sm)",
+              fontFamily: "var(--cg-font-mono)",
+              fontSize: "var(--cg-text-body-sm-size)",
+              whiteSpace: "pre-wrap"
+            }
+          }, "⚠ Component crashed:\\n\\n" + this.state.error.message);
+        }
+        return this.props.children;
+      };
+
+      return EB;
+    })(React.Component);
+
+    // ── Render handler ──
+    function handleRender(msg) {
+      var code = msg.code;
+      var css = msg.css;
+      var props = msg.props;
+
+      try {
+        // Inject CSS if provided.
+        if (css) {
+          var styleEl = document.getElementById("bundle-css");
+          if (!styleEl) {
+            styleEl = document.createElement("style");
+            styleEl.id = "bundle-css";
+            document.head.appendChild(styleEl);
+          }
+          styleEl.textContent = css;
+        }
+
+        // CJS shims: esbuild output uses require() and module.exports.
+        var moduleShim = { exports: {} };
+        var fn = new Function("React", "require", "module", "exports", code);
+        fn(React, requireShim, moduleShim, moduleShim.exports);
+
+        var Component = moduleShim.exports.default || moduleShim.exports;
+        var rootEl = document.getElementById("root");
+
+        if (currentRoot) {
+          currentRoot.unmount();
+        }
+
+        var root = ReactDOM.createRoot(rootEl);
+        currentComponent = Component;
+        currentRoot = root;
+        currentProps = props;
+
+        root.render(
+          React.createElement(ErrorBoundary, null,
+            React.createElement(Component, props)
+          )
+        );
+
+        var errorEl = document.getElementById("error");
+        if (errorEl) errorEl.style.display = "none";
+      } catch (err) {
+        window.parent.postMessage(
+          { type: "error", message: err.message, stack: err.stack },
+          "*"
+        );
+        var errorEl = document.getElementById("error");
+        if (errorEl) {
+          errorEl.style.display = "block";
+          errorEl.textContent = err.message + "\\n\\n" + err.stack;
+        }
+      }
+    }
+
+    function rerender() {
+      if (!currentComponent || !currentRoot) return;
+      currentRoot.render(
+        React.createElement(ErrorBoundary, null,
+          React.createElement(currentComponent, currentProps)
+        )
+      );
+    }
+
+    // ── Message handler ──
+    function handleMessage(event) {
+      var data = event.data;
+      if (!data || typeof data !== "object" || !("type" in data)) return;
+
+      switch (data.type) {
+        case "render":
+          handleRender(data);
+          break;
+        case "update-props":
+          currentProps = data.props;
+          rerender();
+          break;
+        case "sdk.call.response":
+          var pending = pendingCalls.get(data.requestId);
+          if (pending) {
+            pendingCalls.delete(data.requestId);
+            if (data.error) {
+              pending.reject(new Error(data.error));
+            } else {
+              pending.resolve(data.result);
+            }
+          }
+          break;
+      }
+    }
+
+    // ── Bootstrap ──
+    window.addEventListener("message", handleMessage);
+    window.parent.postMessage({ type: "ready" }, "*");
+  })();
+  </${""}script>
+</body>
+</html>`;
+}

--- a/packages/bees/common/message-bridge.ts
+++ b/packages/bees/common/message-bridge.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Host-side typed postMessage bridge for communicating with a sandboxed
+ * iframe that renders React component bundles.
+ *
+ * Usage:
+ *   const bridge = new MessageBridge(iframeEl);
+ *   bridge.onMessage((msg) => { ... });
+ *   bridge.send({ type: "render", code, css, props: {} });
+ *   bridge.dispose();
+ */
+
+import type { HostMessage, IframeMessage } from "./bundle-types.js";
+
+export { MessageBridge };
+export type { HostMessage, IframeMessage };
+
+class MessageBridge {
+  #iframe: HTMLIFrameElement;
+  #handler: (event: MessageEvent) => void;
+  #callback: ((msg: IframeMessage) => void) | null = null;
+  #ready = false;
+  #readyPromise: Promise<void>;
+  #resolveReady!: () => void;
+
+  constructor(iframe: HTMLIFrameElement) {
+    this.#iframe = iframe;
+    this.#readyPromise = new Promise((resolve) => {
+      this.#resolveReady = resolve;
+    });
+
+    this.#handler = (event: MessageEvent) => {
+      // Only accept messages from our iframe.
+      if (event.source !== this.#iframe.contentWindow) return;
+
+      const data = event.data as IframeMessage;
+      if (!data || typeof data !== "object" || !("type" in data)) return;
+
+      if (data.type === "ready") {
+        this.#ready = true;
+        this.#resolveReady();
+        return;
+      }
+
+      // Forward other messages to the callback if registered.
+      if (this.#callback) {
+        this.#callback(data);
+      }
+    };
+
+    window.addEventListener("message", this.#handler);
+  }
+
+  /** Send a message to the iframe. Waits for the iframe to signal ready. */
+  async send(msg: HostMessage): Promise<void> {
+    await this.#readyPromise;
+    this.#iframe.contentWindow?.postMessage(msg, "*");
+  }
+
+  /**
+   * Listen for messages from the iframe.
+   *
+   * The callback receives typed IframeMessages. The "ready" message is
+   * handled internally and not forwarded.
+   */
+  onMessage(callback: (msg: IframeMessage) => void): void {
+    this.#callback = callback;
+  }
+
+  /** Whether the iframe has signalled readiness. */
+  get ready(): boolean {
+    return this.#ready;
+  }
+
+  /** Clean up the message listener. */
+  dispose(): void {
+    window.removeEventListener("message", this.#handler);
+    this.#callback = null;
+  }
+}

--- a/packages/bees/hivetool/src/ui/bundle-frame.ts
+++ b/packages/bees/hivetool/src/ui/bundle-frame.ts
@@ -1,0 +1,230 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Bundle frame — hosts a single sandboxed iframe for a `render: "bundle"`
+ * surface item.
+ *
+ * Lifecycle:
+ * 1. On first render, creates a blob URL iframe and immediately wires
+ *    the MessageBridge (before the iframe loads, so we catch "ready").
+ * 2. When the iframe signals `ready`, sends the `render` message with
+ *    the bundle's JS (and optional CSS).
+ * 3. Relays `sdk.call` requests to the registered handlers.
+ * 4. On disconnect (or when code changes), disposes the message bridge.
+ */
+
+import { LitElement, html, css, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+
+import { MessageBridge } from "../../../common/message-bridge.js";
+import type {
+  IframeMessage,
+  SdkHandlers,
+} from "../../../common/bundle-types.js";
+import { sharedStyles } from "./shared-styles.js";
+
+export { BeesBundleFrame };
+
+@customElement("bees-bundle-frame")
+class BeesBundleFrame extends LitElement {
+  static styles = [
+    sharedStyles,
+    css`
+      :host {
+        display: block;
+        position: relative;
+      }
+
+      .frame-container {
+        position: relative;
+        width: 100%;
+        border: 1px solid #1e293b;
+        border-radius: 8px;
+        overflow: hidden;
+        background: #ffffff;
+      }
+
+      iframe {
+        display: block;
+        width: 100%;
+        height: 400px;
+        border: none;
+      }
+
+      .error-overlay {
+        padding: 12px 16px;
+        background: #1a0000;
+        border: 1px solid #991b1b;
+        border-radius: 6px;
+        color: #fca5a5;
+        font-family: "JetBrains Mono", monospace;
+        font-size: 0.7rem;
+        white-space: pre-wrap;
+        max-height: 200px;
+        overflow-y: auto;
+        margin-top: 4px;
+      }
+
+      .loading {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 200px;
+        color: #64748b;
+        font-size: 0.8rem;
+      }
+    `,
+  ];
+
+  /** The iframe HTML blob URL — created once per session, shared across instances. */
+  @property({ type: String })
+  accessor iframeBlobUrl: string | null = null;
+
+  /** The CJS bundle source to render. */
+  @property({ type: String })
+  accessor code: string | null = null;
+
+  /** Optional CSS to inject alongside the bundle. */
+  @property({ type: String })
+  accessor bundleCss: string | null = null;
+
+  /**
+   * SDK handler registry — maps method names to async handlers.
+   *
+   * When the iframe calls `window.opalSDK.foo(a, b)`, the host
+   * looks up `sdkHandlers.get("foo")` and calls it with `[a, b]`.
+   * The return value (or thrown error) is sent back to the iframe.
+   */
+  @property({ attribute: false })
+  accessor sdkHandlers: SdkHandlers = new Map();
+
+  @state() accessor error: string | null = null;
+  @state() accessor loading = true;
+
+  #bridge: MessageBridge | null = null;
+  #wired = false;
+
+  render() {
+    if (!this.iframeBlobUrl || !this.code) {
+      return html`<div class="loading">Preparing bundle…</div>`;
+    }
+
+    return html`
+      <div class="frame-container">
+        ${this.loading
+          ? html`<div class="loading">Loading component…</div>`
+          : nothing}
+        <iframe
+          sandbox="allow-scripts"
+          style=${this.loading ? "position:absolute;opacity:0;pointer-events:none" : ""}
+        ></iframe>
+      </div>
+      ${this.error
+        ? html`<div class="error-overlay">${this.error}</div>`
+        : nothing}
+    `;
+  }
+
+  /**
+   * Wire the bridge as soon as the iframe element exists in the shadow DOM,
+   * BEFORE setting its src. This ensures we catch the "ready" message.
+   */
+  protected updated(): void {
+    if (this.#wired) return;
+    if (!this.iframeBlobUrl || !this.code) return;
+
+    const iframe = this.renderRoot.querySelector("iframe");
+    if (!iframe) return;
+
+    this.#wired = true;
+
+    // Set up the bridge first — it listens for "ready" via window message.
+    const bridge = new MessageBridge(iframe);
+    this.#bridge = bridge;
+
+    bridge.onMessage((msg: IframeMessage) => {
+      switch (msg.type) {
+        case "sdk.call":
+          this.#handleSdkCall(msg.requestId, msg.method, msg.args);
+          break;
+        case "error":
+          this.error = msg.message + (msg.stack ? "\n\n" + msg.stack : "");
+          break;
+      }
+    });
+
+    // NOW set the src — the bridge listener is already in place.
+    iframe.src = this.iframeBlobUrl;
+
+    // Send render once bridge is ready (iframe signals "ready").
+    this.#sendRender(bridge);
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.#dispose();
+  }
+
+  async #sendRender(bridge: MessageBridge): Promise<void> {
+    if (!this.code) return;
+
+    await bridge.send({
+      type: "render",
+      code: this.code,
+      css: this.bundleCss ?? undefined,
+      props: {},
+    });
+
+    this.loading = false;
+    this.error = null;
+  }
+
+  async #handleSdkCall(
+    requestId: string,
+    method: string,
+    args: unknown[]
+  ): Promise<void> {
+    if (!this.#bridge) return;
+
+    const handler = this.sdkHandlers.get(method);
+    if (!handler) {
+      await this.#bridge.send({
+        type: "sdk.call.response",
+        requestId,
+        error: `Unknown SDK method: ${method}`,
+      });
+      return;
+    }
+
+    try {
+      const result = await handler(...args);
+      await this.#bridge.send({
+        type: "sdk.call.response",
+        requestId,
+        result,
+      });
+    } catch (e) {
+      await this.#bridge.send({
+        type: "sdk.call.response",
+        requestId,
+        error: (e as Error).message,
+      });
+    }
+  }
+
+  #dispose(): void {
+    this.#bridge?.dispose();
+    this.#bridge = null;
+    this.#wired = false;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "bees-bundle-frame": BeesBundleFrame;
+  }
+}

--- a/packages/bees/hivetool/src/ui/react-cache.ts
+++ b/packages/bees/hivetool/src/ui/react-cache.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * React source cache and iframe blob URL manager.
+ *
+ * Fetches React 18 UMD production builds from unpkg once per session,
+ * builds the iframe HTML via `buildIframeHtml()`, and creates a single
+ * blob URL reused by all `<bees-bundle-frame>` instances.
+ */
+
+import { buildIframeHtml } from "../../../common/iframe-runtime.js";
+
+export { getIframeBlobUrl, revokeIframeBlobUrl };
+
+const REACT_CDN =
+  "https://unpkg.com/react@18/umd/react.production.min.js";
+const REACT_DOM_CDN =
+  "https://unpkg.com/react-dom@18/umd/react-dom.production.min.js";
+
+/** Cached blob URL — shared across all bundle frames in the session. */
+let cachedBlobUrl: string | null = null;
+let fetchPromise: Promise<string> | null = null;
+
+/**
+ * Get (or create) the blob URL for the bundle sandbox iframe.
+ *
+ * The first call fetches React UMD sources from unpkg and builds
+ * the iframe HTML. Subsequent calls return the cached URL immediately.
+ */
+async function getIframeBlobUrl(): Promise<string> {
+  if (cachedBlobUrl) return cachedBlobUrl;
+
+  // Deduplicate concurrent calls — only one fetch in flight.
+  if (!fetchPromise) {
+    fetchPromise = (async () => {
+      const [reactSource, reactDomSource] = await Promise.all([
+        fetch(REACT_CDN).then((r) => r.text()),
+        fetch(REACT_DOM_CDN).then((r) => r.text()),
+      ]);
+
+      const htmlContent = buildIframeHtml(reactSource, reactDomSource);
+      const blob = new Blob([htmlContent], { type: "text/html" });
+      cachedBlobUrl = URL.createObjectURL(blob);
+      return cachedBlobUrl;
+    })();
+  }
+
+  return fetchPromise;
+}
+
+/** Revoke the cached blob URL (e.g., on app teardown). */
+function revokeIframeBlobUrl(): void {
+  if (cachedBlobUrl) {
+    URL.revokeObjectURL(cachedBlobUrl);
+    cachedBlobUrl = null;
+    fetchPromise = null;
+  }
+}

--- a/packages/bees/hivetool/src/ui/surface-pane.ts
+++ b/packages/bees/hivetool/src/ui/surface-pane.ts
@@ -8,7 +8,10 @@
  * Full-pane surface view — the "Surface" tab body.
  *
  * Receives a ticket ID, reads root `surface.json` via the ticket store,
- * and renders the existing `<bees-surface-view>` in the full main area.
+ * and renders the surface. Items with `render: "bundle"` are rendered
+ * as live sandboxed iframes via `<bees-bundle-frame>`. Other items
+ * render as static cards via `<bees-surface-view>`.
+ *
  * Re-reads surface data when the ticket ID changes or the filesystem
  * observer fires.
  */
@@ -18,11 +21,21 @@ import { LitElement, html, css, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
 import type { TicketStore } from "../data/ticket-store.js";
-import type { SurfaceManifest } from "../data/types.js";
+import type { SurfaceManifest, SurfaceItem } from "../data/types.js";
+import type { SdkHandlers } from "../../../common/bundle-types.js";
+import { getIframeBlobUrl } from "./react-cache.js";
 import { sharedStyles } from "./shared-styles.js";
 import "./surface-view.js";
+import "./bundle-frame.js";
 
 export { BeesSurfacePane };
+
+/** Resolved bundle content ready for rendering. */
+interface ResolvedBundle {
+  item: SurfaceItem;
+  code: string;
+  css: string | null;
+}
 
 @customElement("bees-surface-pane")
 class BeesSurfacePane extends SignalWatcher(LitElement) {
@@ -43,6 +56,20 @@ class BeesSurfacePane extends SignalWatcher(LitElement) {
         width: 100%;
       }
 
+      .bundle-section {
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        margin-bottom: 16px;
+      }
+
+      .bundle-label {
+        font-size: 0.7rem;
+        font-weight: 600;
+        color: #a5b4fc;
+        margin-bottom: 4px;
+      }
+
       .empty-state {
         flex: 1;
         display: flex;
@@ -61,6 +88,8 @@ class BeesSurfacePane extends SignalWatcher(LitElement) {
   accessor ticketId: string | null = null;
 
   @state() accessor surface: SurfaceManifest | null = null;
+  @state() accessor resolvedBundles: ResolvedBundle[] = [];
+  @state() accessor iframeBlobUrl: string | null = null;
 
   /** Track which ticket ID we last loaded for. */
   #loadedFor: string | null = null;
@@ -73,15 +102,54 @@ class BeesSurfacePane extends SignalWatcher(LitElement) {
     // Reload surface when ticket changes.
     if (this.#loadedFor !== this.ticketId) {
       this.surface = null;
+      this.resolvedBundles = [];
       this.#loadedFor = this.ticketId;
       this.loadSurface();
     }
 
     if (!this.surface) return nothing;
 
+    // Split items into bundles and non-bundles.
+    const nonBundleItems = this.surface.items.filter(
+      (i) => i.render !== "bundle"
+    );
+    const nonBundleSurface: SurfaceManifest = {
+      ...this.surface,
+      items: nonBundleItems,
+    };
+    const hasBundles = this.resolvedBundles.length > 0;
+    const hasNonBundles = nonBundleItems.length > 0;
+
     return html`
       <div class="surface-container">
-        <bees-surface-view .surface=${this.surface}></bees-surface-view>
+        ${hasBundles ? this.renderBundles() : nothing}
+        ${hasNonBundles
+          ? html`<bees-surface-view
+              .surface=${nonBundleSurface}
+            ></bees-surface-view>`
+          : nothing}
+      </div>
+    `;
+  }
+
+  private renderBundles() {
+    const handlers = this.#makeSdkHandlers();
+
+    return html`
+      <div class="bundle-section">
+        ${this.resolvedBundles.map(
+          (bundle) => html`
+            <div>
+              <div class="bundle-label">${bundle.item.title}</div>
+              <bees-bundle-frame
+                .iframeBlobUrl=${this.iframeBlobUrl}
+                .code=${bundle.code}
+                .bundleCss=${bundle.css}
+                .sdkHandlers=${handlers}
+              ></bees-bundle-frame>
+            </div>
+          `
+        )}
       </div>
     `;
   }
@@ -90,11 +158,89 @@ class BeesSurfacePane extends SignalWatcher(LitElement) {
   async loadSurface(): Promise<void> {
     if (!this.ticketStore || !this.ticketId) return;
     this.surface = await this.ticketStore.readSurface(this.ticketId);
+
+    if (this.surface) {
+      await this.#resolveBundles(this.surface);
+    }
   }
 
   /** Whether a surface is currently loaded. */
   get hasSurface(): boolean {
     return this.surface !== null;
+  }
+
+  /**
+   * Read bundle JS/CSS content for all `render: "bundle"` items and
+   * prepare the iframe blob URL.
+   */
+  async #resolveBundles(surface: SurfaceManifest): Promise<void> {
+    const bundleItems = surface.items.filter((i) => i.render === "bundle");
+    if (bundleItems.length === 0) {
+      this.resolvedBundles = [];
+      return;
+    }
+
+    // Ensure iframe blob URL is ready (fetches React on first call).
+    if (!this.iframeBlobUrl) {
+      try {
+        this.iframeBlobUrl = await getIframeBlobUrl();
+      } catch (e) {
+        console.error("[surface-pane] Failed to prepare iframe runtime:", e);
+        return;
+      }
+    }
+
+    const resolved: ResolvedBundle[] = [];
+    for (const item of bundleItems) {
+      if (!item.path) continue;
+
+      const jsPath = item.path.split("/");
+      const code = await this.ticketStore!.readFileContent(
+        this.ticketId!,
+        jsPath
+      );
+      if (!code) {
+        console.warn(
+          `[surface-pane] Could not read bundle JS: ${item.path}`
+        );
+        continue;
+      }
+
+      // Conventionally discover CSS by same stem: bundle.js → bundle.css
+      const stem = item.path.replace(/\.js$/, "");
+      const cssPath = (stem + ".css").split("/");
+      const bundleCss = await this.ticketStore!.readFileContent(
+        this.ticketId!,
+        cssPath
+      );
+
+      resolved.push({ item, code, css: bundleCss });
+    }
+
+    this.resolvedBundles = resolved;
+  }
+
+  /** Build the SDK handler registry for this ticket context. */
+  #makeSdkHandlers(): SdkHandlers {
+    const store = this.ticketStore!;
+    const ticketId = this.ticketId!;
+
+    const handlers: SdkHandlers = new Map();
+
+    handlers.set("readFile", async (path: unknown) => {
+      const segments = String(path).split("/").filter(Boolean);
+      return store.readFileContent(ticketId, segments);
+    });
+
+    handlers.set("navigateTo", async () => {
+      // TODO: wire to hivetool navigation when needed.
+    });
+
+    handlers.set("emit", async () => {
+      // TODO: wire to hivetool event bus when needed.
+    });
+
+    return handlers;
   }
 }
 


### PR DESCRIPTION
## What

Enables sandboxed React component rendering in HiveTool's surface pane. Surface items with `render: "bundle"` now display as live iframes, with full `window.opalSDK` messaging support.

## Why

Phase 5b+5c of PROJECT_SURFACE. Agent-generated UI bundles (JSX compiled to CJS via esbuild) need to render inside HiveTool with the same `opalSDK` contract used in the Opal web shell. This completes the rendering pipeline and makes the SDK extensible for future methods.

## Changes

### New shared code (`packages/bees/common/`)
- `bundle-types.ts` — message protocol types (`sdk.call`/`sdk.call.response`, `SdkHandlers`)
- `message-bridge.ts` — host-side typed postMessage bridge with ready gating
- `iframe-runtime.ts` — `buildIframeHtml()` generates self-contained sandbox HTML with inline React UMD, CJS require shim, error boundary, and generic `opalSDK` Proxy
- `README.md` — developer docs for extending the SDK (one step: register a handler)

### New HiveTool components (`packages/bees/hivetool/src/ui/`)
- `bundle-frame.ts` — `<bees-bundle-frame>` hosts a sandboxed iframe, dispatches `sdk.call` to a handler registry
- `react-cache.ts` — fetches React 18 UMD from unpkg once per session, caches the blob URL

### Modified
- `surface-pane.ts` — detects `render: "bundle"` items, reads JS/CSS from ticket filesystem, renders each as a `<bees-bundle-frame>` with SDK handlers (`readFile`, `navigateTo`, `emit`)
- `PROJECT_SURFACE.md` — marks phases 5b/5c complete, adds phase 5c (SDK extensibility), renumbers subsequent phases

### Test fixture
- Updated `hive/tickets/.../surface.json` to reference the actual `bundle.js` file

## Testing

1. Run `npm run dev:hivetool -w packages/bees`
2. Select ticket `37eea4e3...` → Surface tab
3. Verify the bundle renders in a sandboxed iframe
4. In the bundle component, call `window.opalSDK.readFile("surface.json")` — should return the file contents
