### PR TITLE
[bees] Session Clean Up & Authoritative Store Logging

### DIFF
--- a/PROJECT_REWIND.md
+++ b/PROJECT_REWIND.md
@@ -511,7 +511,7 @@ and inspectable in hivetool.
 
 ---
 
-## Phase 5 — Session Clean Up
+## Phase 5 — Session Clean Up ✅
 
 ### 🎯 Objective
 
@@ -519,10 +519,10 @@ Eliminate the session dual-identity by making the persistent session store (`tic
 
 ### Changes
 
-- [ ] **LogStore scanning refactor**: Scan the `tickets/` task subdirectories instead of the legacy `logs/` leftover directory. Load each task's metadata and all its session UUID subdirectories.
-- [ ] **Sidebar task-grouped rendering**: Renders task headers (task title + status badge) with nested, clickable session cards in `log-list.ts`.
-- [ ] **Prune leftover logs**: Drop the deprecated `logs/` folder and its `.log.json` parsing code entirely from Hivetool's data store and observer path.
-- [ ] **Unify routing & selection highlights**:
+- [x] **LogStore scanning refactor**: Scan the `tickets/` task subdirectories instead of the legacy `logs/` leftover directory. Load each task's metadata and all its session UUID subdirectories.
+- [x] **Sidebar task-grouped rendering**: Renders task headers (task title + status badge) with nested, clickable session cards in `log-list.ts`.
+- [x] **Prune leftover logs**: Drop the deprecated `logs/` folder and its `.log.json` parsing code entirely from Hivetool's data store and observer path.
+- [x] **Unify routing & selection highlights**:
   - Update the `"session"` chip in task details ([ticket-pane.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/bees/hivetool/src/ui/ticket-pane.ts)) to display and route using the **actual active session UUID** instead of the `ticket.id`.
   - Highlight the parent task card correctly in the Sessions sidebar when inspecting any of its session UUIDs or superseded ancestor lineages.
 

--- a/packages/bees/hivetool/src/data/log-store.ts
+++ b/packages/bees/hivetool/src/data/log-store.ts
@@ -5,241 +5,183 @@
  */
 
 /**
- * Signal-backed reactive store for log files.
+ * Signal-backed reactive store for session files grouped by parent tasks.
  *
- * Resolves the `hive/logs/` subdirectory via a shared StateAccess,
+ * Resolves the `hive/tickets/` subdirectory via a shared StateAccess,
  * uses FileSystemObserver for live updates, and manages session grouping.
  */
 
 import { Signal } from "signal-polyfill";
 import type { StateAccess } from "./state-access.js";
 import type {
-  LogRunEntry,
-  LogFileInfo,
-  LogSession,
-  MergedSessionView,
-  SessionSegment,
-  TurnGroup,
+  TaskGroupedSessions,
+  SidebarSessionInfo,
 } from "./types.js";
 
 export { LogStore };
 
+interface LineageJson {
+  forked_from?: { session: string; at_turn: number };
+  forked_to?: { session: string; at_turn: number };
+}
+
 class LogStore {
   constructor(private access: StateAccess) {}
 
-  // ── Public reactive state (read via .get() in SignalWatcher renders) ──
+  // ── Public reactive state (read via .get() in render methods) ──
 
-  readonly sessions = new Signal.State<LogSession[]>([]);
+  readonly taskGroups = new Signal.State<TaskGroupedSessions[]>([]);
   readonly selectedSessionId = new Signal.State<string | null>(null);
-  readonly selectedView = new Signal.State<MergedSessionView | null>(null);
   readonly recentlyUpdatedSession = new Signal.State<{ id: string; at: number } | null>(null);
+
+  /** Resolved active task for the currently selected session. */
+  readonly selectedTaskId = new Signal.Computed(() => {
+    const selectedSid = this.selectedSessionId.get();
+    if (!selectedSid) return null;
+    for (const group of this.taskGroups.get()) {
+      if (group.taskId === selectedSid) return group.taskId; // selected by ticket ID fallback
+      if (group.sessions.some((s) => s.sessionId === selectedSid)) {
+        return group.taskId;
+      }
+    }
+    return null;
+  });
 
   // ── Private ──
 
-  /** The ``hive/logs/`` subdirectory. */
-  #logsHandle: FileSystemDirectoryHandle | null = null;
+  #ticketsHandle: FileSystemDirectoryHandle | null = null;
   #observer: { disconnect(): void } | null = null;
-  #cache = new Map<string, { data: LogRunEntry; lastModified: number }>();
   #activated = false;
-
 
   // ── Lifecycle ──
 
-  /** Activate the store — resolves logs/ subdir, scans, observes. */
+  /** Activate the store — resolves tickets/ subdir, scans, observes. */
   async activate(): Promise<void> {
     if (this.#activated) return;
     if (this.access.accessState.get() !== "ready") return;
 
-    const logsHandle = await this.access.getSubdirectory("logs");
-    if (!logsHandle) {
-      console.warn("Could not find logs/ subdirectory in hive/");
+    const ticketsHandle = await this.access.getSubdirectory("tickets");
+    if (!ticketsHandle) {
+      console.warn("Could not find tickets/ subdirectory in hive/");
       return;
     }
 
-    this.#logsHandle = logsHandle;
+    this.#ticketsHandle = ticketsHandle;
     this.#activated = true;
     await this.scan();
     this.#startObserver();
   }
 
-  /** Scan the logs subdirectory and rebuild sessions. */
+  /** Scan the tickets subdirectory, load tasks metadata and their sessions. */
   async scan(): Promise<void> {
-    if (!this.#logsHandle) return;
+    if (!this.#ticketsHandle) return;
 
-    const filenames: string[] = [];
-    for await (const [name, entry] of (
-      this.#logsHandle as FileSystemDirectoryHandle & {
-        entries(): AsyncIterable<[string, FileSystemHandle]>;
-      }
-    ).entries()) {
-      if (entry.kind === "file" && name.endsWith(".log.json")) {
-        filenames.push(name);
-      }
-    }
+    const groups: TaskGroupedSessions[] = [];
 
-    let cacheUpdated = false;
+    try {
+      for await (const [name, entry] of (
+        this.#ticketsHandle as FileSystemDirectoryHandle & {
+          entries(): AsyncIterable<[string, FileSystemHandle]>;
+        }
+      ).entries()) {
+        if (entry.kind !== "directory") continue;
 
-    for (const filename of filenames) {
-      const fileHandle = await this.#logsHandle.getFileHandle(filename);
-      const file = await fileHandle.getFile();
-      const cached = this.#cache.get(filename);
+        const ticketDir = await this.#ticketsHandle.getDirectoryHandle(name);
+        const metadata = await this.#readJson(ticketDir, "metadata.json") as Record<string, unknown> | null;
+        if (!metadata) continue;
+        if (metadata.kind === "coordination") continue;
 
-      if (!cached || cached.lastModified < file.lastModified) {
-        const data = await this.#readFile(filename);
-        if (!data) continue;
-        const runEntry = (data as Array<Record<string, unknown>>).find(
-          (e) => e.type === "run"
-        ) as LogRunEntry | undefined;
-        if (runEntry) {
-          this.#cache.set(filename, { data: runEntry, lastModified: file.lastModified });
-          cacheUpdated = true;
-          if (this.#observer) {
-            this.recentlyUpdatedSession.set({ id: runEntry.sessionId, at: Date.now() });
+        const title = (metadata.title as string) || `Task ${name.slice(0, 8)}`;
+        const status = (metadata.status as string) || "unknown";
+        const activeSessionId = (metadata.active_session as string) || null;
+
+        const sessions: SidebarSessionInfo[] = [];
+        try {
+          const sessionsDir = await ticketDir.getDirectoryHandle("sessions");
+          for await (const [sName, sEntry] of (
+            sessionsDir as FileSystemDirectoryHandle & {
+              entries(): AsyncIterable<[string, FileSystemHandle]>;
+            }
+          ).entries()) {
+            if (sEntry.kind !== "directory") continue;
+
+            const sessionDir = await sessionsDir.getDirectoryHandle(sName);
+            const sStatus = (await this.#readText(sessionDir, "status"))?.trim() ?? "unknown";
+            const lineage = await this.#readJson(sessionDir, "lineage.json") as LineageJson | null;
+
+            let eventCount = 0;
+            let lastModified = 0;
+
+            try {
+              const eventsHandle = await sessionDir.getFileHandle("events.jsonl");
+              const eventsFile = await eventsHandle.getFile();
+              lastModified = eventsFile.lastModified;
+              const eventsText = await eventsFile.text();
+              if (eventsText) {
+                eventCount = eventsText.split("\n").filter(Boolean).length;
+              }
+            } catch {
+              try {
+                const statusHandle = await sessionDir.getFileHandle("status");
+                const statusFile = await statusHandle.getFile();
+                lastModified = statusFile.lastModified;
+              } catch {
+                // Ignore missing status file
+              }
+            }
+
+            sessions.push({
+              sessionId: sName,
+              status: sStatus,
+              eventCount,
+              lastModified,
+              isForked: !!lineage?.forked_from,
+              forkedFrom: lineage?.forked_from,
+              forkedTo: lineage?.forked_to,
+            });
           }
+        } catch {
+          // No sessions directory yet
         }
-      }
-    }
 
-    // Prune deleted files.
-    for (const key of this.#cache.keys()) {
-      if (!filenames.includes(key)) {
-        this.#cache.delete(key);
-        cacheUpdated = true;
-      }
-    }
+        // Sort sessions by lastModified descending (most recently updated first)
+        sessions.sort((a, b) => b.lastModified - a.lastModified);
 
-    if (cacheUpdated) {
-      this.#rebuildSessions();
-      const selectedId = this.selectedSessionId.get();
-      if (selectedId) {
-        this.selectedView.set(this.#computeMergedView(selectedId));
-      }
-    }
-  }
-
-
-  /** Select a session — computes the merged timeline view. */
-  selectSession(sessionId: string): void {
-    this.selectedSessionId.set(sessionId);
-    this.selectedView.set(this.#computeMergedView(sessionId));
-  }
-
-  #computeMergedView(sessionId: string): MergedSessionView | null {
-    // Gather all cached entries for this session.
-    const entries: { filename: string; data: LogRunEntry }[] = [];
-    for (const [filename, entry] of this.#cache) {
-      if (entry.data.sessionId === sessionId) {
-        entries.push({ filename, data: entry.data });
-      }
-    }
-
-    if (entries.length === 0) return null;
-
-    // Sort oldest-first.
-    entries.sort((a, b) =>
-      a.data.startedDateTime.localeCompare(b.data.startedDateTime)
-    );
-
-    const segments: SessionSegment[] = [];
-
-    for (let i = 0; i < entries.length; i++) {
-      const { filename, data } = entries[i];
-      const ctx = data.context;
-      const turns = data.turns;
-
-      // Build per-turn groups from the structured turn boundaries.
-      // Function response entries are input to the turn whose sendRequest
-      // carries them, so scan backward to pull them into the right group.
-      const turnGroups: TurnGroup[] = [];
-
-      // First pass: compute adjusted starts.
-      const starts: number[] = [];
-      for (let t = 0; t < turns.length; t++) {
-        let start = turns[t].contextLengthAtStart;
-        // Pull in preceding function response entries.
-        while (start > 0) {
-          const prev = ctx[start - 1];
-          if (
-            prev?.role === "user" &&
-            prev.parts?.some((p) => "functionResponse" in p)
-          ) {
-            start--;
-          } else {
-            break;
-          }
-        }
-        // For the first turn, include the user prompt if the scan
-        // didn't already pull in a function response.
-        if (
-          t === 0 &&
-          start === turns[t].contextLengthAtStart &&
-          start > 0
-        ) {
-          start--;
-        }
-        starts.push(start);
-      }
-
-      // Second pass: build groups using adjusted starts.
-      for (let t = 0; t < turns.length; t++) {
-        const start = starts[t];
-        const end =
-          t < turns.length - 1 ? starts[t + 1] : ctx.length;
-        turnGroups.push({
-          turnIndex: t,
-          entries: ctx.slice(start, end),
-          tokenMetadata: turns[t].tokenMetadata,
+        groups.push({
+          taskId: name,
+          title,
+          status,
+          activeSessionId,
+          sessions,
         });
       }
-
-      segments.push({
-        filename,
-        segmentIndex: i,
-        startedDateTime: data.startedDateTime,
-        totalDurationMs: data.totalDurationMs,
-        turnCount: data.turnCount,
-        turnGroups,
-        totalThoughts: data.totalThoughts,
-        totalFunctionCalls: data.totalFunctionCalls,
-        totalTokens: data.tokenMetadata?.totalTokens ?? 0,
-        config: data.config,
-        tokenMetadata: data.tokenMetadata,
-      });
+    } catch (e) {
+      console.error("Failed to scan tickets/ sessions:", e);
     }
 
-    return {
-      sessionId,
-      segments,
-      totalDurationMs: entries.reduce(
-        (s, e) => s + e.data.totalDurationMs,
-        0
-      ),
-      totalTurns: entries.reduce((s, e) => s + e.data.turnCount, 0),
-      totalThoughts: entries.reduce(
-        (s, e) => s + e.data.totalThoughts,
-        0
-      ),
-      totalFunctionCalls: entries.reduce(
-        (s, e) => s + e.data.totalFunctionCalls,
-        0
-      ),
-      totalTokens: entries.reduce(
-        (s, e) => s + (e.data.tokenMetadata?.totalTokens ?? 0),
-        0
-      ),
-    };
+    // Sort taskGroups by their most recently updated session's lastModified, descending
+    groups.sort((a, b) => {
+      const aMax = a.sessions.length > 0 ? Math.max(...a.sessions.map((s) => s.lastModified)) : 0;
+      const bMax = b.sessions.length > 0 ? Math.max(...b.sessions.map((s) => s.lastModified)) : 0;
+      return bMax - aMax;
+    });
+
+    this.taskGroups.set(groups);
+  }
+
+  /** Select a session ID. */
+  selectSession(sessionId: string): void {
+    this.selectedSessionId.set(sessionId);
   }
 
   /** Tear down all state so the store can be re-activated against a new hive. */
   reset(): void {
     this.#observer?.disconnect();
     this.#observer = null;
-    this.#logsHandle = null;
-    this.#cache.clear();
+    this.#ticketsHandle = null;
     this.#activated = false;
-    this.sessions.set([]);
+    this.taskGroups.set([]);
     this.selectedSessionId.set(null);
-    this.selectedView.set(null);
     this.recentlyUpdatedSession.set(null);
   }
 
@@ -251,44 +193,12 @@ class LogStore {
 
   // ── Private helpers ──
 
-  #rebuildSessions(): void {
-    const sessionMap = new Map<string, LogFileInfo[]>();
-    for (const [filename, entry] of this.#cache) {
-      const sid = entry.data.sessionId || "unknown";
-      if (!sessionMap.has(sid)) sessionMap.set(sid, []);
-      sessionMap.get(sid)!.push({
-        filename,
-        sessionId: sid,
-        startedDateTime: entry.data.startedDateTime,
-        totalDurationMs: entry.data.totalDurationMs,
-        turnCount: entry.data.turnCount,
-        totalThoughts: entry.data.totalThoughts,
-        totalFunctionCalls: entry.data.totalFunctionCalls,
-        totalTokens: entry.data.tokenMetadata?.totalTokens ?? 0,
-      });
-    }
-
-
-    const sessions = Array.from(sessionMap.entries())
-      .map(([sessionId, files]) => ({
-        sessionId,
-        files: files.sort((a, b) =>
-          b.startedDateTime.localeCompare(a.startedDateTime)
-        ),
-      }))
-      .sort((a, b) => {
-        const aLatest = a.files.at(-1)?.startedDateTime ?? "";
-        const bLatest = b.files.at(-1)?.startedDateTime ?? "";
-        return bLatest.localeCompare(aLatest);
-      });
-
-    this.sessions.set(sessions);
-  }
-
-  async #readFile(filename: string): Promise<unknown[] | null> {
-    if (!this.#logsHandle) return null;
+  async #readJson(
+    dir: FileSystemDirectoryHandle,
+    filename: string
+  ): Promise<unknown | null> {
     try {
-      const fileHandle = await this.#logsHandle.getFileHandle(filename);
+      const fileHandle = await dir.getFileHandle(filename);
       const file = await fileHandle.getFile();
       const text = await file.text();
       return JSON.parse(text);
@@ -297,17 +207,51 @@ class LogStore {
     }
   }
 
+  async #readText(
+    dir: FileSystemDirectoryHandle,
+    filename: string
+  ): Promise<string | null> {
+    try {
+      const fileHandle = await dir.getFileHandle(filename);
+      const file = await fileHandle.getFile();
+      return await file.text();
+    } catch {
+      return null;
+    }
+  }
+
   #startObserver(): void {
-    if (!this.#logsHandle) return;
+    if (!this.#ticketsHandle) return;
     if (!("FileSystemObserver" in globalThis)) return;
     try {
-      // FileSystemObserver is experimental — access via dynamic typing.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const Ctor = (globalThis as any).FileSystemObserver;
       const observer = new Ctor((records: unknown[]) => {
-        if (records.length > 0) this.scan();
+        if (records.length > 0) {
+          this.scan();
+          
+          // Fire recentlyUpdatedSession animation trigger if we can resolve a sessionId
+          interface FileSystemChangeRecord {
+            relativePathComponents?: string[];
+            relativePath?: string;
+          }
+          for (const record of records) {
+            const r = record as FileSystemChangeRecord;
+            let segments: string[] = [];
+            if (Array.isArray(r.relativePathComponents)) {
+              segments = r.relativePathComponents;
+            } else if (typeof r.relativePath === "string") {
+              segments = r.relativePath.split("/").filter(Boolean);
+            }
+            // [ticketId, "sessions", sessionId, ...]
+            if (segments.length >= 3 && segments[1] === "sessions") {
+              this.recentlyUpdatedSession.set({ id: segments[2], at: Date.now() });
+              break;
+            }
+          }
+        }
       });
-      observer.observe(this.#logsHandle, { recursive: false });
+      observer.observe(this.#ticketsHandle, { recursive: true });
       this.#observer = observer;
     } catch (e) {
       console.warn("FileSystemObserver not available:", e);

--- a/packages/bees/hivetool/src/data/session-store-reader.ts
+++ b/packages/bees/hivetool/src/data/session-store-reader.ts
@@ -37,6 +37,11 @@ function compileEventsToSegment(sessionId: string, events: Record<string, unknow
   let totalFunctionCalls = 0;
   let totalTokens = 0;
   
+  let totalPromptTokens = 0;
+  let totalCandidatesTokens = 0;
+  let totalThoughtsTokens = 0;
+  let totalCachedTokens = 0;
+  
   let systemInstruction: LogConfig["systemInstruction"] = undefined;
   let tools: LogConfig["tools"] = [];
   const turnGroups: TurnGroup[] = [];
@@ -110,7 +115,12 @@ function compileEventsToSegment(sessionId: string, events: Record<string, unknow
         const usageMetadata = event.usageMetadata as Record<string, unknown> || {};
         const metadata = usageMetadata.metadata as Record<string, unknown> || {};
         currentTurnGroup.tokenMetadata = metadata as unknown as LogTurnTokenMetadata;
-        totalTokens += metadata.totalTokenCount as number || 0;
+        
+        totalPromptTokens += (metadata.promptTokenCount as number) || 0;
+        totalCandidatesTokens += (metadata.candidatesTokenCount as number) || 0;
+        totalThoughtsTokens += (metadata.thoughtsTokenCount as number) || 0;
+        totalCachedTokens += (metadata.cachedContentTokenCount as number) || 0;
+        totalTokens += (metadata.totalTokenCount as number) || 0;
       }
     }
   }
@@ -130,10 +140,10 @@ function compileEventsToSegment(sessionId: string, events: Record<string, unknow
       tools
     },
     tokenMetadata: {
-      totalPromptTokens: 0,
-      totalCandidatesTokens: 0,
-      totalThoughtsTokens: 0,
-      totalCachedTokens: 0,
+      totalPromptTokens,
+      totalCandidatesTokens,
+      totalThoughtsTokens,
+      totalCachedTokens,
       totalTokens
     }
   };

--- a/packages/bees/hivetool/src/data/types.ts
+++ b/packages/bees/hivetool/src/data/types.ts
@@ -90,22 +90,22 @@ export interface LogPart {
   thoughtSignature?: string;
 }
 
-/** Summary info extracted from a log file (for sidebar display). */
-export interface LogFileInfo {
-  filename: string;
+export interface SidebarSessionInfo {
   sessionId: string;
-  startedDateTime: string;
-  totalDurationMs: number;
-  turnCount: number;
-  totalThoughts: number;
-  totalFunctionCalls: number;
-  totalTokens: number;
+  status: string;
+  eventCount: number;
+  lastModified: number;
+  isForked: boolean;
+  forkedFrom?: { session: string; at_turn: number };
+  forkedTo?: { session: string; at_turn: number };
 }
 
-/** A group of log files sharing the same session/ticket ID. */
-export interface LogSession {
-  sessionId: string;
-  files: LogFileInfo[];
+export interface TaskGroupedSessions {
+  taskId: string;
+  title: string;
+  status: string;
+  activeSessionId: string | null;
+  sessions: SidebarSessionInfo[];
 }
 
 /** A single API turn within a segment — its conversation entries + token data. */

--- a/packages/bees/hivetool/src/ui/app.ts
+++ b/packages/bees/hivetool/src/ui/app.ts
@@ -973,7 +973,6 @@ class BeesApp extends SignalWatcher(LitElement) {
         ></bees-event-detail>`;
       case "logs":
         return html`<bees-log-detail
-          .data=${this.logStore.selectedView.get()}
           .stateAccess=${this.stateAccess}
           .ticketStore=${this.ticketStore}
           .mutationClient=${this.mutationClient}

--- a/packages/bees/hivetool/src/ui/log-detail.styles.ts
+++ b/packages/bees/hivetool/src/ui/log-detail.styles.ts
@@ -574,6 +574,44 @@ const logDetailBaseStyles = css`
     font-family: "Google Mono", "Roboto Mono", monospace;
     font-weight: 600;
   }
