### PR TITLE
[bees] Dynamic and Scoped Sub-Agents in Bees

### DIFF
--- a/hives/chat-app/config/TEMPLATES.yaml
+++ b/hives/chat-app/config/TEMPLATES.yaml
@@ -134,3 +134,10 @@
     - gmail.*
     - calendar.*
     - people.*
+
+- name: delegator
+  title: Delegator
+  description: You chat with the user and delegate work to sub-agents
+  functions:
+    - chat.*
+    - tasks.*

--- a/packages/bees/bees/declarations/tasks.instruction.md
+++ b/packages/bees/bees/declarations/tasks.instruction.md
@@ -5,8 +5,12 @@ You can delegate work to subagents using tasks.
 When you create a task, a scheduler will assign a subagent to the task as soon
 as it is able. The availability depends on the current workload and will vary.
 
-There are several pre-defined task types that are accessible via the
-"tasks_list_types" function. Choose the right type for the new task.
+Available task types are resolved dynamically via the "tasks_list_types"
+function. New task templates or overrides can be created or modified inside the
+`templates/` directory of your workspace during execution. You MUST always call
+"tasks_list_types" to discover the current, most up-to-date list of available
+task types before creating a task, especially if you or the system have
+dynamically created or edited templates.
 
 You can create tasks using the "tasks_create_task" function, check the status of
 the task using the "tasks_check_status" function, and request task cancellation
@@ -16,10 +20,8 @@ You can send events to a running subagent using "tasks_send_event". The agent
 receives the event as a context update. Use this to provide additional
 instructions, clarifications, or data while the subagent is working.
 
-When creating a task, you can opt to wait until the task is done by setting the
-"wait_ms_before_async" parameter to a sufficiently large value. Note that in the
-worst case, this will block your ability to do anything else for this amount of
-time. Use it with care.
+Unless the objective explicitly calls for itit, keep the "wait_ms_before_async"
+parameter at 0 and let the tasks run asynchronously.
 
 For tasks that run asynchronously, the scheduler will issue a context update
 when each task completes. The update will contain the outcome of the completed

--- a/packages/bees/bees/disk_file_system.py
+++ b/packages/bees/bees/disk_file_system.py
@@ -351,12 +351,15 @@ class DiskFileSystem:
             for item in self._work_dir.rglob("*"):
                 if item.is_file():
                     rel = item.relative_to(self._work_dir)
-                    if not any(part.startswith(".") or part in _SKIP_DIRS for part in rel.parts):
+                    if not any(part.startswith(".") or part in _SKIP_DIRS or part == "templates" for part in rel.parts):
                         item.unlink(missing_ok=True)
 
-            # Clean up empty directories
+            # Clean up empty directories (protect templates directory)
             for item in sorted(self._work_dir.rglob("*"), key=lambda p: len(p.parts), reverse=True):
                 if item.is_dir():
+                    rel = item.relative_to(self._work_dir)
+                    if any(part.startswith(".") or part in _SKIP_DIRS or part == "templates" for part in rel.parts):
+                        continue
                     try:
                         item.rmdir()
                     except OSError:

--- a/packages/bees/bees/functions/tasks.py
+++ b/packages/bees/bees/functions/tasks.py
@@ -40,21 +40,29 @@ def _make_handlers(
             status_cb("Listing available task types")
             
         allowed_tasks = []
+        workspace_dir = None
         if caller_ticket_id:
             task = scheduler.store.get(caller_ticket_id) if scheduler else None
-            if task and task.metadata.tasks:
-                allowed_tasks = task.metadata.tasks
+            if task:
+                workspace_dir = task.fs_dir
+                if task.metadata.tasks:
+                    allowed_tasks = task.metadata.tasks
                 
         task_types = []
         from bees.playbook import list_playbooks, load_playbook
         
         config_dir = scheduler.store.hive_dir / "config"
         
-        for name in list_playbooks(config_dir):
+        global_names = set(list_playbooks(config_dir))
+        all_names = list_playbooks(config_dir, workspace_dir)
+        
+        for name in all_names:
             try:
-                data = load_playbook(name, config_dir)
+                data = load_playbook(name, config_dir, workspace_dir)
                 task_name = data.get("name", name)
-                if task_name in allowed_tasks:
+                is_local = task_name not in global_names
+                
+                if is_local or task_name in allowed_tasks:
                     task_types.append({
                         "name": task_name,
                         "title": data.get("title", name),
@@ -84,8 +92,12 @@ def _make_handlers(
             
         from bees.playbook import load_playbook, stamp_child_task
         config_dir = scheduler.store.hive_dir / "config"
+        
+        parent = scheduler.store.get(caller_ticket_id) if scheduler and caller_ticket_id else None
+        workspace_dir = parent.fs_dir if parent else None
+        
         try:
-            load_playbook(task_type, config_dir)
+            load_playbook(task_type, config_dir, workspace_dir)
         except FileNotFoundError:
             return {"error": f"Task type not found: {task_type}"}
 

--- a/packages/bees/bees/playbook.py
+++ b/packages/bees/bees/playbook.py
@@ -42,7 +42,7 @@ class PlaybookAborted(Exception):
 
 
 def _load_templates(config_dir: Path) -> list[dict[str, Any]]:
-    """Parse TEMPLATES.yaml and return the list of template dicts."""
+    """Parse TEMPLATES.yaml and return the list of template dicts (legacy)."""
     templates_path = config_dir / "TEMPLATES.yaml"
     if not templates_path.exists():
         return []
@@ -54,17 +54,68 @@ def _load_templates(config_dir: Path) -> list[dict[str, Any]]:
     return data
 
 
-def list_playbooks(config_dir: Path) -> list[str]:
+def load_all_templates(config_dir: Path, workspace_dir: Path | None = None) -> list[dict[str, Any]]:
+    """Load and merge all templates from global and local sources."""
+    templates: dict[str, dict[str, Any]] = {}
+
+    def _load_file(path: Path) -> list[dict[str, Any]]:
+        if not path.exists():
+            return []
+        try:
+            with open(path, encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+            if isinstance(data, dict):
+                if "name" not in data:
+                    data["name"] = path.stem
+                return [data]
+            elif isinstance(data, list):
+                for i, item in enumerate(data):
+                    if isinstance(item, dict) and "name" not in item:
+                        item["name"] = f"{path.stem}_{i}"
+                return [item for item in data if isinstance(item, dict)]
+            else:
+                logger.warning("Template file %s must be a list or dictionary; got %s", path, type(data).__name__)
+        except Exception as e:
+            logger.warning("Failed to load template from %s: %s", path, e)
+        return []
+
+    def _scan_dir(templates_dir: Path) -> list[dict[str, Any]]:
+        items = []
+        if not templates_dir.is_dir():
+            return []
+        for child in sorted(templates_dir.iterdir()):
+            if child.is_file() and child.suffix in (".yaml", ".yml"):
+                items.extend(_load_file(child))
+        return items
+
+    # 1. Global Legacy
+    global_legacy = config_dir / "TEMPLATES.yaml"
+    if global_legacy.exists():
+        for item in _load_file(global_legacy):
+            t_name = item.get("name")
+            if t_name:
+                templates[t_name] = item
+
+    # 2. Local Workspace templates
+    if workspace_dir:
+        local_dir = workspace_dir / "templates"
+        if local_dir.is_dir():
+            for item in _scan_dir(local_dir):
+                t_name = item.get("name")
+                if t_name:
+                    templates[t_name] = item
+
+    return list(templates.values())
+
+
+def list_playbooks(config_dir: Path, workspace_dir: Path | None = None) -> list[str]:
     """Return the names of all available templates."""
-    return [t["name"] for t in _load_templates(config_dir) if "name" in t]
+    return [t["name"] for t in load_all_templates(config_dir, workspace_dir) if "name" in t]
 
 
-def load_playbook(name: str, config_dir: Path) -> dict[str, Any]:
-    """Load a template by name.
-
-    Returns the template dict directly (flat — no ``steps`` wrapper).
-    """
-    for t in _load_templates(config_dir):
+def load_playbook(name: str, config_dir: Path, workspace_dir: Path | None = None) -> dict[str, Any]:
+    """Load a template by name."""
+    for t in load_all_templates(config_dir, workspace_dir):
         if t.get("name") == name:
             return t
     raise FileNotFoundError(f"Template not found: {name}")
@@ -104,6 +155,7 @@ def run_playbook(
     context: str | None = None,
     owning_task_id: str | None = None,
     slug: str | None = None,
+    workspace_dir: Path | None = None,
 ) -> Ticket:
     """Create a task from a template.
 
@@ -121,7 +173,7 @@ def run_playbook(
     config_dir = hive_dir / "config"
     hooks_dir = config_dir / "hooks"
 
-    data = load_playbook(name, config_dir)
+    data = load_playbook(name, config_dir, workspace_dir)
 
     # Run on_run_playbook hook if present.
     hooks = _load_hooks(name, hooks_dir)
@@ -200,6 +252,7 @@ def stamp_child_task(
         context=context,
         owning_task_id=child_scope.workspace_root_id,
         slug=child_scope.slug_path,
+        workspace_dir=parent_task.fs_dir,
     )
 
     if child_scope.slug_path:

--- a/packages/bees/bees/provisioner.py
+++ b/packages/bees/bees/provisioner.py
@@ -107,10 +107,23 @@ def provision_session(
     )
     disk_fs = DiskFileSystem(work_dir)
 
-    # 4. Seed initial files (skills) directly to disk.
+    # 4. Seed initial files (skills and templates) directly to disk.
     if seed_files:
         for name, content in session_files.items():
             disk_fs.write(name, content)
+
+        try:
+            import yaml
+            from bees.playbook import _load_templates
+            global_templates = _load_templates(hive_dir / "config")
+            for t in global_templates:
+                t_name = t.get("name")
+                if t_name:
+                    t_content = yaml.dump(t, sort_keys=False, allow_unicode=True)
+                    disk_fs.write(f"templates/{t_name}.yaml", t_content)
+        except Exception as exc:
+            import logging
+            logging.getLogger(__name__).warning("Failed to seed templates into workspace: %s", exc)
 
     # 5. Assemble function group factories.
     workspace_root_id = scope.workspace_root_id if scope else None

--- a/packages/bees/bees/scheduler.py
+++ b/packages/bees/bees/scheduler.py
@@ -395,26 +395,27 @@ class Scheduler:
         """Deliver, inject, or buffer a context update for a task.
 
         Three delivery paths, tried in order:
-        1. **Mid-stream** — task is running and has a live context
-           queue.  Push pre-formatted parts for injection at the next
-           turn boundary.
-        2. **Immediate resume** — task is suspended and idle.  Write
-           ``response.json`` and flip assignee to trigger resume.
-        3. **Buffer** — task is busy but has no live queue (e.g.
-           batch mode).  Append to ``pending_context_updates`` in
-           metadata for later drain.
+        1. **Mid-stream injection** (Live sessions only) — task is running
+           and has an active real-time WebSocket stream. Pushes context
+           parts for immediate live injection.
+        2. **Immediate resume** — task is suspended and waiting for user
+           input. Writes ``response.json`` and flips assignee to trigger
+           resumption.
+        3. **Buffer** — task is busy or turn-based (batch mode). Appends
+           to ``pending_context_updates`` in metadata to be drained on settle
+           or next resume.
         """
-        # Path 1: mid-stream injection via live stream.
-        stream = self._active_streams.get(target_id)
-        if stream is not None:
-            parts = updates_to_context_parts([update])
-            asyncio.create_task(stream.send_context(parts))
-            logger.info("Context update injected mid-stream for %s", target_id)
-            return
-
         target = self.store.get(target_id)
         if not target:
             logger.warning("Failed to load task %s for context update", target_id)
+            return
+
+        # Path 1: mid-stream injection via live stream (Live sessions only)
+        stream = self._active_streams.get(target_id)
+        if stream is not None and target.metadata.runner == "live":
+            parts = updates_to_context_parts([update])
+            asyncio.create_task(stream.send_context(parts))
+            logger.info("Context update injected mid-stream for %s", target_id)
             return
 
         # Path 2: immediate resume via response.json.

--- a/packages/bees/bees/task_runner.py
+++ b/packages/bees/bees/task_runner.py
@@ -447,6 +447,8 @@ class TaskRunner:
             if fresh:
                 if fresh.metadata.queued_updates:
                     task.metadata.queued_updates = fresh.metadata.queued_updates
+                if fresh.metadata.pending_context_updates:
+                    task.metadata.pending_context_updates = fresh.metadata.pending_context_updates
                 if fresh.metadata.title != task.metadata.title:
                     task.metadata.title = fresh.metadata.title
 
@@ -454,7 +456,18 @@ class TaskRunner:
             # the runner before yielding.
             suspend_event = dict(result.suspend_event) if result.suspend_event else {}
 
-            if getattr(task.metadata, "queued_updates", None):
+            if getattr(task.metadata, "pending_context_updates", None):
+                updates = list(task.metadata.pending_context_updates)
+                task.metadata.pending_context_updates = []
+                response_path = task.dir / "response.json"
+                response_path.write_text(
+                    json.dumps({"context_updates": updates}, indent=2, ensure_ascii=False) + "\n"
+                )
+                task.metadata.status = "suspended"
+                task.metadata.assignee = "agent"
+                task.metadata.suspend_event = suspend_event
+                print(f"  [{task.id[:8]}] 📩 auto-resume with buffered context updates", file=sys.stderr)
+            elif getattr(task.metadata, "queued_updates", None):
                 update = task.metadata.queued_updates.pop(0)
                 response_path = task.dir / "response.json"
                 response_path.write_text(

--- a/packages/bees/hive/skills/create-task-type/SKILL.md
+++ b/packages/bees/hive/skills/create-task-type/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: create-task-type
+title: How to Create Custom Task Types (Sub-Agents)
+description:
+  Learn how to design and write custom task templates (sub-agents) inside your workspace, so you can delegate specialized work to custom sub-agents.
+allowed-tools:
+  - files.write_file
+  - tasks.list_types
+  - tasks.create_task
+---
+
+You have the ability to dynamically design and spawn custom, highly-specialized sub-agents. This is done by authoring a YAML task template inside your workspace's `templates/` directory.
+
+## How to Create a Custom Task Type
+
+1. **Design the Sub-Agent**: Decide what capabilities (functions), instructions (objective/skills), and model the sub-agent needs.
+2. **Write the Template File**: Write a YAML file into `templates/{name}.yaml` in your workspace. 
+   - Replace `{name}` with a URL-safe, lower-case name (e.g., `sql-optimizer.yaml`).
+   - Ensure the file conforms to the Template Schema below.
+3. **List and Spawn**: Call `tasks_list_types` to verify the new type is loaded, then call `tasks_create_task` to spawn it!
+
+## Template Schema Reference
+
+A task template file must be a YAML dictionary with the following fields:
+
+- **`name`**: (string) Logical identifier (e.g. `sql-optimizer`). Must match the filename without `.yaml`.
+- **`title`**: (string) A short human-readable name shown in UIs (e.g. `SQL Performance Optimizer`).
+- **`description`**: (string) A brief sentence describing what this sub-agent does.
+- **`objective`**: (string) The core instructions/prompt for the agent.
+  - *Tip*: Use `{{system.context}}` in the objective to pass through your delegation instructions when spawning the task.
+- **`functions`**: (array of strings, optional) Allowed function glob patterns. 
+  - Common values: `["files.*", "system.*"]` (for simple workers) or `["files.*", "tasks.*", "system.*"]` (if the sub-agent needs to delegate to other agents).
+  - Leaving `functions` empty/omitted grants access to ALL available functions.
+- **`skills`**: (array of strings, optional) Names of active skills to load (e.g. `["research"]`).
+- **`model`**: (string, optional) Specific model override (e.g., `gemini-3.1-pro-preview`).
+
+### Example Template File (`templates/sql-optimizer.yaml`):
+```yaml
+name: sql-optimizer
+title: SQL Performance Optimizer
+description: Analyzes SQL files and optimizes slow queries.
+objective: |
+  You are a database performance expert. Your job is to optimize the SQL query passed via context:
+
+  {{system.context}}
+
+  Read the files, profile the queries, and write the optimized query to optimized.sql.
+functions:
+  - files.*
+  - system.*
+skills:
+  - research
+```
+
+## Best Practices
+
+- **Free the Main Thread**: Delegate complex, long-running, or analytical work to custom sub-agents so you remain responsive to the user/parent.
+- **Principle of Least Privilege**: Restrict the sub-agent's `functions` to only what it needs. For example, simple workers don't need `tasks.*` or `chat.*`.
+- **Objective Interpolation**: Always include `{{system.context}}` in the sub-agent's objective so you can supply it with custom instructions when spawning it.
+- **Clean Namespaces**: Always write templates inside the `templates/` directory of your workspace (e.g., `templates/my-agent.yaml`). Do not try to write to other folders.

--- a/packages/bees/hivetool/src/data/template-store.ts
+++ b/packages/bees/hivetool/src/data/template-store.ts
@@ -34,6 +34,8 @@ interface TemplateData {
   autostart?: string[];
   runner?: "generate" | "live";
   voice?: string;
+  isWorkspaceScoped?: boolean;
+  ticketId?: string;
 }
 
 class TemplateStore {
@@ -57,11 +59,14 @@ class TemplateStore {
     await this.scan();
   }
 
-  /** Read and parse TEMPLATES.yaml from the hive handle. */
-  async scan(): Promise<void> {
+  /** Read and parse TEMPLATES.yaml from the config folder, AND scan any local templates in the active ticket. */
+  async scan(activeTicketId?: string | null): Promise<void> {
     const handle = this.access.handle;
     if (!handle) return;
 
+    const allTemplates: TemplateData[] = [];
+
+    // 1. Read and parse legacy TEMPLATES.yaml from config/
     try {
       const configDir = await handle.getDirectoryHandle("config");
       const fileHandle = await configDir.getFileHandle("TEMPLATES.yaml");
@@ -69,17 +74,81 @@ class TemplateStore {
       const text = await file.text();
       const data = yaml.load(text);
 
-      if (!Array.isArray(data)) {
-        console.warn("TEMPLATES.yaml must be a list; got", typeof data);
-        this.templates.set([]);
-        return;
+      if (Array.isArray(data)) {
+        allTemplates.push(...(data as TemplateData[]));
       }
-
-      this.templates.set(data as TemplateData[]);
     } catch (e) {
-      console.warn("Could not read TEMPLATES.yaml:", e);
-      this.templates.set([]);
+      console.warn("Could not read config/TEMPLATES.yaml:", e);
     }
+
+    // 2. If an active ticket ID is provided, scan tickets/{id}/filesystem/templates/*.yaml
+    if (activeTicketId) {
+      try {
+        const ticketsDir = await handle.getDirectoryHandle("tickets");
+        const ticketDir = await ticketsDir.getDirectoryHandle(activeTicketId);
+        
+        let fsDir: FileSystemDirectoryHandle;
+        let activeSession: string | null = null;
+        try {
+          const metaFile = await ticketDir.getFileHandle("metadata.json");
+          const metaText = await (await metaFile.getFile()).text();
+          const meta = JSON.parse(metaText);
+          activeSession = meta?.active_session ?? null;
+        } catch {
+          // Meta might not exist yet — ignore
+        }
+
+        if (activeSession) {
+          const sessionsDir = await ticketDir.getDirectoryHandle("sessions");
+          const sessionDir = await sessionsDir.getDirectoryHandle(activeSession);
+          fsDir = await sessionDir.getDirectoryHandle("workspace");
+        } else {
+          fsDir = await ticketDir.getDirectoryHandle("filesystem");
+        }
+
+        const templatesDir = await fsDir.getDirectoryHandle("templates");
+        
+        for await (const [name, entry] of (
+          templatesDir as FileSystemDirectoryHandle & {
+            entries(): AsyncIterable<[string, FileSystemHandle]>;
+          }
+        ).entries()) {
+          if (entry.kind !== "file" || (!name.endsWith(".yaml") && !name.endsWith(".yml"))) {
+            continue;
+          }
+          try {
+            const fileHandle = await templatesDir.getFileHandle(name);
+            const file = await fileHandle.getFile();
+            const text = await file.text();
+            const tData = yaml.load(text);
+            if (tData && typeof tData === "object") {
+              const template = tData as TemplateData;
+              if (!template.name) {
+                template.name = name.substring(0, name.lastIndexOf("."));
+              }
+              
+              // Inject metadata for visual badge and route rendering
+              template.isWorkspaceScoped = true;
+              if (activeTicketId) template.ticketId = activeTicketId;
+
+              // Overwrite global templates with workspace definitions if they match names
+              const existingIndex = allTemplates.findIndex((t) => t.name === template.name);
+              if (existingIndex !== -1) {
+                allTemplates[existingIndex] = template;
+              } else {
+                allTemplates.push(template);
+              }
+            }
+          } catch (e) {
+            console.warn(`Could not load local template ${name}:`, e);
+          }
+        }
+      } catch {
+        // Quietly catch when filesystem/templates directory does not exist yet
+      }
+    }
+
+    this.templates.set(allTemplates);
   }
 
   selectTemplate(name: string): void {
@@ -89,37 +158,135 @@ class TemplateStore {
   // ── Write operations ──
 
   /** Save an existing template by replacing its entry and writing to disk. */
-  async saveTemplate(originalName: string, data: TemplateData): Promise<void> {
-    const current = this.templates.get();
-    const index = current.findIndex((t) => t.name === originalName);
-    if (index === -1) throw new Error(`Template "${originalName}" not found`);
+  async saveTemplate(originalName: string, data: TemplateData, activeTicketId?: string | null): Promise<void> {
+    if (data.isWorkspaceScoped && activeTicketId) {
+      await this.#writeLocalTemplate(activeTicketId, data);
+    } else {
+      const current = this.templates.get();
+      const index = current.findIndex((t) => t.name === originalName);
+      if (index === -1) throw new Error(`Template "${originalName}" not found`);
 
-    const updated = [...current];
-    updated[index] = data;
-    await this.#writeTemplates(updated);
+      const updated = [...current];
+      updated[index] = data;
+      const globalsOnly = updated.filter((t) => !t.isWorkspaceScoped);
+      await this.#writeTemplates(globalsOnly);
+    }
+    await this.scan(activeTicketId);
   }
 
   /** Create a new template by appending it and writing to disk. */
-  async createTemplate(data: TemplateData): Promise<void> {
+  async createTemplate(data: TemplateData, activeTicketId?: string | null, saveLocal = false): Promise<void> {
     const current = this.templates.get();
     if (current.some((t) => t.name === data.name))
       throw new Error(`Template "${data.name}" already exists`);
 
-    const updated = [...current, data];
-    await this.#writeTemplates(updated);
+    if (saveLocal && activeTicketId) {
+      data.isWorkspaceScoped = true;
+      data.ticketId = activeTicketId;
+      await this.#writeLocalTemplate(activeTicketId, data);
+    } else {
+      const globalsOnly = current.filter((t) => !t.isWorkspaceScoped);
+      const updated = [...globalsOnly, data];
+      await this.#writeTemplates(updated);
+    }
+    await this.scan(activeTicketId);
     this.selectedTemplateName.set(data.name);
   }
 
   /** Delete a template by name and write to disk. */
-  async deleteTemplate(name: string): Promise<void> {
+  async deleteTemplate(name: string, activeTicketId?: string | null): Promise<void> {
     const current = this.templates.get();
-    const updated = current.filter((t) => t.name !== name);
-    if (updated.length === current.length)
-      throw new Error(`Template "${name}" not found`);
+    const target = current.find((t) => t.name === name);
+    if (!target) throw new Error(`Template "${name}" not found`);
 
-    await this.#writeTemplates(updated);
+    if (target.isWorkspaceScoped && activeTicketId) {
+      await this.#deleteLocalTemplate(activeTicketId, name);
+    } else {
+      const globalsOnly = current.filter((t) => t.name !== name && !t.isWorkspaceScoped);
+      await this.#writeTemplates(globalsOnly);
+    }
+    
+    await this.scan(activeTicketId);
     if (this.selectedTemplateName.get() === name)
       this.selectedTemplateName.set(null);
+  }
+
+  async #writeLocalTemplate(ticketId: string, template: TemplateData): Promise<void> {
+    const handle = this.access.handle;
+    if (!handle) throw new Error("No hive directory handle");
+
+    const ticketsDir = await handle.getDirectoryHandle("tickets");
+    const ticketDir = await ticketsDir.getDirectoryHandle(ticketId);
+    
+    let fsDir: FileSystemDirectoryHandle;
+    let activeSession: string | null = null;
+    try {
+      const metaFile = await ticketDir.getFileHandle("metadata.json");
+      const metaText = await (await metaFile.getFile()).text();
+      const meta = JSON.parse(metaText);
+      activeSession = meta?.active_session ?? null;
+    } catch {
+      // Meta might not exist yet
+    }
+
+    if (activeSession) {
+      const sessionsDir = await ticketDir.getDirectoryHandle("sessions");
+      const sessionDir = await sessionsDir.getDirectoryHandle(activeSession);
+      fsDir = await sessionDir.getDirectoryHandle("workspace");
+    } else {
+      fsDir = await ticketDir.getDirectoryHandle("filesystem");
+    }
+
+    const templatesDir = await fsDir.getDirectoryHandle("templates", { create: true });
+    const fileHandle = await templatesDir.getFileHandle(`${template.name}.yaml`, { create: true });
+    const writable = await fileHandle.createWritable();
+
+    const cleaned: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(template)) {
+      if (key === "isWorkspaceScoped" || key === "ticketId") continue;
+      if (value === undefined || value === null || value === "" || (Array.isArray(value) && value.length === 0)) continue;
+      cleaned[key] = value;
+    }
+
+    const content = yaml.dump(cleaned, {
+      lineWidth: 80,
+      noRefs: true,
+      quotingType: '"',
+      forceQuotes: false,
+    });
+
+    await writable.write(content);
+    await writable.close();
+  }
+
+  async #deleteLocalTemplate(ticketId: string, name: string): Promise<void> {
+    const handle = this.access.handle;
+    if (!handle) throw new Error("No hive directory handle");
+
+    const ticketsDir = await handle.getDirectoryHandle("tickets");
+    const ticketDir = await ticketsDir.getDirectoryHandle(ticketId);
+    
+    let fsDir: FileSystemDirectoryHandle;
+    let activeSession: string | null = null;
+    try {
+      const metaFile = await ticketDir.getFileHandle("metadata.json");
+      const metaText = await (await metaFile.getFile()).text();
+      const meta = JSON.parse(metaText);
+      activeSession = meta?.active_session ?? null;
+    } catch {
+      // Meta might not exist yet
+    }
+
+    if (activeSession) {
+      const sessionsDir = await ticketDir.getDirectoryHandle("sessions");
+      const sessionDir = await sessionsDir.getDirectoryHandle(activeSession);
+      fsDir = await sessionDir.getDirectoryHandle("workspace");
+    } else {
+      fsDir = await ticketDir.getDirectoryHandle("filesystem");
+    }
+
+    const templatesDir = await fsDir.getDirectoryHandle("templates");
+    await templatesDir.removeEntry(`${name}.yaml`);
   }
 
   /**

--- a/packages/bees/hivetool/src/ui/app.ts
+++ b/packages/bees/hivetool/src/ui/app.ts
@@ -12,7 +12,7 @@
  */
 
 import { SignalWatcher } from "@lit-labs/signals";
-import { LitElement, html, css, nothing } from "lit";
+import { LitElement, html, css, nothing, PropertyValues } from "lit";
 import { customElement, state } from "lit/decorators.js";
 
 import { APP_ICON, APP_NAME } from "../constants.js";
@@ -430,6 +430,15 @@ class BeesApp extends SignalWatcher(LitElement) {
     }
   `,
   ];
+
+  willUpdate(changedProperties: PropertyValues) {
+    super.willUpdate(changedProperties);
+    
+    const activeTicketId = this.ticketStore.selectedTicketId.get();
+    if (this.stateAccess.accessState.get() === "ready") {
+      this.templateStore.scan(activeTicketId);
+    }
+  }
 
   connectedCallback() {
     super.connectedCallback();

--- a/packages/bees/hivetool/src/ui/chat-panel.ts
+++ b/packages/bees/hivetool/src/ui/chat-panel.ts
@@ -165,6 +165,10 @@ class BeesChatPanel extends SignalWatcher(LitElement) {
         color: #e2e8f0;
         font-size: 0.85rem;
         line-height: 1.6;
+        max-height: 300px;
+        overflow-y: auto;
+        scrollbar-width: thin;
+        scrollbar-color: #334155 transparent;
       }
 
       .agent-prompt p {

--- a/packages/bees/hivetool/src/ui/template-detail.ts
+++ b/packages/bees/hivetool/src/ui/template-detail.ts
@@ -299,6 +299,7 @@ class BeesTemplateDetail extends SignalWatcher(LitElement) {
   @state() accessor saving = false;
   @state() accessor error: string | null = null;
   @state() accessor draft: TemplateData | null = null;
+  @state() accessor saveLocal = false;
 
   // ── Run state ──
   @state() accessor showRunDialog = false;
@@ -574,6 +575,23 @@ class BeesTemplateDetail extends SignalWatcher(LitElement) {
             : nothing}
 
           <div class="edit-form">
+            ${isNew && this.ticketStore?.selectedTicketId.get()
+              ? html`
+                  <div class="edit-row" style="align-items:center;margin-bottom:8px">
+                    <label style="display:flex;align-items:center;gap:8px;font-size:0.8rem;color:#cbd5e1;cursor:pointer">
+                      <input
+                        type="checkbox"
+                        ?checked=${this.saveLocal}
+                        @change=${(e: Event) => {
+                          this.saveLocal = (e.target as HTMLInputElement).checked;
+                        }}
+                        style="cursor:pointer"
+                      />
+                      Save as Local Template in Active Task Workspace
+                    </label>
+                  </div>
+                `
+              : nothing}
             <!-- Identity fields -->
             <div class="edit-row">
               <bees-editable-field
@@ -744,6 +762,7 @@ class BeesTemplateDetail extends SignalWatcher(LitElement) {
   private startEditing(template: TemplateData) {
     this.#originalName = template.name;
     this.draft = { ...template };
+    this.saveLocal = !!template.isWorkspaceScoped;
     this.editing = true;
     this.error = null;
   }
@@ -751,6 +770,7 @@ class BeesTemplateDetail extends SignalWatcher(LitElement) {
   startCreating() {
     this.#originalName = null;
     this.draft = { name: "" };
+    this.saveLocal = false;
     this.creating = true;
     this.editing = false;
     this.error = null;
@@ -808,11 +828,13 @@ class BeesTemplateDetail extends SignalWatcher(LitElement) {
     this.saving = true;
     this.error = null;
 
+    const activeTicketId = this.ticketStore?.selectedTicketId.get();
+
     try {
       if (this.creating) {
-        await this.templateStore.createTemplate(this.draft);
+        await this.templateStore.createTemplate(this.draft, activeTicketId, this.saveLocal);
       } else if (this.#originalName) {
-        await this.templateStore.saveTemplate(this.#originalName, this.draft);
+        await this.templateStore.saveTemplate(this.#originalName, this.draft, activeTicketId);
         // If name changed, update selection.
         if (this.draft.name !== this.#originalName) {
           this.templateStore.selectTemplate(this.draft.name);
@@ -842,8 +864,10 @@ class BeesTemplateDetail extends SignalWatcher(LitElement) {
     this.saving = true;
     this.error = null;
 
+    const activeTicketId = this.ticketStore?.selectedTicketId.get();
+
     try {
-      await this.templateStore.deleteTemplate(this.#originalName);
+      await this.templateStore.deleteTemplate(this.#originalName, activeTicketId);
       this.cancelEditing();
     } catch (e) {
       this.error =

--- a/packages/bees/hivetool/src/ui/template-list.ts
+++ b/packages/bees/hivetool/src/ui/template-list.ts
@@ -63,6 +63,8 @@ class BeesTemplateList extends SignalWatcher(LitElement) {
         color: #c4b5fd;
         font-family: "Google Mono", "Roboto Mono", monospace;
       }
+
+
     `,
   ];
 

--- a/packages/bees/tests/test_dynamic_templates.py
+++ b/packages/bees/tests/test_dynamic_templates.py
@@ -1,0 +1,311 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for dynamic, workspace-scoped sub-agents and templates."""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+import pytest
+import yaml
+
+from bees.playbook import (
+    load_all_templates,
+    list_playbooks,
+    load_playbook,
+    run_playbook,
+    stamp_child_task,
+)
+from bees.task_store import TaskStore
+from bees.provisioner import provision_session
+from bees.ticket import Ticket
+from bees.subagent_scope import SubagentScope
+
+@pytest.fixture
+def temp_hive(tmp_path):
+    """Set up a temporary hive directory structure."""
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    tickets_dir = tmp_path / "tickets"
+    tickets_dir.mkdir()
+    
+    # Write global legacy templates
+    templates_path = config_dir / "TEMPLATES.yaml"
+    global_templates = [
+        {
+            "name": "opie",
+            "title": "Opie Assistant",
+            "objective": "Help the user.",
+            "tasks": ["researcher"],
+        },
+        {
+            "name": "researcher",
+            "title": "Researcher Agent",
+            "objective": "Research things.",
+        }
+    ]
+    templates_path.write_text(yaml.dump(global_templates, default_flow_style=False))
+    
+    return tmp_path
+
+
+def test_seeding_global_templates(temp_hive):
+    """Verify that provision_session seeds global templates into templates/*.yaml."""
+    store = TaskStore(temp_hive)
+    parent_task = store.create(
+        "Test objective",
+        title="Test Task",
+        playbook_id="opie",
+        tasks=["researcher"],
+    )
+    
+    # Provision the session
+    config = provision_session(
+        segments=[],
+        ticket_id=parent_task.id,
+        ticket_dir=parent_task.dir,
+        hive_dir=temp_hive,
+        scope=SubagentScope.for_ticket(parent_task),
+    )
+    
+    # Verify that templates are seeded in workspace/templates/
+    templates_dir = parent_task.fs_dir / "templates"
+    assert templates_dir.is_dir()
+    assert (templates_dir / "opie.yaml").is_file()
+    assert (templates_dir / "researcher.yaml").is_file()
+    
+    # Verify contents
+    opie_data = yaml.safe_load((templates_dir / "opie.yaml").read_text())
+    assert opie_data["name"] == "opie"
+    assert opie_data["title"] == "Opie Assistant"
+
+
+def test_dynamic_template_loading(temp_hive):
+    """Verify that load_all_templates loads both global and local workspace templates."""
+    store = TaskStore(temp_hive)
+    parent_task = store.create(
+        "Test objective",
+        title="Test Task",
+        playbook_id="opie",
+    )
+    
+    config_dir = temp_hive / "config"
+    workspace_dir = parent_task.fs_dir
+    
+    # 1. Initially, only global templates are loaded
+    all_templates = load_all_templates(config_dir, workspace_dir)
+    global_names = {t["name"] for t in all_templates}
+    assert "opie" in global_names
+    assert "researcher" in global_names
+    assert "custom-worker" not in global_names
+    
+    # 2. Write a custom template directly in the workspace
+    local_templates_dir = workspace_dir / "templates"
+    local_templates_dir.mkdir(parents=True, exist_ok=True)
+    custom_template = {
+        "name": "custom-worker",
+        "title": "Custom Worker",
+        "objective": "Execute custom task.",
+    }
+    (local_templates_dir / "custom-worker.yaml").write_text(yaml.dump(custom_template))
+    
+    # 3. Re-load templates and verify the custom one is included
+    all_templates_scoped = load_all_templates(config_dir, workspace_dir)
+    names_scoped = {t["name"] for t in all_templates_scoped}
+    assert "opie" in names_scoped
+    assert "researcher" in names_scoped
+    assert "custom-worker" in names_scoped
+    
+    # 4. Verify override capability: overwrite researcher locally
+    override_template = {
+        "name": "researcher",
+        "title": "Overridden Researcher",
+        "objective": "Supercharged research objective.",
+    }
+    (local_templates_dir / "researcher.yaml").write_text(yaml.dump(override_template))
+    
+    loaded_override = load_playbook("researcher", config_dir, workspace_dir)
+    assert loaded_override["title"] == "Overridden Researcher"
+    assert loaded_override["objective"] == "Supercharged research objective."
+
+
+@pytest.mark.asyncio
+async def test_tasks_list_types_dynamic_allowed(temp_hive):
+    """Verify tasks_list_types handles dynamic allowed and local workspace templates."""
+    from bees.functions.tasks import get_tasks_function_group_factory
+    
+    store = TaskStore(temp_hive)
+    parent_task = store.create(
+        "Test objective",
+        title="Test Task",
+        playbook_id="opie",
+        tasks=["researcher"], # only researcher is statically allowed globally
+    )
+    
+    # Ensure templates folder exists and write a custom worker
+    workspace_dir = parent_task.fs_dir
+    local_templates_dir = workspace_dir / "templates"
+    local_templates_dir.mkdir(parents=True, exist_ok=True)
+    
+    custom_template = {
+        "name": "custom-worker",
+        "title": "Custom Worker",
+        "objective": "Execute custom task.",
+    }
+    (local_templates_dir / "custom-worker.yaml").write_text(yaml.dump(custom_template))
+    
+    # Mock scheduler and hooks
+    class MockScheduler:
+        def __init__(self, store):
+            self.store = store
+    
+    scheduler = MockScheduler(store)
+    
+    factory = get_tasks_function_group_factory(
+        scope=SubagentScope.for_ticket(parent_task),
+        caller_ticket_id=parent_task.id,
+        scheduler=scheduler,
+        ticket_id=parent_task.id,
+    )
+    
+    # Duck-typed class satisfying SessionHooks
+    class MockHooks:
+        @property
+        def controller(self):
+            return None
+        @property
+        def file_system(self):
+            return None
+        @property
+        def task_tree_manager(self):
+            return None
+        
+    group = factory(MockHooks())
+    
+    # Retrieve function handlers from definitions
+    list_types = next(d.handler for name, d in group.definitions if name == "tasks_list_types")
+    
+    # Call tasks_list_types
+    result = await list_types({}, None)
+    task_types = result.get("task_types", [])
+    
+    # Verify that:
+    # - 'researcher' is included (statically allowed global)
+    # - 'custom-worker' is included (dynamically allowed workspace template)
+    # - 'opie' is filtered out (global but not in tasks allowlist)
+    names = {t["name"] for t in task_types}
+    assert "researcher" in names
+    assert "custom-worker" in names
+    assert "opie" not in names
+
+
+@pytest.mark.asyncio
+async def test_tasks_create_task_dynamic(temp_hive):
+    """Verify tasks_create_task successfully creates task from dynamically authored templates."""
+    from bees.functions.tasks import get_tasks_function_group_factory
+    
+    store = TaskStore(temp_hive)
+    parent_task = store.create(
+        "Test objective",
+        title="Test Task",
+        playbook_id="opie",
+        tasks=["researcher"],
+    )
+    
+    # Add dynamic template
+    workspace_dir = parent_task.fs_dir
+    local_templates_dir = workspace_dir / "templates"
+    local_templates_dir.mkdir(parents=True, exist_ok=True)
+    
+    custom_template = {
+        "name": "custom-worker",
+        "title": "Custom Worker",
+        "objective": "Execute custom task for {{system.context}}.",
+    }
+    (local_templates_dir / "custom-worker.yaml").write_text(yaml.dump(custom_template))
+    
+    class MockScheduler:
+        def __init__(self, store):
+            self.store = store
+            self.tasks_delivered = []
+        async def wait_for_task(self, task_id, wait_ms):
+            return "completed"
+            
+    scheduler = MockScheduler(store)
+    
+    factory = get_tasks_function_group_factory(
+        scope=SubagentScope.for_ticket(parent_task),
+        caller_ticket_id=parent_task.id,
+        scheduler=scheduler,
+        ticket_id=parent_task.id,
+    )
+    
+    class MockHooks:
+        @property
+        def controller(self):
+            return None
+        @property
+        def file_system(self):
+            return None
+        @property
+        def task_tree_manager(self):
+            return None
+
+    group = factory(MockHooks())
+    create_task = next(d.handler for name, d in group.definitions if name == "tasks_create_task")
+    
+    # Spawn child task using custom template
+    args = {
+        "type": "custom-worker",
+        "summary": "My Custom Run",
+        "objective": "some custom parameters",
+        "slug": "custom-run",
+        "wait_ms_before_async": 10,
+    }
+    
+    result = await create_task(args, None)
+    assert "error" not in result
+    
+    # Verify child was written to store successfully
+    all_tickets = store.query_all()
+    child_tickets = [t for t in all_tickets if t.metadata.parent_task_id == parent_task.id]
+    assert len(child_tickets) == 1
+    
+    child = child_tickets[0]
+    assert child.metadata.playbook_id == "custom-worker"
+    assert child.metadata.slug == "custom-run"
+    assert child.metadata.context == "some custom parameters"
+
+
+def test_templates_protection_during_hydration(tmp_path):
+    """Verify that hydrate_from_snapshot protects the templates folder from being unlinked."""
+    from bees.disk_file_system import DiskFileSystem
+    
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    
+    fs = DiskFileSystem(work_dir)
+    
+    # 1. Create a simple text file in workspace
+    fs.write("notes.txt", "hello")
+    
+    # 2. Capture snapshot (only contains notes.txt)
+    snapshot = fs.snapshot
+    assert "notes.txt" in snapshot.files
+    assert "templates/my-template.yaml" not in snapshot.files
+    
+    # 3. Simulate writing a template file from the outside
+    templates_dir = work_dir / "templates"
+    templates_dir.mkdir()
+    (templates_dir / "my-template.yaml").write_text("name: my-template", encoding="utf-8")
+    assert (templates_dir / "my-template.yaml").is_file()
+    
+    # 4. Call hydrate_from_snapshot
+    fs.hydrate_from_snapshot(snapshot)
+    
+    # 5. Assert notes.txt is restored and my-template.yaml survives!
+    assert (work_dir / "notes.txt").is_file()
+    assert (templates_dir / "my-template.yaml").is_file()
+    assert (templates_dir / "my-template.yaml").read_text(encoding="utf-8") == "name: my-template"

--- a/packages/bees/tests/test_scheduler.py
+++ b/packages/bees/tests/test_scheduler.py
@@ -165,6 +165,59 @@ async def test_deliver_context_update_immediate(mock_clients):
     assert fresh_creator.metadata.assignee == "agent"
 
 
+@pytest.mark.asyncio
+async def test_deliver_context_update_running_buffers_and_autoresumes_on_suspend(mock_clients):
+    _, backend = mock_clients
+    scheduler = Scheduler(store=GLOBAL_STORE, runners={"generate": backend})
+    
+    creator = GLOBAL_STORE.create("Parent Objective")
+    creator.metadata.status = "running"
+    creator.metadata.assignee = "agent"
+    creator.metadata.runner = "generate"  # Batch runner
+    GLOBAL_STORE.save_metadata(creator)
+    
+    # Mock active stream to simulate running state
+    mock_stream = AsyncMock()
+    scheduler._active_streams[creator.id] = mock_stream
+    
+    update = {"task_id": "sub-1", "outcome": "done"}
+    scheduler._deliver_context_update(creator.id, update)
+    
+    # Assert that it was NOT injected mid-stream (Path 1 skipped for generate)
+    mock_stream.send_context.assert_not_called()
+    
+    # Assert that it was buffered in pending_context_updates (Path 3)
+    fresh_creator = GLOBAL_STORE.get(creator.id)
+    assert fresh_creator.metadata.pending_context_updates == [update]
+    
+    # Now simulate that the parent turn finishes and it suspends
+    from bees.protocols.session import SessionResult
+    result = SessionResult(
+        session_id="s1",
+        status="suspended",
+        events=1,
+        output="",
+        suspended=True,
+        suspend_event={"waitForInput": {}},
+    )
+    
+    scheduler._task_runner._handle_suspend(creator, result)
+    scheduler.store.save_metadata(creator)
+    
+    # Assert that the pending updates were consumed, response.json written, and assignee flipped to agent (auto-resume!)
+    response_path = creator.dir / "response.json"
+    assert response_path.exists()
+    
+    import json
+    content = json.loads(response_path.read_text())
+    assert content["context_updates"] == [update]
+    
+    fresh_creator2 = GLOBAL_STORE.get(creator.id)
+    assert fresh_creator2.metadata.assignee == "agent"
+    assert fresh_creator2.metadata.status == "suspended"
+    assert fresh_creator2.metadata.pending_context_updates == []
+
+
 # ---------------------------------------------------------------------------
 # Tag enrichment tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
Transforms the Bees agent framework from a Closed World model to an Open World model by allowing agents to dynamically author and execute specialized, workspace-scoped sub-agent templates. Also includes an atomic turn-settlement context buffering and auto-resume architecture, dynamic OPFS scans, and visual streamlining in Hivetool.

## Why
Enables the agent swarm to autonomously specialize and delegate work at runtime while maintaining strict security boundaries (gating parent-level bash tools) and eliminating timing race conditions under dynamic steering.

## Changes
### Python Backend
- **provisioner.py**: Seeds legacy global templates as separate files under the ticket's workspace `templates/` directory on startup.
- **playbook.py**: Implements merged template loading (`load_all_templates()`) prioritizing local workspace-scoped overrides over global definitions.
- **functions/tasks.py**: Updates tasks listing/creation tools to distinguish and dynamically allow all workspace-scoped templates while securing global ones.
- **disk_file_system.py**: Protects the `templates/` directory from being unlinked during turn resumption hydration wipes, ensuring dynamic definitions survive.
- **scheduler.py**: Restricts mid-stream context updates to live streaming sessions, ensuring turn-based batch sessions buffer updates to preserve turn atomicity.
- **task_runner.py**: Refactors `_handle_suspend` to immediately auto-resume suspended batch sessions if new context updates are buffered during turn execution.
- **declarations/tasks.instruction.md**: Refines tasks instructions to teach agents that available task types are dynamic and must be listed before delegation.

### Hive Resources
- **skills/create-task-type/SKILL.md**: Created a dynamic sub-agent authoring instructions skill for Gemini agents.

### Hivetool Lit Workbench
- **template-store.ts**: Merges, writes, and deletes workspace-scoped templates reactively based on the active ticket ID.
- **template-list.ts**: Streamlines the template selector card list layout by removing the workspace badge.
- **template-detail.ts**: Adds a save-destination toggle to the creation form so templates can be isolatingly written to the active task workspace.
- **chat-panel.ts**: Constrains the agent prompt panel to a scrollable `max-height: 300px` with thin scrollbars to prevent tall outputs from breaking input elements.

## Testing
- Created `test_dynamic_templates.py` (covering seeding, overrides loading, allowed gating, child task creation).
- Added a new test in `test_scheduler.py` verifying turn-level context buffering and auto-resumption.
- Ran all 24 templates/scheduler pytest cases successfully (100% green).
- Confirmed Lit workbench type safety (`tsc --noEmit`), ESLint clean checks (`npm run lint`), and successful production compilation (`npm run build`).
