### PR TITLE
[bees] UI Builder Evaluation Hive and Hivetool Readonly Mode

### DIFF
--- a/hives/ui-builder/README.md
+++ b/hives/ui-builder/README.md
@@ -1,0 +1,66 @@
+# UI Builder — Quality Hill Climb Environment
+
+Use this hive to hill climb on UI builder quality.
+
+## 1. One-Time Setup
+
+Ensure your development environment is configured before starting:
+
+- **Environment Variables**: Verify your `.env` file in `packages/bees/.env`
+  contains a valid `GEMINI_KEY`.
+- **Python Setup**: Run `npm run setup -w bees` to initialize the virtual
+  environment and install dependencies.
+
+## 2. Run the Evaluation Session
+
+Start the evaluation session using the top-level npm script. This executes a
+batch eval against the `ui-builder` template:
+
+```bash
+npm run eval:ui-builder
+```
+
+This command copies this hive to a pristine working directory under
+`packages/bees/results/<timestamp>/hive`, boots the `ui-builder` template, and
+runs all cycles autonomously without modifying your source files.
+
+## 3. Wait for Completion
+
+Let the session run to completion. The batch runner will print progress logs and
+summarize the final cycle status, total duration, and task counts to stderr.
+
+## 4. Examine Results in Hivetool
+
+Open Hivetool (the framework's developer workbench) in your browser: 👉
+https://breadboard-ai.github.io/breadboard/hivetool/
+
+When prompted by Hivetool's directory picker, point it at
+`packages/bees/results/`. Selecting the parent results folder allows you to
+seamlessly select between different timestamped runs using Hivetool's built-in
+hive picker.
+
+In Hivetool, inspect:
+
+- **Tasks Tab**: Check generated component code, tickets, and final file
+  manifests.
+- **Sessions Tab**: Drill into turn-by-turn reasoning, tool calls
+  (`execute_bash` for bundling, `files_write_file`), and token usage metrics.
+
+## 5. Tweak Template & Skills
+
+To adjust agent instructions, use Hivetool's hive picker to switch to your
+source hive (`hives/ui-builder/`):
+
+- **Templates Tab**: Use the inline editor to refine the objective, system
+  prompt, or model parameters. Press "Save" (or Cmd+S) to write changes directly
+  to `config/TEMPLATES.yaml`.
+- **Skills Tab**: Modify or add skills in hivetool or edit directly in `skills/`
+  directory.
+
+When you are ready to review your next run, simply switch back to
+`packages/bees/results/` using the hive picker.
+
+## 6. Iterate
+
+Repeat steps 2 through 5 until the generated UI meets your high standard of
+excellence. Happy hill climbing!

--- a/hives/ui-builder/config/SYSTEM.yaml
+++ b/hives/ui-builder/config/SYSTEM.yaml
@@ -1,0 +1,3 @@
+# Hive system configuration.
+title: ui-builder
+description: "UI Builder evaluation and hill-climb environment"

--- a/hives/ui-builder/config/TEMPLATES.yaml
+++ b/hives/ui-builder/config/TEMPLATES.yaml
@@ -1,0 +1,27 @@
+# Ticket templates — see docs/patterns.md for the field reference.
+
+- name: ui-builder
+  title: React App Builder
+  description: Builds a high-quality React App
+  objective: >-
+    Create a weather data file named weather_data.json, showing weather for a
+    location. Simulate the weather data for Los Altos, CA.
+
+
+    Then, build a high-quality React app according to this specification:
+
+
+    - A weather widget that loads from weather_data.json and displays it
+
+    - Anytime the file changes, use the opal SDK to read and update the display.
+
+
+    Finally, add a surface to display this app as a single primary item.
+  model: gemini-3.1-pro-preview
+  skills:
+    - build-react-apps
+    - run-in-sandbox
+    - surface
+    - use-opal-sdk
+  functions:
+    - system.*

--- a/hives/ui-builder/eval/config.yaml
+++ b/hives/ui-builder/eval/config.yaml
@@ -1,0 +1,9 @@
+max_iterations: 20
+simulated_user:
+  title: "Simulated User"
+  model: gemini-3.1-flash-preview
+  objective: >-
+    You are evaluating a UI builder agent. When the agent asks questions or requests confirmation,
+    provide concise, persona-consistent guidance to steer the UI towards high aesthetic and functional quality.
+  functions:
+    - chat.*

--- a/hives/ui-builder/skills/build-react-apps/SKILL.md
+++ b/hives/ui-builder/skills/build-react-apps/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: build-react-apps
+title: How to build React apps
+description: Produce high-quality React apps from natural language descriptions.
+allowed-tools:
+  - files.*
+  - sandbox.*
+---
+
+# How to build high-quality React apps
+
+## What You're Building
+
+A **multi-file React component bundle** rendered in a sandboxed iframe. The
+bundle consists of:
+
+- `App.jsx` — the root component that accepts configuration props
+- `components/*.jsx` — reusable sub-components
+- `styles.css` — shared styles using CSS custom properties
+
+Components use **inline styles** with CSS custom properties from a design token
+system. Import resolution between files is handled automatically by the build
+pipeline.
+
+## Workflow
+
+Your UI MUST work from 320px to 1200px+. This is not optional.
+
+1. Write the app an its components as files in your directory.
+
+2. Build the bundle with [bundler.mjs](./scripts/bundler.mjs):
+
+```bash
+node ./skills/{name of this skill}/scripts/bundler.mjs
+```
+
+If you do not run this exact command, the user will see a blank screen.
+
+3. Once bundling is successful, return a brief confirmation that the UI was
+   generated and bundled. Don't enclose produced files.
+
+## Developer Rules
+
+Follow these rules strictly.
+
+1. **App.jsx is the entry point.** It must be named exactly `App.jsx` and
+   contain a function called `App`.
+2. **App carries the configuration.** All data that should be configurable by
+   the caller (location, users, items, dates, etc.) appears as props on `App`
+   with realistic defaults.
+3. **Sub-components are reusable.** Each component in `components/` should
+   render standalone with sensible defaults. Document all props with `@prop`
+   JSDoc.
+4. **Every file imports what it uses.** Include `import React from "react"` in
+   every JSX file. Import sub-components with relative paths (e.g.
+   `import Header from "./components/Header"`).
+5. **CSS imports work.** Use `import "./styles.css"` in App.jsx for shared
+   styles.
+6. **Export default.** Each component file must `export default` its component
+   function.
+7. **All colors, spacing, typography, and radii MUST use `--cg-` design
+   tokens.** No hex colors, no `rgb()`, no named colors, no raw pixel values.
+   Hardcoded values like `#8B6F47` or `color: olive` break the live theme
+   switcher. This is a build error, not a suggestion.
+8. **Your output renders inside a host application.** Don't create app names,
+   brand headers, splash screens, or taglines. Start with the actual task UI.
+   The host provides the chrome.
+9. **No client storage APIs.** Do not use `localStorage`, `sessionStorage`,
+   `IndexedDB`, or any Web Storage APIs. The iframe environment may not have
+   storage access due to origin restrictions. All state lives in React component
+   state or is passed via props and the SDK.
+10. **Respect the host theme.** Use design tokens. Backgrounds must use
+    `var(--cg-color-surface*)` tokens and all text must use
+    `var(--cg-color-on-surface*)` tokens. The tokens will natively map to their
+    theme variants.
+11. **Use `flex-wrap: wrap`** on any flex container with multiple children that
+    should stack on narrow screens.
+12. **Use CSS Grid with `auto-fit` / `minmax`** for multi-column layouts:
+    `grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr))`.
+13. **Use `clamp()` for font sizes** that should scale with viewport:
+    `font-size: clamp(1rem, 2vw + 0.5rem, 2rem)`.
+14. **Test your mental model** at 375px, 768px, and 1200px before finishing.
+
+These particular paterns are forbidden.
+
+- **No fixed pixel widths** on containers or layout elements. Never write
+  `width: 800px`, `width: 600px`, or similar. Use `max-width` with a percentage
+  or `min()` instead: `max-width: min(100%, 800px)`.
+- **No `min-width` exceeding 320px** on any layout container. This prevents
+  rendering on small screens.
+- **No horizontal overflow.** If your layout causes a horizontal scrollbar at
+  any viewport width ≥ 320px, it is broken.
+
+**CRITICAL FORBIDDEN PATTERN: NO TAILWIND!**
+
+- You MUST NOT use Tailwind CSS utility classes (e.g., `flex`, `min-h-screen`,
+  `p-4`, `bg-red-500`). Tailwind is NOT INSTALLED.
+- You MUST use standard semantic CSS class names (e.g.,
+  `className="hero-container"`).
+- You MUST write a separate `styles.css` file using **Vanilla CSS**.
+- You MUST include `import "./styles.css";` at the top of your `App.jsx`. If you
+  don't write and import a CSS file, your design will be completely unstyled.
+
+## Configuration Props
+
+When creating a component, think about what data the _caller_ would want to
+customize. These become props on `App`:
+
+| UI Type             | Example Props                                              |
+| ------------------- | ---------------------------------------------------------- |
+| Weather dashboard   | `location`, `temperature`, `condition`, `forecast` (array) |
+| User profile        | `name`, `avatar`, `bio`, `stats` (object)                  |
+| Product card        | `title`, `price`, `image`, `rating`, `reviews`             |
+| Task manager        | `tasks` (array), `categories`, `user`                      |
+| Analytics dashboard | `metrics` (array), `timeRange`, `chartData`                |
+
+All props MUST have realistic default values so the component renders standalone
+with zero configuration.
+
+## Design Token System
+
+**Reminder: this is a hard rule (see above).** Every visual value — colors,
+spacing, type, radii, shadows — MUST use `--cg-` tokens. No exceptions.
+
+### Token Rules
+
+| Category      | Use                                                  | Never                                   |
+| ------------- | ---------------------------------------------------- | --------------------------------------- |
+| Colors        | `var(--cg-color-...)`                                | `#hex`, `rgb()`, named colors           |
+| Spacing       | `var(--cg-sp-...)`                                   | Raw pixel values for padding/margin/gap |
+| Font sizes    | `var(--cg-text-...-size)`                            | `14px`, `1rem`                          |
+| Border radius | `var(--cg-radius-...)` or `var(--cg-card-radius)`    | `12px`, `24px`                          |
+| Shadows       | `var(--cg-elevation-...)` or `var(--cg-card-shadow)` | Raw `box-shadow` values                 |
+| Font family   | `var(--cg-font-sans)` or `var(--cg-font-mono)`       | `'Arial'`, `sans-serif`                 |
+
+### Available Tokens
+
+**Colors:** `--cg-color-surface-dim`, `--cg-color-surface`,
+`--cg-color-surface-bright`, `--cg-color-surface-container-lowest`,
+`--cg-color-surface-container-low`, `--cg-color-surface-container`,
+`--cg-color-surface-container-high`, `--cg-color-surface-container-highest`,
+`--cg-color-on-surface`, `--cg-color-on-surface-muted`, `--cg-color-primary`,
+`--cg-color-primary-container`, `--cg-color-on-primary`,
+`--cg-color-on-primary-container`, `--cg-color-secondary`,
+`--cg-color-secondary-container`, `--cg-color-on-secondary`,
+`--cg-color-on-secondary-container`, `--cg-color-tertiary`,
+`--cg-color-tertiary-container`, `--cg-color-on-tertiary`,
+`--cg-color-on-tertiary-container`, `--cg-color-error`,
+`--cg-color-error-container`, `--cg-color-on-error`,
+`--cg-color-on-error-container`, `--cg-color-outline`,
+`--cg-color-outline-variant`
+
+**Typography:** `--cg-font-sans`, `--cg-font-mono`,
+`--cg-text-display-{lg,md,sm}-{size,weight}`,
+`--cg-text-headline-{lg,md,sm}-{size,weight}`,
+`--cg-text-title-{lg,md,sm}-{size,weight}`,
+`--cg-text-body-{lg,md,sm}-{size,weight}`,
+`--cg-text-label-{lg,md,sm}-{size,weight}`
+
+**Spacing (4px grid):** `--cg-sp-0` through `--cg-sp-16`
+
+**Radius:** `--cg-radius-{xs,sm,md,lg,xl,full}`
+
+**Elevation:** `--cg-elevation-{1,2,3}`
+
+**Motion:** `--cg-motion-duration-{short,medium,long}`,
+`--cg-motion-easing-{standard,decel,accel}`
+
+**Component tokens:** Card: `--cg-card-{bg,radius,padding,shadow}`, Button:
+`--cg-button-{radius,padding,bg,color,font-size,font-weight}`, Input:
+`--cg-input-{bg,border,radius,padding,color,placeholder}`, Badge:
+`--cg-badge-{bg,color,radius,padding,font-size}`, Divider:
+`--cg-divider-{color,thickness,style}`
+
+**Expressive:** `--cg-border-{style,width}`,
+`--cg-heading-{transform,letter-spacing}`,
+`--cg-img-{radius,border,shadow,filter}`, `--cg-hover-{scale,brightness,shadow}`
+
+## Component Design
+
+### Decomposition
+
+- **Compose, don't monolith.** A dashboard should be built from `Header`,
+  `MetricsGrid`, `ForecastCard`, etc.
+- **Each component renders standalone** with realistic defaults.
+- **The top-level App composes everything** into a cohesive layout.
+
+### Icons
+
+Google Material Symbols Outlined is available via a web font:
+
+```jsx
+<span className="material-symbols-outlined" style={{ fontSize: "20px" }}>
+  search
+</span>
+```
+
+**CRITICAL: DO NOT import third-party icon packages.** You do not have
+`lucide-react`, `heroicons`, or `react-icons` installed. Using them will break
+the build. ONLY use the `material-symbols-outlined` span.
+
+### Interactivity
+
+Components should be interactive where appropriate. Use `useState`, `useEffect`
+with cleanup. Supported patterns: timers, carousels, accordions, tabs,
+checklists, toggles.
+
+### Stable Defaults
+
+Never use `Date.now()`, `Math.random()`, or `new Date()` in default parameters.
+Compute once at module level or use `useState(() => ...)`.
+
+### Critical: You're building a Segment, Not a Standalone App
+
+Your React app is **one segment** of a wider orchestrated journey. Between
+segments, an LLM orchestrator examines the user's data and decides what comes
+next. This means:
+
+- **Don't brand it.** No app names, no splash screens, no taglines. The host
+  application provides the chrome and framing. Start with the task UI.
+
+### File Structure
+
+Each state gets its own component file named after the state:
+
+- `App.jsx` — shell that renders the initial state
+- `views/InputRequirements.jsx` — one view per state
+- `views/SelectModels.jsx`
+- `views/DetailedComparison.jsx`
+- `views/DecisionReport.jsx`
+- `components/*.jsx` — shared sub-components (reusable across views)
+- `styles.css` — shared styles
+
+### View Contract
+
+Each view component receives two props:
+
+- `data` — the journey context relevant to this state
+- `onTransition` — callback for state transitions (wired to
+  `window.opalSDK.navigateTo`)
+
+```jsx
+export default function SelectModels({ data = {}, onTransition }) {
+  const handleSelect = (item) => {
+    onTransition("detailed_comparison", {
+      ...data,
+      shortlist: [...(data.shortlist || []), item],
+    });
+  };
+  // ...
+}
+```
+
+### Rules
+
+1. **One view per state.** Don't merge states into a single component.
+2. **Views are self-contained.** Each view renders standalone with defaults.
+3. **Shared components go in `components/`.** Headers, cards, buttons used
+   across multiple views should be extracted.
+4. **Context flows forward.** Each transition carries the data the next view
+   needs. Views may also use `readFile` to load shared workspace data.
+5. **Responsive.** The user may view this UI on a mobile device, so ensure that
+   you make every component and the app itself responsive.
+
+## Available Globals
+
+`React`, `useState`, `useEffect`, `useRef`, `useCallback`, `useMemo`,
+`useContext`, `useReducer`, `useLayoutEffect`, `memo`, `forwardRef`,
+`createContext`, `Fragment`
+
+Be creative and visually impressive.

--- a/hives/ui-builder/skills/build-react-apps/scripts/bundler.mjs
+++ b/hives/ui-builder/skills/build-react-apps/scripts/bundler.mjs
@@ -1,0 +1,198 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Standalone JSX bundler for the ui-generator skill.
+ *
+ * Reads JSX/CSS files from the current working directory, bundles them
+ * into a single CJS output (with React as external), and writes
+ * `bundle.js` + `bundle.css` to the same directory.
+ *
+ * Usage (via execute_bash):
+ *   node skills/ui-generator/tools/bundler.mjs
+ *
+ * Entry point: App.jsx in the current directory.
+ * React is provided by the iframe runtime — not bundled here.
+ */
+
+/* global process, console */
+
+import { build } from "esbuild";
+import { readFileSync, writeFileSync, readdirSync, statSync } from "fs";
+import { join, extname, relative } from "path";
+
+const cwd = process.cwd();
+
+// ── Collect files from disk ──────────────────────────────────────────────
+
+/** Recursively collect files into a flat map: relative-path → content. */
+function collectFiles(dir, base = dir) {
+  const result = {};
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const rel = relative(base, full);
+    if (statSync(full).isDirectory()) {
+      // Skip node_modules, hidden dirs, and output files.
+      if (entry.startsWith(".") || entry === "node_modules") continue;
+      Object.assign(result, collectFiles(full, base));
+    } else {
+      const ext = extname(entry);
+      if ([".jsx", ".js", ".css"].includes(ext)) {
+        result[rel] = readFileSync(full, "utf-8");
+      }
+    }
+  }
+  return result;
+}
+
+const files = collectFiles(cwd);
+
+const entryFile = files["App.jsx"] ? "App.jsx" : files["app.jsx"] ? "app.jsx" : null;
+
+if (!entryFile) {
+  console.error("Error: No App.jsx or app.jsx found in", cwd);
+  process.exit(1);
+}
+
+// ── Auto-export ──────────────────────────────────────────────────────────
+
+/**
+ * If a JSX source has no explicit export, detect the component name
+ * and append `export default ComponentName;`.
+ */
+function autoExport(source) {
+  if (source.includes("export default") || source.includes("module.exports")) {
+    return source;
+  }
+  const match =
+    source.match(/^function\s+([A-Z]\w*)/m) ??
+    source.match(/^const\s+([A-Z]\w*)\s*=/m);
+  if (match) {
+    return source + `\nexport default ${match[1]};\n`;
+  }
+  return source;
+}
+
+// ── Collect CSS ──────────────────────────────────────────────────────────
+
+const cssChunks = [];
+
+// ── Bundle ───────────────────────────────────────────────────────────────
+
+/**
+ * Find a file key in the files map, trying with the given extensions.
+ */
+function findFileKey(path, extensions) {
+  if (files[path]) return path;
+  for (const ext of extensions) {
+    const withExt = path + ext;
+    if (files[withExt]) return withExt;
+  }
+  return undefined;
+}
+
+try {
+  const result = await build({
+    stdin: {
+      contents: autoExport(files[entryFile]),
+      loader: "jsx",
+      resolveDir: "/",
+    },
+    bundle: true,
+    write: false,
+    format: "cjs",
+    jsx: "transform",
+    jsxFactory: "React.createElement",
+    jsxFragment: "React.Fragment",
+    plugins: [
+      {
+        name: "virtual-modules",
+        setup(build) {
+          // React → external (provided by iframe's requireShim).
+          build.onResolve({ filter: /.*/ }, (args) => {
+            if (args.path === "react" || args.path.startsWith("react/")) {
+              return { path: args.path, external: true };
+            }
+
+            // Resolve relative paths.
+            let normalized = args.path;
+            if (
+              (args.path.startsWith("./") || args.path.startsWith("../")) &&
+              args.importer
+            ) {
+              const importerDir = args.importer.includes("/")
+                ? args.importer.substring(0, args.importer.lastIndexOf("/") + 1)
+                : "";
+              const joined = importerDir + args.path;
+              const parts = joined.split("/");
+              const resolved = [];
+              for (const part of parts) {
+                if (part === "..") resolved.pop();
+                else if (part !== ".") resolved.push(part);
+              }
+              normalized = resolved.join("/");
+            } else {
+              normalized = normalized.replace(/^\.\//, "");
+            }
+
+            // Resolve to any known file, then assign namespace by extension.
+            const jsExts = [".jsx", ".js"];
+            const cssExts = [".css"];
+            const allExts = [...jsExts, ...cssExts];
+
+            const key =
+              findFileKey(normalized, allExts) ??
+              findFileKey(normalized + ".jsx", []) ??
+              findFileKey(normalized + ".js", []) ??
+              findFileKey(normalized + ".css", []);
+
+            if (key) {
+              const ns = key.endsWith(".css") ? "virtual-css" : "virtual-jsx";
+              return { path: key, namespace: ns };
+            }
+
+            return undefined;
+          });
+
+          // Load virtual JSX modules (auto-export if needed).
+          build.onLoad({ filter: /.*/, namespace: "virtual-jsx" }, (args) => ({
+            contents: autoExport(files[args.path] ?? ""),
+            loader: "jsx",
+          }));
+
+          // Load virtual CSS — collect it and return empty JS.
+          build.onLoad({ filter: /.*/, namespace: "virtual-css" }, (args) => {
+            cssChunks.push(files[args.path] ?? "");
+            return { contents: "", loader: "js" };
+          });
+        },
+      },
+    ],
+  });
+
+  const output = result.outputFiles?.[0];
+  if (!output) {
+    throw new Error("esbuild.build produced no output");
+  }
+
+  // Write bundle.js
+  writeFileSync(join(cwd, "bundle.js"), output.text, "utf-8");
+
+  // Write bundle.css (concatenated CSS chunks)
+  if (cssChunks.length > 0) {
+    writeFileSync(join(cwd, "bundle.css"), cssChunks.join("\n"), "utf-8");
+  }
+
+  console.log(
+    `✓ Bundled: bundle.js (${output.text.length} bytes)` +
+      (cssChunks.length > 0
+        ? `, bundle.css (${cssChunks.join("\n").length} bytes)`
+        : "")
+  );
+} catch (err) {
+  console.error("Bundle failed:", err.message);
+  process.exit(1);
+}

--- a/hives/ui-builder/skills/run-in-sandbox/SKILL.md
+++ b/hives/ui-builder/skills/run-in-sandbox/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: run-in-sandbox
+title: How to run in sandbox
+description:
+  Teaches you how to properly operate in the sandboxed environment you're in.
+allowed-tools:
+  - sandbox.*
+---
+
+# The sandbox
+
+When you call `execute_bash` function, it runs in a sandboxed environment. You
+have acess to most bash commands. The `PATH` is configured to give you access to
+`node` and `python3`.
+
+Even though you can use heredoc to write and `cat` to read files, prefer the
+built-in file functions, if they available.

--- a/hives/ui-builder/skills/surface/SKILL.md
+++ b/hives/ui-builder/skills/surface/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: surface
+title: Presenting Your Work via Surface
+description:
+  Learn how to present your work as a structured surface — a curated manifest of
+  artifacts that the user's application renders in real time.
+allowed-tools:
+  - files.*
+  - events.*
+---
+
+# What is a Surface?
+
+A **surface** is a structured manifest that tells the user's application what to
+display. It contains links to various files to present to the user and
+optionally, groups them into sections.
+
+A surface is a living document you update as you work, so the user sees your
+progress in real time.
+
+# The Workflow
+
+Every time you produce, update, or receive a meaningful artifact, follow these
+steps:
+
+1. **Write `surface.json`.** Overwrite it with the complete current state of
+   what you want to present, including the new/updated artifact. Increment the
+   `version` counter.
+2. **Broadcast.** Call `events_broadcast` with type `surface_updated`. The
+   consumer application listens for `surface_updated` and re-reads
+   `surface.json` to update the display.
+
+# Format
+
+`surface.json` is a single JSON file that you overwrite on every change.
+
+```json
+{
+  "version": 1,
+  "title": "My Surface Title",
+  "sections": [{ "id": "main", "title": "Main Results" }],
+  "items": [
+    {
+      "id": "findings",
+      "title": "Research Findings",
+      "path": "research_notes.md",
+      "description": "Key findings from the analysis",
+      "section": "main"
+    }
+  ]
+}
+```
+
+## Top-level fields
+
+| Field      | Required | Description                                             |
+| ---------- | -------- | ------------------------------------------------------- |
+| `version`  | **yes**  | Integer. Start at 1, increment on every write.          |
+| `title`    | no       | Human-readable name for the surface.                    |
+| `sections` | no       | Declared section groups. Omit if no grouping is needed. |
+| `items`    | **yes**  | Ordered list of content items.                          |
+
+## Sections
+
+Sections are optional named groups. Items reference them by `id`.
+
+| Field         | Required | Description                                                                                          |
+| ------------- | -------- | ---------------------------------------------------------------------------------------------------- |
+| `id`          | **yes**  | Stable identifier, referenced by items.                                                              |
+| `title`       | **yes**  | Human-readable heading.                                                                              |
+| `description` | no       | Brief description of the section.                                                                    |
+| `active`      | no       | When `true`, this section is selected by default in tabbed views. At most one section should be active. |
+
+## Items
+
+Each item represents one piece of content you want to present.
+
+| Field         | Required | Description                                                                                                      |
+| ------------- | -------- | ---------------------------------------------------------------------------------------------------------------- |
+| `id`          | **yes**  | Stable identifier, unique within the surface.                                                                    |
+| `title`       | **yes**  | Human-readable label.                                                                                            |
+| `path`        | no       | File path (workspace-relative). At least one of `path` or `description` must be present.                         |
+| `description` | no       | Inline text — standalone content, preview, or metadata. At least one of `path` or `description` must be present. |
+| `render`      | no       | Rendering override. Use `bundle` for JS files that should render in a sandboxed iframe.                          |
+| `role`        | no       | Semantic role: `primary` (hero), `supporting` (detail), `status` (lightweight indicator).                        |
+| `section`     | no       | The section `id` this item belongs to. Ungrouped items go to a default section.                                  |
+
+# Rules
+
+## Paths match `files_write_file`
+
+The `path` field in items uses the same workspace-relative format as
+`files_write_file`. If you write a file with `files_write_file` using
+`research/findings.md`, reference it in the surface as
+`"path": "research/findings.md"`.
+
+## Write `surface.json` in your writable directory
+
+Use `files_write_file` with `"file_name": "surface.json"`. If you are a
+sub-agent with a scope restriction, write it within your assigned directory
+(e.g., `research/surface.json`). The consumer discovers surface files by walking
+the filesystem tree.
+
+## The surface is complete state, not a diff
+
+Every time you write `surface.json`, include **all** items you want displayed —
+not just the ones that changed. If you previously had 3 items and now have 4,
+write all 4. If you want to remove an item, omit it from the next write.
+
+## Increment version on every write
+
+The `version` counter lets the consumer detect changes. Start at 1. Increment by
+1 on every write, even if only the ordering changed.
+
+## Always broadcast after writing
+
+After writing `surface.json`, call `events_broadcast` with:
+
+- `type`: `surface_updated`
+- `message`: brief description of what changed (e.g., "Added research findings")
+
+## Items without files are valid
+
+Not every item needs a file. Use `description` alone for lightweight status
+indicators:
+
+```json
+{
+  "id": "status",
+  "title": "Progress",
+  "description": "3 of 5 sources analyzed",
+  "role": "status"
+}
+```
+
+## Bundles use a render hint
+
+If you produce a JavaScript bundle (e.g., an interactive chart), set
+`"render": "bundle"` on the item. The consumer loads the JS in a sandboxed
+iframe and discovers a companion CSS file by convention (same filename stem).
+
+## Update the surface incrementally as you work
+
+Don't wait until the end. The surface is most valuable when the user can see
+progress. A good pattern:
+
+1. Write an initial surface with a status item: "Starting analysis..."
+2. As you produce content files, add them to the surface.
+3. Update status items to reflect progress.
+4. When done, write the final surface with all artifacts and remove status
+   items.
+
+# Example: Research Agent with Surface
+
+A research agent doing competitive analysis might produce this sequence:
+
+**After starting (version 1):**
+
+```json
+{
+  "version": 1,
+  "items": [
+    {
+      "id": "status",
+      "title": "Status",
+      "description": "Researching competitors — 3 searches in progress",
+      "role": "status"
+    }
+  ]
+}
+```
+
+**After first results (version 2):**
+
+```json
+{
+  "version": 2,
+  "title": "Competitive Analysis",
+  "sections": [{ "id": "findings", "title": "Findings" }],
+  "items": [
+    {
+      "id": "market-overview",
+      "title": "Market Overview",
+      "path": "research/market_overview.md",
+      "description": "Current market landscape and key players",
+      "role": "primary",
+      "section": "findings"
+    },
+    {
+      "id": "status",
+      "title": "Status",
+      "description": "2 of 3 research threads complete",
+      "role": "status"
+    }
+  ]
+}
+```
+
+**Final surface (version 3):**
+
+```json
+{
+  "version": 3,
+  "title": "Competitive Analysis",
+  "sections": [
+    { "id": "findings", "title": "Findings" },
+    { "id": "data", "title": "Supporting Data" }
+  ],
+  "items": [
+    {
+      "id": "market-overview",
+      "title": "Market Overview",
+      "path": "research/market_overview.md",
+      "description": "Current market landscape and key players",
+      "role": "primary",
+      "section": "findings"
+    },
+    {
+      "id": "competitor-matrix",
+      "title": "Competitor Comparison",
+      "path": "research/competitor_matrix.md",
+      "description": "Feature-by-feature comparison of top 5 competitors",
+      "section": "findings"
+    },
+    {
+      "id": "raw-data",
+      "title": "Research Data",
+      "path": "research/raw_data.json",
+      "description": "Structured data from all sources",
+      "role": "supporting",
+      "section": "data"
+    }
+  ]
+}
+```
+
+Each version was followed by an `events_broadcast` with type `surface_updated`.

--- a/hives/ui-builder/skills/use-opal-sdk/SKILL.md
+++ b/hives/ui-builder/skills/use-opal-sdk/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: use-opal-sdk
+title: Using the Opal SDK from a React component
+description:
+  Learn how to use `window.opalSDK` inside your sandboxed React component to
+  read files, call host services, and listen for events from the application.
+allowed-tools:
+  - files.*
+---
+
+# What is `window.opalSDK`?
+
+When your React component runs inside the sandbox, it has no network access and
+no direct access to the host application. Instead, the host injects
+`window.opalSDK` — a bridge object that lets you:
+
+1. **Call methods** on the host (read files, navigate, etc.)
+2. **Listen for events** pushed by the host (data updates, file changes, etc.)
+
+All communication goes through `postMessage` under the hood. You never need to
+call `postMessage` directly.
+
+# Calling SDK Methods
+
+Every method call on `window.opalSDK` is asynchronous and returns a `Promise`.
+
+```jsx
+// Read a file from the workspace
+const content = await window.opalSDK.readFile("data/results.json");
+
+// Parse and use it
+const data = JSON.parse(content);
+```
+
+## Available Methods
+
+| Method                        | Returns           | Description                                  |
+| ----------------------------- | ----------------- | -------------------------------------------- |
+| `readFile(path)`              | `Promise<string>` | Read a file from the workspace.              |
+| `navigateTo(viewId, params?)` | `Promise<void>`   | Navigate to a different view in the host UI. |
+| `emit(event, payload?)`       | `Promise<void>`   | Send a fire-and-forget event to the host.    |
+
+Paths are workspace-relative, same as `files_write_file`. For example, if you
+wrote a file with `files_write_file` using `data/results.json`, read it with
+`window.opalSDK.readFile("data/results.json")`.
+
+## Error Handling
+
+If a method call fails (e.g., file not found), the Promise rejects with an
+`Error`. Always handle errors:
+
+```jsx
+try {
+  const content = await window.opalSDK.readFile("missing.txt");
+} catch (err) {
+  console.error("Could not read file:", err.message);
+}
+```
+
+# Listening for Events
+
+The SDK implements the standard DOM `addEventListener` API. The host pushes
+events to your component automatically.
+
+## The `filechange` Event
+
+The most important event is `filechange`. It fires whenever a file in your
+working directory changes — for example, when you or another agent writes a file
+with `files_write_file`.
+
+```jsx
+useEffect(() => {
+  function onFileChange(e) {
+    console.log("File changed:", e.detail.path);
+  }
+
+  window.opalSDK.addEventListener("filechange", onFileChange);
+
+  return () => {
+    window.opalSDK.removeEventListener("filechange", onFileChange);
+  };
+}, []);
+```
+
+The event detail contains:
+
+| Field  | Type     | Description                                        |
+| ------ | -------- | -------------------------------------------------- |
+| `path` | `string` | Workspace-relative path of the file that changed.  |
+
+## Key Points
+
+- Events arrive as standard `CustomEvent` objects.
+- The payload is on `e.detail`.
+- Always clean up listeners in your `useEffect` return function to prevent
+  memory leaks.
+
+# Example: Auto-Refreshing Data Display
+
+Here's a complete component that loads data from a JSON file and automatically
+re-reads it whenever the file changes on disk:
+
+```jsx
+import React, { useState, useEffect, useCallback } from "react";
+
+export default function DataView() {
+  const [data, setData] = useState(null);
+  const [error, setError] = useState(null);
+
+  const loadData = useCallback(async () => {
+    try {
+      const raw = await window.opalSDK.readFile("data.json");
+      setData(JSON.parse(raw));
+      setError(null);
+    } catch (err) {
+      setError(err.message);
+    }
+  }, []);
+
+  // Load initial data.
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  // Re-read when the file changes.
+  useEffect(() => {
+    function onFileChange(e) {
+      if (e.detail.path === "data.json") {
+        loadData();
+      }
+    }
+
+    window.opalSDK.addEventListener("filechange", onFileChange);
+
+    return () => {
+      window.opalSDK.removeEventListener("filechange", onFileChange);
+    };
+  }, [loadData]);
+
+  if (error) return <div>Error: {error}</div>;
+  if (!data) return <div>Loading…</div>;
+
+  return (
+    <div>
+      <h2>{data.title}</h2>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </div>
+  );
+}
+```
+
+This pattern — load once, then listen for changes — is the standard way to
+build reactive components. The host watches the filesystem and pushes
+`filechange` events automatically; your component just needs to re-read the
+files it cares about.
+
+# Rules
+
+## Always use `window.opalSDK`, never `postMessage`
+
+The SDK handles serialization, request IDs, and error propagation for you. Raw
+`postMessage` calls will not be understood by the host.
+
+## All methods are async
+
+Even fire-and-forget methods like `navigateTo` return a Promise. You can `await`
+them or ignore the return value — both work.
+
+## Clean up event listeners
+
+If your component unmounts and re-mounts, stale listeners will fire on the old
+component instance. Always return a cleanup function from `useEffect`.
+
+## Filter `filechange` by path
+
+The `filechange` event fires for every file in the working directory, not just
+yours. Check `e.detail.path` before reacting:
+
+```jsx
+function onFileChange(e) {
+  if (e.detail.path === "my-data.json") {
+    reload();
+  }
+}
+```

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "prepare": "husky",
     "setup:python": "wireit",
     "test:python": "wireit",
-    "show:archived-projects": "git log --diff-filter=D --name-only --pretty=format:'%h %s' -- 'PROJECT_*.md'"
+    "show:archived-projects": "git log --diff-filter=D --name-only --pretty=format:'%h %s' -- 'PROJECT_*.md'",
+    "eval:ui-builder": "npm run eval -w bees -- run ../../hives/ui-builder --root ui-builder"
   },
   "wireit": {
     "build": {

--- a/packages/bees/bees/eval/runner.py
+++ b/packages/bees/bees/eval/runner.py
@@ -182,6 +182,7 @@ async def run_case(
     if work_dir.exists():
         shutil.rmtree(work_dir)
     shutil.copytree(hive_dir, work_dir)
+    (work_dir / ".readonly").touch()
 
     logger.info("Running case '%s': %s → %s", name, hive_dir, work_dir)
 

--- a/packages/bees/hivetool/src/data/skill-store.ts
+++ b/packages/bees/hivetool/src/data/skill-store.ts
@@ -57,7 +57,7 @@ function parseFrontmatter(text: string): {
 }
 
 class SkillStore {
-  constructor(private access: StateAccess) {}
+  constructor(readonly access: StateAccess) {}
 
   readonly skills = new Signal.State<SkillData[]>([]);
   readonly selectedSkillDir = new Signal.State<string | null>(null);

--- a/packages/bees/hivetool/src/data/state-access.ts
+++ b/packages/bees/hivetool/src/data/state-access.ts
@@ -49,6 +49,7 @@ class StateAccess {
   readonly isMultiHive = new Signal.State<boolean>(false);
   readonly cases = new Signal.State<Array<{ id: string; name: string }>>([]);
   readonly activeCaseId = new Signal.State<string | null>(null);
+  readonly isReadonly = new Signal.State<boolean>(false);
 
   #handle: FileSystemDirectoryHandle | null = null;
   #resultsRootHandle: FileSystemDirectoryHandle | null = null;
@@ -207,6 +208,7 @@ class StateAccess {
       this.activeCaseId.set(null);
       this.#resultsRootHandle = null;
       this.#handle = handle;
+      await this.#checkReadonly(handle);
     } else {
       this.isMultiHive.set(true);
       this.#resultsRootHandle = handle;
@@ -219,6 +221,7 @@ class StateAccess {
       } else {
         this.#handle = null;
         this.activeCaseId.set(null);
+        this.isReadonly.set(false);
       }
     }
   }
@@ -277,8 +280,18 @@ class StateAccess {
       }
       this.#handle = current;
       this.activeCaseId.set(caseId);
+      await this.#checkReadonly(current);
     } catch (e) {
       console.error(`Failed to switch to case ${caseId}:`, e);
+    }
+  }
+
+  async #checkReadonly(handle: FileSystemDirectoryHandle): Promise<void> {
+    try {
+      await handle.getFileHandle(".readonly");
+      this.isReadonly.set(true);
+    } catch {
+      this.isReadonly.set(false);
     }
   }
 

--- a/packages/bees/hivetool/src/data/system-store.ts
+++ b/packages/bees/hivetool/src/data/system-store.ts
@@ -56,7 +56,7 @@ interface SystemData {
 const EMPTY: SystemData = { title: "", description: "", root: "", mcp: [] };
 
 class SystemStore {
-  constructor(private access: StateAccess) {}
+  constructor(readonly access: StateAccess) {}
 
   readonly config = new Signal.State<SystemData>(EMPTY);
 

--- a/packages/bees/hivetool/src/data/template-store.ts
+++ b/packages/bees/hivetool/src/data/template-store.ts
@@ -39,7 +39,7 @@ interface TemplateData {
 }
 
 class TemplateStore {
-  constructor(private access: StateAccess) {}
+  constructor(readonly access: StateAccess) {}
 
   readonly templates = new Signal.State<TemplateData[]>([]);
   readonly selectedTemplateName = new Signal.State<string | null>(null);

--- a/packages/bees/hivetool/src/ui/app.ts
+++ b/packages/bees/hivetool/src/ui/app.ts
@@ -935,6 +935,7 @@ class BeesApp extends SignalWatcher(LitElement) {
             this.syncHash();
           }}
           @create=${() => {
+            if (this.stateAccess.isReadonly.get()) return;
             // Tell the detail panel to enter create mode.
             const detail = this.renderRoot.querySelector(
               "bees-template-detail"
@@ -951,6 +952,7 @@ class BeesApp extends SignalWatcher(LitElement) {
             this.syncHash();
           }}
           @create=${() => {
+            if (this.stateAccess.isReadonly.get()) return;
             const detail = this.renderRoot.querySelector(
               "bees-skill-detail"
             );

--- a/packages/bees/hivetool/src/ui/skill-detail.ts
+++ b/packages/bees/hivetool/src/ui/skill-detail.ts
@@ -154,9 +154,11 @@ class BeesSkillDetail extends SignalWatcher(LitElement) {
           <div class="job-detail-header-top">
             <h2 class="job-detail-title">${skill.title || skill.name}</h2>
             <div style="display:flex;align-items:center;gap:8px">
+              ${this.skillStore!.access.isReadonly.get() ? nothing : html`
               <button class="edit-btn" @click=${() => this.startEditing(skill)}>
                 ✏️ Edit
               </button>
+              `}
               <div class="skill-badge">SKILL</div>
             </div>
           </div>

--- a/packages/bees/hivetool/src/ui/skill-list.ts
+++ b/packages/bees/hivetool/src/ui/skill-list.ts
@@ -70,6 +70,7 @@ class BeesSkillList extends SignalWatcher(LitElement) {
 
     return html`
       <div class="sidebar-toolbar">
+        ${this.store.access.isReadonly.get() ? nothing : html`
         <button
           class="add-btn"
           @click=${() => this.handleCreate()}
@@ -77,6 +78,7 @@ class BeesSkillList extends SignalWatcher(LitElement) {
         >
           +
         </button>
+        `}
       </div>
       ${skills.length === 0
         ? html`<div class="empty-state">No skills found.</div>`

--- a/packages/bees/hivetool/src/ui/system-detail.ts
+++ b/packages/bees/hivetool/src/ui/system-detail.ts
@@ -579,12 +579,14 @@ class BeesSystemDetail extends SignalWatcher(LitElement) {
           <div class="job-detail-header-top">
             <h2 class="job-detail-title">${config.title || "Untitled Hive"}</h2>
             <div style="display:flex;align-items:center;gap:8px">
+              ${this.systemStore!.access.isReadonly.get() ? nothing : html`
               <button
                 class="edit-btn"
                 @click=${() => this.startEditing(config)}
               >
                 ✏️ Edit
               </button>
+              `}
               <div class="system-badge">SYSTEM</div>
             </div>
           </div>

--- a/packages/bees/hivetool/src/ui/template-detail.ts
+++ b/packages/bees/hivetool/src/ui/template-detail.ts
@@ -364,9 +364,11 @@ class BeesTemplateDetail extends SignalWatcher(LitElement) {
               <button class="run-btn" @click=${() => this.handleRun(template)}>
                 ▶ Run
               </button>
+              ${this.templateStore!.access.isReadonly.get() ? nothing : html`
               <button class="edit-btn" @click=${() => this.startEditing(template)}>
                 ✏️ Edit
               </button>
+              `}
               <div class="template-badge">TEMPLATE</div>
             </div>
           </div>

--- a/packages/bees/hivetool/src/ui/template-list.ts
+++ b/packages/bees/hivetool/src/ui/template-list.ts
@@ -78,6 +78,7 @@ class BeesTemplateList extends SignalWatcher(LitElement) {
 
     return html`
       <div class="sidebar-toolbar">
+        ${this.store.access.isReadonly.get() ? nothing : html`
         <button
           class="add-btn"
           @click=${() => this.handleCreate()}
@@ -85,6 +86,7 @@ class BeesTemplateList extends SignalWatcher(LitElement) {
         >
           +
         </button>
+        `}
       </div>
       ${templates.length === 0
         ? html`<div class="empty-state">No templates found.</div>`


### PR DESCRIPTION
## What
Introduces a dedicated `ui-builder` evaluation hive and implements a `.readonly` sentinel protection mode across the evaluation runner and Hivetool workbench.

## Why
To provide onboarding engineers with an observable, frictionless hill-climbing environment for autonomous UI generation, while preventing accidental edits to read-only execution copies in Hivetool.

## Changes
- **Scaffolding (`hives/ui-builder`)**: Created a self-contained evaluation hive with `SYSTEM.yaml`, `TEMPLATES.yaml`, `eval/config.yaml`, 4 core UI generation skills, and an onboarding `README.md`.
- **Root Orchestration**: Added `"eval:ui-builder": "npm run eval -w bees -- run ../../hives/ui-builder --root ui-builder"` script to `package.json`.
- **Eval Runner**: Updated `runner.py` to automatically write a `.readonly` sentinel file to cloned execution results.
- **Hivetool**: Added reactive `isReadonly` state tracking to `StateAccess` and exposed data stores to hide inline editing controls and creation buttons when inspecting read-only result copies.

## Testing
- Run `npm run eval:ui-builder`.
- Verify successful evaluation run and output generation in `packages/bees/results/<timestamp>/hive`.
- Open Hivetool (`https://breadboard-ai.github.io/breadboard/hivetool/`), point it to `packages/bees/results/`, and verify that all editing/creation controls are hidden when inspecting results, but visible when switching to `hives/ui-builder/`.
