### PR TITLE
[bees] Hivetool Tasks Tab Fixes

### DIFF
--- a/packages/bees/hivetool/src/data/agent-store.ts
+++ b/packages/bees/hivetool/src/data/agent-store.ts
@@ -86,14 +86,18 @@ class AgentStore {
     if (this.#activated) return;
     if (this.access.accessState.get() !== "ready") return;
 
-    const agentsHandle = await this.access.getSubdirectory("agents");
+    const agentsHandle = await this.access.getSubdirectory("agents", {
+      create: true,
+    });
     if (!agentsHandle) {
-      console.warn("Could not find agents/ subdirectory in hive/");
+      console.warn("Could not resolve agents/ subdirectory in hive/");
       return;
     }
 
     this.#agentsHandle = agentsHandle;
-    this.#tasksHandle = await this.access.getSubdirectory("tasks");
+    this.#tasksHandle = await this.access.getSubdirectory("tasks", {
+      create: true,
+    });
     this.#activated = true;
     await this.scan();
     this.#startObserver();

--- a/packages/bees/hivetool/src/ui/task-detail.ts
+++ b/packages/bees/hivetool/src/ui/task-detail.ts
@@ -19,6 +19,8 @@ import type { AgentStore } from "../data/agent-store.js";
 import type { TaskItemData } from "../data/types.js";
 import { getRelativeTime } from "../utils.js";
 import { sharedStyles } from "./shared-styles.js";
+import { renderJson } from "./json-tree.js";
+import { jsonTreeStyles } from "./json-tree.styles.js";
 import "./truncated-text.js";
 
 export { BeesTaskDetail };
@@ -27,6 +29,7 @@ export { BeesTaskDetail };
 class BeesTaskDetail extends SignalWatcher(LitElement) {
   static styles = [
     sharedStyles,
+    jsonTreeStyles,
     css`
       .status-timeline {
         display: flex;
@@ -89,6 +92,27 @@ class BeesTaskDetail extends SignalWatcher(LitElement) {
         border: 1px solid #1e293b;
         max-height: 300px;
         overflow-y: auto;
+      }
+
+      .outcome-parts {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+      }
+
+      .outcome-parts img {
+        max-width: 100%;
+        border-radius: 6px;
+        border: 1px solid #1e293b;
+        display: block;
+      }
+
+      .outcome-parts .part-text {
+        font-size: 0.8rem;
+        color: #e2e8f0;
+        line-height: 1.5;
+        white-space: pre-wrap;
+        word-break: break-word;
       }
     `,
   ];
@@ -280,7 +304,7 @@ class BeesTaskDetail extends SignalWatcher(LitElement) {
                 <div class="block outcome">
                   <div class="block-header">Outcome Content</div>
                   <div class="block-content">
-                    <div class="outcome-json">${JSON.stringify(task.outcome_content, null, 2)}</div>
+                    ${this.renderOutcomeContent(task.outcome_content)}
                   </div>
                 </div>
               `
@@ -337,6 +361,49 @@ class BeesTaskDetail extends SignalWatcher(LitElement) {
         bubbles: true,
       })
     );
+  }
+
+  /**
+   * Render outcome_content with Gemini content-parts awareness.
+   *
+   * If the value has a `parts` array (Gemini Content shape), renders
+   * text parts as paragraphs and inlineData parts as inline images.
+   * Falls back to JSON for anything else.
+   */
+  private renderOutcomeContent(content: Record<string, unknown>) {
+    const parts = content.parts as Array<Record<string, unknown>> | undefined;
+    if (!Array.isArray(parts) || parts.length === 0) {
+      return html`<div class="json-tree">${renderJson(content)}</div>`;
+    }
+
+    return html`
+      <div class="outcome-parts">
+        ${parts.map((part) => {
+          // Text part.
+          if (typeof part.text === "string") {
+            return html`<div class="part-text">${part.text}</div>`;
+          }
+          // Inline data (image, audio, video).
+          const inlineData = part.inlineData as
+            | { mimeType: string; data: string }
+            | undefined;
+          if (inlineData?.data && inlineData?.mimeType) {
+            const dataUrl = `data:${inlineData.mimeType};base64,${inlineData.data}`;
+            if (inlineData.mimeType.startsWith("image/")) {
+              return html`<img src="${dataUrl}" alt="outcome image" />`;
+            }
+            if (inlineData.mimeType.startsWith("video/")) {
+              return html`<video src="${dataUrl}" controls style="max-width:100%;border-radius:6px"></video>`;
+            }
+            if (inlineData.mimeType.startsWith("audio/")) {
+              return html`<audio src="${dataUrl}" controls style="max-width:100%"></audio>`;
+            }
+          }
+          // Unknown part shape — show as JSON tree.
+          return html`<div class="json-tree">${renderJson(part)}</div>`;
+        })}
+      </div>
+    `;
   }
 }
 


### PR DESCRIPTION
## What

Two fixes for the Tasks tab shipped in #8536: fresh hive activation crash and
raw JSON rendering of multimodal outcome content.

## Why

1. On a fresh hive with no `agents/` directory, `AgentStore.activate()` silently
   bailed, leaving the store uninitialized. Creating a task from a template then
   threw "Agents handle not available."
2. Task outcome content containing Gemini content parts (text + base64 images)
   rendered as a wall of JSON instead of viewable media.

## Changes

### `agent-store.ts`
- `activate()` now creates `agents/` and `tasks/` directories on demand via
  `{ create: true }`, so fresh hives work without waiting for the box to boot.

### `task-detail.ts`
- Added `renderOutcomeContent()`: detects Gemini `{ parts: [...] }` shape and
  renders text as paragraphs, `inlineData` images as `<img>`, video/audio with
  native controls.
- JSON fallback uses the collapsible `renderJson` tree component instead of
  raw `JSON.stringify`.
- Added `jsonTreeStyles` and `outcome-parts` CSS for the rich content layout.

## Testing

- Verified fresh hive: open hivetool → create task from template → no crash.
- Verified multimodal outcome: task with image parts renders inline images
  alongside descriptive text.
