### PR TITLE
[bees] Task queuing for busy agents

### DIFF
--- a/hives/swarm-test/config/TEMPLATES.yaml
+++ b/hives/swarm-test/config/TEMPLATES.yaml
@@ -1,3 +1,5 @@
+# Ticket templates — see docs/patterns.md for the field reference.
+
 - name: async-chat
   title: Async Opie
   description: A chat app that makes apps and multimedia
@@ -29,8 +31,7 @@
 - name: workspace-test
   title: Test Workspace MCP 2
   description: Tests workspace MCP integration
-  objective:
-    Chat with the user and fulfill their requests with the tools that you have.
+  objective: Chat with the user and fulfill their requests with the tools that you have.
   functions:
     - chat.*
     - drive.*
@@ -67,12 +68,14 @@
     types, then assign two sequential tasks to an "infinite-poet" agent with
     slug "poet".
 
+
     Task 1: Write a haiku about bees. Save it to haiku.txt. Task 2: Write a
     haiku about ants. Save it to ants.txt.
 
-    After assigning task 1, wait for it to complete using agents_await. Then
-    assign task 2 to the same slug and wait again. When both tasks are complete,
-    mark your objective as fulfilled with a summary of the results.
+    After assigning task 1, don't wait for it to complete, and immediately
+    assign task 2 to the same slug and wait for both tasks to complete. When
+    both tasks are complete, mark your objective as fulfilled with a summary of
+    the results.
   functions:
     - agents.*
     - system.*
@@ -122,9 +125,9 @@
   options_schema:
     aspect_ratio:
       type: string
-      description:
-        "Target aspect ratio. Valid values: '1:1', '3:4', '4:3', '9:16', '16:9',
-        '1:2', '2:1', '3:2', '2:3', '5:4', '4:5', '7:5', '5:7', '21:9', '9:21'."
+      description: >-
+        Target aspect ratio. Valid values: '1:1', '3:4', '4:3', '9:16', '16:9',
+        '1:2', '2:1', '3:2', '2:3', '5:4', '4:5', '7:5', '5:7', '21:9', '9:21'.
       enum:
         - "1:1"
         - "3:4"
@@ -143,22 +146,21 @@
         - "9:21"
     image_size:
       type: string
-      description:
-        "Target resolution or image size. Valid values: '512', '1K', '2K', '4K'."
+      description: "Target resolution or image size. Valid values: '512', '1K', '2K', '4K'."
       enum:
         - "512"
-        - "1K"
-        - "2K"
-        - "4K"
+        - 1K
+        - 2K
+        - 4K
     person_generation:
       type: string
-      description:
-        "Person generation policy. Valid values: 'allow_all', 'dont_allow',
-        'allow_adult'."
+      description: >-
+        Person generation policy. Valid values: 'allow_all', 'dont_allow',
+        'allow_adult'.
       enum:
-        - "allow_all"
-        - "dont_allow"
-        - "allow_adult"
+        - allow_all
+        - dont_allow
+        - allow_adult
   description: >-
     An extremely versatile image generator, powered by Gemini. Use it for any
     tasks that involve generation of images based on a prompt. Always writes its
@@ -182,13 +184,13 @@
         - "1:1"
     resolution:
       type: string
-      description:
-        "Target resolution. Valid values: '720p', '1080p', '4k'. Extension is
-        limited to 720p."
+      description: >-
+        Target resolution. Valid values: '720p', '1080p', '4k'. Extension is
+        limited to 720p.
       enum:
-        - "720p"
-        - "1080p"
-        - "4k"
+        - 720p
+        - 1080p
+        - 4k
     duration_seconds:
       type: number
       description: "Target duration in seconds. Valid values: 4, 6, 8."
@@ -198,13 +200,13 @@
         - 8
     person_generation:
       type: string
-      description:
-        "Person generation policy. Valid values: 'allow_all', 'dont_allow',
-        'allow_adult'."
+      description: >-
+        Person generation policy. Valid values: 'allow_all', 'dont_allow',
+        'allow_adult'.
       enum:
-        - "allow_all"
-        - "dont_allow"
-        - "allow_adult"
+        - allow_all
+        - dont_allow
+        - allow_adult
     first_frame:
       type: string
       description: >-
