### PR TITLE
[opal-backend] Built-in Gemini tools in opal_backend

### DIFF
--- a/hives/swarm-test/config/TEMPLATES.yaml
+++ b/hives/swarm-test/config/TEMPLATES.yaml
@@ -31,7 +31,8 @@
 - name: workspace-test
   title: Test Workspace MCP 2
   description: Tests workspace MCP integration
-  objective: Chat with the user and fulfill their requests with the tools that you have.
+  objective:
+    Chat with the user and fulfill their requests with the tools that you have.
   functions:
     - chat.*
     - drive.*
@@ -81,6 +82,41 @@
     - system.*
   tasks:
     - infinite-poet
+
+- name: weather-orchestrator
+  title: Weather Orchestrator
+  objective: >-
+    You are a weather-checking orchestrator. Use agents_list_types to discover
+    available agent types, then assign two sequential tasks to a
+    "weather-checker" agent with slug "checker".
+
+    - Task 1: Check the weather in San Francisco, CA. Save it to sfo.txt. 
+    - Task 2: Check the weather in London. Save it to lon.txt.
+
+    After assigning task 1, don't wait for it to complete, and immediately
+    assign task 2 to the same slug and wait for both tasks to complete. When
+    both tasks are complete, mark your objective as fulfilled with a summary of
+    the results.
+  functions:
+    - agents.*
+    - system.*
+  tasks:
+    - weather-checker
+
+- name: weather-checker
+  title: Weather Checker
+  objective: >-
+    You are a weather checker. You will receive tasks describing what locations
+    to provide the weather information for. For each task, write the requested
+    content to a file in your workspace, then call events_yield with a summary
+    of what you produced.
+
+
+    Your first task: {{system.context}}
+  functions:
+    - files.*
+    - events.*
+    - builtin.search_grounding
 
 - name: infinite-poet
   title: Infinite Poet
@@ -146,7 +182,8 @@
         - "9:21"
     image_size:
       type: string
-      description: "Target resolution or image size. Valid values: '512', '1K', '2K', '4K'."
+      description:
+        "Target resolution or image size. Valid values: '512', '1K', '2K', '4K'."
       enum:
         - "512"
         - 1K

--- a/packages/opal-backend/opal_backend/loop.py
+++ b/packages/opal-backend/opal_backend/loop.py
@@ -76,6 +76,13 @@ class AgentRunArgs:
     singleton_cached_content_name: str | None = None
     model: str | None = None
     context_queue: asyncio.Queue | None = None
+    builtin_tools: list[dict[str, Any]] = field(default_factory=list)
+    """Gemini built-in tool objects (e.g. ``{"googleSearch": {}}``).
+
+    When non-empty, these are merged into the ``tools`` array alongside
+    custom ``functionDeclarations`` and ``includeServerSideToolInvocations``
+    is set in the tool config to enable tool context circulation.
+    """
 
 
 @dataclass
@@ -186,7 +193,11 @@ class Loop:
             for group in args.function_groups:
                 all_declarations.extend(group.declarations)
 
-            tools = [{"functionDeclarations": all_declarations}]
+            tools: list[dict[str, Any]] = [
+                {"functionDeclarations": all_declarations},
+            ]
+            if args.builtin_tools:
+                tools.extend(args.builtin_tools)
 
             # Build the function definition map for dispatch
             definition_map: dict[str, Any] = {}
@@ -211,6 +222,13 @@ class Loop:
             # 0 means the cache only has the static envelope (SI + tools).
             cached_content_count = 0
 
