### PR TITLE
[bees] Swarm post-completion cleanup

### DIFF
--- a/hives/swarm-test/config/SYSTEM.yaml
+++ b/hives/swarm-test/config/SYSTEM.yaml
@@ -4,4 +4,3 @@
 # Root auto-boots an orchestrator that autostarts a writer.
 title: swarm-test
 description: "Smoke test for Swarm layout"
-root: orchestrator

--- a/hives/swarm-test/config/TEMPLATES.yaml
+++ b/hives/swarm-test/config/TEMPLATES.yaml
@@ -1,17 +1,62 @@
+- name: async-chat
+  title: Async Opie
+  description: A chat app that makes apps and multimedia
+  objective: >-
+    Converse with the user as Opie, a friendly assistant. 
+
+    In the conversation, strive to be helpful: concise but not terse, effective
+    but not brash. Ok to stop and ask questions if request is not clear.
+
+    In the first message, briefly introduce yourself and tell the user what you
+    can do.
+
+    When the new app is build, add it to your surface, so that the user can see
+    it.
+  functions:
+    - chat.*
+    - agents.*
+  tasks:
+    - generate_images
+    - generate_video
+    - generate_speech
+    - app_builder
+  skills:
+    - surface
+
+- name: app_builder
+  title: App Builder
+  description: Builds high-quality React Apps
+  objective: >-
+    You are an app builder, invoked by a parent agent. Your job is to build
+    React app bundles as specified by the parent agent.
+
+    You will receive tasks describing what to write. For each task, write the
+    requested content to a file in your workspace, then call events_yield with a
+    summary of what you produced.
+
+    Your first task: {{system.context}}
+  model: gemini-3.1-pro-preview
+  skills:
+    - build-react-apps
+    - run-in-sandbox
+    - use-opal-sdk
+  functions:
+    - events.*
+    - files.*
+
 - name: orchestrator
   title: Orchestrator
   objective: >-
-    You are an orchestrator. Use agents_list_types to discover available
-    agent types, then assign two sequential tasks to an "infinite-poet"
-    agent with slug "poet".
+    You are an orchestrator. Use agents_list_types to discover available agent
+    types, then assign two sequential tasks to an "infinite-poet" agent with
+    slug "poet".
 
-    Task 1: Write a haiku about bees. Save it to haiku.txt.
-    Task 2: Write a haiku about ants. Save it to ants.txt.
+    Task 1: Write a haiku about bees. Save it to haiku.txt. Task 2: Write a
+    haiku about ants. Save it to ants.txt.
 
-    After assigning task 1, wait for it to complete using agents_await.
-    Then assign task 2 to the same slug and wait again.
-    When both tasks are complete, mark your objective as fulfilled with
-    a summary of the results.
+    After assigning task 1, wait for it to complete using agents_await. Then
+    assign task 2 to the same slug and wait again. When both tasks are complete,
+    mark your objective as fulfilled with a summary of the results.
   functions:
     - agents.*
     - system.*
@@ -21,13 +66,11 @@
 - name: infinite-poet
   title: Infinite Poet
   objective: >-
-    You are a poet. You will receive tasks describing what to write.
-    For each task, write the requested content to a file in your
-    workspace, then call events_yield with a summary of what you
-    produced.
+    You are a poet. You will receive tasks describing what to write. For each
+    task, write the requested content to a file in your workspace, then call
+    events_yield with a summary of what you produced.
 
-    Your first task:
-    {{system.context}}
+    Your first task: {{system.context}}
   functions:
     - files.*
     - events.*
@@ -40,3 +83,287 @@
   functions:
     - files.*
     - system.*
+
+- name: generate_text
+  title: Text Generator
+  runner: direct_model
+  model: gemini-3-flash-preview
+  objective: "{{system.context}}"
+  functions:
+    - builtin.search_grounding
+  description: >-
+    An extremely versatile text generator, powered by Gemini. Use it for any
+    tasks that involve generation of text. Supports multimodal content input.
+    Always writes its output to {slug}/text.md.
+
+- name: generate_images
+  title: Image Generator
+  runner: direct_model
+  model: gemini-3.1-flash-image-preview
+  tags:
+    - image
+  objective: "{{system.context}}"
+  options_schema:
+    aspect_ratio:
+      type: string
+      description:
+        "Target aspect ratio. Valid values: '1:1', '3:4', '4:3', '9:16', '16:9',
+        '1:2', '2:1', '3:2', '2:3', '5:4', '4:5', '7:5', '5:7', '21:9', '9:21'."
+      enum:
+        - "1:1"
+        - "3:4"
+        - "4:3"
+        - "9:16"
+        - "16:9"
+        - "1:2"
+        - "2:1"
+        - "3:2"
+        - "2:3"
+        - "5:4"
+        - "4:5"
+        - "7:5"
+        - "5:7"
+        - "21:9"
+        - "9:21"
+    image_size:
+      type: string
+      description:
+        "Target resolution or image size. Valid values: '512', '1K', '2K', '4K'."
+      enum:
+        - "512"
+        - "1K"
+        - "2K"
+        - "4K"
+    person_generation:
+      type: string
+      description:
+        "Person generation policy. Valid values: 'allow_all', 'dont_allow',
+        'allow_adult'."
+      enum:
+        - "allow_all"
+        - "dont_allow"
+        - "allow_adult"
+  description: >-
+    An extremely versatile image generator, powered by Gemini. Use it for any
+    tasks that involve generation of images based on a prompt. Always writes its
+    output to {slug}/image_0.png. If passing references, pass them as in <file>
+    tags.
+
+- name: generate_video
+  title: Video Generator
+  runner: direct_model
+  model: veo-3.1-generate-preview
+  tags:
+    - video
+  objective: "{{system.context}}"
+  options_schema:
+    aspect_ratio:
+      type: string
+      description: "Target aspect ratio. Valid values: '16:9', '9:16', '1:1'."
+      enum:
+        - "16:9"
+        - "9:16"
+        - "1:1"
+    resolution:
+      type: string
+      description:
+        "Target resolution. Valid values: '720p', '1080p', '4k'. Extension is
+        limited to 720p."
+      enum:
+        - "720p"
+        - "1080p"
+        - "4k"
+    duration_seconds:
+      type: number
+      description: "Target duration in seconds. Valid values: 4, 6, 8."
+      enum:
+        - 4
+        - 6
+        - 8
+    person_generation:
+      type: string
+      description:
+        "Person generation policy. Valid values: 'allow_all', 'dont_allow',
+        'allow_adult'."
+      enum:
+        - "allow_all"
+        - "dont_allow"
+        - "allow_adult"
+    first_frame:
+      type: string
+      description: >-
+        Path to a starting frame image for image-to-video generation. The video
+        will begin from this image and animate forward.
+    last_frame:
+      type: string
+      description: >-
+        Path to an ending frame image for keyframe interpolation. Use together
+        with first_frame to generate a video that transitions between two
+        specific frames.
+    extend_video:
+      type: string
+      description: >-
+        Path to a previously generated video to extend by ~7 seconds. The video
+        must have been generated by a prior generate_video task (e.g.
+        'intro/video_0.mp4'). Extension is always 720p and produces a single
+        combined video.
+    reference_images:
+      type: array
+      description: >-
+        Up to 3 paths to reference images that guide the video's visual content.
+        Use to preserve a subject's appearance (e.g. a person, character,
+        product, or outfit).
+  description: >-
+    A cinematic video generator powered by Veo 3.1. Use it to generate
+    high-fidelity 8-second videos with native audio from text prompts.
+
+    Supports advanced cinematic direction via options: - **Image-to-video**: Set
+    first_frame to a starting image. - **Interpolation**: Set both first_frame
+    and last_frame to
+      generate a video transitioning between two keyframes.
+    - **Extension**: Set extend_video to a previously generated video
+      path to extend it by ~7 seconds (always 720p, up to 20 times).
+    - **Reference images**: Set reference_images to up to 3 image paths
+      to guide visual content (subjects, outfits, products).
+    - **Resolution**: Choose 720p, 1080p, or 4k (higher = slower).
+
+    Always writes its output to {slug}/video_0.mp4.
+
+- name: generate_speech
+  title: Speech Generator
+  runner: direct_model
+  model: gemini-3.1-flash-tts-preview
+  tags:
+    - speech
+  objective: "{{system.context}}"
+  options_schema:
+    voice:
+      type: string
+      description: >-
+        Voice preset name. Each voice has a distinct personality: Achernar
+        (clear, friendly), Achird (warm, conversational), Algenib (deep,
+        authoritative), Algieba (rich, dramatic), Alnilam (smooth, neutral),
+        Aoede (breezy, intelligent), Autonoe (mature, wise), Callirrhoe (bright,
+        animated), Charon (informative, calm), Despina (gentle, soothing),
+        Enceladus (breathy, intimate), Erinome (crisp, precise), Fenrir
+        (excitable, energetic), Gacrux (steady, grounded), Iapetus (resonant,
+        measured), Kore (firm, clear), Laomedeia (melodic, expressive), Leda
+        (professional, composed), Orus (bold, commanding), Puck (upbeat,
+        youthful), Pulcherrima (elegant, polished), Rasalgethi (gravelly,
+        textured), Sadachbia (soft, contemplative), Sadaltager (neutral,
+        versatile), Schedar (warm, reassuring), Sulafat (lively, playful),
+        Umbriel (mysterious, atmospheric), Vindemiatrix (articulate, refined),
+        Zephyr (bright, perky), Zubenelgenubi (deep, resonant).
+      enum:
+        - "Achernar"
+        - "Achird"
+        - "Algenib"
+        - "Algieba"
+        - "Alnilam"
+        - "Aoede"
+        - "Autonoe"
+        - "Callirrhoe"
+        - "Charon"
+        - "Despina"
+        - "Enceladus"
+        - "Erinome"
+        - "Fenrir"
+        - "Gacrux"
+        - "Iapetus"
+        - "Kore"
+        - "Laomedeia"
+        - "Leda"
+        - "Orus"
+        - "Puck"
+        - "Pulcherrima"
+        - "Rasalgethi"
+        - "Sadachbia"
+        - "Sadaltager"
+        - "Schedar"
+        - "Sulafat"
+        - "Umbriel"
+        - "Vindemiatrix"
+        - "Zephyr"
+        - "Zubenelgenubi"
+    speaker_1:
+      type: string
+      description: >-
+        First speaker for multi-speaker dialogue, in "Alias:VoiceName" format
+        (e.g. "Host:Aoede"). The alias must match what appears in the
+        transcript. Both speaker_1 and speaker_2 must be set for multi-speaker
+        mode.
+    speaker_2:
+      type: string
+      description: >-
+        Second speaker for multi-speaker dialogue, in "Alias:VoiceName" format
+        (e.g. "Guest:Puck"). The alias must match what appears in the
+        transcript. Both speaker_1 and speaker_2 must be set for multi-speaker
+        mode.
+  description: >-
+    An expressive speech generator powered by Gemini TTS. Use it for narration,
+    voiceover, dialogue, and podcast-style multi-speaker audio.
+
+    **Single speaker**: Set the `voice` option to choose a voice preset.
+    Defaults to Kore if unspecified.
+
+    **Multi-speaker dialogue**: Set `speaker_1` and `speaker_2` options using
+    "Alias:VoiceName" format (e.g. speaker_1: "Host:Aoede", speaker_2:
+    "Guest:Puck"). Write the transcript using "Alias: text" format on each line.
+    The API currently supports exactly 2 speakers.
+
+    **Expressive control**: Embed audio tags directly in the transcript to
+    direct performance: [whispers], [laughs], [excitedly], [slowly, with
+    gravity], [sighs], [pauses]. The model interprets these as stage directions
+    for natural delivery.
+
+    Always writes its output to {slug}/audio_0.wav.
+
+- name: generate_music
+  title: Music Generator
+  runner: direct_model
+  model: lyria-3-pro-preview
+  tags:
+    - music
+  objective: "{{system.context}}"
+  description: >-
+    An extremely versatile music generator, powered by Lyria. Use it for any
+    tasks that involve generation of music or songs based on a prompt. Always
+    writes its output to {slug}/audio_0.wav.
+
+- name: test_multi_speaker_speech
+  title: Multi-Speaker Speech Test
+  description: >-
+    Test harness for multi-speaker TTS. Spawns a generate_speech task with
+    two-speaker dialogue using the speakers option to verify the
+    multiSpeakerVoiceConfig pipeline end-to-end.
+  model: gemini-3-flash-preview
+  objective: >-
+    You are a test harness for the multi-speaker speech pipeline. Run these
+    steps in order:
+
+
+    Step 1: Assign a `generate_speech` task with slug "dialogue" and this
+    objective (include it exactly as the transcript):
+
+    "Host: Welcome to the AI podcast! Today we're exploring how autonomous
+    agents collaborate on creative tasks. [excitedly] It's going to be a great
+    episode! Guest: Thanks for having me! [laughs] I've been looking forward to
+    this conversation. Let me tell you about something fascinating."
+
+    Set options: { "speaker_1": "Host:Aoede", "speaker_2": "Guest:Puck" }. Then
+    call agents_await to wait for it to complete.
+
+
+    Step 2: Assign a second `generate_speech` task with slug "narration" and
+    objective "The morning sun cast long shadows across the ancient library.
+    [slowly, with gravity] Within its walls, secrets waited to be discovered."
+    Set options: { "voice": "Charon" }. Then call agents_await to wait for it to
+    complete.
+
+
+    Report whether both tasks succeeded and describe the results.
+  functions:
+    - system.*
+    - agents.*
+  tasks:
+    - generate_speech

