### PR TITLE
[bees] Swarm Phase 2a — Scheduler Accepts Agent Objects

### DIFF
--- a/packages/bees/bees/agent.py
+++ b/packages/bees/bees/agent.py
@@ -96,10 +96,43 @@ class AgentMetadata:
     playbook_id: str | None = None
     """Template name that created this agent."""
 
+    playbook_run_id: str | None = None
+    """Run-scoped ID for coordination signal routing.
+
+    Temporary bridge from ``TicketMetadata`` — coordination uses this
+    to scope broadcasts to a single playbook run. Will be replaced by
+    root-ancestor matching in Phase 6.
+    """
+
     tasks: list[str] | None = None
     """Allowlist for child agent types (template names)."""
 
     tags: list[str] | None = None
+
+    # -- Execution state (bridge fields from TicketMetadata) ---------------
+    # These are written by the scheduler and task runner during execution.
+    # In the future, some move to TaskRecord (outcome, title, context)
+    # and others stay on the agent (error, suspend_event, assignee).
+
+    depends_on: list[str] | None = None
+    error: str | None = None
+    outcome: str | None = None
+    outcome_content: dict[str, Any] | None = None
+    assignee: str | None = None
+    """``'user'`` or ``'agent'`` — who owns the next move."""
+
+    suspend_event: dict[str, Any] | None = None
+    kind: str = "work"
+    """``'work'`` or ``'coordination'``."""
+
+    delivered_to: list[str] | None = None
+    """Coordination delivery tracking."""
+
+    context: str | None = None
+    title: str | None = None
+    turns: int = 0
+    thoughts: int = 0
+    files: list[dict[str, str]] | None = None
 
     def to_dict(self) -> dict[str, Any]:
         d = asdict(self)
@@ -112,6 +145,7 @@ class AgentMetadata:
             type=data.get("type", ""),
             slug=data.get("slug", ""),
             status=data.get("status", "available"),
+            # playbook_run_id populated below
             finite=data.get("finite", True),
             runner=data.get("runner", "generate"),
             parent_id=data.get("parent_id"),
@@ -130,8 +164,22 @@ class AgentMetadata:
             completed_at=data.get("completed_at"),
             paused_from=data.get("paused_from"),
             playbook_id=data.get("playbook_id"),
+            playbook_run_id=data.get("playbook_run_id"),
             tasks=data.get("tasks"),
             tags=data.get("tags"),
+            depends_on=data.get("depends_on"),
+            error=data.get("error"),
+            outcome=data.get("outcome"),
+            outcome_content=data.get("outcome_content"),
+            assignee=data.get("assignee"),
+            suspend_event=data.get("suspend_event"),
+            kind=data.get("kind", "work"),
+            delivered_to=data.get("delivered_to"),
+            context=data.get("context"),
+            title=data.get("title"),
+            turns=data.get("turns", 0),
+            thoughts=data.get("thoughts", 0),
+            files=data.get("files"),
         )
 
 
@@ -142,6 +190,13 @@ class Agent:
     id: str
     dir: Path
     metadata: AgentMetadata = field(default_factory=AgentMetadata)
+    objective: str = ""
+    """Transient objective text.
+
+    During the ``tickets/`` era the objective lives in ``objective.md``
+    and is populated by the adapter. Once ``TaskRecord`` takes over
+    (Phase 3+) this field is removed — objectives belong on tasks.
+    """
 
     @property
     def fs_dir(self) -> Path:

--- a/packages/bees/bees/agent_adapter.py
+++ b/packages/bees/bees/agent_adapter.py
@@ -2,20 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Adapter: read tickets/ as agents.
+Bidirectional adapter: tickets ↔ agents.
 
 Bridges the existing ``tickets/{uuid}/`` directory layout into the
-new ``Agent`` data model. This enables Phase 1 tests and hivetool
-to exercise backward-compatible reads without waiting for Phase 2a.
-
-Pure read adapter — no writes.
+new ``Agent`` data model and back. This enables Phase 2a to run the
+scheduler on ``Agent`` objects while the on-disk layout stays
+``tickets/``.
 """
 
 from __future__ import annotations
 
 from bees.agent import Agent, AgentMetadata
 from bees.task_store import TaskStore
-from bees.ticket import Ticket
+from bees.ticket import Ticket, TicketMetadata
 
 
 def _has_system_functions(functions: list[str] | None) -> bool:
@@ -36,11 +35,14 @@ def ticket_to_agent(ticket: Ticket) -> Agent:
     - ``parent_task_id`` → ``parent_id``
     - ``owning_task_id`` → ``workspace_root_id``
     - ``functions`` list determines ``finite``
+    - ``playbook_run_id`` → ``playbook_run_id`` (temporary bridge)
+    - ``objective`` → ``objective`` (transient field)
     """
     meta = ticket.metadata
     return Agent(
         id=ticket.id,
         dir=ticket.dir,
+        objective=ticket.objective,
         metadata=AgentMetadata(
             type=meta.playbook_id or "",
             slug=meta.slug or "",
@@ -63,8 +65,77 @@ def ticket_to_agent(ticket: Ticket) -> Agent:
             completed_at=meta.completed_at,
             paused_from=meta.paused_from,
             playbook_id=meta.playbook_id,
+            playbook_run_id=meta.playbook_run_id,
             tasks=meta.tasks,
             tags=meta.tags,
+            # Execution-state bridge fields
+            depends_on=meta.depends_on,
+            error=meta.error,
+            outcome=meta.outcome,
+            outcome_content=meta.outcome_content,
+            assignee=meta.assignee,
+            suspend_event=meta.suspend_event,
+            kind=meta.kind,
+            delivered_to=meta.delivered_to,
+            context=meta.context,
+            title=meta.title,
+            turns=meta.turns,
+            thoughts=meta.thoughts,
+            files=meta.files,
+        ),
+    )
+
+
+def agent_to_ticket(agent: Agent) -> Ticket:
+    """Convert an Agent back to a Ticket.
+
+    Reverse mapping for the bidirectional adapter. Enables the
+    ``UnifiedAgentStore`` to write ``Agent`` state back through
+    the existing ``TaskStore`` during the ``tickets/`` era.
+    """
+    meta = agent.metadata
+    return Ticket(
+        id=agent.id,
+        objective=agent.objective,
+        dir=agent.dir,
+        metadata=TicketMetadata(
+            status=meta.status,
+            created_at=meta.created_at,
+            completed_at=meta.completed_at,
+            turns=meta.turns,
+            thoughts=meta.thoughts,
+            error=meta.error,
+            outcome=meta.outcome,
+            outcome_content=meta.outcome_content,
+            assignee=meta.assignee,
+            suspend_event=meta.suspend_event,
+            depends_on=meta.depends_on,
+            tags=meta.tags,
+            functions=meta.functions,
+            skills=meta.skills,
+            title=meta.title,
+            playbook_id=meta.playbook_id,
+            playbook_run_id=meta.playbook_run_id,
+            owning_task_id=meta.workspace_root_id
+            if meta.workspace_root_id != agent.id
+            else None,
+            model=meta.model,
+            context=meta.context,
+            watch_events=meta.watch_events,
+            queued_updates=meta.queued_updates,
+            kind=meta.kind or "work",
+            signal_type=meta.signal_type,
+            delivered_to=meta.delivered_to,
+            tasks=meta.tasks,
+            parent_task_id=meta.parent_id,
+            slug=meta.slug or None,
+            pending_context_updates=meta.pending_context_updates,
+            paused_from=meta.paused_from,
+            active_session=meta.active_session,
+            runner=meta.runner,
+            voice=meta.voice,
+            options=meta.options,
+            files=meta.files,
         ),
     )
 

--- a/packages/bees/bees/bees.py
+++ b/packages/bees/bees/bees.py
@@ -7,9 +7,11 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Any, Awaitable, Callable, TypeVar
 
+from bees.agent import Agent
+from bees.agent_adapter import agent_to_ticket
 from bees.protocols.events import SchedulerEvent
 from bees.protocols.session import SessionRunner
-from bees.task_store import TaskStore
+from bees.unified_agent_store import UnifiedAgentStore
 from bees.task_node import TaskNode
 from bees.scheduler import Scheduler
 
@@ -32,7 +34,7 @@ class Bees:
         *,
         root_override: str | None = None,
     ):
-        self._store = TaskStore(hive_dir)
+        self._store = UnifiedAgentStore(hive_dir)
         self._observers: dict[type[SchedulerEvent], list[EventCallback]] = defaultdict(list)
         self._loop_task = None
 
@@ -73,10 +75,10 @@ class Bees:
         Returns the number of tasks resumed.
         """
         count = 0
-        for task in self._store.query_all(status="paused"):
-            task.metadata.status = task.metadata.paused_from or "available"
-            task.metadata.paused_from = None
-            self._store.save_metadata(task)
+        for agent in self._store.query_all(status="paused"):
+            agent.metadata.status = agent.metadata.paused_from or "available"
+            agent.metadata.paused_from = None
+            self._store.save_metadata(agent)
             count += 1
         return count
 
@@ -129,29 +131,31 @@ class Bees:
     @property
     def children(self) -> list[TaskNode]:
         """Returns all tasks that have no parents, as TaskNodes."""
-        return [TaskNode(task, self) for task in self._store.get_children(None)]
+        agents = self._store.get_children(None)
+        return [TaskNode(agent_to_ticket(a), self) for a in agents]
 
     @property
     def all(self) -> list[TaskNode]:
         """Returns all tasks in the hive."""
-        return [TaskNode(task, self) for task in self._store.query_all()]
+        agents = self._store.query_all()
+        return [TaskNode(agent_to_ticket(a), self) for a in agents]
 
     def get_by_id(self, task_id: str) -> TaskNode | None:
         """Looks up a task by ID and returns it as a TaskNode."""
-        task = self._store.get(task_id)
-        return TaskNode(task, self) if task else None
+        agent = self._store.get(task_id)
+        return TaskNode(agent_to_ticket(agent), self) if agent else None
 
     def query(self, tags: list[str]) -> list[TaskNode]:
         """Searches for tasks that contain all of the specified tags."""
-        all_tasks = self._store.query_all()
+        all_agents = self._store.query_all()
         matching_nodes: list[TaskNode] = []
-        for task in all_tasks:
-            task_tags = task.metadata.tags or []
-            if all(tag in task_tags for tag in tags):
-                matching_nodes.append(TaskNode(task, self))
+        for agent in all_agents:
+            agent_tags = agent.metadata.tags or []
+            if all(tag in agent_tags for tag in tags):
+                matching_nodes.append(TaskNode(agent_to_ticket(agent), self))
         return matching_nodes
 
     async def create_child(self, objective: str, **kwargs) -> TaskNode:
         """Creates a root task."""
-        task = await self._scheduler.create_task(objective, **kwargs)
-        return TaskNode(task, self)
+        agent = await self._scheduler.create_task(objective, **kwargs)
+        return TaskNode(agent_to_ticket(agent), self)

--- a/packages/bees/bees/coordination.py
+++ b/packages/bees/bees/coordination.py
@@ -18,10 +18,11 @@ import logging
 from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable
 
+from bees.agent import Agent
+from bees.agent_adapter import agent_to_ticket
 from bees.playbook import run_event_hooks
 from bees.protocols.events import BroadcastReceived, EventEmitter, TaskDone
-from bees.task_store import TaskStore
-from bees.ticket import Ticket
+from bees.unified_agent_store import UnifiedAgentStore
 
 logger = logging.getLogger(__name__)
 
@@ -29,8 +30,8 @@ __all__ = ["route_coordination_task"]
 
 
 async def route_coordination_task(
-    task: Ticket,
-    store: TaskStore,
+    agent: Agent,
+    store: UnifiedAgentStore,
     running_tasks: set[str],
     emit: EventEmitter,
 ) -> None:
@@ -44,16 +45,16 @@ async def route_coordination_task(
     This design survives server restarts — undelivered coordination
     tasks remain ``available`` on disk and are re-routed on startup.
     """
