### PR TITLE
[bees] Task-aware rollback for multi-task agents (Swarm Phase 5)

### DIFF
--- a/packages/bees/bees/functions/events.py
+++ b/packages/bees/bees/functions/events.py
@@ -11,6 +11,7 @@ so agents can communicate mid-session.
 
 from __future__ import annotations
 
+import json
 import logging
 import uuid
 from pathlib import Path
@@ -44,6 +45,53 @@ _DECLARATIONS_DIR = Path(__file__).resolve().parent.parent / "declarations"
 # Load declarations once at module level.
 _LOADED = load_declarations("events", declarations_dir=_DECLARATIONS_DIR)
 
+
+def _record_task_completion(
+    agent_id: str,
+    scheduler: Any,
+    task: Any,
+) -> None:
+    """Append a task completion record to the session's tracking file.
+
+    Records ``{task_id, turn, completed_at}`` in
+    ``task_completions.json`` inside the session directory.  This is
+    read by the rollback handler to identify tasks completed after a
+    fork point so they can be re-queued.
+
+    Best-effort — failures are logged but don't block the yield.
+    """
+    try:
+        agent = scheduler.store.get(agent_id)
+        if not agent or not agent.metadata.active_session:
+            return
+
+        session_dir = (
+            agent.dir / "sessions" / agent.metadata.active_session
+        )
+        if not session_dir.exists():
+            return
+
+        completions_file = session_dir / "task_completions.json"
+        completions: list[dict[str, Any]] = []
+        if completions_file.exists():
+            completions = json.loads(
+                completions_file.read_text(encoding="utf-8")
+            )
+
+        completions.append({
+            "task_id": task.id,
+            "turn": agent.metadata.turns or 0,
+            "completed_at": task.completed_at,
+        })
+
+        completions_file.write_text(
+            json.dumps(completions, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to record task completion for rollback: %s", exc,
+        )
 
 def _make_handlers(
     *,
@@ -181,6 +229,14 @@ def _make_handlers(
                 logger.info(
                     "events_yield: task %s completed for agent %s",
                     active_task.id[:8], agent_id[:8],
+                )
+
+                # 2b. Record completion for rollback correlation.
+                # Written to task_completions.json in the session dir
+                # so rollback can identify tasks completed after the
+                # fork point and re-queue them.
+                _record_task_completion(
+                    agent_id, scheduler, active_task,
                 )
 
         # 3. Deliver completion update to parent.

--- a/packages/bees/bees/mutations.py
+++ b/packages/bees/bees/mutations.py
@@ -790,7 +790,78 @@ class MutationManager:
         except Exception as e:
             logger.warning("Failed to clean up child tasks during rollback: %s", e)
 
-        return {}
+        # 14. Re-queue tasks completed after the fork point.
+        # Read task_completions.json from the source session to find
+        # which tasks were completed at which turns. Tasks completed
+        # after turn_index revert to available; pre-fork completions
+        # are copied to the new session.
+        requeued_tasks: list[str] = []
+        try:
+            completions_file = sdir / "task_completions.json"
+            if completions_file.exists():
+                completions = json.loads(
+                    completions_file.read_text(encoding="utf-8")
+                )
+
+                pre_fork: list[dict[str, Any]] = []
+                for entry in completions:
+                    if entry.get("turn", 0) > turn_index:
+                        # Revert this task to available.
+                        task_record = store._task_file_store.get(
+                            entry["task_id"]
+                        )
+                        if task_record and task_record.status == "completed":
+                            task_record.status = "available"
+                            task_record.outcome = None
+                            task_record.outcome_content = None
+                            task_record.completed_at = None
+                            store._task_file_store.save(task_record)
+                            requeued_tasks.append(entry["task_id"])
+                            logger.info(
+                                "Re-queued task %s (completed at turn %d)",
+                                entry["task_id"][:8],
+                                entry.get("turn", -1),
+                            )
+                    else:
+                        pre_fork.append(entry)
+
+                # Copy pre-fork completions to the new session.
+                if pre_fork:
+                    new_completions_file = new_sdir / "task_completions.json"
+                    new_completions_file.write_text(
+                        json.dumps(
+                            pre_fork, indent=2, ensure_ascii=False
+                        ) + "\n",
+                        encoding="utf-8",
+                    )
+        except Exception as e:
+            logger.warning("Failed to re-queue tasks during rollback: %s", e)
+
+        # 15. Buffer re-queued tasks as pending context updates so the
+        # agent receives them on resume — mirrors how agents_assign_task
+        # delivers tasks via scheduler.deliver_to_task.
+        if requeued_tasks and store.layout == "swarm":
+            pending = agent.metadata.pending_context_updates or []
+            for task_id in requeued_tasks:
+                task_record = store._task_file_store.get(task_id)
+                if task_record:
+                    pending.append({
+                        "type": "task_assigned",
+                        "objective": task_record.objective,
+                    })
+            agent.metadata.pending_context_updates = pending
+            store.save_metadata(agent)
+
+        result: dict[str, Any] = {}
+        if requeued_tasks:
+            result["requeued_tasks"] = requeued_tasks
+            logger.info(
+                "Rollback re-queued %d task(s): %s",
+                len(requeued_tasks),
+                ", ".join(tid[:8] for tid in requeued_tasks),
+            )
+        return result
+
 
     # -- Utilities ---------------------------------------------------------
 

--- a/packages/bees/hivetool/src/data/session-store-reader.ts
+++ b/packages/bees/hivetool/src/data/session-store-reader.ts
@@ -9,13 +9,19 @@ import type { StateAccess } from "./state-access.js";
 import type { SessionSegment, TurnGroup, LogTurnTokenMetadata, LogConfig, LogPart } from "./types.js";
 
 export { SessionStoreReader, compileEventsToSegment };
-export type { SessionLineageInfo, TurnCheckpointInfo };
+export type { SessionLineageInfo, TurnCheckpointInfo, TaskCompletionInfo };
 
 interface TurnCheckpointInfo {
   turn: number;
   context_length: number;
   file_system: Record<string, unknown> | null;
   token_metadata: Record<string, unknown> | null;
+}
+
+interface TaskCompletionInfo {
+  task_id: string;
+  turn: number;
+  completed_at: string;
 }
 
 interface SessionLineageInfo {
@@ -347,6 +353,22 @@ class SessionStoreReader {
       return await this.#readJson(sessionDir, "interaction.json");
     } catch {
       return null;
+    }
+  }
+
+  async readTaskCompletions(ticketId: string, sessionId: string): Promise<TaskCompletionInfo[]> {
+    const entityDir = await this.#getEntityDir(ticketId);
+    if (!entityDir) return [];
+    try {
+      const sessionsDir = await entityDir.getDirectoryHandle("sessions");
+      const sessionDir = await sessionsDir.getDirectoryHandle(sessionId);
+      const data = await this.#readJson(sessionDir, "task_completions.json");
+      if (Array.isArray(data)) {
+        return data as TaskCompletionInfo[];
+      }
+      return [];
+    } catch {
+      return [];
     }
   }
 

--- a/packages/bees/hivetool/src/ui/log-detail.ts
+++ b/packages/bees/hivetool/src/ui/log-detail.ts
@@ -21,7 +21,7 @@ import type {
   LogTurnTokenMetadata,
 } from "../data/types.js";
 import { SessionStoreReader, compileEventsToSegment } from "../data/session-store-reader.js";
-import type { TurnCheckpointInfo, SessionLineageInfo } from "../data/session-store-reader.js";
+import type { TurnCheckpointInfo, SessionLineageInfo, TaskCompletionInfo } from "../data/session-store-reader.js";
 import type { StateAccess } from "../data/state-access.js";
 import type { TicketStore } from "../data/ticket-store.js";
 import type { MutationClient } from "../data/mutation-client.js";
@@ -856,9 +856,26 @@ class BeesLogDetail extends SignalWatcher(LitElement) {
     if (!this.mutationClient || !this.ticketId) return;
 
     this.rollbackTurnIndex = turnIndex;
+
+    // Check for tasks that would be re-queued (infinite agents).
+    let requeueMessage = "";
+    if (this.sessionReader && this.activeSessionId) {
+      const completions = await this.sessionReader.readTaskCompletions(
+        this.ticketId, this.activeSessionId
+      );
+      const requeued = completions.filter((c) => c.turn > turnIndex);
+      if (requeued.length > 0) {
+        const taskIds = requeued.map((c) => c.task_id.slice(0, 8));
+        requeueMessage =
+          ` ${requeued.length} completed task${requeued.length > 1 ? "s" : ""}` +
+          ` will be re-queued: ${taskIds.join(", ")}.`;
+      }
+    }
+
     this.confirmMessage =
       `Fork at turn ${turnIndex + 1}? A new session will be created and turns ` +
-      `${turnIndex + 2} onwards will be preserved in the superseded session.`;
+      `${turnIndex + 2} onwards will be preserved in the superseded session.` +
+      requeueMessage;
     this.showConfirmDialog = true;
   }
 

--- a/packages/bees/tests/test_events_yield.py
+++ b/packages/bees/tests/test_events_yield.py
@@ -214,6 +214,49 @@ async def test_events_yield_sets_agent_outcome(tmp_path):
     assert refreshed.metadata.outcome == "Analysis complete"
 
 
+@pytest.mark.asyncio
+async def test_events_yield_records_task_completion(tmp_path):
+    """events_yield writes a task_completions.json entry for rollback."""
+    agent = _make_agent(tmp_path)
+    # Create a session directory so the recording has somewhere to write.
+    session_id = "test-session-111"
+    agent_dir = tmp_path / "agents" / "agent-111"
+    session_dir = agent_dir / "sessions" / session_id
+    session_dir.mkdir(parents=True, exist_ok=True)
+    # Set the agent's active_session and turns metadata.
+    meta = agent.metadata
+    meta.active_session = session_id
+    meta.turns = 3
+    (agent_dir / "metadata.json").write_text(
+        json.dumps(meta.to_dict(), indent=2)
+    )
+
+    store = UnifiedAgentStore(tmp_path)
+    task_file_store, task = _make_in_progress_task(store)
+    scheduler = _mock_scheduler(store)
+
+    handlers = _make_handlers(
+        caller_agent_id="agent-111",
+        scheduler=scheduler,
+        deliver_to_parent=MagicMock(),
+    )
+
+    with pytest.raises(SuspendError):
+        await handlers["events_yield"](
+            {"outcome": "Done"}, None,
+        )
+
+    # Verify task_completions.json was created in the session directory.
+    completions_file = session_dir / "task_completions.json"
+    assert completions_file.exists()
+
+    completions = json.loads(completions_file.read_text())
+    assert len(completions) == 1
+    assert completions[0]["task_id"] == task.id
+    assert completions[0]["turn"] == 3
+    assert completions[0]["completed_at"] is not None
+
+
 # ---------------------------------------------------------------------------
 # events_yield — error cases
 # ---------------------------------------------------------------------------

--- a/packages/bees/tests/test_mutations.py
+++ b/packages/bees/tests/test_mutations.py
@@ -653,6 +653,207 @@ class TestRollbackToTurn:
         # File system workspace should hydrate from session_1's snapshot
         assert (new_sdir / "workspace" / "notes.md").read_text() == "hello from session 1"
 
+    def _create_swarm_agent_for_rollback(
+        self, hive: Path, *, session_id: str = "test-session-999"
+    ) -> tuple[str, Path]:
+        """Helper: create a suspended swarm agent with a session, turns, and interaction."""
+        from bees.agent import AgentMetadata
+        from bees.agent_store import AgentStore
+
+        agent_store = AgentStore(hive)
+        agent = agent_store.create(
+            type="infinite-poet",
+            slug="poet",
+            finite=False,
+            runner="generate",
+        )
+        agent.metadata.status = "suspended"
+        agent.metadata.active_session = session_id
+        agent.metadata.turns = 4
+        agent_store.save_metadata(agent)
+
+        # Write objective for backward compat.
+        (agent.dir / "objective.md").write_text("Write poems")
+
+        sdir = agent.dir / "sessions" / session_id
+        sdir.mkdir(parents=True, exist_ok=True)
+
+        # Minimal interaction state.
+        interaction_data = {
+            "session_id": session_id,
+            "contents": [
+                {"parts": [{"text": f"Turn {i}"}], "role": "user"} for i in range(8)
+            ],
+            "file_system": {"files": {}, "routes": {}, "file_count": 0},
+            "function_call_part": {},
+            "task_tree": {"tree": None},
+            "consents_granted": [],
+            "flags": {},
+            "graph": {},
+            "model": "gemini-2.5-pro",
+            "completed_function_responses": [],
+            "is_precondition_check": False,
+        }
+        (sdir / "interaction.json").write_text(json.dumps(interaction_data))
+
+        # Turn checkpoints.
+        turns_data = [
+            {"turn": i, "context_length": (i + 1) * 2, "file_system": None, "token_metadata": None}
+            for i in range(4)
+        ]
+        (sdir / "turns.json").write_text(json.dumps(turns_data))
+
+        # Events (minimal — one sendRequest per turn).
+        events_lines = [
+            json.dumps({"sendRequest": {"body": {"contents": [{"parts": [{"text": f"Turn {i}"}], "role": "user"}]}}})
+            for i in range(4)
+        ]
+        (sdir / "events.jsonl").write_text("\n".join(events_lines) + "\n")
+
+        return agent.id, sdir
+
+    def test_rollback_requeues_tasks_after_fork_point(self, tmp_path):
+        """Tasks completed after the fork turn revert to available."""
+        from bees.task_file_store import TaskFileStore
+
+        hive = tmp_path
+        (hive / "mutations").mkdir(parents=True, exist_ok=True)
+
+        agent_id, sdir = self._create_swarm_agent_for_rollback(hive)
+
+        # Create three completed tasks via TaskFileStore.
+        task_store = TaskFileStore(hive)
+        task_a = task_store.create(objective="Task A", assignee=agent_id)
+        task_a.status = "completed"
+        task_a.outcome = "Done A"
+        task_a.completed_at = "2026-05-01T00:00:00Z"
+        task_store.save(task_a)
+
+        task_b = task_store.create(objective="Task B", assignee=agent_id)
+        task_b.status = "completed"
+        task_b.outcome = "Done B"
+        task_b.completed_at = "2026-05-02T00:00:00Z"
+        task_store.save(task_b)
+
+        task_c = task_store.create(objective="Task C", assignee=agent_id)
+        task_c.status = "completed"
+        task_c.outcome = "Done C"
+        task_c.completed_at = "2026-05-03T00:00:00Z"
+        task_store.save(task_c)
+
+        # Write task_completions.json: A at turn 1, B at turn 2, C at turn 3.
+        completions = [
+            {"task_id": task_a.id, "turn": 1, "completed_at": task_a.completed_at},
+            {"task_id": task_b.id, "turn": 2, "completed_at": task_b.completed_at},
+            {"task_id": task_c.id, "turn": 3, "completed_at": task_c.completed_at},
+        ]
+        (sdir / "task_completions.json").write_text(json.dumps(completions))
+
+        # Rollback to turn 1 — tasks B and C should be re-queued.
+        _write_mutation(hive, {
+            "type": "rollback-to-turn",
+            "task_id": agent_id,
+            "turn_index": 1,
+        })
+        manager = MutationManager(hive)
+        outcome = asyncio.run(manager.process_inline())
+        assert outcome.hot_processed == 1
+
+        # Task A stays completed (turn 1 <= fork point 1).
+        assert task_store.get(task_a.id).status == "completed"
+        assert task_store.get(task_a.id).outcome == "Done A"
+
+        # Task B reverts to available (turn 2 > fork point 1).
+        reloaded_b = task_store.get(task_b.id)
+        assert reloaded_b.status == "available"
+        assert reloaded_b.outcome is None
+        assert reloaded_b.completed_at is None
+
+        # Task C reverts to available (turn 3 > fork point 1).
+        reloaded_c = task_store.get(task_c.id)
+        assert reloaded_c.status == "available"
+        assert reloaded_c.outcome is None
+
+        # New session should carry only the pre-fork completion (task A).
+        from bees.unified_agent_store import UnifiedAgentStore
+        store = UnifiedAgentStore(hive)
+        agent = store.get(agent_id)
+        new_sdir = agent.dir / "sessions" / agent.metadata.active_session
+        new_completions = json.loads(
+            (new_sdir / "task_completions.json").read_text()
+        )
+        assert len(new_completions) == 1
+        assert new_completions[0]["task_id"] == task_a.id
+
+        # Re-queued tasks should be buffered as pending context updates
+        # so the agent receives them on resume.
+        pending = agent.metadata.pending_context_updates
+        assert pending is not None
+        assert len(pending) == 2
+        objectives = {u["objective"] for u in pending}
+        assert "Task B" in objectives
+        assert "Task C" in objectives
+        assert all(u["type"] == "task_assigned" for u in pending)
+
+    def test_rollback_no_completions_file_is_backward_compat(self, tmp_path):
+        """Rollback works if there's no task_completions.json (legacy/finite agent)."""
+        hive = tmp_path
+        (hive / "mutations").mkdir(parents=True, exist_ok=True)
+
+        agent_id, sdir = self._create_swarm_agent_for_rollback(hive)
+
+        # No task_completions.json — simulate a legacy or finite agent.
+        _write_mutation(hive, {
+            "type": "rollback-to-turn",
+            "task_id": agent_id,
+            "turn_index": 1,
+        })
+        manager = MutationManager(hive)
+        outcome = asyncio.run(manager.process_inline())
+        assert outcome.hot_processed == 1
+
+        # Agent should still be rolled back correctly.
+        from bees.unified_agent_store import UnifiedAgentStore
+        store = UnifiedAgentStore(hive)
+        agent = store.get(agent_id)
+        assert agent.metadata.status == "available"
+        assert agent.metadata.turns == 1
+
+    def test_rollback_all_tasks_before_fork_point(self, tmp_path):
+        """When all completions are before the fork point, nothing is re-queued."""
+        from bees.task_file_store import TaskFileStore
+
+        hive = tmp_path
+        (hive / "mutations").mkdir(parents=True, exist_ok=True)
+
+        agent_id, sdir = self._create_swarm_agent_for_rollback(hive)
+
+        task_store = TaskFileStore(hive)
+        task_a = task_store.create(objective="Task A", assignee=agent_id)
+        task_a.status = "completed"
+        task_a.outcome = "Done A"
+        task_a.completed_at = "2026-05-01T00:00:00Z"
+        task_store.save(task_a)
+
+        completions = [
+            {"task_id": task_a.id, "turn": 1, "completed_at": task_a.completed_at},
+        ]
+        (sdir / "task_completions.json").write_text(json.dumps(completions))
+
+        # Rollback to turn 2 — task A at turn 1 is before fork point.
+        _write_mutation(hive, {
+            "type": "rollback-to-turn",
+            "task_id": agent_id,
+            "turn_index": 2,
+        })
+        manager = MutationManager(hive)
+        outcome = asyncio.run(manager.process_inline())
+        assert outcome.hot_processed == 1
+
+        # Task A stays completed.
+        assert task_store.get(task_a.id).status == "completed"
+        assert task_store.get(task_a.id).outcome == "Done A"
+
 
 # ---------------------------------------------------------------------------
 # Unknown mutations

--- a/projects/swarm/PROJECT.md
+++ b/projects/swarm/PROJECT.md
@@ -948,31 +948,49 @@ rollback confirmation dialog.
 5. The agent resumes from the fork point. Task B is delivered as a new context
    update. The agent works on it again.
 
+### Design Decision
+
+The blueprint proposed extending `TurnCheckpoint` in
+`opal-backend/sessions/store.py` with a `task_completions` field. This was
+rejected because `TurnCheckpoint` is a cross-package protocol shared with the
+unified server — task completion tracking is a bees-specific concern.
+
+Instead, `events_yield` writes to a dedicated **`task_completions.json`** file
+in the session directory (alongside `turns.json` and `events.jsonl`). Format:
+
+```json
+[
+  {"task_id": "uuid", "turn": 2, "completed_at": "2026-05-17T..."},
+  {"task_id": "uuid", "turn": 4, "completed_at": "2026-05-17T..."}
+]
+```
+
 ### Python Changes
 
-- [ ] **[MODIFY] `session.py`** — Add `task_completions` field to turn
-      checkpoints in `turns.json`. Each checkpoint records which task IDs were
-      completed at that turn boundary, enabling rollback to correlate turns with
-      task completion events.
-- [ ] **[MODIFY] `mutations.py`** — Update `rollback-to-turn` handler. After
-      forking the session, use the turn checkpoint's `task_completions` field to
-      identify tasks completed after the fork point. Clear their outcome, revert
-      status to `available`.
+- [x] **[MODIFY] `functions/events.py`** — `events_yield` records task
+      completions via `_record_task_completion()`. After marking a task as
+      completed, appends `{task_id, turn, completed_at}` to
+      `task_completions.json` in the agent's active session directory.
+- [x] **[MODIFY] `mutations.py`** — `_handle_rollback_to_turn` step 14: reads
+      `task_completions.json` from the source session, reverts tasks completed
+      after the fork point to `available`, copies pre-fork completions to the
+      new session.
 
 ### Hivetool Changes
 
-- [ ] **[MODIFY] `log-detail.ts`** — Rollback confirmation dialog shows which
-      tasks will be re-queued: "Tasks B and C will be re-queued."
-- [ ] **[MODIFY] `mutation-client.ts`** — Rollback mutation targets agent ID
-      (not task ID). The handler navigates from agent → session.
+- [x] **[MODIFY] `session-store-reader.ts`** — Added `readTaskCompletions()`
+      method and `TaskCompletionInfo` type.
+- [x] **[MODIFY] `log-detail.ts`** — Rollback confirmation dialog reads task
+      completions and shows which tasks will be re-queued.
 
 ### Verification
 
-- [ ] Unit test: rollback on agent with 3 completed tasks at mid-point.
-- [ ] Unit test: rollback on a finite agent with one completed task.
-- [ ] Verify re-queued tasks are delivered to the agent on resume.
-- [ ] Hivetool: rollback dialog shows correct task list, post-rollback task
-      queue reflects re-queued items.
+- [x] Unit test: `events_yield` records completion in `task_completions.json`.
+- [x] Unit test: rollback re-queues tasks completed after the fork point.
+- [x] Unit test: rollback with no `task_completions.json` (backward compat).
+- [x] Unit test: all completions before fork point — nothing re-queued.
+- [ ] End-to-end: run `swarm-test` hive, rollback infinite-poet, verify
+      re-queued task is re-delivered.
 
 ---
 
@@ -999,6 +1017,74 @@ Remove backward-compat shims. Deprecate `tasks_*` function group.
       exclusively from `agents/` + `tasks/`.
 - [ ] **[RENAME]** UI components: `ticket-*` → `agent-*` where appropriate. Tab
       label: "Tasks" → "Agents".
+
+---
+
+## Phase 7 — Context Update Deduplication
+
+### 🎯 Objective
+
+Context updates delivered to infinite agents are received exactly once. No
+duplicate task assignments, no phantom re-execution of already-completed work.
+
+**Observable proof:**
+
+1. Run orchestrator → infinite-poet with 2 sequential tasks.
+2. Each task is received and executed exactly once.
+3. The poet suspends cleanly after the second task with no spurious third yield.
+
+### Bug: Duplicate `task_assigned` Delivery
+
+**Found during Phase 5 verification.** The `swarm-test` smoke test shows the
+infinite-poet receiving the ants task twice, producing a third spurious yield
+with outcome "I have written **another** haiku about ants."
+
+**Root cause — two delivery paths collide:**
+
+1. **Inline path**: `agents_assign_task` calls `scheduler.deliver_to_task()`,
+   which appends the update to `agent.metadata.pending_context_updates` and
+   saves. When the poet's `events_yield` fires, it checks
+   `pending_context_updates`, finds the buffered update, and returns
+   `{"resumed": true}` — the poet processes the task in the same session run.
+
+2. **Auto-resume path**: After the poet calls `events_yield` a second time
+   (completing the ants task), `drain_session` returns with
+   `result.suspended = True`. `_handle_suspend` in `task_runner.py` then
+   **reloads** the agent from disk (line 459) and checks
+   `pending_context_updates` again. If the orchestrator delivered the update
+   between the inline check and the suspend reload, the same update appears
+   twice — once consumed inline, once triggering auto-resume.
+
+**The result**: the poet gets the ants task as both an inline `events_yield`
+return and a `response.json` auto-resume, executing it twice.
+
+### Proposed Fix
+
+Deduplicate at the consumption site. Options:
+
+- [ ] **Option A: Clear on consumption.** When `events_yield` returns inline
+      updates, immediately clear `pending_context_updates` and persist. The
+      auto-resume path in `_handle_suspend` then finds nothing.
+      — Simplest, but fragile if new updates arrive between clear and persist.
+
+- [ ] **Option B: Stamp-and-skip.** Each context update gets a unique ID
+      (assigned by `deliver_to_task`). `events_yield` and `_handle_suspend`
+      track consumed IDs. Duplicates are skipped.
+      — More robust, slightly more complex.
+
+- [ ] **Option C: Single delivery path.** Remove the inline check from
+      `events_yield` entirely. All deliveries go through the suspend →
+      auto-resume path in `_handle_suspend`. One code path, no race.
+      — Cleanest, but adds a suspend/resume round-trip to every delivery.
+
+### Reproduction
+
+```bash
+BEES_HIVE_DIR=../../hives/swarm-test npm run dev:box -w bees
+# After completion, inspect:
+# - Orchestrator's pending_context_updates (3 entries, expected 2)
+# - Poet's events.jsonl (duplicate task_assigned context_update)
+```
 
 ---
 


### PR DESCRIPTION
## What

Rollback on an infinite agent now correctly re-queues tasks that were completed after the fork point, reverting them to `available` and buffering them as pending context updates so they're re-delivered on resume.

## Why

The existing rollback mechanism had no task awareness. Rolling back an infinite agent that completed tasks A, B, C would fork the session but leave all three tasks marked `completed` — the agent would resume with no work to do.

## Changes

### Python — recording + re-queuing
- **`functions/events.py`**: `events_yield` records each task completion in `task_completions.json` (session directory, alongside `turns.json`). Append-only `[{task_id, turn, completed_at}]`.
- **`mutations.py`**: `_handle_rollback_to_turn` step 14–15: reads completions, reverts post-fork tasks to `available`, copies pre-fork completions to new session, buffers re-queued tasks as `pending_context_updates`.

### Hivetool — rollback dialog
- **`session-store-reader.ts`**: `readTaskCompletions()` + `TaskCompletionInfo` type.
- **`log-detail.ts`**: rollback confirmation shows how many tasks will be re-queued.

### Documentation
- **`PROJECT.md`**: Phase 5 updated with design decision (dedicated file vs. extending `TurnCheckpoint`). Phase 7 filed for duplicate context delivery bug found during verification.

## Testing

```bash
cd packages/bees
python3 -m pytest tests/test_events_yield.py tests/test_mutations.py -x
# 48 passed

# Live verification:
BEES_HIVE_DIR=../../hives/swarm-test npm run dev:box -w bees
# Inspect: agents/*/sessions/*/task_completions.json
```

4 new tests: recording, re-queuing (3 tasks, fork at mid-point), backward compat (no file), no-op (all before fork).