+
+  /* ── Interaction Snapshot Block ── */
+  .interaction-block {
+    background: #13161c;
+    border: 1px solid #1e293b;
+    border-radius: 8px;
+    overflow: hidden;
+    font-size: 0.8rem;
+    max-width: 960px;
+    margin: 16px auto;
+    width: calc(100% - 64px);
+    flex-shrink: 0;
+  }
+
+  .interaction-block-header {
+    padding: 8px 16px;
+    background: #191d24;
+    border-bottom: 1px solid #1e293b;
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #38bdf8;
+  }
+
+  .interaction-block-content {
+    display: flex;
+    gap: 24px;
+    padding: 12px 16px;
+    color: #cbd5e1;
+  }
+
+  .interaction-block-content code {
+    background: #1e293b;
+    padding: 2px 6px;
+    border-radius: 4px;
+    color: #fbbf24;
+  }
 `;
 
 export const logDetailStyles = [logDetailBaseStyles, jsonTreeStyles];

--- a/packages/bees/hivetool/src/ui/log-detail.ts
+++ b/packages/bees/hivetool/src/ui/log-detail.ts
@@ -194,12 +194,12 @@ class BeesLogDetail extends SignalWatcher(LitElement) {
     const s = this.interactionSummary;
     if (!s) return nothing;
     return html`
