### PR TITLE
[bees] Grouped Multi-Case Eval Switcher in Hivetool

### DIFF
--- a/packages/bees/hivetool/src/data/state-access.ts
+++ b/packages/bees/hivetool/src/data/state-access.ts
@@ -24,6 +24,8 @@ interface HiveEntry {
   readonly id: string;
   readonly name: string;
   readonly addedAt: number;
+  readonly isMultiHive?: boolean;
+  readonly cases?: Array<{ id: string; name: string }>;
 }
 
 const DB_NAME = "bees-hive-handles";
@@ -44,7 +46,12 @@ class StateAccess {
   /** ID of the currently active hive. */
   readonly activeHiveId = new Signal.State<string | null>(null);
 
+  readonly isMultiHive = new Signal.State<boolean>(false);
+  readonly cases = new Signal.State<Array<{ id: string; name: string }>>([]);
+  readonly activeCaseId = new Signal.State<string | null>(null);
+
   #handle: FileSystemDirectoryHandle | null = null;
+  #resultsRootHandle: FileSystemDirectoryHandle | null = null;
 
   /** The root `hive/` directory handle, available when access is "ready". */
   get handle(): FileSystemDirectoryHandle | null {
@@ -98,10 +105,7 @@ class StateAccess {
       const entry: HiveEntry = { id, name: handle.name, addedAt };
       this.hives.set([...this.hives.get(), entry]);
 
-      this.#handle = handle;
-      this.hiveName.set(handle.name);
-      this.activeHiveId.set(id);
-      this.accessState.set("ready");
+      await this.#activate(entry);
       return true;
     } catch {
       // User cancelled the picker.
@@ -142,12 +146,12 @@ class StateAccess {
     const handle = await this.#loadHandle(activeId);
     if (!handle) return;
 
-    const granted = await this.#checkPermission(handle);
-    if (!granted) return;
-
-    this.#handle = handle;
-    this.hiveName.set(handle.name);
-    this.accessState.set("ready");
+    const entry = this.hives.get().find((h) => h.id === activeId) ?? {
+      id: activeId,
+      name: handle.name,
+      addedAt: Date.now()
+    };
+    await this.#activate(entry);
   }
 
   /** Resolve a subdirectory from the hive handle. */
@@ -182,9 +186,100 @@ class StateAccess {
       return;
     }
 
-    this.#handle = handle;
     this.hiveName.set(entry.name);
+    await this._detectAndLoadCases(handle);
     this.accessState.set("ready");
+  }
+
+  async _detectAndLoadCases(handle: FileSystemDirectoryHandle): Promise<void> {
+    let isSingleHive = false;
+    try {
+      const configHandle = await handle.getDirectoryHandle("config");
+      await configHandle.getFileHandle("SYSTEM.yaml");
+      isSingleHive = true;
+    } catch {
+      // Not a single hive.
+    }
+
+    if (isSingleHive) {
+      this.isMultiHive.set(false);
+      this.cases.set([]);
+      this.activeCaseId.set(null);
+      this.#resultsRootHandle = null;
+      this.#handle = handle;
+    } else {
+      this.isMultiHive.set(true);
+      this.#resultsRootHandle = handle;
+
+      const discovered = await this._discoverHives(handle);
+      this.cases.set(discovered);
+
+      if (discovered.length > 0) {
+        await this.switchToCase(discovered[0].id);
+      } else {
+        this.#handle = null;
+        this.activeCaseId.set(null);
+      }
+    }
+  }
+
+  async _discoverHives(
+    dirHandle: FileSystemDirectoryHandle,
+    relativeParts: string[] = []
+  ): Promise<Array<{ id: string; name: string }>> {
+    const found: Array<{ id: string; name: string }> = [];
+
+    let isHive = false;
+    try {
+      const configHandle = await dirHandle.getDirectoryHandle("config");
+      await configHandle.getFileHandle("SYSTEM.yaml");
+      isHive = true;
+    } catch {
+      // Not a hive.
+    }
+
+    if (isHive) {
+      const pathStr = relativeParts.join("/");
+      found.push({
+        id: pathStr || dirHandle.name,
+        name: pathStr || dirHandle.name,
+      });
+      return found;
+    }
+
+    if (relativeParts.length >= 3) {
+      return found;
+    }
+
+    try {
+      for await (const [name, handle] of dirHandle.entries()) {
+        if (handle.kind === "directory") {
+          if (name.startsWith(".") || name === "node_modules" || name === "dist") continue;
+          const childCases = await this._discoverHives(handle as FileSystemDirectoryHandle, [...relativeParts, name]);
+          found.push(...childCases);
+        }
+      }
+    } catch (e) {
+      console.error("Failed to read directory entries:", e);
+    }
+
+    return found;
+  }
+
+  async switchToCase(caseId: string): Promise<void> {
+    if (!this.#resultsRootHandle) return;
+    try {
+      const parts = caseId.split("/");
+      let current = this.#resultsRootHandle;
+      for (const part of parts) {
+        if (!part) continue;
+        current = await current.getDirectoryHandle(part);
+      }
+      this.#handle = current;
+      this.activeCaseId.set(caseId);
+    } catch (e) {
+      console.error(`Failed to switch to case ${caseId}:`, e);
+    }
   }
 
   // ── Legacy migration ──

--- a/packages/bees/hivetool/src/ui/app.ts
+++ b/packages/bees/hivetool/src/ui/app.ts
@@ -204,6 +204,23 @@ class BeesApp extends SignalWatcher(LitElement) {
       background: #1e293b;
     }
 
+    .hive-picker-popover .picker-item.sub-item {
+      padding-left: 24px;
+      font-size: 0.7rem;
+      color: #94a3b8;
+      border-left: 2px solid #334155;
+    }
+
+    .hive-picker-popover .picker-item.sub-item:hover {
+      background: #252a34;
+    }
+
+    .hive-picker-popover .picker-item.sub-item.active {
+      color: #3b82f6;
+      border-left-color: #3b82f6;
+      background: #1e293b;
+    }
+
     .hive-picker-popover .picker-item .indicator {
       width: 6px;
       height: 6px;
@@ -478,6 +495,20 @@ class BeesApp extends SignalWatcher(LitElement) {
     }
     this.resetStores();
     await this.stateAccess.switchToHive(id);
+    if (this.stateAccess.accessState.get() === "ready") {
+      await this.activateStores();
+      this.restoreRoute();
+    }
+    this.hivePickerOpen = false;
+  }
+
+  private async handleSwitchToCase(id: string): Promise<void> {
+    if (id === this.stateAccess.activeCaseId.get()) {
+      this.hivePickerOpen = false;
+      return;
+    }
+    this.resetStores();
+    await this.stateAccess.switchToCase(id);
     if (this.stateAccess.accessState.get() === "ready") {
       await this.activateStores();
       this.restoreRoute();
@@ -981,15 +1012,23 @@ class BeesApp extends SignalWatcher(LitElement) {
           ? html`
               <div class="picker-header">Hives</div>
               <div class="picker-list">
-                ${hives.map(
-                  (h) => html`
+                ${hives.map((h) => {
+                  const isActive = h.id === activeId;
+                  const isMulti = isActive && this.stateAccess.isMultiHive.get();
+                  const subCases = isMulti ? this.stateAccess.cases.get() : [];
+                  const activeCaseId = isMulti ? this.stateAccess.activeCaseId.get() : null;
+
+                  return html`
                     <div
-                      class="picker-item ${h.id === activeId
-                        ? "active"
-                        : ""}"
-                      @click=${() => this.handleSwitchToHive(h.id)}
+                      class="picker-item ${isActive && !isMulti ? 'active' : ''}"
+                      style="${isMulti ? 'font-weight: bold; cursor: default; background: transparent;' : ''}"
+                      @click=${() => {
+                        if (!isMulti) {
+                          this.handleSwitchToHive(h.id);
+                        }
+                      }}
                     >
-                      <span class="indicator"></span>
+                      <span class="indicator" style="${isMulti ? 'background: #64748b;' : ''}"></span>
                       <span class="item-name">${h.name}</span>
                       <button
                         class="remove-btn"
@@ -1002,8 +1041,18 @@ class BeesApp extends SignalWatcher(LitElement) {
                         ✕
                       </button>
                     </div>
-                  `,
-                )}
+                    ${subCases.map(
+                      (c) => html`
+                        <div
+                          class="picker-item sub-item ${c.id === activeCaseId ? 'active' : ''}"
+                          @click=${() => this.handleSwitchToCase(c.id)}
+                        >
+                          <span class="item-name">${c.name}</span>
+                        </div>
+                      `
+                    )}
+                  `;
+                })}
               </div>
               <div class="picker-divider"></div>
             `

--- a/packages/bees/hivetool/tests/state-access.test.ts
+++ b/packages/bees/hivetool/tests/state-access.test.ts
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { StateAccess } from "../src/data/state-access.js";
+
+// Mock FileSystemDirectoryHandle for testing discovery.
+function createMockDirectory(
+  name: string,
+  children: Record<string, unknown> = {}
+): unknown {
+  return {
+    name,
+    kind: "directory",
+    getDirectoryHandle: async (subName: string) => {
+      const child = children[subName] as { kind: string } | undefined;
+      if (child && child.kind === "directory") return child;
+      throw new Error(`Directory ${subName} not found`);
+    },
+    getFileHandle: async (fileName: string) => {
+      const child = children[fileName] as { kind: string } | undefined;
+      if (child && child.kind === "file") return child;
+      throw new Error(`File ${fileName} not found`);
+    },
+    entries: async function* () {
+      for (const [key, value] of Object.entries(children)) {
+        yield [key, value];
+      }
+    }
+  };
+}
+
+function createMockFile(name: string): unknown {
+  return {
+    name,
+    kind: "file"
+  };
+}
+
+describe("StateAccess - Directory Detection & Case Discovery", () => {
+  it("detects a standalone Single-Hive directory", async () => {
+    const access = new StateAccess();
+
+    // Create a standalone hive: has config/SYSTEM.yaml at root.
+    const configDir = createMockDirectory("config", {
+      "SYSTEM.yaml": createMockFile("SYSTEM.yaml")
+    });
+    const rootHandle = createMockDirectory("my-standalone-hive", {
+      config: configDir
+    });
+
+    // Call internal detection helper directly.
+    await access._detectAndLoadCases(rootHandle as FileSystemDirectoryHandle);
+
+    assert.equal(access.isMultiHive.get(), false);
+    assert.deepEqual(access.cases.get(), []);
+    assert.equal(access.activeCaseId.get(), null);
+    assert.equal(access.handle, rootHandle as FileSystemDirectoryHandle);
+  });
+
+  it("detects a Multi-Hive parent and programmatically discovers nested sub-hives", async () => {
+    const access = new StateAccess();
+
+    // Create case-1/hive with config/SYSTEM.yaml.
+    const case1Config = createMockDirectory("config", {
+      "SYSTEM.yaml": createMockFile("SYSTEM.yaml")
+    });
+    const case1Hive = createMockDirectory("hive", {
+      config: case1Config
+    });
+    const case1 = createMockDirectory("case-1", {
+      hive: case1Hive
+    });
+
+    // Create case-2/hive with config/SYSTEM.yaml.
+    const case2Config = createMockDirectory("config", {
+      "SYSTEM.yaml": createMockFile("SYSTEM.yaml")
+    });
+    const case2Hive = createMockDirectory("hive", {
+      config: case2Config
+    });
+    const case2 = createMockDirectory("case-2", {
+      hive: case2Hive
+    });
+
+    // Root results directory containing both cases.
+    const resultsDir = createMockDirectory("results", {
+      "case-1": case1,
+      "case-2": case2
+    });
+
+    // Run detection.
+    await access._detectAndLoadCases(resultsDir as FileSystemDirectoryHandle);
+
+    assert.equal(access.isMultiHive.get(), true);
+    
+    const cases = access.cases.get();
+    assert.equal(cases.length, 2);
+    assert.equal(cases[0].id, "case-1/hive");
+    assert.equal(cases[1].id, "case-2/hive");
+
+    // Should auto-select the first discovered case.
+    assert.equal(access.activeCaseId.get(), "case-1/hive");
+    assert.equal(access.handle, case1Hive as FileSystemDirectoryHandle);
+
+    // Switch to case-2 programmatically.
+    await access.switchToCase("case-2/hive");
+    assert.equal(access.activeCaseId.get(), "case-2/hive");
+    assert.equal(access.handle, case2Hive as FileSystemDirectoryHandle);
+  });
+});


### PR DESCRIPTION
## What
Enabled seamless, zero-prompt switching between multiple evaluation cases within a batch run. The existing remembered hives dropdown picker in Hivetool was refactored to display nested cases indented under a single Group Header representing the parent results directory.

## Why
Exploring multiple cases from a batch evaluation was previously highly clunky, requiring users to open the OS directory picker and click through browser permission popups for every single case. By utilizing transitive browser permissions granted to the parent results directory, Hivetool can now programmatically resolve sub-case directory handles and switch between them instantly.

## Changes

### State Access Refactoring (`packages/bees/hivetool/src/data/state-access.ts`)
* Added `isMultiHive`, `cases`, and `activeCaseId` reactive signals to `StateAccess`.
* Implemented directory detection (`_detectAndLoadCases`) and recursive child hive discovery (`_discoverHives`).
* Added programmatic case switching (`switchToCase`) under the authorized parent directory handle.
* Fixed a reactivity bug by consolidating all directory activation pathways (picks, re-authorizations) through `#activate()`, ensuring sub-cases populate immediately without requiring a page refresh.

### UI Integration (`packages/bees/hivetool/src/ui/app.ts`)
* Added `.sub-item` styles in `BeesApp.styles` to cleanly render indented cases.
* Refactored `renderHivePicker()` to display multi-hive parents as Group Headers and nested cases as indented sub-items.
* Wired Group Header `✕` remove button to cleanly delete the entire parent handle and its nested group in one action.
* Connected sub-case selection to reactively trigger `resetStores()`, `switchToCase()`, and `activateStores()`.

### Unit Tests (`packages/bees/hivetool/tests/state-access.test.ts`)
* Added comprehensive unit tests mocking directory structures to verify standalone Single-Hive detection, Multi-Hive parent detection, case discovery, and programmatic case switching.

## Testing
* All 23 Hivetool unit tests are compiling and passing successfully with `npm run test` (0 failures).
* Manually verified that selecting a results directory in Hivetool immediately populates the case list in the picker dropdown, allowing instant case navigation.
