### PR TITLE
[bees] Fix orphaned task records on agent deletion

### DIFF
--- a/packages/bees/bees/mutations.py
+++ b/packages/bees/bees/mutations.py
@@ -576,10 +576,8 @@ class MutationManager:
         for child in children:
             self._delete_fs_recursive(child.id, store, deleted)
 
-        # Remove entity directory.
-        entity_dir = store.entity_dir(task_id)
-        if entity_dir.exists():
-            shutil.rmtree(entity_dir)
+        # Remove agent directory and associated task records.
+        store.delete_agent(task_id)
 
         # Remove matching session logs.
         logs_dir = self._hive_dir / "logs"

--- a/packages/bees/bees/scheduler.py
+++ b/packages/bees/bees/scheduler.py
@@ -37,7 +37,6 @@ while sequential dependencies are strictly preserved without blocking the system
 
 from __future__ import annotations
 
-import shutil
 
 import asyncio
 import logging
@@ -303,10 +302,8 @@ class Scheduler:
         self._deleted_tasks.add(task_id)
         self._running_tasks.discard(task_id)
 
-        # Remove entity directory.
-        entity_dir = self.store.entity_dir(task_id)
-        if entity_dir.exists():
-            shutil.rmtree(entity_dir)
+        # Remove agent directory and associated task records.
+        self.store.delete_agent(task_id)
 
         # Remove matching session logs.
         logs_dir = self.store.hive_dir / "logs"

--- a/packages/bees/bees/task_file_store.py
+++ b/packages/bees/bees/task_file_store.py
@@ -166,3 +166,25 @@ class TaskFileStore:
         task_path.write_text(
             json.dumps(task.to_dict(), indent=2, ensure_ascii=False) + "\n"
         )
+
+    def delete(self, task_id: str) -> bool:
+        """Remove a task file by ID.
+
+        Returns True if the file existed and was removed.
+        """
+        task_path = self.tasks_dir / f"{task_id}.json"
+        if task_path.exists():
+            task_path.unlink()
+            return True
+        return False
+
+    def delete_by_assignee(self, agent_id: str) -> list[str]:
+        """Remove all task files assigned to the given agent.
+
+        Returns the IDs of deleted task records.
+        """
+        deleted: list[str] = []
+        for task in self.query_by_assignee(agent_id):
+            if self.delete(task.id):
+                deleted.append(task.id)
+        return deleted

--- a/packages/bees/bees/unified_agent_store.py
+++ b/packages/bees/bees/unified_agent_store.py
@@ -50,6 +50,22 @@ class UnifiedAgentStore:
         """Resolve the directory for an agent by ID."""
         return self._hive_dir / "agents" / agent_id
 
+    def delete_agent(self, agent_id: str) -> None:
+        """Remove an agent's directory and its associated task records.
+
+        Callers handle recursion into children and log cleanup — this
+        method only deletes the single agent's own data.
+        """
+        import shutil
+
+        # Remove the agent directory (sessions, workspace, metadata).
+        agent_dir = self.entity_dir(agent_id)
+        if agent_dir.exists():
+            shutil.rmtree(agent_dir)
+
+        # Remove task records assigned to this agent.
+        self._task_file_store.delete_by_assignee(agent_id)
+
     # -- Read operations ---------------------------------------------------
 
     def get(self, agent_id: str) -> Agent | None:

--- a/packages/bees/tests/test_mutations.py
+++ b/packages/bees/tests/test_mutations.py
@@ -855,6 +855,65 @@ class TestRollbackToTurn:
 
 
 # ---------------------------------------------------------------------------
