### PR TITLE
[bees] Delete task mutation

### DIFF
--- a/packages/bees/bees/bees.py
+++ b/packages/bees/bees/bees.py
@@ -80,6 +80,18 @@ class Bees:
             count += 1
         return count
 
+    def delete_task(self, task_id: str) -> list[str]:
+        """Delete a task and all its descendants.
+
+        Cancels in-flight work, removes ticket directories and session
+        logs, and marks the task so that post-completion cleanup is
+        skipped for any LLM calls or tool invocations that complete
+        after deletion.
+
+        Returns a list of all deleted task IDs.
+        """
+        return self._scheduler.delete_task(task_id)
+
     async def run(self) -> list[dict]:
         """Run the hive to completion (batch mode).
 

--- a/packages/bees/bees/mutations.py
+++ b/packages/bees/bees/mutations.py
@@ -34,6 +34,8 @@ Supported mutation types:
   to their pre-pause status.
 - **pause-task** (hot) — Pauses a single task by ID.
 - **resume-task** (hot) — Resumes a single paused task by ID.
+- **delete-task** (hot) — Deletes a task and all its descendants,
+  including ticket directories and session logs.
 """
 
 from __future__ import annotations
@@ -286,6 +288,8 @@ class MutationManager:
                     extra = self._handle_pause_task(mutation)
                 case "resume-task":
                     extra = self._handle_resume_task(mutation)
+                case "delete-task":
+                    extra = self._handle_delete_task(mutation)
                 case _:
                     self._write_result(
                         mutation.result_path,
@@ -525,6 +529,65 @@ class MutationManager:
             )
 
         return {"resumed": resumed}
+
+    def _handle_delete_task(self, mutation: PendingMutation) -> dict[str, Any]:
+        """Delete a task and all its descendants.
+
+        Delegates to ``Bees.delete_task()`` when available (cancels
+        in-flight asyncio tasks, marks deleted IDs so post-completion
+        cleanup is skipped).  Falls back to filesystem-only deletion
+        via ``TaskStore`` at startup.
+        """
+        task_id = mutation.data.get("task_id")
+        if not task_id:
+            raise ValueError("delete-task mutation missing 'task_id'")
+
+        if self._bees:
+            deleted = self._bees.delete_task(task_id)
+        else:
+            deleted = self._delete_task_filesystem(task_id)
+
+        logger.info(
+            "Deleted %d task(s): %s",
+            len(deleted),
+            ", ".join(tid[:8] for tid in deleted),
+        )
+        return {"deleted": deleted}
+
+    def _delete_task_filesystem(self, task_id: str) -> list[str]:
+        """Delete a task tree using only filesystem operations.
+
+        Used at startup when no Bees instance is running.
+        """
+        store = TaskStore(self._hive_dir)
+        deleted: list[str] = []
+        self._delete_fs_recursive(task_id, store, deleted)
+        return deleted
+
+    def _delete_fs_recursive(
+        self, task_id: str, store: TaskStore, deleted: list[str],
+    ) -> None:
+        """Recursively delete a task and its children from disk."""
+        # Recurse into children first.
+        children = store.get_children(task_id)
+        for child in children:
+            self._delete_fs_recursive(child.id, store, deleted)
+
+        # Remove ticket directory.
+        ticket_dir = store.tickets_dir / task_id
+        if ticket_dir.exists():
+            shutil.rmtree(ticket_dir)
+
+        # Remove matching session logs.
+        logs_dir = self._hive_dir / "logs"
+        if logs_dir.exists():
+            prefix = f"bees-{task_id[:8]}-"
+            for log_file in logs_dir.iterdir():
+                if log_file.name.startswith(prefix):
+                    log_file.unlink(missing_ok=True)
+
+        deleted.append(task_id)
+        logger.info("Deleted task %s", task_id[:8])
 
     # -- Utilities ---------------------------------------------------------
 

--- a/packages/bees/bees/scheduler.py
+++ b/packages/bees/bees/scheduler.py
@@ -37,6 +37,8 @@ while sequential dependencies are strictly preserved without blocking the system
 
 from __future__ import annotations
 
+import shutil
+
 import asyncio
 import logging
 import sys
