### PR TITLE
[bees] Interactive chat support for the Antigravity runner

### DIFF
--- a/hives/antigravity/config/SYSTEM.yaml
+++ b/hives/antigravity/config/SYSTEM.yaml
@@ -1,4 +1,4 @@
 # Antigravity test hive
 title: Antigravity Test
 description: Test hive for the Antigravity SDK runner
-root: ag-worker
+# root: ag-worker

--- a/hives/antigravity/config/TEMPLATES.yaml
+++ b/hives/antigravity/config/TEMPLATES.yaml
@@ -13,3 +13,15 @@
   functions:
     - system.*
     - files.*
+
+- name: ag-chat
+  runner: antigravity
+  title: AG Chat
+  description: An interactive chat agent that uses the Antigravity SDK
+  objective: >
+    You are a friendly assistant. Greet the user and ask how you can help.
+    When the user asks you to do something, do it and then ask if there's
+    anything else. You can read and write files in your workspace.
+  functions:
+    - chat.*
+    - files.*

--- a/packages/bees/bees/runners/antigravity.py
+++ b/packages/bees/bees/runners/antigravity.py
@@ -27,9 +27,10 @@ import contextlib
 import json
 import logging
 import tempfile
+import uuid
 from collections.abc import AsyncIterator
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from google.antigravity import types as ag_types
 from google.antigravity.agent import Agent
@@ -124,8 +125,15 @@ def _translate_step(step: ag_types.Step) -> list[SessionEvent]:
     ):
         events.append({"complete": {"result": _build_complete_result(step)}})
 
-    # Error → error event.
-    if step.status == ag_types.StepStatus.ERROR:
+    # Error → error event (terminal errors only).
+    # Tool call errors (policy denials, missing files, etc.) are
+    # intermediate — the model sees them and adapts.  Only emit
+    # error events for steps that aren't tool calls, since those
+    # represent unrecoverable model-level failures.
+    if (
+        step.status == ag_types.StepStatus.ERROR
+        and step.type != ag_types.StepType.TOOL_CALL
+    ):
         events.append({"error": {"message": step.error or "Unknown error"}})
 
     # NOTE: WAITING_FOR_USER steps are NOT translated to waitForInput.
@@ -217,11 +225,15 @@ class AntigravityStream:
         exit_stack: contextlib.AsyncExitStack,
         save_dir: str,
         initial_prompt: str,
+        has_chat: bool = False,
+        on_chat_entry: Callable[[str, str], None] | None = None,
     ) -> None:
         self._agent = agent
         self._exit_stack = exit_stack
         self._save_dir = save_dir
         self._initial_prompt = initial_prompt
+        self._has_chat = has_chat
+        self._on_chat_entry = on_chat_entry
 
         self._started = False
         self._exhausted = False
@@ -230,6 +242,7 @@ class AntigravityStream:
         self._resume_blob: bytes | None = None
         self._emitted_send_request = False
         self._emitted_complete = False
+        self._last_user_text: str = ""
 
     # -- async iterator ----------------------------------------------------
 
@@ -279,16 +292,35 @@ class AntigravityStream:
             # The SDK turn is done — the agent went idle.
             self._exhausted = True
             self._capture_resume_state()
-            # If no explicit complete/error event was emitted, synthesize
-            # a complete event — the agent finished by going idle without
-            # calling the FINISH tool.
+
             if not self._emitted_complete:
                 self._emitted_complete = True
+
+                # Chat mode: idle without FINISH = waiting for user input.
+                if self._has_chat and self._last_user_text:
+                    # Log the model's message to the chat log.
+                    if self._on_chat_entry:
+                        self._on_chat_entry("agent", self._last_user_text)
+
+                    # Don't tear down the agent yet — persist state for
+                    # resume, but the cleanup still runs because the
+                    # stream is done from drain_session's perspective.
+                    await self._cleanup()
+                    return {"waitForInput": {
+                        "requestId": str(uuid.uuid4()),
+                        "prompt": {
+                            "parts": [{"text": self._last_user_text}],
+                        },
+                        "inputType": "text",
+                    }}
+
+                # Worker mode: idle without FINISH = done.
                 await self._cleanup()
                 return {"complete": {"result": {
                     "success": True,
                     "outcomes": {"parts": [{"text": ""}]},
                 }}}
+
             await self._cleanup()
             raise
         except Exception as exc:
@@ -303,10 +335,25 @@ class AntigravityStream:
             # Step produced no translatable events — skip to next.
             return await self.__anext__()
 
-        # Track complete/error events.
+        # Track explicit completion events.
+        # NOTE: error events from tool calls (e.g., policy denials) are
+        # intermediate — the model recovers and continues.  Only
+        # explicit complete events gate the idle synthesis.
         for event in events:
-            if "complete" in event or "error" in event:
+            if "complete" in event:
                 self._emitted_complete = True
