### PR TITLE
[bees] Chat UI in Surface Pane (Bento Grid Layout)

### DIFF
--- a/packages/bees/PROJECT_SURFACE.md
+++ b/packages/bees/PROJECT_SURFACE.md
@@ -246,6 +246,31 @@ discoverable and individually viewable in the surface pane.
 
 ---
 
+## Phase 5f — Chat in Surface (Bento Grid Layout)
+
+Chat UI (log + input) rendered as a built-in surface item inside a CSS grid
+with bento box layout rules.
+
+- [x] New `chat-panel.ts` — `<bees-chat-panel>` extracted from
+      `ticket-detail.ts`. Combines chat log and interactive input UI
+      (text reply, choice cards) into a single component. Renders
+      conditionally based on chat history and suspend state.
+- [x] `surface-pane.ts` — bento grid layout. Composes `<bees-chat-panel>`
+      alongside agent-declared surface items. Chat takes the left half
+      when present; content blocks (bundles + surface-view) fill the
+      right half or full width without chat.
+- [x] `ticket-detail.ts` — stripped chat log, reply/choice forms, and
+      related state/styles. Non-interactive suspend fallback preserved.
+- [x] `ticket-pane.ts` — Surface tab shown when surface OR chat content
+      exists. `probeSurface` checks both conditions.
+- [x] Exported `hasChatContent(ticket)` utility for reuse by parent
+      components (tab visibility probing).
+
+🎯 Selecting a task with chat history shows the Surface tab with a bento
+grid layout — chat on the left half, surface items on the right.
+
+---
+
 ## Phase 6 — Reference App Surface Rendering
 
 The reference web app renders surfaces for chat-tagged tasks.

--- a/packages/bees/bees/task_runner.py
+++ b/packages/bees/bees/task_runner.py
@@ -180,11 +180,14 @@ class TaskRunner:
 
         response = json.loads(response_path.read_text())
 
-        # Log user's reply to the chat log (only actual user text,
-        # not context-update-only responses).
+        # Log user's reply to the chat log.
+        # Text replies carry "text"; choice replies carry "selectedIds".
         user_text = response.get("text", "")
         if user_text:
             append_chat_log(task.dir, "user", user_text)
+        elif "selectedIds" in response:
+            ids = response["selectedIds"]
+            append_chat_log(task.dir, "user", ", ".join(ids))
 
         # Load opaque resume state from previous suspend.
         state = load_resume_state(task.dir)

--- a/packages/bees/hive/config/SYSTEM.yaml
+++ b/packages/bees/hive/config/SYSTEM.yaml
@@ -7,4 +7,4 @@
 #               exists yet.
 title: Opal
 description: Personal assistant
-root: live-session
+root: opie

