### PR TITLE
[bees] Enable Hivetool session log rendering for Antigravity runner

### DIFF
--- a/packages/bees/bees/protocols/session.py
+++ b/packages/bees/bees/protocols/session.py
@@ -183,6 +183,16 @@ class SessionConfiguration:
     function handlers write log entries directly.
     """
 
+    persist_events: bool = False
+    """Persist each event to ``events.jsonl`` during draining.
+
+    When ``True``, ``drain_session`` appends every event to the session
+    store's event log (``events.jsonl``).  Runners that bypass opal's
+    ``_tee_events`` loop (e.g. Antigravity) set this so Hivetool can
+    render the session timeline.  Runners using opal leave this
+    ``False`` — opal writes events itself.
+    """
+
     voice: str | None = None
     """Prebuilt voice name for Live API audio output (e.g. ``'Kore'``)."""
 

--- a/packages/bees/bees/runners/antigravity.py
+++ b/packages/bees/bees/runners/antigravity.py
@@ -102,15 +102,30 @@ def _translate_step(step: ag_types.Step) -> list[SessionEvent]:
     ):
         events.append({"systemMessage": {"text": step.content_delta}})
 
-    # Tool calls → functionCall events.
+    # Tool calls / responses.
+    # The SDK emits TOOL_CALL steps twice per invocation:
+    #   1. status=ACTIVE → the model requested the call (functionCall)
+    #   2. status=DONE   → the tool executed and produced a result (functionResponse)
     if step.tool_calls:
+        is_response = (
+            step.type == ag_types.StepType.TOOL_CALL
+            and step.status == ag_types.StepStatus.DONE
+        )
         for tc in step.tool_calls:
             name = tc.name
             if isinstance(name, ag_types.BuiltinTools):
                 name = name.value
-            events.append({
-                "functionCall": {"name": name, "args": tc.args},
-            })
+            if is_response:
+                events.append({
+                    "functionResponse": {
+                        "name": name,
+                        "response": tc.args,
+                    },
+                })
+            else:
+                events.append({
+                    "functionCall": {"name": name, "args": tc.args},
+                })
 
     # Usage metadata → usageMetadata event.
     if step.usage_metadata:
@@ -151,32 +166,63 @@ def _translate_step(step: ag_types.Step) -> list[SessionEvent]:
 
 
 # ---------------------------------------------------------------------------
+# Request config assembly (for Hivetool session header)
+# ---------------------------------------------------------------------------
+
+
+def _build_request_config(
+    capabilities: ag_types.CapabilitiesConfig,
+    custom_tools: list[Callable[..., Any]],
+    custom_instructions: list[str],
+) -> dict[str, Any]:
+    """Build the Hivetool-compatible config dict for the sendRequest body.
+
+    Produces ``systemInstruction`` and ``tools`` fields so Hivetool's
+    session header can render the system prompt and tool list.
+    """
+    result: dict[str, Any] = {}
+
+    # System instruction: join custom tool group instructions.
+    if custom_instructions:
+        text = "\n\n".join(custom_instructions)
+        result["systemInstruction"] = {"parts": [{"text": text}]}
+
+    # Tools: combine SDK builtins + custom tool names.
+    declarations: list[dict[str, str]] = []
+    for bt in capabilities.enabled_tools:
+        name = bt.value if hasattr(bt, "value") else str(bt)
+        declarations.append({"name": name})
+    for tool in custom_tools:
+        declarations.append({"name": getattr(tool, "__name__", "unknown")})
+    if declarations:
+        result["tools"] = [{"functionDeclarations": declarations}]
+
+    return result
+
+
+# ---------------------------------------------------------------------------
 # System instruction assembly
 # ---------------------------------------------------------------------------
 
 
 def _assemble_system_instructions(
-    config: SessionConfiguration,
+    custom_instructions: list[str],
 ) -> ag_types.TemplatedSystemInstructions:
-    """Build SDK system instructions from bees session segments.
+    """Build SDK system instructions from custom tool group instructions.
 
-    Segments are the provisioned input (system prompt, function group
-    instructions, skill instructions, etc.).  We pack them as named
-    sections appended to the SDK's default template.
+    Each custom function group (agents, events, skills) carries an
+    ``instruction`` fragment describing how to use those tools.  These
+    are appended as named sections to the SDK's default template.
+
+    Groups that map to SDK builtins (system, chat, files, sandbox) are
+    excluded — the SDK explains its own tools.
     """
