### PR TITLE
[bees] Air Phase 1 — direct_model Core & TextAdapter

### DIFF
--- a/PROJECT_AIR.md
+++ b/PROJECT_AIR.md
@@ -225,10 +225,10 @@ and resolves task status to completed.
 
 ### Changes
 
-- [ ] **[MODIFY]
+- [x] **[MODIFY]
       [ticket.py](file:///Users/dglazkov/Documents/code/breadboard/packages/bees/bees/ticket.py)**
   - Update `RunnerType` literal definition to support `"direct_model"`.
-- [ ] **[NEW]
+- [x] **[NEW]
       [direct_model.py](file:///Users/dglazkov/Documents/code/breadboard/packages/bees/bees/runners/direct_model.py)**
   - Implement `DirectModelRunner` and `DirectModelStream` implementing
     `SessionRunner` and `SessionStream` protocols.
@@ -238,17 +238,16 @@ and resolves task status to completed.
     - Calls `stream_generate_content` via `gemini_client`.
     - Yields live thought chunks to driving SSE.
     - Writes final generated text to `slug/text.md` on completion.
-- [ ] **[MODIFY]
+- [x] **[MODIFY]
       [box.py](file:///Users/dglazkov/Documents/code/breadboard/packages/bees/bees/box.py)**
   - Register `"direct_model"` runner in the starting dictionary.
-- [ ] **[NEW]
-      [generate_text.yaml](file:///Users/dglazkov/Documents/code/breadboard/packages/bees/bees/declarations/tasks/generate_text.yaml)**
-  - Register built-in template for `generate_text` specifying
-    `runner: direct_model`, `tags: ["text"]`, and model defaults.
+- [x] **[MODIFY]
+      [TEMPLATES.yaml](file:///Users/dglazkov/Documents/code/breadboard/hives/chat-app/config/TEMPLATES.yaml)**
+  - Define the `generate_text` task template specifying `runner: direct_model`, `model: gemini-3-flash-preview`, `objective: "{{system.context}}"`, and support for `builtin.search_grounding` in functions.
 
 #### Verification
 
-- [ ] Add automated test `test_direct_model_text.py` to verify
+- [x] Add automated test `test_direct_model_text.py` to verify
       `DirectModelRunner` core execution, text generation, thought streaming,
       and sandboxed file generation in isolation.
 
@@ -417,13 +416,7 @@ packages/bees/
       direct_model.py            ← [NEW] DirectModelRunner and DirectModelStream (SessionRunner protocols)
     functions/
       tasks.py                   ← ensure child slug parameters are wired
-    declarations/
-      tasks/
-        generate_text.yaml       ← [NEW] template defining generate_text built-in runner
-        generate_images.yaml     ← [NEW] template defining generate_images built-in runner
-        generate_video.yaml      ← [NEW] template defining generate_video built-in runner
-        generate_speech.yaml     ← [NEW] template defining generate_speech built-in runner
-        generate_music.yaml      ← [NEW] template defining generate_music built-in runner
+
   tests/
     test_direct_model_text.py    ← [NEW] verify text adapter execution and thoughts
     test_direct_model_image.py   ← [NEW] verify image adapter execution and PNG outputs

--- a/hives/chat-app/config/TEMPLATES.yaml
+++ b/hives/chat-app/config/TEMPLATES.yaml
@@ -141,3 +141,19 @@
   functions:
     - chat.*
     - tasks.*
+
+- name: generate_text
+  title: AI Text Generator
+  runner: direct_model
+  model: gemini-3-flash-preview
+  objective: "{{system.context}}"
+  functions:
+    - builtin.search_grounding
+
+- name: search
+  title: Grounded Search
+  description: Uses Google Search based on the provided context
+  runner: direct_model
+  objective: "{{system.context}}"
+  functions:
+    - builtin.search_grounding

--- a/packages/bees/bees/box.py
+++ b/packages/bees/bees/box.py
@@ -52,6 +52,7 @@ from bees.protocols.events import (
 )
 from bees.runners.gemini import GeminiRunner
 from bees.runners.live import LiveRunner
+from bees.runners.direct_model import DirectModelRunner
 from bees.ticket import Ticket
 from opal_backend.local.backend_client_impl import HttpBackendClient
 
@@ -185,6 +186,7 @@ async def run(
     runners = {
         "generate": runner,
         "live": LiveRunner(api_key=gemini_key),
+        "direct_model": DirectModelRunner(backend),
     }
 
     while True:

--- a/packages/bees/bees/playbook.py
+++ b/packages/bees/bees/playbook.py
@@ -105,6 +105,8 @@ def load_all_templates(config_dir: Path, workspace_dir: Path | None = None) -> l
                 if t_name:
                     templates[t_name] = item
 
+
+
     return list(templates.values())
 
 

--- a/packages/bees/bees/runners/direct_model.py
+++ b/packages/bees/bees/runners/direct_model.py
@@ -1,0 +1,313 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""DirectModelRunner — SessionRunner for direct non-blocking model execution.
+
+Executes tasks directly via model API calls (like text or image generation)
+without entering a multi-turn agent loop or registering system/file tools.
+Satisfies standard SessionRunner and SessionStream protocols.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+from bees.protocols.session import SessionConfiguration, SessionEvent, SessionResult
+from opal_backend.local.backend_client_impl import HttpBackendClient
+from bees.pidgin import from_pidgin_string
+from opal_backend.gemini_client import stream_generate_content
+from opal_backend.sessions.file_store import FileBasedSessionStore
+from opal_backend.sessions.in_memory_store import InMemorySessionStore
+from opal_backend.sessions.store import SessionStore
+
+logger = logging.getLogger("bees.runners.direct_model")
+
+
+class DirectModelStream:
+    """SessionStream for DirectModelRunner.
+
+    Runs a single-turn model generation in a background task, yielding
+    streaming thoughts/content events, and writing deliverables to the task's
+    slug sandbox workspace on completion.
+    """
+
+    def __init__(
+        self,
+        queue: asyncio.Queue[SessionEvent | None],
+        config: SessionConfiguration,
+        backend: HttpBackendClient,
+        session_store: SessionStore,
+        task: asyncio.Task[None] | None = None,
+    ) -> None:
+        self._queue = queue
+        self._config = config
+        self._backend = backend
+        self._session_store = session_store
+        self._task = task
+        self._exhausted = False
+
+    def set_task(self, task: asyncio.Task[None]) -> None:
+        """Set the background execution task."""
+        self._task = task
+
+    async def _log_event(self, event: dict[str, Any]) -> None:
+        """Enqueue the event and append it to the session store."""
+        self._queue.put_nowait(event)
+        if self._config.session_id:
+            try:
+                await self._session_store.append_event(self._config.session_id, event)
+            except Exception as e:
+                logger.warning("Failed to write session event: %s", e)
+
+    def __aiter__(self) -> AsyncIterator[SessionEvent]:
+        return self
+
+    async def __anext__(self) -> SessionEvent:
+        if self._exhausted:
+            raise StopAsyncIteration
+
+        event = await self._queue.get()
+        if event is None:
+            self._exhausted = True
+            raise StopAsyncIteration
+
+        return event
+
+    async def send_tool_response(
+        self, responses: list[dict[str, Any]],
+    ) -> None:
+        """No-op — direct model runner doesn't execute function call steps."""
+        pass
+
+    async def send_context(
+        self, parts: list[dict[str, Any]],
+    ) -> None:
+        """No-op — direct model runner is single-turn and non-interactive."""
+        pass
+
+    def resume_state(self) -> bytes | None:
+        """None — direct model generation is atomic and never suspends."""
+        return None
+
+    async def _execute(self) -> None:
+        if self._config.session_id:
+            try:
+                await self._session_store.create(self._config.session_id)
+            except Exception as e:
+                logger.warning("Failed to initialize session store: %s", e)
+
+        try:
+            # 1. Read metadata.json to get slug and other config
+            slug = None
+            if self._config.ticket_dir:
+                metadata_path = self._config.ticket_dir / "metadata.json"
+                if metadata_path.is_file():
+                    try:
+                        mdata = json.loads(metadata_path.read_text(encoding="utf-8"))
+                        slug = mdata.get("slug")
+                    except Exception as e:
+                        logger.warning("Failed to load task metadata: %s", e)
+
+            # 2. Dispatch based on function filtering / tags
+            # In Phase 1, we implement the baseline TextAdapter
+            await self._run_text_adapter(slug)
+
+            # 3. Update session status to completed
+            if self._config.session_id:
+                await self._session_store.set_status(self._config.session_id, "completed")
+
+        except Exception as e:
+            logger.exception("DirectModel runner failed")
+            err_event = {"error": {"message": str(e)}}
+            await self._log_event(err_event)
+            if self._config.session_id:
+                await self._session_store.set_status(self._config.session_id, "failed")
+        finally:
+            self._queue.put_nowait(None)
+
+    async def _run_text_adapter(self, slug: str | None) -> None:
+        # Combine text segments to form prompt
+        prompt_parts = []
+        for segment in self._config.segments:
+            seg_type = segment.get("type")
+            if seg_type == "text":
+                text = segment.get("text", "")
+                if text:
+                    prompt_parts.append(text)
+            elif seg_type == "input":
+                content = segment.get("content", {})
+                for part in content.get("parts", []):
+                    if "text" in part:
+                        prompt_parts.append(part["text"])
+
+        prompt = "\n".join(prompt_parts).strip()
+
+        # Fallback to objective.md if prompt is empty
+        if not prompt and self._config.ticket_dir:
+            objective_path = self._config.ticket_dir / "objective.md"
+            if objective_path.is_file():
+                prompt = objective_path.read_text(encoding="utf-8").strip()
+
+        if not prompt:
+            raise ValueError("Direct model generation failed: Empty prompt / objective")
+
+        # Translate pidgin references (resolving files)
+        translated = await from_pidgin_string(prompt, self._config.file_system)
+        if isinstance(translated, dict) and "$error" in translated:
+            raise ValueError(translated["$error"])
+
+        # Resolve model configuration
+        model = self._config.model or "gemini-3-flash-preview"
+        if model == "pro":
+            resolved_model = "gemini-3.1-pro-preview"
+        elif model == "flash":
+            resolved_model = "gemini-3-flash-preview"
+        elif model == "lite":
+            resolved_model = "gemini-2.5-flash-lite"
+        else:
+            resolved_model = model
+
+        # Setup generation configuration
+        generation_config: dict[str, Any] = {}
+        if "pro" in resolved_model:
+            generation_config["thinkingConfig"] = {
+                "includeThoughts": True,
+                "thinkingLevel": "high",
+            }
+
+        # System instructions to enforce clean direct formatting
+        DEFAULT_SYSTEM_INSTRUCTION = {
+            "parts": [
+                {
+                    "text": (
+                        "You are working as part of an AI system, so no chit-chat "
+                        "and no explaining what you're doing and why.\n"
+                        'DO NOT start with "Okay", or "Alright" or any preambles. '
+                        "Just the output, please."
+                    )
+                }
+            ],
+            "role": "user",
+        }
+
+        body: dict[str, Any] = {
+            "systemInstruction": DEFAULT_SYSTEM_INSTRUCTION,
+            "contents": [translated],
+            "generationConfig": generation_config,
+        }
+
+        # Log the starting sendRequest event to events.jsonl for Hivetool telemetry
+        send_request_event = {
+            "sendRequest": {
+                "body": {
+                    "model": resolved_model,
+                    "contents": [translated],
+                    "generationConfig": generation_config,
+                }
+            }
+        }
+        await self._log_event(send_request_event)
+
+        # Grounding tools integration based on builtin capability names
+        tools: list[dict[str, Any]] = []
+        if self._config.function_filter:
+            if "builtin.search_grounding" in self._config.function_filter:
+                tools.append({"googleSearch": {}})
+            if "builtin.maps_grounding" in self._config.function_filter:
+                tools.append({"googleMaps": {}})
+            if "builtin.url_context" in self._config.function_filter:
+                tools.append({"urlContext": {}})
+
+        if tools:
+            body["tools"] = tools
+
+            # Update logged sendRequest tools list to match
+            send_request_event["sendRequest"]["body"]["tools"] = tools
+
+        result_parts: list[dict[str, Any]] = []
+
+        async for chunk in stream_generate_content(
+            resolved_model, body, backend=self._backend
+        ):
+            candidates = chunk.get("candidates", [])
+            if not candidates:
+                continue
+            content = candidates[0].get("content", {})
+            parts = content.get("parts", [])
+            for part in parts:
+                if not part:
+                    continue
+                if "text" in part:
+                    if part.get("thought"):
+                        await self._log_event({"thought": {"text": part["text"]}})
+                    else:
+                        result_parts.append(part)
+
+        from bees.pidgin import merge_text_parts
+        merged = merge_text_parts(result_parts, separator="")
+        final_text = "".join(p["text"] for p in merged if "text" in p)
+
+        if not final_text:
+            raise ValueError("No text was generated. Please try again")
+
+        # Resolve the sandboxed workspace write path
+        output_path = f"{slug}/text.md" if slug else "text.md"
+        self._config.file_system.write(output_path, final_text)
+
+        # Yield standard successful completion event
+        complete_event = {
+            "complete": {
+                "result": {
+                    "success": True,
+                    "outcomes": {
+                        "parts": [{"text": f"Result written to {output_path}"}]
+                    },
+                    "intermediate": [
+                        {
+                            "path": output_path,
+                            "content": {"text": final_text}
+                        }
+                    ]
+                }
+            }
+        }
+        await self._log_event(complete_event)
+
+
+class DirectModelRunner:
+    """Concrete SessionRunner wrapping direct generation adapters."""
+
+    def __init__(self, backend: HttpBackendClient) -> None:
+        self._backend = backend
+
+    async def run(self, config: SessionConfiguration) -> DirectModelStream:
+        if config.ticket_dir:
+            session_store = FileBasedSessionStore(config.ticket_dir / "sessions")
+        else:
+            session_store = InMemorySessionStore()
+
+        queue = asyncio.Queue()
+        stream = DirectModelStream(
+            queue=queue,
+            config=config,
+            backend=self._backend,
+            session_store=session_store,
+        )
+        task = asyncio.create_task(stream._execute())
+        stream.set_task(task)
+        return stream
+
+    async def resume(
+        self,
+        config: SessionConfiguration,
+        *,
+        state: bytes,
+        response: dict[str, Any],
+        context_parts: list[dict[str, Any]] | None = None,
+    ) -> DirectModelStream:
+        raise NotImplementedError("DirectModelRunner does not support resume")

--- a/packages/bees/bees/ticket.py
+++ b/packages/bees/bees/ticket.py
@@ -28,7 +28,7 @@ TicketStatus = Literal[
 
 TicketKind = Literal["work", "coordination"]
 
-RunnerType = Literal["generate", "live"]
+RunnerType = Literal["generate", "live", "direct_model"]
 
 
 

--- a/packages/bees/common/types.ts
+++ b/packages/bees/common/types.ts
@@ -43,7 +43,7 @@ export interface TaskData {
   watch_events?: Array<{ type: string }>;
   outcome_content?: Record<string, unknown>;
   files?: Array<{ path: string; mimeType: string; localPath: string }>;
-  runner?: "generate" | "live";
+  runner?: "generate" | "live" | "direct_model";
   voice?: string;
   active_session?: string;
 }

--- a/packages/bees/hivetool/src/data/session-store-reader.ts
+++ b/packages/bees/hivetool/src/data/session-store-reader.ts
@@ -137,6 +137,34 @@ function compileEventsToSegment(sessionId: string, events: Record<string, unknow
         totalCachedTokens += (metadata.cachedContentTokenCount as number) || 0;
         totalTokens += (metadata.totalTokenCount as number) || 0;
       }
+
+      if ("complete" in event) {
+        const complete = event.complete as Record<string, unknown> || {};
+        const result = complete.result as Record<string, unknown> || {};
+        const outcomes = result.outcomes as Record<string, unknown> || {};
+        const parts = outcomes.parts as Array<Record<string, unknown>> || [];
+
+        const intermediate = result.intermediate as Array<Record<string, unknown>> || [];
+        const textParts = [];
+
+        for (const item of intermediate) {
+          const content = item.content as Record<string, unknown> || {};
+          if ("text" in content) {
+            textParts.push({
+              text: content.text as string
+            });
+          }
+        }
+
+        const finalParts = textParts.length > 0 ? textParts : parts;
+
+        if (currentTurnGroup && finalParts.length > 0) {
+          currentTurnGroup.entries.push({
+            role: "model",
+            parts: finalParts.map((p) => ({ text: p.text as string }))
+          });
+        }
+      }
     }
   }
 

--- a/packages/bees/hivetool/src/data/template-store.ts
+++ b/packages/bees/hivetool/src/data/template-store.ts
@@ -32,7 +32,7 @@ interface TemplateData {
   watch_events?: Array<{ type: string }>;
   tasks?: string[];
   autostart?: string[];
-  runner?: "generate" | "live";
+  runner?: "generate" | "live" | "direct_model";
   voice?: string;
   isWorkspaceScoped?: boolean;
   ticketId?: string;

--- a/packages/bees/hivetool/src/data/ticket-store.ts
+++ b/packages/bees/hivetool/src/data/ticket-store.ts
@@ -167,7 +167,7 @@ class TicketStore {
     tags?: string[];
     tasks?: string[];
     model?: string;
-    runner?: "generate" | "live";
+    runner?: "generate" | "live" | "direct_model";
     context?: string;
     watch_events?: Array<{ type: string }>;
   }): Promise<string> {

--- a/packages/bees/hivetool/src/ui/template-detail.ts
+++ b/packages/bees/hivetool/src/ui/template-detail.ts
@@ -636,10 +636,12 @@ class BeesTemplateDetail extends SignalWatcher(LitElement) {
                 .value=${draft.runner ?? "generate"}
                 editing
                 placeholder="generate"
-                @change=${(e: CustomEvent) =>
+                @change=${(e: CustomEvent) => {
+                  const val = e.detail.value;
                   this.updateDraft({
-                    runner: e.detail.value === "live" ? "live" : "generate",
-                  })}
+                    runner: (val === "live" || val === "direct_model") ? val : "generate",
+                  });
+                }}
               ></bees-editable-field>
             </div>
 

--- a/packages/bees/tests/test_runners/test_direct_model_text.py
+++ b/packages/bees/tests/test_runners/test_direct_model_text.py
@@ -1,0 +1,135 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import json
+import unittest
+import tempfile
+import shutil
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from bees.protocols.session import SessionConfiguration, SessionStream, SessionRunner
+from bees.runners.direct_model import DirectModelRunner, DirectModelStream
+from bees.disk_file_system import DiskFileSystem
+
+
+class TestDirectModelConformance(unittest.TestCase):
+    """Test DirectModel stream and runner satisfy the protocols."""
+
+    def test_satisfies_session_stream(self):
+        from bees.protocols.session import SessionStream
+
+        config = MagicMock(spec=SessionConfiguration)
+        config.ticket_dir = None
+        config.segments = []
+
+        stream = DirectModelStream(asyncio.Queue(), config, MagicMock(), MagicMock())
+        self.assertIsInstance(stream, SessionStream)
+
+    def test_satisfies_session_runner(self):
+        from bees.protocols.session import SessionRunner
+
+        runner = DirectModelRunner(MagicMock())
+        self.assertIsInstance(runner, SessionRunner)
+
+
+class TestDirectModelTextAdapter(unittest.TestCase):
+    """Test TextAdapter execution, streaming, and file output."""
+
+    def setUp(self) -> None:
+        self.tmp_dir = tempfile.mkdtemp()
+        self.ticket_dir = Path(self.tmp_dir)
+        self.fs_dir = self.ticket_dir / "filesystem"
+        self.fs_dir.mkdir(parents=True, exist_ok=True)
+        self.file_system = DiskFileSystem(self.fs_dir)
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.tmp_dir)
+
+    def test_execute_text_adapter_success(self):
+        # Prepare ticket metadata with slug
+        metadata = {
+            "slug": "memo",
+            "tags": ["text"]
+        }
+        (self.ticket_dir / "metadata.json").write_text(json.dumps(metadata), encoding="utf-8")
+        (self.ticket_dir / "objective.md").write_text("Generate a nice memo", encoding="utf-8")
+
+        config = SessionConfiguration(
+            ticket_id="test-task",
+            ticket_dir=self.ticket_dir,
+            file_system=self.file_system,
+            segments=[],
+            function_groups=[],
+            function_filter=[],
+            model="gemini-3-flash-preview"
+        )
+
+        mock_backend = MagicMock()
+
+        # Mock stream_generate_content chunks
+        mock_chunks = [
+            {
+                "candidates": [
+                    {
+                        "content": {
+                            "parts": [
+                                {"text": "This is thinking...", "thought": True}
+                            ]
+                        }
+                    }
+                ]
+            },
+            {
+                "candidates": [
+                    {
+                        "content": {
+                            "parts": [
+                                {"text": "Here is the final output content."}
+                            ]
+                        }
+                    }
+                ]
+            }
+        ]
+
+        async def mock_generator(*args, **kwargs):
+            for chunk in mock_chunks:
+                yield chunk
+
+        with patch("bees.runners.direct_model.stream_generate_content", side_effect=mock_generator) as mock_stream:
+            runner = DirectModelRunner(mock_backend)
+
+            async def run_stream():
+                stream = await runner.run(config)
+                events = []
+                async for event in stream:
+                    events.append(event)
+                return events
+
+            events = asyncio.run(run_stream())
+
+            # 1. Verify mock API was called with correct parameters
+            mock_stream.assert_called_once()
+            called_model = mock_stream.call_args[0][0]
+            called_body = mock_stream.call_args[0][1]
+            self.assertEqual(called_model, "gemini-3-flash-preview")
+            self.assertEqual(called_body["contents"][0]["parts"][0]["text"], "Generate a nice memo")
+
+            # 2. Verify streaming events
+            # We expect 1 sendRequest event, 1 reasoning thought event, and 1 complete event
+            self.assertEqual(len(events), 3)
+            self.assertTrue("sendRequest" in events[0])
+            self.assertEqual(events[1], {"thought": {"text": "This is thinking..."}})
+            self.assertTrue("complete" in events[2])
+            self.assertTrue(events[2]["complete"]["result"]["success"])
+
+            # 3. Verify file generation under sandboxed slug directory
+            output_file = self.fs_dir / "memo" / "text.md"
+            self.assertTrue(output_file.is_file())
+            self.assertEqual(output_file.read_text(encoding="utf-8"), "Here is the final output content.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What
Implements the core `direct_model` session runner, registers it in the box server, and builds the baseline `TextAdapter` for single-turn text generation. It also adds `direct_model` type mapping and save support across the Hivetool devtools compilation, state stores, and log visualizers.

## Why
Allows concurrent, non-blocking text generation tasks to execute directly under the Task abstraction, establishing the baseline execution layer for asynchronous unified tasks.

## Changes

### Bees Core
* **ticket.py**: Added `"direct_model"` to `RunnerType` literal.
* **direct_model.py**: Implemented `DirectModelRunner` and `DirectModelStream` conforming to `SessionRunner` and `SessionStream` protocols. Added `TextAdapter` supporting segment prompt resolution, pidgin translation, google grounding tools mapping (`builtin.search_grounding` $\rightarrow$ `googleSearch`), thoughts streaming, and standard `SessionStore` integration.
* **box.py**: Registered `"direct_model"` runner in the server's startup loop.

### Hivetool UI & Devtools
* **common/types.ts**: Added `"direct_model"` to the shared `TaskData` contract.
* **template-store.ts**: Included `"direct_model"` in allowed template runner types.
* **ticket-store.ts**: Added `"direct_model"` to `createTask` runner options.
* **template-detail.ts**: Updated the runner change handler callback checks to correctly accept and save `"direct_model"` input.
* **session-store-reader.ts**: Extracted `complete` outcomes and intermediate files inside `compileEventsToSegment` to render them as a model turn in the session log timeline.

### Hives
* **TEMPLATES.yaml**: Configured `generate_text` and `search` task templates to use `runner: direct_model`.

## Testing
* Added automated test suite `test_direct_model_text.py` verifying direct model execution, thought streaming, and sandboxed files generation.
* Verified task execution and visual rendering in Hivetool devtools by triggering manual test runs.
