### PR TITLE
[bees] Project Rewind Phase 6 — UI Polish for Session Rollback

### DIFF
--- a/packages/bees/hivetool/src/ui/log-detail.styles.ts
+++ b/packages/bees/hivetool/src/ui/log-detail.styles.ts
@@ -253,6 +253,14 @@ const logDetailBaseStyles = css`
     padding: 12px 16px;
     font-size: 0.8rem;
     line-height: 1.5;
+    transition: all 0.15s ease;
+  }
+
+  .turn.inherited {
+    opacity: 0.75;
+    border-style: dashed !important;
+    border-color: #334155 !important;
+    background: #0f1115;
   }
 
   .turn.user {
@@ -409,6 +417,12 @@ const logDetailBaseStyles = css`
     color: #fbbf24;
   }
 
+  .role-chip.inherited {
+    background: #1e293b;
+    color: #94a3b8;
+    border: 1px solid #334155;
+  }
+
   .part-function-response {
     padding: 6px 10px;
     background: #0f1115;
@@ -539,6 +553,34 @@ const logDetailBaseStyles = css`
     gap: 10px;
     margin: 14px 0 6px;
     padding: 0;
+  }
+
+  .rollback-btn {
+    margin-left: 8px;
+    padding: 2px 8px;
+    font-size: 0.65rem;
+    font-weight: 600;
+    background: #1e293b;
+    color: #94a3b8;
+    border: 1px solid #334155;
+    border-radius: 4px;
+    cursor: pointer;
+    font-family: inherit;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    transition: all 0.15s ease;
+  }
+
+  .rollback-btn:hover {
+    background: #24344d;
+    border-color: #3b82f6;
+    color: #3b82f6;
+    box-shadow: 0 0 8px rgba(59, 130, 246, 0.2);
+  }
+
+  .rollback-btn:active {
+    transform: scale(0.96);
   }
 
   .turn-header-label {

--- a/packages/bees/hivetool/src/ui/log-detail.ts
+++ b/packages/bees/hivetool/src/ui/log-detail.ts
@@ -21,11 +21,12 @@ import type {
   LogTurnTokenMetadata,
 } from "../data/types.js";
 import { SessionStoreReader, compileEventsToSegment } from "../data/session-store-reader.js";
-import type { TurnCheckpointInfo } from "../data/session-store-reader.js";
+import type { TurnCheckpointInfo, SessionLineageInfo } from "../data/session-store-reader.js";
 import type { StateAccess } from "../data/state-access.js";
 import type { TicketStore } from "../data/ticket-store.js";
 import type { MutationClient } from "../data/mutation-client.js";
 import { logDetailStyles } from "./log-detail.styles.js";
+import "./primitives/confirm-dialog.js";
 
 export { BeesLogDetail };
 
@@ -83,8 +84,29 @@ class BeesLogDetail extends SignalWatcher(LitElement) {
   @state() accessor turns: TurnCheckpointInfo[] = [];
   @state() accessor ticketId: string | null = null;
   @state() accessor activeSessionId: string | null = null;
+  @state() accessor showConfirmDialog = false;
+  @state() accessor confirmMessage = "";
+  @state() accessor rollbackTurnIndex = -1;
+  @state() accessor lineage: SessionLineageInfo[] = [];
 
   static styles = [logDetailStyles];
+
+  #rollbackSourceSessionId: string | null = null;
+
+  protected updated(changedProperties: Map<PropertyKey, unknown>) {
+    super.updated(changedProperties);
+
+    if (this.#rollbackSourceSessionId && this.activeTicket) {
+      const currentActive = this.activeTicket.active_session;
+      if (currentActive && currentActive !== this.#rollbackSourceSessionId) {
+        const newActive = currentActive;
+        this.#rollbackSourceSessionId = null;
+        
+        // Auto-navigate Hivetool to the newly forked active session
+        this.#dispatchNavigate("logs", newActive);
+      }
+    }
+  }
 
   #sessionReader: SessionStoreReader | null = null;
 
@@ -125,6 +147,9 @@ class BeesLogDetail extends SignalWatcher(LitElement) {
 
     this.ticketId = ticketId;
     this.activeSessionId = resolvedSessionId;
+
+    const lineage = await this.sessionReader.readLineage(ticketId);
+    this.lineage = lineage;
 
     const events = await this.sessionReader.readEvents(ticketId, resolvedSessionId);
     const interaction = await this.sessionReader.readInteraction(ticketId, resolvedSessionId) as InteractionStateDto | null;
@@ -187,6 +212,15 @@ class BeesLogDetail extends SignalWatcher(LitElement) {
         ${this.renderTools(firstSegment)}
       </div>
       ${this.renderTimeline(d)}
+      <bees-confirm-dialog
+        .open=${this.showConfirmDialog}
+        .title=${"Confirm Session Rewind"}
+        .message=${this.confirmMessage}
+        .confirmLabel=${"Rewind"}
+        .cancelLabel=${"Cancel"}
+        @confirm=${this.executeRollback}
+        @cancel=${this.closeConfirmDialog}
+      ></bees-confirm-dialog>
     `;
   }
 
