### PR TITLE
Require owner on Opal folder

### DIFF
--- a/packages/visual-editor/src/ui/utils/google-drive-host-operations.ts
+++ b/packages/visual-editor/src/ui/utils/google-drive-host-operations.ts
@@ -47,6 +47,7 @@ async function findUserOpalFolder(
   const googleDriveClient = new GoogleDriveClient({ fetchWithCreds });
   const query = `name=${quote(userFolderName)}
   and mimeType="${GOOGLE_DRIVE_FOLDER_MIME_TYPE}"
+  and 'me' in owners
   and trashed=false`;
 
   try {


### PR DESCRIPTION
Avoids accidentally saving Opals into a shared folder.