### PR TITLE
[bees] Hivetool reactivity fixes and dark theme for bundles

### DIFF
--- a/hives/chat-app/config/TEMPLATES.yaml
+++ b/hives/chat-app/config/TEMPLATES.yaml
@@ -23,3 +23,49 @@
     - run-in-sandbox
     - surface
     - use-opal-sdk
+
+- name: chat-chat
+  title: Chat Chat
+  description: A chat app that builds apps
+  objective: >-
+    Build high-quality React apps in response to user requests. If the requests
+    are simple, just respond. If the user asks for a "widget", build a React
+    app. When the user asks to update the widget, update the JSON file that
+    supplies widget's data.
+
+
+    Use generate_text to research the data and ensure that the JSON file
+    information contains accurate data.
+
+
+    Here's how you build a widget:
+
+
+    1) Create a new subdirectory where the app will go. Check to see that this
+    is a new directory.
+
+
+    2) Write the React app using Opal SDK in that subdirectory. Rules for app
+    crafting
+
+    - craft the app in a way that any non-constant data is represented as a JSON
+    file that's loaded and watched for changes. 
+
+    - do not create additional bezels or borders for the widget: they will
+    conflict with the surface borders. Just 10px padding.
+
+
+    3) Create or update the surface to include the widget.
+
+
+    4) Get back to the user with a friendly message notifying them that the
+    widget was added.
+  model: gemini-3.1-pro-preview
+  skills:
+    - build-react-apps
+    - run-in-sandbox
+    - surface
+    - use-opal-sdk
+  functions:
+    - chat.*
+    - generate.text

--- a/hives/chat-app/skills/build-react-apps/SKILL.md
+++ b/hives/chat-app/skills/build-react-apps/SKILL.md
@@ -70,11 +70,10 @@ Follow these rules strictly.
    `IndexedDB`, or any Web Storage APIs. The iframe environment may not have
    storage access due to origin restrictions. All state lives in React component
    state or is passed via props and the SDK.
-10. **Respect the host theme.** We use a light theme. Do not set
-    `background: black`, `background: #000`, `color: #fff`, or any dark-theme
-    values. All backgrounds must use `var(--cg-color-surface*)` tokens and all
-    text must use `var(--cg-color-on-surface*)` tokens. The tokens will natively
-    map to their light theme variants.
+10. **Respect the host theme.** Use design tokens. Backgrounds must use
+    `var(--cg-color-surface*)` tokens and all text must use
+    `var(--cg-color-on-surface*)` tokens. The tokens will natively map to their
+    theme variants.
 11. **Use `flex-wrap: wrap`** on any flex container with multiple children that
     should stack on narrow screens.
 12. **Use CSS Grid with `auto-fit` / `minmax`** for multi-column layouts:
@@ -220,11 +219,6 @@ next. This means:
 
 - **Don't brand it.** No app names, no splash screens, no taglines. The host
   application provides the chrome and framing. Start with the task UI.
-- **Emit your data.** The last view in your segment MUST call `ark.emit()` to
-  hand collected data back to the orchestrator. Without this, the journey
-  stalls.
-- **Receive context.** Your segment may receive data from prior segments as
-  props. Use it to personalize the experience.
 
 ### File Structure
 
@@ -237,73 +231,6 @@ Each state gets its own component file named after the state:
 - `views/DecisionReport.jsx`
 - `components/*.jsx` — shared sub-components (reusable across views)
 - `styles.css` — shared styles