@@ -452,13 +486,16 @@ class BeesLogDetail extends SignalWatcher(LitElement) {
     const checkpoint = this.turns.find((cp) => cp.turn === tg.turnIndex);
     const tokens = this.turnTokens(tg.tokenMetadata || (checkpoint?.token_metadata as unknown as LogTurnTokenMetadata) || null);
 
+    const currentSession = this.lineage.find((l) => l.sessionId === this.activeSessionId);
+    const isInherited = !!(currentSession?.forkedFrom && tg.turnIndex < currentSession.forkedFrom.at_turn);
+
     return html`
-      ${tokens.total > 0 || checkpoint ? this.renderTurnHeader(tokens, checkpoint) : nothing}
-      ${tg.entries.map((turn) => this.renderTurn(turn))}
+      ${tokens.total > 0 || checkpoint ? this.renderTurnHeader(tokens, checkpoint, isInherited) : nothing}
+      ${tg.entries.map((turn) => this.renderTurn(turn, isInherited))}
     `;
   }
 
-  private renderTurnHeader(t: TokenBreakdown, checkpoint?: TurnCheckpointInfo) {
+  private renderTurnHeader(t: TokenBreakdown, checkpoint?: TurnCheckpointInfo, isInherited = false) {
     const TIERS = [
       { cap: 50_000, label: "50K" },
       { cap: 250_000, label: "250K" },
@@ -484,10 +521,10 @@ class BeesLogDetail extends SignalWatcher(LitElement) {
     return html`
       <div class="turn-header">
         <span class="turn-header-label">turn ${checkpoint ? checkpoint.turn + 1 : ""}</span>
+        ${isInherited ? html`<span class="role-chip inherited" style="margin-left: 8px">🧬 Cloned</span>` : nothing}
         ${this.canRollback() && checkpoint ? html`
           <button
             class="rollback-btn"
-            style="margin-left: 8px; padding: 1px 6px; font-size: 0.65rem; font-weight: 600; background: #1e293b; color: #f8fafc; border: 1px solid #334155; border-radius: 4px; cursor: pointer; font-family: inherit; transition: all 0.15s"
             @click=${() => this.handleRollback(checkpoint.turn)}
             title="Rollback session to the start of this turn"
           >
@@ -527,7 +564,7 @@ class BeesLogDetail extends SignalWatcher(LitElement) {
     `;
   }
 
-  private renderTurn(turn: LogTurn) {
+  private renderTurn(turn: LogTurn, isInherited = false) {
     const role = turn.role || "unknown";
     const parts = (turn.parts || []).filter((p) => !this.isEmptyPart(p));
     if (parts.length === 0) return nothing;
@@ -553,7 +590,7 @@ class BeesLogDetail extends SignalWatcher(LitElement) {
       const content = match ? match[1].trim() : p.text!;
       const label = html`<span class="role-chip context-update">context update</span>`;
       return html`
-        <div class="turn context-update">
+        <div class="turn context-update ${isInherited ? "inherited" : ""}">
           <div class="turn-role">${label}</div>
           <div class="turn-parts">
             <bees-truncated-text fadeBg="#1c1a11">${content}</bees-truncated-text>
@@ -574,19 +611,19 @@ class BeesLogDetail extends SignalWatcher(LitElement) {
       return html`${contextCards}${otherParts.map((p) => {
         const name = p.functionResponse!.name;
         const label = html`<span class="role-chip response">response</span> ${name}`;
-        return this.#renderCard("system", label, [p]);
+        return this.#renderCard("system", label, [p], isInherited);
       })}`;
     }
 
     // Model turns: split thoughts and function calls into their own cards.
     if (role === "model") {
-      return this.#renderModelTurn(otherParts);
+      return this.#renderModelTurn(otherParts, isInherited);
     }
 
-    return html`${contextCards}${this.#renderCard(role, role, otherParts)}`;
+    return html`${contextCards}${this.#renderCard(role, role, otherParts, isInherited)}`;
   }
 
-  #renderModelTurn(parts: LogPart[]) {
+  #renderModelTurn(parts: LogPart[], isInherited = false) {
     // Classify each part and render as separate cards.
     type PartKind = "thought" | "call" | "other";
     const classify = (p: LogPart): PartKind => {
@@ -616,7 +653,7 @@ class BeesLogDetail extends SignalWatcher(LitElement) {
             : "thought";
           const isLong = body.length > 300;
           return html`
-            <div class="turn thought">
+            <div class="turn thought ${isInherited ? "inherited" : ""}">
               <div class="turn-role">${label}</div>
               <div class="turn-parts">
                 <div class="part-thought ${isLong ? "long" : ""}">${body}${isLong ? renderExpandButton() : nothing}</div>
@@ -630,7 +667,7 @@ class BeesLogDetail extends SignalWatcher(LitElement) {
           const fc = p.functionCall!;
           const label = html`<span class="role-chip call">call</span> ${fc.name}`;
           return html`
-            <div class="turn call">
+            <div class="turn call ${isInherited ? "inherited" : ""}">
               <div class="turn-role">${label}</div>
               <div class="turn-parts">
                 <div class="json-tree">${renderJson(fc.args)}</div>
@@ -639,13 +676,13 @@ class BeesLogDetail extends SignalWatcher(LitElement) {
           `;
         })}`;
       }
-      return this.#renderCard("model", "model", g.parts);
+      return this.#renderCard("model", "model", g.parts, isInherited);
     })}`;
   }
 
-  #renderCard(roleClass: string, displayRole: unknown, parts: LogPart[]) {
+  #renderCard(roleClass: string, displayRole: unknown, parts: LogPart[], isInherited = false) {
     return html`
-      <div class="turn ${roleClass}">
+      <div class="turn ${roleClass} ${isInherited ? "inherited" : ""}">
         <div class="turn-role">${displayRole}</div>
         <div class="turn-parts">
           ${parts.map((p) => this.renderPart(p))}
@@ -779,17 +816,32 @@ class BeesLogDetail extends SignalWatcher(LitElement) {
   private async handleRollback(turnIndex: number) {
     if (!this.mutationClient || !this.ticketId) return;
 
-    const confirmed = confirm(
+    this.rollbackTurnIndex = turnIndex;
+    this.confirmMessage =
       `Fork at turn ${turnIndex + 1}? A new session will be created and turns ` +
-      `${turnIndex + 2} onwards will be preserved in the superseded session.`
-    );
-    if (!confirmed) return;
+      `${turnIndex + 2} onwards will be preserved in the superseded session.`;
+    this.showConfirmDialog = true;
+  }
+
+  private async executeRollback() {
+    if (!this.mutationClient || !this.ticketId || this.rollbackTurnIndex === -1) return;
+
+    const turnIndex = this.rollbackTurnIndex;
+    this.showConfirmDialog = false;
+    this.rollbackTurnIndex = -1;
 
     try {
+      this.#rollbackSourceSessionId = this.activeSessionId;
       await this.mutationClient.rollbackToTurn(this.ticketId, turnIndex);
     } catch (e) {
+      this.#rollbackSourceSessionId = null;
       console.error("Failed to rollback to turn:", e);
     }
+  }
+
+  private closeConfirmDialog() {
+    this.showConfirmDialog = false;
+    this.rollbackTurnIndex = -1;
   }
 }
 

--- a/packages/bees/hivetool/src/ui/primitives/confirm-dialog.ts
+++ b/packages/bees/hivetool/src/ui/primitives/confirm-dialog.ts
@@ -1,0 +1,231 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { LitElement, html, css } from "lit";
+import { customElement, property, query } from "lit/decorators.js";
+
+export { BeesConfirmDialog };
+
+/**
+ * A beautiful, reusable confirmation modal overlay wrapping the native HTML5 `<dialog>` element.
+ * Inherits and uses native browser focus trapping, Esc-dismiss, and backdrop styling.
+ *
+ * @fires confirm - Dispatched when the user clicks the primary confirm action.
+ * @fires cancel - Dispatched when the dialog is closed/canceled without confirming.
+ */
+@customElement("bees-confirm-dialog")
+class BeesConfirmDialog extends LitElement {
+  @property({ type: Boolean })
+  accessor open = false;
+
+  @property({ type: String })
+  accessor title = "Confirm Action";
+
+  @property({ type: String })
+  accessor message = "Are you sure you want to proceed?";
+
+  @property({ type: String })
+  accessor confirmLabel = "Confirm";
+
+  @property({ type: String })
+  accessor cancelLabel = "Cancel";
+
+  @query("dialog")
+  accessor dialogEl!: HTMLDialogElement;
+
+  static styles = css`
+    :host {
+      display: contents;
+    }
+
+    dialog {
+      border: none;
+      background: #141822;
+      color: #e2e8f0;
+      border-radius: 12px;
+      padding: 0;
+      max-width: 440px;
+      width: 90%;
+      box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.6);
+      font-family: inherit;
+      border: 1px solid #1e293b;
+      outline: none;
+    }
+
+    /* Native dialog backdrop styling */
+    dialog::backdrop {
+      background: rgba(9, 11, 15, 0.75);
+      backdrop-filter: blur(8px);
+      opacity: 0;
+      transition: opacity 0.25s ease;
+    }
+
+    dialog[open]::backdrop {
+      opacity: 1;
+    }
+
+    /* Scale/fade up animation on appearance */
+    dialog[open] {
+      animation: scaleUp 0.25s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+    }
+
+    @keyframes scaleUp {
+      from {
+        transform: scale(0.96);
+        opacity: 0;
+      }
+      to {
+        transform: scale(1);
+        opacity: 1;
+      }
+    }
+
+    .dialog-card {
+      display: flex;
+      flex-direction: column;
+      padding: 24px;
+      gap: 16px;
+    }
+
+    .dialog-title {
+      font-size: 1.1rem;
+      font-weight: 600;
+      color: #f8fafc;
+      margin: 0;
+    }
+
+    .dialog-message {
+      font-size: 0.85rem;
+      line-height: 1.5;
+      color: #94a3b8;
+      margin: 0;
+      white-space: pre-wrap;
+    }
+
+    .dialog-actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 12px;
+      margin-top: 8px;
+    }
+
+    button {
+      font-family: inherit;
+      padding: 8px 16px;
+      border-radius: 6px;
+      font-weight: 600;
+      font-size: 0.8rem;
+      cursor: pointer;
+      transition: all 0.15s ease;
+      border: 1px solid transparent;
+    }
+
+    button.btn-cancel {
+      background: #1e293b;
+      color: #94a3b8;
+      border-color: #334155;
+    }
+
+    button.btn-cancel:hover {
+      background: #253347;
+      color: #cbd5e1;
+      border-color: #475569;
+    }
+
+    button.btn-confirm {
+      background: linear-gradient(135deg, #3b82f6, #1d4ed8);
+      color: #ffffff;
+      box-shadow: 0 4px 12px rgba(59, 130, 246, 0.2);
+    }
+
+    button.btn-confirm:hover {
+      opacity: 0.95;
+      box-shadow: 0 4px 16px rgba(59, 130, 246, 0.3);
+    }
+
+    button:active {
+      transform: scale(0.96);
+    }
+  `;
+
+  protected updated(changedProperties: Map<PropertyKey, unknown>) {
+    super.updated(changedProperties);
+
+    if (changedProperties.has("open") && this.dialogEl) {
+      if (this.open) {
+        if (!this.dialogEl.open) {
+          this.dialogEl.showModal();
+        }
+      } else {
+        if (this.dialogEl.open) {
+          this.dialogEl.close();
+        }
+      }
+    }
+  }
+
+  render() {
+    return html`
+      <dialog
+        @click=${this.handleDialogClick}
+        @close=${this.handleDialogClose}
+      >
+        <div class="dialog-card">
+          <h3 class="dialog-title">${this.title}</h3>
+          <p class="dialog-message">${this.message}</p>
+          <div class="dialog-actions">
+            <button
+              class="btn-cancel"
+              @click=${this.handleCancel}
+            >
+              ${this.cancelLabel}
+            </button>
+            <button
+              class="btn-confirm"
+              @click=${this.handleConfirm}
+            >
+              ${this.confirmLabel}
+            </button>
+          </div>
+        </div>
+      </dialog>
+    `;
+  }
+
+  private handleDialogClick(e: MouseEvent) {
+    // Click outside card (on Native Backdrop) closes dialogue.
+    // Since dialog takes full page bounds, clicking dialog edge is clicking backdrop.
+    const rect = this.dialogEl.getBoundingClientRect();
+    const isInDialog =
+      rect.top <= e.clientY &&
+      e.clientY <= rect.top + rect.height &&
+      rect.left <= e.clientX &&
+      e.clientX <= rect.left + rect.width;
+
+    if (!isInDialog) {
+      this.handleCancel();
+    }
+  }
+
+  private handleDialogClose() {
+    // Native escape key or close() triggers native close event
+    this.dispatchEvent(new CustomEvent("cancel", { bubbles: true, composed: true }));
+  }
+
+  private handleCancel() {
+    this.dispatchEvent(new CustomEvent("cancel", { bubbles: true, composed: true }));
+  }
+
+  private handleConfirm() {
+    this.dispatchEvent(new CustomEvent("confirm", { bubbles: true, composed: true }));
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "bees-confirm-dialog": BeesConfirmDialog;
+  }
+}

--- a/packages/bees/hivetool/src/ui/session-lineage.ts
+++ b/packages/bees/hivetool/src/ui/session-lineage.ts
@@ -36,12 +36,60 @@ class BeesSessionLineage extends SignalWatcher(LitElement) {
         display: flex;
         align-items: center;
         justify-content: space-between;
+        margin-bottom: 4px;
       }
 
+      /* Visual Timeline Track Container */
       .sessions-container {
+        position: relative;
+        padding-left: 22px;
         display: flex;
         flex-direction: column;
-        gap: 8px;
+        gap: 10px;
+      }
+
+      /* Timeline vertical rail line */
+      .sessions-container::before {
+        content: "";
+        position: absolute;
+        left: 7px;
+        top: 8px;
+        bottom: 8px;
+        width: 2px;
+        background: #1e293b;
+      }
+
+      /* Node wrappers on the timeline rail */
+      .session-node {
+        position: relative;
+        width: 100%;
+      }
+
+      /* Bullet node points */
+      .session-node::before {
+        content: "";
+        position: absolute;
+        left: -20px;
+        top: 15px;
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        background: #1e293b;
+        border: 2px solid #0f1115;
+        z-index: 2;
+        transition: all 0.15s ease;
+      }
+
+      /* Bullet state styles */
+      .session-node.active::before {
+        background: #3b82f6;
+        border-color: #0f1115;
+        box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.15);
+      }
+
+      .session-node.superseded::before {
+        background: #475569;
+        border-color: #0f1115;
       }
 
       .session-card {
@@ -61,9 +109,11 @@ class BeesSessionLineage extends SignalWatcher(LitElement) {
         border-color: #334155;
       }
 
-      .session-card.active {
-        background: #1e3a5f22;
+      /* Active session card styling */
+      .session-card.selected {
+        background: #141924;
         border-color: #3b82f6;
+        box-shadow: 0 0 12px rgba(59, 130, 246, 0.25);
       }
 
       .session-card-header {
@@ -79,47 +129,63 @@ class BeesSessionLineage extends SignalWatcher(LitElement) {
         color: #f8fafc;
       }
 
-      .session-card.active .session-id {
+      .session-card.selected .session-id {
         color: #60a5fa;
       }
 
+      /* Curated Badge & HSL Palette System */
       .status-badge {
         font-size: 0.65rem;
-        font-weight: 600;
+        font-weight: 700;
         padding: 2px 8px;
         border-radius: 999px;
         text-transform: uppercase;
         letter-spacing: 0.05em;
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+      }
+
+      .status-badge svg {
+        flex-shrink: 0;
+      }
+
+      .status-badge svg.spin {
+        animation: badgeSpin 1s linear infinite;
+      }
+
+      @keyframes badgeSpin {
+        to { transform: rotate(360deg); }
       }
 
       .status-badge.running {
-        background: #1d4ed822;
-        color: #60a5fa;
-        border: 1px solid #1d4ed8;
+        background: hsla(217, 91%, 60%, 0.12);
+        color: hsl(217, 91%, 65%);
+        border: 1px solid hsla(217, 91%, 60%, 0.3);
       }
 
       .status-badge.suspended {
-        background: #92400e22;
-        color: #fbbf24;
-        border: 1px solid #92400e;
+        background: hsla(38, 92%, 50%, 0.12);
+        color: hsl(38, 92%, 55%);
+        border: 1px solid hsla(38, 92%, 50%, 0.3);
       }
 
       .status-badge.completed {
-        background: #065f4622;
-        color: #34d399;
-        border: 1px solid #065f46;
+        background: hsla(142, 70%, 45%, 0.12);
+        color: hsl(142, 70%, 50%);
+        border: 1px solid hsla(142, 70%, 45%, 0.3);
       }
 
       .status-badge.failed {
-        background: #991b1b22;
-        color: #f87171;
-        border: 1px solid #991b1b;
+        background: hsla(0, 84%, 60%, 0.12);
+        color: hsl(0, 84%, 65%);
+        border: 1px solid hsla(0, 84%, 60%, 0.3);
       }
 
       .status-badge.superseded {
-        background: #33415544;
-        color: #94a3b8;
-        border: 1px solid #334155;
+        background: hsla(215, 16%, 47%, 0.12);
+        color: hsl(215, 16%, 55%);
+        border: 1px solid hsla(215, 16%, 47%, 0.3);
       }
 
       .session-meta {
@@ -133,6 +199,7 @@ class BeesSessionLineage extends SignalWatcher(LitElement) {
       .fork-info {
         font-style: italic;
         color: #fbbf24;
+        font-size: 0.7rem;
       }
     `,
   ];
@@ -151,13 +218,15 @@ class BeesSessionLineage extends SignalWatcher(LitElement) {
       return html`<div class="empty-state" style="font-size:0.75rem">No session history found</div>`;
     }
 
+    const sortedLineage = this.getSortedLineage();
+
     return html`
       <div class="lineage-header">
         <span>Session Lineage</span>
         <span style="font-size:0.7rem;color:#64748b">${this.lineage.length} sessions</span>
       </div>
       <div class="sessions-container">
-        ${this.lineage.map((s) => {
+        ${sortedLineage.map((s) => {
           const isActive = s.sessionId === this.activeSessionId;
           const isSelected = s.sessionId === (this.selectedSessionId || this.activeSessionId);
           const forkFromLabel = s.forkedFrom
@@ -165,26 +234,120 @@ class BeesSessionLineage extends SignalWatcher(LitElement) {
             : nothing;
 
           return html`
-            <div
-              class="session-card ${isSelected ? "active" : ""}"
-              @click=${() => this.#onSelect(s.sessionId)}
-            >
-              <div class="session-card-header">
-                <span class="session-id">
-                  ${s.sessionId.slice(0, 13)}...
-                  ${isActive ? html`<span style="font-size:0.65rem;color:#60a5fa;font-weight:normal"> (Active)</span>` : nothing}
-                </span>
-                <span class="status-badge ${s.status}">${s.status}</span>
-              </div>
-              <div class="session-meta">
-                <span>${s.eventCount} events</span>
-                ${forkFromLabel}
+            <div class="session-node ${isSelected ? "active" : "superseded"}">
+              <div
+                class="session-card ${isSelected ? "selected" : ""}"
+                @click=${() => this.#onSelect(s.sessionId)}
+              >
+                <div class="session-card-header">
+                  <span class="session-id">
+                    ${s.sessionId.slice(0, 13)}...
+                    ${isActive ? html`<span style="font-size:0.65rem;color:#60a5fa;font-weight:normal"> (Active)</span>` : nothing}
+                  </span>
+                  <span class="status-badge ${s.status}">
+                    ${this.renderStatusIcon(s.status)}
+                    ${s.status}
+                  </span>
+                </div>
+                <div class="session-meta">
+                  <span>${s.eventCount} events</span>
+                  ${forkFromLabel}
+                </div>
               </div>
             </div>
           `;
         })}
       </div>
     `;
+  }
+
+  private getSortedLineage(): SessionLineageInfo[] {
+    const sorted: SessionLineageInfo[] = [];
+    const visited = new Set<string>();
+    const map = new Map<string, SessionLineageInfo>();
+    for (const s of this.lineage) {
+      map.set(s.sessionId, s);
+    }
+
+    // Find root session(s): those with no forkedFrom, or parent not in list
+    const roots = this.lineage.filter(
+      (s) => !s.forkedFrom || !map.has(s.forkedFrom.session)
+    );
+
+    const visit = (sessionId: string) => {
+      if (visited.has(sessionId)) return;
+      visited.add(sessionId);
+
+      const s = map.get(sessionId);
+      if (s) {
+        sorted.push(s);
+      }
+
+      // Retrieve children (forked from current sessionId)
+      const children = this.lineage.filter(
+        (child) => child.forkedFrom?.session === sessionId
+      );
+      // Sort children by fork turn index
+      children.sort((a, b) => (a.forkedFrom?.at_turn ?? 0) - (b.forkedFrom?.at_turn ?? 0));
+
+      for (const child of children) {
+        visit(child.sessionId);
+      }
+    };
+
+    for (const root of roots) {
+      visit(root.sessionId);
+    }
+
+    // Ensure no session was left out due to isolated references
+    for (const s of this.lineage) {
+      if (!visited.has(s.sessionId)) {
+        sorted.push(s);
+      }
+    }
+
+    return sorted;
+  }
+
+  private renderStatusIcon(status: string) {
+    switch (status) {
+      case "running":
+        return html`
+          <svg class="spin" style="width: 8px; height: 8px;" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="4">
+            <circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" fill="none" opacity="0.3"></circle>
+            <path d="M12 2a10 10 0 0 1 10 10" stroke-linecap="round"></path>
+          </svg>
+        `;
+      case "suspended":
+        return html`
+          <svg style="width: 8px; height: 8px;" viewBox="0 0 24 24" fill="currentColor">
+            <rect x="5" y="4" width="4" height="16" rx="1"></rect>
+            <rect x="15" y="4" width="4" height="16" rx="1"></rect>
+          </svg>
+        `;
+      case "completed":
+        return html`
+          <svg style="width: 8px; height: 8px;" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="20 6 9 17 4 12"></polyline>
+          </svg>
+        `;
+      case "failed":
+        return html`
+          <svg style="width: 8px; height: 8px;" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="18" y1="6" x2="6" y2="18"></line>
+            <line x1="6" y1="6" x2="18" y2="18"></line>
+          </svg>
+        `;
+      case "superseded":
+        return html`
+          <svg style="width: 8px; height: 8px;" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="10"></circle>
+            <polyline points="12 6 12 12 16 14"></polyline>
+          </svg>
+        `;
+      default:
+        return nothing;
+    }
   }
 
   #onSelect(sessionId: string) {


### PR DESCRIPTION
## What
Polished and finalized the developer user experience for the session rollback (rewind) capability in Hivetool. Created a native HTML5 `<dialog>` overlay primitive, overhauled the session lineage tree view, highlighted cloned/inherited turn sequences, and added auto-navigation focus.

## Why
Session rollbacks must feel visually outstanding, extremely fluid, and highly responsive. Native accessible modal overlays, chronological timeline tracks, and distinct styling of inherited turns prevent main-thread freezing, minimize confusion, and provide clear historical context.

## Changes

### `packages/bees/hivetool`

- **`<bees-confirm-dialog>` Primitive [NEW]**: Created an accessible native HTML5 `<dialog>` component in `src/ui/primitives/confirm-dialog.ts` utilizing the `showModal()` / `close()` APIs to support native Escape-to-dismiss and backdrop-blur styling.
- **Session Lineage [Modified]**: Refactored `src/ui/session-lineage.ts` to sort lineage chronologically, render vertical timeline tracks with circular node points, display curated status badges (HSL and inline SVGs), and highlight the selected session card with a sapphire glow.
- **Log Timeline & Auto-Navigation [Modified]**: Updated `src/ui/log-detail.ts` and `src/ui/log-detail.styles.ts` to wire the confirm dialog modal, identify and badge inherited turns as `🧬 Cloned` with dashed cards, and implement Signal-backed auto-navigation to the new active session.

## Testing
- Run `npm run test` across the monorepo to verify typescript compilations and unit tests.
- Proved manual end-to-end rollback and timeline auto-focus under local execution (`npm run dev:box`).
