### PR TITLE
[bees] Replace `wait_ms_before_async` with `tasks_await`

### DIFF
--- a/hives/chat-app/config/TEMPLATES.yaml
+++ b/hives/chat-app/config/TEMPLATES.yaml
@@ -219,15 +219,16 @@
 
 
     Step 1: Create a `generate_images` task with slug "reference" and
-    objective "A simple cartoon cat sitting on a red cushion". Wait for
-    it to complete (use wait_ms_before_async: 60000).
+    objective "A simple cartoon cat sitting on a red cushion". Then call
+    tasks_await to wait for it to complete.
 
 
     Step 2: Once Step 1 completes, create a second `generate_images` task
     with slug "grounded" and this objective (including the pidgin file
     tag exactly): "A pencil sketch version of this image
     <file src=\"reference/image_0.png\" />. Draw it in a notebook style."
-    Set options: { "aspect_ratio": "16:9" }. Wait for it to complete.
+    Set options: { "aspect_ratio": "16:9" }. Then call tasks_await to
+    wait for it to complete.
 
 
     Report whether both tasks succeeded and describe what was generated.
@@ -329,23 +330,23 @@
     Step 1: Create a `generate_images` task with slug "frame" and
     objective "A wide shot of a single origami butterfly resting on a
     mossy rock in a sunlit forest clearing, photorealistic". Set options:
-    { "aspect_ratio": "16:9" }. Wait for it to complete
-    (use wait_ms_before_async: 120000).
+    { "aspect_ratio": "16:9" }. Then call tasks_await to wait for it
+    to complete.
 
 
     Step 2: Once Step 1 completes, create a `generate_video` task with
     slug "clip" and objective "The origami butterfly slowly lifts off the
     rock and flutters upward into dappled sunlight, gentle rustling
     sounds". Set options: { "first_frame": "frame/image_0.png",
-    "resolution": "720p" }. Wait for it to complete
-    (use wait_ms_before_async: 180000).
+    "resolution": "720p" }. Then call tasks_await to wait for it
+    to complete.
 
 
     Step 3: Once Step 2 completes, create another `generate_video` task
     with slug "clip" and objective "The butterfly soars higher through
     the canopy, light rays streaming through leaves, birdsong". Set
-    options: { "extend_video": "clip/video_0.mp4" }. Wait for it to
-    complete (use wait_ms_before_async: 180000).
+    options: { "extend_video": "clip/video_0.mp4" }. Then call
+    tasks_await to wait for it to complete.
 
 
     Report whether all three tasks succeeded and describe the result.
@@ -369,21 +370,20 @@
 
     Step 1: Create a `generate_images` task with slug "keyframes" and
     objective "A woman in a red dress standing at the edge of a calm lake
-    at sunrise, wide shot, photorealistic". Wait for it to complete
-    (use wait_ms_before_async: 120000).
+    at sunrise, wide shot, photorealistic". Then call tasks_await to wait
+    for it to complete.
 
 
     Step 2: Create a second `generate_images` task with slug "keyframes_end"
     and objective "The same woman now sitting in a small wooden rowboat
     in the middle of the lake, golden hour light, wide shot,
-    photorealistic". Wait for it to complete
-    (use wait_ms_before_async: 120000).
+    photorealistic". Then call tasks_await to wait for it to complete.
 
 
     Step 3: Create a `generate_images` task with slug "ref" and objective
     "Close-up portrait of a woman with dark hair wearing a flowing red
-    silk dress, soft lighting". Wait for it to complete
-    (use wait_ms_before_async: 120000).
+    silk dress, soft lighting". Then call tasks_await to wait for it
+    to complete.
 
 
     Step 4: Once all images are ready, create a `generate_video` task with
@@ -393,8 +393,8 @@
     to reveal the golden sunrise reflecting on the water". Set options:
     { "first_frame": "keyframes/image_0.png",
     "last_frame": "keyframes_end/image_0.png",
-    "reference_images": ["ref/image_0.png"] }. Wait for it to complete
-    (use wait_ms_before_async: 180000).
+    "reference_images": ["ref/image_0.png"] }. Then call tasks_await
+    to wait for it to complete.
 
 
     Report whether all tasks succeeded and describe the generated video.
@@ -528,14 +528,14 @@
     this conversation. Let me tell you about something fascinating."
 
     Set options: { "speaker_1": "Host:Aoede", "speaker_2": "Guest:Puck" }.
