### PR TITLE
[bees] Project Swarm Phase 3 — `agents_*` function group

### DIFF
--- a/hives/swarm-test/config/TEMPLATES.yaml
+++ b/hives/swarm-test/config/TEMPLATES.yaml
@@ -1,11 +1,12 @@
 - name: orchestrator
   title: Orchestrator
   objective: >-
-    You are a simple orchestrator. Your writer child task will produce a short
-    poem. Once it reports back as completed, mark your own objective as
-    fulfilled.
+    You are a simple orchestrator. Use agents_list_types to discover available
+    agent types, then use agents_assign_task to assign a task to a "writer"
+    agent with slug "poet". Wait for the writer to complete using agents_await,
+    then mark your own objective as fulfilled.
   functions:
-    - tasks.*
+    - agents.*
     - system.*
   tasks:
     - writer

--- a/packages/bees/bees/declarations/agents.functions.json
+++ b/packages/bees/bees/declarations/agents.functions.json
@@ -1,0 +1,103 @@
+[
+  {
+    "name": "agents_list_types",
+    "description": "List available agent types that can be assigned tasks.",
+    "parametersJsonSchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "name": "agents_assign_task",
+    "description": "Assign a task to a named agent. If the agent doesn't exist yet, it is created automatically from the specified type. If it previously completed a task, a fresh instance is created (same name, new session, workspace persists).",
+    "parametersJsonSchema": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The agent type — one of the types returned by agents_list_types."
+        },
+        "slug": {
+          "type": "string",
+          "description": "The agent's name. Use a short, descriptive, lowercase identifier (e.g., 'researcher', 'deep-dive'). The same slug always refers to the same agent."
+        },
+        "objective": {
+          "type": "string",
+          "description": "The task objective. Must include all information necessary for the agent to complete the task."
+        },
+        "summary": {
+          "type": "string",
+          "description": "A short summary for the task in the [Subject] [Action-er] format, under four words, e.g., \"Laptop Finder\", \"Meal Planner\""
+        },
+        "title": {
+          "type": "string",
+          "description": "Optional friendly title for the task."
+        },
+        "options": {
+          "type": "object",
+          "description": "Optional runtime configuration overrides. Supported keys depend on the agent type. Discover available options via agents_list_types.",
+          "additionalProperties": true
+        }
+      },
+      "required": ["type", "slug", "objective", "summary"]
+    }
+  },
+  {
+    "name": "agents_check_status",
+    "description": "Check the status of all agents you have assigned tasks to. Returns agents by name (slug) with their current status and task outcomes.",
+    "parametersJsonSchema": {
+      "type": "object",
+      "properties": {}
+    }
+  },
+  {
+    "name": "agents_cancel",
+    "description": "Cancel a named agent and any pending tasks.",
+    "parametersJsonSchema": {
+      "type": "object",
+      "properties": {
+        "slug": {
+          "type": "string",
+          "description": "The name of the agent to cancel."
+        }
+      },
+      "required": ["slug"]
+    }
+  },
+  {
+    "name": "agents_send_event",
+    "description": "Send a typed event to a named agent. The agent receives the event as a context update. Use this to provide additional instructions, clarifications, or data to a running agent.",
+    "parametersJsonSchema": {
+      "type": "object",
+      "properties": {
+        "slug": {
+          "type": "string",
+          "description": "The name of the agent to send the event to."
+        },
+        "type": {
+          "type": "string",
+          "description": "The type of event (e.g., 'clarification', 'additional_context'). Choose descriptive, stable names."
+        },
+        "message": {
+          "type": "string",
+          "description": "Text payload delivered to the agent. Include all relevant details the agent needs to act on."
+        }
+      },
+      "required": ["slug", "type", "message"]
+    }
+  },
+  {
+    "name": "agents_await",
+    "description": "Suspend execution until a context update arrives (e.g. an agent completes a task or a parent sends an event). Returns immediately if updates are already pending. Call this after assigning tasks to wait for their results.",
+    "parametersJsonSchema": {
+      "type": "object",
+      "properties": {
+        "slugs": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Optional. Agent names to wait for. Currently informational — the function resumes on any context update."
+        }
+      }
+    }
+  }
+]

--- a/packages/bees/bees/declarations/agents.instruction.md
+++ b/packages/bees/bees/declarations/agents.instruction.md
@@ -1,0 +1,63 @@
+# Agents
+
+You manage a team of agents. Each agent is a named worker that you assign tasks
+to. Agents appear on demand — you never create them explicitly.
+
+Available agent types are resolved dynamically via "agents_list_types". New
+agent templates or overrides can be created or modified inside the `templates/`
+directory of your workspace during execution. You MUST always call
+"agents_list_types" to discover the current, most up-to-date list of available
+agent types before assigning a task, especially if you or the system have
+dynamically created or edited templates. When listing agent types, check their
+"options_schema" to see what configuration overrides (if any) can be supplied
+via the "options" parameter of "agents_assign_task".
+
+To assign work, call "agents_assign_task" with the agent type, a name (slug),
+and the task objective. If no agent with that name exists, one is created
+automatically. If a previous agent with that name already finished, a fresh
+instance is created (same name, new session, workspace persists).
+
+Use "agents_check_status" to see the status of all your agents by name. Use
+"agents_send_event" to send a context update to a running agent. Use
+"agents_cancel" to cancel an agent and any pending work.
+
+Tasks run asynchronously — "agents_assign_task" returns immediately. The
+scheduler issues a context update when each agent completes its task, containing
+the outcome or an error message.
+
+To wait for results, call "agents_await". This suspends your execution until a
+context update arrives (e.g. an agent completes or a parent sends you an event).
+If updates are already pending, it returns immediately.
+
+Typical workflow:
+1. Call "agents_list_types" to discover available agent types.
+2. Assign one or more tasks with "agents_assign_task".
+3. Call "agents_await" to suspend until an agent completes.
+4. Check results with "agents_check_status".
+5. Repeat or proceed based on results.
+
+The agents working on tasks have access to a sub-directory of your filesystem,
+specified by the "slug" parameter. You provide a simple directory name (e.g.,
+"research"). If you are yourself a subagent, the system automatically nests
+your slug under your own working directory.
+
+## Agents and user input
+
+To successfully complete tasks, agents may be equipped with the ability to chat
+with the user. This may result in multi-threaded conversations: you are talking
+with the user, as well as your agents are talking with the user. This is
+perfectly fine and is a good pattern of separating conversations on different
+topics.
+
+## Agent statuses
+
+When you check on your agents, each agent has a status:
+
+- **available** — the agent is queued and waiting to start.
+- **running** — the agent is actively working on its task.
+- **suspended** — the agent is waiting for user input or an event.
+- **paused** — the agent is temporarily paused by the scheduler.
+- **completed** — the agent finished its task successfully. The outcome will
+  be delivered to you as a context update.
+- **failed** — the agent encountered an unrecoverable error.
+- **cancelled** — the agent was cancelled before completion.