-      <div class="block" style="margin: 12px 32px; background: #111b2744; border-color: #1e3a8a">
-        <div class="block-header" style="background: #102a45; color: #60a5fa; border-bottom-color: #1e3a8a">Active Interaction Snapshot</div>
-        <div class="block-content" style="display: flex; gap: 24px; padding: 12px 16px; color: #cbd5e1">
-          <div><strong>Conversation Size:</strong> ${s.contextCount} entries</div>
-          <div><strong>Workspace Size:</strong> ${s.fsSize} files</div>
-          ${s.pendingCall ? html`<div><strong>Suspended On:</strong> <code class="mono" style="color:#fbbf24">${s.pendingCall}</code></div>` : nothing}
+      <div class="interaction-block">
+        <div class="interaction-block-header">Active Interaction Snapshot</div>
+        <div class="interaction-block-content">
+          <div><strong>Conversation:</strong> ${s.contextCount} entries</div>
+          <div><strong>Workspace:</strong> ${s.fsSize} files</div>
+          ${s.pendingCall ? html`<div><strong>Suspended On:</strong> <code class="mono">${s.pendingCall}</code></div>` : nothing}
         </div>
       </div>
     `;
@@ -208,6 +208,7 @@ class BeesLogDetail extends SignalWatcher(LitElement) {
   private renderHeader(d: MergedSessionView) {
     const duration = (d.totalDurationMs / 1000).toFixed(1);
     const started = d.segments[0]?.startedDateTime;
+    const tId = this.ticketId || d.sessionId;
     return html`
       <div class="header">
         <div class="header-top">
