### PR TITLE
[bees] Project Air Phase 2 (Asynchronous Unified Tasks & Snapshot Hydration Modes)

### DIFF
--- a/PROJECT_AIR.md
+++ b/PROJECT_AIR.md
@@ -268,7 +268,7 @@ after receiving deliverables inside `memo/text.md`.
 
 ### Changes
 
-- [ ] **[MODIFY]
+- [x] **[MODIFY]
       [TEMPLATES.yaml](file:///Users/dglazkov/Documents/code/breadboard/hives/chat-app/config/TEMPLATES.yaml)**
   - Under templates `chat-chat` and `chat-3`:
     - Remove `generate.text` from the allowed `functions:` allowlist.
@@ -277,7 +277,7 @@ after receiving deliverables inside `memo/text.md`.
       references of calling the `generate_text` function with instructions to
       spawn a `generate_text` sub-task with `slug` set to the desired folder
       name.
-- [ ] **[MODIFY]
+- [x] **[MODIFY]
       [SKILL.md](file:///Users/dglazkov/Documents/code/breadboard/packages/bees/hive/skills/research/SKILL.md)**
   - Remove `generate.text` from the allowed-tools header list.
   - Add `tasks.*` to the allowed-tools list.
@@ -289,7 +289,7 @@ after receiving deliverables inside `memo/text.md`.
 
 #### Verification
 
-- [ ] Run the updated `chat-chat` or `chat-3` agent sessions end-to-end and
+- [x] Run the updated `chat-chat` or `chat-3` agent sessions end-to-end and
       verify they execute concurrent tasks for generation seamlessly.
 
 ---

--- a/hives/chat-app/config/TEMPLATES.yaml
+++ b/hives/chat-app/config/TEMPLATES.yaml
@@ -27,41 +27,41 @@
     - system.*
 
 - name: chat-chat
-  title: Chat Chat
+  title: Opie w/o Workspace
   description: A chat app that builds apps
   objective: >-
-    Build high-quality React apps in response to user requests. If the requests
-    are simple, just respond. If the user asks for a "widget", build a React
-    app. When the user asks to update the widget, update the JSON file that
-    supplies widget's data.
+    Converse with the user as Opie, a friendly assistant. 
 
 
-    Use generate_text to research the data and ensure that the JSON file
-    information contains accurate data.
+    In the conversation, strive to be helpful: concise but not terse, effective
+    but not brash. Ok to stop and ask questions if request is not clear.
 
 
-    Here's how you build a widget:
+    In the first message, briefly introduce yourself and tell the user what you
+    can do.
 
 
-    1) Create a new subdirectory where the app will go. Check to see that this
-    is a new directory.
+    If the requests don't require a UI, reply in chat. If the user asks for a
+    "widget", build a widget. When the user asks to update the widget, update
+    the JSON file that supplies widget's data.
 
 
-    2) Write the React app using Opal SDK in that subdirectory. Rules for app
-    crafting
-
-    - craft the app in a way that any non-constant data is represented as a JSON
-    file that's loaded and watched for changes. 
-
-    - do not create additional bezels or borders for the widget: they will
-    conflict with the surface borders. Just 10px padding.
+    Use a child task of type `generate_text` (using standard tasks tool with
+    `slug` set to a research folder name like `research`) to research the data
+    and ensure that the JSON file information contains accurate data.
 
 
-    3) Create or update the surface to include the widget.
+    Anticipate that user is not very technical, so instead of using technical
+    jargon or terms (like React or generate_text), apply more friendly terms.
 
 
-    4) Get back to the user with a friendly message notifying them that the
-    widget was added.
+    React app bundle = widget
+
+    surface = dashboard
+
+    section = tab in the dashboard
+
+    etc.
   model: gemini-3.1-pro-preview
   skills:
     - build-react-apps
@@ -70,7 +70,9 @@
     - use-opal-sdk
   functions:
     - chat.*
-    - generate.text
+    - tasks.*
+  tasks:
+    - generate_text
 
 - name: workspace-test
   title: Test Workspace MCP 2