--- a/packages/bees/hivetool/src/ui/chat-panel.ts
+++ b/packages/bees/hivetool/src/ui/chat-panel.ts
@@ -1,0 +1,608 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Unified chat panel — chat log + interactive input UI.
+ *
+ * Renders the conversation history from `ticket.chat_history` and,
+ * when the task is suspended waiting for user input, shows a text
+ * reply form or choice selection cards.
+ *
+ * This component is a built-in surface item composed by
+ * `<bees-surface-pane>`, not driven by `surface.json`.
+ */
+
+import { SignalWatcher } from "@lit-labs/signals";
+import { LitElement, html, css, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+
+import type { TicketStore } from "../data/ticket-store.js";
+import type { MutationClient } from "../data/mutation-client.js";
+import type { TaskData } from "../../../common/types.js";
+import { markdown } from "../../../common/markdown.js";
+import { sharedStyles } from "./shared-styles.js";
+
+export { BeesChatPanel };
+
+@customElement("bees-chat-panel")
+class BeesChatPanel extends SignalWatcher(LitElement) {
+  static styles = [
+    sharedStyles,
+    css`
+      :host {
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+      }
+
+      .chat-container {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        overflow: hidden;
+      }
+
+      /* ── Chat log ── */
+      .chat-log {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        padding: 8px 12px;
+        flex: 1;
+        overflow-y: auto;
+        scrollbar-width: thin;
+        scrollbar-color: #334155 transparent;
+      }
+
+      .chat-turn {
+        border-radius: 8px;
+        padding: 10px 14px;
+        font-size: 0.8rem;
+        line-height: 1.5;
+      }
+
+      .chat-turn.user {
+        background: #1e293b;
+        border: 1px solid #334155;
+      }
+
+      .chat-turn.agent {
+        background: #111827;
+        border: 1px solid #1e293b;
+      }
+
+      .chat-role {
+        font-size: 0.65rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        margin-bottom: 4px;
+      }
+
+      .chat-turn.user .chat-role {
+        color: #60a5fa;
+      }
+
+      .chat-turn.agent .chat-role {
+        color: #a78bfa;
+      }
+
+      .chat-text {
+        color: #e2e8f0;
+      }
+
+      .chat-text p {
+        margin: 0.3em 0;
+      }
+
+      .chat-text p:first-child {
+        margin-top: 0;
+      }
+
+      .chat-text p:last-child {
+        margin-bottom: 0;
+      }
+
+      .chat-text code {
+        background: #1e293b;
+        padding: 1px 5px;
+        border-radius: 3px;
+        font-family: "Google Mono", "Roboto Mono", monospace;
+        font-size: 0.85em;
+      }
+
+      .chat-text pre {
+        background: #0f172a;
+        border: 1px solid #1e293b;
+        border-radius: 4px;
+        padding: 8px 12px;
+        overflow-x: auto;
+        margin: 0.5em 0;
+      }
+
+      .chat-text pre code {
+        background: none;
+        padding: 0;
+        font-size: 0.8rem;
+      }
+
+      .chat-text ul,
+      .chat-text ol {
+        margin: 0.4em 0;
+        padding-left: 1.5em;
+      }
+
+      .chat-text a {
+        color: #60a5fa;
+      }
+
+      .chat-text strong {
+        color: #f8fafc;
+      }
+
+      /* ── Response form ── */
+
+      .response-section {
+        border-top: 1px solid #1e293b;
+        padding: 12px;
+        flex-shrink: 0;
+      }
+
+      .response-form {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      .agent-prompt {
+        padding: 12px 16px;
+        background: #111827;
+        border: 1px solid #1e293b;
+        border-radius: 8px;
+        color: #e2e8f0;
+        font-size: 0.85rem;
+        line-height: 1.6;
+      }
+
+      .agent-prompt p {
+        margin: 0.3em 0;
+      }
+
+      .agent-prompt p:first-child {
+        margin-top: 0;
+      }
+
+      .agent-prompt p:last-child {
+        margin-bottom: 0;
+      }
+
+      .agent-prompt code {
+        background: #1e293b;
+        padding: 1px 5px;
+        border-radius: 3px;
+        font-family: "Google Mono", "Roboto Mono", monospace;
+        font-size: 0.85em;
+      }
+
+      .agent-prompt strong {
+        color: #f8fafc;
+      }
+
+      .reply-textarea {
+        width: 100%;
+        min-height: 80px;
+        padding: 10px 12px;
+        background: #0b0c0f;
+        border: 1px solid #334155;
+        border-radius: 6px;
+        color: #e2e8f0;
+        font-family: inherit;
+        font-size: 0.85rem;
+        resize: vertical;
+        outline: none;
+        box-sizing: border-box;
+        transition: border-color 0.15s;
+      }
+
+      .reply-textarea:focus {
+        border-color: #3b82f6;
+      }
+
+      .reply-textarea::placeholder {
+        color: #475569;
+      }
+
+      .reply-actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: 8px;
+      }
+
+      .send-btn {
+        padding: 6px 16px;
+        font-size: 0.8rem;
+        font-weight: 600;
+        background: #1d4ed8;
+        color: #dbeafe;
+        border: 1px solid #2563eb;
+        border-radius: 6px;
+        cursor: pointer;
+        font-family: inherit;
+        transition: all 0.15s;
+      }
+
+      .send-btn:hover {
+        background: #2563eb;
+        color: #fff;
+      }
+
+      .send-btn:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+      }
+
+      /* ── Choice cards ── */
+
+      .choices-grid {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+
+      .choice-card {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 10px 14px;
+        background: #111827;
+        border: 1px solid #1e293b;
+        border-radius: 8px;
+        cursor: pointer;
+        transition: all 0.15s;
+        font-size: 0.8rem;
+        color: #e2e8f0;
+      }
+
+      .choice-card:hover {
+        background: #1e293b;
+        border-color: #334155;
+      }
+
+      .choice-card.selected {
+        background: #1e3a5f;
+        border-color: #3b82f6;
+      }
+
+      .choice-indicator {
+        width: 16px;
+        height: 16px;
+        border-radius: 50%;
+        border: 2px solid #475569;
+        flex-shrink: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: all 0.15s;
+      }
+
+      .choice-card.selected .choice-indicator {
+        border-color: #3b82f6;
+        background: #3b82f6;
+      }
+
+      .choice-indicator::after {
+        content: "";
+        width: 6px;
+        height: 6px;
+        border-radius: 50%;
+        background: transparent;
+        transition: background 0.15s;
+      }
+
+      .choice-card.selected .choice-indicator::after {
+        background: #fff;
+      }
+
+      .choice-label {
+        flex: 1;
+        line-height: 1.4;
+      }
+
+      /* ── Empty state ── */
+      .chat-empty {
+        padding: 24px;
+        text-align: center;
+        color: #475569;
+        font-size: 0.8rem;
+        font-style: italic;
+      }
+    `,
+  ];
+
+  @property({ attribute: false })
+  accessor ticketStore: TicketStore | null = null;
+
+  @property({ attribute: false })
+  accessor mutationClient: MutationClient | null = null;
+
+  @state() accessor replyText = "";
+  @state() accessor selectedChoiceIds = new Set<string>();
+  @state() accessor responding = false;
+
+  /**
+   * Whether this panel has visible content — chat messages or pending
+   * user input. Used by the parent to decide grid layout.
+   */
+  get hasContent(): boolean {
+    const ticket = this.ticketStore?.selectedTicket.get();
+    if (!ticket) return false;
+    return hasChatContent(ticket);
+  }
+
+  render() {
+    if (!this.ticketStore) return nothing;
+    const ticket = this.ticketStore.selectedTicket.get();
+    if (!ticket) return nothing;
+
+    const chatHistory = (ticket.chat_history ?? []).filter(
+      (m) => m.text.trim() !== ""
+    );
+
+    const inputUi = this.renderInputUi(ticket);
+    if (chatHistory.length === 0 && !inputUi) return nothing;
+
+    // When the input panel is showing, the agent's prompt text duplicates
+    // the last agent message in the log. Drop it to avoid the echo.
+    const displayHistory = inputUi
+      ? this.#dropTrailingAgentMessage(chatHistory)
+      : chatHistory;
+
+    return html`
+      <div class="chat-container">
+        ${displayHistory.length > 0
+          ? html`
+              <div class="chat-log">
+                ${displayHistory.map(
+                  (m) => html`
+                    <div
+                      class="chat-turn ${m.role === "user" ? "user" : "agent"}"
+                    >
+                      <div class="chat-role">${m.role}</div>
+                      <div class="chat-text">${markdown(m.text)}</div>
+                    </div>
+                  `
+                )}
+              </div>
+            `
+          : nothing}
+        ${inputUi
+          ? html`<div class="response-section">${inputUi}</div>`
+          : nothing}
+      </div>
+    `;
+  }
+
+  // ── Input UI ──
+
+  /** Render the interactive input area, or null if not applicable. */
+  private renderInputUi(ticket: TaskData): unknown {
+    if (ticket.status !== "suspended" || !ticket.suspend_event) return null;
+
+    const functionName = ticket.suspend_event.function_name as
+      | string
+      | undefined;
+    const isUserFacing =
+      ticket.assignee === "user" &&
+      functionName !== "chat_await_context_update";
+
+    if (!isUserFacing || !this.mutationClient?.boxActive.get()) return null;
+
+    const waitForInput = ticket.suspend_event.waitForInput as
+      | Record<string, unknown>
+      | undefined;
+    const waitForChoice = ticket.suspend_event.waitForChoice as
+      | Record<string, unknown>
+      | undefined;
+
+    if (waitForInput) return this.renderReplyForm(ticket.id, waitForInput);
+    if (waitForChoice) return this.renderChoiceForm(ticket.id, waitForChoice);
+    return null;
+  }
+
+  /** Extract displayable text from an LLMContent prompt. */
+  private extractPromptText(prompt: unknown): string {
+    if (!prompt || typeof prompt !== "object") return "";
+    const p = prompt as { parts?: Array<{ text?: string }> };
+    if (!Array.isArray(p.parts)) return "";
+    return p.parts.map((part) => part.text ?? "").join("");
+  }
+
+  /** Interactive text reply form for waitForInput suspensions. */
+  private renderReplyForm(
+    ticketId: string,
+    waitForInput: Record<string, unknown>
+  ) {
+    const promptText = this.extractPromptText(waitForInput.prompt);
+
+    return html`
+      <div class="response-form">
+        ${promptText
+          ? html`<div class="agent-prompt">${markdown(promptText)}</div>`
+          : nothing}
+        <textarea
+          class="reply-textarea"
+          placeholder="Type your reply…"
+          .value=${this.replyText}
+          ?disabled=${this.responding}
+          @input=${(e: Event) => {
+            this.replyText = (e.target as HTMLTextAreaElement).value;
+          }}
+          @keydown=${(e: KeyboardEvent) => {
+            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+              e.preventDefault();
+              if (this.replyText.trim()) {
+                this.handleTextReply(ticketId);
+              }
+            }
+          }}
+        ></textarea>
+        <div class="reply-actions">
+          <button
+            class="send-btn"
+            ?disabled=${!this.replyText.trim() || this.responding}
+            @click=${() => this.handleTextReply(ticketId)}
+          >
+            ${this.responding ? "Sending…" : "Send"}
+          </button>
+        </div>
+      </div>
+    `;
+  }
+
+  /** Interactive choice selection form for waitForChoice suspensions. */
+  private renderChoiceForm(
+    ticketId: string,
+    waitForChoice: Record<string, unknown>
+  ) {
+    const promptText = this.extractPromptText(waitForChoice.prompt);
+    const choices = (waitForChoice.choices ?? []) as Array<{
+      id: string;
+      content?: { parts?: Array<{ text?: string }> };
+    }>;
+    const selectionMode =
+      (waitForChoice.selectionMode as string) ?? "single";
+
+    return html`
+      <div class="response-form">
+        ${promptText
+          ? html`<div class="agent-prompt">${markdown(promptText)}</div>`
+          : nothing}
+        <div class="choices-grid">
+          ${choices.map((choice) => {
+            const selected = this.selectedChoiceIds.has(choice.id);
+            const label =
+              this.extractPromptText(choice.content) || choice.id;
+            return html`
+              <div
+                class="choice-card ${selected ? "selected" : ""}"
+                @click=${() => this.toggleChoice(choice.id, selectionMode)}
+              >
+                <div class="choice-indicator"></div>
+                <span class="choice-label">${label}</span>
+              </div>
+            `;
+          })}
+        </div>
+        <div class="reply-actions">
+          <button
+            class="send-btn"
+            ?disabled=${this.selectedChoiceIds.size === 0 || this.responding}
+            @click=${() => this.handleChoiceReply(ticketId)}
+          >
+            ${this.responding ? "Sending…" : "Confirm"}
+          </button>
+        </div>
+      </div>
+    `;
+  }
+
+  // ── Interaction handlers ──
+
+  private toggleChoice(choiceId: string, mode: string) {
+    const next = new Set(this.selectedChoiceIds);
+    if (mode === "single") {
+      if (next.has(choiceId)) {
+        next.clear();
+      } else {
+        next.clear();
+        next.add(choiceId);
+      }
+    } else {
+      if (next.has(choiceId)) {
+        next.delete(choiceId);
+      } else {
+        next.add(choiceId);
+      }
+    }
+    this.selectedChoiceIds = next;
+  }
+
+  private async handleTextReply(ticketId: string) {
+    const text = this.replyText.trim();
+    if (!text || !this.mutationClient) return;
+
+    this.responding = true;
+    try {
+      await this.mutationClient.respondToTask(ticketId, { text });
+      this.replyText = "";
+    } catch (e) {
+      console.error("Failed to send reply:", e);
+    } finally {
+      this.responding = false;
+    }
+  }
+
+  private async handleChoiceReply(ticketId: string) {
+    if (this.selectedChoiceIds.size === 0 || !this.mutationClient) return;
+
+    this.responding = true;
+    try {
+      await this.mutationClient.respondToTask(ticketId, {
+        selectedIds: [...this.selectedChoiceIds],
+      });
+      this.selectedChoiceIds = new Set();
+    } catch (e) {
+      console.error("Failed to send choice:", e);
+    } finally {
+      this.responding = false;
+    }
+  }
+
+  /**
+   * Remove the last agent message from the history when it would be
+   * duplicated by the prompt text in the response panel.
+   */
+  #dropTrailingAgentMessage(
+    history: Array<{ role: string; text: string }>
+  ): Array<{ role: string; text: string }> {
+    for (let i = history.length - 1; i >= 0; i--) {
+      if (history[i].role !== "user") {
+        return [...history.slice(0, i), ...history.slice(i + 1)];
+      }
+    }
+    return history;
+  }
+}
+
+/**
+ * Whether a ticket has chat content — messages or pending user input.
+ * Exported for use by parent components (tab visibility probing).
+ */
+export function hasChatContent(ticket: TaskData): boolean {
+  const hasMessages = (ticket.chat_history ?? []).some(
+    (m) => m.text.trim() !== ""
+  );
+  if (hasMessages) return true;
+
+  if (ticket.status === "suspended" && ticket.suspend_event) {
+    const fn = ticket.suspend_event.function_name as string | undefined;
+    const isUserFacing =
+      ticket.assignee === "user" && fn !== "chat_await_context_update";
+    if (isUserFacing) {
+      const hasInput = !!ticket.suspend_event.waitForInput;
+      const hasChoice = !!ticket.suspend_event.waitForChoice;
+      if (hasInput || hasChoice) return true;
+    }
+  }
+
+  return false;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "bees-chat-panel": BeesChatPanel;
+  }
+}