--- a/packages/bees/bees/declarations/agents.metadata.json
+++ b/packages/bees/bees/declarations/agents.metadata.json
@@ -1,0 +1,8 @@
+[
+  {"name": "agents_list_types", "icon": "list", "title": "List Agent Types"},
+  {"name": "agents_assign_task", "icon": "assignment", "title": "Assign Task"},
+  {"name": "agents_check_status", "icon": "fact_check", "title": "Check Agents"},
+  {"name": "agents_cancel", "icon": "cancel", "title": "Cancel Agent"},
+  {"name": "agents_send_event", "icon": "send", "title": "Send Event"},
+  {"name": "agents_await", "icon": "hourglass_empty", "title": "Await"}
+]

--- a/packages/bees/bees/functions/agents.py
+++ b/packages/bees/bees/functions/agents.py
@@ -1,0 +1,383 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Agents function group — slug-based agent management with implicit creation.
+
+Replaces the ``tasks_*`` function group with a model where agents are
+persistent named entities. The parent assigns tasks by ``(type, slug)``
+and the handler materializes agents on demand.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from pathlib import Path
+from typing import Any
+
+from bees.context_updates import updates_to_context_parts
+from bees.protocols.handler_types import (
+    CONTEXT_PARTS_KEY,
+    SuspendError,
+    WaitForInputEvent,
+)
+from bees.subagent_scope import SubagentScope
+
+from bees.protocols.functions import (
+    FunctionGroup,
+    FunctionGroupFactory,
+    SessionHooks,
+    assemble_function_group,
+    load_declarations,
+)
+
+__all__ = ["get_agents_function_group_factory"]
+
+logger = logging.getLogger(__name__)
+
+_DECLARATIONS_DIR = Path(__file__).resolve().parent.parent / "declarations"
+_LOADED = load_declarations("agents", declarations_dir=_DECLARATIONS_DIR)
+
+
+def _make_handlers(
+    scope: SubagentScope | None = None,
+    caller_agent_id: str | None = None,
+    scheduler: Any | None = None,
+) -> dict[str, Any]:
+    """Build the handler map for the agents function group."""
+
+    async def _agents_list_types(args: dict[str, Any], status_cb: Any) -> dict[str, Any]:
+        if status_cb:
+            status_cb("Listing available agent types")
+
+        allowed_tasks = []
+        workspace_dir = None
+        if caller_agent_id:
+            agent = scheduler.store.get(caller_agent_id) if scheduler else None
+            if agent:
+                workspace_dir = agent.fs_dir
+                if agent.metadata.tasks:
+                    allowed_tasks = agent.metadata.tasks
+
+        agent_types = []
+        from bees.playbook import list_playbooks, load_playbook
+
+        config_dir = scheduler.store.hive_dir / "config"
+
+        global_names = set(list_playbooks(config_dir))
+        all_names = list_playbooks(config_dir, workspace_dir)
+
+        for name in all_names:
+            try:
+                data = load_playbook(name, config_dir, workspace_dir)
+                type_name = data.get("name", name)
+                is_local = type_name not in global_names
+
+                if is_local or type_name in allowed_tasks:
+                    item = {
+                        "name": type_name,
+                        "title": data.get("title", name),
+                        "description": data.get("description", ""),
+                    }
+                    if "options_schema" in data:
+                        item["options_schema"] = data["options_schema"]
+                    agent_types.append(item)
+            except Exception as e:
+                logger.warning("agents_list_types: skipping invalid %s: %s", name, e)
+
+        if status_cb:
+            status_cb(None, None)
+
+        return {"agent_types": agent_types}
+
+    async def _agents_assign_task(args: dict[str, Any], status_cb: Any) -> dict[str, Any]:
+        agent_type = args.get("type")
+        slug = args.get("slug")
+        objective = args.get("objective")
+        summary = args.get("summary")
+        title = args.get("title")
+        options = args.get("options")
+
+        if not all([agent_type, slug, objective, summary]):
+            return {"error": "type, slug, objective, and summary are required"}
+
+        if status_cb:
+            status_cb(f"Assigning task to agent: {slug}")
+
+        if not scheduler:
+            return {"error": "Scheduler not available"}
+
+        parent = scheduler.store.get(caller_agent_id) if caller_agent_id else None
+        if not parent:
+            return {"error": "Parent agent not found"}
+
+        # Validate agent type.
+        from bees.playbook import load_playbook
+        config_dir = scheduler.store.hive_dir / "config"
+        workspace_dir = parent.fs_dir
+
+        try:
+            playbook_data = load_playbook(agent_type, config_dir, workspace_dir)
+        except FileNotFoundError:
+            return {"error": f"Agent type not found: {agent_type}"}
+
+        # Validate options if provided.
+        if options:
+            options_schema = playbook_data.get("options_schema")
+            if not options_schema:
+                return {"error": f"Agent type '{agent_type}' does not support configuration options."}
+
+            supported_keys = set(options_schema.keys())
+            provided_keys = set(options.keys())
+            unknown_keys = provided_keys - supported_keys
+            if unknown_keys:
+                unknown_str = ", ".join(sorted(unknown_keys))
+                supported_str = ", ".join(sorted(supported_keys))
+                return {"error": f"Invalid option(s): {unknown_str}. Supported options for '{agent_type}' are: {supported_str}."}
+
+            for key, value in options.items():
+                prop_schema = options_schema.get(key)
+                if prop_schema and "enum" in prop_schema:
+                    valid_values = prop_schema["enum"]
+                    if value not in valid_values:
+                        valid_str = ", ".join(str(v) for v in valid_values)
+                        return {"error": f"Invalid value '{value}' for option '{key}'. Valid values for '{key}' in '{agent_type}' are: {valid_str}."}
+
+        # Resolve: does this slug already exist under this parent?
+        existing = scheduler.store.find_child_by_slug(caller_agent_id, slug)
+
+        try:
+            if existing is None:
+                # New agent — create from template.
+                from bees.playbook import stamp_child_task
+                child = stamp_child_task(
+                    agent_type,
+                    parent=parent,
+                    slug=slug,
+                    store=scheduler.store,
+                    context=objective,
+                    title=title or summary,
+                    scope=scope,
+                    options=options,
+                )
+                if status_cb:
+                    status_cb(None, None)
+                return {"agent_slug": slug, "status": "created"}
+
+            _TERMINAL = {"completed", "failed", "cancelled"}
+            if existing.metadata.status in _TERMINAL:
+                # Fresh instance — reuse the agent with a new session.
+                scheduler.store.reset_for_reuse(
+                    existing,
+                    objective,
+                    title=title or summary,
+                    options=options,
+                )
+
+                # Re-stamp objective with sandbox instructions.
+                if scope:
+                    child_scope = scope.child(slug)
+                    sandbox_block = child_scope.sandbox_instructions(existing.metadata.runner)
+                    blocks = [
+                        f"<subagent_context>\n"
+                        f"Your parent id is: {parent.id}\n"
+                        f"</subagent_context>"
+                    ]
+                    if sandbox_block:
+                        blocks.append(sandbox_block)
+                    full_objective = f"{objective}\n\n" + "\n\n".join(blocks)
+                    existing.objective = full_objective
+                    objective_path = existing.dir / "objective.md"
+                    objective_path.write_text(full_objective)
+                    scheduler.store.save_metadata(existing)
+
+                if status_cb:
+                    status_cb(None, None)
+                return {"agent_slug": slug, "status": "reused"}
+
+            # Non-terminal: agent is busy — can't queue yet (Phase 4).
+            if status_cb:
+                status_cb(None, None)
+            return {
+                "error": f"Agent '{slug}' is currently busy "
+                f"(status: {existing.metadata.status}). "
+                f"Wait for it to complete before assigning a new task."
+            }
+
+        except Exception as e:
+            logger.exception("agents_assign_task failed")
+            return {"error": str(e)}
+
+    async def _agents_check_status(args: dict[str, Any], status_cb: Any) -> dict[str, Any]:
+        if status_cb:
+            status_cb("Checking agent status")
+
+        agents: list[dict[str, Any]] = []
+        if caller_agent_id:
+            from collections import defaultdict
+
+            # Build index: parent_id -> children.
+            children_of: dict[str, list[Any]] = defaultdict(list)
+            for a in (scheduler.store.query_all() if scheduler else []):
+                if a.metadata.parent_id:
+                    children_of[a.metadata.parent_id].append(a)
+
+            def _build_tree(parent_id: str) -> list[dict[str, Any]]:
+                result: list[dict[str, Any]] = []
+                for a in children_of.get(parent_id, []):
+                    slug = a.metadata.slug or ""
+                    tail = slug.rsplit("/", 1)[-1] if "/" in slug else slug
+                    node: dict[str, Any] = {
+                        "agent_slug": tail or a.id[:8],
+                        "type": a.metadata.type or a.metadata.playbook_id or "",
+                        "status": a.metadata.status,
+                    }
+                    if a.metadata.outcome:
+                        node["outcome"] = a.metadata.outcome
+                    if a.metadata.error:
+                        node["error"] = a.metadata.error
+                    children = _build_tree(a.id)
+                    if children:
+                        node["agents"] = children
+                    result.append(node)
+                return result
+
+            agents = _build_tree(caller_agent_id)
+
+        if status_cb:
+            status_cb(None, None)
+
+        if not agents:
+            return {"message": "There are no agents."}
+
+        return {"agents": agents}
+
+    async def _agents_send_event(args: dict[str, Any], status_cb: Any) -> dict[str, Any]:
+        """Send a typed event to a named child agent."""
+        slug = args.get("slug", "")
+        event_type = args.get("type", "")
+        message = args.get("message", "")
+
+        if not slug:
+            return {"error": "slug is required"}
+        if not event_type:
+            return {"error": "type is required"}
+        if not scheduler:
+            return {"error": "Scheduler not available"}
+
+        if status_cb:
+            status_cb(f"Sending event to {slug}: {event_type}")
+
+        # Resolve slug to agent ID.
+        child = scheduler.store.find_child_by_slug(caller_agent_id, slug)
+        if not child:
+            return {"error": f"Agent '{slug}' not found"}
+
+        try:
+            update = {
+                "type": event_type,
+                "message": message,
+                "from_agent_id": caller_agent_id,
+                "from_slug": scope.slug_path if scope else None,
+            }
+            error = scheduler.deliver_to_task(
+                child.id,
+                update,
+                expected_creator=caller_agent_id,
+            )
+        except Exception as e:
+            logger.exception("agents_send_event failed")
+            return {"error": str(e)}
+
+        if status_cb:
+            status_cb(None, None)
+
+        if error:
+            return {"error": error}
+
+        return {
+            "agent_slug": slug,
+            "type": event_type,
+            "delivered": True,
+        }
+
+    async def _agents_cancel(args: dict[str, Any], status_cb: Any) -> dict[str, Any]:
+        """Cancel a named child agent."""
+        slug = args.get("slug", "")
+
+        if not slug:
+            return {"error": "slug is required"}
+        if not scheduler:
+            return {"error": "Scheduler not available"}
+
+        if status_cb:
+            status_cb(f"Cancelling agent: {slug}")
+
+        # Resolve slug to agent ID.
+        child = scheduler.store.find_child_by_slug(caller_agent_id, slug)
+        if not child:
+            return {"error": f"Agent '{slug}' not found"}
+
+        cancelled = scheduler.cancel_task(child.id)
+
+        if status_cb:
+            status_cb(None, None)
+
+        if cancelled:
+            return {"agent_slug": slug, "cancelled": True}
+        else:
+            return {"error": f"Agent '{slug}' could not be cancelled"}
+
+    async def _agents_await(args: dict[str, Any], status_cb: Any) -> dict[str, Any]:
+        """Suspend until a context update arrives.
+
+        If updates are already buffered, returns them immediately without
+        suspending. Otherwise raises ``SuspendError`` and the scheduler
+        resumes the agent when an update is delivered.
+        """
+        # Check for already-buffered context updates.
+        if caller_agent_id and scheduler:
+            agent = scheduler.store.get(caller_agent_id)
+            if agent and agent.metadata.pending_context_updates:
+                updates = agent.metadata.pending_context_updates
+                agent.metadata.pending_context_updates = []
+                scheduler.store.save_metadata(agent)
+                return {
+                    "resumed": True,
+                    CONTEXT_PARTS_KEY: updates_to_context_parts(updates),
+                }
+
+        # No updates pending — suspend.
+        request_id = str(uuid.uuid4())
+        event = WaitForInputEvent(
+            request_id=request_id,
+            prompt={},
+            input_type="any",
+        )
+        function_call_part = {
+            "functionCall": {
+                "name": "agents_await",
+                "args": args,
+            }
+        }
+        raise SuspendError(event, function_call_part)
+
+    return {
+        "agents_list_types": _agents_list_types,
+        "agents_assign_task": _agents_assign_task,
+        "agents_check_status": _agents_check_status,
+        "agents_send_event": _agents_send_event,
+        "agents_cancel": _agents_cancel,
+        "agents_await": _agents_await,
+    }
+
+
+def get_agents_function_group_factory(
+    scope: SubagentScope | None = None,
+    caller_agent_id: str | None = None,
+    scheduler: Any | None = None,
+) -> FunctionGroupFactory:
+    def factory(hooks: SessionHooks) -> FunctionGroup:
+        handlers = _make_handlers(scope, caller_agent_id, scheduler)
+        return assemble_function_group(_LOADED, handlers)
+    return factory