+
+        # Accumulate user-directed text for chat mode suspend prompt.
+        # Reset when a step has no systemMessage — tool calls, user
+        # input replays, etc. clear the accumulator so only the LAST
+        # contiguous model response becomes the suspend prompt.
+        has_model_text = False
+        for event in events:
+            if "systemMessage" in event:
+                has_model_text = True
+                self._last_user_text += event["systemMessage"].get("text", "")
+        if not has_model_text:
+            self._last_user_text = ""
 
         # Check for suspend events — capture resume state eagerly.
         for event in events:
@@ -459,11 +506,16 @@ class AntigravityRunner:
         # 7. Extract the initial prompt from segments.
         initial_prompt = _extract_initial_prompt(config)
 
+        # 8. Detect chat mode from function filter.
+        has_chat = _has_chat_functions(config.function_filter)
+
         return AntigravityStream(
             agent=agent,
             exit_stack=exit_stack,
             save_dir=save_dir,
             initial_prompt=initial_prompt,
+            has_chat=has_chat,
+            on_chat_entry=config.on_chat_entry,
         )
 
     async def resume(
@@ -523,11 +575,16 @@ class AntigravityRunner:
         # 7. Build the resume prompt from the user's response + context.
         resume_prompt = _build_resume_prompt(response, context_parts)
 
+        # 8. Detect chat mode from function filter.
+        has_chat = _has_chat_functions(config.function_filter)
+
         return AntigravityStream(
             agent=agent,
             exit_stack=exit_stack,
             save_dir=save_dir,
             initial_prompt=resume_prompt,
+            has_chat=has_chat,
+            on_chat_entry=config.on_chat_entry,
         )
 
 
@@ -578,6 +635,12 @@ def _build_resume_prompt(
 
     The prompt combines any pending context updates with the user's
     direct response text.
+
+    Handles multiple response shapes:
+    - ``{"text": "..."}`` — direct text.
+    - ``{"parts": [{"text": "..."}]}`` — LLMContent format.
+    - ``{"input": {"parts": [{"text": "..."}]}}`` — waitForInput response
+      from hivetool UI.
     """
     parts: list[str] = []
 
@@ -587,14 +650,31 @@ def _build_resume_prompt(
             if "text" in part:
                 parts.append(part["text"])
 
-    # Extract the user's response text.
-    # The response dict can have various shapes depending on the
-    # suspend type (waitForInput, waitForChoice, etc.).
+    # Extract the user's response text from various shapes.
     if "text" in response:
         parts.append(response["text"])
+    elif "input" in response:
+        # waitForInput response: {"input": {"parts": [{"text": "..."}]}}
+        input_content = response["input"]
+        if isinstance(input_content, dict):
+            for p in input_content.get("parts", []):
+                if "text" in p:
+                    parts.append(p["text"])
     elif "parts" in response:
         for p in response["parts"]:
             if "text" in p:
                 parts.append(p["text"])
 
     return "\n\n".join(parts) if parts else ""
+
+
+def _has_chat_functions(function_filter: list[str] | None) -> bool:
+    """Check if any function filter entry enables chat mode.
+
+    Returns True if any filter starts with ``chat.``, indicating
+    the agent is interactive and idle-without-FINISH should emit
+    ``waitForInput`` instead of ``complete``.
+    """
+    if not function_filter:
+        return False
+    return any(f.startswith("chat.") for f in function_filter)

--- a/packages/bees/bees/task_runner.py
+++ b/packages/bees/bees/task_runner.py
@@ -136,6 +136,8 @@ class TaskRunner:
                     ticket_id=agent.id,
                     on_event=self._make_on_event(agent.id),
                 )
+                # Persist runner-agnostic resume state when suspended.
+                self._persist_resume_state(agent, stream, result)
             finally:
                 self._active_streams.pop(agent.id, None)
 
@@ -269,37 +271,42 @@ class TaskRunner:
             int_file = sdir / "interaction.json"
 
             if not resume_id_file.exists() or not int_file.exists():
-                agent.metadata.status = "failed"
-                agent.metadata.error = "No active resume session files found"
-                self._store.save_metadata(agent)
-                return SessionResult(
-                    session_id="",
-                    status="failed",
-                    events=0,
-                    output="",
-                    error="No active resume session files found",
-                )
-
-            try:
-                interaction_id = resume_id_file.read_text(encoding="utf-8").strip()
-                int_data = json.loads(int_file.read_text(encoding="utf-8"))
-                state_dict = {
-                    "session_id": session_id,
-                    "interaction_id": interaction_id,
-                    "interaction_state": int_data,
-                }
-                state = json.dumps(state_dict, ensure_ascii=False).encode("utf-8")
-            except Exception as e:
-                agent.metadata.status = "failed"
-                agent.metadata.error = f"Failed to load session files: {e}"
-                self._store.save_metadata(agent)
-                return SessionResult(
-                    session_id="",
-                    status="failed",
-                    events=0,
-                    output="",
-                    error=f"Failed to load session files: {e}",
-                )
+                # Check for runner-agnostic resume state file.
+                resume_state_file = sdir / "resume_state.json"
+                if resume_state_file.exists():
+                    state = resume_state_file.read_bytes()
+                else:
+                    agent.metadata.status = "failed"
+                    agent.metadata.error = "No active resume session files found"
+                    self._store.save_metadata(agent)
+                    return SessionResult(
+                        session_id="",
+                        status="failed",
+                        events=0,
+                        output="",
+                        error="No active resume session files found",
+                    )
+            else:
+                try:
+                    interaction_id = resume_id_file.read_text(encoding="utf-8").strip()
+                    int_data = json.loads(int_file.read_text(encoding="utf-8"))
+                    state_dict = {
+                        "session_id": session_id,
+                        "interaction_id": interaction_id,
+                        "interaction_state": int_data,
+                    }
+                    state = json.dumps(state_dict, ensure_ascii=False).encode("utf-8")
+                except Exception as e:
+                    agent.metadata.status = "failed"
+                    agent.metadata.error = f"Failed to load session files: {e}"
+                    self._store.save_metadata(agent)
+                    return SessionResult(
+                        session_id="",
+                        status="failed",
+                        events=0,
+                        output="",
+                        error=f"Failed to load session files: {e}",
+                    )
 
         agent.metadata.status = "running"
         agent.metadata.assignee = "agent"
@@ -366,6 +373,8 @@ class TaskRunner:
                     ticket_id=agent.id,
                     on_event=self._make_on_event(agent.id),
                 )
+                # Persist runner-agnostic resume state when re-suspended.
+                self._persist_resume_state(agent, stream, result)
             finally:
                 self._active_streams.pop(agent.id, None)
 
@@ -397,13 +406,39 @@ class TaskRunner:
         # phantom "Suspended On" indicator.
         if not result.suspended and agent.metadata.active_session:
             sdir = agent.dir / "sessions" / agent.metadata.active_session
-            for stale_file in ("interaction.json", "resume_id"):
+            for stale_file in ("interaction.json", "resume_id", "resume_state.json"):
                 (sdir / stale_file).unlink(missing_ok=True)
 
         self._store.save_metadata(agent)
         return result
 
     # -- internal ----------------------------------------------------------
+
+    def _persist_resume_state(
+        self,
+        agent: Agent,
+        stream: Any,
+        result: SessionResult,
+    ) -> None:
+        """Persist runner-agnostic resume state when a session suspends.
+
+        Writes ``stream.resume_state()`` bytes to a ``resume_state.json``
+        file in the session directory.  This is the runner-agnostic path
+        that ``resume_task()`` prefers over the legacy opal-specific
+        ``resume_id`` + ``interaction.json`` files.
+        """
+        if not result.suspended:
+            return
+        resume_blob = stream.resume_state()
+        if resume_blob is None:
+            return
+        session_id = agent.metadata.active_session
+        if not session_id or not agent.dir:
+            return
+        sdir = agent.dir / "sessions" / session_id
+        sdir.mkdir(parents=True, exist_ok=True)
+        (sdir / "resume_state.json").write_bytes(resume_blob)
+
 
     def _update_metadata(
         self,


### PR DESCRIPTION
## What
Enable the Antigravity runner to suspend on user-directed text and resume when the user replies, completing the interactive chat lifecycle (M2 milestone).

## Why
The Antigravity SDK's LLM can produce text responses natively — unlike the Gemini runner (opal), which requires explicit function calls to initiate chat. This PR bridges the SDK's turn-based model into the bees suspend/resume lifecycle by interpreting idle-after-text as a `waitForInput` signal when `chat.*` is in the function filter.

## Changes

### Antigravity Runner (`packages/bees/bees/runners/antigravity.py`)
- Add `has_chat` flag to `AntigravityStream`, derived from `chat.*` in the function filter
- Accumulate user-directed model text; emit `waitForInput` on idle when in chat mode (instead of synthesizing `complete`)
- Reset text accumulator between model responses to prevent history stacking in suspend prompts
- Only emit terminal `error` events for non-tool-call errors — tool denials (policy, etc.) are intermediate and the model recovers
- Only gate idle synthesis on `complete` events, not intermediate errors
- Wire `on_chat_entry` callback for chat log continuity
- Expand `_build_resume_prompt` to handle `waitForInput` response shape (`{"input": {"parts": [...]}}`)
- Add `_has_chat_functions()` helper

### Task Runner (`packages/bees/bees/task_runner.py`)
- Add `_persist_resume_state()` — writes `stream.resume_state()` bytes to a runner-agnostic `resume_state.json` file in the session directory
- Prefer `resume_state.json` on resume when opal-specific files (`resume_id`, `interaction.json`) are absent
- Clean up stale `resume_state.json` after successful resume

### Hive Template (`hives/antigravity/config/TEMPLATES.yaml`)
- Add `ag-chat` template (`chat.* + files.*`) for interactive agent testing

## Testing
- Boot `ag-chat` template → model greets user → `waitForInput` → session suspends
- Respond via hivetool → harness loads trajectory from `save_dir` → model continues conversation → `waitForInput` → re-suspends
- Verified trajectory recovery across suspend/resume boundaries (Go harness correctly restores from `save_dir` + `conversation_id`)
- Existing test suite: 437/438 pass (1 pre-existing failure unrelated to this change)