--- a/packages/bees/hivetool/src/ui/surface-pane.ts
+++ b/packages/bees/hivetool/src/ui/surface-pane.ts
@@ -7,13 +7,18 @@
 /**
  * Full-pane surface view — the "Surface" tab body.
  *
- * Receives a ticket ID, reads root `surface.json` via the ticket store,
- * and renders the surface. Items with `render: "bundle"` are rendered
- * as live sandboxed iframes via `<bees-bundle-frame>`. Other items
- * render as static cards via `<bees-surface-view>`.
+ * Composes agent-declared surface items and the built-in chat panel
+ * using a CSS grid with bento box layout rules:
  *
- * Re-reads surface data when the ticket ID changes or the filesystem
- * observer fires.
+ *   - 2 columns × N rows
+ *   - Chat takes the left half when present
+ *   - Content blocks fill the right half (or full width without chat)
+ *   - Primary bundles expand to full width when no chat
+ *   - Single block expands to full width
+ *
+ * Items with `render: "bundle"` render as sandboxed iframes via
+ * `<bees-bundle-frame>`. Other items render as static cards via
+ * `<bees-surface-view>`.
  */
 
 import { SignalWatcher } from "@lit-labs/signals";
@@ -21,12 +26,15 @@ import { LitElement, html, css, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
 import type { TicketStore } from "../data/ticket-store.js";
+import type { MutationClient } from "../data/mutation-client.js";
 import type { SurfaceManifest, SurfaceItem } from "../data/types.js";
 import type { SdkHandlers } from "../../../common/bundle-types.js";
+import { hasChatContent } from "./chat-panel.js";
 import { getIframeBlobUrl } from "./react-cache.js";
 import { sharedStyles } from "./shared-styles.js";
 import "./surface-view.js";
 import "./bundle-frame.js";
+import "./chat-panel.js";
 import type { BeesBundleFrame } from "./bundle-frame.js";
 
 export { BeesSurfacePane };
@@ -50,18 +58,72 @@ class BeesSurfacePane extends SignalWatcher(LitElement) {
         overflow-y: auto;
       }
 
-      .surface-container {
+      /* ── Bento grid ── */
+
+      .surface-grid {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 16px;
         padding: 24px 32px;
-        max-width: 960px;
-        margin: 0 auto;
-        width: 100%;
+        flex: 1;
+        min-height: 0;
       }
 
-      .bundle-section {
+      .surface-grid.with-chat {
+        grid-template-columns: 1fr 1fr;
+      }
+
+      /* Chat cell: left column. */
+      .chat-cell {
+        grid-column: 1;
+        min-height: 300px;
+        max-height: calc(100vh - 200px);
+        background: #0f1115;
+        border: 1px solid #1e293b;
+        border-radius: 8px;
+        overflow: hidden;
+      }
+
+      /* When chat is the only content, go full width. */
+      .surface-grid.chat-only .chat-cell {
+        grid-column: 1 / -1;
+        max-height: none;
+      }
+
+      /* Content column wraps bundles + surface-view. */
+      .content-column {
         display: flex;
         flex-direction: column;
         gap: 16px;
-        margin-bottom: 16px;
+        min-width: 0;
+      }
+
+      .surface-grid.with-chat .content-column {
+        grid-column: 2;
+      }
+
+      .surface-grid:not(.with-chat) .content-column {
+        grid-column: 1 / -1;
+      }
+
+      /* ── Bundles within content column ── */
+
+      .bundle-section {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 16px;
+      }
+
+      .bundle-cell {
+        min-width: 0;
+      }
+
+      .bundle-cell.primary {
+        grid-column: 1 / -1;
+      }
+
+      .bundle-cell.solo {
+        grid-column: 1 / -1;
       }
 
       .bundle-label {
@@ -84,6 +146,9 @@ class BeesSurfacePane extends SignalWatcher(LitElement) {
 
   @property({ attribute: false })
   accessor ticketStore: TicketStore | null = null;
+
+  @property({ attribute: false })
+  accessor mutationClient: MutationClient | null = null;
 
   @property({ type: String })
   accessor ticketId: string | null = null;
@@ -131,27 +196,51 @@ class BeesSurfacePane extends SignalWatcher(LitElement) {
       });
     }
 
-    if (!this.surface) return nothing;
+    // Determine what we have.
+    const ticket = this.ticketStore.selectedTicket.get();
+    const showChat = !!ticket && hasChatContent(ticket);
+    const hasSurfaceItems = !!this.surface && this.surface.items.length > 0;
+
+    if (!showChat && !hasSurfaceItems) return nothing;
 
     // Split items into bundles and non-bundles.
-    const nonBundleItems = this.surface.items.filter(
-      (i) => i.render !== "bundle"
-    );
-    const nonBundleSurface: SurfaceManifest = {
-      ...this.surface,
-      items: nonBundleItems,
-    };
+    const nonBundleItems = this.surface
+      ? this.surface.items.filter((i) => i.render !== "bundle")
+      : [];
+    const nonBundleSurface: SurfaceManifest | null =
+      nonBundleItems.length > 0 && this.surface
+        ? { ...this.surface, items: nonBundleItems }
+        : null;
     const hasBundles = this.resolvedBundles.length > 0;
-    const hasNonBundles = nonBundleItems.length > 0;
+    const hasContentItems = hasBundles || nonBundleSurface;
+
+    const gridClass = showChat
+      ? hasContentItems
+        ? "with-chat"
+        : "chat-only"
+      : "";
 
     return html`
-      <div class="surface-container">
-        ${hasBundles ? this.renderBundles() : nothing}
-        ${hasNonBundles
-          ? html`<bees-surface-view
-              .surface=${nonBundleSurface}
-              .contentLoader=${this.#contentLoader}
-            ></bees-surface-view>`
+      <div class="surface-grid ${gridClass}">
+        ${showChat
+          ? html`<bees-chat-panel
+              class="chat-cell"
+              .ticketStore=${this.ticketStore}
+              .mutationClient=${this.mutationClient}
+            ></bees-chat-panel>`
+          : nothing}
+        ${hasContentItems
+          ? html`
+              <div class="content-column">
+                ${hasBundles ? this.renderBundles() : nothing}
+                ${nonBundleSurface
+                  ? html`<bees-surface-view
+                      .surface=${nonBundleSurface}
+                      .contentLoader=${this.#contentLoader}
+                    ></bees-surface-view>`
+                  : nothing}
+              </div>
+            `
           : nothing}
       </div>
     `;
@@ -159,12 +248,15 @@ class BeesSurfacePane extends SignalWatcher(LitElement) {
 
   private renderBundles() {
     const handlers = this.#makeSdkHandlers();
+    const solo = this.resolvedBundles.length === 1;
 
     return html`
       <div class="bundle-section">
-        ${this.resolvedBundles.map(
-          (bundle) => html`
-            <div>
+        ${this.resolvedBundles.map((bundle) => {
+          const isPrimary = bundle.item.role === "primary";
+          const cellClass = solo ? "solo" : isPrimary ? "primary" : "";
+          return html`
+            <div class="bundle-cell ${cellClass}">
               <div class="bundle-label">${bundle.item.title}</div>
               <bees-bundle-frame
                 .iframeBlobUrl=${this.iframeBlobUrl}
@@ -173,8 +265,8 @@ class BeesSurfacePane extends SignalWatcher(LitElement) {
                 .sdkHandlers=${handlers}
               ></bees-bundle-frame>
             </div>
-          `
-        )}
+          `;
+        })}
       </div>
     `;
   }

--- a/packages/bees/hivetool/src/ui/ticket-detail.ts
+++ b/packages/bees/hivetool/src/ui/ticket-detail.ts
@@ -32,55 +32,6 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
     sharedStyles,
     jsonTreeStyles,
     css`
-      /* ── Chat log ── */
-      .chat-log {
-        display: flex;
-        flex-direction: column;
-        gap: 4px;
-        padding: 8px 12px;
-        max-height: 500px;
-        overflow-y: auto;
-      }
-
-      .chat-turn {
-        border-radius: 8px;
-        padding: 10px 14px;
-        font-size: 0.8rem;
-        line-height: 1.5;
-      }
-
-      .chat-turn.user {
-        background: #1e293b;
-        border: 1px solid #334155;
-      }
-
-      .chat-turn.agent {
-        background: #111827;
-        border: 1px solid #1e293b;
-      }
-
-      .chat-role {
-        font-size: 0.65rem;
-        font-weight: 700;
-        text-transform: uppercase;
-        letter-spacing: 0.06em;
-        margin-bottom: 4px;
-      }
-
-      .chat-turn.user .chat-role {
-        color: #60a5fa;
-      }
-
-      .chat-turn.agent .chat-role {
-        color: #a78bfa;
-      }
-
-      .chat-text {
-        color: #e2e8f0;
-        white-space: pre-wrap;
-        word-break: break-word;
-      }
-
       /* ── File tree ── */
       .file-tree {
         font-family: "Google Mono", "Roboto Mono", monospace;
@@ -164,144 +115,6 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
         color: #cbd5e1;
         white-space: pre-wrap;
         word-break: break-word;
-      }
-
-      /* ── Response form ── */
-
-      .response-form {
-        display: flex;
-        flex-direction: column;
-        gap: 12px;
-      }
-
-      .agent-prompt {
-        padding: 12px 16px;
-        background: #111827;
-        border: 1px solid #1e293b;
-        border-radius: 8px;
-        color: #e2e8f0;
-        font-size: 0.85rem;
-        line-height: 1.6;
-        white-space: pre-wrap;
-      }
-
-      .reply-textarea {
-        width: 100%;
-        min-height: 80px;
-        padding: 10px 12px;
-        background: #0b0c0f;
-        border: 1px solid #334155;
-        border-radius: 6px;
-        color: #e2e8f0;
-        font-family: inherit;
-        font-size: 0.85rem;
-        resize: vertical;
-        outline: none;
-        transition: border-color 0.15s;
-      }
-
-      .reply-textarea:focus {
-        border-color: #3b82f6;
-      }
-
-      .reply-textarea::placeholder {
-        color: #475569;
-      }
-
-      .reply-actions {
-        display: flex;
-        justify-content: flex-end;
-        gap: 8px;
-      }
-
-      .send-btn {
-        padding: 6px 16px;
-        font-size: 0.8rem;
-        font-weight: 600;
-        background: #1d4ed8;
-        color: #dbeafe;
-        border: 1px solid #2563eb;
-        border-radius: 6px;
-        cursor: pointer;
-        font-family: inherit;
-        transition: all 0.15s;
-      }
-
-      .send-btn:hover {
-        background: #2563eb;
-        color: #fff;
-      }
-
-      .send-btn:disabled {
-        opacity: 0.4;
-        cursor: not-allowed;
-      }
-
-      /* ── Choice cards ── */
-
-      .choices-grid {
-        display: flex;
-        flex-direction: column;
-        gap: 6px;
-      }
-
-      .choice-card {
-        display: flex;
-        align-items: center;
-        gap: 10px;
-        padding: 10px 14px;
-        background: #111827;
-        border: 1px solid #1e293b;
-        border-radius: 8px;
-        cursor: pointer;
-        transition: all 0.15s;
-        font-size: 0.8rem;
-        color: #e2e8f0;
-      }
-
-      .choice-card:hover {
-        background: #1e293b;
-        border-color: #334155;
-      }
-
-      .choice-card.selected {
-        background: #1e3a5f;
-        border-color: #3b82f6;
-      }
-
-      .choice-indicator {
-        width: 16px;
-        height: 16px;
-        border-radius: 50%;
-        border: 2px solid #475569;
-        flex-shrink: 0;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        transition: all 0.15s;
-      }
-
-      .choice-card.selected .choice-indicator {
-        border-color: #3b82f6;
-        background: #3b82f6;
-      }
-
-      .choice-indicator::after {
-        content: "";
-        width: 6px;
-        height: 6px;
-        border-radius: 50%;
-        background: transparent;
-        transition: background 0.15s;
-      }
-
-      .choice-card.selected .choice-indicator::after {
-        background: #fff;
-      }
-
-      .choice-label {
-        flex: 1;
-        line-height: 1.4;
       }
 
       /* ── Live session panel ── */
@@ -427,11 +240,6 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
   @state() accessor fileTree: FileTreeNode[] = [];
   @state() accessor fileContents: Record<string, string | null> = {};
 
-  // ── Response state ──
-  @state() accessor replyText = "";
-  @state() accessor selectedChoiceIds = new Set<string>();
-  @state() accessor responding = false;
-
   // Live session state is owned by TicketStore.activeConnection —
   // no local client reference needed.
 
@@ -453,9 +261,7 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
       this.#treeLoadedFor = ticket.id;
     }
 
-    const chatHistory = (ticket.chat_history ?? []).filter(
-      (m) => m.text.trim() !== ""
-    );
+
 
     return html`
       <div class="timeline">
@@ -488,29 +294,7 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
               </div>
             `
           : nothing}
-        ${chatHistory.length > 0
-          ? html`
-              <div class="block">
-                <div class="block-header">
-                  Chat (${chatHistory.length} messages)
-                </div>
-                <div class="chat-log">
-                  ${chatHistory.map(
-                    (m) => html`
-                      <div
-                        class="chat-turn ${m.role === "user"
-                          ? "user"
-                          : "agent"}"
-                      >
-                        <div class="chat-role">${m.role}</div>
-                        <div class="chat-text">${m.text}</div>
-                      </div>
-                    `
-                  )}
-                </div>
-              </div>
-            `
-          : nothing}
+
         ${ticket.outcome
           ? html`
               <div class="block outcome">
@@ -538,7 +322,7 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
           ? this.renderLiveSessionPanel(ticket.id)
           : nothing}
         ${ticket.status === "suspended" && ticket.suspend_event
-          ? this.renderSuspendedBlock(ticket.id, ticket.suspend_event, ticket.assignee)
+          ? this.renderSuspendedBlock(ticket.suspend_event)
           : nothing}
         ${ticket.tags && ticket.tags.length > 0
           ? html`
@@ -702,41 +486,17 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
     };
   }
 
-  // ── Suspend / Response ──
+  // ── Suspend ──
 
   /**
-   * Render the suspended block — interactive response form for user-facing
-   * suspensions, JSON tree for everything else.
+   * Render the suspended block — raw JSON tree for non-interactive
+   * suspensions. User-facing interactive input (chat) is handled by
+   * `<bees-chat-panel>` in the surface pane.
    */
   private renderSuspendedBlock(
-    ticketId: string,
-    suspendEvent: Record<string, unknown>,
-    assignee?: string
+    suspendEvent: Record<string, unknown>
   ) {
     const functionName = suspendEvent.function_name as string | undefined;
-    const isUserFacing =
-      assignee === "user" &&
-      functionName !== "chat_await_context_update";
-
-    // For user-facing suspensions, show interactive response UI
-    // only when the box is actively listening for mutations.
-    if (isUserFacing && this.mutationClient?.boxActive.get()) {
-      const waitForInput = suspendEvent.waitForInput as
-        | Record<string, unknown>
-        | undefined;
-      const waitForChoice = suspendEvent.waitForChoice as
-        | Record<string, unknown>
-        | undefined;
-
-      if (waitForInput) {
-        return this.renderReplyForm(ticketId, waitForInput);
-      }
-      if (waitForChoice) {
-        return this.renderChoiceForm(ticketId, waitForChoice);
-      }
-    }
-
-    // Fallback: raw JSON tree for non-interactive or unknown events.
     const label =
       functionName === "chat_await_context_update"
         ? "Waiting for Event"
@@ -751,166 +511,6 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
         </div>
       </div>
     `;
-  }
-
-  /** Extract displayable text from an LLMContent prompt. */
-  private extractPromptText(prompt: unknown): string {
-    if (!prompt || typeof prompt !== "object") return "";
-    const p = prompt as { parts?: Array<{ text?: string }> };
-    if (!Array.isArray(p.parts)) return "";
-    return p.parts.map((part) => part.text ?? "").join("");
-  }
-
-  /** Interactive text reply form for waitForInput suspensions. */
-  private renderReplyForm(
-    ticketId: string,
-    waitForInput: Record<string, unknown>
-  ) {
-    const promptText = this.extractPromptText(waitForInput.prompt);
-
-    return html`
-      <div class="block">
-        <div class="block-header">Reply</div>
-        <div class="block-content">
-          <div class="response-form">
-            ${promptText
-              ? html`<div class="agent-prompt">${promptText}</div>`
-              : nothing}
-            <textarea
-              class="reply-textarea"
-              placeholder="Type your reply…"
-              .value=${this.replyText}
-              ?disabled=${this.responding}
-              @input=${(e: Event) => {
-                this.replyText = (e.target as HTMLTextAreaElement).value;
-              }}
-              @keydown=${(e: KeyboardEvent) => {
-                if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-                  e.preventDefault();
-                  if (this.replyText.trim()) {
-                    this.handleTextReply(ticketId);
-                  }
-                }
-              }}
-            ></textarea>
-            <div class="reply-actions">
-              <button
-                class="send-btn"
-                ?disabled=${!this.replyText.trim() || this.responding}
-                @click=${() => this.handleTextReply(ticketId)}
-              >
-                ${this.responding ? "Sending…" : "Send"}
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-    `;
-  }
-
-  /** Interactive choice selection form for waitForChoice suspensions. */
-  private renderChoiceForm(
-    ticketId: string,
-    waitForChoice: Record<string, unknown>
-  ) {
-    const promptText = this.extractPromptText(waitForChoice.prompt);
-    const choices = (waitForChoice.choices ?? []) as Array<{
-      id: string;
-      content?: { parts?: Array<{ text?: string }> };
-    }>;
-    const selectionMode =
-      (waitForChoice.selectionMode as string) ?? "single";
-
-    return html`
-      <div class="block">
-        <div class="block-header">Choose</div>
-        <div class="block-content">
-          <div class="response-form">
-            ${promptText
-              ? html`<div class="agent-prompt">${promptText}</div>`
-              : nothing}
-            <div class="choices-grid">
-              ${choices.map((choice) => {
-                const selected = this.selectedChoiceIds.has(choice.id);
-                const label = this.extractPromptText(choice.content) || choice.id;
-                return html`
-                  <div
-                    class="choice-card ${selected ? "selected" : ""}"
-                    @click=${() =>
-                      this.toggleChoice(choice.id, selectionMode)}
-                  >
-                    <div class="choice-indicator"></div>
-                    <span class="choice-label">${label}</span>
-                  </div>
-                `;
-              })}
-            </div>
-            <div class="reply-actions">
-              <button
-                class="send-btn"
-                ?disabled=${this.selectedChoiceIds.size === 0 ||
-                  this.responding}
-                @click=${() => this.handleChoiceReply(ticketId)}
-              >
-                ${this.responding ? "Sending…" : "Confirm"}
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-    `;
-  }
-
-  private toggleChoice(choiceId: string, mode: string) {
-    const next = new Set(this.selectedChoiceIds);
-    if (mode === "single") {
-      // Single select: toggle or replace.
-      if (next.has(choiceId)) {
-        next.clear();
-      } else {
-        next.clear();
-        next.add(choiceId);
-      }
-    } else {
-      // Multiple select: toggle.
-      if (next.has(choiceId)) {
-        next.delete(choiceId);
-      } else {
-        next.add(choiceId);
-      }
-    }
-    this.selectedChoiceIds = next;
-  }
-
-  private async handleTextReply(ticketId: string) {
-    const text = this.replyText.trim();
-    if (!text || !this.mutationClient) return;
-
-    this.responding = true;
-    try {
-      await this.mutationClient.respondToTask(ticketId, { text });
-      this.replyText = "";
-    } catch (e) {
-      console.error("Failed to send reply:", e);
-    } finally {
-      this.responding = false;
-    }
-  }
-
-  private async handleChoiceReply(ticketId: string) {
-    if (this.selectedChoiceIds.size === 0 || !this.mutationClient) return;
-
-    this.responding = true;
-    try {
-      await this.mutationClient.respondToTask(ticketId, {
-        selectedIds: [...this.selectedChoiceIds],
-      });
-      this.selectedChoiceIds = new Set();
-    } catch (e) {
-      console.error("Failed to send choice:", e);
-    } finally {
-      this.responding = false;
-    }
   }
 
   // ── Live session ──

--- a/packages/bees/hivetool/src/ui/ticket-pane.ts
+++ b/packages/bees/hivetool/src/ui/ticket-pane.ts
@@ -12,8 +12,8 @@
  * shared across both tabs. Below it sits a `Surface · Detail` tab bar.
  * Each tab body gets the remaining vertical space.
  *
- * Defaults to the Surface tab when a surface exists for the selected
- * ticket, and to the Detail tab otherwise.
+ * Defaults to the Surface tab when a surface or chat content exists
+ * for the selected ticket, and to the Detail tab otherwise.
  */
 
 import { SignalWatcher } from "@lit-labs/signals";
@@ -25,6 +25,7 @@ import type { MutationClient } from "../data/mutation-client.js";
 import type { TemplateStore } from "../data/template-store.js";
 import type { SkillStore } from "../data/skill-store.js";
 import { sharedStyles } from "./shared-styles.js";
+import { hasChatContent } from "./chat-panel.js";
 import "./ticket-detail.js";
 import "./surface-pane.js";
 
@@ -78,7 +79,7 @@ class BeesTicketPane extends SignalWatcher(LitElement) {
         flex: 1;
         display: flex;
         flex-direction: column;
-        overflow: hidden;
+        overflow: auto;
       }
     `,
   ];
@@ -280,6 +281,7 @@ class BeesTicketPane extends SignalWatcher(LitElement) {
                 ${this.activePane === "surface"
                   ? html`<bees-surface-pane
                       .ticketStore=${this.ticketStore}
+                      .mutationClient=${this.mutationClient}
                       .ticketId=${ticket.id}
                     ></bees-surface-pane>`
                   : html`<bees-ticket-detail
@@ -362,11 +364,16 @@ class BeesTicketPane extends SignalWatcher(LitElement) {
 
   private async probeSurface(ticketId: string): Promise<void> {
     if (!this.ticketStore) return;
+
     const surface = await this.ticketStore.readSurface(ticketId);
+    const ticket = this.ticketStore.selectedTicket.get();
+    const chatActive = !!ticket && hasChatContent(ticket);
+    const showSurface = surface !== null || chatActive;
+
     // Only apply if we're still looking at the same ticket.
     if (this.#probedFor === ticketId) {
-      this.hasSurface = surface !== null;
-      this.activePane = surface ? "surface" : "detail";
+      this.hasSurface = showSurface;
+      this.activePane = showSurface ? "surface" : "detail";
     }
   }
 


### PR DESCRIPTION
## What
Extracts chat UI from the Detail tab into a standalone `<bees-chat-panel>` component and composes it as a built-in item in the Surface pane using a CSS grid bento box layout. Also fixes a bug where choice responses were never logged to `chat_log.json`.

## Why
Chat and surface items are conceptually part of the same presentation — the agent's curated output. Unifying them in a single pane with a structured grid layout creates a more cohesive experience (chat on the left, surface content on the right) and sets up the infrastructure for richer bento-style layouts.

## Changes

### Hivetool UI
- **[NEW] `chat-panel.ts`** — extracted `<bees-chat-panel>` combining chat log + input UI (text reply, choice cards). Renders markdown in chat messages and agent prompts. Deduplicates the last agent message when the input panel is showing.
- **`surface-pane.ts`** — bento grid layout owner. Composes chat panel alongside bundles and surface-view. Chat takes left half when present; content fills right half or full width.
- **`ticket-detail.ts`** — removed ~400 lines of chat UI code (log, reply/choice forms, related state and styles). Non-interactive suspend fallback preserved.
- **`ticket-pane.ts`** — Surface tab now shown when surface OR chat content exists. Passes `mutationClient` to surface pane. Fixed `overflow: auto` on tab body for Detail scrolling.
- **Exported `hasChatContent(ticket)`** utility for tab visibility probing.

### Backend
- **`task_runner.py`** — `resume_task` now logs choice responses (`selectedIds`) to `chat_log.json`, not just text replies.

## Testing
- Select a task with chat history but no surface → Surface tab appears, chat renders full-width
- Select a task with surface + chat → two-column bento layout, chat left, items right
- Select a task with surface only → items flow full-width
- Reply to a suspended task (text and choice) → both logged to `chat_log.json`
- Detail tab scrolls correctly