-    Wait for it to complete (use wait_ms_before_async: 120000).
+    Then call tasks_await to wait for it to complete.
 
 
     Step 2: Create a second `generate_speech` task with slug "narration"
     and objective "The morning sun cast long shadows across the ancient
     library. [slowly, with gravity] Within its walls, secrets waited to
     be discovered." Set options: { "voice": "Charon" }.
-    Wait for it to complete (use wait_ms_before_async: 120000).
+    Then call tasks_await to wait for it to complete.
 
 
     Report whether both tasks succeeded and describe the results.

--- a/packages/bees/bees/declarations/chat.instruction.md
+++ b/packages/bees/bees/declarations/chat.instruction.md
@@ -29,9 +29,13 @@ they were user input.
 ## Awaiting Context Updates
 
 The "chat_await_context_update" function suspends your session until an external
-context update arrives. **Only call this function when your objective explicitly
-instructs you to wait for context updates.** Do not call it on your own
-initiative — it is not a general-purpose "wait" or "sleep" tool.
+context update arrives. It is equivalent to "tasks_await" from the tasks
+function group. If you have access to tasks functions, prefer "tasks_await"
+instead — it works identically and is available to all agents.
+
+**Only call this function when your objective explicitly instructs you to wait
+for context updates.** Do not call it on your own initiative — it is not a
+general-purpose "wait" or "sleep" tool.
 
 When the function returns, look for `<context_update>` text parts in the
 conversation, then continue with your objective.

--- a/packages/bees/bees/declarations/tasks.functions.json
+++ b/packages/bees/bees/declarations/tasks.functions.json
@@ -33,10 +33,6 @@
           "type": "string",
           "description": "A single directory name for the task's working area (e.g., 'research'). The system automatically nests this under your own working directory if you are a subagent."
         },
-        "wait_ms_before_async": {
-          "type": "number",
-          "description": "Specifies the number of milliseconds to wait for task completion instead of returning immediately. If the task is completed in that period of time, the outcome of the task will be returned. Otherwise, the task status will be returned. Use only when explicitly requested to wait to return."
-        },
         "options": {
           "type": "object",
           "description": "Optional runtime configuration overrides for the task as key-value pairs. Supported keys and values depend entirely on the task type being created. Discover available options for each task type by calling 'tasks_list_types'.",
@@ -88,6 +84,20 @@
         }
       },
       "required": ["task_id", "type", "message"]
+    }
+  },
+  {
+    "name": "tasks_await",
+    "description": "Suspend execution until a context update arrives (e.g. a child task completes or a parent sends an event). Returns immediately if updates are already pending. Call this after creating tasks to wait for their results.",
+    "parametersJsonSchema": {
+      "type": "object",
+      "properties": {
+        "task_ids": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Optional. Task IDs to wait for. Currently informational — the function resumes on any context update."
+        }
+      }
     }
   }
 ]

--- a/packages/bees/bees/declarations/tasks.instruction.md
+++ b/packages/bees/bees/declarations/tasks.instruction.md
@@ -22,12 +22,19 @@ You can send events to a running subagent using "tasks_send_event". The agent
 receives the event as a context update. Use this to provide additional
 instructions, clarifications, or data while the subagent is working.
 
-Unless the objective explicitly calls for itit, keep the "wait_ms_before_async"
-parameter at 0 and let the tasks run asynchronously.
+Tasks run asynchronously — "tasks_create_task" returns immediately with a
+task ID and status. The scheduler issues a context update when each task
+completes, containing the outcome or an error message.
 
-For tasks that run asynchronously, the scheduler will issue a context update
-when each task completes. The update will contain the outcome of the completed
-task or an error message if the task failed.
+To wait for task results, call "tasks_await". This suspends your execution
+until a context update arrives (e.g. a child task completes or a parent sends
+you an event). If updates are already pending, it returns immediately.
+
+Typical workflow:
+1. Create one or more tasks with "tasks_create_task".
+2. Call "tasks_await" to suspend until a task completes.
+3. Check results with "tasks_check_status".
+4. Repeat or proceed based on results.
 
 The subagents working on tasks have access to a sub-directory of your
 filesystem, specified by the "slug" parameter when creating a task. You provide

--- a/packages/bees/bees/functions/tasks.py
+++ b/packages/bees/bees/functions/tasks.py
@@ -6,9 +6,16 @@
 from __future__ import annotations
 
 import logging
+import uuid
 from pathlib import Path
 from typing import Any
 