@@ -271,36 +273,36 @@
         Umbriel (mysterious, atmospheric), Vindemiatrix (articulate, refined),
         Zephyr (bright, perky), Zubenelgenubi (deep, resonant).
       enum:
-        - "Achernar"
-        - "Achird"
-        - "Algenib"
-        - "Algieba"
-        - "Alnilam"
-        - "Aoede"
-        - "Autonoe"
-        - "Callirrhoe"
-        - "Charon"
-        - "Despina"
-        - "Enceladus"
-        - "Erinome"
-        - "Fenrir"
-        - "Gacrux"
-        - "Iapetus"
-        - "Kore"
-        - "Laomedeia"
-        - "Leda"
-        - "Orus"
-        - "Puck"
-        - "Pulcherrima"
-        - "Rasalgethi"
-        - "Sadachbia"
-        - "Sadaltager"
-        - "Schedar"
-        - "Sulafat"
-        - "Umbriel"
-        - "Vindemiatrix"
-        - "Zephyr"
-        - "Zubenelgenubi"
+        - Achernar
+        - Achird
+        - Algenib
+        - Algieba
+        - Alnilam
+        - Aoede
+        - Autonoe
+        - Callirrhoe
+        - Charon
+        - Despina
+        - Enceladus
+        - Erinome
+        - Fenrir
+        - Gacrux
+        - Iapetus
+        - Kore
+        - Laomedeia
+        - Leda
+        - Orus
+        - Puck
+        - Pulcherrima
+        - Rasalgethi
+        - Sadachbia
+        - Sadaltager
+        - Schedar
+        - Sulafat
+        - Umbriel
+        - Vindemiatrix
+        - Zephyr
+        - Zubenelgenubi
     speaker_1:
       type: string
       description: >-

--- a/packages/bees/bees/functions/agents.py
+++ b/packages/bees/bees/functions/agents.py
@@ -195,18 +195,10 @@ def _make_handlers(
                     status_cb(None, None)
                 return {"agent_slug": slug, "status": "reused"}
 
-            # Non-terminal: agent is busy or suspended.
-            if existing.metadata.finite:
-                # Finite agents process one task at a time via fresh instances.
-                if status_cb:
-                    status_cb(None, None)
-                return {
-                    "error": f"Agent '{slug}' is currently busy "
-                    f"(status: {existing.metadata.status}). "
-                    f"Wait for it to complete before assigning a new task."
-                }
-
-            # Infinite agent: queue the task for delivery.
+            # Non-terminal: agent is busy or suspended — queue the task.
+            # Both finite and infinite agents use the same path: create a
+            # queued TaskRecord and let the scheduler drain it at the right
+            # time (completion for finite, yield for infinite).
             task_file_store = getattr(scheduler.store, '_task_file_store', None)
             if task_file_store:
                 task_file_store.create(
@@ -215,19 +207,18 @@ def _make_handlers(
                     created_by=caller_agent_id,
                     kind="work",
                     title=title or summary,
+                    status="queued",
                 )
 
-            # Deliver task assignment as a context update.
-            task_update = {
-                "type": "task_assigned",
-                "objective": objective,
-                "from_slug": scope.slug_path if scope else None,
-            }
-            scheduler.deliver_to_task(
-                existing.id,
-                task_update,
-                expected_creator=None,  # Allow self-delivery.
-            )
+            # If the infinite agent is already idle (suspended, waiting
+            # for its next task), drain immediately so it doesn't sit
+            # there with work waiting.
+            if (
+                not existing.metadata.finite
+                and existing.metadata.status == "suspended"
+                and existing.metadata.assignee == "user"
+            ):
+                scheduler.drain_task_queue(existing.id)
 
             if status_cb:
                 status_cb(None, None)

--- a/packages/bees/bees/scheduler.py
+++ b/packages/bees/bees/scheduler.py
@@ -388,6 +388,66 @@ class Scheduler:
         self._deliver_context_update(task_id, update)
         return None
 
+    def drain_task_queue(self, agent_id: str) -> bool:
+        """Dequeue the next task for an agent and start it.
+
+        For finite agents: ``reset_for_reuse`` with the next task's
+        objective, then trigger the scheduler to pick it up.
+
+        For infinite agents: deliver the task as a context update
+        via the three-path delivery model.
+
+        Returns True if a task was dequeued and started.
+        """
+        agent = self.store.get(agent_id)
+        if not agent:
+            return False
+
+        task_file_store = getattr(self.store, '_task_file_store', None)
+        if not task_file_store:
+            return False
+
+        next_task = task_file_store.dequeue_next(agent_id)
+        if not next_task:
+            return False
+
+        if agent.metadata.finite:
+            self.store.reset_for_reuse(
+                agent, next_task.objective, title=next_task.title,
+            )
+            self.trigger()
+        else:
+            task_update = {
+                "type": "task_assigned",
+                "objective": next_task.objective,
+            }
+            self._deliver_context_update(agent_id, task_update)
+
+        logger.info(
+            "Drained queued task %s for agent %s",
+            next_task.id[:8], agent_id[:8],
+        )
+        return True
+
+    def _cancel_queued_tasks(self, agent_id: str) -> None:
+        """Cancel all queued tasks for an agent that failed.
+
+        Called when an agent reaches a non-recoverable state.
+        Future alternatives to consider:
+        - Re-queue to a fresh instance of the same agent type.
+        - Leave as queued and let the parent reassign or retry.
+        - Expose a ``retry_failed`` mutation that resets the agent
+          and re-drains the queue.
+        """
+        task_file_store = getattr(self.store, '_task_file_store', None)
+        if task_file_store:
+            count = task_file_store.cancel_queued(agent_id)
+            if count:
+                logger.info(
+                    "Cancelled %d queued task(s) for failed agent %s",
+                    count, agent_id[:8],
+                )
+
     # -- context delivery --------------------------------------------------
 
     def _deliver_context_update(self, target_id: str, update: dict[str, Any]) -> None:
@@ -625,6 +685,12 @@ class Scheduler:
                     }
                     self._deliver_context_update(parent_id, update)
 
+                # Drain task queue: feed the next queued task to the agent.
+                if updated.metadata.finite and updated.metadata.status == "completed":
+                    self.drain_task_queue(updated.id)
+                elif updated.metadata.status == "failed":
+                    self._cancel_queued_tasks(updated.id)
+
                 enriched = self._enrich_parent_tags(updated)
                 if enriched:
                     await self._emit(TaskDone(task=enriched))
@@ -673,6 +739,12 @@ class Scheduler:
                     ),
                 }
                 self._deliver_context_update(parent_id, update)