--- a/hives/swarm-test/skills/build-react-apps/SKILL.md
+++ b/hives/swarm-test/skills/build-react-apps/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: build-react-apps
+title: How to build React apps
+description: Produce high-quality React apps from natural language descriptions.
+allowed-tools:
+  - files.*
+  - sandbox.*
+---
+
+# How to build high-quality React apps
+
+## What You're Building
+
+A **multi-file React component bundle** rendered in a sandboxed iframe. The
+bundle consists of:
+
+- `App.jsx` — the root component that accepts configuration props
+- `components/*.jsx` — reusable sub-components
+- `styles.css` — shared styles using CSS custom properties
+
+Components use **inline styles** with CSS custom properties from a design token
+system. Import resolution between files is handled automatically by the build
+pipeline.
+
+## Workflow
+
+Your UI MUST work from 320px to 1200px+. This is not optional.
+
+1. Write the app an its components as files in your directory.
+
+2. Build the bundle with [bundler.mjs](./scripts/bundler.mjs):
+
+```bash
+node ./skills/{name of this skill}/scripts/bundler.mjs
+```
+
+If you do not run this exact command, the user will see a blank screen.
+
+3. Once bundling is successful, return a brief confirmation that the UI was
+   generated and bundled. Don't enclose produced files.
+
+## Developer Rules
+
+Follow these rules strictly.
+
+1. **App.jsx is the entry point.** It must be named exactly `App.jsx` and
+   contain a function called `App`.
+2. **App carries the configuration.** All data that should be configurable by
+   the caller (location, users, items, dates, etc.) appears as props on `App`
+   with realistic defaults.
+3. **Sub-components are reusable.** Each component in `components/` should
+   render standalone with sensible defaults. Document all props with `@prop`
+   JSDoc.
+4. **Every file imports what it uses.** Include `import React from "react"` in
+   every JSX file. Import sub-components with relative paths (e.g.
+   `import Header from "./components/Header"`).
+5. **CSS imports work.** Use `import "./styles.css"` in App.jsx for shared
+   styles.
+6. **Export default.** Each component file must `export default` its component
+   function.
+7. **All colors, spacing, typography, and radii MUST use `--cg-` design
+   tokens.** No hex colors, no `rgb()`, no named colors, no raw pixel values.
+   Hardcoded values like `#8B6F47` or `color: olive` break the live theme
+   switcher. This is a build error, not a suggestion.
+8. **Your output renders inside a host application.** Don't create app names,
+   brand headers, splash screens, or taglines. Start with the actual task UI.
+   The host provides the chrome.
+9. **No client storage APIs.** Do not use `localStorage`, `sessionStorage`,
+   `IndexedDB`, or any Web Storage APIs. The iframe environment may not have
+   storage access due to origin restrictions. All state lives in React component
+   state or is passed via props and the SDK.
+10. **Respect the host theme.** Use design tokens. Backgrounds must use
+    `var(--cg-color-surface*)` tokens and all text must use
+    `var(--cg-color-on-surface*)` tokens. The tokens will natively map to their
+    theme variants.
+11. **Use `flex-wrap: wrap`** on any flex container with multiple children that
+    should stack on narrow screens.
+12. **Use CSS Grid with `auto-fit` / `minmax`** for multi-column layouts:
+    `grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr))`.
+13. **Use `clamp()` for font sizes** that should scale with viewport:
+    `font-size: clamp(1rem, 2vw + 0.5rem, 2rem)`.
+14. **Test your mental model** at 375px, 768px, and 1200px before finishing.
+
+These particular paterns are forbidden.
+
+- **No fixed pixel widths** on containers or layout elements. Never write
+  `width: 800px`, `width: 600px`, or similar. Use `max-width` with a percentage
+  or `min()` instead: `max-width: min(100%, 800px)`.
+- **No `min-width` exceeding 320px** on any layout container. This prevents
+  rendering on small screens.
+- **No horizontal overflow.** If your layout causes a horizontal scrollbar at
+  any viewport width ≥ 320px, it is broken.
+
+**CRITICAL FORBIDDEN PATTERN: NO TAILWIND!**
+
+- You MUST NOT use Tailwind CSS utility classes (e.g., `flex`, `min-h-screen`,
+  `p-4`, `bg-red-500`). Tailwind is NOT INSTALLED.
+- You MUST use standard semantic CSS class names (e.g.,
+  `className="hero-container"`).
+- You MUST write a separate `styles.css` file using **Vanilla CSS**.
+- You MUST include `import "./styles.css";` at the top of your `App.jsx`. If you
+  don't write and import a CSS file, your design will be completely unstyled.
+
+## Configuration Props
+
+When creating a component, think about what data the _caller_ would want to
+customize. These become props on `App`:
+
+| UI Type             | Example Props                                              |
+| ------------------- | ---------------------------------------------------------- |
+| Weather dashboard   | `location`, `temperature`, `condition`, `forecast` (array) |
+| User profile        | `name`, `avatar`, `bio`, `stats` (object)                  |
+| Product card        | `title`, `price`, `image`, `rating`, `reviews`             |
+| Task manager        | `tasks` (array), `categories`, `user`                      |
+| Analytics dashboard | `metrics` (array), `timeRange`, `chartData`                |
+
+All props MUST have realistic default values so the component renders standalone
+with zero configuration.
+
+## Design Token System
+
+**Reminder: this is a hard rule (see above).** Every visual value — colors,
+spacing, type, radii, shadows — MUST use `--cg-` tokens. No exceptions.
+
+### Token Rules
+
+| Category      | Use                                                  | Never                                   |
+| ------------- | ---------------------------------------------------- | --------------------------------------- |
+| Colors        | `var(--cg-color-...)`                                | `#hex`, `rgb()`, named colors           |
+| Spacing       | `var(--cg-sp-...)`                                   | Raw pixel values for padding/margin/gap |
+| Font sizes    | `var(--cg-text-...-size)`                            | `14px`, `1rem`                          |
+| Border radius | `var(--cg-radius-...)` or `var(--cg-card-radius)`    | `12px`, `24px`                          |
+| Shadows       | `var(--cg-elevation-...)` or `var(--cg-card-shadow)` | Raw `box-shadow` values                 |
+| Font family   | `var(--cg-font-sans)` or `var(--cg-font-mono)`       | `'Arial'`, `sans-serif`                 |
+
+### Available Tokens
+
+**Colors:** `--cg-color-surface-dim`, `--cg-color-surface`,
+`--cg-color-surface-bright`, `--cg-color-surface-container-lowest`,
+`--cg-color-surface-container-low`, `--cg-color-surface-container`,
+`--cg-color-surface-container-high`, `--cg-color-surface-container-highest`,
+`--cg-color-on-surface`, `--cg-color-on-surface-muted`, `--cg-color-primary`,
+`--cg-color-primary-container`, `--cg-color-on-primary`,
+`--cg-color-on-primary-container`, `--cg-color-secondary`,
+`--cg-color-secondary-container`, `--cg-color-on-secondary`,
+`--cg-color-on-secondary-container`, `--cg-color-tertiary`,
+`--cg-color-tertiary-container`, `--cg-color-on-tertiary`,
+`--cg-color-on-tertiary-container`, `--cg-color-error`,
+`--cg-color-error-container`, `--cg-color-on-error`,
+`--cg-color-on-error-container`, `--cg-color-outline`,
+`--cg-color-outline-variant`
+
+**Typography:** `--cg-font-sans`, `--cg-font-mono`,
+`--cg-text-display-{lg,md,sm}-{size,weight}`,
+`--cg-text-headline-{lg,md,sm}-{size,weight}`,
+`--cg-text-title-{lg,md,sm}-{size,weight}`,
+`--cg-text-body-{lg,md,sm}-{size,weight}`,
+`--cg-text-label-{lg,md,sm}-{size,weight}`
+
+**Spacing (4px grid):** `--cg-sp-0` through `--cg-sp-16`
+
+**Radius:** `--cg-radius-{xs,sm,md,lg,xl,full}`
+
+**Elevation:** `--cg-elevation-{1,2,3}`
+
+**Motion:** `--cg-motion-duration-{short,medium,long}`,
+`--cg-motion-easing-{standard,decel,accel}`
+
+**Component tokens:** Card: `--cg-card-{bg,radius,padding,shadow}`, Button:
+`--cg-button-{radius,padding,bg,color,font-size,font-weight}`, Input:
+`--cg-input-{bg,border,radius,padding,color,placeholder}`, Badge:
+`--cg-badge-{bg,color,radius,padding,font-size}`, Divider:
+`--cg-divider-{color,thickness,style}`
+
+**Expressive:** `--cg-border-{style,width}`,
+`--cg-heading-{transform,letter-spacing}`,
+`--cg-img-{radius,border,shadow,filter}`, `--cg-hover-{scale,brightness,shadow}`
+
+## Component Design
+
+### Decomposition
+
+- **Compose, don't monolith.** A dashboard should be built from `Header`,
+  `MetricsGrid`, `ForecastCard`, etc.
+- **Each component renders standalone** with realistic defaults.
+- **The top-level App composes everything** into a cohesive layout.
+
+### Icons
+
+Google Material Symbols Outlined is available via a web font:
+
+```jsx
+<span className="material-symbols-outlined" style={{ fontSize: "20px" }}>
+  search
+</span>
+```
+
+**CRITICAL: DO NOT import third-party icon packages.** You do not have
+`lucide-react`, `heroicons`, or `react-icons` installed. Using them will break
+the build. ONLY use the `material-symbols-outlined` span.
+
+### Interactivity
+
+Components should be interactive where appropriate. Use `useState`, `useEffect`
+with cleanup. Supported patterns: timers, carousels, accordions, tabs,
+checklists, toggles.
+
+### Stable Defaults
+
+Never use `Date.now()`, `Math.random()`, or `new Date()` in default parameters.
+Compute once at module level or use `useState(() => ...)`.
+
+### Critical: You're building a Segment, Not a Standalone App
+
+Your React app is **one segment** of a wider orchestrated journey. Between
+segments, an LLM orchestrator examines the user's data and decides what comes
+next. This means:
+
+- **Don't brand it.** No app names, no splash screens, no taglines. The host
+  application provides the chrome and framing. Start with the task UI.
+
+### File Structure
+
+Each state gets its own component file named after the state:
+
+- `App.jsx` — shell that renders the initial state
+- `views/InputRequirements.jsx` — one view per state
+- `views/SelectModels.jsx`
+- `views/DetailedComparison.jsx`
+- `views/DecisionReport.jsx`
+- `components/*.jsx` — shared sub-components (reusable across views)
+- `styles.css` — shared styles
+
+### View Contract
+
+Each view component receives two props:
+
+- `data` — the journey context relevant to this state
+- `onTransition` — callback for state transitions (wired to
+  `window.opalSDK.navigateTo`)
+
+```jsx
+export default function SelectModels({ data = {}, onTransition }) {
+  const handleSelect = (item) => {
+    onTransition("detailed_comparison", {
+      ...data,
+      shortlist: [...(data.shortlist || []), item],
+    });
+  };
+  // ...
+}
+```
+
+### Rules
+
+1. **One view per state.** Don't merge states into a single component.
+2. **Views are self-contained.** Each view renders standalone with defaults.
+3. **Shared components go in `components/`.** Headers, cards, buttons used
+   across multiple views should be extracted.
+4. **Context flows forward.** Each transition carries the data the next view
+   needs. Views may also use `readFile` to load shared workspace data.
+5. **Responsive.** The user may view this UI on a mobile device, so ensure that
+   you make every component and the app itself responsive.
+
+## Available Globals
+
+`React`, `useState`, `useEffect`, `useRef`, `useCallback`, `useMemo`,
+`useContext`, `useReducer`, `useLayoutEffect`, `memo`, `forwardRef`,
+`createContext`, `Fragment`
+
+Be creative and visually impressive.

