### PR TITLE
[bees] # PR Summary: Remove redundant agent communication functions

### DIFF
--- a/hives/swarm-test/config/TEMPLATES.yaml
+++ b/hives/swarm-test/config/TEMPLATES.yaml
@@ -10,8 +10,11 @@
     In the first message, briefly introduce yourself and tell the user what you
     can do.
 
-    When the new app is build, add it to your surface, so that the user can see
+    When the new app is built, add it to your surface, so that the user can see
     it.
+
+    Never call `agents_await`: your job is to stay responsive to the user, and
+    that means only calling the `chat_*` functions.
   functions:
     - chat.*
     - agents.*

--- a/packages/bees/bees/declarations/agents.functions.json
+++ b/packages/bees/bees/declarations/agents.functions.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "agents_list_types",
-    "description": "List available agent types that can be assigned tasks.",
+    "description": "List available agent types that can be assigned tasks. New agent templates or overrides can be created or modified inside the`templates/` directory of your workspace during execution, so call this function to discover the current list. The `options_schema` of an agent specifies configuration overrides (if any) can be supplied via the `options` parameter of `agents_assign_task`.",
     "parametersJsonSchema": {
       "type": "object",
       "properties": {}
@@ -9,7 +9,7 @@
   },
   {
     "name": "agents_assign_task",
-    "description": "Assign a task to a named agent. If the agent doesn't exist yet, it is created automatically from the specified type. If it previously completed a task, a fresh instance is created (same name, new session, workspace persists).",
+    "description": "Assign a task to a named agent. If the agent doesn't exist yet, it is created automatically from the specified type. If it previously completed a task, a fresh instance is created (same name, new session, workspace persists). Agents run tasks asynchronously -- this function returns immediately",
     "parametersJsonSchema": {
       "type": "object",
       "properties": {
@@ -19,7 +19,7 @@
         },
         "slug": {
           "type": "string",
-          "description": "The agent's name. Use a short, descriptive, lowercase identifier (e.g., 'researcher', 'deep-dive'). The same slug always refers to the same agent."
+          "description": "The agent's name. Use a short, descriptive, lowercase identifier (e.g., 'researcher', 'deep-dive'). The same slug always refers to the same agent. This will give the agent have access to a sub-directory by this name in your filesystem. You provide a simple directory name (e.g., `research`)"
         },
         "objective": {
           "type": "string",
@@ -65,30 +65,8 @@
     }
   },
   {
-    "name": "agents_send_event",
-    "description": "Send a typed event to a named agent. The agent receives the event as a context update. Use this to provide additional instructions, clarifications, or data to a running agent.",
-    "parametersJsonSchema": {
-      "type": "object",
-      "properties": {
-        "slug": {
-          "type": "string",
-          "description": "The name of the agent to send the event to."
-        },
-        "type": {
-          "type": "string",
-          "description": "The type of event (e.g., 'clarification', 'additional_context'). Choose descriptive, stable names."
-        },
-        "message": {
-          "type": "string",
-          "description": "Text payload delivered to the agent. Include all relevant details the agent needs to act on."
-        }
-      },
-      "required": ["slug", "type", "message"]
-    }
-  },
-  {
     "name": "agents_await",
-    "description": "Suspend execution until a context update arrives (e.g. an agent completes a task or a parent sends an event). Returns immediately if updates are already pending. Call this after assigning tasks to wait for their results.",
+    "description": "Wait until the next context update arrives (e.g. an agent completes a task). Call this after assigning tasks to wait for their results, but only if you don't have chat_* functions. When you have chat_*, call them instead -- this allows you to stay responsive to the user while the tasks are being worked on in the background",
     "parametersJsonSchema": {
       "type": "object",
       "properties": {

--- a/packages/bees/bees/declarations/agents.instruction.md
+++ b/packages/bees/bees/declarations/agents.instruction.md
@@ -1,72 +1,7 @@
 # Agents
 
 You manage a team of agents. Each agent is a named worker that you assign tasks
-to. Agents appear on demand — you never create them explicitly.
+to. Agents are created on demand as you assign tasks to them.
 
-Available agent types are resolved dynamically via "agents_list_types". New
-agent templates or overrides can be created or modified inside the `templates/`
-directory of your workspace during execution. Call "agents_list_types" to
-discover the current, most up-to-date list of available agent types before
-assigning a task, especially if you or the system have dynamically created or
-edited templates. When listing agent types, check their "options_schema" to see
-what configuration overrides (if any) can be supplied via the "options"
-parameter of "agents_assign_task".
-
-To assign work, call "agents_assign_task" with the agent type, a name (slug),
-and the task objective. If no agent with that name exists, one is created
-automatically. If a previous agent with that name already finished, a fresh
-instance is created (same name, new session, workspace persists).
-
-Use "agents_check_status" to see the status of all your agents by name. Use
-"agents_send_event" to send a context update to a running agent. Use
-"agents_cancel" to cancel an agent and any pending work.
-
-Tasks run asynchronously — "agents_assign_task" returns immediately. The
-scheduler issues a context update when each agent completes its task, containing
-the outcome or an error message.
-
-If you have chat functions available, use them ("chat_request_user_input" or
-"chat_present_choices"), so that you remain responsive to the user.
-
-If you don't have chat functions, Call "agents_await" to wait for for results.
-This suspends your execution until a context update arrives (e.g. an agent
-completes or a parent sends you an event). If updates are already pending, it
-returns immediately.
-
-Do not call "agents_await" if you have chat functions -- they will block your
-ability to be responsive to the user.
-
-Typical workflow:
-
-1. Call "agents_list_types" to discover available agent types.
-2. Assign one or more tasks with "agents_assign_task".
-3. Continue using chat functions or, if not available, call "agents_await" to
-   suspend until an agent completes.
-4. If needed, check results with "agents_check_status".
-5. Repeat or proceed based on results.
-
-The agents working on tasks have access to a sub-directory of your filesystem,
-specified by the "slug" parameter. You provide a simple directory name (e.g.,
-"research"). If you are yourself a subagent, the system automatically nests your
-slug under your own working directory.
-
-## Agents and user input
-
-To successfully complete tasks, agents may be equipped with the ability to chat
-with the user. This may result in multi-threaded conversations: you are talking
-with the user, as well as your agents are talking with the user. This is
-perfectly fine and is a good pattern of separating conversations on different
-topics.
-
-## Agent statuses
-
-When you check on your agents, each agent has a status:
-
-- **available** — the agent is queued and waiting to start.
-- **running** — the agent is actively working on its task.
-- **suspended** — the agent is waiting for user input or an event.
-- **paused** — the agent is temporarily paused by the scheduler.
-- **completed** — the agent finished its task successfully. The outcome will be
-  delivered to you as a context update.
-- **failed** — the agent encountered an unrecoverable error.
-- **cancelled** — the agent was cancelled before completion.
+Agents run tasks asynchronously, and communicate back to you with a context
+update when upon completion of each task.

--- a/packages/bees/bees/declarations/agents.metadata.json
+++ b/packages/bees/bees/declarations/agents.metadata.json
@@ -3,6 +3,5 @@
   {"name": "agents_assign_task", "icon": "assignment", "title": "Assign Task"},
   {"name": "agents_check_status", "icon": "fact_check", "title": "Check Agents"},
   {"name": "agents_cancel", "icon": "cancel", "title": "Cancel Agent"},
-  {"name": "agents_send_event", "icon": "send", "title": "Send Event"},
   {"name": "agents_await", "icon": "hourglass_empty", "title": "Await"}
 ]

--- a/packages/bees/bees/declarations/chat.functions.json
+++ b/packages/bees/bees/declarations/chat.functions.json
@@ -117,30 +117,5 @@
       },
       "additionalProperties": false
     }
-  },
-  {
-    "name": "chat_await_context_update",
-    "description": "Suspends the agent until an external context update arrives. Use this only when your objective explicitly instructs you to wait for context updates. Do not call this function on your own initiative.",
-    "parametersJsonSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {},
-      "additionalProperties": false
-    },
-    "responseJsonSchema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "type": "object",
-      "properties": {
-        "resumed": {
-          "type": "boolean",
-          "description": "True when the agent has been resumed after a context update arrived."
-        },
-        "error": {
-          "type": "string",
-          "description": "If an error has occurred, will contain a description of the error"
-        }
-      },
-      "additionalProperties": false
-    }
   }
 ]