@@ -104,8 +106,9 @@
     the JSON file that supplies widget's data.
 
 
-    Use generate_text to research the data and ensure that the JSON file
-    information contains accurate data.
+    Use a child task of type `generate_text` (using standard tasks tool with
+    `slug` set to a research folder name like `research`) to research the data
+    and ensure that the JSON file information contains accurate data.
 
 
     Anticipate that user is not very technical, so instead of using technical
@@ -128,12 +131,14 @@
     - build-widgets
   functions:
     - chat.*
-    - generate.text
+    - tasks.*
     - drive.*
     - gchat.*
     - gmail.*
     - calendar.*
     - people.*
+  tasks:
+    - generate_text
 
 - name: delegator
   title: Delegator
@@ -143,17 +148,13 @@
     - tasks.*
 
 - name: generate_text
-  title: AI Text Generator
+  title: Text Generator
   runner: direct_model
   model: gemini-3-flash-preview
   objective: "{{system.context}}"
   functions:
     - builtin.search_grounding
-
-- name: search
-  title: Grounded Search
-  description: Uses Google Search based on the provided context
-  runner: direct_model
-  objective: "{{system.context}}"
-  functions:
-    - builtin.search_grounding
+  description: >-
+    An extremely versatile text generator, powered by Gemini. Use it for any
+    tasks that involve generation of text. Supports multimodal content input.
+    Always writes its output to {slug}/text.md.

--- a/packages/bees/bees/disk_file_system.py
+++ b/packages/bees/bees/disk_file_system.py
@@ -341,13 +341,13 @@ class DiskFileSystem:
             file_count=len(files),
         )
 
-    def hydrate_from_snapshot(self, snapshot: FileSystemSnapshot) -> None:
+    def hydrate_from_snapshot(self, snapshot: FileSystemSnapshot, clear_untracked: bool = True) -> None:
         """Hydrate the disk workspace from a snapshot.
 
         Clears any existing files on disk before writing snapshot files.
         """
         # Clear existing files on disk (excluding hidden files or skipped directories)
-        if self._work_dir.exists():
+        if clear_untracked and self._work_dir.exists():
             for item in self._work_dir.rglob("*"):
                 if item.is_file():
                     rel = item.relative_to(self._work_dir)

--- a/packages/bees/bees/playbook.py
+++ b/packages/bees/bees/playbook.py
@@ -258,14 +258,17 @@ def stamp_child_task(
     )
 
     if child_scope.slug_path:
-        sandbox_block = child_scope.sandbox_instructions()
-        child.objective = (
-            f"{child.objective}\n\n"
+        sandbox_block = child_scope.sandbox_instructions(child.metadata.runner)
+        
+        blocks = [
             f"<subagent_context>\n"
             f"Your parent id is: {parent_task.id}\n"
-            f"</subagent_context>\n"
-            f"{sandbox_block}"
-        )
+            f"</subagent_context>"
+        ]
+        if sandbox_block:
+            blocks.append(sandbox_block)
+
+        child.objective = f"{child.objective}\n\n" + "\n\n".join(blocks)
         store.save(child)
         child_scope.writable_dir(child.fs_dir).mkdir(
             parents=True, exist_ok=True,

--- a/packages/bees/bees/runners/gemini.py
+++ b/packages/bees/bees/runners/gemini.py
@@ -368,7 +368,10 @@ class GeminiRunner:
             interaction_state.file_system is not None
             and hasattr(config.file_system, "hydrate_from_snapshot")
         ):
-            config.file_system.hydrate_from_snapshot(interaction_state.file_system)
+            config.file_system.hydrate_from_snapshot(
+                interaction_state.file_system,
+                clear_untracked=False,
+            )
 
         if self._session_store_factory:
             session_store = self._session_store_factory(config)

--- a/packages/bees/bees/subagent_scope.py
+++ b/packages/bees/bees/subagent_scope.py
@@ -89,12 +89,12 @@ class SubagentScope:
 
     # -- Instruction generation --------------------------------------------
 
-    def sandbox_instructions(self) -> str:
+    def sandbox_instructions(self, runner: str = "generate") -> str:
         """Generate the ``<sandbox_environment>`` block for the objective.
 
         Returns an empty string for root agents (no restriction).
         """