@@ -217,10 +218,10 @@ class BeesLogDetail extends SignalWatcher(LitElement) {
           </h2>
           <span
             class="link-chip"
-            @click=${() => this.#dispatchNavigate("ticket", d.sessionId)}
+            @click=${() => this.#dispatchNavigate("ticket", tId)}
           >
             <span class="link-chip-label">task</span>
-            ${d.sessionId.slice(0, 8)}
+            ${tId.slice(0, 8)}
           </span>
           ${d.segments.length > 1
             ? html`<span class="segment-count"
@@ -494,8 +495,8 @@ class BeesLogDetail extends SignalWatcher(LitElement) {
           </button>
         ` : nothing}
         ${fileCount !== null ? html`
-          <span class="turn-header-fs" style="margin-left: 12px; font-size: 11px; color: #38bdf8; background: #0284c733; padding: 2px 6px; border-radius: 4px; display: inline-flex; align-items: center; gap: 4px; border: 1px solid #0284c744">
-            📂 ${fileCount} files
+          <span class="turn-header-fs" style="margin-left: 12px; font-size: 11px; color: #475569; display: inline-flex; align-items: center; gap: 4px">
+            📂 ${fileCount} file${fileCount !== 1 ? "s" : ""}
           </span>
         ` : nothing}
         <div class="turn-header-bar" style="margin-left: 12px">

--- a/packages/bees/hivetool/src/ui/log-list.ts
+++ b/packages/bees/hivetool/src/ui/log-list.ts
@@ -5,7 +5,7 @@
  */
 
 /**
- * Sidebar list of log sessions.
+ * Sidebar list of log sessions grouped by parent tasks.
  */
 
 import { SignalWatcher } from "@lit-labs/signals";
@@ -27,11 +27,139 @@ class BeesLogList extends SignalWatcher(LitElement) {
         display: flex;
         flex-direction: column;
         height: 100%;
+        overflow: hidden;
       }
 
-      .job-item-group {
+      .jobs-list {
+        flex: 1;
+        overflow-y: auto;
         display: flex;
         flex-direction: column;
+        gap: 16px;
+        padding: 12px 16px;
+      }
+
+      /* Task header container */
+      .task-group {
+        display: flex;
+        flex-direction: column;
+        transition: all 0.2s ease;
+      }
+
+      .task-group-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 6px 0;
+        background: transparent;
+        font-size: 0.7rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: #64748b;
+      }
+
+      .task-group.selected .task-group-header {
+        color: #94a3b8;
+      }
+
+      .task-title {
+        max-width: 220px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      /* Sessions nested list */
+      .task-sessions {
+        display: flex;
+        flex-direction: column;
+        padding: 2px 0;
+        gap: 4px;
+        margin-left: 12px;
+      }
+
+      /* Individual session card */
+      .session-card {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        padding: 8px 12px;
+        border-radius: 6px;
+        cursor: pointer;
+        background: transparent;
+        border: 1px solid transparent;
+        transition: all 0.15s ease;
+      }
+
+      .session-card:hover {
+        background: #13161c;
+      }
+
+      .session-card.selected {
+        background: #1e3a5f33;
+        border-color: #3b82f644;
+      }
+
+      .session-card-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+
+      .session-id {
+        font-family: "Google Mono", "Roboto Mono", monospace;
+        font-size: 0.75rem;
+        font-weight: 600;
+        color: #cbd5e1;
+      }
+
+      .session-card.selected .session-id {
+        color: #60a5fa;
+      }
+
+      .status-badge {
+        font-size: 0.6rem;
+        font-weight: 600;
+        padding: 1px 6px;
+        border-radius: 999px;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+
+      .status-badge.running {
+        background: #1d4ed822;
+        color: #60a5fa;
+        border: 1px solid #1d4ed866;
+      }
+
+      .status-badge.suspended {
+        background: #92400e22;
+        color: #fbbf24;
+        border: 1px solid #92400e66;
+      }
+
+      .status-badge.superseded {
+        background: #33415522;
+        color: #94a3b8;
+        border: 1px solid #33415566;
+      }
+
+      .session-meta {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        font-size: 0.65rem;
+        color: #64748b;
+      }
+
+      .fork-info {
+        font-style: italic;
+        color: #fbbf24;
+        max-width: 150px;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
     `,
   ];
@@ -45,49 +173,57 @@ class BeesLogList extends SignalWatcher(LitElement) {
 
   render() {
     if (!this.store) return nothing;
-    const sessions = this.store.sessions.get();
+    const taskGroups = this.store.taskGroups.get();
     const selectedSid = this.store.selectedSessionId.get();
+    const selectedTaskId = this.store.selectedTaskId.get();
 
-    if (sessions.length === 0) {
-      return html`<div class="empty-state">No log files found.</div>`;
+    if (taskGroups.length === 0) {
+      return html`<div class="empty-state">No log sessions found.</div>`;
     }
 
     return html`
       <div class="jobs-list">
-        ${sessions.map(
-          (session) => html`
-            <div class="job-item-group">
-              <div
-                class="job-item ${selectedSid === session.sessionId
-                  ? "selected"
-                  : ""} ${this.flashLogId === session.sessionId
-                  ? "lightning-flash"
-                  : ""}"
-                @click=${() => this.handleSelect(session.sessionId)}
-              >
-                <div class="job-header">
-                  <div class="job-title mono">
-                    ${session.sessionId.slice(0, 8)}
-                  </div>
-                  <div class="job-meta" style="margin:0">
-                    <span>
-                      ${session.files.length}
-                      run${session.files.length !== 1 ? "s" : ""}
-                    </span>
-                  </div>
-                </div>
-                <div class="job-meta">
-                  <span>
-                    ${getRelativeTime(session.files.at(0)?.startedDateTime)}
-                  </span>
-                  <span>
-                    ${(
-                      session.files.reduce((s, f) => s + f.totalTokens, 0) /
-                      1000
-                    ).toFixed(1)}k
-                    tokens
-                  </span>
-                </div>
+        ${taskGroups.map(
+          (group) => html`
+            <div class="task-group ${selectedTaskId === group.taskId ? "selected" : ""}">
+              <div class="task-group-header">
+                <span class="task-title" title="${group.title}">${group.title}</span>
+                <div class="job-status ${group.status}"></div>
+              </div>
+              <div class="task-sessions">
+                ${group.sessions.length === 0
+                  ? html`<div style="font-size: 0.7rem; color: #475569; padding: 6px 8px; text-align: center;">No active runs</div>`
+                  : group.sessions.map((session) => {
+                      const isSelected = selectedSid === session.sessionId;
+                      const isFlash = this.flashLogId === session.sessionId;
+                      const isActive = session.sessionId === group.activeSessionId;
+
+                      const forkFromLabel = session.forkedFrom
+                        ? html`<span class="fork-info" title="Forked from ${session.forkedFrom.session.slice(0, 8)} at turn ${session.forkedFrom.at_turn}">
+                            ← ${session.forkedFrom.session.slice(0, 8)}:t${session.forkedFrom.at_turn}
+                          </span>`
+                        : nothing;
+
+                      return html`
+                        <div
+                          class="session-card ${isSelected ? "selected" : ""} ${isFlash ? "lightning-flash" : ""}"
+                          @click=${() => this.handleSelect(session.sessionId)}
+                        >
+                          <div class="session-card-header">
+                            <span class="session-id">
+                              ${session.sessionId.slice(0, 13)}...
+                              ${isActive ? html`<span style="font-size:0.65rem;color:#60a5fa;font-weight:normal"> (Active)</span>` : nothing}
+                            </span>
+                            <span class="status-badge ${session.status}">${session.status}</span>
+                          </div>
+                          <div class="session-meta">
+                            <span>${session.eventCount} events</span>
+                            ${forkFromLabel}
+                            <span>${session.lastModified ? getRelativeTime(new Date(session.lastModified).toISOString()) : ""}</span>
+                          </div>
+                        </div>
+                      `;
+                    })}
               </div>
             </div>
           `

--- a/packages/bees/hivetool/src/ui/ticket-pane.ts
+++ b/packages/bees/hivetool/src/ui/ticket-pane.ts
@@ -217,10 +217,11 @@ class BeesTicketPane extends SignalWatcher(LitElement) {
         value: ticket.owning_task_id.slice(0, 8),
         onclick: () => this.navigate("tickets", ticket.owning_task_id!),
       });
+    const sessionVal = ticket.active_session || ticket.id;
     identityChips.push({
       label: "session",
-      value: ticket.id.slice(0, 8),
-      onclick: () => this.navigate("logs", ticket.id),
+      value: sessionVal.slice(0, 8),
+      onclick: () => this.navigate("logs", sessionVal),
     });
     if (ticket.skills && ticket.skills.length > 0) {
       const skillDirs = new Set(


### PR DESCRIPTION
## What
Eliminates the legacy session dual-identity in Hivetool. It refactors the data layer to scan task-level persistent session stores directly instead of legacy log directories, groups session runs cleanly by tasks, and updates the UI to display and route using actual session UUIDs.

## Why
Aligns Hivetool's logs visualization with the persistent session store architecture introduced in Project Rewind, guaranteeing a unified, clean, and reliable developer inspection environment.

## Changes

### Hivetool Data Layer
- **`LogStore` (log-store.ts)**: Transitioned directory scanning to `tickets/` task folders. Excluded `"coordination"` tasks from sidebar scans, grouped runs dynamically, and pruned legacy `.log.json` scanning.
- **`Session Store Reader` (session-store-reader.ts)**: Updated `compileEventsToSegment()` to properly accumulate prompt, candidates, thoughts, and cached token metadata to restore calculation of the top-level `token-visual` bar.

### Hivetool UI Components
- **`Sidebar` (log-list.ts)**: Redesigned task groups into standard borderless section headers with indented clickable session cards (`margin-left: 12px`) instead of boxed widgets.
- **`Session Chip` (ticket-pane.ts)**: Updated task detail's `"session"` chip to use `ticket.active_session || ticket.id` for high-fidelity UUID display and deep-linking.
- **`Task Chip` (log-detail.ts)**: Reworked parent `"task"` chip in session details to link and route utilizing the resolved `ticketId` instead of `sessionId`.
- **`Interaction Panel` (log-detail.ts & log-detail.styles.ts)**: Substituted raw inline styles on the Active Interaction Snapshot block with structured CSS classes matching the dark-mode theme, with `flex-shrink: 0` to prevent vertical layout collapse.
- **`File Tag` (log-detail.ts)**: Redesigned the `.turn-header-fs` tag as a borderless, subtle inline tag matching the TURN label's `#475569` gray, with proper pluralization logic.

## Testing
- Verified build compilation succeeds with 157 modules compiled via `npm run build` in `packages/bees/hivetool`.
- Verified ESLint standards are 100% met with **0 errors** via `npm run lint` in `packages/bees/hivetool`.