-
-### Navigation
-
-**Within** the segment, views navigate using `window.opalSDK.navigateTo`. At the
-**boundary** (the segment's final view), use `window.opalSDK.emit` to send data
-back to the orchestrator.
-
-The **SDK** is available as `window.opalSDK`. It has three methods:
-
-```jsx
-// Navigate to another view WITHIN this segment.
-window.opalSDK.navigateTo("select_models", { teamProfile });
-
-// Send data BACK TO THE ORCHESTRATOR (segment boundary).
-// Use on the final view's CTA — this is what connects segments.
-window.opalSDK.emit("journey:result", { decision, comparisonSet });
-
-// Read a file from the shared workspace (async, returns text or null).
-const data = await window.opalSDK.readFile("groceries.json");
-```
-
-**Do not call any other methods on `window.opalSDK`.** There is no
-`onNavigation`, `subscribe`, or event listener API. Navigation state is managed
-internally by your App component (e.g. `useState` + switch statement), not by
-the SDK.
-
-### Data Loading with `readFile`
-
-Use `readFile` to load data files from the shared workspace at runtime instead
-of hardcoding data into your component. Paths are relative to the workspace
-root. You can read files written by any agent in the workspace — for example, a
-menu planner can read files produced by a diet researcher.
-
-```jsx
-import React, { useState, useEffect } from "react";
-
-export default function GroceryList() {
-  const [items, setItems] = useState([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    window.opalSDK.readFile("groceries.json").then((text) => {
-      if (text) {
-        setItems(JSON.parse(text));
-      }
-      setLoading(false);
-    });
-  }, []);
-
-  if (loading) return <div>Loading…</div>;
-  return (
-    <ul>
-      {items.map((item, i) => (
-        <li key={i}>{item}</li>
-      ))}
-    </ul>
-  );
-}
-```
-
-**Rules for `readFile`:**
-
-- Returns `Promise<string | null>`. `null` means the file was not found.
-- Paths are workspace-relative (e.g. `"analysis/results.json"`,
-  `"diet_research/notes.md"`).
-- Always handle the `null` case gracefully — the file may not exist yet.
-- Show a loading state while data is being fetched.
 
 ### View Contract
 
@@ -333,10 +260,7 @@ export default function SelectModels({ data = {}, onTransition }) {
    across multiple views should be extracted.
 4. **Context flows forward.** Each transition carries the data the next view
    needs. Views may also use `readFile` to load shared workspace data.
-5. **Final view emits.** The last view must include a CTA that calls
-   `window.opalSDK.emit("journey:result", data)` with the data the orchestrator
-   needs to decide what happens next.
-6. **Responsive.** The user may view this UI on a mobile device, so ensure that
+5. **Responsive.** The user may view this UI on a mobile device, so ensure that
    you make every component and the app itself responsive.
 
 ## Available Globals

--- a/packages/bees/common/iframe-runtime.ts
+++ b/packages/bees/common/iframe-runtime.ts
@@ -48,7 +48,7 @@ function buildIframeHtml(reactSource: string, reactDomSource: string): string {
   <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&display=swap" rel="stylesheet" />
 
   <style>
-    /* ── MD3 Design Tokens ──────────────────────────────────────────────── */
+    /* ── MD3 Design Tokens (Dark — Slate) ────────────────────────────────── */
     :root {
       --cg-font-sans: 'Inter', system-ui, -apple-system, sans-serif;
       --cg-font-mono: 'JetBrains Mono', ui-monospace, monospace;
@@ -67,34 +67,34 @@ function buildIframeHtml(reactSource: string, reactDomSource: string): string {
       --cg-text-label-lg-size: 14px;  --cg-text-label-lg-line-height: 20px;  --cg-text-label-lg-weight: 500;
       --cg-text-label-md-size: 12px;  --cg-text-label-md-line-height: 16px;  --cg-text-label-md-weight: 500;
       --cg-text-label-sm-size: 11px;  --cg-text-label-sm-line-height: 16px;  --cg-text-label-sm-weight: 500;
-      --cg-color-surface-dim: #f5f3f0;
-      --cg-color-surface: #fdfcfa;
-      --cg-color-surface-bright: #ffffff;
-      --cg-color-surface-container-lowest: #ffffff;
-      --cg-color-surface-container-low: #f8f6f3;
-      --cg-color-surface-container: #f0eeeb;
-      --cg-color-surface-container-high: #eae8e5;
-      --cg-color-surface-container-highest: #e4e2df;
-      --cg-color-on-surface: #1c1b1f;
-      --cg-color-on-surface-muted: #79757f;
-      --cg-color-primary: #3b5fc0;
-      --cg-color-primary-container: #dbe1f9;
+      --cg-color-surface-dim: #0b0c0f;
+      --cg-color-surface: #0f1115;
+      --cg-color-surface-bright: #14171c;
+      --cg-color-surface-container-lowest: #0b0c0f;
+      --cg-color-surface-container-low: #0f1115;
+      --cg-color-surface-container: #14171c;
+      --cg-color-surface-container-high: #1e293b;
+      --cg-color-surface-container-highest: #253347;
+      --cg-color-on-surface: #e2e8f0;
+      --cg-color-on-surface-muted: #94a3b8;
+      --cg-color-primary: #3b82f6;
+      --cg-color-primary-container: #1e3a5f;
       --cg-color-on-primary: #ffffff;
-      --cg-color-on-primary-container: #0f1b3d;
-      --cg-color-secondary: #bec6dc;
-      --cg-color-secondary-container: #3b4358;
-      --cg-color-on-secondary: #283141;
-      --cg-color-on-secondary-container: #d8e0f8;
-      --cg-color-tertiary: #d4bfff;
-      --cg-color-tertiary-container: #3f2e6e;
-      --cg-color-on-tertiary: #2a1a51;
-      --cg-color-on-tertiary-container: #eedcff;
-      --cg-color-error: #ba1a1a;
-      --cg-color-error-container: #ffdad6;
+      --cg-color-on-primary-container: #93c5fd;
+      --cg-color-secondary: #94a3b8;
+      --cg-color-secondary-container: #1e293b;
+      --cg-color-on-secondary: #e2e8f0;
+      --cg-color-on-secondary-container: #cbd5e1;
+      --cg-color-tertiary: #c4b5fd;
+      --cg-color-tertiary-container: #2d2540;
+      --cg-color-on-tertiary: #ede9fe;
+      --cg-color-on-tertiary-container: #e9d5ff;
+      --cg-color-error: #ef4444;
+      --cg-color-error-container: #450a0a;
       --cg-color-on-error: #ffffff;
-      --cg-color-on-error-container: #410e0b;
-      --cg-color-outline: #7a767e;
-      --cg-color-outline-variant: #e0ddd9;
+      --cg-color-on-error-container: #fca5a5;
+      --cg-color-outline: #334155;
+      --cg-color-outline-variant: #1e293b;
       --cg-sp-0: 0px;    --cg-sp-1: 4px;    --cg-sp-2: 8px;
       --cg-sp-3: 12px;   --cg-sp-4: 16px;   --cg-sp-5: 20px;
       --cg-sp-6: 24px;   --cg-sp-7: 28px;   --cg-sp-8: 32px;

--- a/packages/bees/hivetool/src/data/ticket-store.ts
+++ b/packages/bees/hivetool/src/data/ticket-store.ts
@@ -72,7 +72,7 @@ class TicketStore {
     if (this.#activated) return;
     if (this.access.accessState.get() !== "ready") return;
 
-    const ticketsHandle = await this.access.getSubdirectory("tickets");
+    const ticketsHandle = await this.access.getSubdirectory("tickets", { create: true });
     if (!ticketsHandle) {
       console.warn("Could not find tickets/ subdirectory in hive/");
       return;

--- a/packages/bees/hivetool/src/ui/bundle-frame.ts
+++ b/packages/bees/hivetool/src/ui/bundle-frame.ts
@@ -46,7 +46,7 @@ class BeesBundleFrame extends LitElement {
         border: 1px solid #1e293b;
         border-radius: 8px;
         overflow: hidden;
-        background: #ffffff;
+        background: #0f1115;
       }
 
       iframe {
@@ -109,6 +109,10 @@ class BeesBundleFrame extends LitElement {
   #bridge: MessageBridge | null = null;
   #wired = false;
 
+  /** Track the code that was last sent to the iframe. */
+  #renderedCode: string | null = null;
+  #renderedCss: string | null = null;
+
   render() {
     if (!this.iframeBlobUrl || !this.code) {
       return html`<div class="loading">Preparing bundle…</div>`;
@@ -133,36 +137,49 @@ class BeesBundleFrame extends LitElement {
   /**
    * Wire the bridge as soon as the iframe element exists in the shadow DOM,
    * BEFORE setting its src. This ensures we catch the "ready" message.
+   *
+   * After the initial wire-up, detect code/CSS changes and re-send
+   * the render message to the existing iframe.
    */
   protected updated(): void {
-    if (this.#wired) return;
     if (!this.iframeBlobUrl || !this.code) return;
 
-    const iframe = this.renderRoot.querySelector("iframe");
-    if (!iframe) return;
+    if (!this.#wired) {
+      const iframe = this.renderRoot.querySelector("iframe");
+      if (!iframe) return;
 
-    this.#wired = true;
+      this.#wired = true;
 
-    // Set up the bridge first — it listens for "ready" via window message.
-    const bridge = new MessageBridge(iframe);
-    this.#bridge = bridge;
+      // Set up the bridge first — it listens for "ready" via window message.
+      const bridge = new MessageBridge(iframe);
+      this.#bridge = bridge;
 
-    bridge.onMessage((msg: IframeMessage) => {
-      switch (msg.type) {
-        case "sdk.call":
-          this.#handleSdkCall(msg.requestId, msg.method, msg.args);
-          break;
-        case "error":
-          this.error = msg.message + (msg.stack ? "\n\n" + msg.stack : "");
-          break;
-      }
-    });
+      bridge.onMessage((msg: IframeMessage) => {
+        switch (msg.type) {
+          case "sdk.call":
+            this.#handleSdkCall(msg.requestId, msg.method, msg.args);
+            break;
+          case "error":
+            this.error = msg.message + (msg.stack ? "\n\n" + msg.stack : "");
+            break;
+        }
+      });
 
-    // NOW set the src — the bridge listener is already in place.
-    iframe.src = this.iframeBlobUrl;
+      // NOW set the src — the bridge listener is already in place.
+      iframe.src = this.iframeBlobUrl;
 
-    // Send render once bridge is ready (iframe signals "ready").
-    this.#sendRender(bridge);
+      // Send render once bridge is ready (iframe signals "ready").
+      this.#sendRender(bridge);
+      return;
+    }
+
+    // Bridge already wired — re-send render if code or CSS changed.
+    if (
+      this.#bridge &&
+      (this.code !== this.#renderedCode || this.bundleCss !== this.#renderedCss)
+    ) {
+      this.#sendRender(this.#bridge);
+    }
   }
 
   disconnectedCallback(): void {
@@ -180,6 +197,8 @@ class BeesBundleFrame extends LitElement {
       props: {},
     });
 
+    this.#renderedCode = this.code;
+    this.#renderedCss = this.bundleCss;
     this.loading = false;
     this.error = null;
   }
@@ -226,6 +245,8 @@ class BeesBundleFrame extends LitElement {
     this.#bridge?.dispose();
     this.#bridge = null;
     this.#wired = false;
+    this.#renderedCode = null;
+    this.#renderedCss = null;
   }
 }
 

--- a/packages/bees/hivetool/src/ui/log-detail.styles.ts
+++ b/packages/bees/hivetool/src/ui/log-detail.styles.ts
@@ -39,6 +39,7 @@ const logDetailBaseStyles = css`
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 8px;
     margin-bottom: 8px;
   }
 
@@ -514,6 +515,7 @@ const logDetailBaseStyles = css`
     border: 1px solid #334155;
     cursor: pointer;
     transition: background 0.15s, border-color 0.15s, color 0.15s;
+    margin-left: auto;
   }
 
   .link-chip:hover {

--- a/packages/bees/hivetool/src/ui/log-detail.ts
+++ b/packages/bees/hivetool/src/ui/log-detail.ts
@@ -82,7 +82,7 @@ class BeesLogDetail extends LitElement {
             class="link-chip"
             @click=${() => this.#dispatchNavigate("ticket", d.sessionId)}
           >
-            <span class="link-chip-label">ticket</span>
+            <span class="link-chip-label">task</span>
             ${d.sessionId.slice(0, 8)}
           </span>
           ${d.segments.length > 1

--- a/packages/bees/hivetool/src/ui/ticket-pane.ts
+++ b/packages/bees/hivetool/src/ui/ticket-pane.ts
@@ -100,7 +100,7 @@ class BeesTicketPane extends SignalWatcher(LitElement) {
   accessor flashTicketId: string | null = null;
 
   @state() accessor activePane: PaneTab = "detail";
-  @state() accessor hasSurface = false;
+  @state() accessor hasSurfaceManifest = false;
 
   /**
    * Track the ticket ID for which we last probed,
@@ -116,12 +116,21 @@ class BeesTicketPane extends SignalWatcher(LitElement) {
         Select a ticket to view details
       </div>`;
 
-    // Probe for surface on ticket change.
+    // Probe for surface.json on ticket change (async, once per ticket).
     if (this.#probedFor !== ticket.id) {
       this.#probedFor = ticket.id;
-      this.hasSurface = false;
+      this.hasSurfaceManifest = false;
       this.activePane = "detail";
       this.probeSurface(ticket.id);
+    }
+
+    // Chat content is signal-derived — check reactively every render.
+    const chatActive = hasChatContent(ticket);
+    const showSurface = this.hasSurfaceManifest || chatActive;
+
+    // Auto-switch to Surface tab when content first appears.
+    if (showSurface && this.activePane === "detail" && !this.hasSurfaceManifest) {
+      this.activePane = "surface";
     }
 
     const suspendFn =
@@ -260,7 +269,7 @@ class BeesTicketPane extends SignalWatcher(LitElement) {
             `
           : nothing}
 
-        ${this.hasSurface
+        ${showSurface
           ? html`
               <div class="pane-tabs">
                 <div
@@ -366,14 +375,13 @@ class BeesTicketPane extends SignalWatcher(LitElement) {
     if (!this.ticketStore) return;
 
     const surface = await this.ticketStore.readSurface(ticketId);
-    const ticket = this.ticketStore.selectedTicket.get();
-    const chatActive = !!ticket && hasChatContent(ticket);
-    const showSurface = surface !== null || chatActive;
 
     // Only apply if we're still looking at the same ticket.
     if (this.#probedFor === ticketId) {
-      this.hasSurface = showSurface;
-      this.activePane = showSurface ? "surface" : "detail";
+      this.hasSurfaceManifest = surface !== null;
+      if (surface !== null) {
+        this.activePane = "surface";
+      }
     }
   }
 


### PR DESCRIPTION
## What
Fixes three reactivity bugs in hivetool and switches the bundle iframe's design tokens from a light theme to a dark Slate palette matching the hivetool chrome.

## Why
- Creating a task from a template failed with "Ticket store not activated" when the hive had no `tickets/` directory yet.
- The Surface tab didn't appear when a task first received chat content (e.g., `chat_log.json` created for the first time) — required navigating away and back.
- Updating a bundle's path in `surface.json` updated the title but not the rendered iframe content, because the bridge only sent code once.
- The light-themed bundle iframe looked jarring inside hivetool's dark UI.

## Changes

### `packages/bees/hivetool/src/data/ticket-store.ts`
- Pass `{ create: true }` to `getSubdirectory("tickets")` in `activate()` so the directory is created if missing.

### `packages/bees/hivetool/src/ui/ticket-pane.ts`
- Check `hasChatContent(ticket)` reactively every render instead of only during the one-time async probe.
- Auto-switch to Surface tab when chat content first appears.
- Rename `hasSurface` → `hasSurfaceManifest` to clarify it only tracks the async `surface.json` probe.

### `packages/bees/hivetool/src/ui/bundle-frame.ts`
- Track last-sent code/CSS; re-send `render` message when props change on an already-wired bridge.
- Update iframe container background from white to dark (`#0f1115`).

### `packages/bees/common/iframe-runtime.ts`
- Replace all light MD3 color tokens with dark Slate equivalents derived from hivetool's palette.

### `packages/bees/hivetool/src/ui/log-detail.ts` + `log-detail.styles.ts`
- Rename "ticket" chip label → "task".
- Push `.link-chip` to the right via `margin-left: auto` and add `gap: 8px` to `.header-top`.

## Testing
- Open a hive without a `tickets/` directory → click Run on a template → task should be created without error.
- Start a task that triggers chat input for the first time → Surface tab should appear immediately.
- Update a bundle path in `surface.json` while viewing the Surface tab → iframe should re-render with the new code.
- Verify bundle iframes render with dark backgrounds and light text.
