### PR TITLE
[bees] Extensible Hive Evaluation Script (`hiveval`)

### DIFF
--- a/hives/ui-builder/README.md
+++ b/hives/ui-builder/README.md
@@ -17,7 +17,7 @@ Start the evaluation session using the top-level npm script. This executes a
 batch eval against the `ui-builder` template:
 
 ```bash
-npm run eval:ui-builder
+npm run hiveval -- ui-builder
 ```
 
 This command copies this hive to a pristine working directory under

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "setup:python": "wireit",
     "test:python": "wireit",
     "show:archived-projects": "git log --diff-filter=D --name-only --pretty=format:'%h %s' -- 'PROJECT_*.md'",
-    "eval:ui-builder": "npm run eval -w bees -- run ../../hives/ui-builder --root ui-builder"
+    "hiveval": "npm run hiveval -w bees --"
   },
   "wireit": {
     "build": {

--- a/packages/bees/package.json
+++ b/packages/bees/package.json
@@ -15,6 +15,7 @@
     "create-hive": "node scripts/create-hive.mjs",
     "test:python": ".venv/bin/python -m pytest tests/ -v",
     "eval": ".venv/bin/python -m bees.eval",
+    "hiveval": "node scripts/hiveval.mjs",
     "lint": "cd hivetool && npm run lint"
   },
   "wireit": {

--- a/packages/bees/scripts/hiveval.mjs
+++ b/packages/bees/scripts/hiveval.mjs
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { spawnSync } from "child_process";
+import path from "path";
+
+const args = process.argv.slice(2);
+const hiveName = args[0];
+if (!hiveName) {
+  console.error("Usage: npm run hiveval <hive-name> [template-name]");
+  process.exit(1);
+}
+const templateName = args[1] || hiveName;
+
+const pythonPath = path.resolve(".venv/bin/python");
+const hiveDir = path.resolve("../../hives", hiveName);
+
+const result = spawnSync(
+  pythonPath,
+  ["-m", "bees.eval", "run", hiveDir, "--root", templateName],
+  { stdio: "inherit" }
+);
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## What
Replaces the single-hive evaluation script with a generic, extensible `npm run hiveval` script supporting arbitrary hive and template combinations.

## Why
To make running batch evaluation sessions frictionless across any hive directory and root template without requiring hardcoded npm script entries for each one.

## Changes
- **Helper Script**: Created `packages/bees/scripts/hiveval.mjs` to parse positional arguments, resolve absolute paths, and provide fallback defaults (defaulting the root template to the hive name).
- **Package Wiring**: Updated `packages/bees/package.json` and root `package.json` to expose `"hiveval": "npm run hiveval -w bees --"`.
- **Documentation**: Updated onboarding guide in `hives/ui-builder/README.md` to demonstrate running `npm run hiveval -- ui-builder`.

## Testing
- Run `npm run hiveval -- ui-builder`.
- Verify successful batch evaluation run against the `ui-builder` hive and root template.