--- a/hives/swarm-test/skills/build-react-apps/scripts/bundler.mjs
+++ b/hives/swarm-test/skills/build-react-apps/scripts/bundler.mjs
@@ -1,0 +1,198 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Standalone JSX bundler for the ui-generator skill.
+ *
+ * Reads JSX/CSS files from the current working directory, bundles them
+ * into a single CJS output (with React as external), and writes
+ * `bundle.js` + `bundle.css` to the same directory.
+ *
+ * Usage (via execute_bash):
+ *   node skills/ui-generator/tools/bundler.mjs
+ *
+ * Entry point: App.jsx in the current directory.
+ * React is provided by the iframe runtime — not bundled here.
+ */
+
+/* global process, console */
+
+import { build } from "esbuild";
+import { readFileSync, writeFileSync, readdirSync, statSync } from "fs";
+import { join, extname, relative } from "path";
+
+const cwd = process.cwd();
+
+// ── Collect files from disk ──────────────────────────────────────────────
+
+/** Recursively collect files into a flat map: relative-path → content. */
+function collectFiles(dir, base = dir) {
+  const result = {};
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const rel = relative(base, full);
+    if (statSync(full).isDirectory()) {
+      // Skip node_modules, hidden dirs, and output files.
+      if (entry.startsWith(".") || entry === "node_modules") continue;
+      Object.assign(result, collectFiles(full, base));
+    } else {
+      const ext = extname(entry);
+      if ([".jsx", ".js", ".css"].includes(ext)) {
+        result[rel] = readFileSync(full, "utf-8");
+      }
+    }
+  }
+  return result;
+}
+
+const files = collectFiles(cwd);
+
+const entryFile = files["App.jsx"] ? "App.jsx" : files["app.jsx"] ? "app.jsx" : null;
+
+if (!entryFile) {
+  console.error("Error: No App.jsx or app.jsx found in", cwd);
+  process.exit(1);
+}
+
+// ── Auto-export ──────────────────────────────────────────────────────────
+
+/**
+ * If a JSX source has no explicit export, detect the component name
+ * and append `export default ComponentName;`.
+ */
+function autoExport(source) {
+  if (source.includes("export default") || source.includes("module.exports")) {
+    return source;
+  }
+  const match =
+    source.match(/^function\s+([A-Z]\w*)/m) ??
+    source.match(/^const\s+([A-Z]\w*)\s*=/m);
+  if (match) {
+    return source + `\nexport default ${match[1]};\n`;
+  }
+  return source;
+}
+
+// ── Collect CSS ──────────────────────────────────────────────────────────
+
+const cssChunks = [];
+
+// ── Bundle ───────────────────────────────────────────────────────────────
+
+/**
+ * Find a file key in the files map, trying with the given extensions.
+ */
+function findFileKey(path, extensions) {
+  if (files[path]) return path;
+  for (const ext of extensions) {
+    const withExt = path + ext;
+    if (files[withExt]) return withExt;
+  }
+  return undefined;
+}
+
+try {
+  const result = await build({
+    stdin: {
+      contents: autoExport(files[entryFile]),
+      loader: "jsx",
+      resolveDir: "/",
+    },
+    bundle: true,
+    write: false,
+    format: "cjs",
+    jsx: "transform",
+    jsxFactory: "React.createElement",
+    jsxFragment: "React.Fragment",
+    plugins: [
+      {
+        name: "virtual-modules",
+        setup(build) {
+          // React → external (provided by iframe's requireShim).
+          build.onResolve({ filter: /.*/ }, (args) => {
+            if (args.path === "react" || args.path.startsWith("react/")) {
+              return { path: args.path, external: true };
+            }
+
+            // Resolve relative paths.
+            let normalized = args.path;
+            if (
+              (args.path.startsWith("./") || args.path.startsWith("../")) &&
+              args.importer
+            ) {
+              const importerDir = args.importer.includes("/")
+                ? args.importer.substring(0, args.importer.lastIndexOf("/") + 1)
+                : "";
+              const joined = importerDir + args.path;
+              const parts = joined.split("/");
+              const resolved = [];
+              for (const part of parts) {
+                if (part === "..") resolved.pop();
+                else if (part !== ".") resolved.push(part);
+              }
+              normalized = resolved.join("/");
+            } else {
+              normalized = normalized.replace(/^\.\//, "");
+            }
+
+            // Resolve to any known file, then assign namespace by extension.
+            const jsExts = [".jsx", ".js"];
+            const cssExts = [".css"];
+            const allExts = [...jsExts, ...cssExts];
+
+            const key =
+              findFileKey(normalized, allExts) ??
+              findFileKey(normalized + ".jsx", []) ??
+              findFileKey(normalized + ".js", []) ??
+              findFileKey(normalized + ".css", []);
+
+            if (key) {
+              const ns = key.endsWith(".css") ? "virtual-css" : "virtual-jsx";
+              return { path: key, namespace: ns };
+            }
+
+            return undefined;
+          });
+
+          // Load virtual JSX modules (auto-export if needed).
+          build.onLoad({ filter: /.*/, namespace: "virtual-jsx" }, (args) => ({
+            contents: autoExport(files[args.path] ?? ""),
+            loader: "jsx",
+          }));
+
+          // Load virtual CSS — collect it and return empty JS.
+          build.onLoad({ filter: /.*/, namespace: "virtual-css" }, (args) => {
+            cssChunks.push(files[args.path] ?? "");
+            return { contents: "", loader: "js" };
+          });
+        },
+      },
+    ],
+  });
+
+  const output = result.outputFiles?.[0];
+  if (!output) {
+    throw new Error("esbuild.build produced no output");
+  }
+
+  // Write bundle.js
+  writeFileSync(join(cwd, "bundle.js"), output.text, "utf-8");
+
+  // Write bundle.css (concatenated CSS chunks)
+  if (cssChunks.length > 0) {
+    writeFileSync(join(cwd, "bundle.css"), cssChunks.join("\n"), "utf-8");
+  }
+
+  console.log(
+    `✓ Bundled: bundle.js (${output.text.length} bytes)` +
+      (cssChunks.length > 0
+        ? `, bundle.css (${cssChunks.join("\n").length} bytes)`
+        : "")
+  );
+} catch (err) {
+  console.error("Bundle failed:", err.message);
+  process.exit(1);
+}

--- a/hives/swarm-test/skills/build-widgets/SKILL.md
+++ b/hives/swarm-test/skills/build-widgets/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: build-widgets
+title: How to build widgets
+description: Learn how to make widgets on canvas
+allowed-tools:
+  - files.*
+---
+
+Here's how you build a widget:
+
+1) Create a new subdirectory where the app will go. Check to see that this is a new directory.
+
+2) Write the React app using Opal SDK in that subdirectory. Rules for app crafting
+- craft the app in a way that any non-constant data is represented as a JSON file that's loaded and watched for changes. 
+- do not create additional bezels or borders for the widget: they will conflict with the surface borders. Just 10px padding.
+
+3) Create or update the surface to include the widget.
+
+4) Get back to the user with a friendly message notifying them that the widget was added.

