### PR TITLE
[ve] Autosave Node Title on Focus Blur / Selection Change

### DIFF
--- a/packages/visual-editor/src/sca/actions/step/step-actions.ts
+++ b/packages/visual-editor/src/sca/actions/step/step-actions.ts
@@ -83,7 +83,7 @@ export const applyPendingNodeEdit = asAction(
       pendingEdit.nodeId,
       pendingEdit.graphId,
       pendingEdit.values,
-      null, // metadata
+      pendingEdit.metadata ?? null, // metadata
       pendingEdit.ins ?? null // portsToAutowire
     );
 
@@ -264,7 +264,7 @@ export const applyPendingEditsForNodeAction = asAction(
             pendingEdit.nodeId,
             pendingEdit.graphId,
             pendingEdit.values,
-            null,
+            pendingEdit.metadata ?? null,
             pendingEdit.ins ?? null
           );
           await editor.apply(updateNodeTransform);

--- a/packages/visual-editor/src/sca/types.ts
+++ b/packages/visual-editor/src/sca/types.ts
@@ -532,6 +532,7 @@ export interface PendingEdit {
   graphId: GraphIdentifier;
   nodeId: NodeIdentifier;
   values: InputValues;
+  metadata?: NodeMetadata;
   /** Incoming port connections (from chiclets) to autowire */
   ins?: InPort[];
   /** Graph version when edit was captured - used to detect stale edits */

--- a/packages/visual-editor/src/ui/elements/entity-editor/entity-editor.ts
+++ b/packages/visual-editor/src/ui/elements/entity-editor/entity-editor.ts
@@ -1772,6 +1772,7 @@ export class EntityEditor extends SignalWatcher(LitElement) {
         graphId: prepared.editGraphId,
         nodeId,
         values: prepared.configuration,
+        metadata: prepared.metadata,
         ins: prepared.ins,
         graphVersion: this.sca.controller.editor.graph.version,
       });

--- a/packages/visual-editor/tests/sca/actions/step/step-actions.test.ts
+++ b/packages/visual-editor/tests/sca/actions/step/step-actions.test.ts
@@ -12,6 +12,7 @@ import { ToastType } from "../../../../src/ui/events/events.js";
 import { setDOM, unsetDOM } from "../../../fake-dom.js";
 import { createMockEnvironment } from "../../helpers/mock-environment.js";
 import { defaultRuntimeFlags } from "../../controller/data/default-flags.js";
+import { UpdateNode } from "../../../../src/ui/transforms/index.js";
 
 suite("Step Actions", () => {
   beforeEach(() => {
@@ -79,6 +80,54 @@ suite("Step Actions", () => {
         true,
         "clearPendingEdit should be called before applying (to prevent re-triggers on failure)"
       );
+    });
+
+    test("applies pending node edit with metadata/title when present", async () => {
+      const result: { transform: UpdateNode | null } = { transform: null };
+
+      const mockController = {
+        editor: {
+          step: {
+            pendingEdit: {
+              nodeId: "node-123",
+              graphId: "graph-456",
+              graphVersion: 5,
+              values: { key: "value" },
+              metadata: { title: "New Node Title" },
+            },
+            clearPendingEdit: () => {},
+          },
+          graph: {
+            version: 5,
+            editor: {
+              apply: async (transform: unknown) => {
+                result.transform = transform as UpdateNode;
+                return { success: true };
+              },
+            },
+            lastNodeConfigChange: null,
+          },
+        },
+        global: {
+          toasts: {
+            toast: () => {},
+          },
+        },
+      };
+
+      stepActions.bind({
+        services: {} as never,
+        controller: mockController as never,
+        env: createMockEnvironment(defaultRuntimeFlags),
+      });
+
+      await stepActions.applyPendingNodeEdit();
+
+      assert.ok(result.transform, "apply should be called with transform");
+      assert.strictEqual(result.transform.id, "node-123");
+      assert.strictEqual(result.transform.graphId, "graph-456");
+      assert.deepStrictEqual(result.transform.configuration, { key: "value" });
+      assert.deepStrictEqual(result.transform.metadata, { title: "New Node Title" });
     });
 
     test("shows warning toast and discards edit when graph version mismatches", async () => {


### PR DESCRIPTION
## What
Adds support for node metadata (specifically title edits) to the standard step editor `PendingEdit` flow so they are buffered and saved on blur / selection change.

## Why
Previously, node title updates in the step editor were not saved on focus blur or selection changes; the user had to explicitly press "Enter" to save the title. This aligns the title input save behavior with all other configuration fields and asset titles in the step editor.

## Changes
- **packages/visual-editor/src/sca/types.ts**: Added optional `metadata` property to `PendingEdit` interface.
- **packages/visual-editor/src/ui/elements/entity-editor/entity-editor.ts**: Passed `metadata` from form value to `setPendingEdit`.
- **packages/visual-editor/src/sca/actions/step/step-actions.ts**: Passed `pendingEdit.metadata` into the `UpdateNode` transform.
- **packages/visual-editor/tests/sca/actions/step/step-actions.test.ts**: Added unit test verifying metadata/title application during `applyPendingNodeEdit`.

## Testing
Tested using the automated step unit tests:
```bash
npm run test:file -w packages/visual-editor -- './dist/tsc/tests/sca/actions/step/**/*.js'
npm run test -w packages/visual-editor
```