+            # Tool configuration — built once per run.
+            tool_config: dict[str, Any] = {
+                "functionCallingConfig": {"mode": "ANY"},
+            }
+            if args.builtin_tools:
+                tool_config["includeServerSideToolInvocations"] = True
+
             while not self.controller.terminated:
                 generation_config: dict[str, Any] = {
                     "temperature": 1,
@@ -234,9 +252,7 @@ class Loop:
                     body = {
                         "contents": contents,
                         "generationConfig": generation_config,
-                        "toolConfig": {
-                            "functionCallingConfig": {"mode": "ANY"},
-                        },
+                        "toolConfig": tool_config,
                         "tools": tools,
                     }
                     if system_instruction_text:

--- a/packages/opal-backend/opal_backend/run.py
+++ b/packages/opal-backend/opal_backend/run.py
@@ -94,6 +94,60 @@ class GraphInfo(TypedDict, total=False):
 
 
 # ---------------------------------------------------------------------------
+# Built-in tool mapping
+# ---------------------------------------------------------------------------
+
+# Maps ``builtin.*`` filter entries to Gemini API tool objects.
+# These are server-side tools (Search, Maps, URL Context, Code Execution)
+# that the Gemini API executes internally, as opposed to custom function
+# declarations dispatched by the agent loop.
+BUILTIN_TOOL_MAP: dict[str, dict[str, Any]] = {
+    "builtin.search_grounding": {"googleSearch": {}},
+    "builtin.maps_grounding": {"googleMaps": {}},
+    "builtin.url_context": {"urlContext": {}},
+    "builtin.code_execution": {"codeExecution": {}},
+}
+
+
+def _extract_builtin_tools(
+    function_filter: list[str] | None,
+) -> tuple[list[dict[str, Any]], list[str] | None]:
+    """Split ``builtin.*`` entries from a function filter.
+
+    Returns a ``(builtin_tools, remaining_filter)`` tuple.
+    ``builtin_tools`` is a list of Gemini tool objects ready for the
+    ``tools`` array.  ``remaining_filter`` is the original filter with
+    ``builtin.*`` entries removed (or ``None`` if nothing remains).
+
+    Unknown ``builtin.*`` entries are silently ignored — forward
+    compatibility with new Gemini built-in tools.
+    """
+    if not function_filter:
+        return [], function_filter
+
+    builtin_tools: list[dict[str, Any]] = []
+    remaining: list[str] = []
+
+    for pattern in function_filter:
+        if pattern == "builtin.*":
+            raise ValueError(
+                "builtin.* wildcard is not supported — not all Gemini "
+                "built-in tools can be combined in a single request. "
+                f"Use explicit entries instead: "
+                f"{', '.join(sorted(BUILTIN_TOOL_MAP.keys()))}"
+            )
+        elif (tool := BUILTIN_TOOL_MAP.get(pattern)) is not None:
+            builtin_tools.append(tool)
+        elif pattern.startswith("builtin."):
+            # Unknown builtin — skip silently for forward compat.
+            logger.debug("Ignoring unknown builtin tool: %s", pattern)
+        else:
+            remaining.append(pattern)
+
+    return builtin_tools, remaining or None
+
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -220,6 +274,11 @@ async def run(
         CHAT_LOG_PATH, lambda: chat_mgr.get_chat_log(run_contents),
     )
 
+    # Extract built-in tools (e.g. google_search, url_context) from the
+    # function filter.  These become separate tool objects in the Gemini
+    # request rather than function declarations.
+    builtin_tools, cleaned_filter = _extract_builtin_tools(function_filter)
+
     function_groups = _build_function_groups(
         controller=controller,
         file_system=file_system,
@@ -231,7 +290,7 @@ async def run(
         consents_granted=consents_granted,
         graph_url=graph.get("url", ""),
         extra_groups=extra_groups,
-        function_filter=function_filter,
+        function_filter=cleaned_filter,
     )
 
     if (function_filter is None or len(function_filter) == 0) and (extra_groups is None or len(extra_groups) == 0):
@@ -249,6 +308,7 @@ async def run(
         singleton_cached_content_name=cached_name,
         model=model,
         context_queue=context_queue,
+        builtin_tools=builtin_tools,
     )
 
     async for event in _stream_loop(
@@ -388,6 +448,12 @@ async def resume(
     )
 
     controller = LoopController()
+
+    # Extract built-in tools from the persisted filter (same as run()).
+    builtin_tools, cleaned_filter = _extract_builtin_tools(
+        state.function_filter,
+    )
+
     function_groups = _build_function_groups(
         controller=controller,
         file_system=file_system,
@@ -399,7 +465,7 @@ async def resume(
         consents_granted=state.consents_granted,
         graph_url=(state.graph or {}).get("url", ""),
         extra_groups=extra_groups,
-        function_filter=state.function_filter,
+        function_filter=cleaned_filter,
     )
 
     # Apply the same cache bypass guard as run() — if a function filter
@@ -420,6 +486,7 @@ async def resume(
         singleton_cached_content_name=cached_name,
         model=model_override,
         context_queue=context_queue,
+        builtin_tools=builtin_tools,
     )
 
     async for event in _stream_loop(

--- a/packages/opal-backend/tests/test_builtin_tools.py
+++ b/packages/opal-backend/tests/test_builtin_tools.py
@@ -1,0 +1,355 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for built-in tool extraction and loop integration.
+
+Verifies that ``builtin.*`` entries in the function filter are correctly
+extracted into Gemini API tool objects and that the Loop merges them
+into the request body with ``includeServerSideToolInvocations``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from opal_backend.loop import AgentRunArgs, AgentResult, Loop
+from opal_backend.function_definition import (
+    FunctionDefinition,
+    FunctionGroup,
+    map_definitions,
+)
+from opal_backend.run import _extract_builtin_tools, BUILTIN_TOOL_MAP
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def make_function_call_chunk(name: str, args: dict | None = None) -> dict:
+    """Create a Gemini response chunk with a function call."""
+    return {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {
+                            "functionCall": {
+                                "name": name,
+                                "args": args or {},
+                            }
+                        }
+                    ],
+                    "role": "model",
+                }
+            }
+        ]
+    }
+
+
+def make_system_functions(controller) -> list[FunctionDefinition]:
+    """Create the system termination function wired to a LoopController."""
+
+    async def objective_fulfilled(args, status_cb):
+        controller.terminate(
+            AgentResult(
+                success=True,
+                outcomes={"parts": [{"text": args.get("objective_outcome", "")}]},
+            )
+        )
+        return {}
+
+    return [
+        FunctionDefinition(
+            name="system_objective_fulfilled",
+            description="Indicates completion.",
+            handler=objective_fulfilled,
+        ),
+    ]
+
+
+# =============================================================================
+# _extract_builtin_tools tests
+# =============================================================================
+
+
+class TestExtractBuiltinTools:
+    """Tests for the _extract_builtin_tools helper."""
+
+    def test_none_filter_returns_empty(self):
+        """None filter returns no builtin tools and None remaining."""
+        tools, remaining = _extract_builtin_tools(None)
+        assert tools == []
+        assert remaining is None
+
+    def test_empty_filter_returns_empty(self):
+        """Empty list returns no builtin tools and empty remaining."""
+        tools, remaining = _extract_builtin_tools([])
+        assert tools == []
+        assert remaining == []
+
+    def test_no_builtin_entries(self):
+        """Filter with only function patterns passes through unchanged."""
+        tools, remaining = _extract_builtin_tools(["system.*", "chat.*"])
+        assert tools == []
+        assert remaining == ["system.*", "chat.*"]
+
+    def test_single_builtin_extracted(self):
+        """A single builtin.search_grounding is extracted correctly."""
+        tools, remaining = _extract_builtin_tools(
+            ["system.*", "builtin.search_grounding"],
+        )
+        assert tools == [{"googleSearch": {}}]
+        assert remaining == ["system.*"]
+
+    def test_multiple_builtins_extracted(self):
+        """Multiple builtin entries are all extracted."""
+        tools, remaining = _extract_builtin_tools([
+            "builtin.search_grounding",
+            "system.*",
+            "builtin.url_context",
+            "chat.*",
+        ])
+        assert {"googleSearch": {}} in tools
+        assert {"urlContext": {}} in tools
+        assert len(tools) == 2
+        assert remaining == ["system.*", "chat.*"]
+
+    def test_all_known_builtins(self):
+        """All entries in BUILTIN_TOOL_MAP are extractable."""
+        all_patterns = list(BUILTIN_TOOL_MAP.keys())
+        tools, remaining = _extract_builtin_tools(all_patterns)
+        assert len(tools) == len(BUILTIN_TOOL_MAP)
+        assert remaining is None  # Nothing left
+
+    def test_unknown_builtin_skipped(self):
+        """Unknown builtin.* entries are silently skipped."""
+        tools, remaining = _extract_builtin_tools(
+            ["builtin.future_tool", "system.*"],
+        )
+        assert tools == []
+        assert remaining == ["system.*"]
+
+    def test_only_builtins_returns_none_remaining(self):
+        """When only builtins are in the filter, remaining is None."""
+        tools, remaining = _extract_builtin_tools(
+            ["builtin.search_grounding", "builtin.maps_grounding"],
+        )
+        assert len(tools) == 2
+        assert remaining is None
+
+    def test_maps_grounding(self):
+        """builtin.maps_grounding maps to googleMaps."""
+        tools, _ = _extract_builtin_tools(["builtin.maps_grounding"])
+        assert tools == [{"googleMaps": {}}]
+
+    def test_code_execution(self):
+        """builtin.code_execution maps to codeExecution."""
+        tools, _ = _extract_builtin_tools(["builtin.code_execution"])
+        assert tools == [{"codeExecution": {}}]
+
+    def test_wildcard_raises_error(self):
+        """builtin.* wildcard raises ValueError with guidance."""
+        with pytest.raises(ValueError, match="builtin.* wildcard is not supported"):
+            _extract_builtin_tools(["files.*", "builtin.*", "events.*"])
+
+
+# =============================================================================
+# Loop integration tests — builtin tools in the request body
+# =============================================================================
+
+
+class TestLoopBuiltinTools:
+    """Tests that the Loop correctly merges builtin tools into the API body."""
+
+    @pytest.mark.asyncio
+    async def test_builtin_tools_in_request_body(self):
+        """Builtin tools appear as separate entries in the tools array."""
+        loop = Loop(backend=MagicMock())
+
+        system_fns = make_system_functions(loop.controller)
+        mapped = map_definitions(system_fns)
+        group = FunctionGroup(
+            definitions=mapped.definitions,
+            declarations=mapped.declarations,
+        )
+
+        captured_bodies: list[dict] = []
+
+        async def capturing_stream(model, body, **kwargs):
+            captured_bodies.append(body)
+            yield make_function_call_chunk(
+                "system_objective_fulfilled",
+                {"objective_outcome": "Done"},
+            )
+
+        with patch(
+            "opal_backend.loop.stream_generate_content",
+            side_effect=capturing_stream,
+        ):
+            await loop.run(
+                AgentRunArgs(
+                    objective={"parts": [{"text": "Test"}], "role": "user"},
+                    function_groups=[group],
+                    builtin_tools=[{"googleSearch": {}}],
+                )
+            )
+
+        assert len(captured_bodies) == 1
+        body = captured_bodies[0]
+
+        # tools array should have functionDeclarations + googleSearch
+        tools = body["tools"]
+        assert len(tools) == 2
+        assert "functionDeclarations" in tools[0]
+        assert tools[1] == {"googleSearch": {}}
+
+        # toolConfig should have includeServerSideToolInvocations
+        tool_config = body["toolConfig"]
+        assert tool_config["includeServerSideToolInvocations"] is True
+        assert tool_config["functionCallingConfig"]["mode"] == "ANY"
+
+    @pytest.mark.asyncio
+    async def test_no_builtin_tools_no_flag(self):
+        """Without builtin tools, includeServerSideToolInvocations is absent."""
+        loop = Loop(backend=MagicMock())
+
+        system_fns = make_system_functions(loop.controller)
+        mapped = map_definitions(system_fns)
+        group = FunctionGroup(
+            definitions=mapped.definitions,
+            declarations=mapped.declarations,
+        )
+
+        captured_bodies: list[dict] = []
+
+        async def capturing_stream(model, body, **kwargs):
+            captured_bodies.append(body)
+            yield make_function_call_chunk(
+                "system_objective_fulfilled",
+                {"objective_outcome": "Done"},
+            )
+
+        with patch(
+            "opal_backend.loop.stream_generate_content",
+            side_effect=capturing_stream,
+        ):
+            await loop.run(
+                AgentRunArgs(
+                    objective={"parts": [{"text": "Test"}], "role": "user"},
+                    function_groups=[group],
+                )
+            )
+
+        body = captured_bodies[0]
+
+        # tools array should only have functionDeclarations
+        tools = body["tools"]
+        assert len(tools) == 1
+        assert "functionDeclarations" in tools[0]
+
+        # toolConfig should NOT have includeServerSideToolInvocations
+        tool_config = body["toolConfig"]
+        assert "includeServerSideToolInvocations" not in tool_config
+
+    @pytest.mark.asyncio
+    async def test_multiple_builtin_tools(self):
+        """Multiple builtin tools all appear in the tools array."""
+        loop = Loop(backend=MagicMock())
+
+        system_fns = make_system_functions(loop.controller)
+        mapped = map_definitions(system_fns)
+        group = FunctionGroup(
+            definitions=mapped.definitions,
+            declarations=mapped.declarations,
+        )
+
+        captured_bodies: list[dict] = []
+
+        async def capturing_stream(model, body, **kwargs):
+            captured_bodies.append(body)
+            yield make_function_call_chunk(
+                "system_objective_fulfilled",
+                {"objective_outcome": "Done"},
+            )
+
+        with patch(
+            "opal_backend.loop.stream_generate_content",
+            side_effect=capturing_stream,
+        ):
+            await loop.run(
+                AgentRunArgs(
+                    objective={"parts": [{"text": "Test"}], "role": "user"},
+                    function_groups=[group],
+                    builtin_tools=[
+                        {"googleSearch": {}},
+                        {"urlContext": {}},
+                    ],
+                )
+            )
+
+        tools = captured_bodies[0]["tools"]
+        # functionDeclarations + 2 builtin tools
+        assert len(tools) == 3
+        assert tools[1] == {"googleSearch": {}}
+        assert tools[2] == {"urlContext": {}}
+
+    @pytest.mark.asyncio
+    async def test_builtin_only_turn_continues_loop(self):
+        """A model turn with no function calls (only text) loops back.
+
+        This simulates what happens when the model uses only a built-in
+        tool (which produces text, not functionCall parts) and then calls
+        a custom function on the next turn.
+        """
+        loop = Loop(backend=MagicMock())
+
+        system_fns = make_system_functions(loop.controller)
+        mapped = map_definitions(system_fns)
+        group = FunctionGroup(
+            definitions=mapped.definitions,
+            declarations=mapped.declarations,
+        )
+
+        turn = 0
+
+        async def multi_turn_stream(model, body, **kwargs):
+            nonlocal turn
+            turn += 1
+            if turn == 1:
+                # Turn 1: model responds with text only (simulating
+                # built-in tool producing a text response).
+                yield {
+                    "candidates": [
+                        {
+                            "content": {
+                                "parts": [{"text": "Search results: ..."}],
+                                "role": "model",
+                            }
+                        }
+                    ]
+                }
+            else:
+                # Turn 2: model calls a custom function to finish.
+                yield make_function_call_chunk(
+                    "system_objective_fulfilled",
+                    {"objective_outcome": "Done with search"},
+                )
+
+        with patch(
+            "opal_backend.loop.stream_generate_content",
+            side_effect=multi_turn_stream,
+        ):
+            result = await loop.run(
+                AgentRunArgs(
+                    objective={"parts": [{"text": "Search and finish"}], "role": "user"},
+                    function_groups=[group],
+                    builtin_tools=[{"googleSearch": {}}],
+                )
+            )
+
+        assert isinstance(result, AgentResult)
+        assert result.success is True
+        assert turn == 2  # Both turns executed


### PR DESCRIPTION
## What
Adds support for Gemini's server-side built-in tools (Search, Maps, URL Context, Code Execution) in the opal_backend agent loop, allowing them to be combined with custom function declarations.

## Why
The Gemini API now supports combining built-in tools with custom functions via `includeServerSideToolInvocations`. Until now, only the `direct_model` runner could use built-in tools. This teaches opal_backend's loop the same capability, unlocking grounding for agents using the standard `generate` runner.

## Changes

### `opal_backend/run.py`
- Add `BUILTIN_TOOL_MAP` — single source of truth mapping `builtin.search_grounding` → `{"googleSearch": {}}`, etc.
- Add `_extract_builtin_tools()` — splits `builtin.*` entries out of `function_filter`, returning tool dicts + cleaned filter
- `builtin.*` wildcard raises `ValueError` with guidance (not all built-in tools can be combined)
- Wire extraction into both `run()` and `resume()` — cleaned filter goes to `_build_function_groups`, tool dicts go to `AgentRunArgs`

### `opal_backend/loop.py`
- Add `builtin_tools` field to `AgentRunArgs`
- Merge builtin tools into the `tools` array alongside `functionDeclarations`
- Set `includeServerSideToolInvocations: true` in `toolConfig` when built-in tools are present

### `tests/test_builtin_tools.py` (new)
- 15 tests: extraction logic (all mappings, wildcard rejection, edge cases) + loop integration (body structure, toolConfig, multi-turn)

### `hives/swarm-test/config/TEMPLATES.yaml`
- Add `weather-checker` template using `builtin.search_grounding` for real weather data

## Testing
```bash
cd packages/opal-backend && python3 -m pytest tests/test_builtin_tools.py -v
cd packages/opal-backend && python3 -m pytest tests/ -x -q  # full suite (596 passed)
```