--- a/hives/swarm-test/skills/run-in-sandbox/SKILL.md
+++ b/hives/swarm-test/skills/run-in-sandbox/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: run-in-sandbox
+title: How to run in sandbox
+description:
+  Teaches you how to properly operate in the sandboxed environment you're in.
+allowed-tools:
+  - sandbox.*
+---
+
+# The sandbox
+
+When you call `execute_bash` function, it runs in a sandboxed environment. You
+have acess to most bash commands. The `PATH` is configured to give you access to
+`node` and `python3`.
+
+Even though you can use heredoc to write and `cat` to read files, prefer the
+built-in file functions, if they available.

--- a/hives/swarm-test/skills/surface/SKILL.md
+++ b/hives/swarm-test/skills/surface/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: surface
+title: Presenting Your Work via Surface
+description:
+  Learn how to present your work as a structured surface — a curated manifest of
+  artifacts that the user's application renders in real time.
+allowed-tools:
+  - files.*
+  - events.*
+---
+
+# What is a Surface?
+
+A **surface** is a structured manifest that tells the user's application what to
+display. It contains links to various files to present to the user and
+optionally, groups them into sections.
+
+A surface is a living document you update as you work, so the user sees your
+progress in real time.
+
+# The Workflow
+
+Every time you produce, update, or receive a meaningful artifact, follow these
+steps:
+
+1. **Write `surface.json`.** Overwrite it with the complete current state of
+   what you want to present, including the new/updated artifact. Increment the
+   `version` counter.
+2. **Broadcast.** Call `events_broadcast` with type `surface_updated`. The
+   consumer application listens for `surface_updated` and re-reads
+   `surface.json` to update the display.
+
+# Format
+
+`surface.json` is a single JSON file that you overwrite on every change.
+
+```json
+{
+  "version": 1,
+  "title": "My Surface Title",
+  "sections": [{ "id": "main", "title": "Main Results" }],
+  "items": [
+    {
+      "id": "findings",
+      "title": "Research Findings",
+      "path": "research_notes.md",
+      "description": "Key findings from the analysis",
+      "section": "main"
+    }
+  ]
+}
+```
+
+## Top-level fields
+
+| Field      | Required | Description                                             |
+| ---------- | -------- | ------------------------------------------------------- |
+| `version`  | **yes**  | Integer. Start at 1, increment on every write.          |
+| `title`    | no       | Human-readable name for the surface.                    |
+| `sections` | no       | Declared section groups. Omit if no grouping is needed. |
+| `items`    | **yes**  | Ordered list of content items.                          |
+
+## Sections
+
+Sections are optional named groups. Items reference them by `id`.
+
+| Field         | Required | Description                                                                                          |
+| ------------- | -------- | ---------------------------------------------------------------------------------------------------- |
+| `id`          | **yes**  | Stable identifier, referenced by items.                                                              |
+| `title`       | **yes**  | Human-readable heading.                                                                              |
+| `description` | no       | Brief description of the section.                                                                    |
+| `active`      | no       | When `true`, this section is selected by default in tabbed views. At most one section should be active. |
+
+## Items
+
+Each item represents one piece of content you want to present.
+
+| Field         | Required | Description                                                                                                      |
+| ------------- | -------- | ---------------------------------------------------------------------------------------------------------------- |
+| `id`          | **yes**  | Stable identifier, unique within the surface.                                                                    |
+| `title`       | **yes**  | Human-readable label.                                                                                            |
+| `path`        | no       | File path (workspace-relative). At least one of `path` or `description` must be present.                         |
+| `description` | no       | Inline text — standalone content, preview, or metadata. At least one of `path` or `description` must be present. |
+| `render`      | no       | Rendering override. Use `bundle` for JS files that should render in a sandboxed iframe.                          |
+| `role`        | no       | Semantic role: `primary` (hero), `supporting` (detail), `status` (lightweight indicator).                        |
+| `section`     | no       | The section `id` this item belongs to. Ungrouped items go to a default section.                                  |
+
+# Rules
+
+## Paths match `files_write_file`
+
+The `path` field in items uses the same workspace-relative format as
+`files_write_file`. If you write a file with `files_write_file` using
+`research/findings.md`, reference it in the surface as
+`"path": "research/findings.md"`.
+
+## Write `surface.json` in your writable directory
+
+Use `files_write_file` with `"file_name": "surface.json"`. If you are a
+sub-agent with a scope restriction, write it within your assigned directory
+(e.g., `research/surface.json`). The consumer discovers surface files by walking
+the filesystem tree.
+
+## The surface is complete state, not a diff
+
+Every time you write `surface.json`, include **all** items you want displayed —
+not just the ones that changed. If you previously had 3 items and now have 4,
+write all 4. If you want to remove an item, omit it from the next write.
+
+## Increment version on every write
+
+The `version` counter lets the consumer detect changes. Start at 1. Increment by
+1 on every write, even if only the ordering changed.
+
+## Always broadcast after writing
+
+After writing `surface.json`, call `events_broadcast` with:
+
+- `type`: `surface_updated`
+- `message`: brief description of what changed (e.g., "Added research findings")
+
+## Items without files are valid
+
+Not every item needs a file. Use `description` alone for lightweight status
+indicators:
+
+```json
+{
+  "id": "status",
+  "title": "Progress",
+  "description": "3 of 5 sources analyzed",
+  "role": "status"
+}
+```
+
+## Bundles use a render hint
+
+If you produce a JavaScript bundle (e.g., an interactive chart), set
+`"render": "bundle"` on the item. The consumer loads the JS in a sandboxed
+iframe and discovers a companion CSS file by convention (same filename stem).
+
+## Update the surface incrementally as you work
+
+Don't wait until the end. The surface is most valuable when the user can see
+progress. A good pattern:
+
+1. Write an initial surface with a status item: "Starting analysis..."
+2. As you produce content files, add them to the surface.
+3. Update status items to reflect progress.
+4. When done, write the final surface with all artifacts and remove status
+   items.
+
+# Example: Research Agent with Surface
+
+A research agent doing competitive analysis might produce this sequence:
+
+**After starting (version 1):**
+
+```json
+{
+  "version": 1,
+  "items": [
+    {
+      "id": "status",
+      "title": "Status",
+      "description": "Researching competitors — 3 searches in progress",
+      "role": "status"
+    }
+  ]
+}
+```
+
+**After first results (version 2):**
+
+```json
+{
+  "version": 2,
+  "title": "Competitive Analysis",
+  "sections": [{ "id": "findings", "title": "Findings" }],
+  "items": [
+    {
+      "id": "market-overview",
+      "title": "Market Overview",
+      "path": "research/market_overview.md",
+      "description": "Current market landscape and key players",
+      "role": "primary",
+      "section": "findings"
+    },
+    {
+      "id": "status",
+      "title": "Status",
+      "description": "2 of 3 research threads complete",
+      "role": "status"
+    }
+  ]
+}
+```
+
+**Final surface (version 3):**
+
+```json
+{
+  "version": 3,
+  "title": "Competitive Analysis",
+  "sections": [
+    { "id": "findings", "title": "Findings" },
+    { "id": "data", "title": "Supporting Data" }
+  ],
+  "items": [
+    {
+      "id": "market-overview",
+      "title": "Market Overview",
+      "path": "research/market_overview.md",
+      "description": "Current market landscape and key players",
+      "role": "primary",
+      "section": "findings"
+    },
+    {
+      "id": "competitor-matrix",
+      "title": "Competitor Comparison",
+      "path": "research/competitor_matrix.md",
+      "description": "Feature-by-feature comparison of top 5 competitors",
+      "section": "findings"
+    },
+    {
+      "id": "raw-data",
+      "title": "Research Data",
+      "path": "research/raw_data.json",
+      "description": "Structured data from all sources",
+      "role": "supporting",
+      "section": "data"
+    }
+  ]
+}
+```
+
+Each version was followed by an `events_broadcast` with type `surface_updated`.

