### PR TITLE
[bees] Fix duplicate model turn logging for generate runners in session view

### DIFF
--- a/packages/bees/hivetool/src/data/session-store-reader.ts
+++ b/packages/bees/hivetool/src/data/session-store-reader.ts
@@ -31,7 +31,7 @@ interface LineageJson {
   forked_to?: { session: string; at_turn: number };
 }
 
-function compileEventsToSegment(sessionId: string, events: Record<string, unknown>[]): SessionSegment {
+function compileEventsToSegment(sessionId: string, events: Record<string, unknown>[], runnerType?: string): SessionSegment {
   let turnCount = 0;
   let totalThoughts = 0;
   let totalFunctionCalls = 0;
@@ -138,7 +138,7 @@ function compileEventsToSegment(sessionId: string, events: Record<string, unknow
         totalTokens += (metadata.totalTokenCount as number) || 0;
       }
 
-      if ("complete" in event) {
+      if ("complete" in event && runnerType !== "generate") {
         const complete = event.complete as Record<string, unknown> || {};
         const result = complete.result as Record<string, unknown> || {};
         const outcomes = result.outcomes as Record<string, unknown> || {};

--- a/packages/bees/hivetool/src/ui/log-detail.ts
+++ b/packages/bees/hivetool/src/ui/log-detail.ts
@@ -158,7 +158,8 @@ class BeesLogDetail extends SignalWatcher(LitElement) {
     this.turns = turns;
 
     if (events.length > 0) {
-      const segment = compileEventsToSegment(resolvedSessionId, events as Record<string, unknown>[]);
+      const ticket = tickets.find((t) => t.id === ticketId);
+      const segment = compileEventsToSegment(resolvedSessionId, events as Record<string, unknown>[], ticket?.runner);
       this.storeData = {
         sessionId: resolvedSessionId,
         segments: [segment],


### PR DESCRIPTION
## What
Prevents `"complete"` events from appending redundant `role: "model"` turns to the session log view when inspecting tasks powered by a `generate` runner.

## Why
While appending the final model output on `"complete"` events makes perfect sense for `direct_model` runners (which perform a single direct model call), `generate` runners execute a multi-turn cognitive loop where thoughts and tool calls are already rendered turn-by-turn. Unconditionally appending `"complete"` events caused a large laundry list of duplicate model outputs at the end of the session view.

## Changes
- **Hivetool Data (`session-store-reader.ts`)**: Updated `compileEventsToSegment` to accept an optional `runnerType` parameter and filter out `"complete"` event entries when `runnerType === "generate"`.
- **Hivetool UI (`log-detail.ts`)**: Updated `loadSessionData` to retrieve the active ticket and pass `ticket.runner` to `compileEventsToSegment`.

## Testing
- Verify compilation and test execution with `npm run test`.
- Inspect a session log in Hivetool for a `generate` runner task and verify that duplicate model outputs no longer appear at the end of the run.