-    signal_type = task.metadata.signal_type or ""
-    payload = task.metadata.context or ""
-    source_tags = set(task.metadata.tags or [])
-    delivered = set(task.metadata.delivered_to or [])
+    signal_type = agent.metadata.signal_type or ""
+    payload = agent.metadata.context or ""
+    source_tags = set(agent.metadata.tags or [])
+    delivered = set(agent.metadata.delivered_to or [])
 
     # Find all matching subscribers.
-    source_run_id = task.metadata.playbook_run_id
-    subscribers: list[Ticket] = []
+    source_run_id = agent.metadata.playbook_run_id
+    subscribers: list[Agent] = []
     for candidate in store.query_all():
-        if candidate.id == task.id:
+        if candidate.id == agent.id:
             continue
         if not candidate.metadata.watch_events:
             continue
@@ -82,14 +83,20 @@ async def route_coordination_task(
             continue
 
         # Let the playbook hook intercept before delivery.
-        result = run_event_hooks(signal_type, payload, sub, store)
+        sub_ticket = agent_to_ticket(sub)
+        result = run_event_hooks(
+            signal_type, payload, sub_ticket, store._ticket_store,
+        )
         if result is None:
             # Hook ate the event — mark delivered, skip agent.
             delivered.add(sub.id)
-            store.save_metadata(sub)
+            # Refresh sub from store in case the hook mutated it.
+            refreshed = store.get(sub.id)
+            if refreshed:
+                store.save_metadata(refreshed)
             logger.info(
                 "Coordination %s eaten by hook for %s",
-                task.id[:8],
+                agent.id[:8],
                 sub.id[:8],
             )
             continue
@@ -114,7 +121,7 @@ async def route_coordination_task(
             delivered.add(sub.id)
             logger.info(
                 "Coordination %s delivered to %s",
-                task.id[:8],
+                agent.id[:8],
                 sub.id[:8],
             )
         else:
@@ -122,25 +129,25 @@ async def route_coordination_task(
             all_delivered = False
 
     # Update delivery tracking.
-    task.metadata.delivered_to = list(delivered)
+    agent.metadata.delivered_to = list(delivered)
 
     if all_delivered:
-        task.metadata.status = "completed"
-        task.metadata.completed_at = datetime.now(timezone.utc).isoformat()
+        agent.metadata.status = "completed"
+        agent.metadata.completed_at = datetime.now(timezone.utc).isoformat()
         logger.info(
             "Coordination task %s fully delivered (signal_type=%s)",
-            task.id[:8],
+            agent.id[:8],
             signal_type,
         )
 
-    store.save_metadata(task)
+    store.save_metadata(agent)
 
     # Notify application consumers about the broadcast.
     await emit(BroadcastReceived(
         signal_type=signal_type,
         message=payload,
-        source_task_id=task.id,
+        source_task_id=agent.id,
     ))
 
     # Broadcast the updated coordination task to the UI.
-    await emit(TaskDone(task=task))
+    await emit(TaskDone(task=agent_to_ticket(agent)))

--- a/packages/bees/bees/functions/events.py
+++ b/packages/bees/bees/functions/events.py
@@ -98,7 +98,10 @@ def _make_handlers(
         try:
             if not scheduler:
                 return {"error": "Scheduler not available"}
-            task = scheduler.store.create(
+            # Use the inner TaskStore to create a Ticket (not an Agent)
+            # because on_events_broadcast expects Ticket-typed objects.
+            ticket_store = getattr(scheduler.store, '_ticket_store', scheduler.store)
+            task = ticket_store.create(
                 "",  # No objective — event tickets carry context, not work.
                 kind="coordination",
                 signal_type=event_type,

--- a/packages/bees/bees/functions/tasks.py
+++ b/packages/bees/bees/functions/tasks.py
@@ -133,7 +133,8 @@ def _make_handlers(
                         return {"error": f"Invalid value '{value}' for option '{key}'. Valid values for '{key}' in '{task_type}' are: {valid_str}."}
 
         try:
-            parent = scheduler.store.get(caller_ticket_id) if scheduler and caller_ticket_id else None
+            ticket_store = getattr(scheduler.store, '_ticket_store', scheduler.store) if scheduler else None
+            parent = ticket_store.get(caller_ticket_id) if ticket_store and caller_ticket_id else None
             if not parent:
                 return {"error": "Parent ticket not found"}
 
@@ -141,7 +142,7 @@ def _make_handlers(
                 task_type,
                 parent_task=parent,
                 slug=slug,
-                store=scheduler.store,
+                store=ticket_store,
                 context=objective,
                 title=title or summary,
                 scope=scope,
@@ -166,8 +167,11 @@ def _make_handlers(
             from collections import defaultdict
 
             # Build an index: parent_task_id -> list of child tickets.
+            # Use the inner TaskStore to get Ticket objects (which have
+            # parent_task_id), not Agent objects (which use parent_id).
+            ticket_store = getattr(scheduler.store, '_ticket_store', scheduler.store) if scheduler else None
             children_of: dict[str, list[Any]] = defaultdict(list)
-            for t in (scheduler.store.query_all() if scheduler else []):
+            for t in (ticket_store.query_all() if ticket_store else []):
                 if t.metadata.parent_task_id:
                     children_of[t.metadata.parent_task_id].append(t)
 

--- a/packages/bees/bees/scheduler.py
+++ b/packages/bees/bees/scheduler.py
@@ -44,6 +44,8 @@ import logging
 import sys
 from typing import Any, Awaitable, Callable
 
+from bees.agent import Agent
+from bees.agent_adapter import agent_to_ticket
 from bees.coordination import route_coordination_task
 from bees.playbook import run_task_done_hooks, load_system_config, run_playbook
 from bees.protocols.events import (
@@ -58,7 +60,7 @@ from bees.protocols.events import (
 from bees.protocols.session import SessionResult, SessionRunner, SessionStream
 from bees.task_runner import TaskRunner
 from bees.ticket import Ticket
-from bees.task_store import TaskStore
+from bees.unified_agent_store import UnifiedAgentStore
 from bees.functions.mcp_bridge import MCPRegistry
 from bees.context_updates import updates_to_context_parts
 
@@ -79,7 +81,7 @@ async def _noop_emit(event: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
-def promote_blocked_tasks(store: TaskStore) -> int:
+def promote_blocked_tasks(store: UnifiedAgentStore) -> int:
     """Check blocked tasks and promote those whose deps are met.
 
     Returns the number of tasks promoted.
@@ -87,8 +89,8 @@ def promote_blocked_tasks(store: TaskStore) -> int:
     blocked = store.query_all(status="blocked")
     promoted = 0
 
-    for task in blocked:
-        deps = task.metadata.depends_on or []
+    for agent in blocked:
+        deps = agent.metadata.depends_on or []
         all_met = True
         any_failed = False
 
@@ -105,14 +107,14 @@ def promote_blocked_tasks(store: TaskStore) -> int:
             all_met = False
 
         if any_failed:
-            task.metadata.status = "failed"
-            task.metadata.error = "Dependency failed"
-            store.save_metadata(task)
+            agent.metadata.status = "failed"
+            agent.metadata.error = "Dependency failed"
+            store.save_metadata(agent)
             continue
 
         if all_met:
-            task.metadata.status = "available"
-            store.save_metadata(task)
+            agent.metadata.status = "available"
+            store.save_metadata(agent)
             promoted += 1
 
     return promoted
@@ -139,7 +141,7 @@ class Scheduler:
         self,
         *,
         runners: dict[str, SessionRunner],
-        store: TaskStore,
+        store: UnifiedAgentStore,
         emit: EventEmitter | None = None,
         root_override: str | None = None,
     ) -> None:
@@ -175,9 +177,9 @@ class Scheduler:
         """Wake the scheduler loop."""
         self._trigger.set()
 
-    async def startup(self) -> Ticket | None:
+    async def startup(self) -> Agent | None:
         """Recover stuck tasks, boot root template if needed."""
-        tasks = await self.recover_stuck_tasks()
+        agents = await self.recover_stuck_tasks()
 
         # Connect to MCP servers declared in SYSTEM.yaml.
         config = load_system_config(self.store.hive_dir / "config")
@@ -188,11 +190,11 @@ class Scheduler:
                 mcp_configs, hive_dir=self.store.hive_dir,
             )
 
-        root_task = await self._boot_root_template(tasks)
-        if root_task:
-            tasks.append(root_task)
+        root_agent = await self._boot_root_template(agents)
+        if root_agent:
+            agents.append(root_agent)
 
-        return root_task
+        return root_agent
 
     async def shutdown(self) -> None:
         """Clean up MCP connections and other resources."""
@@ -200,14 +202,14 @@ class Scheduler:
             await self._mcp_registry.disconnect_all()
             self._mcp_registry = None
 
-    async def create_task(self, objective: str, **kwargs) -> Ticket:
+    async def create_task(self, objective: str, **kwargs) -> Agent:
         """Create a new task and emit TaskAdded."""
-        task = self.store.create(objective, **kwargs)
-        await self._emit(TaskAdded(task=task))
+        agent = self.store.create(objective, **kwargs)
+        await self._emit(TaskAdded(task=agent_to_ticket(agent)))
         self.trigger()
-        return task
+        return agent
 
-    async def _boot_root_template(self, tickets: list[Ticket]) -> Ticket | None:
+    async def _boot_root_template(self, agents: list[Agent]) -> Agent | None:
         """Boot the root template if it isn't already running."""
         config = load_system_config(self.store.hive_dir / "config")
         root = self._root_override or config.get("root")
@@ -216,17 +218,18 @@ class Scheduler:
 
         _TERMINAL = {"completed", "failed", "cancelled"}
         already_booted = any(
-            t.metadata.playbook_id == root
-            and t.metadata.status not in _TERMINAL
-            for t in tickets
+            a.metadata.playbook_id == root
+            and a.metadata.status not in _TERMINAL
+            for a in agents
         )
         if already_booted:
             return None
 
         logger.info("Booting root template '%s'", root)
-        task = run_playbook(root, store=self.store)
-        await self._emit(TaskAdded(task=task))
-        return task
+        ticket = run_playbook(root, store=self.store._ticket_store)
+        agent = self.store.get(ticket.id)
+        await self._emit(TaskAdded(task=ticket))
+        return agent
 
     async def wait_for_task(self, task_id: str, timeout_ms: float) -> str:
         """Wait for a task to complete, fail, or suspend.
@@ -261,10 +264,10 @@ class Scheduler:
             self._active_tasks[task_id].cancel()
             cancelled = True
             
-        task = self.store.get(task_id)
-        if task:
-            task.metadata.status = "cancelled"
-            self.store.save_metadata(task)
+        agent = self.store.get(task_id)
+        if agent:
+            agent.metadata.status = "cancelled"
+            self.store.save_metadata(agent)
             cancelled = True
             
         return cancelled
@@ -274,7 +277,7 @@ class Scheduler:
 
         Cancels the asyncio task if running, removes the ticket
         directory and all matching session logs.  Recurses into child
-        tasks (any task whose ``parent_task_id`` matches).
+        tasks (any task whose ``parent_id`` matches).
 
         Marks the task ID in ``_deleted_tasks`` so that
         ``_wrap_execution``'s finally block skips post-completion
@@ -332,10 +335,10 @@ class Scheduler:
         NON_TERMINAL = ("available", "blocked", "running", "suspended")
         count = 0
         for status in NON_TERMINAL:
-            for task in self.store.query_all(status=status):
-                task.metadata.paused_from = task.metadata.status
-                task.metadata.status = "paused"
-                self.store.save_metadata(task)
+            for agent in self.store.query_all(status=status):
+                agent.metadata.paused_from = agent.metadata.status
+                agent.metadata.status = "paused"
+                self.store.save_metadata(agent)
                 count += 1
 
         return count
@@ -347,21 +350,21 @@ class Scheduler:
         ``paused`` with ``paused_from`` set for later resume.
         Returns True if the task was found and paused.
         """
-        task = self.store.get(task_id)
-        if not task:
+        agent = self.store.get(task_id)
+        if not agent:
             return False
 
         # Already in a terminal or paused state — nothing to do.
-        if task.metadata.status in ("completed", "failed", "cancelled", "paused"):
+        if agent.metadata.status in ("completed", "failed", "cancelled", "paused"):
             return False
 
         # Cancel the asyncio task if it's actively running.
         if task_id in self._active_tasks:
             self._active_tasks[task_id].cancel()
 
-        task.metadata.paused_from = task.metadata.status
-        task.metadata.status = "paused"
-        self.store.save_metadata(task)
+        agent.metadata.paused_from = agent.metadata.status
+        agent.metadata.status = "paused"
+        self.store.save_metadata(agent)
         return True
 
     def deliver_to_task(
@@ -376,14 +379,14 @@ class Scheduler:
         Returns ``None`` on success, or an error string on failure.
 
         When ``expected_creator`` is provided the target task's
-        ``parent_task_id`` must match — this prevents one agent from
+        ``parent_id`` must match — this prevents one agent from
         injecting updates into another agent's tasks.
         """
-        task = self.store.get(task_id)
-        if not task:
+        agent = self.store.get(task_id)
+        if not agent:
             return f"Task {task_id} not found"
 
-        if expected_creator and task.metadata.parent_task_id != expected_creator:
+        if expected_creator and agent.metadata.parent_id != expected_creator:
             return f"Task {task_id} is not owned by this agent"
 
         self._deliver_context_update(task_id, update)
@@ -436,17 +439,17 @@ class Scheduler:
 
     # -- tag enrichment ----------------------------------------------------
 
-    def _enrich_parent_tags(self, task: Ticket) -> Ticket | None:
-        """Merge a completed task's tags into its parent's tags.
+    def _enrich_parent_tags(self, agent: Agent) -> Agent | None:
+        """Merge a completed agent's tags into its parent's tags.
 
         Called when a subagent finishes (any terminal status).  Performs
         a deduplicated union — one level up only.
 
-        Returns the enriched parent task so the caller can broadcast
+        Returns the enriched parent agent so the caller can broadcast
         a ``task_update`` via SSE, or ``None`` if nothing changed.
         """
-        parent_id = task.metadata.parent_task_id
-        child_tags = task.metadata.tags
+        parent_id = agent.metadata.parent_id
+        child_tags = agent.metadata.tags
         if not parent_id or not child_tags:
             return None
 
@@ -454,7 +457,7 @@ class Scheduler:
         if not parent:
             logger.warning(
                 "Tag enrichment: parent %s not found for %s",
-                parent_id, task.id[:8],
+                parent_id, agent.id[:8],
             )
             return None
 
@@ -467,7 +470,7 @@ class Scheduler:
         self.store.save_metadata(parent)
         logger.info(
             "Tag enrichment: %s -> %s (added %s)",
-            task.id[:8],
+            agent.id[:8],
             parent_id[:8],
             sorted(merged - existing),
         )
@@ -492,30 +495,30 @@ class Scheduler:
             finally:
                 self._running = False
 
-    async def recover_stuck_tasks(self) -> list[Ticket]:
+    async def recover_stuck_tasks(self) -> list[Agent]:
         """Flip any ``running`` or ``paused`` tasks back to a runnable state.
 
         For ``paused`` tasks with ``paused_from`` set, the original status
         is restored.  Otherwise they become ``available``.
 
-        Returns the full task list (for ``on_startup``).
+        Returns the full agent list (for ``on_startup``).
         """
-        tickets = self.store.query_all()
-        for t in tickets:
-            if t.metadata.status == "running":
-                logger.info("Recovered stuck running task: %s", t.id)
-                t.metadata.status = "available"
-                self.store.save_metadata(t)
-            elif t.metadata.status == "paused":
-                restored = t.metadata.paused_from or "available"
+        agents = self.store.query_all()
+        for a in agents:
+            if a.metadata.status == "running":
+                logger.info("Recovered stuck running task: %s", a.id)
+                a.metadata.status = "available"
+                self.store.save_metadata(a)
+            elif a.metadata.status == "paused":
+                restored = a.metadata.paused_from or "available"
                 logger.info(
                     "Recovered paused task: %s (restoring to %s)",
-                    t.id, restored,
+                    a.id, restored,
                 )
-                t.metadata.status = restored
-                t.metadata.paused_from = None
-                self.store.save_metadata(t)
-        return tickets
+                a.metadata.status = restored
+                a.metadata.paused_from = None
+                self.store.save_metadata(a)
+        return agents
 
     async def run_all_waves(self) -> list[dict]:
         """Batch mode: run cycles until no work remains.
@@ -533,22 +536,22 @@ class Scheduler:
 
             # Route coordination tasks before processing work tasks.
             coordination = [
-                t for t in all_available
-                if t.metadata.kind == "coordination"
+                a for a in all_available
+                if a.metadata.kind == "coordination"
             ]
-            for t in coordination:
+            for a in coordination:
                 await route_coordination_task(
-                    t, self.store, self._running_tasks,
+                    a, self.store, self._running_tasks,
                     self._emit,
                 )
 
             items = [
-                t for t in all_available
-                if t.metadata.kind != "coordination"
+                a for a in all_available
+                if a.metadata.kind != "coordination"
             ]
             resumable = [
-                t for t in self.store.query_all(status="suspended")
-                if t.metadata.assignee == "agent"
+                a for a in self.store.query_all(status="suspended")
+                if a.metadata.assignee == "agent"
             ]
 
             if not items and not resumable:
@@ -609,9 +612,9 @@ class Scheduler:
             # so that parent tasks waiting for children get woken up.
             for item in all_items_in_cycle:
                 updated = self.store.get(item.id) or item
-                run_task_done_hooks(updated)
+                run_task_done_hooks(agent_to_ticket(updated))
 
-                parent_id = updated.metadata.parent_task_id
+                parent_id = updated.metadata.parent_id
                 if parent_id and updated.metadata.status in (
                     "completed", "failed",
                 ):
@@ -628,8 +631,8 @@ class Scheduler:
 
                 enriched = self._enrich_parent_tags(updated)
                 if enriched:
-                    await self._emit(TaskDone(task=enriched))
-                await self._emit(TaskDone(task=updated))
+                    await self._emit(TaskDone(task=agent_to_ticket(enriched)))
+                await self._emit(TaskDone(task=agent_to_ticket(updated)))
 
         await self._emit(CycleComplete(total_cycles=cycle))
 
@@ -642,27 +645,27 @@ class Scheduler:
         self.trigger()
 
     async def _wrap_execution(
-        self, task: Ticket, coro: Awaitable[SessionResult],
+        self, agent: Agent, coro: Awaitable[SessionResult],
     ) -> None:
         """Run a task coroutine and handle post-completion cleanup."""
         try:
             await coro
         finally:
-            self._running_tasks.discard(task.id)
-            self._active_tasks.pop(task.id, None)
+            self._running_tasks.discard(agent.id)
+            self._active_tasks.pop(agent.id, None)
 
             # If the task was deleted while in-flight, skip all
             # post-completion work — the ticket directory is gone,
             # and we must not deliver ghost events or context updates.
-            if task.id in self._deleted_tasks:
-                self._deleted_tasks.discard(task.id)
+            if agent.id in self._deleted_tasks:
+                self._deleted_tasks.discard(agent.id)
                 return
 
-            updated = self.store.get(task.id) or task
-            run_task_done_hooks(updated)
-            self._notify_task_done(task.id)
+            updated = self.store.get(agent.id) or agent
+            run_task_done_hooks(agent_to_ticket(updated))
+            self._notify_task_done(agent.id)
 
-            parent_id = updated.metadata.parent_task_id
+            parent_id = updated.metadata.parent_id
             if parent_id and updated.metadata.status in ("completed", "failed"):
                 update = {
                     "task_id": updated.id,
@@ -677,8 +680,8 @@ class Scheduler:
 
             enriched = self._enrich_parent_tags(updated)
             if enriched:
-                await self._emit(TaskDone(task=enriched))
-            await self._emit(TaskDone(task=updated))
+                await self._emit(TaskDone(task=agent_to_ticket(enriched)))
+            await self._emit(TaskDone(task=agent_to_ticket(updated)))
 
             self.trigger()
 
@@ -697,22 +700,22 @@ class Scheduler:
 
             # Route coordination tasks before processing work tasks.
             coordination = [
-                t for t in all_available
-                if t.metadata.kind == "coordination"
+                a for a in all_available
+                if a.metadata.kind == "coordination"
             ]
-            for t in coordination:
+            for a in coordination:
                 await route_coordination_task(
-                    t, self.store, self._running_tasks,
+                    a, self.store, self._running_tasks,
                     self._emit,
                 )
 
             items = [
-                t for t in all_available
-                if t.metadata.kind != "coordination"
+                a for a in all_available
+                if a.metadata.kind != "coordination"
             ]
             resumable = [
-                t for t in self.store.query_all(status="suspended")
-                if t.metadata.assignee == "agent"
+                a for a in self.store.query_all(status="suspended")
+                if a.metadata.assignee == "agent"
             ]
 
             if not items and not resumable:

--- a/packages/bees/bees/segments.py
+++ b/packages/bees/bees/segments.py
@@ -12,27 +12,28 @@ from __future__ import annotations
 
 from typing import Any
 
-from bees.task_store import TaskStore, _DEP_PATTERN
-from bees.ticket import Ticket
+from bees.agent import Agent
+from bees.task_store import _DEP_PATTERN
+from bees.unified_agent_store import UnifiedAgentStore
 
 __all__ = ["resolve_segments"]
 
 
-def resolve_segments(task: Ticket, store: TaskStore) -> list[dict[str, Any]]:
-    """Build segments from a task's objective, resolving ``{{…}}`` references.
+def resolve_segments(agent: Agent, store: UnifiedAgentStore) -> list[dict[str, Any]]:
+    """Build segments from an agent's objective, resolving ``{{…}}`` references.
 
     References are resolved by namespace:
 
-    - ``{{system.context}}`` — replaced with the task's context string.
-    - ``{{system.ticket_id}}`` — replaced with the task's own ID.
+    - ``{{system.context}}`` — replaced with the agent's context string.
+    - ``{{system.ticket_id}}`` — replaced with the agent's own ID.
     - ``{{ticket-id}}`` — replaced with the dependency's outcome as an
       ``input`` segment carrying LLMContent.
 
     Plain text around references becomes text segments.
     """
-    objective = task.objective
-    deps = task.metadata.depends_on or []
-    context = task.metadata.context or ""
+    objective = agent.objective
+    deps = agent.metadata.depends_on or []
+    context = agent.metadata.context or ""
 
     # Build a lookup from dep ID to resolved outcome.
     dep_outcomes: dict[str, dict[str, Any]] = {}
@@ -56,7 +57,7 @@ def resolve_segments(task: Ticket, store: TaskStore) -> list[dict[str, Any]]:
                 if context:
                     segments.append({"type": "text", "text": context})
             elif part == "system.ticket_id":
-                segments.append({"type": "text", "text": task.id})
+                segments.append({"type": "text", "text": agent.id})
             else:
                 # Dependency ref — resolve to input segment.
                 resolved_id = _find_dep_id(part, deps)

--- a/packages/bees/bees/subagent_scope.py
+++ b/packages/bees/bees/subagent_scope.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from bees.agent import Agent
     from bees.ticket import Ticket
 
 __all__ = ["SubagentScope"]
@@ -50,6 +51,14 @@ class SubagentScope:
         return SubagentScope(
             workspace_root_id=ticket.metadata.owning_task_id or ticket.id,
             slug_path=ticket.metadata.slug,
+        )
+
+    @staticmethod
+    def for_agent(agent: Agent) -> SubagentScope:
+        """Reconstruct a scope from agent metadata."""
+        return SubagentScope(
+            workspace_root_id=agent.metadata.workspace_root_id or agent.id,
+            slug_path=agent.metadata.slug or None,
         )
 
     def child(self, slug: str) -> SubagentScope:

--- a/packages/bees/bees/task_node.py
+++ b/packages/bees/bees/task_node.py
@@ -16,12 +16,19 @@ class ChooseResponse(TypedDict):
 
 
 class TaskNode:
-    """Wraps a Ticket and provides a tree traversal and manipulation API."""
+    """Wraps a Ticket and provides a tree traversal and manipulation API.
+
+    TaskNode is a public-facing API consumed by the server, eval, and
+    hivetool. It continues to expose ``Ticket`` objects. Internally it
+    accesses the ``TaskStore`` (tickets/) directly for queries and
+    mutations, bypassing the Agent-typed ``UnifiedAgentStore``.
+    """
 
     def __init__(self, task: Ticket, bees: Bees):
         self._task = task
         self._bees = bees
-        self._store = bees._store
+        # Use the inner TaskStore for Ticket-typed queries/mutations.
+        self._ticket_store = bees._store._ticket_store
 
     @property
     def task(self) -> Ticket:
@@ -36,7 +43,7 @@ class TaskNode:
     @property
     def children(self) -> list[TaskNode]:
         """Returns children of this task."""
-        tasks = self._store.get_children(self._task.id)
+        tasks = self._ticket_store.get_children(self._task.id)
         return [TaskNode(t, self._bees) for t in tasks]
 
     @property
@@ -44,7 +51,7 @@ class TaskNode:
         """Returns the parent of this task."""
         if not self._task.metadata.parent_task_id:
             return None
-        parent_task = self._store.get(self._task.metadata.parent_task_id)
+        parent_task = self._ticket_store.get(self._task.metadata.parent_task_id)
         return TaskNode(parent_task, self._bees) if parent_task else None
 
     @property
@@ -54,7 +61,7 @@ class TaskNode:
 
     def query(self, tags: list[str]) -> list[TaskNode]:
         """Searches for tasks in the subtree that contain all of the specified tags."""
-        all_tickets = self._store.query_all()
+        all_tickets = self._ticket_store.query_all()
         
         # Build child map
         from collections import defaultdict
@@ -93,10 +100,11 @@ class TaskNode:
 
     async def create_child(self, objective: str, **kwargs) -> TaskNode:
         """Creates a child task under this task."""
+        from bees.agent_adapter import agent_to_ticket
         kwargs['owning_task_id'] = self.id
         kwargs['parent_task_id'] = self.id
-        ticket = await self._bees._scheduler.create_task(objective, **kwargs)
-        return TaskNode(ticket, self._bees)
+        agent = await self._bees._scheduler.create_task(objective, **kwargs)
+        return TaskNode(agent_to_ticket(agent), self._bees)
 
     @overload
     def respond(self, response: ReplyResponse) -> Ticket: ...
@@ -135,13 +143,13 @@ class TaskNode:
             else:
                 payload["selectedIds"] = selectedIds
 
-        self._task = self._store.respond(self.id, payload)
+        self._task = self._ticket_store.respond(self.id, payload)
         self._bees.trigger()
         return self._task
 
     def save(self):
         """Saves the task metadata."""
-        self._store.save_metadata(self._task)
+        self._ticket_store.save_metadata(self._task)
 
     def retry(self):
         """Retries a paused task."""
@@ -161,7 +169,7 @@ class TaskNode:
         paused = self._bees._scheduler.pause_task(self.id)
         if paused:
             # Refresh our snapshot.
-            refreshed = self._store.get(self.id)
+            refreshed = self._ticket_store.get(self.id)
             if refreshed:
                 self._task = refreshed
         return paused

--- a/packages/bees/bees/task_runner.py
+++ b/packages/bees/bees/task_runner.py
@@ -19,6 +19,8 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable
 
+from bees.agent import Agent
+from bees.agent_adapter import agent_to_ticket
 from bees.context_updates import updates_to_context_parts
 from bees.protocols.events import (
     EventEmitter,
@@ -35,8 +37,8 @@ from bees.session import (
 )
 from opal_backend.sessions.file_store import FileBasedSessionStore
 from bees.subagent_scope import SubagentScope
-from bees.task_store import TaskStore
 from bees.ticket import Ticket
+from bees.unified_agent_store import UnifiedAgentStore
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +57,7 @@ class TaskRunner:
         self,
         *,
         runners: dict[str, SessionRunner],
-        store: TaskStore,
+        store: UnifiedAgentStore,
         scheduler_ref: Any,
         active_streams: dict[str, SessionStream],
         get_mcp_factories: Callable[[], list | None],
@@ -76,72 +78,72 @@ class TaskRunner:
 
     async def run_task(
         self,
-        task: Ticket,
+        agent: Agent,
     ) -> SessionResult:
         """Run a single task's session and update its metadata."""
         # Reload title from disk — it may have been renamed by an on_event
         # hook during coordination routing earlier in this cycle, while the
-        # in-memory task object (from list_tickets) still has the old value.
-        fresh = self._store.get(task.id)
-        if fresh and fresh.metadata.title != task.metadata.title:
-            task.metadata.title = fresh.metadata.title
+        # in-memory agent object (from list_tickets) still has the old value.
+        fresh = self._store.get(agent.id)
+        if fresh and fresh.metadata.title != agent.metadata.title:
+            agent.metadata.title = fresh.metadata.title
 
         # Set active_session on first run
-        if task.metadata.active_session is None:
-            task.metadata.active_session = str(uuid.uuid4())
+        if agent.metadata.active_session is None:
+            agent.metadata.active_session = str(uuid.uuid4())
 
-        task.metadata.status = "running"
-        self._store.save_metadata(task)
-        await self._emit(TaskStarted(task=task))
+        agent.metadata.status = "running"
+        self._store.save_metadata(agent)
+        await self._emit(TaskStarted(task=agent_to_ticket(agent)))
 
-        label = task.id[:8]
-        print(f"▶ [{label}] {task.objective!r}", file=sys.stderr)
+        label = agent.id[:8]
+        print(f"▶ [{label}] {agent.objective!r}", file=sys.stderr)
 
         try:
-            segments = resolve_segments(task, self._store)
-            scope = SubagentScope.for_ticket(task)
+            segments = resolve_segments(agent, self._store)
+            scope = SubagentScope.for_agent(agent)
             config = provision_session(
                 segments=segments,
-                ticket_id=task.id,
-                ticket_dir=task.dir,
-                fs_dir=task.fs_dir,
-                session_id=task.metadata.active_session,
-                function_filter=task.metadata.functions,
-                allowed_skills=task.metadata.skills,
-                model=task.metadata.model,
+                ticket_id=agent.id,
+                ticket_dir=agent.dir,
+                fs_dir=agent.fs_dir,
+                session_id=agent.metadata.active_session,
+                function_filter=agent.metadata.functions,
+                allowed_skills=agent.metadata.skills,
+                model=agent.metadata.model,
                 on_events_broadcast=self._on_events_broadcast,
-                deliver_to_parent=self._make_deliver_to_parent(task),
+                deliver_to_parent=self._make_deliver_to_parent(agent),
                 scope=scope,
                 scheduler=self._scheduler_ref,
                 mcp_factories=self._get_mcp_factories(),
                 on_chat_entry=lambda role, text: append_chat_log(
-                    task.dir, role, text,
+                    agent.dir, role, text,
                 ),
-                voice=task.metadata.voice,
+                voice=agent.metadata.voice,
             )
 
             # Live sessions need context-level chat extraction because
             # they lack function-level chat handlers.
-            if task.metadata.runner == "live":
+            if agent.metadata.runner == "live":
                 config.extract_chat_from_context = True
 
-            stream = await self._runner_for(task).run(config)
-            self._active_streams[task.id] = stream
+            stream = await self._runner_for(agent).run(config)
+            self._active_streams[agent.id] = stream
             try:
                 result = await drain_session(
                     stream,
                     config=config,
-                    ticket_id=task.id,
-                    on_event=self._make_on_event(task.id),
+                    ticket_id=agent.id,
+                    on_event=self._make_on_event(agent.id),
                 )
             finally:
-                self._active_streams.pop(task.id, None)
+                self._active_streams.pop(agent.id, None)
 
         except Exception as exc:
-            task.metadata.status = "failed"
-            task.metadata.completed_at = datetime.now(timezone.utc).isoformat()
-            task.metadata.error = str(exc)
-            self._store.save_metadata(task)
+            agent.metadata.status = "failed"
+            agent.metadata.completed_at = datetime.now(timezone.utc).isoformat()
+            agent.metadata.error = str(exc)
+            self._store.save_metadata(agent)
             print(f"  [{label}] ❌ {exc}", file=sys.stderr)
             return SessionResult(
                 session_id="",
@@ -151,26 +153,26 @@ class TaskRunner:
                 error=str(exc),
             )
 
-        self._update_metadata(task, result)
-        self._handle_suspend(task, result)
-        self._handle_pause(task, result)
-        self._store.save_metadata(task)
+        self._update_metadata(agent, result)
+        self._handle_suspend(agent, result)
+        self._handle_pause(agent, result)
+        self._store.save_metadata(agent)
         return result
 
     async def resume_task(
         self,
-        task: Ticket,
+        agent: Agent,
     ) -> SessionResult:
         """Resume a suspended task with the user's response."""
-        label = task.id[:8]
-        print(f"▶ [{label}] resuming {task.objective!r}", file=sys.stderr)
+        label = agent.id[:8]
+        print(f"▶ [{label}] resuming {agent.objective!r}", file=sys.stderr)
 
         # Load the user's response.
-        response_path = task.dir / "response.json"
+        response_path = agent.dir / "response.json"
         if not response_path.exists():
-            task.metadata.status = "failed"
-            task.metadata.error = "No response.json found for resume"
-            self._store.save_metadata(task)
+            agent.metadata.status = "failed"
+            agent.metadata.error = "No response.json found for resume"
+            self._store.save_metadata(agent)
             return SessionResult(
                 session_id="",
                 status="failed",
@@ -195,17 +197,17 @@ class TaskRunner:
             selected_ids = selected_obj["ids"]
 
         if user_text:
-            append_chat_log(task.dir, "user", user_text)
+            append_chat_log(agent.dir, "user", user_text)
         elif selected_ids:
-            append_chat_log(task.dir, "user", ", ".join(selected_ids))
+            append_chat_log(agent.dir, "user", ", ".join(selected_ids))
 
         # Dynamic inline migration for legacy tasks
-        if task.metadata.active_session is None:
-            state_path = task.dir / "session_state.json"
+        if agent.metadata.active_session is None:
+            state_path = agent.dir / "session_state.json"
             if not state_path.exists():
-                task.metadata.status = "failed"
-                task.metadata.error = "No saved session state or active session found"
-                self._store.save_metadata(task)
+                agent.metadata.status = "failed"
+                agent.metadata.error = "No saved session state or active session found"
+                self._store.save_metadata(agent)
                 return SessionResult(
                     session_id="",
                     status="failed",
@@ -220,10 +222,10 @@ class TaskRunner:
                 interaction_id = state_data["interaction_id"]
                 interaction_state = state_data["interaction_state"]
 
-                logger.info("Migrating legacy task %s to session-specific path...", task.id[:8])
+                logger.info("Migrating legacy task %s to session-specific path...", agent.id[:8])
 
                 # Initialize session directory
-                sdir = task.dir / "sessions" / session_id
+                sdir = agent.dir / "sessions" / session_id
                 sdir.mkdir(parents=True, exist_ok=True)
 
                 # Write status, resume_id, interaction.json
@@ -235,23 +237,23 @@ class TaskRunner:
                 )
 
                 # Migrate filesystem workspace
-                legacy_fs = task.dir / "filesystem"
+                legacy_fs = agent.dir / "filesystem"
                 if legacy_fs.exists():
                     new_ws = sdir / "workspace"
                     new_ws.parent.mkdir(parents=True, exist_ok=True)
                     legacy_fs.rename(new_ws)
 
-                # Update task metadata
-                task.metadata.active_session = session_id
-                self._store.save_metadata(task)
+                # Update agent metadata
+                agent.metadata.active_session = session_id
+                self._store.save_metadata(agent)
 
                 # Clean up legacy file
                 state_path.unlink(missing_ok=True)
                 state = state_bytes
             except Exception as e:
-                task.metadata.status = "failed"
-                task.metadata.error = f"Migration failed: {e}"
-                self._store.save_metadata(task)
+                agent.metadata.status = "failed"
+                agent.metadata.error = f"Migration failed: {e}"
+                self._store.save_metadata(agent)
                 return SessionResult(
                     session_id="",
                     status="failed",
@@ -261,15 +263,15 @@ class TaskRunner:
                 )
         else:
             # Load and construct state bytes dynamically from the persistent session store
-            session_id = task.metadata.active_session
-            sdir = task.dir / "sessions" / session_id
+            session_id = agent.metadata.active_session
+            sdir = agent.dir / "sessions" / session_id
             resume_id_file = sdir / "resume_id"
             int_file = sdir / "interaction.json"
 
             if not resume_id_file.exists() or not int_file.exists():
-                task.metadata.status = "failed"
-                task.metadata.error = "No active resume session files found"
-                self._store.save_metadata(task)
+                agent.metadata.status = "failed"
+                agent.metadata.error = "No active resume session files found"
+                self._store.save_metadata(agent)
                 return SessionResult(
                     session_id="",
                     status="failed",
@@ -288,9 +290,9 @@ class TaskRunner:
                 }
                 state = json.dumps(state_dict, ensure_ascii=False).encode("utf-8")
             except Exception as e:
-                task.metadata.status = "failed"
-                task.metadata.error = f"Failed to load session files: {e}"
-                self._store.save_metadata(task)
+                agent.metadata.status = "failed"
+                agent.metadata.error = f"Failed to load session files: {e}"
+                self._store.save_metadata(agent)
                 return SessionResult(
                     session_id="",
                     status="failed",
@@ -299,24 +301,24 @@ class TaskRunner:
                     error=f"Failed to load session files: {e}",
                 )
 
-        task.metadata.status = "running"
-        task.metadata.assignee = "agent"
-        self._store.save_metadata(task)
-        await self._emit(TaskStarted(task=task))
+        agent.metadata.status = "running"
+        agent.metadata.assignee = "agent"
+        self._store.save_metadata(agent)
+        await self._emit(TaskStarted(task=agent_to_ticket(agent)))
 
         try:
             # Assemble context updates from both sources:
             #   1. response.json may contain context_updates (from delivery)
-            #   2. ticket metadata may have pending_context_updates (buffered)
+            #   2. agent metadata may have pending_context_updates (buffered)
             all_updates: list = []
             response_updates = response.pop("context_updates", None)
             if response_updates:
                 all_updates.extend(response_updates)
 
-            if task.metadata.pending_context_updates:
-                all_updates.extend(task.metadata.pending_context_updates)
-                task.metadata.pending_context_updates = []
-                self._store.save_metadata(task)
+            if agent.metadata.pending_context_updates:
+                all_updates.extend(agent.metadata.pending_context_updates)
+                agent.metadata.pending_context_updates = []
+                self._store.save_metadata(agent)
 
             context_parts = (
                 updates_to_context_parts(all_updates)
@@ -324,56 +326,56 @@ class TaskRunner:
                 else None
             )
 
-            scope = SubagentScope.for_ticket(task)
+            scope = SubagentScope.for_agent(agent)
             config = provision_session(
                 segments=[],  # Not used for resume.
-                ticket_id=task.id,
-                ticket_dir=task.dir,
-                fs_dir=task.fs_dir,
-                session_id=task.metadata.active_session,
-                function_filter=task.metadata.functions,
-                allowed_skills=task.metadata.skills,
+                ticket_id=agent.id,
+                ticket_dir=agent.dir,
+                fs_dir=agent.fs_dir,
+                session_id=agent.metadata.active_session,
+                function_filter=agent.metadata.functions,
+                allowed_skills=agent.metadata.skills,
                 on_events_broadcast=self._on_events_broadcast,
-                deliver_to_parent=self._make_deliver_to_parent(task),
+                deliver_to_parent=self._make_deliver_to_parent(agent),
                 scope=scope,
                 scheduler=self._scheduler_ref,
                 mcp_factories=self._get_mcp_factories(),
                 on_chat_entry=lambda role, text: append_chat_log(
-                    task.dir, role, text,
+                    agent.dir, role, text,
                 ),
                 seed_files=False,  # Files already on disk from previous run.
-                voice=task.metadata.voice,
+                voice=agent.metadata.voice,
             )
 
             # Live sessions need context-level chat extraction because
             # they lack function-level chat handlers.
-            if task.metadata.runner == "live":
+            if agent.metadata.runner == "live":
                 config.extract_chat_from_context = True
 
-            stream = await self._runner_for(task).resume(
+            stream = await self._runner_for(agent).resume(
                 config,
                 state=state,
                 response=response,
                 context_parts=context_parts,
             )
-            self._active_streams[task.id] = stream
+            self._active_streams[agent.id] = stream
             try:
                 result = await drain_session(
                     stream,
                     config=config,
-                    ticket_id=task.id,
-                    on_event=self._make_on_event(task.id),
+                    ticket_id=agent.id,
+                    on_event=self._make_on_event(agent.id),
                 )
             finally:
-                self._active_streams.pop(task.id, None)
+                self._active_streams.pop(agent.id, None)
 
             # Clean up response file.
             response_path.unlink(missing_ok=True)
         except Exception as exc:
-            task.metadata.status = "failed"
-            task.metadata.completed_at = datetime.now(timezone.utc).isoformat()
-            task.metadata.error = str(exc)
-            self._store.save_metadata(task)
+            agent.metadata.status = "failed"
+            agent.metadata.completed_at = datetime.now(timezone.utc).isoformat()
+            agent.metadata.error = str(exc)
+            self._store.save_metadata(agent)
             print(f"  [{label}] ❌ {exc}", file=sys.stderr)
             return SessionResult(
                 session_id="",
@@ -383,121 +385,121 @@ class TaskRunner:
                 error=str(exc),
             )
 
-        self._update_metadata(task, result, accumulate=True)
-        self._handle_suspend(task, result)
-        self._handle_pause(task, result)
+        self._update_metadata(agent, result, accumulate=True)
+        self._handle_suspend(agent, result)
+        self._handle_pause(agent, result)
 
-        self._store.save_metadata(task)
+        self._store.save_metadata(agent)
         return result
 
     # -- internal ----------------------------------------------------------
 
     def _update_metadata(
         self,
-        task: Ticket,
+        agent: Agent,
         result: SessionResult,
         *,
         accumulate: bool = False,
     ) -> None:
-        """Update task metadata from a session result.
+        """Update agent metadata from a session result.
 
         When ``accumulate`` is True (used on resume), turns and thoughts
         are added to the existing values rather than replaced.
         """
-        task.metadata.completed_at = datetime.now(timezone.utc).isoformat()
+        agent.metadata.completed_at = datetime.now(timezone.utc).isoformat()
 
         if result.status == "completed":
-            task.metadata.status = "completed"
+            agent.metadata.status = "completed"
         elif result.paused:
             # Transient Gemini error — don't set completed_at, the task
             # is not done.  Status is set by _handle_pause below.
-            task.metadata.completed_at = None
+            agent.metadata.completed_at = None
         else:
-            task.metadata.status = "failed"
+            agent.metadata.status = "failed"
 
         if accumulate:
-            task.metadata.turns += result.turns
-            task.metadata.thoughts += result.thoughts
+            agent.metadata.turns += result.turns
+            agent.metadata.thoughts += result.thoughts
         else:
-            task.metadata.turns = result.turns
-            task.metadata.thoughts = result.thoughts
+            agent.metadata.turns = result.turns
+            agent.metadata.thoughts = result.thoughts
 
         if result.error:
-            task.metadata.error = result.error
+            agent.metadata.error = result.error
         if result.outcome:
-            task.metadata.outcome = result.outcome
+            agent.metadata.outcome = result.outcome
         if result.outcome_content:
-            task.metadata.outcome_content = result.outcome_content
+            agent.metadata.outcome_content = result.outcome_content
 
         # Extract agent file system to task directory.
         file_manifest = extract_files(
-            result.intermediate, task.fs_dir,
+            result.intermediate, agent.fs_dir,
         )
         if file_manifest:
-            task.metadata.files = file_manifest
+            agent.metadata.files = file_manifest
 
-    def _handle_suspend(self, task: Ticket, result: SessionResult) -> None:
+    def _handle_suspend(self, agent: Agent, result: SessionResult) -> None:
         """Handle suspend state, including queued-update auto-resume."""
         if result.suspended:
             # Reload fields that may have been modified externally while
             # the session was running (e.g., by on_event hooks or
-            # coordination delivery).  The in-memory task object is
+            # coordination delivery).  The in-memory agent object is
             # stale for these fields.
-            fresh = self._store.get(task.id)
+            fresh = self._store.get(agent.id)
             if fresh:
                 if fresh.metadata.queued_updates:
-                    task.metadata.queued_updates = fresh.metadata.queued_updates
+                    agent.metadata.queued_updates = fresh.metadata.queued_updates
                 if fresh.metadata.pending_context_updates:
-                    task.metadata.pending_context_updates = fresh.metadata.pending_context_updates
-                if fresh.metadata.title != task.metadata.title:
-                    task.metadata.title = fresh.metadata.title
+                    agent.metadata.pending_context_updates = fresh.metadata.pending_context_updates
+                if fresh.metadata.title != agent.metadata.title:
+                    agent.metadata.title = fresh.metadata.title
 
             # function_name is already in suspend_event — enriched by
             # the runner before yielding.
             suspend_event = dict(result.suspend_event) if result.suspend_event else {}
 
-            if getattr(task.metadata, "pending_context_updates", None):
-                updates = list(task.metadata.pending_context_updates)
-                task.metadata.pending_context_updates = []
-                response_path = task.dir / "response.json"
+            if getattr(agent.metadata, "pending_context_updates", None):
+                updates = list(agent.metadata.pending_context_updates)
+                agent.metadata.pending_context_updates = []
+                response_path = agent.dir / "response.json"
                 response_path.write_text(
                     json.dumps({"context_updates": updates}, indent=2, ensure_ascii=False) + "\n"
                 )
-                task.metadata.status = "suspended"
-                task.metadata.assignee = "agent"
-                task.metadata.suspend_event = suspend_event
-                print(f"  [{task.id[:8]}] 📩 auto-resume with buffered context updates", file=sys.stderr)
-            elif getattr(task.metadata, "queued_updates", None):
-                update = task.metadata.queued_updates.pop(0)
-                response_path = task.dir / "response.json"
+                agent.metadata.status = "suspended"
+                agent.metadata.assignee = "agent"
+                agent.metadata.suspend_event = suspend_event
+                print(f"  [{agent.id[:8]}] 📩 auto-resume with buffered context updates", file=sys.stderr)
+            elif getattr(agent.metadata, "queued_updates", None):
+                update = agent.metadata.queued_updates.pop(0)
+                response_path = agent.dir / "response.json"
                 response_path.write_text(
                     json.dumps({"context_updates": [update]}, indent=2, ensure_ascii=False) + "\n"
                 )
-                task.metadata.status = "suspended"
-                task.metadata.assignee = "agent"
-                task.metadata.suspend_event = suspend_event
-                print(f"  [{task.id[:8]}] 📩 auto-resume with queued update", file=sys.stderr)
+                agent.metadata.status = "suspended"
+                agent.metadata.assignee = "agent"
+                agent.metadata.suspend_event = suspend_event
+                print(f"  [{agent.id[:8]}] 📩 auto-resume with queued update", file=sys.stderr)
             else:
-                task.metadata.status = "suspended"
-                task.metadata.assignee = "user"
-                task.metadata.suspend_event = suspend_event
+                agent.metadata.status = "suspended"
+                agent.metadata.assignee = "user"
+                agent.metadata.suspend_event = suspend_event
         else:
-            task.metadata.assignee = None
-            task.metadata.suspend_event = None
+            agent.metadata.assignee = None
+            agent.metadata.suspend_event = None
 
-    def _handle_pause(self, task: Ticket, result: SessionResult) -> None:
+    def _handle_pause(self, agent: Agent, result: SessionResult) -> None:
         """Handle pause state from transient Gemini API errors."""
         if result.paused:
-            task.metadata.status = "paused"
-            task.metadata.assignee = None
+            agent.metadata.status = "paused"
+            agent.metadata.assignee = None
             print(
-                f"  [{task.id[:8]}] ⏸ paused: {result.error}",
+                f"  [{agent.id[:8]}] ⏸ paused: {result.error}",
                 file=sys.stderr,
             )
 
-    def _make_deliver_to_parent(self, task: Ticket) -> Callable[[dict[str, Any]], None] | None:
-        """Create a callback that delivers an update to this task's parent."""
-        parent_id = task.metadata.parent_task_id
+    def _make_deliver_to_parent(self, agent: Agent) -> Callable[[dict[str, Any]], None] | None:
+        """Create a callback that delivers an update to this agent's parent."""
+        parent_id = agent.metadata.parent_id
         if not parent_id:
             return None
 
@@ -515,9 +517,9 @@ class TaskRunner:
 
         return on_event
 
-    def _runner_for(self, task: Ticket) -> SessionRunner:
-        """Select the session runner for a task based on its metadata."""
-        runner_type = task.metadata.runner
+    def _runner_for(self, agent: Agent) -> SessionRunner:
+        """Select the session runner for an agent based on its metadata."""
+        runner_type = agent.metadata.runner
         runner = self._runners.get(runner_type)
         if runner is None:
             available = ", ".join(sorted(self._runners.keys()))

--- a/packages/bees/bees/unified_agent_store.py
+++ b/packages/bees/bees/unified_agent_store.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unified agent store — bidirectional adapter over tickets/.
+
+Wraps ``TaskStore`` (which reads/writes ``tickets/``) and exposes an
+``Agent``-typed API for the scheduler, task runner, and provisioner.
+
+Reads: ``Ticket`` → ``Agent`` (via ``ticket_to_agent``).
+Writes: ``Agent`` → ``Ticket`` (via ``agent_to_ticket``).
+
+This store is the single internal access point during Phase 2a. It
+will be replaced by a direct ``AgentStore`` + ``TaskFileStore``
+combination in Phase 2b when the on-disk layout switches to
+``agents/`` + ``tasks/``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from bees.agent import Agent, AgentStatus
+from bees.agent_adapter import agent_to_ticket, ticket_to_agent
+from bees.task_store import TaskStore
+from bees.ticket import TicketKind, RunnerType
+
+__all__ = ["UnifiedAgentStore"]
+
+
+class UnifiedAgentStore:
+    """Agent-typed CRUD over the existing ``tickets/`` directory.
+
+    Bidirectional adapter: reads ``tickets/`` as ``Agent`` objects,
+    writes ``Agent`` state back as ``Ticket`` state.
+    """
+
+    def __init__(self, hive_dir: Path):
+        self._ticket_store = TaskStore(hive_dir)
+
+    # -- Delegate properties -----------------------------------------------
+
+    @property
+    def hive_dir(self) -> Path:
+        return self._ticket_store.hive_dir
+
+    @property
+    def tickets_dir(self) -> Path:
+        """Backward-compat: ticket directory for deletion, log cleanup."""
+        return self._ticket_store.tickets_dir
+
+    # -- Read operations ---------------------------------------------------
+
+    def get(self, agent_id: str) -> Agent | None:
+        """Load an agent by ID from ``tickets/``."""
+        ticket = self._ticket_store.get(agent_id)
+        if ticket is None:
+            return None
+        return ticket_to_agent(ticket)
+
+    def query_all(self, status: AgentStatus | None = None) -> list[Agent]:
+        """List agents, optionally filtered by status."""
+        tickets = self._ticket_store.query_all(status=status)
+        return [ticket_to_agent(t) for t in tickets]
+
+    def get_children(self, parent_id: str | None = None) -> list[Agent]:
+        """Children of an agent, or root agents if parent_id is None."""
+        tickets = self._ticket_store.get_children(parent_id)
+        return [ticket_to_agent(t) for t in tickets]
+
+    # -- Write operations --------------------------------------------------
+
+    def save(self, agent: Agent) -> None:
+        """Persist agent to disk as a ticket."""
+        self._ticket_store.save(agent_to_ticket(agent))
+
+    def save_metadata(self, agent: Agent) -> None:
+        """Persist only the metadata."""
+        self._ticket_store.save_metadata(agent_to_ticket(agent))
+
+    def respond(self, agent_id: str, response: dict[str, Any]) -> Agent:
+        """Save user response to a suspended agent."""
+        ticket = self._ticket_store.respond(agent_id, response)
+        return ticket_to_agent(ticket)
+
+    def create(self, objective: str, **kwargs: Any) -> Agent:
+        """Create a new agent (as a ticket on disk).
+
+        Accepts the same kwargs as ``TaskStore.create``.
+        """
+        ticket = self._ticket_store.create(objective, **kwargs)
+        return ticket_to_agent(ticket)

--- a/packages/bees/tests/test_coordination.py
+++ b/packages/bees/tests/test_coordination.py
@@ -13,12 +13,13 @@ import pytest
 
 from bees.coordination import route_coordination_task
 from bees.protocols.events import BroadcastReceived, TaskDone
-from bees.task_store import TaskStore
+from bees.unified_agent_store import UnifiedAgentStore
 
 
 @pytest.fixture
 def store(tmp_path):
-    return TaskStore(tmp_path)
+    (tmp_path / "tickets").mkdir()
+    return UnifiedAgentStore(tmp_path)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/bees/tests/test_eval.py
+++ b/packages/bees/tests/test_eval.py
@@ -16,7 +16,7 @@ from bees import Bees
 from bees.protocols.events import TaskDone
 from bees.protocols.session import SessionResult
 from bees.scheduler import Scheduler
-from bees.task_store import TaskStore
+from bees.unified_agent_store import UnifiedAgentStore
 
 
 # ---------------------------------------------------------------------------
@@ -47,8 +47,9 @@ def hive(tmp_path):
 
 @pytest.fixture
 def store(tmp_path):
-    """Create a TaskStore backed by tmp_path."""
-    return TaskStore(tmp_path)
+    """Create a UnifiedAgentStore backed by tmp_path."""
+    (tmp_path / "tickets").mkdir(exist_ok=True)
+    return UnifiedAgentStore(tmp_path)
 
 
 # ---------------------------------------------------------------------------
@@ -72,7 +73,7 @@ async def test_run_all_waves_delivers_context_to_parent(store):
 
     # Create child (available, linked to parent).
     child = store.create("Child objective")
-    child.metadata.parent_task_id = parent.id
+    child.metadata.parent_id = parent.id
     child.metadata.status = "available"
     store.save_metadata(child)
 
@@ -153,12 +154,13 @@ async def test_run_all_waves_emits_task_done(store):
     # The post-completion loop iterates items after gather.
     # Since run_all_waves needs actual run_task calls, test the hook
     # path by calling the inner logic directly.
+    from bees.agent_adapter import agent_to_ticket
     from bees.playbook import run_task_done_hooks
 
-    run_task_done_hooks(task)
+    run_task_done_hooks(agent_to_ticket(task))
 
     enriched = scheduler._enrich_parent_tags(task)
-    await capture_emit(TaskDone(task=task))
+    await capture_emit(TaskDone(task=agent_to_ticket(task)))
 
     assert len(done_events) == 1
     assert done_events[0].task.id == task.id
@@ -205,6 +207,7 @@ async def test_bees_run_boots_root_template(hive):
     assert isinstance(summaries, list)
 
     # Verify the root ticket was created.
+    from bees.task_store import TaskStore
     store = TaskStore(hive)
     all_tasks = store.query_all()
     assert len(all_tasks) >= 1

--- a/packages/bees/tests/test_events.py
+++ b/packages/bees/tests/test_events.py
@@ -112,5 +112,38 @@ async def test_events_send_to_parent_no_parent():
     assert "error" in result
 
 
+# ---------------------------------------------------------------------------
+# UnifiedAgentStore regression
+# ---------------------------------------------------------------------------
 
+
+@pytest.mark.asyncio
+async def test_events_broadcast_returns_ticket_via_unified_store(tmp_path):
+    """Callback must receive a Ticket (not an Agent) when store is UnifiedAgentStore."""
+    from bees.functions.events import _make_handlers
+    from bees.unified_agent_store import UnifiedAgentStore
+    from bees.ticket import Ticket
+
+    (tmp_path / "tickets").mkdir()
+    store = UnifiedAgentStore(tmp_path)
+
+    callback = MagicMock()
+    mock_scheduler = MagicMock()
+    mock_scheduler.store = store
+    handlers = _make_handlers(on_events_broadcast=callback, scheduler=mock_scheduler)
+
+    result = await handlers["events_broadcast"](
+        {"type": "app_update", "message": "New app"}, None,
+    )
+
+    assert result["broadcast"] is True
+    callback.assert_called_once()
+
+    # The callback must receive a Ticket, not an Agent.
+    task = callback.call_args[0][0]
+    assert isinstance(task, Ticket), (
+        f"Expected Ticket, got {type(task).__name__}"
+    )
+    assert task.metadata.kind == "coordination"
+    assert task.metadata.signal_type == "app_update"
 

--- a/packages/bees/tests/test_scheduler.py
+++ b/packages/bees/tests/test_scheduler.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import yaml
 
 from bees.scheduler import Scheduler
-from bees.task_store import TaskStore
+from bees.unified_agent_store import UnifiedAgentStore
 
 
 @pytest.fixture
@@ -28,7 +28,7 @@ def tickets_dir(tmp_path, monkeypatch):
     global GLOBAL_STORE
     tickets_dir = tmp_path / "tickets"
     tickets_dir.mkdir()
-    GLOBAL_STORE = TaskStore(tmp_path)
+    GLOBAL_STORE = UnifiedAgentStore(tmp_path)
     return tickets_dir
 
 @pytest.fixture
@@ -231,7 +231,7 @@ async def test_enrich_parent_tags_merges(mock_clients):
 
     parent = GLOBAL_STORE.create("Parent", tags=["b", "c"])
     child = GLOBAL_STORE.create("Child", tags=["a", "b"])
-    child.metadata.parent_task_id = parent.id
+    child.metadata.parent_id = parent.id
     GLOBAL_STORE.save_metadata(child)
 
     result = scheduler._enrich_parent_tags(child)
@@ -249,7 +249,7 @@ async def test_enrich_parent_tags_no_parent(mock_clients):
     scheduler = Scheduler(store=GLOBAL_STORE, runners={"generate": backend})
 
     child = GLOBAL_STORE.create("Child", tags=["a"])
-    child.metadata.parent_task_id = "nonexistent-id"
+    child.metadata.parent_id = "nonexistent-id"
     GLOBAL_STORE.save_metadata(child)
 
     # Should not raise, returns None.
@@ -264,7 +264,7 @@ async def test_enrich_parent_tags_no_tags(mock_clients):
 
     parent = GLOBAL_STORE.create("Parent", tags=["x"])
     child = GLOBAL_STORE.create("Child")  # No tags.
-    child.metadata.parent_task_id = parent.id
+    child.metadata.parent_id = parent.id
     GLOBAL_STORE.save_metadata(child)
 
     assert scheduler._enrich_parent_tags(child) is None
@@ -281,7 +281,7 @@ async def test_enrich_parent_tags_parent_has_no_tags(mock_clients):
 
     parent = GLOBAL_STORE.create("Parent")  # tags=None
     child = GLOBAL_STORE.create("Child", tags=["a"])
-    child.metadata.parent_task_id = parent.id
+    child.metadata.parent_id = parent.id
     GLOBAL_STORE.save_metadata(child)
 
     result = scheduler._enrich_parent_tags(child)
@@ -408,14 +408,15 @@ async def test_skips_when_root_already_booted(mock_clients, write_template, tmp_
     system_path.write_text(yaml.dump({"root": "opie"}))
     
     from bees.playbook import run_playbook
-    existing = run_playbook("opie", store=GLOBAL_STORE)
+    ticket = run_playbook("opie", store=GLOBAL_STORE._ticket_store)
+    existing = GLOBAL_STORE.get(ticket.id)
     
     _, backend = mock_clients
     scheduler = Scheduler(store=GLOBAL_STORE, runners={"generate": backend})
 
-    ticket = await scheduler._boot_root_template([existing])
+    result = await scheduler._boot_root_template([existing])
 
-    assert ticket is None
+    assert result is None
 
 
 @pytest.mark.asyncio

--- a/packages/bees/tests/test_tasks.py
+++ b/packages/bees/tests/test_tasks.py
@@ -335,3 +335,94 @@ def test_task_store_get_malformed_metadata():
     # Partially written JSON
     (ticket_dir / "metadata.json").write_text('{"status": "avail')
     assert store.get(ticket_id) is None
+
+
+# ---------------------------------------------------------------------------
+# UnifiedAgentStore integration — regression tests
+#
+# These tests exercise the production code path where scheduler.store is a
+# UnifiedAgentStore (returns Agent objects). The bug: function handlers
+# received Agent objects but passed them to Ticket-typed APIs, silently
+# dropping parent_task_id and producing empty trees.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def unified_store(tmp_path):
+    """Create a UnifiedAgentStore backed by a temp directory."""
+    from bees.unified_agent_store import UnifiedAgentStore
+    (tmp_path / "tickets").mkdir(exist_ok=True)
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(exist_ok=True)
+    config_dir.joinpath("hooks").mkdir(exist_ok=True)
+    return UnifiedAgentStore(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_create_task_sets_parent_id_via_unified_store(
+    unified_store, write_template,
+):
+    """parent_task_id must survive the Agent→Ticket round-trip in stamp_child_task."""
+    write_template({
+        "name": "child-type",
+        "title": "Child",
+        "objective": "Do child work.",
+    })
+
+    # Create a parent via the unified store (returns Agent).
+    parent = unified_store.create("I'm the parent")
+    parent.metadata.tasks = ["child-type"]
+    unified_store.save_metadata(parent)
+
+    scope = SubagentScope(workspace_root_id=parent.id)
+    mock_scheduler = MagicMock()
+    mock_scheduler.store = unified_store
+    handlers = _make_handlers(
+        scope=scope,
+        caller_ticket_id=parent.id,
+        scheduler=mock_scheduler,
+    )
+
+    result = await handlers["tasks_create_task"]({
+        "type": "child-type",
+        "summary": "Child task",
+        "objective": "Full child objective",
+        "slug": "child-slug",
+    }, None)
+
+    assert "task_id" in result, f"Expected task_id, got: {result}"
+
+    # Read the child back via the inner TaskStore to verify the on-disk
+    # Ticket has parent_task_id set correctly.
+    child_ticket = unified_store._ticket_store.get(result["task_id"])
+    assert child_ticket is not None
+    assert child_ticket.metadata.parent_task_id == parent.id
+
+
+@pytest.mark.asyncio
+async def test_check_status_builds_tree_via_unified_store(unified_store):
+    """tasks_check_status must find children when store is UnifiedAgentStore."""
+    parent = unified_store.create("Parent objective")
+
+    # Create a child with parent_task_id set on the inner TaskStore
+    # (simulating what stamp_child_task does after the fix).
+    child_ticket = unified_store._ticket_store.create("Child objective")
+    child_ticket.metadata.parent_task_id = parent.id
+    child_ticket.metadata.title = "Child Title"
+    child_ticket.metadata.status = "running"
+    unified_store._ticket_store.save_metadata(child_ticket)
+
+    mock_scheduler = MagicMock()
+    mock_scheduler.store = unified_store
+    handlers = _make_handlers(
+        caller_ticket_id=parent.id,
+        scheduler=mock_scheduler,
+    )
+
+    result = await handlers["tasks_check_status"]({}, None)
+
+    assert "tasks" in result, f"Expected tree, got: {result}"
+    assert len(result["tasks"]) == 1
+    assert result["tasks"][0]["task_id"] == child_ticket.id
+    assert result["tasks"][0]["summary"] == "Child Title"
+    assert result["tasks"][0]["status"] == "running"

--- a/packages/bees/tests/test_tree.py
+++ b/packages/bees/tests/test_tree.py
@@ -109,14 +109,16 @@ def test_query_by_tags(temp_hive):
 
 @pytest.mark.asyncio
 async def test_bees_create_child(temp_hive):
+    from bees.agent import Agent, AgentMetadata
     bees = Bees(temp_hive, runners={"generate": Mock()})
     bees._scheduler = Mock()
     
-    mock_ticket = Mock()
-    mock_ticket.id = "task1"
-    mock_ticket.metadata = Mock()
-    mock_ticket.metadata.tags = []
-    bees._scheduler.create_task = AsyncMock(return_value=mock_ticket)
+    mock_agent = Agent(
+        id="task1",
+        dir=temp_hive / "tickets" / "task1",
+        metadata=AgentMetadata(tags=[]),
+    )
+    bees._scheduler.create_task = AsyncMock(return_value=mock_agent)
     
     node = await bees.create_child("New Task", tags=["test"])
     
@@ -126,14 +128,16 @@ async def test_bees_create_child(temp_hive):
 
 @pytest.mark.asyncio
 async def test_task_node_create_child(temp_hive):
+    from bees.agent import Agent, AgentMetadata
     bees = Bees(temp_hive, runners={"generate": Mock()})
     bees._scheduler = Mock()
     
-    mock_ticket = Mock()
-    mock_ticket.id = "child1"
-    mock_ticket.metadata = Mock()
-    mock_ticket.metadata.tags = []
-    bees._scheduler.create_task = AsyncMock(return_value=mock_ticket)
+    mock_agent = Agent(
+        id="child1",
+        dir=temp_hive / "tickets" / "child1",
+        metadata=AgentMetadata(tags=[]),
+    )
+    bees._scheduler.create_task = AsyncMock(return_value=mock_agent)
     
     parent_ticket = Mock()
     parent_ticket.id = "parent1"
@@ -150,8 +154,8 @@ async def test_task_node_create_child(temp_hive):
 
 def test_task_node_respond(temp_hive):
     bees = Bees(temp_hive, runners={"generate": Mock()})
-    store_mock = Mock()
-    bees._store = store_mock
+    ticket_store_mock = Mock()
+    bees._store._ticket_store = ticket_store_mock
     
     ticket = Mock()
     ticket.id = "task1"
@@ -159,13 +163,13 @@ def test_task_node_respond(temp_hive):
     
     node.respond({"text": "reply"})
     
-    store_mock.respond.assert_called_once_with("task1", {"text": "reply"})
+    ticket_store_mock.respond.assert_called_once_with("task1", {"text": "reply"})
 
 
 def test_task_node_respond_with_text_kwarg(temp_hive):
     bees = Bees(temp_hive, runners={"generate": Mock()})
-    store_mock = Mock()
-    bees._store = store_mock
+    ticket_store_mock = Mock()
+    bees._store._ticket_store = ticket_store_mock
     
     ticket = Mock()
     ticket.id = "task1"
@@ -173,13 +177,13 @@ def test_task_node_respond_with_text_kwarg(temp_hive):
     
     node.respond(text="reply")
     
-    store_mock.respond.assert_called_once_with("task1", {"text": "reply"})
+    ticket_store_mock.respond.assert_called_once_with("task1", {"text": "reply"})
 
 
 def test_task_node_respond_with_selected_ids_kwarg(temp_hive):
     bees = Bees(temp_hive, runners={"generate": Mock()})
-    store_mock = Mock()
-    bees._store = store_mock
+    ticket_store_mock = Mock()
+    bees._store._ticket_store = ticket_store_mock
     
     ticket = Mock()
     ticket.id = "task1"
@@ -187,7 +191,7 @@ def test_task_node_respond_with_selected_ids_kwarg(temp_hive):
     
     node.respond(selectedIds=["choice1"])
     
-    store_mock.respond.assert_called_once_with("task1", {"selectedIds": ["choice1"]})
+    ticket_store_mock.respond.assert_called_once_with("task1", {"selectedIds": ["choice1"]})
 
 
 def test_task_node_respond_mutually_exclusive_kwargs(temp_hive):
@@ -251,22 +255,12 @@ def test_task_node_awaiting_response(temp_hive):
 
 def test_bees_all(temp_hive):
     bees = Bees(temp_hive, runners={"generate": Mock()})
-    store_mock = Mock()
-    bees._store = store_mock
+    store = bees._store
     
-    t1 = Mock()
-    t1.id = "t1"
-    t1.metadata = Mock()
-    t1.metadata.tags = []
-    
-    t2 = Mock()
-    t2.id = "t2"
-    t2.metadata = Mock()
-    t2.metadata.tags = []
-    
-    store_mock.query_all.return_value = [t1, t2]
+    t1 = store.create("Task 1")
+    t2 = store.create("Task 2")
     
     all_nodes = bees.all
     assert len(all_nodes) == 2
-    assert all_nodes[0].id == "t1"
-    assert all_nodes[1].id == "t2"
+    all_ids = {n.id for n in all_nodes}
+    assert all_ids == {t1.id, t2.id}

--- a/projects/swarm/PROJECT.md
+++ b/projects/swarm/PROJECT.md
@@ -494,7 +494,7 @@ read from both `agents/` and `tickets/` directory layouts.
 This phase is split into three independently-verifiable sub-phases. Each
 sub-phase delivers working, hivetool-observable state.
 
-### Phase 2a — Scheduler Accepts Agent Objects
+### Phase 2a — Scheduler Accepts Agent Objects ✅
 
 Internal refactor: the scheduler, task runner, and provisioner accept `Agent`
 objects instead of `Ticket` objects. The on-disk layout is still `tickets/` —
@@ -506,28 +506,64 @@ everything working as before. Existing batch-mode tests pass.
 
 #### Python Changes
 
-- [ ] **[MODIFY] `scheduler.py`** — Replace ticket-driven cycle loop with
-      agent-driven loop. Query `AgentStore` for available/suspended agents.
-      Fire `TaskRunner` per agent, not per ticket.
-- [ ] **[MODIFY] `task_runner.py`** — Accept an `Agent` instead of a `Ticket`.
+- [x] **[MODIFY] `scheduler.py`** — Replace ticket-driven cycle loop with
+      agent-driven loop. Query `UnifiedAgentStore` for available/suspended
+      agents. Fire `TaskRunner` per agent, not per ticket.
+- [x] **[MODIFY] `task_runner.py`** — Accept an `Agent` instead of a `Ticket`.
       Wire session using agent's config (model, tools, session, workspace).
-      For finite agents, derive objective from the assigned task.
-- [ ] **[MODIFY] `provisioner.py`** — Accept agent config instead of ticket
-      metadata. No functional change — just the parameter source shifts.
-- [ ] **[MODIFY] `bees.py`** — `Bees.__init__` creates `AgentStore` +
-      `TaskStore`. Public methods operate on agents, not tickets.
-- [ ] **[MODIFY] `task_node.py`** → **`agent_node.py`** — Rename and refactor.
-      `AgentNode` wraps `Agent`. Tree traversal uses `parent_id`.
-- [ ] **[MODIFY] `protocols/events.py`** — Event types carry `Agent` instead
-      of `Ticket`. Keep type aliases for backward compat.
-- [ ] **[NEW] Adapter layer** — Bridges `AgentStore`/`TaskStore` reads to
-      existing `tickets/` directory layout during transition.
+- [x] **[MODIFY] `coordination.py`** — Accept `Agent` and `UnifiedAgentStore`.
+      Playbook hooks still receive `Ticket` via `agent_to_ticket()`.
+- [x] **[MODIFY] `segments.py`** — Accept `Agent` and `UnifiedAgentStore`.
+- [x] **[MODIFY] `bees.py`** — `Bees.__init__` creates `UnifiedAgentStore`.
+      Public methods reconstruct `Ticket` via `agent_to_ticket()` at boundary.
+- [x] **[MODIFY] `task_node.py`** — Uses inner `_ticket_store` for
+      `Ticket`-typed queries. Public API unchanged.
+- [x] **[NEW] `unified_agent_store.py`** — Bidirectional adapter wrapping
+      `TaskStore`, exposing `Agent`-typed CRUD.
+- [x] **[MODIFY] `agent_adapter.py`** — Added `agent_to_ticket()` reverse
+      mapping and execution-state bridge fields.
+- [x] **[MODIFY] `agent.py`** — Added execution-state bridge fields to
+      `AgentMetadata`, `playbook_run_id`, and transient `objective` on `Agent`.
+- [x] **[MODIFY] `subagent_scope.py`** — Added `for_agent()` factory method.
+
+##### Deferred
+
+- `provisioner.py` — Not modified. It accepts unpacked parameters, not a
+  typed entity, so the refactor is a no-op. Revisit in Phase 2b.
+- `task_node.py` → `agent_node.py` rename — Deferred. The public API still
+  returns `Ticket` objects; renaming before the full entity migration would
+  create a misleading name.
+- `protocols/events.py` — Event types still carry `Ticket`. Changing them
+  would cascade into the SSE/Hivetool stack. Deferred to Phase 4.
+
+#### Adjustments Made
+
+1. **Execution-state bridge fields on `AgentMetadata`** — The original
+   blueprint assumed the scheduler would only read identity/config fields
+   from `AgentMetadata`. In practice, the scheduler and task runner write
+   execution state (`error`, `outcome`, `turns`, `assignee`, `suspend_event`,
+   etc.) during every session. These fields must live on `AgentMetadata`
+   during the adapter era to survive the `Agent` → `Ticket` → disk →
+   `Ticket` → `Agent` round-trip. In Phase 3+, some move to `TaskRecord`,
+   others stay.
+
+2. **`TaskNode` uses inner `_ticket_store` directly** — Rather than
+   converting between `Agent` and `Ticket` in the tree API, `TaskNode`
+   accesses the inner `TaskStore` for all read operations. This keeps the
+   public API stable and avoids a double-conversion penalty.
+
+3. **`UnifiedAgentStore` instead of separate `AgentStore` + `TaskStore`** —
+   The blueprint proposed the scheduler use `AgentStore` with `TaskStore`
+   alongside. Since the on-disk layout is still `tickets/` (fused), a
+   single bidirectional adapter (`UnifiedAgentStore`) is cleaner than
+   two stores pointing at the same directory. The split into separate stores
+   happens in Phase 2b when the layout actually diverges.
 
 #### Verification
 
-- [ ] All existing batch-mode tests pass (adapter layer transparent).
-- [ ] Hivetool unchanged — still reads from `tickets/`.
-- [ ] Coordination smoke test: two agents with `watch_events`, broadcast a
+- [x] All existing batch-mode tests pass (339 passed, adapter transparent).
+- [x] Hivetool unchanged — still reads from `tickets/`.
+- [x] Coordination smoke test: two agents with `watch_events`, broadcast a
       signal, verify delivery via `route_coordination_task` using Agent objects.
 
 ### Phase 2b — Box and Mutations Route Through New Stores


### PR DESCRIPTION
## What

Refactors the Bees scheduler internals to operate on `Agent` objects instead of
`Ticket` objects, bridged by a bidirectional `UnifiedAgentStore` adapter that
keeps the `tickets/` on-disk layout unchanged. Fixes a bug where function
handlers (`tasks_create_task`, `tasks_check_status`, `events_broadcast`) were
silently receiving `Agent` objects from the adapter but passing them to
`Ticket`-typed APIs, causing subagents to appear as peers and parent agents
to stay suspended after child completion.

## Why

Project Swarm decouples the fused Ticket identity into persistent Agents and
lightweight Tasks. Phase 2a is the internal pivot: the scheduler, task runner,
and coordination layer now speak `Agent`, while the filesystem and Hivetool
remain on `tickets/`. This establishes the foundation for the directory layout
split in Phase 2b.

## Changes

### Core Entity Model (`packages/bees/bees/`)

- **`agent.py`** — Added execution-state bridge fields to `AgentMetadata`
  (`error`, `outcome`, `turns`, `assignee`, `suspend_event`, etc.) so they
  survive the Agent→Ticket→disk→Ticket→Agent round-trip.
- **`agent_adapter.py`** — Added `agent_to_ticket()` reverse mapping, covering
  all bridge fields. Both directions are now fully symmetric.
- **`unified_agent_store.py`** — New bidirectional adapter wrapping `TaskStore`.
  Exposes Agent-typed CRUD; delegates to `tickets/` on disk.
- **`subagent_scope.py`** — Added `for_agent()` factory method.

### Scheduler & Task Runner

- **`scheduler.py`** — Cycle loop queries `UnifiedAgentStore` for agents.
  All orchestration logic (`_wrap_execution`, `_deliver_context_update`,
  `_enrich_parent_tags`) operates on `Agent`.
- **`task_runner.py`** — `run_task()` and `resume_task()` accept `Agent`.
  Session wiring uses agent config. Events emit `Ticket` via `agent_to_ticket()`.
- **`coordination.py`** — Accepts `Agent` + `UnifiedAgentStore`. Playbook hooks
  still receive `Ticket` at the boundary.
- **`segments.py`** — Accepts `Agent` + `UnifiedAgentStore`.

### Public API Layer

- **`bees.py`** — Creates `UnifiedAgentStore`. Public methods reconstruct
  `Ticket` via `agent_to_ticket()` at the API boundary.
- **`task_node.py`** — Uses inner `_ticket_store` directly for Ticket-typed
  tree queries. Public API unchanged.

### Bug Fix: Function Handlers

- **`functions/tasks.py`** — `stamp_child_task` was receiving an `Agent` as
  `parent_task` and `UnifiedAgentStore` as `store`. `parent_task_id` was being
  set on `AgentMetadata` (which has no such field), so it was silently lost.
  `tasks_check_status` iterated Agents and checked `.metadata.parent_task_id`
  (absent on `AgentMetadata`), returning empty trees. Fixed: use inner
  `_ticket_store` for all Ticket-typed operations.
- **`functions/events.py`** — `events_broadcast` passed an `Agent` to a
  `Ticket`-typed callback. Fixed: create coordination tickets via inner
  `_ticket_store`.

### Tests

- **`test_scheduler.py`** — Fixtures use `UnifiedAgentStore`.
- **`test_coordination.py`** — Updated to Agent + `UnifiedAgentStore`.
- **`test_tree.py`** — Uses inner `_ticket_store` for mock injection.
- **`test_eval.py`** — Updated to Agent-typed metadata.

### Documentation

- **`projects/swarm/PROJECT.md`** — Phase 2a marked ✅. Added "Adjustments
  Made" section documenting bridge fields, inner-store pattern, and unified
  adapter rationale.

## Testing

- 521 tests pass (excluding 21 pre-existing `asyncio.get_event_loop` failures
  in protocol conformance tests — unrelated to this change).
- Verified with live hive run (`hives/chat-app`): subagents now appear as
  children in Hivetool and parent agents resume after child completion.