--- a/packages/bees/bees/provisioner.py
+++ b/packages/bees/bees/provisioner.py
@@ -30,6 +30,7 @@ from bees.functions.sandbox import get_sandbox_function_group_factory
 from bees.functions.files import get_files_function_group_factory
 from bees.functions.skills import get_skills_function_group
 from bees.functions.system import get_system_function_group_factory
+from bees.functions.agents import get_agents_function_group_factory
 from bees.functions.tasks import get_tasks_function_group_factory
 from bees.protocols.session import SessionConfiguration
 from bees.skill_filter import filter_skills, merge_function_filter
@@ -149,6 +150,11 @@ def provision_session(
             caller_ticket_id=ticket_id,
             scheduler=scheduler,
             ticket_id=ticket_id,
+        ),
+        get_agents_function_group_factory(
+            scope=scope,
+            caller_agent_id=ticket_id,
+            scheduler=scheduler,
         ),
         get_chat_function_group_factory(
             on_chat_entry=on_chat_entry,

--- a/packages/bees/bees/task_runner.py
+++ b/packages/bees/bees/task_runner.py
@@ -389,6 +389,17 @@ class TaskRunner:
         self._handle_suspend(agent, result)
         self._handle_pause(agent, result)
 
+        # Clean up stale suspend artifacts after a successful resume.
+        # When a session suspends, the runner writes interaction.json and
+        # resume_id to the session directory. If the resumed session
+        # completes normally (not re-suspended), these files are stale —
+        # but they were never cleaned up, causing hivetool to show a
+        # phantom "Suspended On" indicator.
+        if not result.suspended and agent.metadata.active_session:
+            sdir = agent.dir / "sessions" / agent.metadata.active_session
+            for stale_file in ("interaction.json", "resume_id"):
+                (sdir / stale_file).unlink(missing_ok=True)
+
         self._store.save_metadata(agent)
         return result
 

--- a/packages/bees/bees/unified_agent_store.py
+++ b/packages/bees/bees/unified_agent_store.py
@@ -328,4 +328,93 @@ class UnifiedAgentStore:
             if changed:
                 self._task_file_store.save(task)
 
+    # -- Slug resolution ---------------------------------------------------
+
+    def find_child_by_slug(self, parent_id: str, slug: str) -> Agent | None:
+        """Find a child agent by slug under a given parent.
+
+        Scans the parent's children for a matching ``metadata.slug``.
+        Returns the first match, or ``None`` if not found.
+
+        The slug stored in metadata is the full slug path (e.g.,
+        ``"poet"`` for a direct child, ``"app/tests"`` for a nested
+        child). The caller provides just the child's own slug segment —
+        we match against the tail of the stored slug path.
+        """
+        children = self.get_children(parent_id)
+        for child in children:
+            stored = child.metadata.slug or ""
+            # Match the tail segment of the slug path.
+            tail = stored.rsplit("/", 1)[-1] if "/" in stored else stored
+            if tail == slug:
+                return child
+        return None
+
+    # -- Fresh-instance reuse ----------------------------------------------
+
+    _TERMINAL_STATUSES = frozenset({"completed", "failed", "cancelled"})
+
+    def reset_for_reuse(
+        self,
+        agent: Agent,
+        objective: str,
+        *,
+        title: str | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> None:
+        """Reset a terminal agent for a new task assignment.
+
+        Used by ``agents_assign_task`` when a finite agent that has
+        already completed receives a new task for the same slug.
+
+        Resets status, creates a new session ID, clears outcome and
+        error fields, writes the new objective, and creates a new task
+        record. The UUID and workspace persist — the slug→UUID mapping
+        is stable.
+
+        Raises ``ValueError`` if the agent is not in a terminal state.
+        """
+        if agent.metadata.status not in self._TERMINAL_STATUSES:
+            raise ValueError(
+                f"Cannot reset agent {agent.id[:8]} — "
+                f"status is '{agent.metadata.status}', not terminal"
+            )
+
+        # Reset metadata for a fresh run.
+        agent.metadata.status = "available"
+        agent.metadata.active_session = str(uuid.uuid4())
+        agent.metadata.outcome = None
+        agent.metadata.outcome_content = None
+        agent.metadata.error = None
+        agent.metadata.completed_at = None
+        agent.metadata.assignee = None
+        agent.metadata.suspend_event = None
+        agent.metadata.turns = 0
+        agent.metadata.thoughts = 0
+        agent.metadata.files = None
+        agent.metadata.pending_context_updates = None
+        agent.metadata.queued_updates = None
+
+        if title:
+            agent.metadata.title = title
+        if options:
+            agent.metadata.options = options
+
+        # Write new objective.
+        agent.objective = objective
+        objective_path = agent.dir / "objective.md"
+        objective_path.write_text(objective)
+
+        # Save updated metadata.
+        self.save_metadata(agent)
+
+        # Create new task record for the new assignment.
+        if self._layout == "swarm":
+            self._task_file_store.create(
+                objective=objective,
+                assignee=agent.id,
+                created_by=agent.metadata.parent_id,
+                kind="work",
+                title=title,
+            )
 

--- a/packages/bees/hivetool/src/data/ticket-store.ts
+++ b/packages/bees/hivetool/src/data/ticket-store.ts
@@ -72,6 +72,11 @@ class TicketStore {
   #observer: { disconnect(): void } | null = null;
   #activated = false;
 
+  /** Cached tasks indexed by assignee agent ID. */
+  readonly #tasksByAssignee = new Signal.State<Map<string, TaskItemData[]>>(
+    new Map(),
+  );
+
   /** Activate the store — resolves entity directories, scans, observes.
    *
    * Tries `agents/` first (Project Swarm layout). Falls back to
@@ -210,6 +215,9 @@ class TicketStore {
       }
     }
 
+    // Cache task data for getTasksForAgent().
+    this.#tasksByAssignee.set(tasksByAssignee);
+
     const entries: TicketData[] = [];
 
     for await (const [name, entry] of (
@@ -276,6 +284,16 @@ class TicketStore {
     }
 
     return entries;
+  }
+
+  /**
+   * Get task records assigned to a given agent.
+   *
+   * Returns tasks from the cached `tasks/` scan. The data refreshes
+   * on every `scan()` cycle, so it stays current with disk changes.
+   */
+  getTasksForAgent(agentId: string): TaskItemData[] {
+    return this.#tasksByAssignee.get().get(agentId) ?? [];
   }
 
   selectTicket(id: string | null): void {

--- a/packages/bees/hivetool/src/ui/ticket-detail.ts
+++ b/packages/bees/hivetool/src/ui/ticket-detail.ts
@@ -18,6 +18,7 @@ import { LitElement, html, css, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 
 import type { TicketStore, FileTreeNode } from "../data/ticket-store.js";
+import type { TaskItemData } from "../data/types.js";
 import type { MutationClient } from "../data/mutation-client.js";
 import { SessionStoreReader, type SessionLineageInfo } from "../data/session-store-reader.js";
 import type { StateAccess } from "../data/state-access.js";
@@ -35,6 +36,53 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
     sharedStyles,
     jsonTreeStyles,
     css`
+      /* ── Task queue ── */
+      .task-queue-item {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 8px 12px;
+        border: 1px solid #1e293b;
+        border-radius: 6px;
+        margin-bottom: 6px;
+        background: #0a0f1a;
+      }
+
+      .task-queue-status {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        flex-shrink: 0;
+      }
+
+      .task-queue-status.available { background: #475569; }
+      .task-queue-status.in_progress { background: #3b82f6; }
+      .task-queue-status.completed { background: #22c55e; }
+      .task-queue-status.failed { background: #ef4444; }
+      .task-queue-status.cancelled { background: #64748b; }
+
+      .task-queue-body {
+        flex: 1;
+        min-width: 0;
+      }
+
+      .task-queue-title {
+        font-size: 0.8rem;
+        color: #e2e8f0;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .task-queue-outcome {
+        font-size: 0.7rem;
+        color: #94a3b8;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        margin-top: 2px;
+      }
+
       /* ── File tree ── */
       .file-tree {
         font-family: "Google Mono", "Roboto Mono", monospace;
@@ -342,6 +390,7 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
               </div>
             `
           : nothing}
+        ${this.renderTaskQueue(ticket.id)}
         ${ticket.error
           ? html`
               <div class="block error">
@@ -442,6 +491,44 @@ class BeesTicketDetail extends SignalWatcher(LitElement) {
             `
           : nothing}
         ${this.renderFileTree(ticket.id)}
+      </div>
+    `;
+  }
+
+  // --- Task Queue ---
+
+  /**
+   * Render the task queue for an agent — the work items from `tasks/`
+   * assigned to this entity. For Phase 3 (finite agents), this is
+   * typically one task; the structure supports multiple for Phase 4.
+   */
+  private renderTaskQueue(ticketId: string) {
+    if (!this.ticketStore) return nothing;
+    const tasks = this.ticketStore.getTasksForAgent(ticketId);
+    if (tasks.length === 0) return nothing;
+
+    return html`
+      <div class="block">
+        <div class="block-header">Tasks (${tasks.length})</div>
+        <div class="block-content">
+          ${tasks.map((task) => this.renderTaskQueueItem(task))}
+        </div>
+      </div>
+    `;
+  }
+
+  private renderTaskQueueItem(task: TaskItemData) {
+    return html`
+      <div class="task-queue-item">
+        <span class="task-queue-status ${task.status ?? "available"}"></span>
+        <div class="task-queue-body">
+          <div class="task-queue-title">
+            ${task.title ?? task.objective?.slice(0, 80) ?? task.id.slice(0, 8)}
+          </div>
+          ${task.outcome
+            ? html`<div class="task-queue-outcome">${task.outcome}</div>`
+            : nothing}
+        </div>
       </div>
     `;
   }

--- a/packages/bees/hivetool/src/ui/ticket-list.ts
+++ b/packages/bees/hivetool/src/ui/ticket-list.ts
@@ -143,7 +143,7 @@ class BeesTicketList extends SignalWatcher(LitElement) {
         @click=${() => this.handleSelect(t.id)}
       >
         <div class="job-header">
-          <div class="job-title">${t.title || t.id.slice(0, 8)}</div>
+          <div class="job-title">${this.displayName(t)}</div>
           <div class="job-status ${t.status}"></div>
         </div>
         <div class="job-meta">
@@ -204,6 +204,24 @@ class BeesTicketList extends SignalWatcher(LitElement) {
     this.dispatchEvent(
       new CustomEvent("select", { detail: { id }, bubbles: true })
     );
+  }
+
+  /**
+   * Pick the best display name for an entity.
+   *
+   * Priority: slug tail → title → truncated UUID.
+   * The slug is what the parent uses via `agents_*` — making it
+   * visible confirms the named-agent model works.
+   */
+  private displayName(t: TicketData): string {
+    if (t.slug) {
+      // Show just the tail segment for nested slugs.
+      const tail = t.slug.includes("/")
+        ? t.slug.split("/").pop()!
+        : t.slug;
+      return tail;
+    }
+    return t.title || t.id.slice(0, 8);
   }
 }
 

--- a/packages/bees/tests/test_agents.py
+++ b/packages/bees/tests/test_agents.py
@@ -1,0 +1,614 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the agents function group."""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from bees.functions.agents import _make_handlers
+from bees.subagent_scope import SubagentScope
+from bees.unified_agent_store import UnifiedAgentStore
+
+
+GLOBAL_STORE: UnifiedAgentStore | None = None
+
+
+@pytest.fixture(autouse=True)
+def _temp_dirs(tmp_path):
+    """Set up a fresh swarm-layout store with config directory."""
+    global GLOBAL_STORE
+    # Don't create tickets/ — force swarm layout.
+    GLOBAL_STORE = UnifiedAgentStore(tmp_path)
+
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    hooks_dir = config_dir / "hooks"
+    hooks_dir.mkdir()
+
+    yield tmp_path
+
+
+@pytest.fixture
+def write_template(tmp_path):
+    """Helper to write template entries to the temp TEMPLATES.yaml."""
+    templates_path = tmp_path / "config" / "TEMPLATES.yaml"
+
+    def _write(*templates: dict) -> Path:
+        templates_path.write_text(
+            yaml.dump(list(templates), default_flow_style=False)
+        )
+        return templates_path
+
+    return _write
+
+
+def _scheduler_mock():
+    """Create a mock scheduler with the global store."""
+    mock = MagicMock()
+    mock.store = GLOBAL_STORE
+    mock.cancel_task = MagicMock(return_value=True)
+    mock.deliver_to_task = MagicMock(return_value=None)
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# agents_list_types
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agents_list_types_scoped(write_template):
+    write_template(
+        {
+            "name": "researcher",
+            "title": "Researcher",
+            "description": "Research agent",
+            "objective": "Research things.",
+        },
+        {
+            "name": "writer",
+            "title": "Writer",
+            "description": "Writing agent",
+            "objective": "Write things.",
+        },
+    )
+
+    caller = GLOBAL_STORE.create("I'm the caller")
+    caller.metadata.tasks = ["researcher"]  # Only researcher allowed
+    GLOBAL_STORE.save_metadata(caller)
+
+    scope = SubagentScope(workspace_root_id=caller.id)
+    scheduler = _scheduler_mock()
+    handlers = _make_handlers(
+        scope=scope, caller_agent_id=caller.id, scheduler=scheduler,
+    )
+
+    result = await handlers["agents_list_types"]({}, None)
+
+    assert "agent_types" in result
+    assert len(result["agent_types"]) == 1
+    assert result["agent_types"][0]["name"] == "researcher"
+
+
+# ---------------------------------------------------------------------------
+# agents_assign_task — implicit creation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agents_assign_task_creates_new_agent(write_template):
+    write_template({
+        "name": "writer",
+        "title": "Writer",
+        "objective": "Write things.",
+        "functions": ["files.*", "system.*"],
+    })
+
+    caller = GLOBAL_STORE.create("I'm the orchestrator")
+    caller.metadata.tasks = ["writer"]
+    GLOBAL_STORE.save_metadata(caller)
+
+    scope = SubagentScope(workspace_root_id=caller.id)
+    scheduler = _scheduler_mock()
+    handlers = _make_handlers(
+        scope=scope, caller_agent_id=caller.id, scheduler=scheduler,
+    )
+
+    result = await handlers["agents_assign_task"]({
+        "type": "writer",
+        "slug": "poet",
+        "objective": "Write a haiku about bees",
+        "summary": "Haiku Writer",
+    }, None)
+
+    assert result["agent_slug"] == "poet"
+    assert result["status"] == "created"
+
+    # Verify the child agent was created.
+    child = GLOBAL_STORE.find_child_by_slug(caller.id, "poet")
+    assert child is not None
+    assert child.metadata.parent_id == caller.id
+    assert child.metadata.type == "writer"
+    assert child.metadata.title == "Haiku Writer"
+    assert child.metadata.context == "Write a haiku about bees"
+
+
+@pytest.mark.asyncio
+async def test_agents_assign_task_missing_required_fields(write_template):
+    write_template({
+        "name": "writer",
+        "title": "Writer",
+        "objective": "Write things.",
+    })
+
+    caller = GLOBAL_STORE.create("I'm the orchestrator")
+    scheduler = _scheduler_mock()
+    handlers = _make_handlers(
+        caller_agent_id=caller.id, scheduler=scheduler,
+    )
+
+    # Missing slug
+    result = await handlers["agents_assign_task"]({
+        "type": "writer",
+        "objective": "Write a haiku",
+        "summary": "Haiku Writer",
+    }, None)
+    assert "error" in result
+
+    # Missing objective
+    result = await handlers["agents_assign_task"]({
+        "type": "writer",
+        "slug": "poet",
+        "summary": "Haiku Writer",
+    }, None)
+    assert "error" in result
+
+
+@pytest.mark.asyncio
+async def test_agents_assign_task_invalid_type(write_template):
+    write_template({
+        "name": "writer",
+        "title": "Writer",
+        "objective": "Write things.",
+    })
+
+    caller = GLOBAL_STORE.create("I'm the orchestrator")
+    caller.metadata.tasks = ["writer"]
+    GLOBAL_STORE.save_metadata(caller)
+
+    scope = SubagentScope(workspace_root_id=caller.id)
+    scheduler = _scheduler_mock()
+    handlers = _make_handlers(
+        scope=scope, caller_agent_id=caller.id, scheduler=scheduler,
+    )
+
+    result = await handlers["agents_assign_task"]({
+        "type": "nonexistent",
+        "slug": "poet",
+        "objective": "Write a haiku",
+        "summary": "Haiku Writer",
+    }, None)
+
+    assert "error" in result
+    assert "not found" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# agents_assign_task — fresh instance (terminal slug reuse)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agents_assign_task_fresh_instance(write_template):
+    """A terminal agent with the same slug gets reset for reuse."""
+    write_template({
+        "name": "writer",
+        "title": "Writer",
+        "objective": "Write things.",
+        "functions": ["files.*", "system.*"],
+    })
+
+    caller = GLOBAL_STORE.create("I'm the orchestrator")
+    caller.metadata.tasks = ["writer"]
+    GLOBAL_STORE.save_metadata(caller)
+
+    scope = SubagentScope(workspace_root_id=caller.id)
+    scheduler = _scheduler_mock()
+    handlers = _make_handlers(
+        scope=scope, caller_agent_id=caller.id, scheduler=scheduler,
+    )
+
+    # First assignment — creates the agent.
+    result1 = await handlers["agents_assign_task"]({
+        "type": "writer",
+        "slug": "poet",
+        "objective": "Write haiku #1",
+        "summary": "First Haiku",
+    }, None)
+    assert result1["status"] == "created"
+
+    # Mark the agent as completed (simulating scheduler behavior).
+    child = GLOBAL_STORE.find_child_by_slug(caller.id, "poet")
+    assert child is not None
+    original_id = child.id
+    child.metadata.status = "completed"
+    child.metadata.outcome = "Done with haiku #1"
+    GLOBAL_STORE.save_metadata(child)
+
+    # Second assignment to the same slug — should reuse.
+    result2 = await handlers["agents_assign_task"]({
+        "type": "writer",
+        "slug": "poet",
+        "objective": "Write haiku #2",
+        "summary": "Second Haiku",
+    }, None)
+    assert result2["status"] == "reused"
+    assert result2["agent_slug"] == "poet"
+
+    # Same UUID — slug→UUID mapping is stable.
+    reused = GLOBAL_STORE.find_child_by_slug(caller.id, "poet")
+    assert reused is not None
+    assert reused.id == original_id
+    assert reused.metadata.status == "available"
+    assert "Write haiku #2" in reused.objective  # reset_for_reuse writes to objective
+
+
+# ---------------------------------------------------------------------------
+# agents_assign_task — busy agent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agents_assign_task_busy_agent(write_template):
+    """A non-terminal agent returns an error (queuing deferred to Phase 4)."""
+    write_template({
+        "name": "writer",
+        "title": "Writer",
+        "objective": "Write things.",
+        "functions": ["files.*", "system.*"],
+    })
+
+    caller = GLOBAL_STORE.create("I'm the orchestrator")
+    caller.metadata.tasks = ["writer"]
+    GLOBAL_STORE.save_metadata(caller)
+
+    scope = SubagentScope(workspace_root_id=caller.id)
+    scheduler = _scheduler_mock()
+    handlers = _make_handlers(
+        scope=scope, caller_agent_id=caller.id, scheduler=scheduler,
+    )
+
+    # Create agent.
+    await handlers["agents_assign_task"]({
+        "type": "writer",
+        "slug": "poet",
+        "objective": "Write haiku #1",
+        "summary": "First Haiku",
+    }, None)
+
+    # Mark as running (not terminal).
+    child = GLOBAL_STORE.find_child_by_slug(caller.id, "poet")
+    child.metadata.status = "running"
+    GLOBAL_STORE.save_metadata(child)
+
+    # Try to assign again — should get error.
+    result = await handlers["agents_assign_task"]({
+        "type": "writer",
+        "slug": "poet",
+        "objective": "Write haiku #2",
+        "summary": "Second Haiku",
+    }, None)
+
+    assert "error" in result
+    assert "busy" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# agents_check_status
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agents_check_status_by_slug():
+    """Status tree uses slug-based naming."""
+    parent = GLOBAL_STORE.create("Parent objective")
+
+    child = GLOBAL_STORE.create("Child objective")
+    child.metadata.parent_id = parent.id
+    child.metadata.slug = "researcher"
+    child.metadata.type = "researcher"
+    child.metadata.status = "running"
+    GLOBAL_STORE.save_metadata(child)
+
+    scheduler = _scheduler_mock()
+    handlers = _make_handlers(
+        caller_agent_id=parent.id, scheduler=scheduler,
+    )
+
+    result = await handlers["agents_check_status"]({}, None)
+
+    assert "agents" in result
+    agents = result["agents"]
+    assert len(agents) == 1
+    assert agents[0]["agent_slug"] == "researcher"
+    assert agents[0]["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_agents_check_status_empty():
+    parent = GLOBAL_STORE.create("Parent objective")
+
+    scheduler = _scheduler_mock()
+    handlers = _make_handlers(
+        caller_agent_id=parent.id, scheduler=scheduler,
+    )
+
+    result = await handlers["agents_check_status"]({}, None)
+    assert result["message"] == "There are no agents."
+
+
+@pytest.mark.asyncio
+async def test_agents_check_status_nested_tree():
+    """Nested children appear in the tree."""
+    root = GLOBAL_STORE.create("Root")
+
+    child = GLOBAL_STORE.create("Child")
+    child.metadata.parent_id = root.id
+    child.metadata.slug = "orchestrator"
+    child.metadata.type = "orchestrator"
+    child.metadata.status = "suspended"
+    GLOBAL_STORE.save_metadata(child)
+
+    grandchild = GLOBAL_STORE.create("Grandchild")
+    grandchild.metadata.parent_id = child.id
+    grandchild.metadata.slug = "orchestrator/worker"
+    grandchild.metadata.type = "worker"
+    grandchild.metadata.status = "completed"
+    grandchild.metadata.outcome = "Done!"
+    GLOBAL_STORE.save_metadata(grandchild)
+
+    scheduler = _scheduler_mock()
+    handlers = _make_handlers(
+        caller_agent_id=root.id, scheduler=scheduler,
+    )
+
+    result = await handlers["agents_check_status"]({}, None)
+
+    assert len(result["agents"]) == 1
+    orch = result["agents"][0]
+    assert orch["agent_slug"] == "orchestrator"
+    assert "agents" in orch
+    assert len(orch["agents"]) == 1
+    assert orch["agents"][0]["agent_slug"] == "worker"
+    assert orch["agents"][0]["outcome"] == "Done!"
+
+
+# ---------------------------------------------------------------------------
+# agents_send_event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agents_send_event_by_slug():
+    parent = GLOBAL_STORE.create("Parent")
+
+    child = GLOBAL_STORE.create("Child")
+    child.metadata.parent_id = parent.id
+    child.metadata.slug = "researcher"
+    child.metadata.status = "suspended"
+    GLOBAL_STORE.save_metadata(child)
+
+    scheduler = _scheduler_mock()
+    scope = SubagentScope(workspace_root_id=parent.id)
+    handlers = _make_handlers(
+        scope=scope, caller_agent_id=parent.id, scheduler=scheduler,
+    )
+
+    result = await handlers["agents_send_event"]({
+        "slug": "researcher",
+        "type": "clarification",
+        "message": "Please focus on pricing",
+    }, None)
+
+    assert result["delivered"] is True
+    assert result["agent_slug"] == "researcher"
+    scheduler.deliver_to_task.assert_called_once()
+    call_args = scheduler.deliver_to_task.call_args
+    assert call_args[0][0] == child.id
+
+
+@pytest.mark.asyncio
+async def test_agents_send_event_not_found():
+    parent = GLOBAL_STORE.create("Parent")
+
+    scheduler = _scheduler_mock()
+    handlers = _make_handlers(
+        caller_agent_id=parent.id, scheduler=scheduler,
+    )
+
+    result = await handlers["agents_send_event"]({
+        "slug": "nonexistent",
+        "type": "clarification",
+        "message": "Hello",
+    }, None)
+
+    assert "error" in result
+    assert "not found" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# agents_cancel
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agents_cancel_by_slug():
+    parent = GLOBAL_STORE.create("Parent")
+
+    child = GLOBAL_STORE.create("Child")
+    child.metadata.parent_id = parent.id
+    child.metadata.slug = "researcher"
+    child.metadata.status = "running"
+    GLOBAL_STORE.save_metadata(child)
+
+    scheduler = _scheduler_mock()
+    handlers = _make_handlers(
+        caller_agent_id=parent.id, scheduler=scheduler,
+    )
+
+    result = await handlers["agents_cancel"]({
+        "slug": "researcher",
+    }, None)
+
+    assert result["cancelled"] is True
+    assert result["agent_slug"] == "researcher"
+    scheduler.cancel_task.assert_called_once_with(child.id)
+
+
+@pytest.mark.asyncio
+async def test_agents_cancel_not_found():
+    parent = GLOBAL_STORE.create("Parent")
+
+    scheduler = _scheduler_mock()
+    handlers = _make_handlers(
+        caller_agent_id=parent.id, scheduler=scheduler,
+    )
+
+    result = await handlers["agents_cancel"]({
+        "slug": "nonexistent",
+    }, None)
+
+    assert "error" in result
+    assert "not found" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# agents_await
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agents_await_with_pending_updates():
+    """agents_await returns immediately when context updates are buffered."""
+    from bees.protocols.handler_types import CONTEXT_PARTS_KEY
+
+    caller = GLOBAL_STORE.create("I'm the caller")
+    caller.metadata.pending_context_updates = [
+        {"type": "task_completed", "message": "Agent done"},
+    ]
+    GLOBAL_STORE.save_metadata(caller)
+
+    scheduler = _scheduler_mock()
+    handlers = _make_handlers(
+        caller_agent_id=caller.id, scheduler=scheduler,
+    )
+
+    result = await handlers["agents_await"]({}, None)
+
+    assert result["resumed"] is True
+    assert CONTEXT_PARTS_KEY in result
+
+    fresh = GLOBAL_STORE.get(caller.id)
+    assert fresh.metadata.pending_context_updates == []
+
+
+@pytest.mark.asyncio
+async def test_agents_await_suspends_when_no_updates():
+    """agents_await raises SuspendError when no updates are pending."""
+    from bees.protocols.handler_types import SuspendError
+
+    caller = GLOBAL_STORE.create("I'm the caller")
+    caller.metadata.pending_context_updates = []
+    GLOBAL_STORE.save_metadata(caller)
+
+    scheduler = _scheduler_mock()
+    handlers = _make_handlers(
+        caller_agent_id=caller.id, scheduler=scheduler,
+    )
+
+    with pytest.raises(SuspendError) as exc_info:
+        await handlers["agents_await"]({}, None)
+
+    fc = exc_info.value.function_call_part
+    assert fc["functionCall"]["name"] == "agents_await"
+
+
+# ---------------------------------------------------------------------------
+# UnifiedAgentStore — find_child_by_slug / reset_for_reuse
+# ---------------------------------------------------------------------------
+
+
+def test_find_child_by_slug():
+    parent = GLOBAL_STORE.create("Parent")
+
+    child = GLOBAL_STORE.create("Child")
+    child.metadata.parent_id = parent.id
+    child.metadata.slug = "researcher"
+    GLOBAL_STORE.save_metadata(child)
+
+    found = GLOBAL_STORE.find_child_by_slug(parent.id, "researcher")
+    assert found is not None
+    assert found.id == child.id
+
+
+def test_find_child_by_slug_not_found():
+    parent = GLOBAL_STORE.create("Parent")
+    found = GLOBAL_STORE.find_child_by_slug(parent.id, "nonexistent")
+    assert found is None
+
+
+def test_find_child_by_slug_nested_path():
+    """Slug stored as 'app/tests' should match tail segment 'tests'."""
+    parent = GLOBAL_STORE.create("Parent")
+
+    child = GLOBAL_STORE.create("Child")
+    child.metadata.parent_id = parent.id
+    child.metadata.slug = "app/tests"
+    GLOBAL_STORE.save_metadata(child)
+
+    found = GLOBAL_STORE.find_child_by_slug(parent.id, "tests")
+    assert found is not None
+    assert found.id == child.id
+
+
+def test_reset_for_reuse():
+    parent = GLOBAL_STORE.create("Parent")
+
+    child = GLOBAL_STORE.create("Child objective #1")
+    child.metadata.parent_id = parent.id
+    child.metadata.slug = "poet"
+    child.metadata.status = "completed"
+    child.metadata.outcome = "Old outcome"
+    child.metadata.turns = 5
+    GLOBAL_STORE.save_metadata(child)
+
+    original_session = child.metadata.active_session
+
+    GLOBAL_STORE.reset_for_reuse(
+        child,
+        "New objective #2",
+        title="New Title",
+    )
+
+    # Verify reset.
+    assert child.metadata.status == "available"
+    assert child.metadata.outcome is None
+    assert child.metadata.error is None
+    assert child.metadata.turns == 0
+    assert child.metadata.active_session != original_session
+    assert child.objective == "New objective #2"
+    assert child.metadata.title == "New Title"
+
+
+def test_reset_for_reuse_rejects_non_terminal():
+    child = GLOBAL_STORE.create("Child")
+    child.metadata.status = "running"
+    GLOBAL_STORE.save_metadata(child)
+
+    with pytest.raises(ValueError, match="not terminal"):
+        GLOBAL_STORE.reset_for_reuse(child, "New objective")

--- a/projects/swarm/PROJECT.md
+++ b/projects/swarm/PROJECT.md
@@ -784,18 +784,20 @@ on demand. Hivetool displays the agent→task hierarchy.
 
 ### Python Changes
 
-- [ ] **[NEW] `functions/agents.py`** — New function group implementing:
+- [x] **[NEW] `functions/agents.py`** — New function group implementing:
       `agents_list_types`, `agents_assign_task` (with implicit creation),
       `agents_check_status`, `agents_send_event`, `agents_cancel`,
       `agents_await`.
-- [ ] **[NEW] `declarations/agents.functions.json`** — Function declarations.
+- [x] **[NEW] `declarations/agents.functions.json`** — Function declarations.
       `agents_assign_task` takes `type`, `slug`, `objective`, and optional
       `options`. Slug is required.
-- [ ] **[NEW] `declarations/agents.instruction.md`** — LLM instructions
+- [x] **[NEW] `declarations/agents.instruction.md`** — LLM instructions
       explaining the implicit creation model: "assign tasks, agents appear."
-- [ ] **[MODIFY] `provisioner.py`** — Wire `agents_*` function group.
+- [x] **[MODIFY] `provisioner.py`** — Wire `agents_*` function group.
+- [x] **[MODIFY] `unified_agent_store.py`** — Added `find_child_by_slug()`
+      and `reset_for_reuse()` for slug resolution and fresh-instance reuse.
 - [ ] **[DEPRECATE] `functions/tasks.py`** — Keep for backward compat but route
-      through agents internally.
+      through agents internally. (Deferred to Phase 6 — both groups coexist.)
 
 **Function group coexistence rule:** The template's `functions` list in
 TEMPLATES.yaml controls which function set is active for each agent type.
@@ -807,19 +809,36 @@ the agent uses `tasks.*` or `agents.*`.
 
 ### Hivetool Changes
 
-- [ ] **[MODIFY] `ticket-list.ts`** — Show agents by slug in sidebar. Agents as
+- [x] **[MODIFY] `ticket-list.ts`** — Show agents by slug in sidebar. Agents as
       primary items, tasks nested or shown as status indicators.
-- [ ] **[MODIFY] `ticket-detail.ts`** — Agent detail view: show the agent's task
+- [x] **[MODIFY] `ticket-detail.ts`** — Agent detail view: show the agent's task
       queue alongside session, workspace, and surface.
+- [x] **[MODIFY] `ticket-store.ts`** — Cached `tasksByAssignee` signal and
+      `getTasksForAgent()` method for task queue display.
 
 ### Verification
 
-- [ ] Unit tests for each `agents_*` handler, including implicit creation (new
+- [x] Unit tests for each `agents_*` handler, including implicit creation (new
       slug), reuse (existing slug, non-terminal), and fresh instance (existing
-      slug, terminal).
-- [ ] Integration test: parent assigns task → agent appears → check status.
+      slug, terminal). (20 tests in `tests/test_agents.py`)
+- [x] Integration test: parent assigns task → agent appears → check status.
+      (Verified via `swarm-test` hive with `agents.*` functions.)
 - [ ] Integration test: parent assigns two tasks to same slug → both complete.
-- [ ] Hivetool: agent visible by slug with task in sidebar.
+      (Deferred — requires agent with multi-task objective.)
+- [x] Hivetool: agent visible by slug with task in sidebar.
+
+### Adjustments Made
+
+- **`summary` field retained**: LLM testing showed the model prefers `summary`
+  over `title` for the human-readable task label. Kept as a required field in
+  `agents_assign_task`.
+- **Stale suspend artifact cleanup**: Found and fixed a pre-existing bug where
+  `interaction.json` and `resume_id` files persisted in the session directory
+  after a successful resume, causing hivetool to show phantom "Suspended On"
+  indicators. Fix applied in `task_runner.py` `resume_task()`.
+- **Task queuing for busy agents**: Deferred to Phase 4. In Phase 3,
+  `agents_assign_task` returns an error if the target agent is non-terminal
+  (busy). Phase 4 adds infinite agent support with proper queueing.
 
 ---
 


### PR DESCRIPTION
## What

Adds the `agents_*` LLM-facing function group for slug-based agent orchestration with implicit creation. A parent agent assigns tasks by `(type, slug)` and the system materializes agents on demand — no explicit creation step.

## Why

Phase 3 of Project Swarm. The existing `tasks_*` API exposes raw UUIDs and requires the parent to track task IDs. The `agents_*` group replaces this with human-readable slug addressing, making agent hierarchies legible to both the LLM and hivetool operators.

## Changes

### Python — `agents_*` handlers
- **New** `functions/agents.py` — six handlers: `agents_list_types`, `agents_assign_task` (implicit creation + fresh-instance reuse for terminal agents), `agents_check_status` (slug-based tree), `agents_send_event`, `agents_cancel`, `agents_await`
- **New** declaration files (`agents.functions.json`, `agents.instruction.md`, `agents.metadata.json`)
- **Modified** `unified_agent_store.py` — `find_child_by_slug()` for slug resolution, `reset_for_reuse()` for terminal agent recycling
- **Modified** `provisioner.py` — wire agents function group factory alongside tasks

### Bug fix — stale suspend artifacts
- **Modified** `task_runner.py` — clean up `interaction.json` and `resume_id` from the session directory after a successful resume. Previously these files persisted after completion, causing hivetool to show a phantom "Suspended On" indicator.

### Hivetool
- **Modified** `ticket-list.ts` — sidebar shows slug as primary name (slug → title → UUID)
- **Modified** `ticket-detail.ts` — task queue section with status dots and outcomes
- **Modified** `ticket-store.ts` — cached `tasksByAssignee` signal, `getTasksForAgent()` method

### Config & docs
- **Modified** `swarm-test/TEMPLATES.yaml` — orchestrator switched from `tasks.*` to `agents.*`
- **Modified** `PROJECT.md` — Phase 3 marked complete with adjustments noted

## Testing

- 20 new unit tests in `tests/test_agents.py` — all passing
- 85 existing tests (test_tasks, test_scheduler, test_playbook) — no regressions
- End-to-end verified: `swarm-test` hive with orchestrator using `agents.*` to assign a task to a writer agent by slug `"poet"`. Full lifecycle completed in 8 seconds (4 orchestrator turns + 2 writer turns)