-    sections: list[ag_types.SystemInstructionSection] = []
-
-    for i, segment in enumerate(config.segments):
-        # Segments are dicts with a "text" key (from opal's segment format).
-        text = segment.get("text", "")
-        if not text:
-            # Some segments carry only structured data (no text).
-            continue
-        title = segment.get("title", f"segment_{i}")
-        sections.append(
-            ag_types.SystemInstructionSection(content=text, title=title),
+    sections = [
+        ag_types.SystemInstructionSection(
+            content=text, title=f"tools_{i}",
         )
-
+        for i, text in enumerate(custom_instructions)
+    ]
     return ag_types.TemplatedSystemInstructions(sections=sections)
 
 
@@ -227,6 +273,7 @@ class AntigravityStream:
         initial_prompt: str,
         has_chat: bool = False,
         on_chat_entry: Callable[[str, str], None] | None = None,
+        request_config: dict[str, Any] | None = None,
     ) -> None:
         self._agent = agent
         self._exit_stack = exit_stack
@@ -234,6 +281,7 @@ class AntigravityStream:
         self._initial_prompt = initial_prompt
         self._has_chat = has_chat
         self._on_chat_entry = on_chat_entry
+        self._request_config = request_config or {}
 
         self._started = False
         self._exhausted = False
@@ -260,18 +308,16 @@ class AntigravityStream:
         # Synthesize the initial sendRequest event (once).
         if not self._emitted_send_request:
             self._emitted_send_request = True
