### PR TITLE
[bees] OAuth 2.0 for MCP Servers (Project ARMS)

### DIFF
--- a/PROJECT_ARMS.md
+++ b/PROJECT_ARMS.md
@@ -1,0 +1,249 @@
+# Project ARMS — Authenticated Remote MCP Servers
+
+The MCP bridge in Bees connects to external tool providers via stdio or HTTP.
+Today, HTTP servers can authenticate with static headers (API keys). But
+Google Workspace MCP servers — Gmail, Drive, Calendar, Chat, People — require
+**OAuth 2.0 Authorization Code + PKCE** with user consent, token refresh,
+and per-server scopes. Project ARMS adds OAuth as a first-class auth mode
+for remote MCP servers.
+
+## Architecture
+
+```
+                     SYSTEM.yaml                     .mcp-tokens/
+                 ┌──────────────┐                 ┌──────────────┐
+                 │ mcp:         │                 │ gmail.json   │
+                 │   - name:    │                 │ drive.json   │
+                 │     url:     │                 │ calendar.json│
+                 │     oauth:   │                 └──────┬───────┘
+                 │       scopes │                        │
+                 └──────┬───────┘                        │
+                        │                                │
+         ┌──────────────▼───────────────────────────────▼──────────┐
+         │                    MCPRegistry                           │
+         │                                                         │
+         │  _connect_http()          _connect_http_oauth()          │
+         │  ┌───────────────┐        ┌──────────────────────────┐  │
+         │  │ httpx.AsyncClient      │ httpx.AsyncClient         │  │
+         │  │ (headers=...)  │       │ (auth=OAuthClientProvider)│  │
+         │  └───────┬───────┘        └───────────┬──────────────┘  │
+         │          │                            │                  │
+         │          ▼                            ▼                  │
+         │     streamable_http_client ──────────────────────────►  │
+         └─────────────────────────────────────────────────────────┘
+```
+
+Key insight: the MCP Python SDK (v1.27.0) provides `OAuthClientProvider`,
+an `httpx.Auth` subclass that handles the full OAuth flow. The integration
+point is clean: `httpx.AsyncClient(auth=provider)` passes through
+`streamable_http_client` unchanged.
+
+### Auth Mode Selection
+
+The SYSTEM.yaml entry determines the auth mode for each MCP server:
+
+| Config present | Auth mode | Route |
+|---|---|---|
+| `oauth` | OAuth 2.0 | `_connect_http_oauth()` |
+| `headers` (or neither) | Static headers / anonymous | `_connect_http()` |
+| `command` | Stdio subprocess | `_connect_stdio()` |
+| Both `oauth` + `headers` | **Validation error** | — |
+
+### Token Ownership
+
+Hivetool owns the OAuth consent flow (it's already in a browser). The box
+is a token *consumer* — on startup, if tokens are missing for an OAuth
+server, it logs a message and skips that server gracefully.
+
+### Storage
+
+Token storage lives at `hive/.mcp-tokens/`, a top-level directory the
+box's `classify_change` already ignores — no cold restarts, no scheduler
+triggers. Client credentials are always `${ENV_VAR}` references.
+
+## SYSTEM.yaml Schema
+
+```yaml
+mcp:
+  - name: gmail
+    description: Gmail MCP Server
+    url: https://gmailmcp.googleapis.com/mcp/v1
+    oauth:
+      client_id: "${GOOGLE_OAUTH_CLIENT_ID}"
+      client_secret: "${GOOGLE_OAUTH_CLIENT_SECRET}"
+      scopes:
+        - https://www.googleapis.com/auth/gmail.readonly
+        - https://www.googleapis.com/auth/gmail.compose
+
+  - name: drive
+    description: Google Drive MCP Server
+    url: https://drivemcp.googleapis.com/mcp/v1
+    oauth:
+      client_id: "${GOOGLE_OAUTH_CLIENT_ID}"
+      client_secret: "${GOOGLE_OAUTH_CLIENT_SECRET}"
+      scopes:
+        - https://www.googleapis.com/auth/drive.readonly
+        - https://www.googleapis.com/auth/drive.file
+```
+
+Multiple servers share the same client credentials (same env vars),
+each with its own scopes and token set.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `oauth` | object | no | OAuth 2.0 configuration. Mutually exclusive with `headers`. |
+| `oauth.client_id` | string | yes | `${ENV_VAR}` reference to the OAuth client ID. |
+| `oauth.client_secret` | string | yes | `${ENV_VAR}` reference to the OAuth client secret. |
+| `oauth.scopes` | list\<string\> | yes | OAuth scopes to request during consent. |
+
+---
+
+## Phase 1 — OAuth Connection Path (Python)
+
+### 🎯 Objective
+
+The box connects to a Google Workspace MCP server using pre-existing
+OAuth tokens. When tokens are missing, it skips the server gracefully
+instead of crashing.
+
+**Observable proof:** Configure a Gmail MCP server with `oauth` in
+SYSTEM.yaml. Place a valid token file in `.mcp-tokens/gmail.json`.
+Start the box. The scheduler connects, discovers Gmail tools
+(`create_draft`, `search_threads`, etc.), and an agent successfully
+calls a Gmail tool. Remove the token file, restart — the box logs
+"authenticate via hivetool" and starts without Gmail.
+
+### Changes
+
+- [x] `bees/functions/mcp_bridge.py` — add `OAuthConfig` dataclass
+      (client_id, client_secret, scopes).
+- [x] `bees/functions/mcp_bridge.py` — add `HiveTokenStorage` class
+      implementing the MCP SDK's `TokenStorage` protocol. Reads/writes
+      `hive/.mcp-tokens/<name>.json`.
+- [x] `bees/functions/mcp_bridge.py` — add `_connect_http_oauth()` on
+      `MCPRegistry`. Constructs `OAuthClientProvider` with
+      `HiveTokenStorage` and no redirect handler. Wraps in
+      `httpx.AsyncClient(auth=provider)`.
+- [x] `bees/functions/mcp_bridge.py` — update `connect_all()`: validate
+      `oauth` + `url` required together, `oauth` + `headers` forbidden.
+      Route to `_connect_http_oauth()` when `oauth` present.
+- [x] `bees/functions/mcp_bridge.py` — graceful skip: if `_connect_http_oauth`
+      fails due to missing tokens, log a warning and continue startup
+      (don't raise).
+- [x] `docs/system-config.md` — document the `oauth` field and token
+      storage location.
+- [x] Tests: `HiveTokenStorage` read/write round-trip, config validation
+      (oauth without url, oauth with headers), graceful skip on missing
+      tokens. 39 total, 20 new.
+
+---
+
+## Phase 2 — Hivetool OAuth Config UI
+
+### 🎯 Objective
+
+Hivetool understands the `oauth` schema and lets users configure it
+visually. Token status is visible per MCP server.
+
+**Observable proof:** Open hivetool, go to System tab. An MCP server
+with `oauth` config shows scopes and client_id reference in view mode.
+Edit mode has an "OAuth" toggle that reveals client_id, client_secret,
+and scopes fields. Token status (authenticated / not authenticated)
+is shown based on whether `.mcp-tokens/<name>.json` exists.
+
+### Changes
+
+- [x] `hivetool/src/data/system-store.ts` — add `OAuthConfig` type
+      (`client_id`, `client_secret`, `scopes`). Add `oauth?` field to
+      `MCPServerConfig`. Parse from YAML in `scan()`, serialize in
+      `save()`.
+- [ ] `hivetool/src/data/system-store.ts` — add `tokenStatus` signal
+      or method. Read `.mcp-tokens/` directory to determine per-server
+      auth status (file exists → "authenticated", missing → "not
+      authenticated"). *(Deferred to Phase 3 — pairs with consent flow.)*
+- [x] `hivetool/src/ui/system-detail.ts` — MCP view cards: show oauth
+      scopes, client_id env var reference, and OAuth badge.
+- [x] `hivetool/src/ui/system-detail.ts` — MCP edit cards: add auth
+      mode toggle (Headers/OAuth, mutually exclusive). OAuth mode shows
+      client_id, client_secret (env var input fields), and scopes
+      (list editor). Headers hidden when OAuth active.
+
+---
+
+## Phase 3 — Hivetool Consent Flow
+
+### 🎯 Objective
+
+Users can complete the full OAuth consent flow from within hivetool,
+eliminating the need for manual token provisioning.
+
+**Observable proof:** Open hivetool. Add a Gmail MCP server with OAuth
+config in the System tab. Click "Authenticate". A popup opens Google's
+consent page. Approve. The popup closes, token status changes to
+"Connected" with granted scopes. Restart the box — it picks up the
+token and connects without prompting.
+
+### Changes
+
+- [x] `hivetool/src/data/oauth-flow.ts` — **[NEW]** OAuth consent
+      orchestrator:
+      - Build authorization URL (from client_id, scopes, redirect URI,
+        PKCE code verifier/challenge).
+      - Open popup window to Google's consent page.
+      - Catch redirect via `postMessage` from
+        `oauth-callback.html`.
+      - Exchange authorization code for tokens via `fetch` to Google's
+        token endpoint.
+      - Write token file to `hive/.mcp-tokens/<name>.json` via File
+        System Access API.
+      - Read `.env` from hive root to expand `${VAR}` credential refs.
+- [x] `hivetool/public/oauth-callback.html` — **[NEW]** Static callback
+      page served by Vite. Extracts code/state from URL params,
+      `postMessage`s to opener, auto-closes.
+- [x] `hivetool/src/ui/system-detail.ts` — "Authenticate" button per
+      OAuth-configured MCP server. Token status indicator (Connected /
+      Not Authenticated / Pending). Wires to oauth-flow. Re-authenticate
+      support.
+- [x] `hivetool/src/data/system-store.ts` — Token status via
+      `checkTokenStatus()` (deferred from Phase 2).
+- [x] `hivetool/src/ui/app.ts` — Pass `stateAccess` to system-detail.
+- [x] Handle edge cases: popup blocked, user cancels consent, token
+      exchange fails, state mismatch, timeout (5 min).
+
+---
+
+## Non-Goals
+
+- **Box-initiated consent.** The box is a headless watcher. OAuth consent
+  is inherently interactive — hivetool owns it. The box consumes tokens.
+- **MCP server-initiated auth.** The MCP spec defines server-side OAuth
+  discovery (`.well-known/oauth-authorization-server`). We don't rely on
+  it — the client drives auth from explicit config.
+- **Automatic scope negotiation.** Scopes are declared in SYSTEM.yaml.
+  We don't query the server for required scopes.
+- **Multi-user tokens.** One token set per server per hive. The token
+  belongs to whoever approved the consent screen.
+
+## File Map
+
+```
+packages/bees/
+  bees/functions/
+    mcp_bridge.py              ← OAuthConfig, HiveTokenStorage,
+                                 _connect_http_oauth()
+  hivetool/
+    public/
+      oauth-callback.html      ← [NEW] Static OAuth redirect page
+    src/
+      data/
+        system-store.ts        ← OAuthConfig type
+        oauth-flow.ts          ← [NEW] Browser-side OAuth consent
+      ui/
+        system-detail.ts       ← OAuth fields, Authenticate button,
+                                 token status indicator
+        app.ts                 ← stateAccess wiring
+  docs/
+    system-config.md           ← oauth field documentation
+  tests/
+    test_mcp_bridge.py         ← OAuth path tests
+```

--- a/hives/chat-app/.gitignore
+++ b/hives/chat-app/.gitignore
@@ -2,3 +2,5 @@
 tickets/
 logs/
 mutations/
+.env
+.mcp-tokens/

--- a/hives/chat-app/config/SYSTEM.yaml
+++ b/hives/chat-app/config/SYSTEM.yaml
@@ -5,3 +5,58 @@
 # root        — Template name to auto-boot at startup. Leave blank to start idle.
 title: chat-app
 description: "A chat app"
+
+mcp:
+  - name: gmail
+    description: Gmail MCP Server
+    url: https://gmailmcp.googleapis.com/mcp/v1
+    oauth:
+      client_id: "${GOOGLE_OAUTH_CLIENT_ID}"
+      client_secret: "${GOOGLE_OAUTH_CLIENT_SECRET}"
+      scopes:
+        - https://www.googleapis.com/auth/gmail.readonly
+        - https://www.googleapis.com/auth/gmail.compose
+
+  - name: drive
+    description: Google Drive MCP Server
+    url: https://drivemcp.googleapis.com/mcp/v1
+    oauth:
+      client_id: "${GOOGLE_OAUTH_CLIENT_ID}"
+      client_secret: "${GOOGLE_OAUTH_CLIENT_SECRET}"
+      scopes:
+        - https://www.googleapis.com/auth/drive.readonly
+        - https://www.googleapis.com/auth/drive.file
+
+  - name: calendar
+    description: Google Calendar MCP Server
+    url: https://calendarmcp.googleapis.com/mcp/v1
+    oauth:
+      client_id: "${GOOGLE_OAUTH_CLIENT_ID}"
+      client_secret: "${GOOGLE_OAUTH_CLIENT_SECRET}"
+      scopes:
+        - https://www.googleapis.com/auth/calendar.calendarlist.readonly
+        - https://www.googleapis.com/auth/calendar.events.freebusy
+        - https://www.googleapis.com/auth/calendar.events.readonly
+
+  - name: people
+    description: Google People MCP Server
+    url: https://people.googleapis.com/mcp/v1
+    oauth:
+      client_id: "${GOOGLE_OAUTH_CLIENT_ID}"
+      client_secret: "${GOOGLE_OAUTH_CLIENT_SECRET}"
+      scopes:
+        - https://www.googleapis.com/auth/directory.readonly
+        - https://www.googleapis.com/auth/userinfo.profile
+        - https://www.googleapis.com/auth/contacts.readonly
+
+  - name: gchat
+    description: Google Chat MCP Server
+    url: https://chatmcp.googleapis.com/mcp/v1
+    oauth:
+      client_id: "${GOOGLE_OAUTH_CLIENT_ID}"
+      client_secret: "${GOOGLE_OAUTH_CLIENT_SECRET}"
+      scopes:
+        - https://www.googleapis.com/auth/chat.spaces.readonly
+        - https://www.googleapis.com/auth/chat.memberships.readonly
+        - https://www.googleapis.com/auth/chat.messages.readonly
+        - https://www.googleapis.com/auth/chat.users.readstate.readonly

--- a/hives/chat-app/config/TEMPLATES.yaml
+++ b/hives/chat-app/config/TEMPLATES.yaml
@@ -69,3 +69,11 @@
   functions:
     - chat.*
     - generate.text
+
+- name: workspace-test
+  title: Test Workspace MCP
+  description: Tests workspace MCP integration
+  objective: Chat with the user and fulfill their requests with the tools that you have.
+  functions:
+    - chat.*
+    - drive.*

--- a/packages/bees/bees/box.py
+++ b/packages/bees/bees/box.py
@@ -280,6 +280,13 @@ def main() -> None:
     gemini_key = load_gemini_key()
     hive_dir = load_hive_dir()
 
+    # Load hive-specific .env (e.g. OAuth credentials).
+    # Runs after load_hive_dir so we know where the hive is.
+    hive_env = hive_dir / ".env"
+    if hive_env.is_file():
+        load_dotenv(hive_env, override=True)
+        logger.info("Loaded hive .env from %s", hive_env)
+
     http_client = httpx.AsyncClient(timeout=httpx.Timeout(300.0))
     backend = HttpBackendClient(
         upstream_base="",
@@ -306,8 +313,31 @@ def main() -> None:
         loop.close()
 
 
+_shutdown_time: float = 0
+
+
 def _cancel_all(loop: asyncio.AbstractEventLoop) -> None:
-    """Cancel all running tasks for clean shutdown."""
+    """Cancel all running tasks for clean shutdown.
+
+    npm forwards Ctrl+C as both SIGINT and SIGTERM nearly
+    simultaneously, so we debounce: signals within 1 s of the first
+    are treated as duplicates.  A genuinely separate press (>1 s later)
+    force-exits.
+    """
+    import time
+
+    global _shutdown_time
+    now = time.monotonic()
+
+    if _shutdown_time:
+        if now - _shutdown_time < 1.0:
+            return  # Duplicate from npm — ignore.
+        # Genuine second press — force exit.
+        logger.warning("Force-quitting (second signal)")
+        import os
+        os._exit(1)
+
+    _shutdown_time = now
     for task in asyncio.all_tasks(loop):
         task.cancel()
 

--- a/packages/bees/bees/functions/mcp_bridge.py
+++ b/packages/bees/bees/functions/mcp_bridge.py
@@ -25,11 +25,13 @@ multiplexed correctly.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import re
 from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 from bees.protocols.functions import (
@@ -45,6 +47,7 @@ _BUILTIN_GROUP_NAMES = frozenset({
     "system", "chat", "files", "sandbox",
     "events", "tasks", "skills", "generate",
 })
+MCP_TOKENS_DIR = ".mcp-tokens"
 
 
 # ---------------------------------------------------------------------------
@@ -80,6 +83,119 @@ def _expand_env_values(
         key: _ENV_VAR_PATTERN.sub(_replace, val)
         for key, val in mapping.items()
     }
+
+
+# ---------------------------------------------------------------------------
+# OAuth configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class OAuthConfig:
+    """OAuth 2.0 configuration parsed from SYSTEM.yaml.
+
+    Client credentials are always ``${ENV_VAR}`` references, expanded
+    at connect time via ``_expand_env_values``.
+    """
+
+    client_id: str
+    client_secret: str
+    scopes: list[str]
+
+
+def _parse_oauth_config(
+    raw: dict[str, Any] | None,
+) -> OAuthConfig | None:
+    """Parse an ``oauth`` block from an MCP server config entry.
+
+    Returns ``None`` if the block is absent or empty.
+    """
+    if not raw:
+        return None
+    return OAuthConfig(
+        client_id=str(raw.get("client_id", "")),
+        client_secret=str(raw.get("client_secret", "")),
+        scopes=[str(s) for s in raw.get("scopes", [])],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Token storage (filesystem-backed)
+# ---------------------------------------------------------------------------
+
+
+class HiveTokenStorage:
+    """Persist OAuth tokens at ``hive/.mcp-tokens/<server>.json``.
+
+    Implements the MCP SDK's ``TokenStorage`` protocol.  The ``.mcp-tokens``
+    directory sits at the hive root, outside ``config/``, so writes do
+    not trigger cold restarts in the box's file watcher.
+    """
+
+    def __init__(self, hive_dir: Path, server_name: str) -> None:
+        self._dir = hive_dir / MCP_TOKENS_DIR
+        self._path = self._dir / f"{server_name}.json"
+
+    def _read(self) -> dict[str, Any]:
+        """Read the token file, returning an empty dict if missing."""
+        if not self._path.exists():
+            return {}
+        try:
+            return json.loads(self._path.read_text())
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning(
+                "Failed to read token file %s: %s", self._path, exc,
+            )
+            return {}
+
+    def _write(self, data: dict[str, Any]) -> None:
+        """Write the token file, creating the directory if needed."""
+        self._dir.mkdir(parents=True, exist_ok=True)
+        self._path.write_text(
+            json.dumps(data, indent=2, default=str) + "\n",
+        )
+
+    # -- TokenStorage protocol -----------------------------------------
+
+    async def get_tokens(self) -> Any:
+        """Get stored OAuth tokens."""
+        from mcp.shared.auth import OAuthToken
+
+        data = self._read()
+        tokens = data.get("tokens")
+        if not tokens:
+            return None
+        try:
+            return OAuthToken(**tokens)
+        except Exception:
+            logger.warning("Invalid token data in %s", self._path)
+            return None
+
+    async def set_tokens(self, tokens: Any) -> None:
+        """Store OAuth tokens."""
+        data = self._read()
+        data["tokens"] = tokens.model_dump()
+        self._write(data)
+
+    async def get_client_info(self) -> Any:
+        """Get stored client information."""
+        from mcp.shared.auth import OAuthClientInformationFull
+
+        data = self._read()
+        client_info = data.get("client_info")
+        if not client_info:
+            return None
+        try:
+            return OAuthClientInformationFull(**client_info)
+        except Exception:
+            logger.warning("Invalid client info in %s", self._path)
+            return None
+
+    async def set_client_info(self, client_info: Any) -> None:
+        """Store client information."""
+        data = self._read()
+        data["client_info"] = client_info.model_dump()
+        self._write(data)
 
 
 # ---------------------------------------------------------------------------
@@ -237,7 +353,12 @@ class MCPRegistry:
         self._factories: list[FunctionGroupFactory] = []
         self._exit_stack = AsyncExitStack()
 
-    async def connect_all(self, configs: list[dict[str, Any]]) -> None:
+    async def connect_all(
+        self,
+        configs: list[dict[str, Any]],
+        *,
+        hive_dir: Path | None = None,
+    ) -> None:
         """Connect to all MCP servers described in the config list.
 
         Each config dict has:
@@ -248,9 +369,17 @@ class MCPRegistry:
         - ``headers``: optional HTTP headers (values support ``${ENV_VAR}``)
         - ``env``: optional environment variables for stdio (values support
           ``${ENV_VAR}``)
+        - ``oauth``: optional OAuth 2.0 configuration (mutually exclusive
+          with ``headers``)
 
         Exactly one of ``command`` or ``url`` must be provided.
-        Raises on connection failure (fail-fast at startup).
+        Raises on connection failure (fail-fast at startup), except for
+        OAuth servers with missing tokens which are skipped gracefully.
+
+        Args:
+            configs: List of MCP server configurations.
+            hive_dir: Path to the hive directory. Required when any
+                server uses OAuth (for token storage).
         """
         # Validate all configs before connecting.
         for config in configs:
@@ -266,17 +395,42 @@ class MCPRegistry:
 
             has_command = bool(config.get("command"))
             has_url = bool(config.get("url"))
+            has_oauth = bool(config.get("oauth"))
+            has_headers = bool(config.get("headers"))
+
             if not has_command and not has_url:
                 raise ValueError(
                     f"MCP server '{name}' requires either 'command' "
                     f"(stdio) or 'url' (HTTP)."
                 )
 
+            if has_oauth and has_headers:
+                raise ValueError(
+                    f"MCP server '{name}' has both 'oauth' and 'headers'. "
+                    f"These are mutually exclusive."
+                )
+
+            if has_oauth and not has_url:
+                raise ValueError(
+                    f"MCP server '{name}' has 'oauth' but no 'url'. "
+                    f"OAuth requires HTTP transport."
+                )
+
+            if has_oauth and not hive_dir:
+                raise ValueError(
+                    f"MCP server '{name}' uses OAuth but no hive_dir "
+                    f"was provided for token storage."
+                )
+
         for config in configs:
             name = config["name"]
-            url = config.get("url")
+            has_oauth = bool(config.get("oauth"))
+            has_url = bool(config.get("url"))
 
-            if url:
+            if has_oauth:
+                assert hive_dir is not None
+                await self._connect_http_oauth(config, hive_dir)
+            elif has_url:
                 await self._connect_http(config)
             else:
                 await self._connect_stdio(config)
@@ -338,6 +492,118 @@ class MCPRegistry:
         await session.initialize()
         await self._register_connection(config, session)
 
+    async def _connect_http_oauth(
+        self, config: dict[str, Any], hive_dir: Path,
+    ) -> None:
+        """Connect to an MCP server using OAuth 2.0 authentication.
+
+        Uses the MCP SDK's ``OAuthClientProvider`` as an ``httpx.Auth``
+        handler.  Tokens are stored at ``hive/.mcp-tokens/<name>.json``.
+
+        If tokens don't exist yet, the connection is skipped gracefully
+        with a warning — the user must authenticate via hivetool first.
+        """
+        from mcp import ClientSession
+        from mcp.client.streamable_http import streamable_http_client
+        from mcp.client.auth.oauth2 import OAuthClientProvider
+        from mcp.shared.auth import OAuthClientMetadata
+
+        import httpx
+
+        name = config["name"]
+        url = config["url"]
+        oauth_config = _parse_oauth_config(config.get("oauth"))
+
+        if not oauth_config:
+            logger.warning(
+                "MCP server '%s' has empty oauth config — skipping", name,
+            )
+            return
+
+        # Expand env var references in credentials.
+        expanded = _expand_env_values({
+            "client_id": oauth_config.client_id,
+            "client_secret": oauth_config.client_secret,
+        })
+        assert expanded is not None
+        client_id = expanded["client_id"]
+        client_secret = expanded["client_secret"]
+
+        if not client_id:
+            logger.warning(
+                "MCP server '%s': OAuth client_id is empty after "
+                "env expansion — skipping",
+                name,
+            )
+            return
+
+        storage = HiveTokenStorage(hive_dir, name)
+
+        # Pre-seed client_info so the SDK doesn't attempt dynamic
+        # client registration (Google Workspace doesn't support it).
+        existing_client_info = await storage.get_client_info()
+        if not existing_client_info:
+            from mcp.shared.auth import OAuthClientInformationFull
+
+            client_info = OAuthClientInformationFull(
+                client_id=client_id,
+                client_secret=client_secret,
+                redirect_uris=None,
+            )
+            await storage.set_client_info(client_info)
+
+        # Check if tokens exist.  Without tokens AND without a
+        # redirect/callback handler, the SDK will raise OAuthFlowError
+        # on 401.  Better to skip gracefully now.
+        existing_tokens = await storage.get_tokens()
+        if not existing_tokens:
+            logger.warning(
+                "MCP server '%s' requires OAuth but no tokens found at %s. "
+                "Authenticate via hivetool to connect.",
+                name, storage._path,
+            )
+            return
+
+        scope_str = " ".join(oauth_config.scopes)
+
+        client_metadata = OAuthClientMetadata(
+            client_name=f"bees-{name}",
+            redirect_uris=None,
+            scope=scope_str if scope_str else None,
+        )
+
+        provider = OAuthClientProvider(
+            server_url=url,
+            client_metadata=client_metadata,
+            storage=storage,
+        )
+
+        logger.info(
+            "Connecting to MCP server '%s' (OAuth HTTP): %s", name, url,
+        )
+
+        http_client = httpx.AsyncClient(auth=provider)
+
+        try:
+            transport = await self._exit_stack.enter_async_context(
+                streamable_http_client(url=url, http_client=http_client)
+            )
+            read_stream, write_stream, _ = transport
+
+            session = await self._exit_stack.enter_async_context(
+                ClientSession(read_stream, write_stream)
+            )
+            await session.initialize()
+            await self._register_connection(config, session)
+        except Exception as exc:
+            logger.warning(
+                "MCP server '%s' OAuth connection failed: %s. "
+                "Re-authenticate via hivetool.",
+                name, exc,
+            )
+            # Graceful skip — don't bring down the whole scheduler.
+            return
+
     async def _register_connection(
         self, config: dict[str, Any], session: Any,
     ) -> None:
@@ -377,8 +643,24 @@ class MCPRegistry:
         return list(self._factories)
 
     async def disconnect_all(self) -> None:
-        """Disconnect from all MCP servers and clean up."""
+        """Disconnect from all MCP servers and clean up.
+
+        Shielded from cancellation so that a second SIGINT doesn't
+        strand the process in a half-closed state.
+        """
+        import asyncio
+
         logger.info("Disconnecting from %d MCP server(s)", len(self._connections))
-        await self._exit_stack.aclose()
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(self._exit_stack.aclose()),
+                timeout=5.0,
+            )
+        except (TimeoutError, asyncio.TimeoutError):
+            logger.warning(
+                "MCP disconnect timed out after 5s — forcing shutdown"
+            )
+        except (asyncio.CancelledError, Exception) as exc:
+            logger.warning("MCP disconnect interrupted: %s", exc)
         self._connections.clear()
         self._factories.clear()

--- a/packages/bees/bees/scheduler.py
+++ b/packages/bees/bees/scheduler.py
@@ -181,7 +181,9 @@ class Scheduler:
         mcp_configs = config.get("mcp", [])
         if mcp_configs:
             self._mcp_registry = MCPRegistry()
-            await self._mcp_registry.connect_all(mcp_configs)
+            await self._mcp_registry.connect_all(
+                mcp_configs, hive_dir=self.store.hive_dir,
+            )
 
         root_task = await self._boot_root_template(tasks)
         if root_task:

--- a/packages/bees/docs/README.md
+++ b/packages/bees/docs/README.md
@@ -27,6 +27,12 @@
   identity, root template, and MCP server registration (transports, env var
   expansion, runtime behavior).
 
+## Guides
+
+- [oauth-setup.md](oauth-setup.md) — Step-by-step: create a Google OAuth
+  client, configure credentials, authenticate in hivetool, and connect
+  Google Workspace MCP servers (Gmail, Drive, Calendar, etc.).
+
 ## Tooling
 
 - [box.md](box.md) — The filesystem-driven orchestrator. Watches the hive for

--- a/packages/bees/docs/oauth-setup.md
+++ b/packages/bees/docs/oauth-setup.md
@@ -1,0 +1,204 @@
+# Setting Up OAuth for MCP Servers
+
+This guide walks you through configuring OAuth 2.0 for remote MCP servers that
+require it — most notably the
+[Google Workspace MCP servers](https://developers.google.com/workspace/guides/configure-mcp-servers)
+(Gmail, Drive, Calendar, Chat, People).
+
+## Prerequisites
+
+- A hive directory with a working `SYSTEM.yaml`
+- [Hivetool](hivetool.md) running, pointing at the hive directory.
+- Access to the [Google Cloud Console](https://console.cloud.google.com/)
+
+---
+
+## Step 1 — Create an OAuth Client
+
+1. Open the [Google Cloud Console](https://console.cloud.google.com/).
+2. Select or create a project.
+3. Navigate to **APIs & Services → Credentials**.
+4. Click **+ Create Credentials → OAuth client ID**.
+5. For **Application type**, choose **Desktop app**.
+6. Give it a name (e.g., "Bees MCP OAuth") and click **Create**.
+7. Copy the **Client ID** and **Client secret** values.
+
+> [!NOTE] Desktop app is the correct type. It allows `http://localhost` redirect
+> URIs with any port, which is how hivetool receives the authorization code.
+
+### Enable the APIs
+
+For each Google Workspace MCP server you want to use, enable the corresponding
+API:
+
+| MCP Server      | API to Enable       |
+| --------------- | ------------------- |
+| Gmail           | Gmail API           |
+| Google Drive    | Google Drive API    |
+| Google Calendar | Google Calendar API |
+| Google Chat     | Google Chat API     |
+| Google Contacts | People API          |
+
+Navigate to **APIs & Services → Library**, search for each API, and click
+**Enable**.
+
+---
+
+## Step 2 — Store Credentials in `.env`
+
+Create or edit the `.env` file at the **root of your hive directory**:
+
+```env
+GOOGLE_OAUTH_CLIENT_ID=123456789-abcdef.apps.googleusercontent.com
+GOOGLE_OAUTH_CLIENT_SECRET=GOCSPX-abcdef123456
+```
+
+> [!IMPORTANT] Never commit `.env` files to version control. Add `.env` to your
+> `.gitignore`.
+
+The variable names are up to you — they just need to match the `${VAR}`
+references you'll use in `SYSTEM.yaml`.
+
+---
+
+## Step 3 — Configure MCP Servers in SYSTEM.yaml
+
+Add an MCP server entry with an `oauth` block for each Google Workspace service
+you want. Here's a full example with Gmail and Drive:
+
+```yaml
+mcp:
+  - name: gmail
+    description: Gmail MCP Server
+    url: https://gmailmcp.googleapis.com/mcp/v1
+    oauth:
+      client_id: "${GOOGLE_OAUTH_CLIENT_ID}"
+      client_secret: "${GOOGLE_OAUTH_CLIENT_SECRET}"
+      scopes:
+        - https://www.googleapis.com/auth/gmail.readonly
+        - https://www.googleapis.com/auth/gmail.compose
+
+  - name: drive
+    description: Google Drive MCP Server
+    url: https://drivemcp.googleapis.com/mcp/v1
+    oauth:
+      client_id: "${GOOGLE_OAUTH_CLIENT_ID}"
+      client_secret: "${GOOGLE_OAUTH_CLIENT_SECRET}"
+      scopes:
+        - https://www.googleapis.com/auth/drive.readonly
+```
+
+### Configuration rules
+
+- **`oauth` and `headers` are mutually exclusive.** A server uses one or the
+  other, not both.
+- **`oauth` requires `url`.** Only HTTP transport supports OAuth (not
+  stdio/local servers).
+- **Credentials must be `${ENV_VAR}` references**, not inline values.
+
+You can also configure this visually in hivetool's System tab — use the **HTTP**
+transport toggle, then switch the authentication mode from **Headers** to
+**OAuth**.
+
+### Scopes reference
+
+See Google's documentation for available scopes:
+
+- [Gmail scopes](https://developers.google.com/gmail/api/auth/scopes)
+- [Drive scopes](https://developers.google.com/drive/api/guides/api-specific-auth)
+- [Calendar scopes](https://developers.google.com/calendar/api/auth)
+
+Request only the scopes your agents actually need.
+
+---
+
+## Step 4 — Authenticate in Hivetool
+
+1. Open hivetool and go to the **System** tab.
+2. Each OAuth-configured MCP server shows an **Authenticate** button and a
+   status indicator:
+   - 🟡 **Not Authenticated** — no token file exists yet.
+   - 🟢 **Connected** — valid tokens are stored.
+   - 🔵 **Pending** — authentication is in progress.
+3. Click **Authenticate**. A popup opens to Google's consent page.
+4. Sign in with the Google account you want the agents to act on behalf of.
+5. Review and approve the requested permissions.
+6. The popup closes automatically. The status updates to **Connected**.
+
+> [!TIP] If the popup is blocked, your browser will show a notification. Allow
+> popups for `localhost` and try again.
+
+---
+
+## Step 5 — Start the Box
+
+Start (or restart) the box:
+
+```bash
+python -m bees.box path/to/hive
+```
+
+The box reads the token file from `hive/.mcp-tokens/<name>.json` and connects to
+the OAuth-protected MCP server automatically. You should see the server's tools
+listed during startup.
+
+If tokens are missing, the box logs a warning and skips that server:
+
+```
+WARNING — gmail: no OAuth tokens found. Authenticate via hivetool.
+```
+
+---
+
+## Token Storage
+
+Tokens are stored as JSON files in the hive directory:
+
+```
+hive/
+  .mcp-tokens/
+    gmail.json       ← tokens + client info for the "gmail" server
+    drive.json       ← tokens + client info for the "drive" server
+  config/
+    SYSTEM.yaml
+```
+
+Each file contains both the OAuth tokens (`access_token`, `refresh_token`, etc.)
+and the client credentials used to obtain them.
+
+> [!NOTE] The `.mcp-tokens/` directory is intentionally outside `config/` so
+> that writing tokens does not trigger box restarts (the box watches `config/`
+> for changes).
+
+---
+
+## Re-authenticating
+
+To refresh or replace tokens (e.g., after revoking access or changing scopes):
+
+1. Go to the System tab in hivetool.
+2. Click **Re-authenticate** on the server card.
+3. Complete the consent flow again.
+
+The new tokens overwrite the existing file.
+
+---
+
+## Multiple Servers, Shared Client
+
+Multiple MCP servers can share the same OAuth client credentials (same
+`${ENV_VAR}` references) with different scopes. Each server gets its own token
+file. The user is prompted once per server.
+
+---
+
+## Troubleshooting
+
+| Problem                              | Solution                                                                                                                 |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| "Could not resolve client_id"        | Check that your `.env` file exists at the hive root and the variable names match the `${VAR}` references in SYSTEM.yaml. |
+| Popup blocked                        | Allow popups for `localhost` in your browser settings.                                                                   |
+| "Token exchange failed (400)"        | Verify the client ID/secret are correct and the OAuth client type is "Desktop app."                                      |
+| Box says "authenticate via hivetool" | Open hivetool and click Authenticate on the server card.                                                                 |
+| "State mismatch"                     | Try again — this is a safety check. If it persists, clear browser storage and retry.                                     |
+| Need to change scopes                | Update scopes in SYSTEM.yaml, then re-authenticate to request the new permissions.                                       |

--- a/packages/bees/docs/system-config.md
+++ b/packages/bees/docs/system-config.md
@@ -159,6 +159,47 @@ logged at startup.
 - **No resource or prompt support.** Only the MCP `tools` capability is
   used; `resources` and `prompts` are not surfaced.
 
+### OAuth authentication
+
+Some remote MCP servers — notably the Google Workspace servers (Gmail,
+Drive, Calendar, Chat, People) — require OAuth 2.0 authentication instead
+of static API keys. Add an `oauth` block to use this mode:
+
+```yaml
+mcp:
+  - name: gmail
+    description: Gmail MCP Server
+    url: https://gmailmcp.googleapis.com/mcp/v1
+    oauth:
+      client_id: "${GOOGLE_OAUTH_CLIENT_ID}"
+      client_secret: "${GOOGLE_OAUTH_CLIENT_SECRET}"
+      scopes:
+        - https://www.googleapis.com/auth/gmail.readonly
+        - https://www.googleapis.com/auth/gmail.compose
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `oauth.client_id` | string | yes | `${ENV_VAR}` reference to the OAuth client ID. |
+| `oauth.client_secret` | string | yes | `${ENV_VAR}` reference to the OAuth client secret. |
+| `oauth.scopes` | list | yes | OAuth scopes to request during consent. |
+
+**Rules:**
+
+- `oauth` and `headers` are mutually exclusive on the same server.
+- `oauth` requires `url` (HTTP transport) — stdio servers cannot use OAuth.
+- Client credentials must be `${ENV_VAR}` references, not inline values.
+
+**Token storage.** Tokens are persisted at `hive/.mcp-tokens/<name>.json`,
+outside the `config/` directory, so creating or updating tokens does not
+trigger cold restarts. The box reads these files at startup. If tokens
+are missing, the server is skipped gracefully with a log message directing
+the user to authenticate via hivetool.
+
+**Multiple servers, shared client.** Multiple MCP servers can reference the
+same OAuth client credentials (same env vars) with different scopes. Each
+server gets its own token file.
+
 ### Editing in HiveTool
 
 The HiveTool workbench (System tab) provides a visual editor for MCP server
@@ -181,7 +222,18 @@ mcp:
     headers:
       x-consumer-api-key: "${COMPOSIO_API_KEY}"
 
+  - name: gmail
+    description: Gmail MCP Server
+    url: https://gmailmcp.googleapis.com/mcp/v1
+    oauth:
+      client_id: "${GOOGLE_OAUTH_CLIENT_ID}"
+      client_secret: "${GOOGLE_OAUTH_CLIENT_SECRET}"
+      scopes:
+        - https://www.googleapis.com/auth/gmail.readonly
+        - https://www.googleapis.com/auth/gmail.compose
+
   - name: filesystem
     description: Local filesystem tools
     command: npx -y @modelcontextprotocol/server-filesystem /tmp/workspace
 ```
+

--- a/packages/bees/hivetool/public/oauth-callback.html
+++ b/packages/bees/hivetool/public/oauth-callback.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>OAuth Callback</title>
+  <style>
+    body {
+      font-family: system-ui, sans-serif;
+      background: #0f172a;
+      color: #e2e8f0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      margin: 0;
+    }
+    .card {
+      text-align: center;
+      padding: 2rem;
+      border: 1px solid #334155;
+      border-radius: 12px;
+      background: #1e293b;
+      max-width: 400px;
+    }
+    h2 { margin: 0 0 0.5rem; }
+    p { color: #94a3b8; margin: 0; }
+    .error { color: #f87171; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h2 id="title">Authenticating…</h2>
+    <p id="message">Sending credentials back to hivetool.</p>
+  </div>
+  <script>
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get("code");
+    const state = params.get("state");
+    const error = params.get("error");
+
+    if (error) {
+      document.getElementById("title").textContent = "Authentication Failed";
+      document.getElementById("message").textContent = error;
+      document.getElementById("message").classList.add("error");
+    } else if (code && window.opener) {
+      window.opener.postMessage(
+        { type: "oauth-callback", code, state },
+        window.location.origin
+      );
+      document.getElementById("title").textContent = "Authenticated ✓";
+      document.getElementById("message").textContent =
+        "You can close this window.";
+      // Auto-close after a brief delay so the user sees the success state.
+      setTimeout(() => window.close(), 1500);
+    } else {
+      document.getElementById("title").textContent = "Error";
+      document.getElementById("message").textContent =
+        "No authorization code received. Please try again.";
+      document.getElementById("message").classList.add("error");
+    }
+  </script>
+</body>
+</html>

--- a/packages/bees/hivetool/src/data/oauth-flow.ts
+++ b/packages/bees/hivetool/src/data/oauth-flow.ts
@@ -1,0 +1,371 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Browser-side OAuth 2.0 consent flow for MCP servers.
+ *
+ * Orchestrates the Authorization Code + PKCE flow entirely from the
+ * browser:
+ *
+ * 1. Read `.env` from the hive root to expand `${VAR}` references.
+ * 2. Build the authorization URL with PKCE challenge.
+ * 3. Open a popup to the OAuth consent page.
+ * 4. Receive the authorization code via `postMessage` from the callback
+ *    page (`/oauth-callback.html`).
+ * 5. Exchange the code for tokens via `fetch` to the token endpoint.
+ * 6. Write the token file to `hive/.mcp-tokens/<name>.json`.
+ *
+ * The token file format matches what `HiveTokenStorage` (Python) reads,
+ * so the box can consume tokens written by hivetool and vice versa.
+ */
+
+import type { OAuthConfig } from "./system-store.js";
+
+export { startOAuthFlow, checkTokenStatus, type OAuthFlowResult };
+
+// Google's OAuth endpoints.
+const GOOGLE_AUTH_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth";
+const GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
+
+const MCP_TOKENS_DIR = ".mcp-tokens";
+
+/** Result of a consent flow attempt. */
+interface OAuthFlowResult {
+  success: boolean;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// PKCE
+// ---------------------------------------------------------------------------
+
+function generateCodeVerifier(): string {
+  const array = new Uint8Array(32);
+  crypto.getRandomValues(array);
+  return base64urlEncode(array);
+}
+
+async function generateCodeChallenge(verifier: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const digest = await crypto.subtle.digest("SHA-256", encoder.encode(verifier));
+  return base64urlEncode(new Uint8Array(digest));
+}
+
+function base64urlEncode(bytes: Uint8Array): string {
+  const binary = Array.from(bytes, (b) => String.fromCharCode(b)).join("");
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function generateState(): string {
+  const array = new Uint8Array(24);
+  crypto.getRandomValues(array);
+  return base64urlEncode(array);
+}
+
+// ---------------------------------------------------------------------------
+// .env file reading
+// ---------------------------------------------------------------------------
+
+/**
+ * Read and parse a `.env` file from the hive root directory.
+ * Returns a map of VAR_NAME → value.
+ */
+async function readEnvFile(
+  hiveHandle: FileSystemDirectoryHandle,
+): Promise<Record<string, string>> {
+  const env: Record<string, string> = {};
+  try {
+    const fileHandle = await hiveHandle.getFileHandle(".env");
+    const file = await fileHandle.getFile();
+    const text = await file.text();
+
+    for (const line of text.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+
+      const eqIdx = trimmed.indexOf("=");
+      if (eqIdx < 0) continue;
+
+      const key = trimmed.slice(0, eqIdx).trim();
+      let value = trimmed.slice(eqIdx + 1).trim();
+
+      // Strip surrounding quotes.
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+      env[key] = value;
+    }
+  } catch {
+    // .env file doesn't exist — that's fine.
+  }
+  return env;
+}
+
+/**
+ * Expand `${VAR}` references in a string using the provided env map.
+ */
+function expandEnvRefs(value: string, env: Record<string, string>): string {
+  return value.replace(/\$\{([^}]+)\}/g, (_, name) => env[name] ?? "");
+}
+
+// ---------------------------------------------------------------------------
+// Token file I/O
+// ---------------------------------------------------------------------------
+
+async function writeTokenFile(
+  hiveHandle: FileSystemDirectoryHandle,
+  serverName: string,
+  data: Record<string, unknown>,
+): Promise<void> {
+  const tokensDir = await hiveHandle.getDirectoryHandle(MCP_TOKENS_DIR, {
+    create: true,
+  });
+  const fileHandle = await tokensDir.getFileHandle(`${serverName}.json`, {
+    create: true,
+  });
+  const writable = await fileHandle.createWritable();
+  await writable.write(JSON.stringify(data, null, 2) + "\n");
+  await writable.close();
+}
+
+async function readTokenFile(
+  hiveHandle: FileSystemDirectoryHandle,
+  serverName: string,
+): Promise<Record<string, unknown> | null> {
+  try {
+    const tokensDir = await hiveHandle.getDirectoryHandle(MCP_TOKENS_DIR);
+    const fileHandle = await tokensDir.getFileHandle(`${serverName}.json`);
+    const file = await fileHandle.getFile();
+    const text = await file.text();
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Token status
+// ---------------------------------------------------------------------------
+
+/**
+ * Check whether a token file exists for the given MCP server.
+ * Returns "authenticated" if tokens exist, "none" otherwise.
+ */
+async function checkTokenStatus(
+  hiveHandle: FileSystemDirectoryHandle,
+  serverName: string,
+): Promise<"authenticated" | "none"> {
+  const data = await readTokenFile(hiveHandle, serverName);
+  if (data && data.tokens) return "authenticated";
+  return "none";
+}
+
+// ---------------------------------------------------------------------------
+// OAuth flow
+// ---------------------------------------------------------------------------
+
+/**
+ * Start the OAuth consent flow for an MCP server.
+ *
+ * Opens a popup window to Google's consent page, waits for the callback,
+ * exchanges the code for tokens, and writes the token file.
+ */
+async function startOAuthFlow(
+  hiveHandle: FileSystemDirectoryHandle,
+  serverName: string,
+  oauth: OAuthConfig,
+): Promise<OAuthFlowResult> {
+  // 1. Read .env to expand credential references.
+  const env = await readEnvFile(hiveHandle);
+  const clientId = expandEnvRefs(oauth.client_id, env);
+  const clientSecret = expandEnvRefs(oauth.client_secret, env);
+
+  if (!clientId) {
+    return {
+      success: false,
+      error: `Could not resolve client_id from "${oauth.client_id}". ` +
+        "Check your .env file.",
+    };
+  }
+
+  // 2. Generate PKCE parameters and state.
+  const codeVerifier = generateCodeVerifier();
+  const codeChallenge = await generateCodeChallenge(codeVerifier);
+  const state = generateState();
+  const redirectUri = `${window.location.origin}/oauth-callback.html`;
+
+  // 3. Build authorization URL.
+  const authParams = new URLSearchParams({
+    client_id: clientId,
+    redirect_uri: redirectUri,
+    response_type: "code",
+    scope: oauth.scopes.join(" "),
+    state,
+    code_challenge: codeChallenge,
+    code_challenge_method: "S256",
+    access_type: "offline",
+    prompt: "consent",
+  });
+  const authUrl = `${GOOGLE_AUTH_ENDPOINT}?${authParams}`;
+
+  // 4. Open popup and wait for callback.
+  const callbackResult = await openPopupAndWaitForCallback(authUrl, state);
+  if (!callbackResult.success) return callbackResult;
+  const { code } = callbackResult;
+
+  // 5. Exchange code for tokens.
+  const tokenResult = await exchangeCodeForTokens(
+    code!,
+    clientId,
+    clientSecret,
+    redirectUri,
+    codeVerifier,
+  );
+  if (!tokenResult.success) return tokenResult;
+
+  // 6. Write token file.
+  const tokenData = {
+    tokens: tokenResult.tokens,
+    client_info: {
+      client_id: clientId,
+      client_secret: clientSecret,
+      redirect_uris: null,
+    },
+  };
+
+  try {
+    await writeTokenFile(hiveHandle, serverName, tokenData);
+  } catch (e) {
+    return {
+      success: false,
+      error: `Failed to write token file: ${e instanceof Error ? e.message : e}`,
+    };
+  }
+
+  return { success: true };
+}
+
+// ---------------------------------------------------------------------------
+// Popup management
+// ---------------------------------------------------------------------------
+
+function openPopupAndWaitForCallback(
+  authUrl: string,
+  expectedState: string,
+): Promise<OAuthFlowResult & { code?: string }> {
+  return new Promise((resolve) => {
+    const popup = window.open(
+      authUrl,
+      "oauth-consent",
+      "width=600,height=700,scrollbars=yes,resizable=yes",
+    );
+
+    if (!popup) {
+      resolve({
+        success: false,
+        error: "Popup was blocked. Please allow popups for this site.",
+      });
+      return;
+    }
+
+    // Timeout after 5 minutes.
+    const timeout = setTimeout(() => {
+      cleanup();
+      resolve({
+        success: false,
+        error: "Authentication timed out. Please try again.",
+      });
+    }, 5 * 60 * 1000);
+
+    // Poll for popup closed by user.
+    const pollInterval = setInterval(() => {
+      if (popup.closed) {
+        cleanup();
+        resolve({
+          success: false,
+          error: "Authentication window was closed.",
+        });
+      }
+    }, 500);
+
+    function onMessage(event: MessageEvent) {
+      if (event.origin !== window.location.origin) return;
+      if (event.data?.type !== "oauth-callback") return;
+
+      cleanup();
+
+      const { code, state } = event.data;
+      if (state !== expectedState) {
+        resolve({
+          success: false,
+          error: "State mismatch — possible CSRF attack. Please try again.",
+        });
+        return;
+      }
+
+      resolve({ success: true, code });
+    }
+
+    function cleanup() {
+      clearTimeout(timeout);
+      clearInterval(pollInterval);
+      window.removeEventListener("message", onMessage);
+      try {
+        popup?.close();
+      } catch {
+        // Already closed.
+      }
+    }
+
+    window.addEventListener("message", onMessage);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Token exchange
+// ---------------------------------------------------------------------------
+
+async function exchangeCodeForTokens(
+  code: string,
+  clientId: string,
+  clientSecret: string,
+  redirectUri: string,
+  codeVerifier: string,
+): Promise<OAuthFlowResult & { tokens?: Record<string, unknown> }> {
+  try {
+    const response = await fetch(GOOGLE_TOKEN_ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        client_id: clientId,
+        client_secret: clientSecret,
+        redirect_uri: redirectUri,
+        code_verifier: codeVerifier,
+      }),
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      return {
+        success: false,
+        error: `Token exchange failed (${response.status}): ${body}`,
+      };
+    }
+
+    const tokens = await response.json();
+    return { success: true, tokens };
+  } catch (e) {
+    return {
+      success: false,
+      error: `Token exchange error: ${e instanceof Error ? e.message : e}`,
+    };
+  }
+}

--- a/packages/bees/hivetool/src/data/system-store.ts
+++ b/packages/bees/hivetool/src/data/system-store.ts
@@ -17,7 +17,17 @@ import yaml from "js-yaml";
 import type { StateAccess } from "./state-access.js";
 
 export { SystemStore };
-export type { SystemData, MCPServerConfig };
+export type { SystemData, MCPServerConfig, OAuthConfig };
+
+/** OAuth 2.0 configuration for an MCP server. */
+interface OAuthConfig {
+  /** ${ENV_VAR} reference to the OAuth client ID. */
+  client_id: string;
+  /** ${ENV_VAR} reference to the OAuth client secret. */
+  client_secret: string;
+  /** OAuth scopes to request during consent. */
+  scopes: string[];
+}
 
 /** A single MCP server registration in SYSTEM.yaml. */
 interface MCPServerConfig {
@@ -31,6 +41,8 @@ interface MCPServerConfig {
   headers?: Record<string, string>;
   /** Environment variables for stdio (values may contain ${ENV_VAR}). */
   env?: Record<string, string>;
+  /** OAuth 2.0 configuration. Mutually exclusive with headers. */
+  oauth?: OAuthConfig;
 }
 
 /** The shape of SYSTEM.yaml. */
@@ -102,6 +114,23 @@ class SystemStore {
                 )
               )
             : undefined,
+          oauth: entry.oauth && typeof entry.oauth === "object"
+            ? {
+                client_id: String(
+                  (entry.oauth as Record<string, unknown>).client_id ?? ""
+                ),
+                client_secret: String(
+                  (entry.oauth as Record<string, unknown>).client_secret ?? ""
+                ),
+                scopes: Array.isArray(
+                  (entry.oauth as Record<string, unknown>).scopes
+                )
+                  ? ((entry.oauth as Record<string, unknown>).scopes as unknown[]).map(
+                      (s) => String(s)
+                    )
+                  : [],
+              }
+            : undefined,
         })),
       });
     } catch (e) {
@@ -146,6 +175,13 @@ class SystemStore {
         }
         if (server.env && Object.keys(server.env).length > 0) {
           entry.env = server.env;
+        }
+        if (server.oauth) {
+          entry.oauth = {
+            client_id: server.oauth.client_id,
+            client_secret: server.oauth.client_secret,
+            scopes: server.oauth.scopes,
+          };
         }
         return entry;
       });

--- a/packages/bees/hivetool/src/ui/app.ts
+++ b/packages/bees/hivetool/src/ui/app.ts
@@ -948,6 +948,7 @@ class BeesApp extends SignalWatcher(LitElement) {
           .systemStore=${this.systemStore}
           .templateStore=${this.templateStore}
           .mutationClient=${this.mutationClient}
+          .stateAccess=${this.stateAccess}
         ></bees-system-detail>`;
     }
   }

--- a/packages/bees/hivetool/src/ui/system-detail.ts
+++ b/packages/bees/hivetool/src/ui/system-detail.ts
@@ -22,8 +22,15 @@ import type {
   SystemStore,
   SystemData,
   MCPServerConfig,
+  OAuthConfig,
 } from "../data/system-store.js";
+import type { StateAccess } from "../data/state-access.js";
 import type { TemplateStore } from "../data/template-store.js";
+import {
+  startOAuthFlow,
+  checkTokenStatus,
+  type OAuthFlowResult,
+} from "../data/oauth-flow.js";
 import { sharedStyles } from "./shared-styles.js";
 import "./primitives/editable-field.js";
 import "./primitives/editable-textarea.js";
@@ -161,6 +168,100 @@ class BeesSystemDetail extends SignalWatcher(LitElement) {
         font-size: 0.75rem;
         color: #64748b;
         margin-bottom: 4px;
+      }
+
+      .mcp-oauth-badge {
+        font-size: 0.6rem;
+        font-weight: 600;
+        padding: 2px 6px;
+        border-radius: 4px;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        background: #7c3aed22;
+        color: #a78bfa;
+        border: 1px solid #7c3aed55;
+      }
+
+      .mcp-scopes {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+        margin-top: 6px;
+      }
+
+      .mcp-scope-chip {
+        font-family: "Google Mono", "Roboto Mono", monospace;
+        font-size: 0.65rem;
+        padding: 2px 8px;
+        border-radius: 4px;
+        background: #1e293b;
+        color: #94a3b8;
+        border: 1px solid #334155;
+        word-break: break-all;
+      }
+
+      .mcp-auth-ref {
+        font-family: "Google Mono", "Roboto Mono", monospace;
+        font-size: 0.7rem;
+        color: #64748b;
+        margin-top: 4px;
+      }
+
+      .mcp-auth-actions {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-top: 8px;
+      }
+
+      .auth-btn {
+        font-size: 0.7rem;
+        font-weight: 600;
+        padding: 4px 12px;
+        border-radius: 6px;
+        border: 1px solid #7c3aed55;
+        background: #7c3aed22;
+        color: #a78bfa;
+        cursor: pointer;
+        transition: all 0.15s ease;
+      }
+      .auth-btn:hover {
+        background: #7c3aed44;
+        border-color: #7c3aed88;
+      }
+      .auth-btn:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+
+      .token-status {
+        font-size: 0.65rem;
+        font-weight: 600;
+        padding: 2px 8px;
+        border-radius: 4px;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+      .token-status.authenticated {
+        background: #16a34a22;
+        color: #4ade80;
+        border: 1px solid #16a34a55;
+      }
+      .token-status.none {
+        background: #eab30822;
+        color: #fbbf24;
+        border: 1px solid #eab30855;
+      }
+      .token-status.pending {
+        background: #3b82f622;
+        color: #60a5fa;
+        border: 1px solid #3b82f655;
+      }
+
+      .auth-error {
+        font-size: 0.7rem;
+        color: #f87171;
+        margin-top: 4px;
       }
 
       .kv-table {
@@ -409,11 +510,17 @@ class BeesSystemDetail extends SignalWatcher(LitElement) {
   @property({ attribute: false })
   accessor mutationClient: MutationClient | null = null;
 
+  @property({ attribute: false })
+  accessor stateAccess: StateAccess | null = null;
+
   // ── Edit state ──
   @state() accessor editing = false;
   @state() accessor saving = false;
   @state() accessor error: string | null = null;
   @state() accessor draft: SystemData | null = null;
+
+  /** Per-server token status: "authenticated" | "none" | "pending". */
+  @state() accessor tokenStatuses: Record<string, string> = {};
 
   #original: SystemData | null = null;
 
@@ -426,7 +533,37 @@ class BeesSystemDetail extends SignalWatcher(LitElement) {
       return this.renderEditMode(this.draft);
     }
 
+    // Refresh token statuses for OAuth servers (async, non-blocking).
+    this.#refreshTokenStatuses(config);
+
     return this.renderViewMode(config);
+  }
+
+  #tokenRefreshPending = false;
+
+  async #refreshTokenStatuses(config: SystemData): Promise<void> {
+    if (this.#tokenRefreshPending) return;
+    const handle = this.stateAccess?.handle;
+    if (!handle) return;
+
+    const oauthServers = config.mcp.filter((s) => s.oauth);
+    if (oauthServers.length === 0) return;
+
+    this.#tokenRefreshPending = true;
+    try {
+      const statuses: Record<string, string> = { ...this.tokenStatuses };
+      let changed = false;
+      for (const server of oauthServers) {
+        const status = await checkTokenStatus(handle, server.name);
+        if (statuses[server.name] !== status) {
+          statuses[server.name] = status;
+          changed = true;
+        }
+      }
+      if (changed) this.tokenStatuses = statuses;
+    } finally {
+      this.#tokenRefreshPending = false;
+    }
   }
 
   // ── View Mode ──
@@ -537,6 +674,9 @@ class BeesSystemDetail extends SignalWatcher(LitElement) {
           <span class="mcp-transport ${isHttp ? "http" : "stdio"}">
             ${isHttp ? "HTTP" : "stdio"}
           </span>
+          ${server.oauth
+            ? html`<span class="mcp-oauth-badge">OAuth</span>`
+            : nothing}
         </div>
         ${server.description
           ? html`<div class="mcp-desc">${server.description}</div>`
@@ -544,6 +684,48 @@ class BeesSystemDetail extends SignalWatcher(LitElement) {
         ${server.url ? html`<div class="mcp-url">${server.url}</div>` : nothing}
         ${server.command
           ? html`<div class="mcp-command">${server.command}</div>`
+          : nothing}
+        ${server.oauth
+          ? html`
+              <div class="mcp-auth-ref">
+                client: ${server.oauth.client_id}
+              </div>
+              ${server.oauth.scopes.length > 0
+                ? html`
+                    <div class="mcp-scopes">
+                      ${server.oauth.scopes.map(
+                        (scope) => html`
+                          <span class="mcp-scope-chip">${scope}</span>
+                        `
+                      )}
+                    </div>
+                  `
+                : nothing}
+              <div class="mcp-auth-actions">
+                <button
+                  class="auth-btn"
+                  ?disabled=${this.tokenStatuses[server.name] === "pending"}
+                  @click=${() => this.handleAuthenticate(server)}
+                >
+                  ${this.tokenStatuses[server.name] === "pending"
+                    ? "Authenticating…"
+                    : this.tokenStatuses[server.name] === "authenticated"
+                      ? "Re-authenticate"
+                      : "Authenticate"}
+                </button>
+                ${this.tokenStatuses[server.name] === "authenticated"
+                  ? html`<span class="token-status authenticated"
+                      >Connected</span
+                    >`
+                  : this.tokenStatuses[server.name] === "pending"
+                    ? html`<span class="token-status pending"
+                        >Pending</span
+                      >`
+                    : html`<span class="token-status none"
+                        >Not Authenticated</span
+                      >`}
+              </div>
+            `
           : nothing}
         ${kvEntries.length > 0
           ? html`
@@ -662,6 +844,7 @@ class BeesSystemDetail extends SignalWatcher(LitElement) {
 
   private renderMCPEditCard(server: MCPServerConfig, index: number) {
     const isHttp = server.command === undefined;
+    const hasOAuth = !!server.oauth;
 
     return html`
       <div class="mcp-edit-card">
@@ -718,6 +901,7 @@ class BeesSystemDetail extends SignalWatcher(LitElement) {
                   command: server.command ?? "",
                   url: undefined,
                   headers: undefined,
+                  oauth: undefined,
                 })}
             >
               Local
@@ -737,11 +921,44 @@ class BeesSystemDetail extends SignalWatcher(LitElement) {
                     })}
                 ></bees-editable-field>
 
-                ${this.renderKVEditor(
-                  "Headers",
-                  server.headers ?? {},
-                  (headers) => this.updateMCPServer(index, { headers })
-                )}
+                <!-- Auth mode chooser -->
+                <div>
+                  <div class="kv-label">Authentication</div>
+                  <div class="transport-toggle">
+                    <button
+                      class="http ${!hasOAuth ? "active" : ""}"
+                      @click=${() =>
+                        this.updateMCPServer(index, {
+                          oauth: undefined,
+                          headers: server.headers ?? {},
+                        })}
+                    >
+                      Headers
+                    </button>
+                    <button
+                      class="local ${hasOAuth ? "active" : ""}"
+                      @click=${() =>
+                        this.updateMCPServer(index, {
+                          headers: undefined,
+                          oauth: server.oauth ?? {
+                            client_id: "",
+                            client_secret: "",
+                            scopes: [],
+                          },
+                        })}
+                    >
+                      OAuth
+                    </button>
+                  </div>
+                </div>
+
+                ${hasOAuth
+                  ? this.renderOAuthEditor(server.oauth!, index)
+                  : this.renderKVEditor(
+                      "Headers",
+                      server.headers ?? {},
+                      (headers) => this.updateMCPServer(index, { headers })
+                    )}
               `
             : html`
                 <bees-editable-field
@@ -761,6 +978,78 @@ class BeesSystemDetail extends SignalWatcher(LitElement) {
                   (env) => this.updateMCPServer(index, { env })
                 )}
               `}
+        </div>
+      </div>
+    `;
+  }
+
+  // ── OAuth Editor ──
+
+  private renderOAuthEditor(oauth: OAuthConfig, serverIndex: number) {
+    return html`
+      <div class="mcp-edit-fields" style="gap: 8px">
+        <div class="mcp-edit-row">
+          <bees-editable-field
+            label="Client ID (env var)"
+            .value=${oauth.client_id}
+            editing
+            placeholder="\${GOOGLE_OAUTH_CLIENT_ID}"
+            @change=${(e: CustomEvent) =>
+              this.updateMCPServerOAuth(serverIndex, {
+                client_id: e.detail.value,
+              })}
+          ></bees-editable-field>
+
+          <bees-editable-field
+            label="Client Secret (env var)"
+            .value=${oauth.client_secret}
+            editing
+            placeholder="\${GOOGLE_OAUTH_CLIENT_SECRET}"
+            @change=${(e: CustomEvent) =>
+              this.updateMCPServerOAuth(serverIndex, {
+                client_secret: e.detail.value,
+              })}
+          ></bees-editable-field>
+        </div>
+
+        <div>
+          <div class="kv-label">Scopes</div>
+          <div class="kv-edit-table">
+            ${oauth.scopes.map(
+              (scope, i) => html`
+                <div class="kv-edit-row" style="grid-template-columns: 1fr auto">
+                  <input
+                    .value=${scope}
+                    placeholder="https://www.googleapis.com/auth/..."
+                    @input=${(e: InputEvent) => {
+                      const newVal = (e.currentTarget as HTMLInputElement).value;
+                      const scopes = [...oauth.scopes];
+                      scopes[i] = newVal;
+                      this.updateMCPServerOAuth(serverIndex, { scopes });
+                    }}
+                  />
+                  <span
+                    class="kv-remove"
+                    @click=${() => {
+                      const scopes = oauth.scopes.filter((_, j) => j !== i);
+                      this.updateMCPServerOAuth(serverIndex, { scopes });
+                    }}
+                    title="Remove scope"
+                    >✕</span
+                  >
+                </div>
+              `
+            )}
+            <button
+              class="kv-add-btn"
+              @click=${() => {
+                const scopes = [...oauth.scopes, ""];
+                this.updateMCPServerOAuth(serverIndex, { scopes });
+              }}
+            >
+              + Add Scope
+            </button>
+          </div>
         </div>
       </div>
     `;
@@ -888,6 +1177,18 @@ class BeesSystemDetail extends SignalWatcher(LitElement) {
     this.draft = { ...this.draft, mcp };
   }
 
+  private updateMCPServerOAuth(
+    index: number,
+    partial: Partial<OAuthConfig>,
+  ) {
+    if (!this.draft) return;
+    const server = this.draft.mcp[index];
+    if (!server?.oauth) return;
+    this.updateMCPServer(index, {
+      oauth: { ...server.oauth, ...partial },
+    });
+  }
+
   private isDirty(): boolean {
     if (!this.draft || !this.#original) return false;
     return JSON.stringify(this.#original) !== JSON.stringify(this.draft);
@@ -915,6 +1216,14 @@ class BeesSystemDetail extends SignalWatcher(LitElement) {
         this.error = `MCP server "${server.name}" needs either a URL or command.`;
         return;
       }
+      if (server.oauth && server.headers) {
+        this.error = `MCP server "${server.name}" cannot have both OAuth and headers.`;
+        return;
+      }
+      if (server.oauth && !server.url) {
+        this.error = `MCP server "${server.name}" uses OAuth, which requires HTTP (URL).`;
+        return;
+      }
     }
 
     this.saving = true;
@@ -936,6 +1245,36 @@ class BeesSystemDetail extends SignalWatcher(LitElement) {
       console.error("System config save error:", e);
     } finally {
       this.saving = false;
+    }
+  }
+
+  // ── OAuth flow ──
+
+  private async handleAuthenticate(server: MCPServerConfig) {
+    if (!server.oauth || !this.stateAccess?.handle) return;
+
+    const name = server.name;
+    this.tokenStatuses = { ...this.tokenStatuses, [name]: "pending" };
+
+    try {
+      const result = await startOAuthFlow(
+        this.stateAccess.handle,
+        name,
+        server.oauth,
+      );
+
+      if (result.success) {
+        this.tokenStatuses = {
+          ...this.tokenStatuses,
+          [name]: "authenticated",
+        };
+      } else {
+        this.tokenStatuses = { ...this.tokenStatuses, [name]: "none" };
+        this.error = result.error ?? "Authentication failed.";
+      }
+    } catch (e) {
+      this.tokenStatuses = { ...this.tokenStatuses, [name]: "none" };
+      this.error = e instanceof Error ? e.message : "Authentication failed.";
     }
   }
 

--- a/packages/bees/scripts/create-hive.mjs
+++ b/packages/bees/scripts/create-hive.mjs
@@ -52,6 +52,8 @@ const GITIGNORE = `\
 tickets/
 logs/
 mutations/
+.env
+.mcp-tokens/
 `;
 
 async function main() {

--- a/packages/bees/tests/test_mcp_bridge.py
+++ b/packages/bees/tests/test_mcp_bridge.py
@@ -5,19 +5,24 @@
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from bees.functions.mcp_bridge import (
+    HiveTokenStorage,
     MCPConnection,
     MCPRegistry,
+    OAuthConfig,
     _build_function_group,
     _expand_env_values,
     _make_proxy_handler,
     _mcp_tool_to_declaration,
+    _parse_oauth_config,
 )
 
 
@@ -282,6 +287,156 @@ class TestEnvExpansion:
 
 
 # ---------------------------------------------------------------------------
+# OAuth config parsing
+# ---------------------------------------------------------------------------
+
+
+class TestOAuthConfigParsing:
+    """Test parsing the oauth block from MCP server config."""
+
+    def test_parse_full_config(self):
+        raw = {
+            "client_id": "${GOOGLE_CLIENT_ID}",
+            "client_secret": "${GOOGLE_CLIENT_SECRET}",
+            "scopes": [
+                "https://www.googleapis.com/auth/gmail.readonly",
+                "https://www.googleapis.com/auth/gmail.compose",
+            ],
+        }
+        config = _parse_oauth_config(raw)
+
+        assert config is not None
+        assert config.client_id == "${GOOGLE_CLIENT_ID}"
+        assert config.client_secret == "${GOOGLE_CLIENT_SECRET}"
+        assert len(config.scopes) == 2
+
+    def test_parse_none(self):
+        assert _parse_oauth_config(None) is None
+
+    def test_parse_empty_dict(self):
+        assert _parse_oauth_config({}) is None
+
+    def test_parse_missing_fields(self):
+        config = _parse_oauth_config({"client_id": "abc"})
+        assert config is not None
+        assert config.client_id == "abc"
+        assert config.client_secret == ""
+        assert config.scopes == []
+
+
+# ---------------------------------------------------------------------------
+# HiveTokenStorage
+# ---------------------------------------------------------------------------
+
+
+class TestHiveTokenStorage:
+    """Test filesystem-backed OAuth token storage."""
+
+    @pytest.mark.asyncio
+    async def test_read_missing_tokens(self, tmp_path):
+        storage = HiveTokenStorage(tmp_path, "gmail")
+        tokens = await storage.get_tokens()
+        assert tokens is None
+
+    @pytest.mark.asyncio
+    async def test_read_missing_client_info(self, tmp_path):
+        storage = HiveTokenStorage(tmp_path, "gmail")
+        info = await storage.get_client_info()
+        assert info is None
+
+    @pytest.mark.asyncio
+    async def test_token_round_trip(self, tmp_path):
+        from mcp.shared.auth import OAuthToken
+
+        storage = HiveTokenStorage(tmp_path, "gmail")
+
+        token = OAuthToken(
+            access_token="access123",
+            refresh_token="refresh456",
+            expires_in=3600,
+        )
+        await storage.set_tokens(token)
+
+        loaded = await storage.get_tokens()
+        assert loaded is not None
+        assert loaded.access_token == "access123"
+        assert loaded.refresh_token == "refresh456"
+
+    @pytest.mark.asyncio
+    async def test_client_info_round_trip(self, tmp_path):
+        from mcp.shared.auth import OAuthClientInformationFull
+
+        storage = HiveTokenStorage(tmp_path, "gmail")
+
+        client_info = OAuthClientInformationFull(
+            client_id="my-client-id",
+            client_secret="my-secret",
+            redirect_uris=None,
+        )
+        await storage.set_client_info(client_info)
+
+        loaded = await storage.get_client_info()
+        assert loaded is not None
+        assert loaded.client_id == "my-client-id"
+        assert loaded.client_secret == "my-secret"
+
+    @pytest.mark.asyncio
+    async def test_combined_storage(self, tmp_path):
+        """Tokens and client_info coexist in the same file."""
+        from mcp.shared.auth import OAuthClientInformationFull, OAuthToken
+
+        storage = HiveTokenStorage(tmp_path, "drive")
+
+        await storage.set_client_info(OAuthClientInformationFull(
+            client_id="cid", client_secret="cs", redirect_uris=None,
+        ))
+        await storage.set_tokens(OAuthToken(
+            access_token="at", refresh_token="rt",
+        ))
+
+        # Both should be readable.
+        info = await storage.get_client_info()
+        tokens = await storage.get_tokens()
+        assert info is not None and info.client_id == "cid"
+        assert tokens is not None and tokens.access_token == "at"
+
+        # Verify on-disk structure.
+        raw = json.loads(storage._path.read_text())
+        assert "tokens" in raw
+        assert "client_info" in raw
+
+    @pytest.mark.asyncio
+    async def test_directory_created_on_write(self, tmp_path):
+        storage = HiveTokenStorage(tmp_path, "calendar")
+        from mcp.shared.auth import OAuthToken
+
+        await storage.set_tokens(OAuthToken(access_token="x"))
+        assert storage._path.exists()
+        assert storage._dir.is_dir()
+
+    @pytest.mark.asyncio
+    async def test_corrupt_json_returns_none(self, tmp_path):
+        storage = HiveTokenStorage(tmp_path, "gmail")
+        storage._dir.mkdir(parents=True, exist_ok=True)
+        storage._path.write_text("not valid json{{{")
+
+        tokens = await storage.get_tokens()
+        assert tokens is None
+
+    @pytest.mark.asyncio
+    async def test_invalid_token_data_returns_none(self, tmp_path):
+        storage = HiveTokenStorage(tmp_path, "gmail")
+        storage._dir.mkdir(parents=True, exist_ok=True)
+        # Valid JSON but invalid token structure.
+        storage._path.write_text(json.dumps({
+            "tokens": {"unexpected_field": True},
+        }))
+
+        tokens = await storage.get_tokens()
+        assert tokens is None
+
+
+# ---------------------------------------------------------------------------
 # Registry
 # ---------------------------------------------------------------------------
 
@@ -308,3 +463,116 @@ class TestRegistry:
             await registry.connect_all(configs)
 
 
+# ---------------------------------------------------------------------------
+# Registry OAuth validation
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryOAuthValidation:
+    """Test connect_all validation for OAuth configs."""
+
+    @pytest.mark.asyncio
+    async def test_oauth_without_url_raises(self):
+        registry = MCPRegistry()
+        configs = [{
+            "name": "gmail",
+            "command": "echo",
+            "oauth": {"client_id": "x", "client_secret": "y", "scopes": []},
+        }]
+
+        with pytest.raises(ValueError, match="OAuth requires HTTP"):
+            await registry.connect_all(configs, hive_dir=Path("/tmp"))
+
+    @pytest.mark.asyncio
+    async def test_oauth_with_headers_raises(self):
+        registry = MCPRegistry()
+        configs = [{
+            "name": "gmail",
+            "url": "https://example.com/mcp",
+            "oauth": {"client_id": "x", "client_secret": "y", "scopes": []},
+            "headers": {"x-api-key": "should-not-be-here"},
+        }]
+
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            await registry.connect_all(configs, hive_dir=Path("/tmp"))
+
+    @pytest.mark.asyncio
+    async def test_oauth_without_hive_dir_raises(self):
+        registry = MCPRegistry()
+        configs = [{
+            "name": "gmail",
+            "url": "https://example.com/mcp",
+            "oauth": {"client_id": "x", "client_secret": "y", "scopes": []},
+        }]
+
+        with pytest.raises(ValueError, match="hive_dir"):
+            await registry.connect_all(configs)
+
+    @pytest.mark.asyncio
+    async def test_oauth_skips_when_no_tokens(self, tmp_path, monkeypatch):
+        """OAuth server with no tokens should skip gracefully."""
+        monkeypatch.setenv("GOOGLE_CLIENT_ID", "test-id")
+        monkeypatch.setenv("GOOGLE_CLIENT_SECRET", "test-secret")
+
+        registry = MCPRegistry()
+        configs = [{
+            "name": "gmail",
+            "url": "https://gmailmcp.googleapis.com/mcp/v1",
+            "oauth": {
+                "client_id": "${GOOGLE_CLIENT_ID}",
+                "client_secret": "${GOOGLE_CLIENT_SECRET}",
+                "scopes": ["https://www.googleapis.com/auth/gmail.readonly"],
+            },
+        }]
+
+        # Should not raise — graceful skip.
+        await registry.connect_all(configs, hive_dir=tmp_path)
+
+        # No connections established.
+        assert registry.get_factories() == []
+
+    @pytest.mark.asyncio
+    async def test_oauth_skips_when_client_id_empty(self, tmp_path, monkeypatch):
+        """OAuth server with empty client_id after expansion should skip."""
+        monkeypatch.delenv("MISSING_VAR", raising=False)
+
+        registry = MCPRegistry()
+        configs = [{
+            "name": "gmail",
+            "url": "https://gmailmcp.googleapis.com/mcp/v1",
+            "oauth": {
+                "client_id": "${MISSING_VAR}",
+                "client_secret": "${MISSING_VAR}",
+                "scopes": [],
+            },
+        }]
+
+        await registry.connect_all(configs, hive_dir=tmp_path)
+        assert registry.get_factories() == []
+
+    @pytest.mark.asyncio
+    async def test_oauth_seeds_client_info(self, tmp_path, monkeypatch):
+        """OAuth connect should pre-seed client_info in token storage."""
+        monkeypatch.setenv("CID", "my-client-id")
+        monkeypatch.setenv("CS", "my-secret")
+
+        registry = MCPRegistry()
+        configs = [{
+            "name": "gmail",
+            "url": "https://gmailmcp.googleapis.com/mcp/v1",
+            "oauth": {
+                "client_id": "${CID}",
+                "client_secret": "${CS}",
+                "scopes": ["email"],
+            },
+        }]
+
+        await registry.connect_all(configs, hive_dir=tmp_path)
+
+        # Token file should have client_info even though we skipped
+        # (no tokens).
+        storage = HiveTokenStorage(tmp_path, "gmail")
+        info = await storage.get_client_info()
+        assert info is not None
+        assert info.client_id == "my-client-id"
+        assert info.client_secret == "my-secret"


### PR DESCRIPTION
Adds OAuth 2.0 authentication for remote MCP servers, enabling Google Workspace MCP servers (Gmail, Drive, Calendar, Chat, People) to work with Bees. Users configure OAuth credentials in SYSTEM.yaml and complete the consent flow through hivetool's browser UI.

Google Workspace MCP servers require OAuth 2.0 — static API keys won't work. This bridges the gap between the box (headless, consumes tokens) and hivetool (interactive, runs the consent flow), so users can authenticate once in the browser and have the box pick up tokens automatically.

- `OAuthConfig` dataclass for the `oauth` block in SYSTEM.yaml
- `HiveTokenStorage` — filesystem-backed token persistence at `hive/.mcp-tokens/<name>.json`
- `_connect_http_oauth()` — new connection path using `OAuthClientProvider` with PKCE
- `connect_all()` — validation (oauth+headers mutual exclusion, oauth requires URL)
- Graceful skip when tokens are missing (logs warning, doesn't crash)

- Loads `hive/.env` in addition to cwd `.env` so hive-specific credentials (OAuth client IDs) are available to the scheduler

- `OAuthConfig` type in `system-store.ts` with YAML parse/serialize
- Auth mode toggle (Headers / OAuth) in MCP edit cards
- OAuth badge, scope chips, client ref in MCP view cards
- "Authenticate" button with token status indicator (Connected / Not Authenticated / Pending)

- `oauth-flow.ts` — browser-side OAuth orchestrator: reads `.env` for credential expansion, PKCE via Web Crypto, popup management, token exchange, file write
- `oauth-callback.html` — static redirect page that `postMessage`s the auth code back to the opener

- `create-hive.mjs` — new hives now include `.env` and `.mcp-tokens/` in `.gitignore`
- `oauth-setup.md` — step-by-step setup guide (Cloud Console → .env → SYSTEM.yaml → authenticate → start box)
- `system-config.md` — documents the `oauth` field and token storage

- 39 Python tests passing (20 new) — token storage round-trips, config validation, graceful skip logic
- TypeScript compiles clean (`tsc --noEmit`)
- End-to-end verified: authenticated all 5 Google Workspace MCP servers via hivetool, box connected and discovered tools (Gmail: 10, Drive: 8, Calendar: 8, People: 3)