+# Delete task
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteTask:
+    """delete-task mutation removes agent directories AND task records."""
+
+    def test_delete_removes_task_records(self, hive, store):
+        """Deleting an agent also removes its tasks/*.json files."""
+        agent_id = _create_task(store)
+
+        # Verify task records exist.
+        tasks_before = store._task_file_store.query_by_assignee(agent_id)
+        assert len(tasks_before) == 1
+
+        _write_mutation(hive, {"type": "delete-task", "task_id": agent_id})
+        manager = MutationManager(hive)
+        outcome = asyncio.run(manager.process_inline())
+
+        assert outcome.hot_processed == 1
+
+        # Agent directory should be gone.
+        assert not store.entity_dir(agent_id).exists()
+
+        # Task records should also be gone.
+        tasks_after = store._task_file_store.query_by_assignee(agent_id)
+        assert tasks_after == []
+
+    def test_delete_recursive_cleans_child_task_records(self, hive, store):
+        """Deleting a parent removes task records for all descendants."""
+        parent_id = _create_task(store)
+        child_id = _create_task(store, parent_task_id=parent_id)
+
+        # Verify both have task records.
+        assert len(store._task_file_store.query_by_assignee(parent_id)) == 1
+        assert len(store._task_file_store.query_by_assignee(child_id)) == 1
+
+        _write_mutation(hive, {"type": "delete-task", "task_id": parent_id})
+        manager = MutationManager(hive)
+        outcome = asyncio.run(manager.process_inline())
+
+        assert outcome.hot_processed == 1
+
+        # Both agent dirs gone.
+        assert not store.entity_dir(parent_id).exists()
+        assert not store.entity_dir(child_id).exists()
+
+        # Both task records gone.
+        assert store._task_file_store.query_by_assignee(parent_id) == []
+        assert store._task_file_store.query_by_assignee(child_id) == []
+
+    def test_delete_missing_task_id(self, hive):
+        _write_mutation(hive, {"type": "delete-task"})
+        manager = MutationManager(hive)
+        outcome = asyncio.run(manager.process_inline())
+        assert outcome.hot_processed == 0
+
+
+# ---------------------------------------------------------------------------
 # Unknown mutations
 # ---------------------------------------------------------------------------
 

--- a/packages/bees/tests/test_task_file_store.py
+++ b/packages/bees/tests/test_task_file_store.py
@@ -161,3 +161,40 @@ class TestTaskRecordRoundTrip:
         assert task.status == "available"
         assert task.kind == "work"
         assert task.assignee is None
+
+
+class TestDelete:
+    def test_delete_existing(self, store: TaskFileStore) -> None:
+        task = store.create("Find pricing")
+        task_path = store.tasks_dir / f"{task.id}.json"
+        assert task_path.exists()
+
+        result = store.delete(task.id)
+        assert result is True
+        assert not task_path.exists()
+        assert store.get(task.id) is None
+
+    def test_delete_nonexistent_returns_false(self, store: TaskFileStore) -> None:
+        assert store.delete("nonexistent-id") is False
+
+
+class TestDeleteByAssignee:
+    def test_deletes_matching_tasks(self, store: TaskFileStore) -> None:
+        store.create("Task 1", assignee="agent-1")
+        store.create("Task 2", assignee="agent-1")
+        store.create("Task 3", assignee="agent-2")
+
+        deleted = store.delete_by_assignee("agent-1")
+        assert len(deleted) == 2
+
+        # Only agent-2's task should remain.
+        remaining = store.query_all()
+        assert len(remaining) == 1
+        assert remaining[0].assignee == "agent-2"
+
+    def test_no_matching_tasks(self, store: TaskFileStore) -> None:
+        store.create("Unrelated", assignee="agent-x")
+        deleted = store.delete_by_assignee("agent-y")
+        assert deleted == []
+        assert len(store.query_all()) == 1
+


### PR DESCRIPTION
## What
Deleting an agent now also removes its associated `tasks/*.json` files. Previously, only the `agents/{uuid}/` directory and session logs were cleaned up, leaving orphaned task records on disk.

## Why
Project Swarm decoupled agents and tasks into separate directories (`agents/` and `tasks/`). The deletion paths in `Scheduler` and `MutationManager` were only removing the agent directory — the task record cleanup was never added. Orphaned task files would accumulate over time, especially for agents reused via `reset_for_reuse` (which creates new task records on each assignment).

## Changes

### `bees/task_file_store.py`
- Added `delete(task_id)` — removes a single task JSON file
- Added `delete_by_assignee(agent_id)` — removes all task files assigned to a given agent

### `bees/unified_agent_store.py`
- Added `delete_agent(agent_id)` — centralizes removal of the agent directory + its task records in one method

### `bees/scheduler.py`
- `_delete_recursive` now delegates to `store.delete_agent()` instead of `shutil.rmtree`
- Removed unused `shutil` import

### `bees/mutations.py`
- `_delete_fs_recursive` now delegates to `store.delete_agent()` instead of `shutil.rmtree`

### Tests
- 3 unit tests for `TaskFileStore.delete` / `delete_by_assignee`
- 3 integration tests for `delete-task` mutation: single agent, recursive parent→child, missing ID

## Testing
```bash
cd packages/bees && python3 -m pytest tests/test_task_file_store.py tests/test_mutations.py -x -q
```
