### PR TITLE
Show user consent page before running shared Opals

### DIFF
--- a/packages/types/src/consent-manager.ts
+++ b/packages/types/src/consent-manager.ts
@@ -7,6 +7,7 @@
 export enum ConsentType {
   GET_ANY_WEBPAGE = "GET_ANY_WEBPAGE",
   OPEN_WEBPAGE = "OPEN_WEBPAGE",
+  ACCESS_DRIVE_FILE_CONTENT = "ACCESS_DRIVE_FILE_CONTENT",
   // TODO: Add MCP, etc.
 }
 
@@ -29,6 +30,10 @@ export type ConsentRequest = (
     }
   | {
       type: ConsentType.OPEN_WEBPAGE;
+      scope: string;
+    }
+  | {
+      type: ConsentType.ACCESS_DRIVE_FILE_CONTENT;
       scope: string;
     }
 ) & { graphUrl: string };

--- a/packages/types/src/consent-manager.ts
+++ b/packages/types/src/consent-manager.ts
@@ -7,7 +7,7 @@
 export enum ConsentType {
   GET_ANY_WEBPAGE = "GET_ANY_WEBPAGE",
   OPEN_WEBPAGE = "OPEN_WEBPAGE",
-  ACCESS_DRIVE_FILE_CONTENT = "ACCESS_DRIVE_FILE_CONTENT",
+  ACCESS_ASSET = "ACCESS_ASSET",
   // TODO: Add MCP, etc.
 }
 
@@ -33,7 +33,7 @@ export type ConsentRequest = (
       scope: string;
     }
   | {
-      type: ConsentType.ACCESS_DRIVE_FILE_CONTENT;
+      type: ConsentType.ACCESS_ASSET;
       scope: string;
     }
 ) & { graphUrl: string };