+
+            # Drain task queue: feed the next queued task to the agent.
+            if updated.metadata.finite and updated.metadata.status == "completed":
+                self.drain_task_queue(updated.id)
+            elif updated.metadata.status == "failed":
+                self._cancel_queued_tasks(updated.id)
 
             enriched = self._enrich_parent_tags(updated)
             if enriched:

--- a/packages/bees/bees/task_file_store.py
+++ b/packages/bees/bees/task_file_store.py
@@ -23,7 +23,7 @@ from typing import Any, Literal
 
 
 TaskStatus = Literal[
-    "available", "in_progress", "completed", "failed", "cancelled"
+    "available", "queued", "in_progress", "completed", "failed", "cancelled"
 ]
 
 TaskKind = Literal["work", "coordination"]
@@ -100,6 +100,7 @@ class TaskFileStore:
         context: str | None = None,
         tags: list[str] | None = None,
         depends_on: list[str] | None = None,
+        status: TaskStatus = "available",
     ) -> TaskRecord:
         """Create a new task file.
 
@@ -111,7 +112,7 @@ class TaskFileStore:
             objective=objective,
             assignee=assignee,
             created_by=created_by,
-            status="available",
+            status=status,
             kind=kind,
             title=title,
             context=context,
@@ -158,6 +159,50 @@ class TaskFileStore:
     def query_by_assignee(self, agent_id: str) -> list[TaskRecord]:
         """Return all tasks assigned to the given agent."""
         return [t for t in self.query_all() if t.assignee == agent_id]
+
+    def dequeue_next(self, agent_id: str) -> TaskRecord | None:
+        """Dequeue the oldest queued task for an agent.
+
+        Finds the first task with ``status='queued'`` assigned to
+        ``agent_id`` (ordered by ``created_at`` ascending), transitions
+        it to ``in_progress``, persists, and returns it.
+
+        Returns ``None`` if no queued tasks exist.
+        """
+        tasks = self.query_by_assignee(agent_id)
+        queued = [
+            t for t in tasks if t.status == "queued"
+        ]
+        # query_all sorts by created_at descending; we want FIFO.
+        queued.sort(key=lambda t: t.created_at or "")
+        if not queued:
+            return None
+
+        task = queued[0]
+        task.status = "in_progress"
+        self.save(task)
+        return task
+
+    def cancel_queued(self, agent_id: str) -> int:
+        """Cancel all queued tasks for an agent.
+
+        Returns the number of tasks cancelled.
+
+        Called when an agent fails — remaining queued work is no longer
+        viable.  Future alternatives to consider:
+        - Re-queue to a fresh instance of the same agent type.
+        - Leave as queued and let the parent reassign or retry.
+        - Expose a ``retry_failed`` mutation that resets the agent and
+          re-drains the queue.
+        """
+        tasks = self.query_by_assignee(agent_id)
+        count = 0
+        for task in tasks:
+            if task.status == "queued":
+                task.status = "cancelled"
+                self.save(task)
+                count += 1
+        return count
 
     def save(self, task: TaskRecord) -> None:
         """Persist a task to disk as a JSON file."""

--- a/packages/bees/bees/task_runner.py
+++ b/packages/bees/bees/task_runner.py
@@ -490,6 +490,9 @@ class TaskRunner:
                 agent.metadata.assignee = "agent"
                 agent.metadata.suspend_event = suspend_event
                 print(f"  [{agent.id[:8]}] 📩 auto-resume with queued update", file=sys.stderr)
+            elif self._drain_queued_task(agent, suspend_event):
+                # Persistent task queue had a waiting task — auto-resume.
+                pass
             else:
                 agent.metadata.status = "suspended"
                 agent.metadata.assignee = "user"
@@ -497,6 +500,45 @@ class TaskRunner:
         else:
             agent.metadata.assignee = None
             agent.metadata.suspend_event = None
+
+    def _drain_queued_task(
+        self, agent: Agent, suspend_event: dict[str, Any],
+    ) -> bool:
+        """Check the persistent task queue for the next queued task.
+
+        If a queued task exists, dequeues it, writes a context update
+        to ``response.json``, and sets the agent to auto-resume.
+
+        Returns True if a task was dequeued (agent will auto-resume),
+        False otherwise.
+        """
+        task_file_store = getattr(self._store, '_task_file_store', None)
+        if not task_file_store:
+            return False
+
+        next_task = task_file_store.dequeue_next(agent.id)
+        if not next_task:
+            return False
+
+        task_update = {
+            "type": "task_assigned",
+            "objective": next_task.objective,
+        }
+        response_path = agent.dir / "response.json"
+        response_path.write_text(
+            json.dumps(
+                {"context_updates": [task_update]},
+                indent=2, ensure_ascii=False,
+            ) + "\n"
+        )
+        agent.metadata.status = "suspended"
+        agent.metadata.assignee = "agent"
+        agent.metadata.suspend_event = suspend_event
+        print(
+            f"  [{agent.id[:8]}] 📩 auto-resume with queued task {next_task.id[:8]}",
+            file=sys.stderr,
+        )
+        return True
 
     def _handle_pause(self, agent: Agent, result: SessionResult) -> None:
         """Handle pause state from transient Gemini API errors."""

--- a/packages/bees/bees/unified_agent_store.py
+++ b/packages/bees/bees/unified_agent_store.py
@@ -222,12 +222,13 @@ class UnifiedAgentStore:
             changed = False
 
             if task.status != task_status:
-                # Don't downgrade a task that's already terminal.
-                # For infinite agents, events_yield marks individual tasks
-                # as completed while the agent is still running. The
-                # agent-level sync must not revert those to in_progress.
-                _TERMINAL_TASK = {"completed", "failed", "cancelled"}
-                if task.status in _TERMINAL_TASK and task_status not in _TERMINAL_TASK:
+                # Don't overwrite tasks that are terminal or still queued.
+                # Terminal: events_yield marks individual tasks as completed
+                # while the agent is still running — don't revert to in_progress.
+                # Queued: waiting in the task queue — must not be dragged to
+                # in_progress by the agent's current execution state.
+                _SKIP_TASK = {"completed", "failed", "cancelled", "queued"}
+                if task.status in _SKIP_TASK and task_status not in {"completed", "failed", "cancelled"}:
                     continue
                 task.status = task_status
                 changed = True

--- a/packages/bees/tests/test_agents.py
+++ b/packages/bees/tests/test_agents.py
@@ -259,13 +259,13 @@ async def test_agents_assign_task_fresh_instance(write_template):
 
 
 # ---------------------------------------------------------------------------
-# agents_assign_task — busy agent
+# agents_assign_task — task queue
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_agents_assign_task_busy_agent(write_template):
-    """A non-terminal agent returns an error (queuing deferred to Phase 4)."""
+async def test_agents_assign_task_queues_busy_finite(write_template):
+    """A busy finite agent queues the task instead of erroring."""
     write_template({
         "name": "writer",
         "title": "Writer",
@@ -296,7 +296,7 @@ async def test_agents_assign_task_busy_agent(write_template):
     child.metadata.status = "running"
     GLOBAL_STORE.save_metadata(child)
 
-    # Try to assign again — should get error.
+    # Assign again — should queue, not error.
     result = await handlers["agents_assign_task"]({
         "type": "writer",
         "slug": "poet",
@@ -304,8 +304,176 @@ async def test_agents_assign_task_busy_agent(write_template):
         "summary": "Second Haiku",
     }, None)
 
-    assert "error" in result
-    assert "busy" in result["error"]
+    assert result["status"] == "queued"
+    assert result["agent_slug"] == "poet"
+
+    # Verify a TaskRecord was created with status "queued".
+    task_file_store = GLOBAL_STORE._task_file_store
+    tasks = task_file_store.query_by_assignee(child.id)
+    queued = [t for t in tasks if t.status == "queued"]
+    assert len(queued) == 1
+    assert queued[0].objective == "Write haiku #2"
+
+
+@pytest.mark.asyncio
+async def test_agents_assign_task_queues_busy_infinite(write_template):
+    """A busy infinite agent queues without immediate context delivery."""
+    write_template({
+        "name": "researcher",
+        "title": "Researcher",
+        "objective": "Research things.",
+        "functions": ["files.*", "events.*"],  # No system.* = infinite
+    })
+
+    caller = GLOBAL_STORE.create("I'm the orchestrator")
+    caller.metadata.tasks = ["researcher"]
+    GLOBAL_STORE.save_metadata(caller)
+
+    scope = SubagentScope(workspace_root_id=caller.id)
+    scheduler = _scheduler_mock()
+    handlers = _make_handlers(
+        scope=scope, caller_agent_id=caller.id, scheduler=scheduler,
+    )
+
+    # Create agent.
+    await handlers["agents_assign_task"]({
+        "type": "researcher",
+        "slug": "deep-dive",
+        "objective": "Research topic A",
+        "summary": "Topic A",
+    }, None)
+
+    # Mark as running.
+    child = GLOBAL_STORE.find_child_by_slug(caller.id, "deep-dive")
+    child.metadata.status = "running"
+    GLOBAL_STORE.save_metadata(child)
+
+    # Assign another task while busy.
+    result = await handlers["agents_assign_task"]({
+        "type": "researcher",
+        "slug": "deep-dive",
+        "objective": "Research topic B",
+        "summary": "Topic B",
+    }, None)
+
+    assert result["status"] == "queued"
+
+    # Must NOT have delivered a context update — that's the scheduler's job.
+    scheduler.deliver_to_task.assert_not_called()
+
+    # Verify queued task exists.
+    task_file_store = GLOBAL_STORE._task_file_store
+    queued = [
+        t for t in task_file_store.query_by_assignee(child.id)
+        if t.status == "queued"
+    ]
+    assert len(queued) == 1
+    assert queued[0].objective == "Research topic B"
+
+
+@pytest.mark.asyncio
+async def test_agents_assign_task_drains_idle_infinite(write_template):
+    """A suspended infinite agent gets immediate drain when task is queued."""
+    write_template({
+        "name": "researcher",
+        "title": "Researcher",
+        "objective": "Research things.",
+        "functions": ["files.*", "events.*"],
+    })
+
+    caller = GLOBAL_STORE.create("I'm the orchestrator")
+    caller.metadata.tasks = ["researcher"]
+    GLOBAL_STORE.save_metadata(caller)
+
+    scope = SubagentScope(workspace_root_id=caller.id)
+    scheduler = _scheduler_mock()
+    handlers = _make_handlers(
+        scope=scope, caller_agent_id=caller.id, scheduler=scheduler,
+    )
+
+    # Create and mark as idle (suspended, waiting for task).
+    await handlers["agents_assign_task"]({
+        "type": "researcher",
+        "slug": "deep-dive",
+        "objective": "Research topic A",
+        "summary": "Topic A",
+    }, None)
+
+    child = GLOBAL_STORE.find_child_by_slug(caller.id, "deep-dive")
+    child.metadata.status = "suspended"
+    child.metadata.assignee = "user"
+    child.metadata.finite = False
+    GLOBAL_STORE.save_metadata(child)
+
+    # Assign — should call drain_task_queue since agent is idle.
+    result = await handlers["agents_assign_task"]({
+        "type": "researcher",
+        "slug": "deep-dive",
+        "objective": "Research topic B",
+        "summary": "Topic B",
+    }, None)
+
+    assert result["status"] == "queued"
+    scheduler.drain_task_queue.assert_called_once_with(child.id)
+
+
+@pytest.mark.asyncio
+async def test_agents_assign_task_queue_fifo(write_template):
+    """Multiple queued tasks are ordered by creation time (FIFO)."""
+    write_template({
+        "name": "writer",
+        "title": "Writer",
+        "objective": "Write things.",
+        "functions": ["files.*", "system.*"],
+    })
+
+    caller = GLOBAL_STORE.create("I'm the orchestrator")
+    caller.metadata.tasks = ["writer"]
+    GLOBAL_STORE.save_metadata(caller)
+
+    scope = SubagentScope(workspace_root_id=caller.id)
+    scheduler = _scheduler_mock()
+    handlers = _make_handlers(
+        scope=scope, caller_agent_id=caller.id, scheduler=scheduler,
+    )
+
+    # Create agent and mark as running.
+    await handlers["agents_assign_task"]({
+        "type": "writer",
+        "slug": "poet",
+        "objective": "Haiku #1",
+        "summary": "First",
+    }, None)
+
+    child = GLOBAL_STORE.find_child_by_slug(caller.id, "poet")
+    child.metadata.status = "running"
+    GLOBAL_STORE.save_metadata(child)
+
+    # Queue three tasks.
+    for i in range(2, 5):
+        await handlers["agents_assign_task"]({
+            "type": "writer",
+            "slug": "poet",
+            "objective": f"Haiku #{i}",
+            "summary": f"Haiku {i}",
+        }, None)
+
+    # Dequeue — should be FIFO.
+    task_file_store = GLOBAL_STORE._task_file_store
+    first = task_file_store.dequeue_next(child.id)
+    assert first is not None
+    assert first.objective == "Haiku #2"
+
+    second = task_file_store.dequeue_next(child.id)
+    assert second is not None
+    assert second.objective == "Haiku #3"
+
+    third = task_file_store.dequeue_next(child.id)
+    assert third is not None
+    assert third.objective == "Haiku #4"
+
+    # Queue is empty.
+    assert task_file_store.dequeue_next(child.id) is None
 
 
 # ---------------------------------------------------------------------------

--- a/packages/bees/tests/test_events_yield.py
+++ b/packages/bees/tests/test_events_yield.py
@@ -344,10 +344,16 @@ async def test_assign_task_queues_for_infinite_agent(tmp_path):
         status="suspended",
         parent_id="parent-000",
     )
+    # Set assignee to "user" to simulate idle state (waiting for task).
+    agent.metadata.assignee = "user"
+    (agent.dir / "metadata.json").write_text(
+        json.dumps(agent.metadata.to_dict(), indent=2)
+    )
 
     store = UnifiedAgentStore(tmp_path)
     scheduler = _mock_scheduler(store)
     scheduler.deliver_to_task = MagicMock(return_value=None)
+    scheduler.drain_task_queue = MagicMock(return_value=True)
 
     # Create the playbook data that load_playbook would return.
     import yaml
@@ -383,25 +389,23 @@ async def test_assign_task_queues_for_infinite_agent(tmp_path):
     assert result.get("status") == "queued"
     assert result.get("agent_slug") == "deep-dive"
 
-    # Verify task record was created.
+    # Verify task record was created with "queued" status.
     task_file_store = store._task_file_store
     tasks = task_file_store.query_by_assignee("child-222")
-    assert len(tasks) >= 1
-    queued_task = tasks[0]
-    assert queued_task.objective == "Find pricing for X"
+    queued = [t for t in tasks if t.status == "queued"]
+    assert len(queued) == 1
+    assert queued[0].objective == "Find pricing for X"
 
-    # Verify context update was delivered.
-    scheduler.deliver_to_task.assert_called_once()
-    call_args = scheduler.deliver_to_task.call_args
-    assert call_args[0][0] == "child-222"
-    update = call_args[0][1]
-    assert update["type"] == "task_assigned"
-    assert update["objective"] == "Find pricing for X"
+    # Must NOT deliver context update directly — that's the scheduler's job.
+    scheduler.deliver_to_task.assert_not_called()
+
+    # Agent was idle (suspended+user), so drain should have been called.
+    scheduler.drain_task_queue.assert_called_once_with("child-222")
 
 
 @pytest.mark.asyncio
-async def test_assign_task_rejects_busy_finite_agent(tmp_path):
-    """agents_assign_task returns an error for a non-terminal finite agent."""
+async def test_assign_task_queues_busy_finite_agent(tmp_path):
+    """agents_assign_task queues a task for a non-terminal finite agent."""
     from bees.functions.agents import _make_handlers as _make_agent_handlers
 
     # Create parent agent first.
@@ -455,5 +459,14 @@ async def test_assign_task_rejects_busy_finite_agent(tmp_path):
         None,
     )
 
-    assert "error" in result
-    assert "busy" in result["error"]
+    assert result.get("status") == "queued"
+    assert result.get("agent_slug") == "writer"
+
+    # Verify queued task record exists.
+    task_file_store = store._task_file_store
+    queued = [
+        t for t in task_file_store.query_by_assignee("child-333")
+        if t.status == "queued"
+    ]
+    assert len(queued) == 1
+    assert queued[0].objective == "Write a poem"


### PR DESCRIPTION
## What
When a parent assigns a task to an agent that's already busy, the task is now queued instead of rejected (finite) or eagerly delivered mid-stream (infinite). The scheduler drains the queue at the right lifecycle moment.

## Why
Previously, finite agents returned a "busy" error forcing the parent to poll and retry, and infinite agents received context updates mid-stream which could cause duplicate processing. Decoupling task creation from task delivery gives us a proper FIFO queue with clean drain triggers.

## Changes

### `task_file_store.py`
- Added `"queued"` to `TaskStatus`
- Added `status` parameter to `create()` (default remains `"available"`)
- Added `dequeue_next(agent_id)` — FIFO dequeue with transition to `in_progress`
- Added `cancel_queued(agent_id)` — bulk cancel for failed agents

### `agents.py`
- Unified the non-terminal agent path: both finite and infinite agents create a `TaskRecord(status="queued")` — no more "busy" error, no more immediate `deliver_to_task()`
- If an infinite agent is already idle (suspended + assignee=user), triggers immediate `drain_task_queue()`

### `scheduler.py`
- Added `drain_task_queue(agent_id)` — dequeues next task, then `reset_for_reuse` (finite) or `_deliver_context_update` (infinite)
- Added `_cancel_queued_tasks(agent_id)` — cancels queue on agent failure, with comments documenting future alternatives
- Wired drain into both `_wrap_execution` (server mode) and `run_all_waves` (batch mode)

### `task_runner.py`
- Added `_drain_queued_task()` as third auto-resume source in `_handle_suspend`, after `pending_context_updates` and `queued_updates`

### `unified_agent_store.py`
- Extended `_sync_task_record` guard to skip `queued` tasks (prevents them from being dragged to `in_progress` by the agent's current execution state)

## Testing
- Updated `test_agents_assign_task_busy_agent` → now expects `"queued"` instead of `"error"`
- Updated 2 cross-reference tests in `test_events_yield.py` for new behavior
- Added 4 new tests: finite queue, infinite queue, idle drain, FIFO ordering
- 51 targeted tests pass, 537 suite-wide pass, 0 regressions
