### PR TITLE
[bees] Project Swarm Phase 2c — Hivetool reads from new layout

### DIFF
--- a/hives/swarm-test/config/TEMPLATES.yaml
+++ b/hives/swarm-test/config/TEMPLATES.yaml
@@ -7,7 +7,7 @@
   functions:
     - tasks.*
     - system.*
-  autostart:
+  tasks:
     - writer
 
 - name: writer

--- a/packages/bees/bees/unified_agent_store.py
+++ b/packages/bees/bees/unified_agent_store.py
@@ -153,9 +153,15 @@ class UnifiedAgentStore:
         self._ticket_store.save(agent_to_ticket(agent))
 
     def save_metadata(self, agent: Agent) -> None:
-        """Persist only the metadata."""
+        """Persist only the metadata.
+
+        In swarm layout, also syncs the corresponding task record's status
+        and outcome so that ``tasks/{uuid}.json`` stays consistent with
+        the agent's lifecycle transitions.
+        """
         if self._layout == "swarm":
             self._agent_store.save_metadata(agent)
+            self._sync_task_record(agent)
             return
 
         # Phase 6: remove legacy path
@@ -253,3 +259,73 @@ class UnifiedAgentStore:
         )
 
         return agent
+
+    # -- Task record sync --------------------------------------------------
+
+    # Agent statuses that warrant syncing to the task record.
+    # Not every save_metadata call changes the agent's externally-visible
+    # status — most are incremental bookkeeping (turns++, file list, etc.).
+    # We only pay the cost of scanning tasks/ when the agent enters a
+    # status that a task consumer would care about.
+    _SYNC_WORTHY_STATUSES = frozenset({
+        "running", "suspended", "completed", "failed", "cancelled",
+    })
+
+    # Agent status → task status mapping.
+    _AGENT_TO_TASK_STATUS: dict[str, str] = {
+        "available": "available",
+        "blocked": "available",
+        "running": "in_progress",
+        "suspended": "in_progress",
+        "paused": "in_progress",
+        "completed": "completed",
+        "failed": "failed",
+        "cancelled": "cancelled",
+    }
+
+    def _sync_task_record(self, agent: Agent) -> None:
+        """Sync the task record assigned to this agent.
+
+        Only runs when the agent's status is significant (running,
+        terminal). Finds the task whose ``assignee`` matches the agent
+        ID, then updates its ``status``, ``outcome``, ``outcome_content``,
+        and ``completed_at``.
+
+        Best-effort — missing or malformed task files are silently skipped.
+        The agent metadata is the source of truth; the task file is a
+        read model.
+        """
+        if agent.metadata.status not in self._SYNC_WORTHY_STATUSES:
+            return
+
+        tasks = self._task_file_store.query_by_assignee(agent.id)
+        if not tasks:
+            return
+
+        task_status = self._AGENT_TO_TASK_STATUS.get(
+            agent.metadata.status, "available"
+        )
+
+        for task in tasks:
+            changed = False
+
+            if task.status != task_status:
+                task.status = task_status
+                changed = True
+
+            if agent.metadata.outcome and task.outcome != agent.metadata.outcome:
+                task.outcome = agent.metadata.outcome
+                changed = True
+
+            if agent.metadata.outcome_content and task.outcome_content != agent.metadata.outcome_content:
+                task.outcome_content = agent.metadata.outcome_content
+                changed = True
+
+            if agent.metadata.completed_at and task.completed_at != agent.metadata.completed_at:
+                task.completed_at = agent.metadata.completed_at
+                changed = True
+
+            if changed:
+                self._task_file_store.save(task)
+
+

--- a/packages/bees/hivetool/src/data/log-store.ts
+++ b/packages/bees/hivetool/src/data/log-store.ts
@@ -5,10 +5,11 @@
  */
 
 /**
- * Signal-backed reactive store for session files grouped by parent tasks.
+ * Signal-backed reactive store for session files grouped by parent entities.
  *
- * Resolves the `hive/tickets/` subdirectory via a shared StateAccess,
- * uses FileSystemObserver for live updates, and manages session grouping.
+ * Resolves the entity directory (`agents/` or `tickets/`) via a shared
+ * StateAccess, uses FileSystemObserver for live updates, and manages
+ * session grouping.
  */
 
 import { Signal } from "signal-polyfill";