-            return {
-                "sendRequest": {
-                    "body": {
-                        "contents": [
-                            {
-                                "role": "user",
-                                "parts": [{"text": self._initial_prompt}],
-                            },
-                        ],
+            body: dict[str, Any] = {
+                "contents": [
+                    {
+                        "role": "user",
+                        "parts": [{"text": self._initial_prompt}],
                     },
-                },
+                ],
+                **self._request_config,
             }
+            return {"sendRequest": {"body": body}}
 
         # Start the conversation if not yet started.
         if not self._started:
@@ -464,14 +510,16 @@ class AntigravityRunner:
         """
         # 1. Map function filter to SDK capabilities.
         stub_hooks = _StubSessionHooks(config.file_system)
-        capabilities, custom_tools = map_function_filter(
+        capabilities, custom_tools, custom_instructions = map_function_filter(
             config.function_filter,
             config.function_groups,
             stub_hooks,
         )
 
-        # 2. Assemble system instructions.
-        system_instructions = _assemble_system_instructions(config)
+        # 2. Assemble system instructions from custom tool groups.
+        system_instructions = _assemble_system_instructions(
+            custom_instructions,
+        )
 
         # 3. Build workspace path.
         workspace = _workspace_path(config)
@@ -509,6 +557,10 @@ class AntigravityRunner:
         # 8. Detect chat mode from function filter.
         has_chat = _has_chat_functions(config.function_filter)
 
+        request_config = _build_request_config(
+            capabilities, custom_tools, custom_instructions,
+        )
+
         return AntigravityStream(
             agent=agent,
             exit_stack=exit_stack,
@@ -516,6 +568,7 @@ class AntigravityRunner:
             initial_prompt=initial_prompt,
             has_chat=has_chat,
             on_chat_entry=config.on_chat_entry,
+            request_config=request_config,
         )
 
     async def resume(
@@ -540,14 +593,16 @@ class AntigravityRunner:
 
         # 2. Map function filter to SDK capabilities (same as run).
         stub_hooks = _StubSessionHooks(config.file_system)
-        capabilities, custom_tools = map_function_filter(
+        capabilities, custom_tools, custom_instructions = map_function_filter(
             config.function_filter,
             config.function_groups,
             stub_hooks,
         )
 
-        # 3. Assemble system instructions.
-        system_instructions = _assemble_system_instructions(config)
+        # 3. Assemble system instructions from custom tool groups.
+        system_instructions = _assemble_system_instructions(
+            custom_instructions,
+        )
 
         # 4. Build workspace path.
         workspace = _workspace_path(config)
@@ -578,6 +633,10 @@ class AntigravityRunner:
         # 8. Detect chat mode from function filter.
         has_chat = _has_chat_functions(config.function_filter)
 
+        request_config = _build_request_config(
+            capabilities, custom_tools, custom_instructions,
+        )
+
         return AntigravityStream(
             agent=agent,
             exit_stack=exit_stack,
@@ -585,6 +644,7 @@ class AntigravityRunner:
             initial_prompt=resume_prompt,
             has_chat=has_chat,
             on_chat_entry=config.on_chat_entry,
+            request_config=request_config,
         )
 
 

--- a/packages/bees/bees/runners/tool_mapping.py
+++ b/packages/bees/bees/runners/tool_mapping.py
@@ -85,7 +85,7 @@ def map_function_filter(
     function_filter: list[str] | None,
     function_groups: list[FunctionGroupFactory],
     hooks: SessionHooks,
-) -> tuple[ag_types.CapabilitiesConfig, list[Callable[..., Any]]]:
+) -> tuple[ag_types.CapabilitiesConfig, list[Callable[..., Any]], list[str]]:
     """Map bees function filters to SDK capabilities and custom tools.
 
     Args:
@@ -97,21 +97,26 @@ def map_function_filter(
         hooks: Session hooks for late-binding function group factories.
 
     Returns:
-        A ``(capabilities, custom_tools)`` tuple:
+        A ``(capabilities, custom_tools, custom_instructions)`` tuple:
 
         - ``capabilities``: SDK ``CapabilitiesConfig`` with the appropriate
           ``enabled_tools`` list.
         - ``custom_tools``: Python callables to register with the SDK's
           ``tools=[...]`` parameter.
+        - ``custom_instructions``: System instruction fragments from
+          custom tool groups (e.g. agents, events, skills).  Groups
+          that map to SDK builtins are excluded — the SDK explains
+          its own tools.
     """
     enabled_builtins: set[ag_types.BuiltinTools] = set()
     custom_tools: list[Callable[..., Any]] = []
+    custom_instructions: list[str] = []
 
     if function_filter is None:
         # No filter → enable all SDK builtins (except excluded).
         enabled_builtins = set(ag_types.BuiltinTools) - _EXCLUDED_BUILTINS
         # Also instantiate all custom-tool groups.
-        custom_tools = _extract_custom_tools(
+        custom_tools, custom_instructions = _extract_custom_tools(
             function_groups, hooks, include_groups=None,
         )
     else:
@@ -133,7 +138,7 @@ def map_function_filter(
         enabled_builtins -= _EXCLUDED_BUILTINS
 
         # Extract custom tools from matching function groups.
-        custom_tools = _extract_custom_tools(
+        custom_tools, custom_instructions = _extract_custom_tools(
             function_groups, hooks, include_groups=custom_group_names,
         )
 
@@ -142,7 +147,7 @@ def map_function_filter(
         enable_subagents=False,  # Bees manages its own agent hierarchy.
     )
 
-    return capabilities, custom_tools
+    return capabilities, custom_tools, custom_instructions
 
 
 # ---------------------------------------------------------------------------
@@ -211,7 +216,7 @@ def _extract_custom_tools(
     hooks: SessionHooks,
     *,
     include_groups: set[str] | None,
-) -> list[Callable[..., Any]]:
+) -> tuple[list[Callable[..., Any]], list[str]]:
     """Instantiate function groups and wrap their definitions as custom tools.
 
     Args:
@@ -220,8 +225,13 @@ def _extract_custom_tools(
         include_groups: If not None, only include groups whose ``name``
             is in this set.  If None, include all groups that map to
             custom tools.
+
+    Returns:
+        A ``(tools, instructions)`` tuple.  ``instructions`` contains
+        the non-empty ``group.instruction`` strings from matched groups.
     """
     tools: list[Callable[..., Any]] = []
+    instructions: list[str] = []
 
     for entry in function_groups:
         # function_groups contains both FunctionGroupFactory callables
@@ -254,4 +264,7 @@ def _extract_custom_tools(
         for _name, func_def in group.definitions:
             tools.append(wrap_bees_handler(func_def))
 
-    return tools
+        if group.instruction:
+            instructions.append(group.instruction)
+
+    return tools, instructions

--- a/packages/bees/bees/session.py
+++ b/packages/bees/bees/session.py
@@ -422,6 +422,11 @@ async def drain_session(
             event_count += 1
             _print_event_summary(event, prefix=prefix)
 
+            # Persist the raw event to events.jsonl when the runner
+            # doesn't use opal's _tee_events (which writes events itself).
+            if config.persist_events:
+                await session_store.append_event(session_id, event)
+
             # Record turn boundary and checkpoint on sendRequest
             if "sendRequest" in event:
                 contents = event["sendRequest"].get("body", {}).get("contents", [])

--- a/packages/bees/bees/task_runner.py
+++ b/packages/bees/bees/task_runner.py
@@ -122,6 +122,11 @@ class TaskRunner:
                 voice=agent.metadata.voice,
             )
 
+            # Antigravity bypasses opal's _tee_events, so drain_session
+            # must persist events to events.jsonl itself.
+            if agent.metadata.runner == "antigravity":
+                config.persist_events = True
+
             # Live sessions need context-level chat extraction because
             # they lack function-level chat handlers.
             if agent.metadata.runner == "live":
@@ -353,6 +358,11 @@ class TaskRunner:
                 seed_files=False,  # Files already on disk from previous run.
                 voice=agent.metadata.voice,
             )
+
+            # Antigravity bypasses opal's _tee_events, so drain_session
+            # must persist events to events.jsonl itself.
+            if agent.metadata.runner == "antigravity":
+                config.persist_events = True
 
             # Live sessions need context-level chat extraction because
             # they lack function-level chat handlers.

--- a/packages/bees/hivetool/src/data/session-store-reader.ts
+++ b/packages/bees/hivetool/src/data/session-store-reader.ts
@@ -120,10 +120,22 @@ function compileEventsToSegment(sessionId: string, events: Record<string, unknow
       if ("systemMessage" in event) {
         const sm = event.systemMessage as Record<string, unknown> || {};
         const text = sm.text as string || "";
-        currentTurnGroup.entries.push({
-          role: "model",
-          parts: [{ text, systemMessage: true }]
-        });
+        // Collate consecutive systemMessage events into a single entry
+        // (Antigravity streams text in small deltas).
+        const lastEntry = currentTurnGroup.entries.at(-1);
+        if (
+          lastEntry?.role === "model" &&
+          lastEntry.parts.length === 1 &&
+          lastEntry.parts[0].systemMessage &&
+          lastEntry.parts[0].text !== undefined
+        ) {
+          lastEntry.parts[0].text += text;
+        } else {
+          currentTurnGroup.entries.push({
+            role: "model",
+            parts: [{ text, systemMessage: true }]
+          });
+        }
       }
       
       if ("functionCall" in event) {
@@ -139,6 +151,19 @@ function compileEventsToSegment(sessionId: string, events: Record<string, unknow
           }]
         });
         totalFunctionCalls++;
+      }
+
+      if ("functionResponse" in event) {
+        const fr = event.functionResponse as Record<string, unknown> || {};
+        currentTurnGroup.entries.push({
+          role: "user",
+          parts: [{
+            functionResponse: {
+              name: fr.name as string || "",
+              response: fr.response as Record<string, unknown> || {},
+            }
+          }]
+        });
       }
       
       if ("usageMetadata" in event) {


### PR DESCRIPTION
## What
Antigravity runner sessions now produce valid `events.jsonl` files that Hivetool can render, with correct event types and session header metadata.

## Why
The Antigravity runner bypasses opal's `_tee_events` loop, so `events.jsonl` was never written. Hivetool showed empty session logs for antigravity agents.

## Changes

### Event persistence (`session.py`, `protocols/session.py`, `task_runner.py`)
- Add `persist_events: bool` flag to `SessionConfiguration`
- `drain_session` appends events to `events.jsonl` when flag is set
- `TaskRunner` enables the flag for the `"antigravity"` runner in both `run_task` and `resume_task`

### Event translation (`antigravity.py`)
- Distinguish tool calls from tool responses: SDK emits `TOOL_CALL` steps twice (ACTIVE → call, DONE → response). Now emits `functionResponse` events for completed tool calls instead of duplicate `functionCall` events
- Fix system instruction assembly: use function group `.instruction` fragments (from custom tool groups like agents/events/skills) instead of segments. Segments are the objective (user prompt), not system instructions
- Build Hivetool-compatible `sendRequest` config with `systemInstruction` and `tools` from the correct sources

### Tool mapping (`tool_mapping.py`)
- `map_function_filter` returns a 3-tuple `(capabilities, custom_tools, custom_instructions)` — instruction fragments from custom tool groups are now surfaced alongside the tools

### Hivetool rendering (`session-store-reader.ts`)
- Collate consecutive `systemMessage` events into a single entry (Antigravity SDK streams text in small deltas)
- Handle `functionResponse` events in the timeline compiler

## Testing
Run an antigravity agent via `BEES_HIVE_DIR=../../hives/antigravity npm run dev:box -w bees`, then open Hivetool to verify:
- Session timeline renders with thoughts, function calls, function responses, and collated text output
- Session header shows tool list and system instruction (from custom groups only, not the objective)
- Existing Gemini runner sessions are unaffected (`persist_events` defaults to `False`)