--- a/hives/swarm-test/skills/use-opal-sdk/SKILL.md
+++ b/hives/swarm-test/skills/use-opal-sdk/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: use-opal-sdk
+title: Using the Opal SDK from a React component
+description:
+  Learn how to use `window.opalSDK` inside your sandboxed React component to
+  read files, call host services, and listen for events from the application.
+allowed-tools:
+  - files.*
+---
+
+# What is `window.opalSDK`?
+
+When your React component runs inside the sandbox, it has no network access and
+no direct access to the host application. Instead, the host injects
+`window.opalSDK` — a bridge object that lets you:
+
+1. **Call methods** on the host (read files, navigate, etc.)
+2. **Listen for events** pushed by the host (data updates, file changes, etc.)
+
+All communication goes through `postMessage` under the hood. You never need to
+call `postMessage` directly.
+
+# Calling SDK Methods
+
+Every method call on `window.opalSDK` is asynchronous and returns a `Promise`.
+
+```jsx
+// Read a file from the workspace
+const content = await window.opalSDK.readFile("data/results.json");
+
+// Parse and use it
+const data = JSON.parse(content);
+```
+
+## Available Methods
+
+| Method                        | Returns           | Description                                  |
+| ----------------------------- | ----------------- | -------------------------------------------- |
+| `readFile(path)`              | `Promise<string>` | Read a file from the workspace.              |
+| `navigateTo(viewId, params?)` | `Promise<void>`   | Navigate to a different view in the host UI. |
+| `emit(event, payload?)`       | `Promise<void>`   | Send a fire-and-forget event to the host.    |
+
+Paths are workspace-relative, same as `files_write_file`. For example, if you
+wrote a file with `files_write_file` using `data/results.json`, read it with
+`window.opalSDK.readFile("data/results.json")`.
+
+## Error Handling
+
+If a method call fails (e.g., file not found), the Promise rejects with an
+`Error`. Always handle errors:
+
+```jsx
+try {
+  const content = await window.opalSDK.readFile("missing.txt");
+} catch (err) {
+  console.error("Could not read file:", err.message);
+}
+```
+
+# Listening for Events
+
+The SDK implements the standard DOM `addEventListener` API. The host pushes
+events to your component automatically.
+
+## The `filechange` Event
+
+The most important event is `filechange`. It fires whenever a file in your
+working directory changes — for example, when you or another agent writes a file
+with `files_write_file`.
+
+```jsx
+useEffect(() => {
+  function onFileChange(e) {
+    console.log("File changed:", e.detail.path);
+  }
+
+  window.opalSDK.addEventListener("filechange", onFileChange);
+
+  return () => {
+    window.opalSDK.removeEventListener("filechange", onFileChange);
+  };
+}, []);
+```
+
+The event detail contains:
+
+| Field  | Type     | Description                                        |
+| ------ | -------- | -------------------------------------------------- |
+| `path` | `string` | Workspace-relative path of the file that changed.  |
+
+## Key Points
+
+- Events arrive as standard `CustomEvent` objects.
+- The payload is on `e.detail`.
+- Always clean up listeners in your `useEffect` return function to prevent
+  memory leaks.
+
+# Example: Auto-Refreshing Data Display
+
+Here's a complete component that loads data from a JSON file and automatically
+re-reads it whenever the file changes on disk:
+
+```jsx
+import React, { useState, useEffect, useCallback } from "react";
+
+export default function DataView() {
+  const [data, setData] = useState(null);
+  const [error, setError] = useState(null);
+
+  const loadData = useCallback(async () => {
+    try {
+      const raw = await window.opalSDK.readFile("data.json");
+      setData(JSON.parse(raw));
+      setError(null);
+    } catch (err) {
+      setError(err.message);
+    }
+  }, []);
+
+  // Load initial data.
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  // Re-read when the file changes.
+  useEffect(() => {
+    function onFileChange(e) {
+      if (e.detail.path === "data.json") {
+        loadData();
+      }
+    }
+
+    window.opalSDK.addEventListener("filechange", onFileChange);
+
+    return () => {
+      window.opalSDK.removeEventListener("filechange", onFileChange);
+    };
+  }, [loadData]);
+
+  if (error) return <div>Error: {error}</div>;
+  if (!data) return <div>Loading…</div>;
+
+  return (
+    <div>
+      <h2>{data.title}</h2>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </div>
+  );
+}
+```
+
+This pattern — load once, then listen for changes — is the standard way to
+build reactive components. The host watches the filesystem and pushes
+`filechange` events automatically; your component just needs to re-read the
+files it cares about.
+
+# Rules
+
+## Always use `window.opalSDK`, never `postMessage`
+
+The SDK handles serialization, request IDs, and error propagation for you. Raw
+`postMessage` calls will not be understood by the host.
+
+## All methods are async
+
+Even fire-and-forget methods like `navigateTo` return a Promise. You can `await`
+them or ignore the return value — both work.
+
+## Clean up event listeners
+
+If your component unmounts and re-mounts, stale listeners will fire on the old
+component instance. Always return a cleanup function from `useEffect`.
+
+## Filter `filechange` by path
+
+The `filechange` event fires for every file in the working directory, not just
+yours. Check `e.detail.path` before reacting:
+
+```jsx
+function onFileChange(e) {
+  if (e.detail.path === "my-data.json") {
+    reload();
+  }
+}
+```