@@ -49,45 +50,58 @@ class LogStore {
 
   // ── Private ──
 
-  #ticketsHandle: FileSystemDirectoryHandle | null = null;
+  /** Handle for the primary entity directory (agents/ or tickets/). */
+  #entityHandle: FileSystemDirectoryHandle | null = null;
   #observer: { disconnect(): void } | null = null;
   #activated = false;
 
   // ── Lifecycle ──
 
-  /** Activate the store — resolves tickets/ subdir, scans, observes. */
+  /**
+   * Activate the store — resolves the entity directory, scans, observes.
+   *
+   * Tries `agents/` first (Project Swarm layout), then falls back
+   * to `tickets/` (legacy layout).
+   */
   async activate(): Promise<void> {
     if (this.#activated) return;
     if (this.access.accessState.get() !== "ready") return;
 
-    const ticketsHandle = await this.access.getSubdirectory("tickets");
-    if (!ticketsHandle) {
-      console.warn("Could not find tickets/ subdirectory in hive/");
-      return;
+    // Try agents/ first (Project Swarm layout).
+    const agentsHandle = await this.access.getSubdirectory("agents");
+    if (agentsHandle) {
+      this.#entityHandle = agentsHandle;
+    } else {
+      // Fall back to tickets/ (legacy layout).
+      const ticketsHandle = await this.access.getSubdirectory("tickets");
+      if (!ticketsHandle) {
+        console.warn("Could not find agents/ or tickets/ subdirectory in hive/");
+        return;
+      }
+      this.#entityHandle = ticketsHandle;
     }
 
-    this.#ticketsHandle = ticketsHandle;
     this.#activated = true;
     await this.scan();
     this.#startObserver();
   }
 
-  /** Scan the tickets subdirectory, load tasks metadata and their sessions. */
+  /** Scan the entity directory, load entity metadata and their sessions. */
   async scan(): Promise<void> {
-    if (!this.#ticketsHandle) return;
+    if (!this.#entityHandle) return;
 
     const groups: TaskGroupedSessions[] = [];
 
     try {
       for await (const [name, entry] of (
-        this.#ticketsHandle as FileSystemDirectoryHandle & {
+        this.#entityHandle as FileSystemDirectoryHandle & {
           entries(): AsyncIterable<[string, FileSystemHandle]>;
         }
       ).entries()) {
         if (entry.kind !== "directory") continue;
 
-        const ticketDir = await this.#ticketsHandle.getDirectoryHandle(name);
-        const metadata = await this.#readJson(ticketDir, "metadata.json") as Record<string, unknown> | null;
+        const entityDir = await this.#entityHandle.getDirectoryHandle(name);
+        const metadata = await this.#readJson(entityDir, "metadata.json") as Record<string, unknown> | null;
         if (!metadata) continue;
         if (metadata.kind === "coordination") continue;
 
@@ -97,7 +111,7 @@ class LogStore {
 
         const sessions: SidebarSessionInfo[] = [];
         try {
-          const sessionsDir = await ticketDir.getDirectoryHandle("sessions");
+          const sessionsDir = await entityDir.getDirectoryHandle("sessions");
           for await (const [sName, sEntry] of (
             sessionsDir as FileSystemDirectoryHandle & {
               entries(): AsyncIterable<[string, FileSystemHandle]>;
@@ -156,7 +170,7 @@ class LogStore {
         });
       }
     } catch (e) {
-      console.error("Failed to scan tickets/ sessions:", e);
+      console.error("Failed to scan entity sessions:", e);
     }
 
     // Sort taskGroups by their most recently updated session's lastModified, descending
@@ -178,7 +192,7 @@ class LogStore {
   reset(): void {
     this.#observer?.disconnect();
     this.#observer = null;
-    this.#ticketsHandle = null;
+    this.#entityHandle = null;
     this.#activated = false;
     this.taskGroups.set([]);
     this.selectedSessionId.set(null);
@@ -221,7 +235,7 @@ class LogStore {
   }
 
   #startObserver(): void {
-    if (!this.#ticketsHandle) return;
+    if (!this.#entityHandle) return;
     if (!("FileSystemObserver" in globalThis)) return;
     try {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -243,7 +257,7 @@ class LogStore {
             } else if (typeof r.relativePath === "string") {
               segments = r.relativePath.split("/").filter(Boolean);
             }
-            // [ticketId, "sessions", sessionId, ...]
+            // [entityId, "sessions", sessionId, ...]
             if (segments.length >= 3 && segments[1] === "sessions") {
               this.recentlyUpdatedSession.set({ id: segments[2], at: Date.now() });
               break;
@@ -251,7 +265,7 @@ class LogStore {
           }
         }
       });
-      observer.observe(this.#ticketsHandle, { recursive: true });
+      observer.observe(this.#entityHandle, { recursive: true });
       this.#observer = observer;
     } catch (e) {
       console.warn("FileSystemObserver not available:", e);

--- a/packages/bees/hivetool/src/data/session-store-reader.ts
+++ b/packages/bees/hivetool/src/data/session-store-reader.ts
@@ -208,38 +208,68 @@ function compileEventsToSegment(sessionId: string, events: Record<string, unknow
 class SessionStoreReader {
   constructor(private access: StateAccess) {}
 
-  async findTicketForSession(sessionId: string): Promise<string | null> {
-    const ticketsHandle = await this.access.getSubdirectory("tickets");
-    if (!ticketsHandle) return null;
-    try {
-      for await (const [name, entry] of (
-        ticketsHandle as FileSystemDirectoryHandle & {
-          entries(): AsyncIterable<[string, FileSystemHandle]>;
-        }
-      ).entries()) {
-        if (entry.kind !== "directory") continue;
-        const ticketDir = await ticketsHandle.getDirectoryHandle(name);
-        try {
-          const sessionsDir = await ticketDir.getDirectoryHandle("sessions");
-          await sessionsDir.getDirectoryHandle(sessionId);
-          return name;
-        } catch {
-          // Not in this ticket
-        }
+  /**
+   * Resolve the directory handle for an entity by ID.
+   *
+   * Tries `agents/{id}` first (Project Swarm layout), then falls back
+   * to `tickets/{id}` (legacy layout).
+   */
+  async #getEntityDir(entityId: string): Promise<FileSystemDirectoryHandle | null> {
+    // Try agents/ first.
+    const agentsHandle = await this.access.getSubdirectory("agents");
+    if (agentsHandle) {
+      try {
+        return await agentsHandle.getDirectoryHandle(entityId);
+      } catch {
+        // Not in agents/, try tickets/.
       }
-    } catch {
-      // Ignore scanning errors
+    }
+    // Fall back to tickets/.
+    const ticketsHandle = await this.access.getSubdirectory("tickets");
+    if (ticketsHandle) {
+      try {
+        return await ticketsHandle.getDirectoryHandle(entityId);
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  async findTicketForSession(sessionId: string): Promise<string | null> {
+    // Search agents/ first, then tickets/.
+    for (const dirName of ["agents", "tickets"]) {
+      const dirHandle = await this.access.getSubdirectory(dirName);
+      if (!dirHandle) continue;
+      try {
+        for await (const [name, entry] of (
+          dirHandle as FileSystemDirectoryHandle & {
+            entries(): AsyncIterable<[string, FileSystemHandle]>;
+          }
+        ).entries()) {
+          if (entry.kind !== "directory") continue;
+          const entityDir = await dirHandle.getDirectoryHandle(name);
+          try {
+            const sessionsDir = await entityDir.getDirectoryHandle("sessions");
+            await sessionsDir.getDirectoryHandle(sessionId);
+            return name;
+          } catch {
+            // Not in this entity
+          }
+        }
+      } catch {
+        // Ignore scanning errors
+      }
     }
     return null;
   }
 
   async readLineage(ticketId: string): Promise<SessionLineageInfo[]> {
-    const ticketsHandle = await this.access.getSubdirectory("tickets");
-    if (!ticketsHandle) return [];
+    const entityDir = await this.#getEntityDir(ticketId);
+    if (!entityDir) return [];
 
     try {
-      const ticketDir = await ticketsHandle.getDirectoryHandle(ticketId);
-      const sessionsDir = await ticketDir.getDirectoryHandle("sessions");
+      const sessionsDir = await entityDir.getDirectoryHandle("sessions");
       const result: SessionLineageInfo[] = [];
 
       for await (const [name, entry] of (
@@ -279,11 +309,10 @@ class SessionStoreReader {
   }
 
   async readTurns(ticketId: string, sessionId: string): Promise<TurnCheckpointInfo[]> {
-    const ticketsHandle = await this.access.getSubdirectory("tickets");
-    if (!ticketsHandle) return [];
+    const entityDir = await this.#getEntityDir(ticketId);
+    if (!entityDir) return [];
     try {
-      const ticketDir = await ticketsHandle.getDirectoryHandle(ticketId);
-      const sessionsDir = await ticketDir.getDirectoryHandle("sessions");
+      const sessionsDir = await entityDir.getDirectoryHandle("sessions");
       const sessionDir = await sessionsDir.getDirectoryHandle(sessionId);
       const turns = await this.#readJson(sessionDir, "turns.json");
       if (Array.isArray(turns)) {
@@ -296,11 +325,10 @@ class SessionStoreReader {
   }
 
   async readEvents(ticketId: string, sessionId: string): Promise<unknown[]> {
-    const ticketsHandle = await this.access.getSubdirectory("tickets");
-    if (!ticketsHandle) return [];
+    const entityDir = await this.#getEntityDir(ticketId);
+    if (!entityDir) return [];
     try {
-      const ticketDir = await ticketsHandle.getDirectoryHandle(ticketId);
-      const sessionsDir = await ticketDir.getDirectoryHandle("sessions");
+      const sessionsDir = await entityDir.getDirectoryHandle("sessions");
       const sessionDir = await sessionsDir.getDirectoryHandle(sessionId);
       const text = await this.#readText(sessionDir, "events.jsonl");
       if (!text) return [];
@@ -311,11 +339,10 @@ class SessionStoreReader {
   }
 
   async readInteraction(ticketId: string, sessionId: string): Promise<unknown | null> {
-    const ticketsHandle = await this.access.getSubdirectory("tickets");
-    if (!ticketsHandle) return null;
+    const entityDir = await this.#getEntityDir(ticketId);
+    if (!entityDir) return null;
     try {
-      const ticketDir = await ticketsHandle.getDirectoryHandle(ticketId);
-      const sessionsDir = await ticketDir.getDirectoryHandle("sessions");
+      const sessionsDir = await entityDir.getDirectoryHandle("sessions");
       const sessionDir = await sessionsDir.getDirectoryHandle(sessionId);
       return await this.#readJson(sessionDir, "interaction.json");
     } catch {

--- a/packages/bees/hivetool/src/data/ticket-store.ts
+++ b/packages/bees/hivetool/src/data/ticket-store.ts
@@ -5,16 +5,17 @@
  */
 
 /**
- * Signal-backed reactive store for ticket directories.
+ * Signal-backed reactive store for entity directories.
  *
- * Reads ticket data from `hive/tickets/{uuid}/` directories,
- * combining `metadata.json` and `objective.md` into TicketData objects.
+ * Reads entity data from `hive/agents/{uuid}/` (Project Swarm layout)
+ * or `hive/tickets/{uuid}/` (legacy layout), combining `metadata.json`
+ * and `objective.md` into TicketData objects for the UI.
  * Uses FileSystemObserver for live updates.
  */
 
 import { Signal } from "signal-polyfill";
 import type { StateAccess } from "./state-access.js";
-import type { TicketData, AgentData, TaskItemData, SurfaceManifest } from "./types.js";
+import type { TicketData, TaskItemData, SurfaceManifest } from "./types.js";
 import { LiveSessionClient } from "./live-session.js";
 
 export { TicketStore };
@@ -222,36 +223,54 @@ class TicketStore {
       const metadata = await this.#readJson(agentDir, "metadata.json");
       if (!metadata) continue;
 
-      const agentData = metadata as AgentData;
+      // The full agent metadata — includes execution-state bridge fields.
+      const md = metadata as Record<string, unknown>;
       const agentTasks = tasksByAssignee.get(name) ?? [];
       const chatLog = await this.#readJson(agentDir, "chat_log.json");
 
-      // Pick the first task's objective as the agent's objective,
-      // or fall back to the agent's type as a label.
-      const primaryTask = agentTasks[0];
-      const objective = primaryTask?.objective ?? `Agent: ${agentData.type}`;
+      // Read objective.md from the agent directory.
+      const objectiveMd = await this.#readText(agentDir, "objective.md");
 
-      // Shim agent data into TicketData shape.
+      // Pick the first task's objective, then objective.md, then type label.
+      const primaryTask = agentTasks[0];
+      const objective =
+        primaryTask?.objective ?? objectiveMd ?? `Agent: ${md.type}`;
+
+      // Shim agent data into TicketData shape — map every field the
+      // detail/pane components read.
       entries.push({
         id: name,
         objective,
-        status: agentData.status,
-        created_at: agentData.created_at,
-        completed_at: agentData.completed_at,
-        slug: agentData.slug,
-        model: agentData.model,
-        runner: agentData.runner,
-        voice: agentData.voice,
-        functions: agentData.functions,
-        skills: agentData.skills,
-        tags: agentData.tags,
-        playbook_id: agentData.playbook_id,
-        parent_task_id: agentData.parent_id,
-        owning_task_id: agentData.workspace_root_id,
-        active_session: agentData.active_session,
-        title: primaryTask?.title,
-        outcome: primaryTask?.outcome,
-        kind: primaryTask?.kind,
+        status: md.status as string,
+        created_at: md.created_at as string | undefined,
+        completed_at: md.completed_at as string | undefined,
+        slug: md.slug as string | undefined,
+        model: md.model as string | undefined,
+        runner: md.runner as TicketData["runner"],
+        voice: md.voice as string | undefined,
+        functions: md.functions as string[] | undefined,
+        skills: md.skills as string[] | undefined,
+        tags: md.tags as string[] | undefined,
+        playbook_id: md.playbook_id as string | undefined,
+        playbook_run_id: md.playbook_run_id as string | undefined,
+        parent_task_id: md.parent_id as string | undefined,
+        owning_task_id: md.workspace_root_id as string | undefined,
+        active_session: md.active_session as string | undefined,
+        title: (md.title as string | undefined) ?? primaryTask?.title,
+        outcome: (md.outcome as string | undefined) ?? primaryTask?.outcome,
+        kind: (md.kind as string | undefined) ?? primaryTask?.kind,
+        // Execution-state bridge fields.
+        error: md.error as string | undefined,
+        suspend_event: md.suspend_event as Record<string, unknown> | undefined,
+        context: md.context as string | undefined,
+        turns: md.turns as number | undefined,
+        thoughts: md.thoughts as number | undefined,
+        assignee: md.assignee as string | undefined,
+        depends_on: md.depends_on as string[] | undefined,
+        options: md.options as Record<string, unknown> | undefined,
+        files: md.files as TicketData["files"],
+        watch_events: md.watch_events as TicketData["watch_events"],
+        outcome_content: md.outcome_content as Record<string, unknown> | undefined,
         ...(chatLog ? { chat_history: chatLog as TicketData["chat_history"] } : {}),
       } as TicketData);
     }
@@ -286,15 +305,135 @@ class TicketStore {
   }
 
   /**
-   * Create a new task by writing files to `tickets/{uuid}/`.
+   * Create a new task.
    *
-   * Writes `objective.md` and `metadata.json` — the minimal structure
-   * the scheduler expects. The box's file watcher will detect the new
-   * directory and trigger the scheduler automatically.
+   * In swarm layout (agents/ exists), creates:
+   *   - `agents/{uuid}/metadata.json` and `agents/{uuid}/objective.md`
+   *   - `tasks/{uuid}.json`
+   * In legacy layout, creates `tickets/{uuid}/` with `objective.md`
+   * and `metadata.json`.
    *
-   * Returns the generated task ID (UUID).
+   * The box's file watcher detects the new directory and triggers the
+   * scheduler automatically.
+   *
+   * Returns the generated entity ID (UUID).
    */
   async createTask(opts: {
+    objective: string;
+    playbook_id?: string;
+    title?: string;
+    functions?: string[];
+    skills?: string[];
+    tags?: string[];
+    tasks?: string[];
+    model?: string;
+    runner?: "generate" | "live" | "direct_model";
+    context?: string;
+    watch_events?: Array<{ type: string }>;
+    options?: Record<string, unknown>;
+  }): Promise<string> {
+    if (this.#agentsHandle) {
+      return this.#createTaskSwarm(opts);
+    }
+    return this.#createTaskLegacy(opts);
+  }
+
+  /** Create agent + task in the Project Swarm layout. */
+  async #createTaskSwarm(opts: {
+    objective: string;
+    playbook_id?: string;
+    title?: string;
+    functions?: string[];
+    skills?: string[];
+    tags?: string[];
+    tasks?: string[];
+    model?: string;
+    runner?: "generate" | "live" | "direct_model";
+    context?: string;
+    watch_events?: Array<{ type: string }>;
+    options?: Record<string, unknown>;
+  }): Promise<string> {
+    if (!this.#agentsHandle) throw new Error("Agents handle not available");
+
+    const agentId = crypto.randomUUID();
+    const agentDir = await this.#agentsHandle.getDirectoryHandle(agentId, {
+      create: true,
+    });
+
+    // Determine if system.* functions are present.
+    const hasSystem = opts.functions?.some((f) => f.startsWith("system.")) ?? false;
+
+    // Write objective.md
+    const objectiveHandle = await agentDir.getFileHandle("objective.md", {
+      create: true,
+    });
+    const objectiveWritable = await objectiveHandle.createWritable();
+    await objectiveWritable.write(opts.objective);
+    await objectiveWritable.close();
+
+    // Build agent metadata — mirrors UnifiedAgentStore._create_swarm().
+    const metadata: Record<string, unknown> = {
+      type: opts.playbook_id ?? "",
+      slug: "",
+      status: "available",
+      finite: hasSystem,
+      runner: opts.runner ?? "generate",
+      created_at: new Date().toISOString(),
+      kind: "work",
+    };
+    if (opts.playbook_id) metadata.playbook_id = opts.playbook_id;
+    if (opts.playbook_id) metadata.playbook_run_id = crypto.randomUUID();
+    if (opts.title) metadata.title = opts.title;
+    if (opts.functions?.length) metadata.functions = opts.functions;
+    if (opts.skills?.length) metadata.skills = opts.skills;
+    if (opts.tags?.length) metadata.tags = opts.tags;
+    if (opts.tasks?.length) metadata.tasks = opts.tasks;
+    if (opts.model) metadata.model = opts.model;
+    if (opts.context) metadata.context = opts.context;
+    if (opts.watch_events?.length) metadata.watch_events = opts.watch_events;
+    if (opts.options && Object.keys(opts.options).length) metadata.options = opts.options;
+
+    // Write agent metadata.json
+    const metadataHandle = await agentDir.getFileHandle("metadata.json", {
+      create: true,
+    });
+    const metadataWritable = await metadataHandle.createWritable();
+    await metadataWritable.write(
+      JSON.stringify(metadata, null, 2) + "\n"
+    );
+    await metadataWritable.close();
+
+    // Write lightweight task record to tasks/.
+    if (this.#tasksHandle) {
+      const taskId = crypto.randomUUID();
+      const taskRecord: Record<string, unknown> = {
+        id: taskId,
+        objective: opts.objective,
+        status: "available",
+        assignee: agentId,
+        kind: "work",
+        created_at: new Date().toISOString(),
+      };
+      if (opts.title) taskRecord.title = opts.title;
+      if (opts.context) taskRecord.context = opts.context;
+      if (opts.tags?.length) taskRecord.tags = opts.tags;
+
+      const taskFileHandle = await this.#tasksHandle.getFileHandle(
+        `${taskId}.json`,
+        { create: true },
+      );
+      const taskWritable = await taskFileHandle.createWritable();
+      await taskWritable.write(
+        JSON.stringify(taskRecord, null, 2) + "\n"
+      );
+      await taskWritable.close();
+    }
+
+    return agentId;
+  }
+
+  /** Create task in the legacy tickets/ layout. */
+  async #createTaskLegacy(opts: {
     objective: string;
     playbook_id?: string;
     title?: string;
@@ -618,7 +757,7 @@ class TicketStore {
   // ── Live session detection ──
 
   async #detectLiveSessions(tickets: TicketData[]): Promise<void> {
-    if (!this.#ticketsHandle) return;
+    if (!this.#ticketsHandle && !this.#agentsHandle) return;
 
     const liveTickets = tickets.filter((t) => t.runner === "live");
     if (liveTickets.length === 0) {
@@ -631,10 +770,8 @@ class TicketStore {
     const activeIds = new Set<string>();
     for (const ticket of liveTickets) {
       try {
-        const ticketDir = await this.#ticketsHandle.getDirectoryHandle(
-          ticket.id,
-        );
-        if (await LiveSessionClient.hasActiveSession(ticketDir)) {
+        const entityDir = await this.#getEntityDirHandle(ticket.id);
+        if (entityDir && await LiveSessionClient.hasActiveSession(entityDir)) {
           activeIds.add(ticket.id);
         }
       } catch {
@@ -653,7 +790,11 @@ class TicketStore {
   }
 
   #startObserver(): void {
-    if (!this.#ticketsHandle) return;
+    // Observe the primary entity directory: agents/ in swarm layout,
+    // tickets/ in legacy layout. One recursive observer covers both
+    // metadata changes and workspace file writes.
+    const handle = this.#agentsHandle ?? this.#ticketsHandle;
+    if (!handle) return;
     if (!("FileSystemObserver" in globalThis)) return;
     try {
       // FileSystemObserver is experimental — access via dynamic typing.
@@ -711,8 +852,8 @@ class TicketStore {
           }
         }
       });
-      // Recursive — ticket subdirectories may be added/modified.
-      observer.observe(this.#ticketsHandle, { recursive: true });
+      // Recursive — entity subdirectories may be added/modified.
+      observer.observe(handle, { recursive: true });
       this.#observer = observer;
     } catch (e) {
       console.warn("FileSystemObserver not available:", e);

--- a/projects/swarm/PROJECT.md
+++ b/projects/swarm/PROJECT.md
@@ -677,7 +677,7 @@ idle and waits for Hivetool to create tasks. Since Hivetool isn't updated until
 Phase 2c, `swarm-test` is the only hive that exercises the full boot → run →
 complete lifecycle in swarm mode.
 
-### Phase 2c — Hivetool Reads From New Layout
+### Phase 2c — Hivetool Reads From New Layout ✅
 
 Hivetool's `TicketStore` reads from both `agents/` + `tasks/` and `tickets/`
 directories. This is the dual-directory scanning mode that enables the lockstep
@@ -689,20 +689,75 @@ agent lifecycle, workspace, and surface correctly from `agents/` paths.
 
 #### Hivetool Changes
 
-- [ ] **[MODIFY] `ticket-store.ts`** — Accept both `agents/` and `tickets/` as
-      root. Scan `tasks/` for task data alongside agent metadata. Update
-      `readTree()`, `readSurface()`, `readFileContent()` for agent paths
-      (`agents/{uuid}/sessions/{sid}/workspace`). Update `createTask()` to
-      create agents + tasks in new layout when operating against new hives.
-- [ ] **[MODIFY] `mutation-client.ts`** — Update internal mutation vocabulary.
-      Rollback targets agent, not task.
-- [ ] **[MODIFY] `ticket-pane.ts`** — Wire agent-based workspace paths.
+- [x] **[MODIFY] `ticket-store.ts`** — Accept both `agents/` and `tickets/` as
+      root. Scan `tasks/` for task data alongside agent metadata. Complete
+      metadata shim (all TicketData fields mapped from AgentMetadata). Read
+      `objective.md` from agent directories. Dual-mode `createTask()` creates
+      agents + tasks in swarm layout. Observer watches `agents/` when available.
+      Live session detection checks `agents/` too.
+- [x] **[MODIFY] `session-store-reader.ts`** — Entity-aware path resolution:
+      all five methods (`findTicketForSession`, `readLineage`, `readTurns`,
+      `readEvents`, `readInteraction`) now try `agents/` first, falling back
+      to `tickets/`.
+- [x] **[MODIFY] `log-store.ts`** — Dual-directory activation: `activate()`
+      tries `agents/` first, falls back to `tickets/`. Observer watches
+      whichever directory is active.
+- [ ] ~~**[MODIFY] `mutation-client.ts`**~~ — Deferred. The mutation protocol
+      vocabulary (`task_id` in payloads) continues to work because the Python
+      handler treats it as an entity ID. Renaming to `agent_id` is Phase 6.
+- [ ] ~~**[MODIFY] `ticket-pane.ts`**~~ — Not needed. Workspace paths already
+      resolve through `#getEntityDirHandle()` and `readTree()`/`readSurface()`/
+      `readFileContent()` use `active_session`-aware path resolution that works
+      for both `agents/{uuid}/sessions/{sid}/workspace` and legacy
+      `tickets/{uuid}/filesystem`.
+
+#### Adjustments Made
+
+1. **Scope was broader than blueprint planned** — The blueprint listed only
+   `ticket-store.ts`, `mutation-client.ts`, and `ticket-pane.ts`. In practice,
+   making session lineage, log detail, and rollback work required updating
+   `session-store-reader.ts` (all five methods hardcoded to `tickets/`) and
+   `log-store.ts` (activation and scanning only saw `tickets/`).
+
+2. **Metadata shim was incomplete** — The original `#scanAgentsDir()` only
+   mapped identity/config fields. The ticket-detail and ticket-pane components
+   read execution-state fields (`error`, `suspend_event`, `context`, `turns`,
+   `thoughts`, `assignee`, `depends_on`, `options`, `files`,
+   `playbook_run_id`, `watch_events`, `outcome_content`). All are now mapped.
+
+3. **`objective.md` was not read** — Agents store their objective in a
+   separate `objective.md` file (same as `AgentStore.get()` on the Python
+   side), but `#scanAgentsDir()` never read it. Added `#readText()` call
+   with fallback chain: task objective → `objective.md` → type label.
+
+4. **`mutation-client.ts` changes deferred** — The mutation payload uses
+   `task_id` as the entity identifier. The Python `MutationManager` already
+   routes this through `UnifiedAgentStore.get()`, which resolves both agent
+   and ticket IDs. No functional change needed until Phase 6 cleanup.
+
+5. **Task record status never synced** — `UnifiedAgentStore.save_metadata()`
+   wrote to `agents/{id}/metadata.json` but never updated the corresponding
+   `tasks/{id}.json` record. All task files remained at `status: "available"`
+   forever. Fixed by adding `_sync_task_record()` which maps agent status to
+   task status (`running/suspended` → `in_progress`, terminal states 1:1)
+   and updates outcome/completed_at. Gated by `_SYNC_WORTHY_STATUSES` so
+   incremental bookkeeping saves don't pay the scan cost.
+
+6. **Duplicate agents from `autostart` + LLM creation** — The `swarm-test`
+   orchestrator template had `autostart: [writer]` which stamped a writer
+   child at creation time. But the orchestrator's objective also instructed
+   the LLM to create a writer child via `tasks_create_task`, producing a
+   duplicate. Fixed by replacing `autostart` with `tasks` (the allowlist
+   field) so the LLM drives the creation, exercising the full lifecycle.
 
 #### Verification
 
-- [ ] Hivetool shows agents from `agents/` layout in real time.
-- [ ] Hivetool shows agents from legacy `tickets/` layout (backward compat).
-- [ ] File tree, surface, and session lineage work with agent paths.
+- [x] TypeScript build passes (`tsc --noEmit` clean).
+- [x] Python tests pass (418 passed, 1 pre-existing failure unrelated).
+- [x] Manual: hivetool shows agents from `agents/` layout in real time.
+- [x] Manual: single orchestrator → single writer child, no duplicates.
+- [x] Manual: task record status synced (verified `tasks/*.json` after run).
+- [x] Manual: full lifecycle: boot → create child → await → resume → complete.
 
 ---
 


### PR DESCRIPTION
## What
Updates all Hivetool data stores to support dual-directory scanning (`agents/` + `tasks/` alongside legacy `tickets/`), and adds task record lifecycle sync to `UnifiedAgentStore`.

## Why
Phase 2c of Project Swarm. The Python box already writes to the new `agents/` + `tasks/` layout (Phases 2a/2b), but Hivetool was still hardcoded to read only from `tickets/`. This made the devtools UI blank for swarm-layout hives.

## Changes

### Hivetool (TypeScript)
- **`ticket-store.ts`** — Complete metadata shim in `#scanAgentsDir()` (15+ missing fields), read `objective.md`, dual-mode `createTask()`, observer watches `agents/` when available, live session detection across both layouts
- **`session-store-reader.ts`** — New `#getEntityDir()` helper tries `agents/` then `tickets/`; all five reader methods use entity-aware resolution
- **`log-store.ts`** — `activate()` tries `agents/` first, single `#entityHandle` replaces old `#ticketsHandle`

### Backend (Python)
- **`unified_agent_store.py`** — `_sync_task_record()` syncs task file status/outcome when agent enters significant states (`running`, `completed`, `failed`, `cancelled`). Gated by `_SYNC_WORTHY_STATUSES` to avoid scanning `tasks/` on every bookkeeping save

### Config
- **`swarm-test/TEMPLATES.yaml`** — Replace `autostart: [writer]` with `tasks: [writer]` to prevent duplicate child agents (autostart + LLM creation)

## Testing
- `tsc --noEmit` clean
- Python tests: 418 passed
- Manual: `swarm-test` hive — full lifecycle verified (boot → create child → await → resume → complete), Hivetool shows agents in real time, task records sync correctly