+from bees.context_updates import updates_to_context_parts
+from bees.protocols.handler_types import (
+    CONTEXT_PARTS_KEY,
+    SuspendError,
+    WaitForInputEvent,
+)
 from bees.subagent_scope import SubagentScope
 
 from bees.protocols.functions import (
@@ -85,7 +92,6 @@ def _make_handlers(
         summary = args.get("summary")
         objective = args.get("objective")
         slug = args.get("slug")
-        wait_ms = args.get("wait_ms_before_async")
         options = args.get("options")
         
         if not all([task_type, summary, objective, slug]):
@@ -148,20 +154,7 @@ def _make_handlers(
             
         if status_cb:
             status_cb(None, None)
-            
-        if wait_ms and scheduler:
-            if status_cb:
-                status_cb(f"Waiting for task {task.id}...")
-            status = await scheduler.wait_for_task(task.id, wait_ms)
-            if status_cb:
-                status_cb(None, None)
-                
-            if status == "completed":
-                fresh = scheduler.store.get(task.id) if scheduler else None
-                return {"outcome": fresh.metadata.outcome if fresh else "completed"}
-            else:
-                return {"task_id": task.id, "status": status}
-        
+
         return {"task_id": task.id, "status": task.metadata.status}
 
     async def _tasks_check_status(args: dict[str, Any], status_cb: Any) -> dict[str, Any]:
@@ -266,12 +259,48 @@ def _make_handlers(
             "delivered": True,
         }
 
+    async def _tasks_await(args: dict[str, Any], status_cb: Any) -> dict[str, Any]:
+        """Suspend until a context update arrives (e.g. child task completes).
+
+        If updates are already buffered in the task's metadata, returns
+        them immediately without suspending.  Otherwise raises
+        ``SuspendError`` and the scheduler resumes the agent when an
+        update is delivered.
+        """
+        # Check for already-buffered context updates.
+        if caller_ticket_id and scheduler:
+            task = scheduler.store.get(caller_ticket_id)
+            if task and task.metadata.pending_context_updates:
+                updates = task.metadata.pending_context_updates
+                task.metadata.pending_context_updates = []
+                scheduler.store.save_metadata(task)
+                return {
+                    "resumed": True,
+                    CONTEXT_PARTS_KEY: updates_to_context_parts(updates),
+                }
+
+        # No updates pending — suspend.
+        request_id = str(uuid.uuid4())
+        event = WaitForInputEvent(
+            request_id=request_id,
+            prompt={},
+            input_type="any",
+        )
+        function_call_part = {
+            "functionCall": {
+                "name": "tasks_await",
+                "args": args,
+            }
+        }
+        raise SuspendError(event, function_call_part)
+
     return {
         "tasks_list_types": _tasks_list_types,
         "tasks_create_task": _tasks_create_task,
         "tasks_check_status": _tasks_check_status,
         "tasks_cancel_task": _tasks_cancel_task,
         "tasks_send_event": _tasks_send_event,
+        "tasks_await": _tasks_await,
     }
 
 

--- a/packages/bees/docs/architecture.md
+++ b/packages/bees/docs/architecture.md
@@ -289,7 +289,7 @@ The built-in function groups are:
 
 | Group    | Filter prefix | Purpose                                                                                                                 |
 | -------- | ------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `tasks`  | `tasks.*`     | Task management: `tasks_list_types`, `tasks_create_task`, `tasks_check_status`, `tasks_cancel_task`, `tasks_send_event` |
+| `tasks`  | `tasks.*`     | Task management: `tasks_list_types`, `tasks_create_task`, `tasks_check_status`, `tasks_cancel_task`, `tasks_send_event`, `tasks_await` |
 | `events` | `events.*`    | Cross-agent communication: `events_broadcast`, `events_send_to_parent`                                                  |
 
 #### Task trees

--- a/packages/bees/docs/session.md
+++ b/packages/bees/docs/session.md
@@ -105,7 +105,7 @@ using bees-native protocols from `bees/protocols/`:
 | `sandbox`      | `sandbox.*`      | Sandboxed bash execution in the task's working directory.                                                                |
 | `chat`         | `chat.*`         | User interaction: `chat_request_user_input`, `chat_present_choices`, `chat_await_context_update`.                        |
 | `events`       | `events.*`       | Cross-agent communication: `events_broadcast`, `events_send_to_parent`.                                                  |
-| `tasks`        | `tasks.*`        | Task management: `tasks_list_types`, `tasks_create_task`, `tasks_check_status`, `tasks_cancel_task`, `tasks_send_event`. |
+| `tasks`        | `tasks.*`        | Task management: `tasks_list_types`, `tasks_create_task`, `tasks_check_status`, `tasks_cancel_task`, `tasks_send_event`, `tasks_await`. |
 | `skills`       | `skills.*`       | Instruction-only: injects a system instruction listing available skills. No callable functions.                          |
 | `live`         | `live.*`         | Instruction-only: voice-native system instruction for `runner: live` sessions. No callable functions.                    |
 
@@ -169,7 +169,8 @@ includes:
 ### Suspend
 
 When the model calls a suspend function (`chat.request_user_input`,
-`chat.present_choices`, or `chat.await_context_update`), the agent loop raises a
+`chat.present_choices`, `chat.await_context_update`, or `tasks.await`), the
+agent loop raises a
 `SuspendError`. The session state is persisted to `session_state.json` in the
 task directory:
 

--- a/packages/bees/hivetool/src/ui/chat-panel.ts
+++ b/packages/bees/hivetool/src/ui/chat-panel.ts
@@ -561,7 +561,8 @@ class BeesChatPanel extends SignalWatcher(LitElement) {
       | undefined;
     const isUserFacing =
       ticket.assignee === "user" &&
-      functionName !== "chat_await_context_update";
+      functionName !== "chat_await_context_update" &&
+      functionName !== "tasks_await";
 
     if (!isUserFacing || !this.mutationClient?.boxActive.get()) return null;
 
@@ -770,7 +771,9 @@ export function hasChatContent(ticket: TaskData): boolean {
   if (ticket.status === "suspended" && ticket.suspend_event) {
     const fn = ticket.suspend_event.function_name as string | undefined;
     const isUserFacing =
-      ticket.assignee === "user" && fn !== "chat_await_context_update";
+      ticket.assignee === "user" &&
+      fn !== "chat_await_context_update" &&
+      fn !== "tasks_await";
     if (isUserFacing) {
       const hasInput = !!ticket.suspend_event.waitForInput;
       const hasChoice = !!ticket.suspend_event.waitForChoice;

--- a/packages/bees/hivetool/src/ui/ticket-detail.ts
+++ b/packages/bees/hivetool/src/ui/ticket-detail.ts
@@ -581,7 +581,8 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
   ) {
     const functionName = suspendEvent.function_name as string | undefined;
     const label =
-      functionName === "chat_await_context_update"
+      functionName === "chat_await_context_update" ||
+      functionName === "tasks_await"
         ? "Waiting for Event"
         : "Suspended";
     return html`

--- a/packages/bees/hivetool/src/ui/ticket-pane.ts
+++ b/packages/bees/hivetool/src/ui/ticket-pane.ts
@@ -169,10 +169,13 @@ class BeesTicketPane extends SignalWatcher(LitElement) {
 
     const suspendFn =
       ticket.suspend_event?.function_name as string | undefined;
+    const isAwaitSuspend =
+      suspendFn === "chat_await_context_update" ||
+      suspendFn === "tasks_await";
     const statusLabel =
       ticket.status === "suspended" &&
       ticket.assignee === "user" &&
-      suspendFn !== "chat_await_context_update"
+      !isAwaitSuspend
         ? "waiting for user"
         : ticket.status === "suspended"
           ? "waiting for event"

--- a/packages/bees/spec/handler-bodies.md
+++ b/packages/bees/spec/handler-bodies.md
@@ -182,7 +182,8 @@ For each file, the migration is:
 - The `SessionHooks` protocol
 - The `assemble_function_group` call
 - The loaded declarations
-- The bees-local wrappers in `chat.py` (`chat_await_context_update`)
+- The bees-local wrappers in `chat.py` (`chat_await_context_update` — now a
+  thin alias for the shared `tasks_await` suspend logic)
 
 ### After this spec
 

--- a/packages/bees/tests/test_dynamic_templates.py
+++ b/packages/bees/tests/test_dynamic_templates.py
@@ -262,7 +262,6 @@ async def test_tasks_create_task_dynamic(temp_hive):
         "summary": "My Custom Run",
         "objective": "some custom parameters",
         "slug": "custom-run",
-        "wait_ms_before_async": 10,
     }
     
     result = await create_task(args, None)

--- a/packages/bees/tests/test_tasks.py
+++ b/packages/bees/tests/test_tasks.py
@@ -196,35 +196,53 @@ async def test_tasks_create_task_async(write_template):
 
 
 @pytest.mark.asyncio
-async def test_tasks_create_task_sync_wait_timeout(write_template, monkeypatch):
-    write_template({
-        "name": "my-task",
-        "title": "My Task Template",
+async def test_tasks_await_with_pending_updates():
+    """tasks_await returns immediately when context updates are buffered."""
+    from bees.protocols.handler_types import CONTEXT_PARTS_KEY
 
-        "objective": "Do it.",
-    })
+    caller = GLOBAL_STORE.create("I'm the caller")
+    caller.metadata.pending_context_updates = [
+        {"type": "task_completed", "message": "Task abc done"},
+    ]
+    GLOBAL_STORE.save_metadata(caller)
 
     mock_scheduler = MagicMock()
     mock_scheduler.store = GLOBAL_STORE
-    mock_scheduler.wait_for_task = AsyncMock(return_value="running")
 
-    caller = GLOBAL_STORE.create("I'm the caller")
     scope = SubagentScope(workspace_root_id=caller.id)
     handlers = _make_handlers(scope=scope, caller_ticket_id=caller.id, scheduler=mock_scheduler)
 
-    args = {
-        "type": "my-task",
-        "summary": "Testing create sync",
-        "objective": "Full objective",
-        "slug": "my-slug",
-        "wait_ms_before_async": 1000
-    }
+    result = await handlers["tasks_await"]({}, None)
 
-    result = await handlers["tasks_create_task"](args, None)
+    assert result["resumed"] is True
+    assert CONTEXT_PARTS_KEY in result
 
-    assert "task_id" in result
-    assert result["status"] == "running"
-    mock_scheduler.wait_for_task.assert_called_once()
+    # Pending updates should be drained.
+    fresh = GLOBAL_STORE.get(caller.id)
+    assert fresh.metadata.pending_context_updates == []
+
+
+@pytest.mark.asyncio
+async def test_tasks_await_suspends_when_no_updates():
+    """tasks_await raises SuspendError when no updates are pending."""
+    from bees.protocols.handler_types import SuspendError
+
+    caller = GLOBAL_STORE.create("I'm the caller")
+    caller.metadata.pending_context_updates = []
+    GLOBAL_STORE.save_metadata(caller)
+
+    mock_scheduler = MagicMock()
+    mock_scheduler.store = GLOBAL_STORE
+
+    scope = SubagentScope(workspace_root_id=caller.id)
+    handlers = _make_handlers(scope=scope, caller_ticket_id=caller.id, scheduler=mock_scheduler)
+
+    with pytest.raises(SuspendError) as exc_info:
+        await handlers["tasks_await"]({}, None)
+
+    # The function call part should identify as tasks_await.
+    fc = exc_info.value.function_call_part
+    assert fc["functionCall"]["name"] == "tasks_await"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What
Removes the synchronous `wait_ms_before_async` parameter from `tasks_create_task` and adds `tasks_await` — a first-class suspend primitive that lets any agent with `tasks.*` pause until a context update arrives (e.g. child task completion).

## Why
`wait_ms_before_async` was an inline blocking hack with arbitrary timeouts. `tasks_await` uses the existing suspend/resume machinery (`SuspendError` → scheduler resume on context update), giving agents a clean async workflow: create tasks, await, check status, repeat. This also unifies the pattern with `chat_await_context_update`, which is now documented as an alias.

## Changes

### Core (`packages/bees`)
- **`tasks.py`** — Removed `wait_ms_before_async` handling, added `tasks_await` handler (checks pending updates → returns immediately, otherwise raises `SuspendError`)
- **`tasks.functions.json`** — Removed `wait_ms_before_async` property, added `tasks_await` declaration with optional `task_ids` param
- **`tasks.instruction.md`** — Documents the `tasks_await` workflow, removes `wait_ms_before_async` guidance
- **`chat.instruction.md`** — Notes `tasks_await` as the preferred equivalent of `chat_await_context_update`

### Hivetool UI
- **`ticket-pane.ts`**, **`ticket-detail.ts`**, **`chat-panel.ts`** — Recognize `tasks_await` as a non-user-facing suspend (shows "waiting for event")

### Templates
- **`hives/chat-app/config/TEMPLATES.yaml`** — 4 test harnesses (`test_image_grounding`, `test_video_extension`, `test_video_interpolation`, `test_multi_speaker_speech`) rewritten to use `tasks_await`

### Docs
- **`architecture.md`**, **`session.md`**, **`handler-bodies.md`** — Updated function group tables and suspend references

### Tests
- **`test_tasks.py`** — Replaced `wait_ms` test with `test_tasks_await_with_pending_updates` and `test_tasks_await_suspends_when_no_updates`
- **`test_dynamic_templates.py`** — Removed `wait_ms_before_async` from test args

## Testing
```bash
cd packages/bees && python3 -m pytest tests/test_tasks.py tests/test_chat.py tests/test_dynamic_templates.py -v
```
17 tests pass.