--- a/packages/bees/bees/declarations/agents.instruction.md
+++ b/packages/bees/bees/declarations/agents.instruction.md
@@ -5,12 +5,12 @@ to. Agents appear on demand — you never create them explicitly.
 
 Available agent types are resolved dynamically via "agents_list_types". New
 agent templates or overrides can be created or modified inside the `templates/`
-directory of your workspace during execution. You MUST always call
-"agents_list_types" to discover the current, most up-to-date list of available
-agent types before assigning a task, especially if you or the system have
-dynamically created or edited templates. When listing agent types, check their
-"options_schema" to see what configuration overrides (if any) can be supplied
-via the "options" parameter of "agents_assign_task".
+directory of your workspace during execution. Call "agents_list_types" to
+discover the current, most up-to-date list of available agent types before
+assigning a task, especially if you or the system have dynamically created or
+edited templates. When listing agent types, check their "options_schema" to see
+what configuration overrides (if any) can be supplied via the "options"
+parameter of "agents_assign_task".
 
 To assign work, call "agents_assign_task" with the agent type, a name (slug),
 and the task objective. If no agent with that name exists, one is created
@@ -25,21 +25,30 @@ Tasks run asynchronously — "agents_assign_task" returns immediately. The
 scheduler issues a context update when each agent completes its task, containing
 the outcome or an error message.
 
-To wait for results, call "agents_await". This suspends your execution until a
-context update arrives (e.g. an agent completes or a parent sends you an event).
-If updates are already pending, it returns immediately.
+If you have chat functions available, use them ("chat_request_user_input" or
+"chat_present_choices"), so that you remain responsive to the user.
+
+If you don't have chat functions, Call "agents_await" to wait for for results.
+This suspends your execution until a context update arrives (e.g. an agent
+completes or a parent sends you an event). If updates are already pending, it
+returns immediately.
+
+Do not call "agents_await" if you have chat functions -- they will block your
+ability to be responsive to the user.
 
 Typical workflow:
+
 1. Call "agents_list_types" to discover available agent types.
 2. Assign one or more tasks with "agents_assign_task".
-3. Call "agents_await" to suspend until an agent completes.
-4. Check results with "agents_check_status".
+3. Continue using chat functions or, if not available, call "agents_await" to
+   suspend until an agent completes.
+4. If needed, check results with "agents_check_status".
 5. Repeat or proceed based on results.
 
 The agents working on tasks have access to a sub-directory of your filesystem,
 specified by the "slug" parameter. You provide a simple directory name (e.g.,
-"research"). If you are yourself a subagent, the system automatically nests
-your slug under your own working directory.
+"research"). If you are yourself a subagent, the system automatically nests your
+slug under your own working directory.
 
 ## Agents and user input
 
@@ -57,7 +66,7 @@ When you check on your agents, each agent has a status:
 - **running** — the agent is actively working on its task.
 - **suspended** — the agent is waiting for user input or an event.
 - **paused** — the agent is temporarily paused by the scheduler.
-- **completed** — the agent finished its task successfully. The outcome will
-  be delivered to you as a context update.
+- **completed** — the agent finished its task successfully. The outcome will be
+  delivered to you as a context update.
 - **failed** — the agent encountered an unrecoverable error.
 - **cancelled** — the agent was cancelled before completion.

--- a/packages/bees/bees/runners/gemini.py
+++ b/packages/bees/bees/runners/gemini.py
@@ -25,6 +25,7 @@ from collections.abc import AsyncIterator
 from typing import Any, Callable
 
 from opal_backend.local.backend_client_impl import HttpBackendClient
+from bees.disk_file_system import DiskFileSystem
 from opal_backend.local.interaction_store_impl import InMemoryInteractionStore
 from opal_backend.interaction_store import InteractionState, InteractionStore
 from opal_backend.sessions.api import (
@@ -285,8 +286,13 @@ class GeminiRunner:
 
         session_id = config.session_id or str(uuid.uuid4())
 
-        # Pre-hydrate the disk workspace if this is a pre-seeded fork session
-        if isinstance(interaction_store, FileBasedSessionStore):
+        # Pre-hydrate the disk workspace if this is a pre-seeded fork session.
+        # Skip for DiskFileSystem — the disk is the source of truth and the
+        # rollback handler (mutations.py) already hydrates the workspace.
+        if (
+            isinstance(interaction_store, FileBasedSessionStore)
+            and not isinstance(config.file_system, DiskFileSystem)
+        ):
             sdir = interaction_store._session_dir(session_id)
             int_file = sdir / "interaction.json"
             if int_file.exists():
@@ -363,10 +369,15 @@ class GeminiRunner:
             state_data["interaction_state"],
         )
 