--- a/packages/types/src/flags.ts
+++ b/packages/types/src/flags.ts
@@ -43,8 +43,6 @@ export type RuntimeFlags = {
    */
   outputTemplates: boolean;
 
-
-
   /**
    * Enables "export to Drive" capability for the agent
    */
@@ -89,6 +87,11 @@ export type RuntimeFlags = {
    * backend and reuse the cached content ID across client calls.
    */
   enableSingletonPrefixCache: boolean;
+
+  /**
+   * Show the asset access consent dialog when running a shared Opal.
+   */
+  enableAssetAccessConsent: boolean;
 };
 
 /**
@@ -174,8 +177,6 @@ export const RUNTIME_FLAG_META: Record<keyof RuntimeFlags, RuntimeFlagMeta> = {
     visibility: "experimental",
   },
 
-
-
   enableGoogleDriveTools: {
     title: "Google Drive Tools",
     description: "Enable 'export to Drive' capability",
@@ -221,6 +222,12 @@ export const RUNTIME_FLAG_META: Record<keyof RuntimeFlags, RuntimeFlagMeta> = {
     title: "Singleton Prefix Cache",
     description:
       "Cache agent prefix on the backend and reuse the cached content ID",
+    visibility: "experimental",
+  },
+  enableAssetAccessConsent: {
+    title: "Asset Access Consent",
+    description:
+      "Show the asset access consent dialog when running a shared Opal.",
     visibility: "experimental",
   },
 };

--- a/packages/unified-server/src/config.ts
+++ b/packages/unified-server/src/config.ts
@@ -79,6 +79,7 @@ export async function createClientConfig(opts: {
       enableOpalBackend: flags.ENABLE_OPAL_BACKEND,
       enableSessionsBackend: flags.ENABLE_SESSIONS_BACKEND,
       enableSingletonPrefixCache: flags.ENABLE_SINGLETON_PREFIX_CACHE,
+      enableAssetAccessConsent: flags.ENABLE_ASSET_ACCESS_CONSENT,
     },
   };
 }

--- a/packages/unified-server/src/flags.ts
+++ b/packages/unified-server/src/flags.ts
@@ -78,6 +78,10 @@ export const ENABLE_SINGLETON_PREFIX_CACHE = getBoolean(
 
 export const ENABLE_TEXT_EDITOR_REMIX = getBoolean("ENABLE_TEXT_EDITOR_REMIX");
 
+export const ENABLE_ASSET_ACCESS_CONSENT = getBoolean(
+  "ENABLE_ASSET_ACCESS_CONSENT"
+);
+
 export const ENVIRONMENT_NAME = getString("ENVIRONMENT_NAME");
 
 export const FAKE_DRIVE_PORT = Number(process.env["FAKE_DRIVE_PORT"] || 3110);

--- a/packages/utils/src/google-drive/utils.ts
+++ b/packages/utils/src/google-drive/utils.ts
@@ -132,7 +132,8 @@ export type GoogleDriveAsset = {
 };
 
 export function findGoogleDriveAssetsInGraph(
-  graph: GraphDescriptor
+  graph: GraphDescriptor,
+  options?: { omitSplashImages?: boolean }
 ): GoogleDriveAsset[] {
   // Use a map because there can be duplicates.
   const files = new Map<string, GoogleDriveAsset>();
@@ -155,17 +156,19 @@ export function findGoogleDriveAssetsInGraph(
   }
 
   // Theme splash images are not listed in assets.
-  const themes = graph.metadata?.visual?.presentation?.themes;
-  if (themes) {
-    for (const { splashScreen } of Object.values(themes)) {
-      if (splashScreen) {
-        const fileId = partToDriveFileId(splashScreen);
-        if (fileId) {
-          files.set(fileId.id, {
-            fileId,
-            managed: true,
-            part: splashScreen,
-          });
+  if (!options?.omitSplashImages) {
+    const themes = graph.metadata?.visual?.presentation?.themes;
+    if (themes) {
+      for (const { splashScreen } of Object.values(themes)) {
+        if (splashScreen) {
+          const fileId = partToDriveFileId(splashScreen);
+          if (fileId) {
+            files.set(fileId.id, {
+              fileId,
+              managed: true,
+              part: splashScreen,
+            });
+          }
         }
       }
     }

--- a/packages/visual-editor/eval/eval.ts
+++ b/packages/visual-editor/eval/eval.ts
@@ -248,6 +248,7 @@ class EvalRun implements EvalHarnessRuntimeArgs {
     },
     notebookLmApiClient: {} as never,
     agentService: new AgentService(),
+    googleDriveClient: {} as never,
 
     context: {
       currentGraph: {

--- a/packages/visual-editor/src/a2/a2/data-transforms.ts
+++ b/packages/visual-editor/src/a2/a2/data-transforms.ts
@@ -12,8 +12,6 @@ import {
   InlineDataCapabilityPart,
   Outcome,
   StoredDataCapabilityPart,
-  ConsentType,
-  ConsentUIType,
 } from "@breadboard-ai/types";
 import { err, ok, isNotebookLmUrl } from "@breadboard-ai/utils";
 import { A2ModuleArgs } from "../runnable-module-factory.js";
@@ -95,42 +93,7 @@ async function driveFileToGeminiFile(
 ): Promise<Outcome<FileDataPart>> {
   const driveFileId = part.fileData.fileUri.replace(/^drive:\/+/, "");
   const { resourceKey } = part.fileData;
-  const consentController = moduleArgs.getConsentController();
-  const graphUrl = moduleArgs.context.currentGraph?.url || "";
 
-  let fileName = driveFileId;
-  try {
-    const meta = await moduleArgs.googleDriveClient.getFileMetadata(
-      { id: driveFileId, resourceKey },
-      { fields: ["name"] }
-    );
-    if (meta?.name) {
-      fileName = meta.name;
-    }
-  } catch {
-    // Fallback to file ID
-  }
-
-  const scopeObj = {
-    fileId: driveFileId,
-    fileName,
-    resourceKey: resourceKey || "",
-  };
-
-  const allowed = await consentController.queryConsent(
-    {
-      type: ConsentType.ACCESS_DRIVE_FILE_CONTENT,
-      scope: JSON.stringify(scopeObj),
-      graphUrl,
-    },
-    ConsentUIType.IN_APP
-  );
-
-  if (!allowed) {
-    return err(
-      `Execution stopped: Consent denied to read and process the contents of Google Drive asset "${fileName}".`
-    );
-  }
   const request: UploadGeminiFileRequest = { driveFileId };
   if (resourceKey) {
     request.driveResourceKey = resourceKey;
@@ -191,44 +154,7 @@ async function driveFileToBlob(
   }
 
   const driveFileId = existingHandle.replace("drive:/", "");
-  const { resourceKey } = part.storedData;
 
-  const consentController = moduleArgs.getConsentController();
-  const graphUrl = moduleArgs.context.currentGraph?.url || "";
-
-  let fileName = driveFileId;
-  try {
-    const meta = await moduleArgs.googleDriveClient.getFileMetadata(
-      { id: driveFileId, resourceKey },
-      { fields: ["name"] }
-    );
-    if (meta?.name) {
-      fileName = meta.name;
-    }
-  } catch {
-    // Fallback to file ID
-  }
-
-  const scopeObj = {
-    fileId: driveFileId,
-    fileName,
-    resourceKey: resourceKey || "",
-  };
-
-  const allowed = await consentController.queryConsent(
-    {
-      type: ConsentType.ACCESS_DRIVE_FILE_CONTENT,
-      scope: JSON.stringify(scopeObj),
-      graphUrl,
-    },
-    ConsentUIType.IN_APP
-  );
-
-  if (!allowed) {
-    return err(
-      `Execution stopped: Consent denied to read and process the contents of Google Drive asset "${fileName}".`
-    );
-  }
   const request: UploadBlobFileRequest = { driveFileId };
   const response: Outcome<UploadBlobFileResponse> = await callBackend(
     moduleArgs,

--- a/packages/visual-editor/src/a2/a2/data-transforms.ts
+++ b/packages/visual-editor/src/a2/a2/data-transforms.ts
@@ -12,6 +12,8 @@ import {
   InlineDataCapabilityPart,
   Outcome,
   StoredDataCapabilityPart,
+  ConsentType,
+  ConsentUIType,
 } from "@breadboard-ai/types";
 import { err, ok, isNotebookLmUrl } from "@breadboard-ai/utils";
 import { A2ModuleArgs } from "../runnable-module-factory.js";
@@ -93,6 +95,42 @@ async function driveFileToGeminiFile(
 ): Promise<Outcome<FileDataPart>> {
   const driveFileId = part.fileData.fileUri.replace(/^drive:\/+/, "");
   const { resourceKey } = part.fileData;
+  const consentController = moduleArgs.getConsentController();
+  const graphUrl = moduleArgs.context.currentGraph?.url || "";
+
+  let fileName = driveFileId;
+  try {
+    const meta = await moduleArgs.googleDriveClient.getFileMetadata(
+      { id: driveFileId, resourceKey },
+      { fields: ["name"] }
+    );
+    if (meta?.name) {
+      fileName = meta.name;
+    }
+  } catch {
+    // Fallback to file ID
+  }
+
+  const scopeObj = {
+    fileId: driveFileId,
+    fileName,
+    resourceKey: resourceKey || "",
+  };
+
+  const allowed = await consentController.queryConsent(
+    {
+      type: ConsentType.ACCESS_DRIVE_FILE_CONTENT,
+      scope: JSON.stringify(scopeObj),
+      graphUrl,
+    },
+    ConsentUIType.IN_APP
+  );
+
+  if (!allowed) {
+    return err(
+      `Execution stopped: Consent denied to read and process the contents of Google Drive asset "${fileName}".`
+    );
+  }
   const request: UploadGeminiFileRequest = { driveFileId };
   if (resourceKey) {
     request.driveResourceKey = resourceKey;
@@ -153,6 +191,44 @@ async function driveFileToBlob(
   }
 
   const driveFileId = existingHandle.replace("drive:/", "");
+  const { resourceKey } = part.storedData;
+
+  const consentController = moduleArgs.getConsentController();
+  const graphUrl = moduleArgs.context.currentGraph?.url || "";
+
+  let fileName = driveFileId;
+  try {
+    const meta = await moduleArgs.googleDriveClient.getFileMetadata(
+      { id: driveFileId, resourceKey },
+      { fields: ["name"] }
+    );
+    if (meta?.name) {
+      fileName = meta.name;
+    }
+  } catch {
+    // Fallback to file ID
+  }
+
+  const scopeObj = {
+    fileId: driveFileId,
+    fileName,
+    resourceKey: resourceKey || "",
+  };
+
+  const allowed = await consentController.queryConsent(
+    {
+      type: ConsentType.ACCESS_DRIVE_FILE_CONTENT,
+      scope: JSON.stringify(scopeObj),
+      graphUrl,
+    },
+    ConsentUIType.IN_APP
+  );
+
+  if (!allowed) {
+    return err(
+      `Execution stopped: Consent denied to read and process the contents of Google Drive asset "${fileName}".`
+    );
+  }
   const request: UploadBlobFileRequest = { driveFileId };
   const response: Outcome<UploadBlobFileResponse> = await callBackend(
     moduleArgs,

--- a/packages/visual-editor/src/a2/runnable-module-factory.ts
+++ b/packages/visual-editor/src/a2/runnable-module-factory.ts
@@ -24,6 +24,7 @@ export type A2ModuleFactoryArgs = {
   agentContext: AgentContext;
   agentService: AgentService;
   notebookLmApiClient: NotebookLmApiClient;
+  googleDriveClient: GoogleDriveClient;
 };
 
 export type A2ModuleArgs = A2ModuleFactoryArgs & {

--- a/packages/visual-editor/src/a2/runnable-module-factory.ts
+++ b/packages/visual-editor/src/a2/runnable-module-factory.ts
@@ -5,6 +5,7 @@
  */
 
 import type { NodeHandlerContext } from "@breadboard-ai/types";
+import { GoogleDriveClient } from "@breadboard-ai/utils/google-drive/google-drive-client.js";
 
 import { OpalShellHostProtocol } from "@breadboard-ai/types/opal-shell-protocol.js";
 import { McpClientManager } from "../mcp/index.js";

--- a/packages/visual-editor/src/main-base.ts
+++ b/packages/visual-editor/src/main-base.ts
@@ -803,6 +803,11 @@ abstract class MainBase extends SignalWatcher(LitElement) {
   }
 
   protected renderConsentRequests() {
+    // Batch consent modal takes priority over individual modals.
+    if (this.sca.controller.global.consent.pendingBatchConsent) {
+      return html`<bb-batch-consent-modal></bb-batch-consent-modal>`;
+    }
+
     if (this.sca.controller.global.consent.pendingModal.length === 0)
       return nothing;
 

--- a/packages/visual-editor/src/sca/actions/board/board-actions.ts
+++ b/packages/visual-editor/src/sca/actions/board/board-actions.ts
@@ -949,7 +949,7 @@ async function runBoard(): Promise<void> {
   // Check batch consent for all Drive assets in the graph before running.
   // This shows a single modal listing all Drive files instead of one per asset.
   // Gated behind the enableAssetAccessConsent flag.
-  if (bind.env.flags.get("enableAssetAccessConsent") && gc.readOnly && gc.graph) {
+  if (gc.readOnly && gc.graph && bind.env.flags.env().enableAssetAccessConsent) {
     const driveAssets = findGoogleDriveAssetsInGraph(gc.graph, {
       omitSplashImages: true,
     });

--- a/packages/visual-editor/src/sca/actions/board/board-actions.ts
+++ b/packages/visual-editor/src/sca/actions/board/board-actions.ts
@@ -11,6 +11,7 @@ import type {
   OutputValues,
 } from "@breadboard-ai/types";
 import { ConsentType, ConsentUIType } from "@breadboard-ai/types";
+import { findGoogleDriveAssetsInGraph } from "@breadboard-ai/utils/google-drive/utils.js";
 import { SnackType, type SnackbarUUID } from "../../types.js";
 import type { StateEvent } from "../../../ui/events/events.js";
 import { parseUrl } from "../../../ui/navigation/urls.js";
@@ -941,6 +942,78 @@ async function runBoard(): Promise<void> {
 
       if (!hasConsent) {
         return;
+      }
+    }
+  }
+
+  // Check batch consent for all Drive assets in the graph before running.
+  // This shows a single modal listing all Drive files instead of one per asset.
+  if (gc.readOnly && gc.graph) {
+    const driveAssets = findGoogleDriveAssetsInGraph(gc.graph);
+    if (driveAssets.length > 0) {
+      const consentCtrl = controller.global.consent;
+      const graphUrl = gc.url || "";
+
+      // Build consent info for assets that haven't been consented yet.
+      const unconsented = driveAssets
+        .map((asset) => {
+          const scopeObj = {
+            fileId: asset.fileId.id,
+            fileName: asset.fileId.id,
+            iconLink: "",
+            resourceKey: asset.fileId.resourceKey || "",
+          };
+          const request = {
+            type: ConsentType.ACCESS_DRIVE_FILE_CONTENT as const,
+            scope: JSON.stringify(scopeObj),
+            graphUrl,
+          };
+          return { asset, scopeObj, request };
+        })
+        .filter(({ request }) => !consentCtrl.hasConsent(request));
+
+      if (unconsented.length > 0) {
+        // Fetch metadata (name, iconLink) for all unconsented assets.
+        const assetInfos = await Promise.all(
+          unconsented.map(async ({ asset, scopeObj, request }) => {
+            try {
+              const meta =
+                await services.googleDriveClient.getFileMetadata(
+                  {
+                    id: asset.fileId.id,
+                    resourceKey: asset.fileId.resourceKey,
+                  },
+                  { fields: ["name", "iconLink"] }
+                );
+              if (meta?.name) scopeObj.fileName = meta.name;
+              if (meta?.iconLink) scopeObj.iconLink = meta.iconLink;
+            } catch {
+              // Fallback: use file ID as name
+            }
+            // Update the scope with the fetched metadata.
+            request.scope = JSON.stringify(scopeObj);
+            return {
+              fileId: asset.fileId.id,
+              fileName: scopeObj.fileName,
+              iconLink: scopeObj.iconLink,
+              resourceKey: scopeObj.resourceKey,
+              request,
+            };
+          })
+        );
+
+        const allowed =
+          await consentCtrl.requestBatchConsent(assetInfos);
+
+        if (!allowed) {
+          logger.log(
+            Utils.Logging.Formatter.warning(
+              "Execution stopped: consent denied for Drive assets"
+            ),
+            LABEL
+          );
+          return;
+        }
       }
     }
   }

--- a/packages/visual-editor/src/sca/actions/board/board-actions.ts
+++ b/packages/visual-editor/src/sca/actions/board/board-actions.ts
@@ -11,10 +11,7 @@ import type {
   OutputValues,
 } from "@breadboard-ai/types";
 import { ConsentType, ConsentUIType } from "@breadboard-ai/types";
-import {
-  findGoogleDriveAssetsInGraph,
-  partToDriveFileId,
-} from "@breadboard-ai/utils/google-drive/utils.js";
+import { findGoogleDriveAssetsInGraph } from "@breadboard-ai/utils/google-drive/utils.js";
 import { SnackType, type SnackbarUUID } from "../../types.js";
 import type { StateEvent } from "../../../ui/events/events.js";
 import { parseUrl } from "../../../ui/navigation/urls.js";
@@ -953,21 +950,9 @@ async function runBoard(): Promise<void> {
   // This shows a single modal listing all Drive files instead of one per asset.
   // Gated behind the enableAssetAccessConsent flag.
   if (bind.env.flags.get("enableAssetAccessConsent") && gc.readOnly && gc.graph) {
-    // Collect splash screen file IDs to exclude — these are decorative
-    // theme images, not data assets the Opal processes.
-    const splashScreenIds = new Set<string>();
-    const themes = gc.graph.metadata?.visual?.presentation?.themes;
-    if (themes) {
-      for (const { splashScreen } of Object.values(themes)) {
-        if (splashScreen) {
-          const fileId = partToDriveFileId(splashScreen);
-          if (fileId) splashScreenIds.add(fileId.id);
-        }
-      }
-    }
-
-    const driveAssets = findGoogleDriveAssetsInGraph(gc.graph)
-      .filter((asset) => !splashScreenIds.has(asset.fileId.id));
+    const driveAssets = findGoogleDriveAssetsInGraph(gc.graph, {
+      omitSplashImages: true,
+    });
     if (driveAssets.length > 0) {
       const consentCtrl = controller.global.consent;
       const graphUrl = gc.url || "";

--- a/packages/visual-editor/src/sca/actions/board/board-actions.ts
+++ b/packages/visual-editor/src/sca/actions/board/board-actions.ts
@@ -949,7 +949,7 @@ async function runBoard(): Promise<void> {
   // Check batch consent for all Drive assets in the graph before running.
   // This shows a single modal listing all Drive files instead of one per asset.
   // Gated behind the enableAssetAccessConsent flag.
-  if (gc.readOnly && gc.graph && bind.env.flags.env().enableAssetAccessConsent) {
+  if (gc.readOnly && gc.graph && bind.env.flags.get("enableAssetAccessConsent")) {
     const driveAssets = findGoogleDriveAssetsInGraph(gc.graph, {
       omitSplashImages: true,
     });

--- a/packages/visual-editor/src/sca/actions/board/board-actions.ts
+++ b/packages/visual-editor/src/sca/actions/board/board-actions.ts
@@ -955,27 +955,29 @@ async function runBoard(): Promise<void> {
       const graphUrl = gc.url || "";
 
       // Build consent info for assets that haven't been consented yet.
+      // The consent scope uses only stable identifiers (fileId +
+      // resourceKey) so that hasConsent() matches on subsequent runs.
+      // Display metadata (fileName, iconLink) is passed separately.
       const unconsented = driveAssets
         .map((asset) => {
-          const scopeObj = {
-            fileId: asset.fileId.id,
-            fileName: asset.fileId.id,
-            iconLink: "",
-            resourceKey: asset.fileId.resourceKey || "",
-          };
           const request = {
             type: ConsentType.ACCESS_DRIVE_FILE_CONTENT as const,
-            scope: JSON.stringify(scopeObj),
+            scope: JSON.stringify({
+              fileId: asset.fileId.id,
+              resourceKey: asset.fileId.resourceKey || "",
+            }),
             graphUrl,
           };
-          return { asset, scopeObj, request };
+          return { asset, request };
         })
         .filter(({ request }) => !consentCtrl.hasConsent(request));
 
       if (unconsented.length > 0) {
-        // Fetch metadata (name, iconLink) for all unconsented assets.
+        // Fetch metadata (name, iconLink) for the modal display.
         const assetInfos = await Promise.all(
-          unconsented.map(async ({ asset, scopeObj, request }) => {
+          unconsented.map(async ({ asset, request }) => {
+            let fileName = asset.fileId.id;
+            let iconLink = "";
             try {
               const meta =
                 await services.googleDriveClient.getFileMetadata(
@@ -985,18 +987,16 @@ async function runBoard(): Promise<void> {
                   },
                   { fields: ["name", "iconLink"] }
                 );
-              if (meta?.name) scopeObj.fileName = meta.name;
-              if (meta?.iconLink) scopeObj.iconLink = meta.iconLink;
+              if (meta?.name) fileName = meta.name;
+              if (meta?.iconLink) iconLink = meta.iconLink;
             } catch {
               // Fallback: use file ID as name
             }
-            // Update the scope with the fetched metadata.
-            request.scope = JSON.stringify(scopeObj);
             return {
               fileId: asset.fileId.id,
-              fileName: scopeObj.fileName,
-              iconLink: scopeObj.iconLink,
-              resourceKey: scopeObj.resourceKey,
+              fileName,
+              iconLink,
+              resourceKey: asset.fileId.resourceKey || "",
               request,
             };
           })

--- a/packages/visual-editor/src/sca/actions/board/board-actions.ts
+++ b/packages/visual-editor/src/sca/actions/board/board-actions.ts
@@ -978,7 +978,7 @@ async function runBoard(): Promise<void> {
       const unconsented = driveAssets
         .map((asset) => {
           const request = {
-            type: ConsentType.ACCESS_DRIVE_FILE_CONTENT as const,
+            type: ConsentType.ACCESS_ASSET as const,
             scope: JSON.stringify({
               fileId: asset.fileId.id,
               resourceKey: asset.fileId.resourceKey || "",

--- a/packages/visual-editor/src/sca/actions/board/board-actions.ts
+++ b/packages/visual-editor/src/sca/actions/board/board-actions.ts
@@ -11,7 +11,10 @@ import type {
   OutputValues,
 } from "@breadboard-ai/types";
 import { ConsentType, ConsentUIType } from "@breadboard-ai/types";
-import { findGoogleDriveAssetsInGraph } from "@breadboard-ai/utils/google-drive/utils.js";
+import {
+  findGoogleDriveAssetsInGraph,
+  partToDriveFileId,
+} from "@breadboard-ai/utils/google-drive/utils.js";
 import { SnackType, type SnackbarUUID } from "../../types.js";
 import type { StateEvent } from "../../../ui/events/events.js";
 import { parseUrl } from "../../../ui/navigation/urls.js";
@@ -949,7 +952,21 @@ async function runBoard(): Promise<void> {
   // Check batch consent for all Drive assets in the graph before running.
   // This shows a single modal listing all Drive files instead of one per asset.
   if (gc.readOnly && gc.graph) {
-    const driveAssets = findGoogleDriveAssetsInGraph(gc.graph);
+    // Collect splash screen file IDs to exclude — these are decorative
+    // theme images, not data assets the Opal processes.
+    const splashScreenIds = new Set<string>();
+    const themes = gc.graph.metadata?.visual?.presentation?.themes;
+    if (themes) {
+      for (const { splashScreen } of Object.values(themes)) {
+        if (splashScreen) {
+          const fileId = partToDriveFileId(splashScreen);
+          if (fileId) splashScreenIds.add(fileId.id);
+        }
+      }
+    }
+
+    const driveAssets = findGoogleDriveAssetsInGraph(gc.graph)
+      .filter((asset) => !splashScreenIds.has(asset.fileId.id));
     if (driveAssets.length > 0) {
       const consentCtrl = controller.global.consent;
       const graphUrl = gc.url || "";

--- a/packages/visual-editor/src/sca/actions/board/board-actions.ts
+++ b/packages/visual-editor/src/sca/actions/board/board-actions.ts
@@ -951,7 +951,8 @@ async function runBoard(): Promise<void> {
 
   // Check batch consent for all Drive assets in the graph before running.
   // This shows a single modal listing all Drive files instead of one per asset.
-  if (gc.readOnly && gc.graph) {
+  // Gated behind the enableAssetAccessConsent flag.
+  if (bind.env.flags.get("enableAssetAccessConsent") && gc.readOnly && gc.graph) {
     // Collect splash screen file IDs to exclude — these are decorative
     // theme images, not data assets the Opal processes.
     const splashScreenIds = new Set<string>();

--- a/packages/visual-editor/src/sca/controller/subcontrollers/global/consent-controller.ts
+++ b/packages/visual-editor/src/sca/controller/subcontrollers/global/consent-controller.ts
@@ -44,6 +44,9 @@ export class ConsentController extends RootController {
   @field({ persist: "idb", deep: true })
   private accessor _consents = new Map<ConsentKey, ConsentRecord>();
 
+  @field({ persist: "idb", deep: true })
+  private accessor _sharedAssetsConsents = new Set<string>();
+
   @field({ deep: true })
   private accessor _pendingConsents = new Map<
     PendingConsent,
@@ -174,5 +177,18 @@ export class ConsentController extends RootController {
 
   async clearAllConsents(): Promise<void> {
     this._consents.clear();
+    this._sharedAssetsConsents.clear();
+  }
+
+  hasSharedAssetsConsent(graphUrl: string): boolean {
+    return this._sharedAssetsConsents.has(graphUrl);
+  }
+
+  grantSharedAssetsConsent(graphUrl: string): void {
+    this._sharedAssetsConsents.add(graphUrl);
+  }
+
+  revokeSharedAssetsConsent(graphUrl: string): void {
+    this._sharedAssetsConsents.delete(graphUrl);
   }
 }

--- a/packages/visual-editor/src/sca/controller/subcontrollers/global/consent-controller.ts
+++ b/packages/visual-editor/src/sca/controller/subcontrollers/global/consent-controller.ts
@@ -11,7 +11,11 @@ import {
 } from "@breadboard-ai/types";
 import { field } from "../../decorators/field.js";
 import { RootController } from "../root-controller.js";
-import { PendingConsent } from "../../../types.js";
+import {
+  PendingConsent,
+  type DriveAssetConsentInfo,
+  type PendingBatchConsent,
+} from "../../../types.js";
 
 // eslint-disable-next-line local-rules/no-exported-types-outside-types-ts
 export interface ConsentRecord {
@@ -45,6 +49,9 @@ export class ConsentController extends RootController {
     PendingConsent,
     (value: ConsentAction) => void
   >();
+
+  @field()
+  accessor pendingBatchConsent: PendingBatchConsent | null = null;
 
   get consents(): ReadonlyMap<ConsentKey, ConsentRecord> {
     return this._consents;
@@ -125,6 +132,44 @@ export class ConsentController extends RootController {
     }
 
     return Boolean(allow);
+  }
+
+  /**
+   * Checks if consent has already been granted for a request without
+   * triggering any UI. Returns true if consented, false otherwise.
+   */
+  hasConsent(request: ConsentRequest): boolean {
+    const consentKey = createConsentKey(request);
+    const record = this._consents.get(consentKey);
+    return record?.allow === true;
+  }
+
+  /**
+   * Shows a batch consent modal for multiple Drive assets and awaits the
+   * user's decision. Returns true if all assets were approved.
+   */
+  requestBatchConsent(assets: DriveAssetConsentInfo[]): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      this.pendingBatchConsent = { assets, resolve };
+    });
+  }
+
+  /**
+   * Resolves the pending batch consent with the user's decision.
+   * If allowed, persists consent for all assets.
+   */
+  resolveBatchConsent(allowed: boolean): void {
+    const pending = this.pendingBatchConsent;
+    if (!pending) return;
+
+    if (allowed) {
+      for (const asset of pending.assets) {
+        this.#setConsent(asset.request, true);
+      }
+    }
+
+    this.pendingBatchConsent = null;
+    pending.resolve(allowed);
   }
 
   async clearAllConsents(): Promise<void> {

--- a/packages/visual-editor/src/sca/controller/subcontrollers/global/consent-controller.ts
+++ b/packages/visual-editor/src/sca/controller/subcontrollers/global/consent-controller.ts
@@ -44,8 +44,7 @@ export class ConsentController extends RootController {
   @field({ persist: "idb", deep: true })
   private accessor _consents = new Map<ConsentKey, ConsentRecord>();
 
-  @field({ persist: "idb", deep: true })
-  private accessor _sharedAssetsConsents = new Set<string>();
+
 
   @field({ deep: true })
   private accessor _pendingConsents = new Map<
@@ -177,18 +176,6 @@ export class ConsentController extends RootController {
 
   async clearAllConsents(): Promise<void> {
     this._consents.clear();
-    this._sharedAssetsConsents.clear();
   }
 
-  hasSharedAssetsConsent(graphUrl: string): boolean {
-    return this._sharedAssetsConsents.has(graphUrl);
-  }
-
-  grantSharedAssetsConsent(graphUrl: string): void {
-    this._sharedAssetsConsents.add(graphUrl);
-  }
-
-  revokeSharedAssetsConsent(graphUrl: string): void {
-    this._sharedAssetsConsents.delete(graphUrl);
-  }
 }

--- a/packages/visual-editor/src/sca/services/services.ts
+++ b/packages/visual-editor/src/sca/services/services.ts
@@ -155,6 +155,7 @@ export function services(
       agentContext,
       agentService,
       notebookLmApiClient,
+      googleDriveClient,
     });
     const googleDriveBoardServer = createGoogleDriveBoardServer(
       signinAdapter,

--- a/packages/visual-editor/src/sca/types.ts
+++ b/packages/visual-editor/src/sca/types.ts
@@ -525,6 +525,27 @@ export interface PendingConsent {
 }
 
 /**
+ * Metadata for a single Drive asset displayed in the batch consent modal.
+ */
+export interface DriveAssetConsentInfo {
+  fileId: string;
+  fileName: string;
+  iconLink: string;
+  resourceKey: string;
+  /** The consent request that will be persisted when approved. */
+  request: ConsentRequest;
+}
+
+/**
+ * Represents a pending batch consent prompt for multiple Drive assets.
+ * The modal shows all assets at once and the user approves or denies all.
+ */
+export interface PendingBatchConsent {
+  assets: DriveAssetConsentInfo[];
+  resolve: (allowed: boolean) => void;
+}
+
+/**
  * Represents a pending edit to a node's configuration.
  * Values should already be transformed to the proper configuration format.
  */

--- a/packages/visual-editor/src/ui/app-templates/basic/index.ts
+++ b/packages/visual-editor/src/ui/app-templates/basic/index.ts
@@ -84,7 +84,6 @@ import { scaContext } from "../../../sca/context/context.js";
 import { SCA } from "../../../sca/sca.js";
 import { AppScreenPresenter } from "../../presenters/app-screen-presenter.js";
 
-
 function getHTMLOutput(screen: AppScreenOutput): string | null {
   const outputs = Object.values(screen.output);
   const singleOutput = outputs.length === 1;
@@ -356,12 +355,12 @@ export class Template extends SignalWatcher(LitElement) implements AppTemplate {
 
     // TypeScript struggles to disambiguate this, so marking it as `any`.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const detypedConsentRequest = consentRequest as any;
+    const detypedRequest = consentRequest.request as any;
     return html`
       <div id="consent" class="default">
         <section id="consent-content-container">
           <h1>${renderInfo.name}</h1>
-          ${renderInfo.description(detypedConsentRequest)}
+          ${renderInfo.description(detypedRequest)}
           <button
             id="grant-consent"
             @click=${() => {

--- a/packages/visual-editor/src/ui/config/client-deployment-configuration.ts
+++ b/packages/visual-editor/src/ui/config/client-deployment-configuration.ts
@@ -30,6 +30,7 @@ const DEFAULT_FLAG_VALUES: RuntimeFlags = {
   enableOpalBackend: false,
   enableSessionsBackend: false,
   enableSingletonPrefixCache: false,
+  enableAssetAccessConsent: false,
 };
 
 function populateFlags<T extends Partial<ClientDeploymentConfiguration>>(

--- a/packages/visual-editor/src/ui/elements/elements.ts
+++ b/packages/visual-editor/src/ui/elements/elements.ts
@@ -12,6 +12,7 @@ export { PublishButton } from "./shell/publish-button.js";
 export { VEModal } from "./shell/modal.js";
 export { VEMCPServersSettings } from "./shell/mcp-server-settings.js";
 export { VEConsentRequestModal } from "./shell/consent-request.js";
+export { VEBatchConsentModal } from "./shell/batch-consent-modal.js";
 export { VERuntimeFlags } from "./shell/runtime-flags.js";
 export { VEGlobalSettingsModal } from "./shell/global-settings.js";
 export { VEWarmWelcomeModal } from "./shell/warm-welcome.js";

--- a/packages/visual-editor/src/ui/elements/shell/batch-consent-modal.ts
+++ b/packages/visual-editor/src/ui/elements/shell/batch-consent-modal.ts
@@ -1,0 +1,157 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import { LitElement, html, css, nothing } from "lit";
+import { customElement } from "lit/decorators.js";
+import { baseColors } from "../../styles/host/base-colors.js";
+import { type } from "../../styles/host/type.js";
+import { SignalWatcher } from "@lit-labs/signals";
+import { ModalDismissedEvent } from "../../events/events.js";
+import { consume } from "@lit/context";
+import { scaContext } from "../../../sca/context/context.js";
+import { SCA } from "../../../sca/sca.js";
+import type { DriveAssetConsentInfo } from "../../../sca/types.js";
+
+@customElement("bb-batch-consent-modal")
+export class VEBatchConsentModal extends SignalWatcher(LitElement) {
+  @consume({ context: scaContext })
+  accessor sca!: SCA;
+
+  static styles = [
+    type,
+    baseColors,
+    css`
+      :host {
+        display: block;
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        z-index: 1;
+      }
+
+      bb-modal {
+        &::part(container) {
+          display: flex;
+          flex-direction: column;
+          width: 520px;
+          max-width: 85%;
+        }
+      }
+
+      .consent-body {
+        color: var(--light-dark-n-30);
+
+        & p {
+          font-family: var(--bb-font-family, var(--default-font-family));
+          font-size: 14px;
+          line-height: 20px;
+          margin: 0 0 var(--bb-grid-size-3) 0;
+        }
+      }
+
+      .asset-list {
+        list-style: none;
+        margin: var(--bb-grid-size-3) 0;
+        padding: 0;
+        max-height: 240px;
+        overflow-y: auto;
+      }
+
+      .asset-item {
+        display: flex;
+        align-items: center;
+        gap: var(--bb-grid-size-2);
+        padding: var(--bb-grid-size-2) var(--bb-grid-size-3);
+        border: 1px solid var(--light-dark-p-90);
+        border-radius: var(--bb-grid-size-2);
+        background: var(--light-dark-p-98);
+        margin-bottom: var(--bb-grid-size-2);
+
+        & img {
+          width: 20px;
+          height: 20px;
+          flex-shrink: 0;
+        }
+
+        & a {
+          color: var(--light-dark-p-40);
+          text-decoration: none;
+          font-weight: 500;
+          font-size: 14px;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+
+          &:hover {
+            text-decoration: underline;
+          }
+        }
+      }
+    `,
+  ];
+
+  #handleModalDismissed({ withSave }: ModalDismissedEvent) {
+    this.sca.controller.global.consent.resolveBatchConsent(withSave);
+  }
+
+  #buildDriveUrl(asset: DriveAssetConsentInfo): string {
+    const url = new URL("https://drive.google.com/open");
+    url.searchParams.set("id", asset.fileId);
+    if (asset.resourceKey) {
+      url.searchParams.set("resourcekey", asset.resourceKey);
+    }
+    return url.href;
+  }
+
+  render() {
+    const pending = this.sca.controller.global.consent.pendingBatchConsent;
+    if (!pending) {
+      return nothing;
+    }
+
+    const { assets } = pending;
+
+    return html`<bb-modal
+      modalTitle="Opal App - Drive Assets Used"
+      .showCloseButton=${true}
+      .showSaveCancel=${true}
+      .blurBackground=${true}
+      appearance="basic"
+      saveButtonLabel="Allow & Continue"
+      @bbmodaldismissed=${this.#handleModalDismissed}
+    >
+      <div class="consent-body">
+        <p>
+          This Opal app uses the following Google Drive
+          ${assets.length === 1 ? "file" : "files"}. By continuing, you allow
+          the app to read and process ${assets.length === 1 ? "its" : "their"}
+          contents.
+        </p>
+
+        <ul class="asset-list">
+          ${assets.map((asset) => {
+            const iconSrc = asset.iconLink?.replace(/\/16\//, "/32/") || "";
+            return html`
+              <li class="asset-item">
+                ${iconSrc
+                  ? html`<img src=${iconSrc} alt="" />`
+                  : nothing}
+                <a href=${this.#buildDriveUrl(asset)} target="_blank">
+                  ${asset.fileName}
+                </a>
+              </li>
+            `;
+          })}
+        </ul>
+
+        <p>
+          If you do not trust this app, click Cancel to stop execution.
+        </p>
+      </div>
+    </bb-modal>`;
+  }
+}

--- a/packages/visual-editor/src/ui/elements/shell/batch-consent-modal.ts
+++ b/packages/visual-editor/src/ui/elements/shell/batch-consent-modal.ts
@@ -119,7 +119,7 @@ export class VEBatchConsentModal extends SignalWatcher(LitElement) {
       modalTitle="Opal App - Drive Assets Used"
       .showCloseButton=${true}
       .showSaveCancel=${true}
-      .blurBackground=${true}
+      .blurBackground=${false}
       appearance="basic"
       saveButtonLabel="Allow & Continue"
       @bbmodaldismissed=${this.#handleModalDismissed}

--- a/packages/visual-editor/src/ui/elements/shell/batch-consent-modal.ts
+++ b/packages/visual-editor/src/ui/elements/shell/batch-consent-modal.ts
@@ -126,10 +126,8 @@ export class VEBatchConsentModal extends SignalWatcher(LitElement) {
     >
       <div class="consent-body">
         <p>
-          This Opal app uses the following Google Drive
-          ${assets.length === 1 ? "file" : "files"}. By continuing, you allow
-          the app to read and process ${assets.length === 1 ? "its" : "their"}
-          contents.
+          This Opal requires access to the following Google Drive
+          ${assets.length === 1 ? "file" : "files"}.
         </p>
 
         <ul class="asset-list">
@@ -137,9 +135,7 @@ export class VEBatchConsentModal extends SignalWatcher(LitElement) {
             const iconSrc = asset.iconLink?.replace(/\/16\//, "/32/") || "";
             return html`
               <li class="asset-item">
-                ${iconSrc
-                  ? html`<img src=${iconSrc} alt="" />`
-                  : nothing}
+                ${iconSrc ? html`<img src=${iconSrc} alt="" />` : nothing}
                 <a href=${this.#buildDriveUrl(asset)} target="_blank">
                   ${asset.fileName}
                 </a>
@@ -149,7 +145,8 @@ export class VEBatchConsentModal extends SignalWatcher(LitElement) {
         </ul>
 
         <p>
-          If you do not trust this app, click Cancel to stop execution.
+          If you don't trust these files or the person who sent you this Opal,
+          click cancel to exit.
         </p>
       </div>
     </bb-modal>`;

--- a/packages/visual-editor/src/ui/elements/shell/consent-request.ts
+++ b/packages/visual-editor/src/ui/elements/shell/consent-request.ts
@@ -7,6 +7,7 @@ import { LitElement, html, css, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { baseColors } from "../../styles/host/base-colors.js";
 import { type } from "../../styles/host/type.js";
+
 import "@material/web/tabs/primary-tab.js";
 import "@material/web/tabs/tabs.js";
 import "@material/web/checkbox/checkbox.js";
@@ -49,8 +50,16 @@ export class VEConsentRequestModal extends SignalWatcher(LitElement) {
           max-width: 80%;
         }
       }
-      .center {
-        text-align: center;
+
+      .consent-body {
+        color: var(--light-dark-n-30);
+
+        & p {
+          font-family: var(--bb-font-family, var(--default-font-family));
+          font-size: 14px;
+          line-height: 20px;
+          margin: 0 0 var(--bb-grid-size-3) 0;
+        }
       }
     `,
   ];
@@ -82,13 +91,18 @@ export class VEConsentRequestModal extends SignalWatcher(LitElement) {
       modalTitle=${renderInfo.name}
       .showCloseButton=${true}
       .showSaveCancel=${true}
-      saveButtonLabel="Always Allow"
+      .blurBackground=${true}
+      appearance="basic"
+      saveButtonLabel=${renderInfo.saveButtonLabel ?? "Always Allow"}
       @bbmodaldismissed=${this.#handleModalDismissed}
     >
-      ${renderInfo.description(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        this.consentRequest.request as any
-      )}
+
+      <div class="consent-body">
+        ${renderInfo.description(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          this.consentRequest.request as any
+        )}
+      </div>
     </bb-modal>`;
   }
 }

--- a/packages/visual-editor/src/ui/utils/consent-content-items.ts
+++ b/packages/visual-editor/src/ui/utils/consent-content-items.ts
@@ -17,6 +17,7 @@ type ConsentRequestOfType<T extends ConsentType> = Extract<
 interface ConsentRenderInfo<T extends ConsentType> {
   name: string;
   description: (request: ConsentRequestOfType<T>) => HTMLTemplateResult;
+  saveButtonLabel?: string;
 }
 
 // The type for the main CONSENT_RENDER_INFO object
@@ -44,6 +45,16 @@ export const CONSENT_RENDER_INFO: ConsentRenderInfoMap = {
       <p>This Opal would like to open a webpage on the following site:</p>
       <p class="center" style="word-break: break-all;">${request.scope}</p>
       <p>Only click allow if you recognize this site and trust the Opal.</p>
+    `,
+  },
+  // Drive file consent is handled by the batch consent modal
+  // (bb-batch-consent-modal). This minimal entry exists only for
+  // ConsentRenderInfoMap type completeness.
+  [ConsentType.ACCESS_DRIVE_FILE_CONTENT]: {
+    name: "Opal App - Drive Assets Used",
+    saveButtonLabel: "Allow & Continue",
+    description: () => html`
+      <p>This Opal app uses Google Drive files. Allow access to continue.</p>
     `,
   },
 };

--- a/packages/visual-editor/src/ui/utils/consent-content-items.ts
+++ b/packages/visual-editor/src/ui/utils/consent-content-items.ts
@@ -47,14 +47,51 @@ export const CONSENT_RENDER_INFO: ConsentRenderInfoMap = {
       <p>Only click allow if you recognize this site and trust the Opal.</p>
     `,
   },
-  // Drive file consent is handled by the batch consent modal
-  // (bb-batch-consent-modal). This minimal entry exists only for
-  // ConsentRenderInfoMap type completeness.
   [ConsentType.ACCESS_DRIVE_FILE_CONTENT]: {
-    name: "Opal App - Drive Assets Used",
-    saveButtonLabel: "Allow & Continue",
-    description: () => html`
-      <p>This Opal app uses Google Drive files. Allow access to continue.</p>
-    `,
+    name: "Opal App - Sensitive Content Awareness",
+    description: (request) => {
+      let fileId = "";
+      let fileName = "Google Drive File";
+      let resourceKey = "";
+      try {
+        const parsed = JSON.parse(request.scope);
+        fileId = parsed.fileId || "";
+        fileName = parsed.fileName || "Google Drive File";
+        resourceKey = parsed.resourceKey || "";
+      } catch {
+        fileId = request.scope;
+        fileName = request.scope;
+      }
+
+      const url = new URL("https://drive.google.com/open");
+      url.searchParams.set("id", fileId);
+      if (resourceKey) {
+        url.searchParams.set("resourcekey", resourceKey);
+      }
+
+      return html`
+        <p>
+          This Opal app would like to read and use the content of the following
+          Google Drive file to run its steps:
+        </p>
+        <p
+          class="center"
+          style="word-break: break-all; margin: var(--bb-grid-size-4) 0;"
+        >
+          <strong>Google Drive File:</strong>
+          <a
+            href=${url.href}
+            target="_blank"
+            style="color: var(--ui-custom-o-100, #1a73e8); text-decoration: none; font-weight: bold; margin-left: 4px;"
+          >
+            ${fileName}
+          </a>
+        </p>
+        <p>
+          Be aware that the contents of this asset will be processed by the Opal
+          app. Click allow to permit reading this file's contents and continue.
+        </p>
+      `;
+    },
   },
 };

--- a/packages/visual-editor/src/ui/utils/consent-content-items.ts
+++ b/packages/visual-editor/src/ui/utils/consent-content-items.ts
@@ -47,7 +47,7 @@ export const CONSENT_RENDER_INFO: ConsentRenderInfoMap = {
       <p>Only click allow if you recognize this site and trust the Opal.</p>
     `,
   },
-  [ConsentType.ACCESS_DRIVE_FILE_CONTENT]: {
+  [ConsentType.ACCESS_ASSET]: {
     name: "Opal App - Sensitive Content Awareness",
     description: (request) => {
       let fileId = "";

--- a/packages/visual-editor/tests/sca/actions/board/board-route-actions.test.ts
+++ b/packages/visual-editor/tests/sca/actions/board/board-route-actions.test.ts
@@ -361,12 +361,15 @@ suite("Board Route Actions", () => {
         new Set(["drive:/gallery-board"]);
       const services = makeMockServices({ boardServer });
 
+      const env = createMockEnvironment(defaultRuntimeFlags);
+
       Board.bind({
         services,
         controller,
-        env: createMockEnvironment(defaultRuntimeFlags),
+        env,
       });
 
+      await env.isHydrated;
       await Board.onRun();
 
       assert.strictEqual(

--- a/packages/visual-editor/tests/sca/controller/data/default-flags.ts
+++ b/packages/visual-editor/tests/sca/controller/data/default-flags.ts
@@ -22,4 +22,5 @@ export const defaultRuntimeFlags: RuntimeFlags = {
   enableOpalBackend: false,
   enableSessionsBackend: false,
   enableSingletonPrefixCache: false,
+  enableAssetAccessConsent: false,
 };

--- a/packages/visual-editor/tests/sca/controller/subcontrollers/global/consent-controller.test.ts
+++ b/packages/visual-editor/tests/sca/controller/subcontrollers/global/consent-controller.test.ts
@@ -203,26 +203,4 @@ suite("ConsentController", () => {
     await store2.isSettled;
     assert.deepStrictEqual(unwrap(store2.consents), new Map());
   });
-
-  test("shared assets consent", async () => {
-    const store = new ConsentController("SharedAssets", "ConsentController");
-    await store.isHydrated;
-
-    const url = "drive:/test-opal";
-    assert.strictEqual(store.hasSharedAssetsConsent(url), false);
-
-    store.grantSharedAssetsConsent(url);
-    await store.isSettled;
-    assert.strictEqual(store.hasSharedAssetsConsent(url), true);
-
-    // Re-hydrate check
-    const store2 = new ConsentController("SharedAssets", "ConsentController");
-    await store2.isHydrated;
-    assert.strictEqual(store2.hasSharedAssetsConsent(url), true);
-
-    // Revoke and verify
-    store2.revokeSharedAssetsConsent(url);
-    await store2.isSettled;
-    assert.strictEqual(store2.hasSharedAssetsConsent(url), false);
-  });
 });

--- a/packages/visual-editor/tests/sca/controller/subcontrollers/global/consent-controller.test.ts
+++ b/packages/visual-editor/tests/sca/controller/subcontrollers/global/consent-controller.test.ts
@@ -203,4 +203,26 @@ suite("ConsentController", () => {
     await store2.isSettled;
     assert.deepStrictEqual(unwrap(store2.consents), new Map());
   });
+
+  test("shared assets consent", async () => {
+    const store = new ConsentController("SharedAssets", "ConsentController");
+    await store.isHydrated;
+
+    const url = "drive:/test-opal";
+    assert.strictEqual(store.hasSharedAssetsConsent(url), false);
+
+    store.grantSharedAssetsConsent(url);
+    await store.isSettled;
+    assert.strictEqual(store.hasSharedAssetsConsent(url), true);
+
+    // Re-hydrate check
+    const store2 = new ConsentController("SharedAssets", "ConsentController");
+    await store2.isHydrated;
+    assert.strictEqual(store2.hasSharedAssetsConsent(url), true);
+
+    // Revoke and verify
+    store2.revokeSharedAssetsConsent(url);
+    await store2.isSettled;
+    assert.strictEqual(store2.hasSharedAssetsConsent(url), false);
+  });
 });

--- a/packages/visual-editor/tests/sca/environment/environment.test.ts
+++ b/packages/visual-editor/tests/sca/environment/environment.test.ts
@@ -41,10 +41,6 @@ function makeRuntimeConfig(
         outputTemplates: false,
         googleOne: false,
 
-
-
-
-
         enableGoogleDriveTools: false,
         enableResumeAgentRun: false,
         enableNotebookLm: false,
@@ -55,7 +51,6 @@ function makeRuntimeConfig(
         enableOpalBackend: false,
         enableSessionsBackend: false,
         enableSingletonPrefixCache: false,
-
       },
     },
     shellHost: {
@@ -79,10 +74,6 @@ const testFlags: RuntimeFlags = {
   outputTemplates: false,
   googleOne: false,
 
-
-
-
-
   enableGoogleDriveTools: false,
   enableResumeAgentRun: false,
   enableNotebookLm: false,
@@ -93,7 +84,7 @@ const testFlags: RuntimeFlags = {
   enableOpalBackend: false,
   enableSessionsBackend: false,
   enableSingletonPrefixCache: false,
-
+  enableAssetAccessConsent: false,
 };
 
 suite("createEnvironment", () => {

--- a/packages/visual-editor/tests/useful-stubs.ts
+++ b/packages/visual-editor/tests/useful-stubs.ts
@@ -42,6 +42,7 @@ const stubModuleArgs: A2ModuleArgs = {
     } as Partial<ConsentController> as ConsentController;
   },
   notebookLmApiClient: {} as never,
+  googleDriveClient: {} as never,
 };
 
 const stubMemoryManager: MemoryManager = {


### PR DESCRIPTION
Show consent pages to the user whenever they are running a shared Opal which uses google drive assets.

[Opal] [Consent Screen] Show the consent screen for the user to agree before loading a shared Opal - https://screencast.googleplex.com/cast/NTQyODQ2MjU0MTA3ODUyOHxlNWFhNWExZC03Zg

[Opal] [Consent Screen] Show the consent screen for the user to agree before loading a shared Opal - User denies - https://screencast.googleplex.com/cast/NTcyNTUyNDU5MTY0MDU3Nnw4MTZhOTM2MC01Yg