### PR TITLE
[ve] Add tooltip to tools button in Entity Editor

### DIFF
--- a/packages/visual-editor/src/ui/elements/entity-editor/entity-editor.ts
+++ b/packages/visual-editor/src/ui/elements/entity-editor/entity-editor.ts
@@ -37,7 +37,9 @@ import { until } from "lit/directives/until.js";
 import { MAIN_BOARD_ID } from "../../../sca/constants.js";
 import {
   FastAccessSelectEvent,
+  HideTooltipEvent,
   IterateOnPromptEvent,
+  ShowTooltipEvent,
   StateEvent,
   ToastEvent,
 } from "../../events/events.js";
@@ -1473,6 +1475,18 @@ export class EntityEditor extends SignalWatcher(LitElement) {
               ${hasTextEditor
                 ? html`<button
                     id="tools"
+                    @pointerover=${(evt: PointerEvent) => {
+                      this.dispatchEvent(
+                        new ShowTooltipEvent(
+                          Strings.from("COMMAND_ADD_TOOLS"),
+                          evt.clientX,
+                          evt.clientY
+                        )
+                      );
+                    }}
+                    @pointerout=${() => {
+                      this.dispatchEvent(new HideTooltipEvent());
+                    }}
                     @pointerdown=${() => {
                       if (!this.#editorRef.value) {
                         return;
@@ -1481,6 +1495,7 @@ export class EntityEditor extends SignalWatcher(LitElement) {
                       this.#editorRef.value.storeLastRange();
                     }}
                     @click=${(evt: PointerEvent) => {
+                      this.dispatchEvent(new HideTooltipEvent());
                       const bounds = new DOMRect(
                         evt.clientX,
                         evt.clientY,

--- a/packages/visual-editor/src/ui/strings/en_US/editor.ts
+++ b/packages/visual-editor/src/ui/strings/en_US/editor.ts
@@ -11,6 +11,9 @@ export default {
   COMMAND_ADD_MISSING_ITEM: {
     str: "Add",
   },
+  COMMAND_ADD_TOOLS: {
+    str: "Add tools",
+  },
   COMMAND_SHOW_LIBRARY: {
     str: "Show Library",
   },


### PR DESCRIPTION
## What
Added the custom tooltip behavior (`ShowTooltipEvent` and `HideTooltipEvent`) to the "Add tools" button in the "Generate" node configuration editor.

## Why
Hovering the mouse over the "Add tools" button in the node editor did not show any tooltip, making the button's action less discoverable.

## Changes
- **Visual Editor**:
  - Added `COMMAND_ADD_TOOLS` to `packages/visual-editor/src/ui/strings/en_US/editor.ts`.
  - Registered `@pointerover` and `@pointerout` handlers to fire tooltip events on `#tools` button in `packages/visual-editor/src/ui/elements/entity-editor/entity-editor.ts`.
  - Added `HideTooltipEvent` dispatch to `@click` to prevent the tooltip from hanging open.

## Testing
- Verified that all unit tests and builds compiled and passed successfully.