-        # Hydrate the disk workspace from the captured snapshot on resume.
+        # Hydrate the workspace from the captured snapshot on resume —
+        # but NOT for DiskFileSystem.  Disk-backed workspaces treat the
+        # on-disk state as authoritative; hydrating from a stale snapshot
+        # would clobber changes made by sibling agents that share the
+        # workspace via workspace_root_id.
         if (
             interaction_state.file_system is not None
             and hasattr(config.file_system, "hydrate_from_snapshot")
+            and not isinstance(config.file_system, DiskFileSystem)
         ):
             config.file_system.hydrate_from_snapshot(
                 interaction_state.file_system,

--- a/packages/bees/hivetool/src/ui/chat-panel.ts
+++ b/packages/bees/hivetool/src/ui/chat-panel.ts
@@ -27,6 +27,14 @@ import { sharedStyles } from "./shared-styles.js";
 
 export { BeesChatPanel };
 
+// Pidgin file-tag patterns (mirrors bees/pidgin.py).
+const FILE_SPLIT_REGEX = /(<file\s+src\s*=\s*"[^"]*"\s*\/>)/;
+const FILE_PARSE_REGEX = /^<file\s+src\s*=\s*"([^"]*)"\s*\/>$/;
+
+const IMAGE_EXTS = new Set([".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg"]);
+const VIDEO_EXTS = new Set([".mp4", ".webm", ".mov"]);
+const AUDIO_EXTS = new Set([".mp3", ".wav", ".ogg"]);
+
 @customElement("bees-chat-panel")
 class BeesChatPanel extends SignalWatcher(LitElement) {
   static styles = [
@@ -137,6 +145,57 @@ class BeesChatPanel extends SignalWatcher(LitElement) {
 
       .chat-text a {
         color: #60a5fa;
+      }
+
+      /* ── Embedded media from pidgin <file> tags ── */
+
+      .chat-media {
+        max-width: 100%;
+        border-radius: 6px;
+        margin: 8px 0;
+        display: block;
+      }
+
+      .chat-audio {
+        width: 100%;
+        margin: 8px 0;
+      }
+
+      .file-placeholder {
+        padding: 12px;
+        background: #1e293b;
+        border: 1px dashed #334155;
+        border-radius: 6px;
+        color: #64748b;
+        font-size: 0.75rem;
+        text-align: center;
+        margin: 8px 0;
+      }
+
+      .file-error {
+        padding: 8px 12px;
+        background: #1c1917;
+        border: 1px solid #991b1b;
+        border-radius: 6px;
+        color: #f87171;
+        font-size: 0.75rem;
+        margin: 8px 0;
+      }
+
+      .chat-file-link {
+        display: inline-block;
+        padding: 6px 12px;
+        background: #1e293b;
+        border: 1px solid #334155;
+        border-radius: 6px;
+        color: #60a5fa;
+        font-size: 0.8rem;
+        text-decoration: none;
+        margin: 4px 0;
+      }
+
+      .chat-file-link:hover {
+        background: #334155;
       }
 
       .chat-text strong {
@@ -481,7 +540,7 @@ class BeesChatPanel extends SignalWatcher(LitElement) {
                        class="chat-turn ${m.role === "user" ? "user" : "agent"}"
                     >
                       <div class="chat-role">${m.role}</div>
-                      <div class="chat-text">${markdown(m.text)}</div>
+                      <div class="chat-text">${this.#renderChatText(agent.id, m.text)}</div>
                     </div>
                   `
                 )}
@@ -494,6 +553,70 @@ class BeesChatPanel extends SignalWatcher(LitElement) {
           : nothing}
       </div>
     `;
+  }
+
+  // ── Pidgin file-tag resolution ──
+
+  /** Cache of resolved file data URLs. Keys are `agentId:path`. */
+  #fileCache = new Map<string, string | null>();
+
+  /**
+   * Look up (or kick off) an async file read.
+   *
+   * Returns the data-URL string when resolved, `null` while loading,
+   * or `""` when the file could not be read.
+   */
+  #resolveFile(agentId: string, src: string): string | null {
+    const key = `${agentId}:${src}`;
+    if (this.#fileCache.has(key)) return this.#fileCache.get(key)!;
+
+    // Mark as in-flight.
+    this.#fileCache.set(key, null);
+    const segments = src.split("/");
+    this.agentStore!.readFileContent(agentId, segments).then((dataUrl) => {
+      this.#fileCache.set(key, dataUrl ?? "");
+      this.requestUpdate();
+    });
+    return null;
+  }
+
+  /** Render chat text, replacing `<file>` tags with embedded media. */
+  #renderChatText(agentId: string, text: string): unknown {
+    if (!text.includes("<file")) return markdown(text);
+
+    const segments = text.split(FILE_SPLIT_REGEX);
+    return segments.map((segment) => {
+      const match = segment.match(FILE_PARSE_REGEX);
+      if (match) {
+        const src = match[1];
+        const resolved = this.#resolveFile(agentId, src);
+        if (resolved === null) {
+          return html`<div class="file-placeholder">Loading ${src}…</div>`;
+        }
+        if (resolved === "") {
+          return html`<div class="file-error">⚠ Could not load ${src}</div>`;
+        }
+        return this.#renderMedia(src, resolved);
+      }
+      return segment ? markdown(segment) : nothing;
+    });
+  }
+
+  /** Render a resolved file as the appropriate media element. */
+  #renderMedia(src: string, dataUrl: string): unknown {
+    const ext = "." + (src.split(".").pop()?.toLowerCase() ?? "");
+    if (IMAGE_EXTS.has(ext)) {
+      return html`<img class="chat-media" src="${dataUrl}" alt="${src}" />`;
+    }
+    if (VIDEO_EXTS.has(ext)) {
+      return html`<video class="chat-media" src="${dataUrl}" controls></video>`;
+    }
+    if (AUDIO_EXTS.has(ext)) {
+      return html`<audio class="chat-audio" src="${dataUrl}" controls></audio>`;
+    }
+    return html`<a class="chat-file-link" href="${dataUrl}" download="${src}"
+      >📎 ${src}</a
+    >`;
   }
 
   private renderLiveSessionPanel(agentId: string) {
@@ -580,12 +703,40 @@ class BeesChatPanel extends SignalWatcher(LitElement) {
     return null;
   }
 
-  /** Extract displayable text from an LLMContent prompt. */
-  private extractPromptText(prompt: unknown): string {
-    if (!prompt || typeof prompt !== "object") return "";
-    const p = prompt as { parts?: Array<{ text?: string }> };
-    if (!Array.isArray(p.parts)) return "";
-    return p.parts.map((part) => part.text ?? "").join("");
+  /**
+   * Render an LLMContent prompt, including both text and inline media.
+   *
+   * After pidgin resolution on the server, prompts contain a mix of
+   * text parts and inlineData parts (images, audio, video). This method
+   * renders all of them instead of discarding non-text parts.
+   */
+  #renderPromptContent(prompt: unknown): unknown {
+    if (!prompt || typeof prompt !== "object") return null;
+    const p = prompt as {
+      parts?: Array<{ text?: string; inlineData?: { mimeType: string; data: string } }>;
+    };
+    if (!Array.isArray(p.parts) || p.parts.length === 0) return null;
+
+    const rendered = p.parts.map((part) => {
+      if (part.text) return markdown(part.text);
+      if (part.inlineData) {
+        const { mimeType, data } = part.inlineData;
+        const dataUrl = `data:${mimeType};base64,${data}`;
+        if (mimeType.startsWith("image/")) {
+          return html`<img class="chat-media" src="${dataUrl}" alt="embedded image" />`;
+        }
+        if (mimeType.startsWith("video/")) {
+          return html`<video class="chat-media" src="${dataUrl}" controls></video>`;
+        }
+        if (mimeType.startsWith("audio/")) {
+          return html`<audio class="chat-audio" src="${dataUrl}" controls></audio>`;
+        }
+      }
+      return nothing;
+    });
+
+    // Return null if every part resolved to nothing.
+    return rendered.some((r) => r !== nothing) ? rendered : null;
   }
 
   /** Interactive text reply form for waitForInput suspensions. */
@@ -593,12 +744,12 @@ class BeesChatPanel extends SignalWatcher(LitElement) {
     ticketId: string,
     waitForInput: Record<string, unknown>
   ) {
-    const promptText = this.extractPromptText(waitForInput.prompt);
+    const promptContent = this.#renderPromptContent(waitForInput.prompt);
 
     return html`
       <div class="response-form">
-        ${promptText
-          ? html`<div class="agent-prompt">${markdown(promptText)}</div>`
+        ${promptContent
+          ? html`<div class="agent-prompt">${promptContent}</div>`
           : nothing}
         <textarea
           class="reply-textarea"
@@ -635,7 +786,7 @@ class BeesChatPanel extends SignalWatcher(LitElement) {
     ticketId: string,
     waitForChoice: Record<string, unknown>
   ) {
-    const promptText = this.extractPromptText(waitForChoice.prompt);
+    const promptContent = this.#renderPromptContent(waitForChoice.prompt);
     const choices = (waitForChoice.choices ?? []) as Array<{
       id: string;
       content?: { parts?: Array<{ text?: string }> };
@@ -645,14 +796,14 @@ class BeesChatPanel extends SignalWatcher(LitElement) {
 
     return html`
       <div class="response-form">
-        ${promptText
-          ? html`<div class="agent-prompt">${markdown(promptText)}</div>`
+        ${promptContent
+          ? html`<div class="agent-prompt">${promptContent}</div>`
           : nothing}
         <div class="choices-grid">
           ${choices.map((choice) => {
             const selected = this.selectedChoiceIds.has(choice.id);
-            const label =
-              this.extractPromptText(choice.content) || choice.id;
+            const choiceContent = this.#renderPromptContent(choice.content);
+            const label = choiceContent || choice.id;
             return html`
               <div
                 class="choice-card ${selected ? "selected" : ""}"

--- a/packages/bees/hivetool/src/ui/surface-pane.ts
+++ b/packages/bees/hivetool/src/ui/surface-pane.ts
@@ -360,8 +360,8 @@ class BeesSurfacePane extends SignalWatcher(LitElement) {
 
   /** Reload the surface — called on agent change and by the parent on fs updates. */
   async loadSurface(): Promise<void> {
-    if (!this.agentStore || !this.ticketId) return;
-    this.surface = await this.agentStore.readSurface(this.ticketId);
+    if (!this.agentStore || !this.agentId) return;
+    this.surface = await this.agentStore.readSurface(this.agentId);
 
     if (this.surface) {
       await this.#resolveBundles(this.surface);
@@ -449,9 +449,9 @@ class BeesSurfacePane extends SignalWatcher(LitElement) {
 
   /** Load file content by path — passed to surface-view as contentLoader. */
   #contentLoader = async (path: string): Promise<string | null> => {
-    if (!this.agentStore || !this.ticketId) return null;
+    if (!this.agentStore || !this.agentId) return null;
     const segments = path.split("/").filter(Boolean);
-    return this.agentStore.readFileContent(this.ticketId, segments);
+    return this.agentStore.readFileContent(this.agentId, segments);
   };
 
   /** Push an event to all active bundle frames in this surface. */

--- a/packages/bees/hivetool/src/ui/surface-view.ts
+++ b/packages/bees/hivetool/src/ui/surface-view.ts
@@ -310,6 +310,24 @@ class BeesSurfaceView extends LitElement {
       color: #94a3b8;
       font-weight: 600;
     }
+
+    /* ── Media previews ── */
+    .content-media img {
+      max-width: 100%;
+      border-radius: 6px;
+      display: block;
+    }
+
+    .content-media video {
+      max-width: 100%;
+      border-radius: 6px;
+      display: block;
+    }
+
+    .content-media audio {
+      width: 100%;
+      display: block;
+    }
   `;
 
   @property({ attribute: false })
@@ -507,7 +525,28 @@ class BeesSurfaceView extends LitElement {
       </div>`;
     }
 
-    const isMarkdown = item.path?.endsWith(".md");
+    const ext = item.path?.split(".").pop()?.toLowerCase() ?? "";
+    const imageExts = new Set(["png", "jpg", "jpeg", "gif", "webp", "svg"]);
+    const videoExts = new Set(["mp4", "webm", "mov"]);
+    const audioExts = new Set(["mp3", "wav"]);
+
+    if (imageExts.has(ext)) {
+      return html`<div class="content-preview content-media">
+        <img src=${content} alt=${item.title ?? ""} />
+      </div>`;
+    }
+    if (videoExts.has(ext)) {
+      return html`<div class="content-preview content-media">
+        <video src=${content} controls></video>
+      </div>`;
+    }
+    if (audioExts.has(ext)) {
+      return html`<div class="content-preview content-media">
+        <audio src=${content} controls></audio>
+      </div>`;
+    }
+
+    const isMarkdown = ext === "md";
     return html`<div class="content-preview">
       ${isMarkdown
         ? html`<div class="content-markdown">${markdown(content)}</div>`

--- a/packages/bees/tests/test_runners/test_gemini_runner.py
+++ b/packages/bees/tests/test_runners/test_gemini_runner.py
@@ -512,43 +512,47 @@ class TestResumeStateBlobFormat(unittest.TestCase):
 
 
 class TestGeminiRunnerForkPrehydration(unittest.TestCase):
-    """GeminiRunner.run() correctly pre-hydrates DiskFileSystem for forked runs."""
+    """GeminiRunner.run() skips pre-hydration for DiskFileSystem.
 
-    def test_pre_hydration_on_fork(self):
+    Disk-backed workspaces treat the on-disk state as authoritative.
+    Hydrating from a stale snapshot would clobber changes made by
+    sibling agents sharing the workspace.  The rollback handler in
+    mutations.py takes care of intentional restoration separately.
+    """
+
+    def test_disk_fs_skips_pre_hydration_on_fork(self):
+        """DiskFileSystem is NOT hydrated from a fork snapshot."""
         from bees.runners.gemini import GeminiRunner
         from bees.protocols.session import SessionConfiguration
-        from opal_backend.sessions.file_store import FileBasedSessionStore
-        from opal_backend.interaction_store import InteractionState
-        
-        # Setup temp dirs
+        from bees.disk_file_system import DiskFileSystem
+
         import tempfile
         import shutil
         from pathlib import Path
-        
+
         tmp_dir = tempfile.mkdtemp()
         try:
             ticket_dir = Path(tmp_dir)
             session_id = "test-fork-session-456"
-            
+
             # Setup the FileBasedSessionStore directories
             sessions_dir = ticket_dir / "sessions"
             sdir = sessions_dir / session_id
             sdir.mkdir(parents=True, exist_ok=True)
-            
-            # Setup mock workspace dir for hydration target
+
             ws_dir = sdir / "workspace"
-            
+
             # Seed interaction.json with mock filesystem snapshot
             fs_snapshot_dict = {
                 "files": {
                     "notes.md": {
                         "data": "fork pre-seeded",
                         "mime_type": "text/plain",
-                        "type": "text"
+                        "type": "text",
                     }
                 },
                 "routes": {},
-                "file_count": 1
+                "file_count": 1,
             }
             interaction_data = {
                 "session_id": session_id,
@@ -561,21 +565,15 @@ class TestGeminiRunnerForkPrehydration(unittest.TestCase):
                 "graph": {},
                 "model": "gemini-2.5-pro",
                 "completed_function_responses": [],
-                "is_precondition_check": False
+                "is_precondition_check": False,
             }
             (sdir / "interaction.json").write_text(json.dumps(interaction_data))
-            
-            # Mock HttpBackendClient
+
             backend = MagicMock()
-            
-            # Setup runner
             runner = GeminiRunner(backend)
-            
-            # Setup DiskFileSystem as target of hydration
-            from bees.disk_file_system import DiskFileSystem
+
             dfs = DiskFileSystem(ws_dir)
-            
-            # SessionConfiguration
+
             config = SessionConfiguration(
                 ticket_id="test-ticket",
                 ticket_dir=ticket_dir,
@@ -584,26 +582,112 @@ class TestGeminiRunnerForkPrehydration(unittest.TestCase):
                 segments=[],
                 function_groups=[],
                 function_filter=None,
-                model="gemini-2.5-pro"
+                model="gemini-2.5-pro",
             )
-            
-            # Mock new_session and start_session
+
             from unittest.mock import patch
-            with patch("bees.runners.gemini.new_session") as mock_new_session, \
-                 patch("bees.runners.gemini.start_session") as mock_start_session, \
-                 patch("bees.runners.gemini.Subscribers") as mock_subscribers:
-                 
-                # Call run()
+
+            with (
+                patch("bees.runners.gemini.new_session") as mock_new_session,
+                patch("bees.runners.gemini.start_session"),
+                patch("bees.runners.gemini.Subscribers"),
+            ):
                 async def run_test():
                     fut = asyncio.Future()
                     fut.set_result(None)
                     mock_new_session.return_value = fut
                     await runner.run(config)
+
                 asyncio.run(run_test())
-                
-            # Confirm workspace file_system was hydrated successfully from snapshot
-            self.assertEqual((ws_dir / "notes.md").read_text(), "fork pre-seeded")
-            
+
+            # DiskFileSystem should NOT have been hydrated — the file
+            # should not exist because we didn't write it ourselves.
+            self.assertFalse(
+                (ws_dir / "notes.md").exists(),
+                "DiskFileSystem was hydrated from snapshot — expected skip",
+            )
+        finally:
+            shutil.rmtree(tmp_dir)
+
+    def test_non_disk_fs_hydrates_on_fork(self):
+        """A non-DiskFileSystem IS hydrated from a fork snapshot."""
+        from bees.runners.gemini import GeminiRunner
+        from bees.protocols.session import SessionConfiguration
+
+        import tempfile
+        import shutil
+        from pathlib import Path
+
+        tmp_dir = tempfile.mkdtemp()
+        try:
+            ticket_dir = Path(tmp_dir)
+            session_id = "test-fork-session-789"
+
+            sessions_dir = ticket_dir / "sessions"
+            sdir = sessions_dir / session_id
+            sdir.mkdir(parents=True, exist_ok=True)
+
+            fs_snapshot_dict = {
+                "files": {
+                    "notes.md": {
+                        "data": "fork pre-seeded",
+                        "mime_type": "text/plain",
+                        "type": "text",
+                    }
+                },
+                "routes": {},
+                "file_count": 1,
+            }
+            interaction_data = {
+                "session_id": session_id,
+                "contents": [],
+                "file_system": fs_snapshot_dict,
+                "function_call_part": {},
+                "task_tree": {"tree": None},
+                "consents_granted": [],
+                "flags": {},
+                "graph": {},
+                "model": "gemini-2.5-pro",
+                "completed_function_responses": [],
+                "is_precondition_check": False,
+            }
+            (sdir / "interaction.json").write_text(json.dumps(interaction_data))
+
+            backend = MagicMock()
+            runner = GeminiRunner(backend)
+
+            # Use a mock file system that is NOT DiskFileSystem.
+            mock_fs = MagicMock()
+            mock_fs.hydrate_from_snapshot = MagicMock()
+
+            config = SessionConfiguration(
+                ticket_id="test-ticket",
+                ticket_dir=ticket_dir,
+                session_id=session_id,
+                file_system=mock_fs,
+                segments=[],
+                function_groups=[],
+                function_filter=None,
+                model="gemini-2.5-pro",
+            )
+
+            from unittest.mock import patch
+
+            with (
+                patch("bees.runners.gemini.new_session") as mock_new_session,
+                patch("bees.runners.gemini.start_session"),
+                patch("bees.runners.gemini.Subscribers"),
+            ):
+                async def run_test():
+                    fut = asyncio.Future()
+                    fut.set_result(None)
+                    mock_new_session.return_value = fut
+                    await runner.run(config)
+
+                asyncio.run(run_test())
+
+            # Non-DiskFileSystem SHOULD have been hydrated.
+            mock_fs.hydrate_from_snapshot.assert_called_once()
         finally:
             shutil.rmtree(tmp_dir)
 


### PR DESCRIPTION
## What
Post-completion fixes and polish for Project Swarm: a shared-workspace snapshot clobbering bug, media rendering in chat/surface, agent instruction improvements, and new hive templates.

## Why
After completing the Swarm migration (agent-centric entity model), real multi-agent workflows exposed a critical data-loss bug where parent session resume overwrites subagent file changes. The other changes improve the chat/surface UI for richer media output and expand the template library for the test hive.

## Changes

### Bug fix: shared workspace snapshot clobbering (`packages/bees`)
- **`runners/gemini.py`** — Skip `hydrate_from_snapshot` for `DiskFileSystem` on both `run()` (fork pre-hydration) and `resume()`. Disk-backed workspaces treat the on-disk state as authoritative; hydrating from a stale snapshot clobbered changes made by sibling agents sharing a workspace via `workspace_root_id`. The rollback path in `mutations.py` (intentional restoration) is unaffected.
- **`tests/test_runners/test_gemini_runner.py`** — Updated fork pre-hydration test to verify DiskFileSystem is *skipped*. Added complementary test confirming non-DiskFileSystem instances still hydrate correctly.

### Chat panel media rendering (`packages/bees/hivetool`)
- **`chat-panel.ts`** — Render `<file>` pidgin tags as embedded media (images, videos, audio) instead of raw text. Resolve file paths via the agent filesystem API and display inline with appropriate `<img>`, `<video>`, or `<audio>` elements. Also render LLMContent prompt parts with inline media support (replaces `extractPromptText` with `#renderPromptContent`).

### Surface view media support (`packages/bees/hivetool`)
- **`surface-view.ts`** — Render image/video/audio surface items as embedded media elements instead of showing raw content strings. Added CSS for media previews.
- **`surface-pane.ts`** — Fix `ticketId` → `agentId` references for surface loading and content loading (stale pre-Swarm naming).

### Agent instructions (`packages/bees`)
- **`agents.instruction.md`** — Soften the "MUST always call agents_list_types" wording. Add guidance on preferring chat functions over `agents_await` for user-facing agents. Restructured workflow steps for clarity.

### Hive config (`hives/swarm-test`)
- **`SYSTEM.yaml`** — Remove auto-boot `root: orchestrator` (manual-start for the test hive).
- **`TEMPLATES.yaml`** — Add `generate_video`, `generate_speech`, `generate_music`, and `test_multi_speaker_speech` templates with full `options_schema` definitions.

## Testing
- `pytest tests/test_runners/test_gemini_runner.py` — 15/15 pass (includes both new hydration-skip tests)
- `pytest tests/test_mutations.py -k rollback` — 6/6 pass (rollback hydration path unaffected)
- Manual: verified subagent file writes persist after parent resume in the swarm-test hive
