### PR TITLE
[ve] Elevate Overflow Menu to Top-Level Component

### DIFF
--- a/packages/visual-editor/src/index-lite.ts
+++ b/packages/visual-editor/src/index-lite.ts
@@ -768,6 +768,7 @@ export class LiteMain extends MainBase implements LiteEditInputController {
   #renderShellUI() {
     return [
       this.renderTooltip(),
+      this.renderOverflowMenu(),
       this.sca.controller.global.main.show.has("NoAccessModal")
         ? this.renderNoAccessModal()
         : nothing,

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -231,6 +231,7 @@ class Main extends MainBase {
           ? this.renderSignInModal()
           : nothing,
         this.renderTooltip(),
+        this.renderOverflowMenu(),
         this.#renderToasts(),
         this.renderSnackbar(),
         this.renderNotebookLmPicker(),

--- a/packages/visual-editor/src/main-base.ts
+++ b/packages/visual-editor/src/main-base.ts
@@ -13,6 +13,7 @@ import { html, LitElement, nothing } from "lit";
 import { state } from "lit/decorators.js";
 
 import { createRef, ref, type Ref } from "lit/directives/ref.js";
+import { styleMap } from "lit/directives/style-map.js";
 import { styles as mainStyles } from "./index.styles.js";
 import "./ui/lite/step-list-view/step-list-view.js";
 import "./ui/lite/input/editor-input-lite.js";
@@ -77,6 +78,22 @@ abstract class MainBase extends SignalWatcher(LitElement) {
   @state()
   protected accessor tosStatus: CheckAppAccessResponse | null = null;
 
+  @state()
+  protected accessor overflowMenuActions:
+    | BreadboardUI.Types.OverflowAction[]
+    | null = null;
+
+  @state()
+  protected accessor overflowMenuX = 0;
+
+  @state()
+  protected accessor overflowMenuY = 0;
+
+  protected overflowMenuOnAction:
+    | ((action: string, value: string | null) => void)
+    | null = null;
+  protected overflowMenuOnDismiss: (() => void) | null = null;
+
   // References.
   // NOTE: selectionState field removed. Selection is now managed
   // entirely by SelectionController via SCA.
@@ -97,6 +114,7 @@ abstract class MainBase extends SignalWatcher(LitElement) {
 
   readonly #onShowTooltipBound = this.#onShowTooltip.bind(this);
   readonly #hideTooltipBound = this.#hideTooltip.bind(this);
+  readonly #onShowOverflowMenuBound = this.#onShowOverflowMenu.bind(this);
   #urlEffectDisposer: (() => void) | null = null;
   #lastHandledUrl: string | null = null;
 
@@ -238,6 +256,10 @@ abstract class MainBase extends SignalWatcher(LitElement) {
     window.addEventListener("bbshowtooltip", this.#onShowTooltipBound);
     window.addEventListener("bbhidetooltip", this.#hideTooltipBound);
     window.addEventListener("pointerdown", this.#hideTooltipBound);
+    window.addEventListener(
+      "bbshowoverflowmenu",
+      this.#onShowOverflowMenuBound
+    );
 
     if (this.sca.services.embedHandler) {
       this.embedState = embedState();
@@ -271,6 +293,10 @@ abstract class MainBase extends SignalWatcher(LitElement) {
     window.removeEventListener("bbshowtooltip", this.#onShowTooltipBound);
     window.removeEventListener("bbhidetooltip", this.#hideTooltipBound);
     window.removeEventListener("pointerdown", this.#hideTooltipBound);
+    window.removeEventListener(
+      "bbshowoverflowmenu",
+      this.#onShowOverflowMenuBound
+    );
 
     // Dispose URL change effect
     if (this.#urlEffectDisposer) {
@@ -564,6 +590,15 @@ abstract class MainBase extends SignalWatcher(LitElement) {
     this.tooltipRef.value.visible = false;
   }
 
+  #onShowOverflowMenu(evt: Event) {
+    const overflowMenuEvent = evt as BreadboardUI.Events.ShowOverflowMenuEvent;
+    this.overflowMenuActions = overflowMenuEvent.actions;
+    this.overflowMenuX = overflowMenuEvent.x;
+    this.overflowMenuY = overflowMenuEvent.y;
+    this.overflowMenuOnAction = overflowMenuEvent.onAction;
+    this.overflowMenuOnDismiss = overflowMenuEvent.onDismiss ?? null;
+  }
+
   /**
    * @deprecated File drop to create new tab is no longer supported
    */
@@ -629,6 +664,44 @@ abstract class MainBase extends SignalWatcher(LitElement) {
 
   protected renderTooltip() {
     return html`<bb-tooltip ${ref(this.tooltipRef)}></bb-tooltip>`;
+  }
+
+  protected renderOverflowMenu() {
+    if (!this.overflowMenuActions) {
+      return nothing;
+    }
+
+    return html`<bb-overflow-menu
+      style=${styleMap({
+        left: `${this.overflowMenuX}px`,
+        top: `${this.overflowMenuY}px`,
+      })}
+      .actions=${this.overflowMenuActions}
+      .disabled=${false}
+      @bboverflowmenuaction=${(
+        evt: BreadboardUI.Events.OverflowMenuActionEvent
+      ) => {
+        evt.stopImmediatePropagation();
+        const action = evt.action;
+        const value = evt.value;
+        const onAction = this.overflowMenuOnAction;
+        this.overflowMenuActions = null;
+        this.overflowMenuOnAction = null;
+        this.overflowMenuOnDismiss = null;
+        if (onAction) {
+          onAction(action, value);
+        }
+      }}
+      @bboverflowmenudismissed=${() => {
+        const onDismiss = this.overflowMenuOnDismiss;
+        this.overflowMenuActions = null;
+        this.overflowMenuOnAction = null;
+        this.overflowMenuOnDismiss = null;
+        if (onDismiss) {
+          onDismiss();
+        }
+      }}
+    ></bb-overflow-menu>`;
   }
 
   protected invokeRemixEventRouteWith(

--- a/packages/visual-editor/src/ui/elements/input/add-asset/add-asset-button.ts
+++ b/packages/visual-editor/src/ui/elements/input/add-asset/add-asset-button.ts
@@ -3,14 +3,13 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-import { LitElement, html, css, HTMLTemplateResult, nothing } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { LitElement, html, css } from "lit";
+import { customElement, property } from "lit/decorators.js";
 import { OverflowAction } from "../../../types/types.js";
 import { notebookLmIcon } from "../../../styles/svg-icons.js";
-import { styleMap } from "lit/directives/style-map.js";
 import {
   AddAssetRequestEvent,
-  OverflowMenuActionEvent,
+  ShowOverflowMenuEvent,
 } from "../../../events/events.js";
 import { icons } from "../../../styles/icons.js";
 
@@ -42,12 +41,6 @@ export class AddAssetButton extends LitElement {
 
   @property()
   accessor anchor: "above" | "below" = "below";
-
-  @state()
-  accessor _showOverflowMenu = false;
-
-  @state()
-  accessor _assetType = "file";
 
   static styles = [
     icons,
@@ -93,118 +86,86 @@ export class AddAssetButton extends LitElement {
           }
         }
       }
-
-      bb-overflow-menu {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: min-content;
-        --border-color: transparent;
-        --inner-border-color: light-dark(var(--n-90), var(--n-30));
-        --background-color: light-dark(var(--p-98), var(--n-20));
-        --text-color: light-dark(var(--n-30), var(--nv-95));
-      }
     `,
   ];
 
-  #overflowMenu: { x: number; y: number } = { x: 0, y: 0 };
-
   render() {
-    let overflowMenu: HTMLTemplateResult | symbol = nothing;
-    const overflowMenuPosition = { ...this.#overflowMenu };
-    if (this._showOverflowMenu) {
-      const actions: OverflowAction[] = [];
+    const actions: OverflowAction[] = [];
 
-      if (this.supportedActions.upload) {
-        actions.push({
-          icon: "upload",
-          name: "upload",
-          title: "Upload from Device",
-        });
-      }
+    if (this.supportedActions.upload) {
+      actions.push({
+        icon: "upload",
+        name: "upload",
+        title: "Upload from Device",
+      });
+    }
 
-      if (this.supportedActions.youtube) {
-        actions.push({
-          icon: "youtube",
-          name: "youtube",
-          title: "Add YouTube Video",
-        });
-      }
+    if (this.supportedActions.youtube) {
+      actions.push({
+        icon: "youtube",
+        name: "youtube",
+        title: "Add YouTube Video",
+      });
+    }
 
-      if (this.supportedActions.gdrive && this.showGDrive) {
-        actions.push({
-          icon: "gdrive",
-          title: "Add from Google Drive",
-          name: "gdrive",
-        });
-      }
+    if (this.supportedActions.gdrive && this.showGDrive) {
+      actions.push({
+        icon: "gdrive",
+        title: "Add from Google Drive",
+        name: "gdrive",
+      });
+    }
 
-      if (this.supportedActions.drawable) {
-        actions.push({
-          icon: "drawable",
-          name: "drawable",
-          title: "Add a Drawing",
-        });
-      }
+    if (this.supportedActions.drawable) {
+      actions.push({
+        icon: "drawable",
+        name: "drawable",
+        title: "Add a Drawing",
+      });
+    }
 
-      if (this.supportedActions.webcamVideo) {
-        actions.push({
-          icon: "videocam",
-          name: "webcam-video",
-          title: "Add a Webcam Video",
-        });
-      }
+    if (this.supportedActions.webcamVideo) {
+      actions.push({
+        icon: "videocam",
+        name: "webcam-video",
+        title: "Add a Webcam Video",
+      });
+    }
 
-      if (this.supportedActions.notebooklm && this.showNotebookLm) {
-        actions.push({
-          icon: notebookLmIcon,
-          name: "notebooklm",
-          title: "NotebookLM",
-        });
-      }
-
-      if (this.anchor === "above") {
-        overflowMenuPosition.y -= 12; // Clearance.
-        overflowMenuPosition.y -= actions.length * BUTTON_HEIGHT; // Menu height.
-      }
-
-      overflowMenu = html`<bb-overflow-menu
-        style=${styleMap({
-          left: `${overflowMenuPosition.x}px`,
-          top: `${overflowMenuPosition.y}px`,
-        })}
-        .actions=${actions}
-        .disabled=${false}
-        @bboverflowmenuaction=${(evt: OverflowMenuActionEvent) => {
-          evt.stopImmediatePropagation();
-          this._showOverflowMenu = false;
-
-          this.dispatchEvent(
-            new AddAssetRequestEvent(evt.action, this.allowedUploadMimeTypes)
-          );
-        }}
-        @bboverflowmenudismissed=${() => {
-          this._showOverflowMenu = false;
-        }}
-      ></bb-overflow-menu>`;
+    if (this.supportedActions.notebooklm && this.showNotebookLm) {
+      actions.push({
+        icon: notebookLmIcon,
+        name: "notebooklm",
+        title: "NotebookLM",
+      });
     }
 
     return html`<button
-        ?disabled=${this.disabled}
-        @click=${(evt: Event) => {
-          if (!(evt.target instanceof HTMLButtonElement)) {
-            return;
-          }
+      ?disabled=${this.disabled}
+      @click=${(evt: Event) => {
+        if (!(evt.target instanceof HTMLButtonElement)) {
+          return;
+        }
 
-          this.#overflowMenu.x = 0;
-          this.#overflowMenu.y = 0;
+        const bounds = evt.target.getBoundingClientRect();
+        const x = bounds.left;
+        let y = bounds.bottom;
 
-          this._showOverflowMenu = true;
-        }}
-        id="add-asset"
-      >
-        <span class="g-icon">add_circle</span>
-      </button>
-      ${overflowMenu}`;
+        if (this.anchor === "above") {
+          y = bounds.top - 12 - actions.length * BUTTON_HEIGHT;
+        }
+
+        this.dispatchEvent(
+          new ShowOverflowMenuEvent(actions, x, y, (action) => {
+            this.dispatchEvent(
+              new AddAssetRequestEvent(action, this.allowedUploadMimeTypes)
+            );
+          })
+        );
+      }}
+      id="add-asset"
+    >
+      <span class="g-icon">add_circle</span>
+    </button>`;
   }
 }

--- a/packages/visual-editor/src/ui/elements/overflow-menu/overflow-menu.ts
+++ b/packages/visual-editor/src/ui/elements/overflow-menu/overflow-menu.ts
@@ -43,13 +43,14 @@ export class OverflowMenu extends LitElement {
           light-dark(var(--n-100), var(--n-15))
         );
         border-radius: var(--bb-grid-size-2);
-        z-index: 2;
+        z-index: 2000;
         box-shadow:
           0px 4px 8px 3px rgba(0, 0, 0, 0.05),
           0px 1px 3px rgba(0, 0, 0, 0.1);
         max-height: 380px;
         scrollbar-width: none;
         overflow-y: scroll;
+        width: max-content;
       }
 
       button {

--- a/packages/visual-editor/src/ui/events/events.ts
+++ b/packages/visual-editor/src/ui/events/events.ts
@@ -17,6 +17,7 @@ import type {
   AppTemplateAdditionalOptionsAvailable,
   Command,
   EdgeData,
+  OverflowAction,
   Tokens,
   UserOutputValues,
   Utterance,
@@ -208,6 +209,19 @@ export class ShowTooltipEvent extends Event {
     }
   ) {
     super(ShowTooltipEvent.eventName, { ...eventInit });
+  }
+}
+
+export class ShowOverflowMenuEvent extends Event {
+  static eventName = "bbshowoverflowmenu";
+  constructor(
+    public readonly actions: OverflowAction[],
+    public readonly x: number,
+    public readonly y: number,
+    public readonly onAction: (action: string, value: string | null) => void,
+    public readonly onDismiss?: () => void
+  ) {
+    super(ShowOverflowMenuEvent.eventName, { ...eventInit });
   }
 }
 


### PR DESCRIPTION
## What
Elevated the `<bb-overflow-menu>` from a nested component to a top-level overlay. Refactored `<bb-add-asset-button>` to trigger the menu by dispatching a viewport-positioned event.

## Why
This solves a layout issue where the overflow menu was partially obscured or clipped by layout dividers (like `bb-splitter` or containing panels) that constrain overflow.

## Changes
- **Events**: Added `ShowOverflowMenuEvent` carrying actions, coordinates, and execution callbacks.
- **Shell**: Added state variables and handlers in `main-base.ts` to listen for the event and render the elevated menu at the root in `index.ts` and `index-lite.ts`.
- **Add Asset Button**: Refactored `add-asset-button.ts` to dispatch `ShowOverflowMenuEvent` with computed bounding rect coordinates instead of rendering the menu locally.
- **Overflow Menu Style**: Set the menu's host `z-index` to `2000` and `width` to `max-content` to snap it cleanly to the width of its items and sit on top of viewport overlays.

## Testing
Verify manually by clicking the "+" (add asset) button inside the console view and ensuring the menu overlay is fully visible above all containers and dividers without being clipped.