--- a/packages/bees/bees/declarations/chat.instruction.md
+++ b/packages/bees/bees/declarations/chat.instruction.md
@@ -25,17 +25,3 @@ wrapped in `<context_update>` tags:
 
 The user is not aware that they are being sent, so do not reply to them as if
 they were user input.
-
-## Awaiting Context Updates
-
-The "chat_await_context_update" function suspends your session until an external
-context update arrives. It is equivalent to "agents_await" from the agents
-function group. If you have access to agents functions, prefer "agents_await"
-instead — it works identically and is available to all agents.
-
-**Only call this function when your objective explicitly instructs you to wait
-for context updates.** Do not call it on your own initiative — it is not a
-general-purpose "wait" or "sleep" tool.
-
-When the function returns, look for `<context_update>` text parts in the
-conversation, then continue with your objective.

--- a/packages/bees/bees/functions/agents.py
+++ b/packages/bees/bees/functions/agents.py
@@ -281,55 +281,6 @@ def _make_handlers(
 
         return {"agents": agents}
 
-    async def _agents_send_event(args: dict[str, Any], status_cb: Any) -> dict[str, Any]:
-        """Send a typed event to a named child agent."""
-        slug = args.get("slug", "")
-        event_type = args.get("type", "")
-        message = args.get("message", "")
-
-        if not slug:
-            return {"error": "slug is required"}
-        if not event_type:
-            return {"error": "type is required"}
-        if not scheduler:
-            return {"error": "Scheduler not available"}
-
-        if status_cb:
-            status_cb(f"Sending event to {slug}: {event_type}")
-
-        # Resolve slug to agent ID.
-        child = scheduler.store.find_child_by_slug(caller_agent_id, slug)
-        if not child:
-            return {"error": f"Agent '{slug}' not found"}
-
-        try:
-            update = {
-                "type": event_type,
-                "message": message,
-                "from_agent_id": caller_agent_id,
-                "from_slug": scope.slug_path if scope else None,
-            }
-            error = scheduler.deliver_to_task(
-                child.id,
-                update,
-                expected_creator=caller_agent_id,
-            )
-        except Exception as e:
-            logger.exception("agents_send_event failed")
-            return {"error": str(e)}
-
-        if status_cb:
-            status_cb(None, None)
-
-        if error:
-            return {"error": error}
-
-        return {
-            "agent_slug": slug,
-            "type": event_type,
-            "delivered": True,
-        }
-
     async def _agents_cancel(args: dict[str, Any], status_cb: Any) -> dict[str, Any]:
         """Cancel a named child agent."""
         slug = args.get("slug", "")
@@ -395,7 +346,6 @@ def _make_handlers(
         "agents_list_types": _agents_list_types,
         "agents_assign_task": _agents_assign_task,
         "agents_check_status": _agents_check_status,
-        "agents_send_event": _agents_send_event,
         "agents_cancel": _agents_cancel,
         "agents_await": _agents_await,
     }

--- a/packages/bees/tests/test_agents.py
+++ b/packages/bees/tests/test_agents.py
@@ -388,57 +388,6 @@ async def test_agents_check_status_nested_tree():
     assert orch["agents"][0]["outcome"] == "Done!"
 
 
-# ---------------------------------------------------------------------------
-# agents_send_event
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_agents_send_event_by_slug():
-    parent = GLOBAL_STORE.create("Parent")
-
-    child = GLOBAL_STORE.create("Child")
-    child.metadata.parent_id = parent.id
-    child.metadata.slug = "researcher"
-    child.metadata.status = "suspended"
-    GLOBAL_STORE.save_metadata(child)
-
-    scheduler = _scheduler_mock()
-    scope = SubagentScope(workspace_root_id=parent.id)
-    handlers = _make_handlers(
-        scope=scope, caller_agent_id=parent.id, scheduler=scheduler,
-    )
-
-    result = await handlers["agents_send_event"]({
-        "slug": "researcher",
-        "type": "clarification",
-        "message": "Please focus on pricing",
-    }, None)
-
-    assert result["delivered"] is True
-    assert result["agent_slug"] == "researcher"
-    scheduler.deliver_to_task.assert_called_once()
-    call_args = scheduler.deliver_to_task.call_args
-    assert call_args[0][0] == child.id
-
-
-@pytest.mark.asyncio
-async def test_agents_send_event_not_found():
-    parent = GLOBAL_STORE.create("Parent")
-
-    scheduler = _scheduler_mock()
-    handlers = _make_handlers(
-        caller_agent_id=parent.id, scheduler=scheduler,
-    )
-
-    result = await handlers["agents_send_event"]({
-        "slug": "nonexistent",
-        "type": "clarification",
-        "message": "Hello",
-    }, None)
-
-    assert "error" in result
-    assert "not found" in result["error"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Remove `agents_send_event` and `chat_await_context_update` — two functions that
overlap with existing primitives and confuse the agent.

## Why

`agents_send_event` is redundant with `agents_assign_task`, which already
delivers context updates to running agents. `chat_await_context_update`
duplicates `agents_await`. Having multiple ways to do the same thing creates
decision fatigue for agents and leads to inconsistent behavior. Simplifying the
function surface makes the orchestration model clearer: assign tasks, check
status, await results.

## Changes

### Agents function group (`packages/bees`)

- **Removed** `agents_send_event` declaration, handler, metadata, and tests
- **Updated** `agents_await` description to remove stale "parent sends an event"
  reference
- **Simplified** `agents.instruction.md` — removed verbose lifecycle state
  documentation

### Chat function group (`packages/bees`)

- **Removed** `chat_await_context_update` declaration and instruction section

## Testing

Run `pytest packages/bees/tests/test_agents.py` — the remaining tests should
pass cleanly with no references to removed functions.