-        if self.slug_path is None:
+        if self.slug_path is None or runner == "direct_model":
             return ""
         return (
             "<sandbox_environment>\n"

--- a/packages/bees/hive/skills/research/SKILL.md
+++ b/packages/bees/hive/skills/research/SKILL.md
@@ -4,7 +4,7 @@ title: How to Do Great Research
 description:
   Uplevel your researching abilities and learn how to research properly.
 allowed-tools:
-  - generate.text
+  - tasks.*
   - files.*
 ---
 
@@ -16,7 +16,9 @@ General flow of the research process:
 2. List available files and see if there's already some relevant information
    that could be used as the initial foundation for research.
 
-3. Call `generate_text` with search grounding for each query in parallel.
+3. Create a child task of type `generate_text` (using the standard tasks tool
+   with `slug` set to a unique folder name like `search_1`, `search_2`, etc.,
+   and `objective` set to your query) for each query in parallel.
 
 4. Organize the information into a coherent whole. Deduplicate and order.
 
@@ -30,15 +32,16 @@ Rule 1: Do not rely on parametric memory for research. Mind the training data
 gap. You are an LLM, and your parametric memory is likely stale. Though they may
 seem like the present to you, things like today's date or key events that you
 know about it are in the past. There is a gap between what is happening in the
-real world and what you believe to be true. To close this gap, use
-`generate_text` with search grounding to get the actual information. Rely on
-`current_date` tag in the metadata to orient in time.
+real world and what you believe to be true. To close this gap, spawn a child
+task of type `generate_text` with search grounding to get the actual
+information. Rely on `current_date` tag in the metadata to orient in time.
 
-Rule 2: Call multiple searches in parallel. Before starting research, decide on
-different facets of information that would be useful to have and start a
-separate `generate_text` with search grounding for each. They will run in
-parallel. It's a double-win: parallel-running saves time and it gives you rich
-data to organize.
+Rule 2: Spawn multiple search child tasks in parallel. Before starting research,
+decide on different facets of information that would be useful to have and start
+a separate child task of type `generate_text` with search grounding for each
+query in parallel, specifying unique `slug` sandbox folders (e.g. `search_1`,
+`search_2`). They will run in parallel. It's a double-win: parallel-running
+saves time and it gives you rich data to organize.
 
 Rule 3: Don't make assumptions or theorize. Good research does not attempt to
 fill in the blanks.

--- a/packages/bees/tests/test_disk_file_system.py
+++ b/packages/bees/tests/test_disk_file_system.py
@@ -376,3 +376,50 @@ class TestProtocolCompliance:
 
         fs = AgentFileSystem()
         assert isinstance(fs, FileSystem)
+
+
+# ---------------------------------------------------------------------------
+# hydrate_from_snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestHydrateFromSnapshot:
+
+    def test_hydrate_recreates_tracked_files(self, tmp_path):
+        fs = DiskFileSystem(tmp_path)
+        fs.write("a.txt", "original-a")
+        snap = fs.snapshot
+
+        # Modify original file on disk
+        (tmp_path / "a.txt").write_text("modified-a")
+
+        # Hydrate should restore original content
+        fs.hydrate_from_snapshot(snap)
+        assert (tmp_path / "a.txt").read_text() == "original-a"
+
+    def test_hydrate_deletes_untracked_files_when_clear_untracked_is_true(self, tmp_path):
+        fs = DiskFileSystem(tmp_path)
+        fs.write("a.txt", "original-a")
+        snap = fs.snapshot
+
+        # Create an untracked file on disk
+        (tmp_path / "untracked.txt").write_text("new-file")
+
+        # Hydrating with default (clear_untracked=True) should delete untracked.txt
+        fs.hydrate_from_snapshot(snap, clear_untracked=True)
+        assert not (tmp_path / "untracked.txt").exists()
+
+    def test_hydrate_preserves_untracked_files_when_clear_untracked_is_false(self, tmp_path):
+        fs = DiskFileSystem(tmp_path)
+        fs.write("a.txt", "original-a")
+        snap = fs.snapshot
+
+        # Create an untracked file on disk
+        (tmp_path / "untracked.txt").write_text("new-file")
+
+        # Hydrating with clear_untracked=False should NOT delete untracked.txt
+        fs.hydrate_from_snapshot(snap, clear_untracked=False)
+        assert (tmp_path / "untracked.txt").exists()
+        assert (tmp_path / "untracked.txt").read_text() == "new-file"
+        assert (tmp_path / "a.txt").read_text() == "original-a"
+

--- a/packages/bees/tests/test_playbook.py
+++ b/packages/bees/tests/test_playbook.py
@@ -366,7 +366,7 @@ class TestStampChildTask:
     def test_sandbox_instructions_appended(self, write_template):
         write_template(
             {"name": "parent", "objective": "Manage."},
-            {"name": "worker", "objective": "Do work."},
+            {"name": "worker", "objective": "Do work.", "runner": "generate"},
         )
 
         parent = run_playbook("parent")
@@ -376,6 +376,20 @@ class TestStampChildTask:
 
         assert "<sandbox_environment>" in child.objective
         assert "my-worker" in child.objective
+        assert "<subagent_context>" in child.objective
+
+    def test_sandbox_instructions_skipped_for_direct_model(self, write_template):
+        write_template(
+            {"name": "parent", "objective": "Manage."},
+            {"name": "worker", "objective": "Do work.", "runner": "direct_model"},
+        )
+
+        parent = run_playbook("parent")
+        child = stamp_child_task(
+            "worker", parent_task=parent, slug="my-worker",
+        )
+
+        assert "<sandbox_environment>" not in child.objective
         assert "<subagent_context>" in child.objective
 
     def test_writable_dir_created(self, write_template):


### PR DESCRIPTION
## What
Migrated `chat-chat` and `chat-3` templates and `research` skill from legacy synchronous functions to concurrent child tasks using the `tasks.*` tool under `direct_model` runner, and resolved concurrency snapshot leaks by distinguishing between forward and backward file hydration.

## Why
Unblocks the agent cognitive loop by transforming blocking media/model calls into durable background tasks, solves tool-calling hallucinations caused by leaky sandbox environment instruction stampings, and prevents snapshot hydration from unlinking/deleting files created by concurrent background subagents.

## Changes

### 🎬 Concurrency & Snapshot Hydration (Forward vs. Backward Motion)
- **`DiskFileSystem`**: Enhanced `hydrate_from_snapshot` to accept a `clear_untracked` flag.
- **`GeminiRunner`**: Passed `clear_untracked=False` during natural turn resumptions (forward motion) to preserve subagent deliverables (e.g. `research/text.md`), while retaining full unlinking behavior (`clear_untracked=True`) during back-in-time rolls (backward motion).

### 🤖 Direct Model Sandbox Gating
- **`SubagentScope`**: Made sandbox environment prompts runner-specific. Skip unlinking/bash instruction prompt injections for stateless, tool-less `direct_model` tasks to systematically prevent LLM function-calling hallucinations.
- **`playbook`**: Retrieve the child task's runner dynamically in `stamp_child_task` and conditionally omit empty sandbox prompts.

### 📁 Declarative Task Templates & Skills
- **`TEMPLATES.yaml`**: Replaced `generate.text` function with standard `tasks.*` and configured the explicit allowed child `tasks` list under `chat-chat` and `chat-3` templates.
- **`SKILL.md`**: Standardized parallel subtask spawning of `generate_text` tasks with dynamic `slug` workspaces instead of inline generation calls.

---

## Testing

### Automated Unit Tests
Enhanced full test coverage in `test_disk_file_system.py` and `test_playbook.py`:
- Verify `clear_untracked=False` successfully preserves untracked files on disk.
- Verify `clear_untracked=True` successfully deletes untracked files.
- Verify direct model templates cleanly omit `<sandbox_environment>` prompt blocks.

Run tests using:
```bash
.venv/bin/python -m pytest tests/test_disk_file_system.py tests/test_playbook.py -v
```