@@ -150,6 +152,7 @@ class Scheduler:
         self._completion_events: dict[str, asyncio.Event] = {}
         self._active_tasks: dict[str, asyncio.Task] = {}
         self._active_streams: dict[str, SessionStream] = {}
+        self._deleted_tasks: set[str] = set()
         self._mcp_registry: MCPRegistry | None = None
 
         self._task_runner = TaskRunner(
@@ -265,6 +268,54 @@ class Scheduler:
             cancelled = True
             
         return cancelled
+
+    def delete_task(self, task_id: str) -> list[str]:
+        """Delete a task and all its descendants.
+
+        Cancels the asyncio task if running, removes the ticket
+        directory and all matching session logs.  Recurses into child
+        tasks (any task whose ``parent_task_id`` matches).
+
+        Marks the task ID in ``_deleted_tasks`` so that
+        ``_wrap_execution``'s finally block skips post-completion
+        cleanup for in-flight work that completes after deletion.
+
+        Returns a list of all deleted task IDs.
+        """
+        deleted: list[str] = []
+        self._delete_recursive(task_id, deleted)
+        return deleted
+
+    def _delete_recursive(self, task_id: str, deleted: list[str]) -> None:
+        """Recursively delete a task and its children."""
+        # Recurse into children first.
+        children = self.store.get_children(task_id)
+        for child in children:
+            self._delete_recursive(child.id, deleted)
+
+        # Cancel in-flight asyncio task.
+        if task_id in self._active_tasks:
+            self._active_tasks[task_id].cancel()
+
+        # Mark as deleted so _wrap_execution skips cleanup.
+        self._deleted_tasks.add(task_id)
+        self._running_tasks.discard(task_id)
+
+        # Remove ticket directory.
+        ticket_dir = self.store.tickets_dir / task_id
+        if ticket_dir.exists():
+            shutil.rmtree(ticket_dir)
+
+        # Remove matching session logs.
+        logs_dir = self.store.hive_dir / "logs"
+        if logs_dir.exists():
+            prefix = f"bees-{task_id[:8]}-"
+            for log_file in logs_dir.iterdir():
+                if log_file.name.startswith(prefix):
+                    log_file.unlink(missing_ok=True)
+
+        deleted.append(task_id)
+        logger.info("Deleted task %s", task_id[:8])
 
     def pause_all_tasks(self) -> int:
         """Pause all running, available, suspended, blocked, and paused tasks.
@@ -598,6 +649,14 @@ class Scheduler:
         finally:
             self._running_tasks.discard(task.id)
             self._active_tasks.pop(task.id, None)
+
+            # If the task was deleted while in-flight, skip all
+            # post-completion work — the ticket directory is gone,
+            # and we must not deliver ghost events or context updates.
+            if task.id in self._deleted_tasks:
+                self._deleted_tasks.discard(task.id)
+                return
+
             updated = self.store.get(task.id) or task
             run_task_done_hooks(updated)
             self._notify_task_done(task.id)

--- a/packages/bees/bees/task_node.py
+++ b/packages/bees/bees/task_node.py
@@ -179,3 +179,11 @@ class TaskNode:
         self.save()
         self._bees.trigger()
         return True
+
+    def delete(self) -> list[str]:
+        """Delete this task and all its descendants.
+
+        Cancels in-flight work, removes ticket directories and session
+        logs.  Returns a list of all deleted task IDs.
+        """
+        return self._bees.delete_task(self.id)

--- a/packages/bees/hivetool/src/data/mutation-client.ts
+++ b/packages/bees/hivetool/src/data/mutation-client.ts
@@ -174,6 +174,18 @@ class MutationClient {
     return this.#writeMutation({ type: "resume-task", task_id: taskId });
   }
 
+  /**
+   * Delete a task and all its descendants.
+   *
+   * Hot mutation: the box cancels in-flight work, removes ticket
+   * directories and session logs, and ensures that any LLM calls
+   * or tool invocations completing after deletion are silently
+   * discarded.
+   */
+  async deleteTask(taskId: string): Promise<string> {
+    return this.#writeMutation({ type: "delete-task", task_id: taskId });
+  }
+
   // -- internal -----------------------------------------------------------
 
   async #writeMutation(data: Record<string, unknown>): Promise<string> {

--- a/packages/bees/hivetool/src/data/ticket-store.ts
+++ b/packages/bees/hivetool/src/data/ticket-store.ts
@@ -125,7 +125,7 @@ class TicketStore {
     await this.#detectLiveSessions(entries);
   }
 
-  selectTicket(id: string): void {
+  selectTicket(id: string | null): void {
     this.selectedTicketId.set(id);
   }
 

--- a/packages/bees/hivetool/src/ui/ticket-pane.ts
+++ b/packages/bees/hivetool/src/ui/ticket-pane.ts
@@ -320,6 +320,18 @@ class BeesTicketPane extends SignalWatcher(LitElement) {
 
     const ACTIVE = new Set(["running", "available", "suspended", "blocked"]);
 
+    const deleteBtn = html`
+      <button
+        style="padding:3px 10px;font-size:0.65rem;font-weight:600;
+               background:transparent;color:#64748b;border:1px solid #334155;
+               border-radius:4px;cursor:pointer;font-family:inherit;
+               transition:all 0.15s"
+        @click=${() => this.handleDeleteTask(taskId)}
+      >
+        🗑 Delete
+      </button>
+    `;
+
     if (ACTIVE.has(status)) {
       return html`
         <button
@@ -331,6 +343,7 @@ class BeesTicketPane extends SignalWatcher(LitElement) {
         >
           ⏸ Pause
         </button>
+        ${deleteBtn}
       `;
     }
 
@@ -345,10 +358,11 @@ class BeesTicketPane extends SignalWatcher(LitElement) {
         >
           ▶ Resume
         </button>
+        ${deleteBtn}
       `;
     }
 
-    return nothing;
+    return deleteBtn;
   }
 
   private async handlePauseTask(taskId: string) {
@@ -366,6 +380,24 @@ class BeesTicketPane extends SignalWatcher(LitElement) {
       await this.mutationClient.resumeTask(taskId);
     } catch (e) {
       console.error("Failed to resume task:", e);
+    }
+  }
+
+  private async handleDeleteTask(taskId: string) {
+    if (!this.mutationClient) return;
+
+    const confirmed = confirm(
+      "Delete this task and all its children? This removes the task, " +
+      "its session logs, and all descendant tasks."
+    );
+    if (!confirmed) return;
+
+    try {
+      await this.mutationClient.deleteTask(taskId);
+      // Deselect the ticket — it no longer exists.
+      this.ticketStore?.selectTicket(null);
+    } catch (e) {
+      console.error("Failed to delete task:", e);
     }
   }
 


### PR DESCRIPTION
## What
Adds a `delete-task` hot mutation that removes a task and all its descendants — including ticket directories, session logs, and in-flight work — from the Hivetool UI.

## Why
Previously there was no way to clean up individual tasks. The only option was a full hive reset. This gives users surgical control over task lifecycle.

## Changes

### Backend (`bees/`)
- **scheduler.py**: `_deleted_tasks` marker set prevents ghost post-completion events when in-flight LLM calls or tools complete after a task is deleted. `delete_task()` cascades recursively through children, cancelling asyncio tasks, removing ticket dirs, and cleaning session logs.
- **bees.py / task_node.py**: Public `delete_task()` / `delete()` API surface.
- **mutations.py**: `delete-task` hot mutation handler. When a `Bees` instance is running, delegates to the scheduler for proper asyncio cancellation. Falls back to filesystem-only delete at startup.

### Frontend (`hivetool/`)
- **mutation-client.ts**: `deleteTask(taskId)` method.
- **ticket-pane.ts**: 🗑 Delete button on every task (with confirm dialog). Visible whenever the box is active, regardless of task status. Deselects the ticket after deletion.
- **ticket-store.ts**: Widened `selectTicket()` to accept `null`.

## Testing
- TypeScript: `npx tsc --noEmit` passes
- Python: 479 tests pass (`pytest tests/ -x -q`)
- Manual: start box + hivetool, create a task, click Delete, confirm the task and its logs are removed. Also tested deleting a running task — in-flight work completes silently without writing ghost events.
