### PR TITLE
[bees] Emit functionResponse events in AntigravityRunner via PostToolCallHook

### DIFF
--- a/hives/antigravity/config/TEMPLATES.yaml
+++ b/hives/antigravity/config/TEMPLATES.yaml
@@ -7,9 +7,9 @@
   objective: >
     You are a simple test agent. Your job is to:
 
-    1. List the files in your workspace directory.
-    2. Create a file called "hello.txt" with the content "Hello from Antigravity!".
-    3. Finish with a brief summary of what you did.
+    1. List the files in your workspace directory. 2. Create a file called
+    "hello.txt" with the content "Hello from Antigravity!". 3. Finish with a
+    brief summary of what you did.
   functions:
     - system.*
     - files.*
@@ -19,9 +19,293 @@
   title: AG Chat
   description: An interactive chat agent that uses the Antigravity SDK
   objective: >
-    You are a friendly assistant. Greet the user and ask how you can help.
-    When the user asks you to do something, do it and then ask if there's
-    anything else. You can read and write files in your workspace.
+    You are a friendly assistant. Greet the user and ask how you can help. When
+    the user asks you to do something, do it and then ask if there's anything
+    else. You can read and write files in your workspace.
   functions:
     - chat.*
     - files.*
+
+- name: weather-orchestrator
+  title: Weather Orchestrator
+  runner: antigravity
+  objective: >-
+    You are a weather-checking orchestrator. Use agents_list_types to discover
+    available agent types, then assign two sequential tasks to a
+    "weather-checker" agent with slug "checker".
+
+    - Task 1: Check the weather in San Francisco, CA. Save it to sfo.txt. 
+    - Task 2: Check the weather in London. Save it to lon.txt.
+
+    After assigning task 1, don't wait for it to complete, and immediately
+    assign task 2 to the same slug and wait for both tasks to complete. When
+    both tasks are complete, mark your objective as fulfilled with a summary of
+    the results.
+  functions:
+    - agents.*
+    - system.*
+  tasks:
+    - weather-checker
+
+- name: weather-checker
+  title: Weather Checker
+  objective: >-
+    You are a weather checker. You will receive tasks describing what locations
+    to provide the weather information for. For each task, write the requested
+    content to a file in your workspace, then call events_yield with a summary
+    of what you produced.
+
+
+    Your first task: {{system.context}}
+  functions:
+    - files.*
+    - events.*
+    - builtin.search_grounding
+
+## Generators
+
+- name: generate_text
+  title: Text Generator
+  runner: direct_model
+  model: gemini-3-flash-preview
+  objective: "{{system.context}}"
+  functions:
+    - builtin.search_grounding
+  description: >-
+    An extremely versatile text generator, powered by Gemini. Use it for any
+    tasks that involve generation of text. Supports multimodal content input.
+    Always writes its output to {slug}/text.md.
+
+- name: generate_images
+  title: Image Generator
+  runner: direct_model
+  model: gemini-3.1-flash-image-preview
+  tags:
+    - image
+  objective: "{{system.context}}"
+  options_schema:
+    aspect_ratio:
+      type: string
+      description: >-
+        Target aspect ratio. Valid values: '1:1', '3:4', '4:3', '9:16', '16:9',
+        '1:2', '2:1', '3:2', '2:3', '5:4', '4:5', '7:5', '5:7', '21:9', '9:21'.
+      enum:
+        - "1:1"
+        - "3:4"
+        - "4:3"
+        - "9:16"
+        - "16:9"
+        - "1:2"
+        - "2:1"
+        - "3:2"
+        - "2:3"
+        - "5:4"
+        - "4:5"
+        - "7:5"
+        - "5:7"
+        - "21:9"
+        - "9:21"
+    image_size:
+      type: string
+      description:
+        "Target resolution or image size. Valid values: '512', '1K', '2K', '4K'."
+      enum:
+        - "512"
+        - 1K
+        - 2K
+        - 4K
+    person_generation:
+      type: string
+      description: >-
+        Person generation policy. Valid values: 'allow_all', 'dont_allow',
+        'allow_adult'.
+      enum:
+        - allow_all
+        - dont_allow
+        - allow_adult
+  description: >-
+    An extremely versatile image generator, powered by Gemini. Use it for any
+    tasks that involve generation of images based on a prompt. Always writes its
+    output to {slug}/image_0.png. If passing references, pass them as in <file>
+    tags.
+
+- name: generate_video
+  title: Video Generator
+  runner: direct_model
+  model: veo-3.1-generate-preview
+  tags:
+    - video
+  objective: "{{system.context}}"
+  options_schema:
+    aspect_ratio:
+      type: string
+      description: "Target aspect ratio. Valid values: '16:9', '9:16', '1:1'."
+      enum:
+        - "16:9"
+        - "9:16"
+        - "1:1"
+    resolution:
+      type: string
+      description: >-
+        Target resolution. Valid values: '720p', '1080p', '4k'. Extension is
+        limited to 720p.
+      enum:
+        - 720p
+        - 1080p
+        - 4k
+    duration_seconds:
+      type: number
+      description: "Target duration in seconds. Valid values: 4, 6, 8."
+      enum:
+        - 4
+        - 6
+        - 8
+    person_generation:
+      type: string
+      description: >-
+        Person generation policy. Valid values: 'allow_all', 'dont_allow',
+        'allow_adult'.
+      enum:
+        - allow_all
+        - dont_allow
+        - allow_adult
+    first_frame:
+      type: string
+      description: >-
+        Path to a starting frame image for image-to-video generation. The video
+        will begin from this image and animate forward.
+    last_frame:
+      type: string
+      description: >-
+        Path to an ending frame image for keyframe interpolation. Use together
+        with first_frame to generate a video that transitions between two
+        specific frames.
+    extend_video:
+      type: string
+      description: >-
+        Path to a previously generated video to extend by ~7 seconds. The video
+        must have been generated by a prior generate_video task (e.g.
+        'intro/video_0.mp4'). Extension is always 720p and produces a single
+        combined video.
+    reference_images:
+      type: array
+      description: >-
+        Up to 3 paths to reference images that guide the video's visual content.
+        Use to preserve a subject's appearance (e.g. a person, character,
+        product, or outfit).
+  description: >-
+    A cinematic video generator powered by Veo 3.1. Use it to generate
+    high-fidelity 8-second videos with native audio from text prompts.
+
+    Supports advanced cinematic direction via options: - **Image-to-video**: Set
+    first_frame to a starting image. - **Interpolation**: Set both first_frame
+    and last_frame to
+      generate a video transitioning between two keyframes.
+    - **Extension**: Set extend_video to a previously generated video
+      path to extend it by ~7 seconds (always 720p, up to 20 times).
+    - **Reference images**: Set reference_images to up to 3 image paths
+      to guide visual content (subjects, outfits, products).
+    - **Resolution**: Choose 720p, 1080p, or 4k (higher = slower).
+
+    Always writes its output to {slug}/video_0.mp4.
+
+- name: generate_speech
+  title: Speech Generator
+  runner: direct_model
+  model: gemini-3.1-flash-tts-preview
+  tags:
+    - speech
+  objective: "{{system.context}}"
+  options_schema:
+    voice:
+      type: string
+      description: >-
+        Voice preset name. Each voice has a distinct personality: Achernar
+        (clear, friendly), Achird (warm, conversational), Algenib (deep,
+        authoritative), Algieba (rich, dramatic), Alnilam (smooth, neutral),
+        Aoede (breezy, intelligent), Autonoe (mature, wise), Callirrhoe (bright,
+        animated), Charon (informative, calm), Despina (gentle, soothing),
+        Enceladus (breathy, intimate), Erinome (crisp, precise), Fenrir
+        (excitable, energetic), Gacrux (steady, grounded), Iapetus (resonant,
+        measured), Kore (firm, clear), Laomedeia (melodic, expressive), Leda
+        (professional, composed), Orus (bold, commanding), Puck (upbeat,
+        youthful), Pulcherrima (elegant, polished), Rasalgethi (gravelly,
+        textured), Sadachbia (soft, contemplative), Sadaltager (neutral,
+        versatile), Schedar (warm, reassuring), Sulafat (lively, playful),
+        Umbriel (mysterious, atmospheric), Vindemiatrix (articulate, refined),
+        Zephyr (bright, perky), Zubenelgenubi (deep, resonant).
+      enum:
+        - Achernar
+        - Achird
+        - Algenib
+        - Algieba
+        - Alnilam
+        - Aoede
+        - Autonoe
+        - Callirrhoe
+        - Charon
+        - Despina
+        - Enceladus
+        - Erinome
+        - Fenrir
+        - Gacrux
+        - Iapetus
+        - Kore
+        - Laomedeia
+        - Leda
+        - Orus
+        - Puck
+        - Pulcherrima
+        - Rasalgethi
+        - Sadachbia
+        - Sadaltager
+        - Schedar
+        - Sulafat
+        - Umbriel
+        - Vindemiatrix
+        - Zephyr
+        - Zubenelgenubi
+    speaker_1:
+      type: string
+      description: >-
+        First speaker for multi-speaker dialogue, in "Alias:VoiceName" format
+        (e.g. "Host:Aoede"). The alias must match what appears in the
+        transcript. Both speaker_1 and speaker_2 must be set for multi-speaker
+        mode.
+    speaker_2:
+      type: string
+      description: >-
+        Second speaker for multi-speaker dialogue, in "Alias:VoiceName" format
+        (e.g. "Guest:Puck"). The alias must match what appears in the
+        transcript. Both speaker_1 and speaker_2 must be set for multi-speaker
+        mode.
+  description: >-
+    An expressive speech generator powered by Gemini TTS. Use it for narration,
+    voiceover, dialogue, and podcast-style multi-speaker audio.
+
+    **Single speaker**: Set the `voice` option to choose a voice preset.
+    Defaults to Kore if unspecified.
+
+    **Multi-speaker dialogue**: Set `speaker_1` and `speaker_2` options using
+    "Alias:VoiceName" format (e.g. speaker_1: "Host:Aoede", speaker_2:
+    "Guest:Puck"). Write the transcript using "Alias: text" format on each line.
+    The API currently supports exactly 2 speakers.
+
+    **Expressive control**: Embed audio tags directly in the transcript to
+    direct performance: [whispers], [laughs], [excitedly], [slowly, with
+    gravity], [sighs], [pauses]. The model interprets these as stage directions
+    for natural delivery.
+
+    Always writes its output to {slug}/audio_0.wav.
+
+- name: generate_music
+  title: Music Generator
+  runner: direct_model
+  model: lyria-3-pro-preview
+  tags:
+    - music
+  objective: "{{system.context}}"
+  description: >-
+    An extremely versatile music generator, powered by Lyria. Use it for any
+    tasks that involve generation of music or songs based on a prompt. Always
+    writes its output to {slug}/audio_0.wav.

--- a/hives/antigravity/skills/build-react-apps/SKILL.md
+++ b/hives/antigravity/skills/build-react-apps/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: build-react-apps
+title: How to build React apps
+description: Produce high-quality React apps from natural language descriptions.
+allowed-tools:
+  - files.*
+  - sandbox.*
+---
+
+# How to build high-quality React apps
+
+## What You're Building
+
+A **multi-file React component bundle** rendered in a sandboxed iframe. The
+bundle consists of:
+
+- `App.jsx` — the root component that accepts configuration props
+- `components/*.jsx` — reusable sub-components
+- `styles.css` — shared styles using CSS custom properties
+
+Components use **inline styles** with CSS custom properties from a design token
+system. Import resolution between files is handled automatically by the build
+pipeline.
+
+## Workflow
+
+Your UI MUST work from 320px to 1200px+. This is not optional.
+
+1. Write the app an its components as files in your directory.
+
+2. Build the bundle with [bundler.mjs](./scripts/bundler.mjs):
+
+```bash
+node ./skills/{name of this skill}/scripts/bundler.mjs
+```
+
+If you do not run this exact command, the user will see a blank screen.
+
+3. Once bundling is successful, return a brief confirmation that the UI was
+   generated and bundled. Don't enclose produced files.
+
+## Developer Rules
+
+Follow these rules strictly.
+
+1. **App.jsx is the entry point.** It must be named exactly `App.jsx` and
+   contain a function called `App`.
+2. **App carries the configuration.** All data that should be configurable by
+   the caller (location, users, items, dates, etc.) appears as props on `App`
+   with realistic defaults.
+3. **Sub-components are reusable.** Each component in `components/` should
+   render standalone with sensible defaults. Document all props with `@prop`
+   JSDoc.
+4. **Every file imports what it uses.** Include `import React from "react"` in
+   every JSX file. Import sub-components with relative paths (e.g.
+   `import Header from "./components/Header"`).
+5. **CSS imports work.** Use `import "./styles.css"` in App.jsx for shared
+   styles.
+6. **Export default.** Each component file must `export default` its component
+   function.
+7. **All colors, spacing, typography, and radii MUST use `--cg-` design
+   tokens.** No hex colors, no `rgb()`, no named colors, no raw pixel values.
+   Hardcoded values like `#8B6F47` or `color: olive` break the live theme
+   switcher. This is a build error, not a suggestion.
+8. **Your output renders inside a host application.** Don't create app names,
+   brand headers, splash screens, or taglines. Start with the actual task UI.
+   The host provides the chrome.
+9. **No client storage APIs.** Do not use `localStorage`, `sessionStorage`,
+   `IndexedDB`, or any Web Storage APIs. The iframe environment may not have
+   storage access due to origin restrictions. All state lives in React component
+   state or is passed via props and the SDK.
+10. **Respect the host theme.** Use design tokens. Backgrounds must use
+    `var(--cg-color-surface*)` tokens and all text must use
+    `var(--cg-color-on-surface*)` tokens. The tokens will natively map to their
+    theme variants.
+11. **Use `flex-wrap: wrap`** on any flex container with multiple children that
+    should stack on narrow screens.
+12. **Use CSS Grid with `auto-fit` / `minmax`** for multi-column layouts:
+    `grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr))`.
+13. **Use `clamp()` for font sizes** that should scale with viewport:
+    `font-size: clamp(1rem, 2vw + 0.5rem, 2rem)`.
+14. **Test your mental model** at 375px, 768px, and 1200px before finishing.
+
+These particular paterns are forbidden.
+
+- **No fixed pixel widths** on containers or layout elements. Never write
+  `width: 800px`, `width: 600px`, or similar. Use `max-width` with a percentage
+  or `min()` instead: `max-width: min(100%, 800px)`.
+- **No `min-width` exceeding 320px** on any layout container. This prevents
+  rendering on small screens.
+- **No horizontal overflow.** If your layout causes a horizontal scrollbar at
+  any viewport width ≥ 320px, it is broken.
+
+**CRITICAL FORBIDDEN PATTERN: NO TAILWIND!**
+
+- You MUST NOT use Tailwind CSS utility classes (e.g., `flex`, `min-h-screen`,
+  `p-4`, `bg-red-500`). Tailwind is NOT INSTALLED.
+- You MUST use standard semantic CSS class names (e.g.,
+  `className="hero-container"`).
+- You MUST write a separate `styles.css` file using **Vanilla CSS**.
+- You MUST include `import "./styles.css";` at the top of your `App.jsx`. If you
+  don't write and import a CSS file, your design will be completely unstyled.
+
+## Configuration Props
+
+When creating a component, think about what data the _caller_ would want to
+customize. These become props on `App`:
+
+| UI Type             | Example Props                                              |
+| ------------------- | ---------------------------------------------------------- |
+| Weather dashboard   | `location`, `temperature`, `condition`, `forecast` (array) |
+| User profile        | `name`, `avatar`, `bio`, `stats` (object)                  |
+| Product card        | `title`, `price`, `image`, `rating`, `reviews`             |
+| Task manager        | `tasks` (array), `categories`, `user`                      |
+| Analytics dashboard | `metrics` (array), `timeRange`, `chartData`                |
+
+All props MUST have realistic default values so the component renders standalone
+with zero configuration.
+
+## Design Token System
+
+**Reminder: this is a hard rule (see above).** Every visual value — colors,
+spacing, type, radii, shadows — MUST use `--cg-` tokens. No exceptions.
+
+### Token Rules
+
+| Category      | Use                                                  | Never                                   |
+| ------------- | ---------------------------------------------------- | --------------------------------------- |
+| Colors        | `var(--cg-color-...)`                                | `#hex`, `rgb()`, named colors           |
+| Spacing       | `var(--cg-sp-...)`                                   | Raw pixel values for padding/margin/gap |
+| Font sizes    | `var(--cg-text-...-size)`                            | `14px`, `1rem`                          |
+| Border radius | `var(--cg-radius-...)` or `var(--cg-card-radius)`    | `12px`, `24px`                          |
+| Shadows       | `var(--cg-elevation-...)` or `var(--cg-card-shadow)` | Raw `box-shadow` values                 |
+| Font family   | `var(--cg-font-sans)` or `var(--cg-font-mono)`       | `'Arial'`, `sans-serif`                 |
+
+### Available Tokens
+
+**Colors:** `--cg-color-surface-dim`, `--cg-color-surface`,
+`--cg-color-surface-bright`, `--cg-color-surface-container-lowest`,
+`--cg-color-surface-container-low`, `--cg-color-surface-container`,
+`--cg-color-surface-container-high`, `--cg-color-surface-container-highest`,
+`--cg-color-on-surface`, `--cg-color-on-surface-muted`, `--cg-color-primary`,
+`--cg-color-primary-container`, `--cg-color-on-primary`,
+`--cg-color-on-primary-container`, `--cg-color-secondary`,
+`--cg-color-secondary-container`, `--cg-color-on-secondary`,
+`--cg-color-on-secondary-container`, `--cg-color-tertiary`,
+`--cg-color-tertiary-container`, `--cg-color-on-tertiary`,
+`--cg-color-on-tertiary-container`, `--cg-color-error`,
+`--cg-color-error-container`, `--cg-color-on-error`,
+`--cg-color-on-error-container`, `--cg-color-outline`,
+`--cg-color-outline-variant`
+
+**Typography:** `--cg-font-sans`, `--cg-font-mono`,
+`--cg-text-display-{lg,md,sm}-{size,weight}`,
+`--cg-text-headline-{lg,md,sm}-{size,weight}`,
+`--cg-text-title-{lg,md,sm}-{size,weight}`,
+`--cg-text-body-{lg,md,sm}-{size,weight}`,
+`--cg-text-label-{lg,md,sm}-{size,weight}`
+
+**Spacing (4px grid):** `--cg-sp-0` through `--cg-sp-16`
+
+**Radius:** `--cg-radius-{xs,sm,md,lg,xl,full}`
+
+**Elevation:** `--cg-elevation-{1,2,3}`
+
+**Motion:** `--cg-motion-duration-{short,medium,long}`,
+`--cg-motion-easing-{standard,decel,accel}`
+
+**Component tokens:** Card: `--cg-card-{bg,radius,padding,shadow}`, Button:
+`--cg-button-{radius,padding,bg,color,font-size,font-weight}`, Input:
+`--cg-input-{bg,border,radius,padding,color,placeholder}`, Badge:
+`--cg-badge-{bg,color,radius,padding,font-size}`, Divider:
+`--cg-divider-{color,thickness,style}`
+
+**Expressive:** `--cg-border-{style,width}`,
+`--cg-heading-{transform,letter-spacing}`,
+`--cg-img-{radius,border,shadow,filter}`, `--cg-hover-{scale,brightness,shadow}`
+
+## Component Design
+
+### Decomposition
+
+- **Compose, don't monolith.** A dashboard should be built from `Header`,
+  `MetricsGrid`, `ForecastCard`, etc.
+- **Each component renders standalone** with realistic defaults.
+- **The top-level App composes everything** into a cohesive layout.
+
+### Icons
+
+Google Material Symbols Outlined is available via a web font:
+
+```jsx
+<span className="material-symbols-outlined" style={{ fontSize: "20px" }}>
+  search
+</span>
+```
+
+**CRITICAL: DO NOT import third-party icon packages.** You do not have
+`lucide-react`, `heroicons`, or `react-icons` installed. Using them will break
+the build. ONLY use the `material-symbols-outlined` span.
+
+### Interactivity
+
+Components should be interactive where appropriate. Use `useState`, `useEffect`
+with cleanup. Supported patterns: timers, carousels, accordions, tabs,
+checklists, toggles.
+
+### Stable Defaults
+
+Never use `Date.now()`, `Math.random()`, or `new Date()` in default parameters.
+Compute once at module level or use `useState(() => ...)`.
+
+### Critical: You're building a Segment, Not a Standalone App
+
+Your React app is **one segment** of a wider orchestrated journey. Between
+segments, an LLM orchestrator examines the user's data and decides what comes
+next. This means:
+
+- **Don't brand it.** No app names, no splash screens, no taglines. The host
+  application provides the chrome and framing. Start with the task UI.
+
+### File Structure
+
+Each state gets its own component file named after the state:
+
+- `App.jsx` — shell that renders the initial state
+- `views/InputRequirements.jsx` — one view per state
+- `views/SelectModels.jsx`
+- `views/DetailedComparison.jsx`
+- `views/DecisionReport.jsx`
+- `components/*.jsx` — shared sub-components (reusable across views)
+- `styles.css` — shared styles
+
+### View Contract
+
+Each view component receives two props:
+
+- `data` — the journey context relevant to this state
+- `onTransition` — callback for state transitions (wired to
+  `window.opalSDK.navigateTo`)
+
+```jsx
+export default function SelectModels({ data = {}, onTransition }) {
+  const handleSelect = (item) => {
+    onTransition("detailed_comparison", {
+      ...data,
+      shortlist: [...(data.shortlist || []), item],
+    });
+  };
+  // ...
+}
+```
+
+### Rules
+
+1. **One view per state.** Don't merge states into a single component.
+2. **Views are self-contained.** Each view renders standalone with defaults.
+3. **Shared components go in `components/`.** Headers, cards, buttons used
+   across multiple views should be extracted.
+4. **Context flows forward.** Each transition carries the data the next view
+   needs. Views may also use `readFile` to load shared workspace data.
+5. **Responsive.** The user may view this UI on a mobile device, so ensure that
+   you make every component and the app itself responsive.
+
+## Available Globals
+
+`React`, `useState`, `useEffect`, `useRef`, `useCallback`, `useMemo`,
+`useContext`, `useReducer`, `useLayoutEffect`, `memo`, `forwardRef`,
+`createContext`, `Fragment`
+
+Be creative and visually impressive.

--- a/hives/antigravity/skills/build-react-apps/scripts/bundler.mjs
+++ b/hives/antigravity/skills/build-react-apps/scripts/bundler.mjs
@@ -1,0 +1,198 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Standalone JSX bundler for the ui-generator skill.
+ *
+ * Reads JSX/CSS files from the current working directory, bundles them
+ * into a single CJS output (with React as external), and writes
+ * `bundle.js` + `bundle.css` to the same directory.
+ *
+ * Usage (via execute_bash):
+ *   node skills/ui-generator/tools/bundler.mjs
+ *
+ * Entry point: App.jsx in the current directory.
+ * React is provided by the iframe runtime — not bundled here.
+ */
+
+/* global process, console */
+
+import { build } from "esbuild";
+import { readFileSync, writeFileSync, readdirSync, statSync } from "fs";
+import { join, extname, relative } from "path";
+
+const cwd = process.cwd();
+
+// ── Collect files from disk ──────────────────────────────────────────────
+
+/** Recursively collect files into a flat map: relative-path → content. */
+function collectFiles(dir, base = dir) {
+  const result = {};
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const rel = relative(base, full);
+    if (statSync(full).isDirectory()) {
+      // Skip node_modules, hidden dirs, and output files.
+      if (entry.startsWith(".") || entry === "node_modules") continue;
+      Object.assign(result, collectFiles(full, base));
+    } else {
+      const ext = extname(entry);
+      if ([".jsx", ".js", ".css"].includes(ext)) {
+        result[rel] = readFileSync(full, "utf-8");
+      }
+    }
+  }
+  return result;
+}
+
+const files = collectFiles(cwd);
+
+const entryFile = files["App.jsx"] ? "App.jsx" : files["app.jsx"] ? "app.jsx" : null;
+
+if (!entryFile) {
+  console.error("Error: No App.jsx or app.jsx found in", cwd);
+  process.exit(1);
+}
+
+// ── Auto-export ──────────────────────────────────────────────────────────
+
+/**
+ * If a JSX source has no explicit export, detect the component name
+ * and append `export default ComponentName;`.
+ */
+function autoExport(source) {
+  if (source.includes("export default") || source.includes("module.exports")) {
+    return source;
+  }
+  const match =
+    source.match(/^function\s+([A-Z]\w*)/m) ??
+    source.match(/^const\s+([A-Z]\w*)\s*=/m);
+  if (match) {
+    return source + `\nexport default ${match[1]};\n`;
+  }
+  return source;
+}
+
+// ── Collect CSS ──────────────────────────────────────────────────────────
+
+const cssChunks = [];
+
+// ── Bundle ───────────────────────────────────────────────────────────────
+
+/**
+ * Find a file key in the files map, trying with the given extensions.
+ */
+function findFileKey(path, extensions) {
+  if (files[path]) return path;
+  for (const ext of extensions) {
+    const withExt = path + ext;
+    if (files[withExt]) return withExt;
+  }
+  return undefined;
+}
+
+try {
+  const result = await build({
+    stdin: {
+      contents: autoExport(files[entryFile]),
+      loader: "jsx",
+      resolveDir: "/",
+    },
+    bundle: true,
+    write: false,
+    format: "cjs",
+    jsx: "transform",
+    jsxFactory: "React.createElement",
+    jsxFragment: "React.Fragment",
+    plugins: [
+      {
+        name: "virtual-modules",
+        setup(build) {
+          // React → external (provided by iframe's requireShim).
+          build.onResolve({ filter: /.*/ }, (args) => {
+            if (args.path === "react" || args.path.startsWith("react/")) {
+              return { path: args.path, external: true };
+            }
+
+            // Resolve relative paths.
+            let normalized = args.path;
+            if (
+              (args.path.startsWith("./") || args.path.startsWith("../")) &&
+              args.importer
+            ) {
+              const importerDir = args.importer.includes("/")
+                ? args.importer.substring(0, args.importer.lastIndexOf("/") + 1)
+                : "";
+              const joined = importerDir + args.path;
+              const parts = joined.split("/");
+              const resolved = [];
+              for (const part of parts) {
+                if (part === "..") resolved.pop();
+                else if (part !== ".") resolved.push(part);
+              }
+              normalized = resolved.join("/");
+            } else {
+              normalized = normalized.replace(/^\.\//, "");
+            }
+
+            // Resolve to any known file, then assign namespace by extension.
+            const jsExts = [".jsx", ".js"];
+            const cssExts = [".css"];
+            const allExts = [...jsExts, ...cssExts];
+
+            const key =
+              findFileKey(normalized, allExts) ??
+              findFileKey(normalized + ".jsx", []) ??
+              findFileKey(normalized + ".js", []) ??
+              findFileKey(normalized + ".css", []);
+
+            if (key) {
+              const ns = key.endsWith(".css") ? "virtual-css" : "virtual-jsx";
+              return { path: key, namespace: ns };
+            }
+
+            return undefined;
+          });
+
+          // Load virtual JSX modules (auto-export if needed).
+          build.onLoad({ filter: /.*/, namespace: "virtual-jsx" }, (args) => ({
+            contents: autoExport(files[args.path] ?? ""),
+            loader: "jsx",
+          }));
+
+          // Load virtual CSS — collect it and return empty JS.
+          build.onLoad({ filter: /.*/, namespace: "virtual-css" }, (args) => {
+            cssChunks.push(files[args.path] ?? "");
+            return { contents: "", loader: "js" };
+          });
+        },
+      },
+    ],
+  });
+
+  const output = result.outputFiles?.[0];
+  if (!output) {
+    throw new Error("esbuild.build produced no output");
+  }
+
+  // Write bundle.js
+  writeFileSync(join(cwd, "bundle.js"), output.text, "utf-8");
+
+  // Write bundle.css (concatenated CSS chunks)
+  if (cssChunks.length > 0) {
+    writeFileSync(join(cwd, "bundle.css"), cssChunks.join("\n"), "utf-8");
+  }
+
+  console.log(
+    `✓ Bundled: bundle.js (${output.text.length} bytes)` +
+      (cssChunks.length > 0
+        ? `, bundle.css (${cssChunks.join("\n").length} bytes)`
+        : "")
+  );
+} catch (err) {
+  console.error("Bundle failed:", err.message);
+  process.exit(1);
+}

--- a/hives/antigravity/skills/build-widgets/SKILL.md
+++ b/hives/antigravity/skills/build-widgets/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: build-widgets
+title: How to build widgets
+description: Learn how to make widgets on canvas
+allowed-tools:
+  - files.*
+---
+
+Here's how you build a widget:
+
+1) Create a new subdirectory where the app will go. Check to see that this is a new directory.
+
+2) Write the React app using Opal SDK in that subdirectory. Rules for app crafting
+- craft the app in a way that any non-constant data is represented as a JSON file that's loaded and watched for changes. 
+- do not create additional bezels or borders for the widget: they will conflict with the surface borders. Just 10px padding.
+
+3) Create or update the surface to include the widget.
+
+4) Get back to the user with a friendly message notifying them that the widget was added.

--- a/hives/antigravity/skills/run-in-sandbox/SKILL.md
+++ b/hives/antigravity/skills/run-in-sandbox/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: run-in-sandbox
+title: How to run in sandbox
+description:
+  Teaches you how to properly operate in the sandboxed environment you're in.
+allowed-tools:
+  - sandbox.*
+---
+
+# The sandbox
+
+When you call `execute_bash` function, it runs in a sandboxed environment. You
+have acess to most bash commands. The `PATH` is configured to give you access to
+`node` and `python3`.
+
+Even though you can use heredoc to write and `cat` to read files, prefer the
+built-in file functions, if they available.

--- a/hives/antigravity/skills/surface/SKILL.md
+++ b/hives/antigravity/skills/surface/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: surface
+title: Presenting Your Work via Surface
+description:
+  Learn how to present your work as a structured surface — a curated manifest of
+  artifacts that the user's application renders in real time.
+allowed-tools:
+  - files.*
+  - events.*
+---
+
+# What is a Surface?
+
+A **surface** is a structured manifest that tells the user's application what to
+display. It contains links to various files to present to the user and
+optionally, groups them into sections.
+
+A surface is a living document you update as you work, so the user sees your
+progress in real time.
+
+# The Workflow
+
+Every time you produce, update, or receive a meaningful artifact, follow these
+steps:
+
+1. **Write `surface.json`.** Overwrite it with the complete current state of
+   what you want to present, including the new/updated artifact. Increment the
+   `version` counter.
+2. **Broadcast.** Call `events_broadcast` with type `surface_updated`. The
+   consumer application listens for `surface_updated` and re-reads
+   `surface.json` to update the display.
+
+# Format
+
+`surface.json` is a single JSON file that you overwrite on every change.
+
+```json
+{
+  "version": 1,
+  "title": "My Surface Title",
+  "sections": [{ "id": "main", "title": "Main Results" }],
+  "items": [
+    {
+      "id": "findings",
+      "title": "Research Findings",
+      "path": "research_notes.md",
+      "description": "Key findings from the analysis",
+      "section": "main"
+    }
+  ]
+}
+```
+
+## Top-level fields
+
+| Field      | Required | Description                                             |
+| ---------- | -------- | ------------------------------------------------------- |
+| `version`  | **yes**  | Integer. Start at 1, increment on every write.          |
+| `title`    | no       | Human-readable name for the surface.                    |
+| `sections` | no       | Declared section groups. Omit if no grouping is needed. |
+| `items`    | **yes**  | Ordered list of content items.                          |
+
+## Sections
+
+Sections are optional named groups. Items reference them by `id`.
+
+| Field         | Required | Description                                                                                          |
+| ------------- | -------- | ---------------------------------------------------------------------------------------------------- |
+| `id`          | **yes**  | Stable identifier, referenced by items.                                                              |
+| `title`       | **yes**  | Human-readable heading.                                                                              |
+| `description` | no       | Brief description of the section.                                                                    |
+| `active`      | no       | When `true`, this section is selected by default in tabbed views. At most one section should be active. |
+
+## Items
+
+Each item represents one piece of content you want to present.
+
+| Field         | Required | Description                                                                                                      |
+| ------------- | -------- | ---------------------------------------------------------------------------------------------------------------- |
+| `id`          | **yes**  | Stable identifier, unique within the surface.                                                                    |
+| `title`       | **yes**  | Human-readable label.                                                                                            |
+| `path`        | no       | File path (workspace-relative). At least one of `path` or `description` must be present.                         |
+| `description` | no       | Inline text — standalone content, preview, or metadata. At least one of `path` or `description` must be present. |
+| `render`      | no       | Rendering override. Use `bundle` for JS files that should render in a sandboxed iframe.                          |
+| `role`        | no       | Semantic role: `primary` (hero), `supporting` (detail), `status` (lightweight indicator).                        |
+| `section`     | no       | The section `id` this item belongs to. Ungrouped items go to a default section.                                  |
+
+# Rules
+
+## Paths match `files_write_file`
+
+The `path` field in items uses the same workspace-relative format as
+`files_write_file`. If you write a file with `files_write_file` using
+`research/findings.md`, reference it in the surface as
+`"path": "research/findings.md"`.
+
+## Write `surface.json` in your writable directory
+
+Use `files_write_file` with `"file_name": "surface.json"`. If you are a
+sub-agent with a scope restriction, write it within your assigned directory
+(e.g., `research/surface.json`). The consumer discovers surface files by walking
+the filesystem tree.
+
+## The surface is complete state, not a diff
+
+Every time you write `surface.json`, include **all** items you want displayed —
+not just the ones that changed. If you previously had 3 items and now have 4,
+write all 4. If you want to remove an item, omit it from the next write.
+
+## Increment version on every write
+
+The `version` counter lets the consumer detect changes. Start at 1. Increment by
+1 on every write, even if only the ordering changed.
+
+## Always broadcast after writing
+
+After writing `surface.json`, call `events_broadcast` with:
+
+- `type`: `surface_updated`
+- `message`: brief description of what changed (e.g., "Added research findings")
+
+## Items without files are valid
+
+Not every item needs a file. Use `description` alone for lightweight status
+indicators:
+
+```json
+{
+  "id": "status",
+  "title": "Progress",
+  "description": "3 of 5 sources analyzed",
+  "role": "status"
+}
+```
+
+## Bundles use a render hint
+
+If you produce a JavaScript bundle (e.g., an interactive chart), set
+`"render": "bundle"` on the item. The consumer loads the JS in a sandboxed
+iframe and discovers a companion CSS file by convention (same filename stem).
+
+## Update the surface incrementally as you work
+
+Don't wait until the end. The surface is most valuable when the user can see
+progress. A good pattern:
+
+1. Write an initial surface with a status item: "Starting analysis..."
+2. As you produce content files, add them to the surface.
+3. Update status items to reflect progress.
+4. When done, write the final surface with all artifacts and remove status
+   items.
+
+# Example: Research Agent with Surface
+
+A research agent doing competitive analysis might produce this sequence:
+
+**After starting (version 1):**
+
+```json
+{
+  "version": 1,
+  "items": [
+    {
+      "id": "status",
+      "title": "Status",
+      "description": "Researching competitors — 3 searches in progress",
+      "role": "status"
+    }
+  ]
+}
+```
+
+**After first results (version 2):**
+
+```json
+{
+  "version": 2,
+  "title": "Competitive Analysis",
+  "sections": [{ "id": "findings", "title": "Findings" }],
+  "items": [
+    {
+      "id": "market-overview",
+      "title": "Market Overview",
+      "path": "research/market_overview.md",
+      "description": "Current market landscape and key players",
+      "role": "primary",
+      "section": "findings"
+    },
+    {
+      "id": "status",
+      "title": "Status",
+      "description": "2 of 3 research threads complete",
+      "role": "status"
+    }
+  ]
+}
+```
+
+**Final surface (version 3):**
+
+```json
+{
+  "version": 3,
+  "title": "Competitive Analysis",
+  "sections": [
+    { "id": "findings", "title": "Findings" },
+    { "id": "data", "title": "Supporting Data" }
+  ],
+  "items": [
+    {
+      "id": "market-overview",
+      "title": "Market Overview",
+      "path": "research/market_overview.md",
+      "description": "Current market landscape and key players",
+      "role": "primary",
+      "section": "findings"
+    },
+    {
+      "id": "competitor-matrix",
+      "title": "Competitor Comparison",
+      "path": "research/competitor_matrix.md",
+      "description": "Feature-by-feature comparison of top 5 competitors",
+      "section": "findings"
+    },
+    {
+      "id": "raw-data",
+      "title": "Research Data",
+      "path": "research/raw_data.json",
+      "description": "Structured data from all sources",
+      "role": "supporting",
+      "section": "data"
+    }
+  ]
+}
+```
+
+Each version was followed by an `events_broadcast` with type `surface_updated`.

--- a/hives/antigravity/skills/use-opal-sdk/SKILL.md
+++ b/hives/antigravity/skills/use-opal-sdk/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: use-opal-sdk
+title: Using the Opal SDK from a React component
+description:
+  Learn how to use `window.opalSDK` inside your sandboxed React component to
+  read files, call host services, and listen for events from the application.
+allowed-tools:
+  - files.*
+---
+
+# What is `window.opalSDK`?
+
+When your React component runs inside the sandbox, it has no network access and
+no direct access to the host application. Instead, the host injects
+`window.opalSDK` — a bridge object that lets you:
+
+1. **Call methods** on the host (read files, navigate, etc.)
+2. **Listen for events** pushed by the host (data updates, file changes, etc.)
+
+All communication goes through `postMessage` under the hood. You never need to
+call `postMessage` directly.
+
+# Calling SDK Methods
+
+Every method call on `window.opalSDK` is asynchronous and returns a `Promise`.
+
+```jsx
+// Read a file from the workspace
+const content = await window.opalSDK.readFile("data/results.json");
+
+// Parse and use it
+const data = JSON.parse(content);
+```
+
+## Available Methods
+
+| Method                        | Returns           | Description                                  |
+| ----------------------------- | ----------------- | -------------------------------------------- |
+| `readFile(path)`              | `Promise<string>` | Read a file from the workspace.              |
+| `navigateTo(viewId, params?)` | `Promise<void>`   | Navigate to a different view in the host UI. |
+| `emit(event, payload?)`       | `Promise<void>`   | Send a fire-and-forget event to the host.    |
+
+Paths are workspace-relative, same as `files_write_file`. For example, if you
+wrote a file with `files_write_file` using `data/results.json`, read it with
+`window.opalSDK.readFile("data/results.json")`.
+
+## Error Handling
+
+If a method call fails (e.g., file not found), the Promise rejects with an
+`Error`. Always handle errors:
+
+```jsx
+try {
+  const content = await window.opalSDK.readFile("missing.txt");
+} catch (err) {
+  console.error("Could not read file:", err.message);
+}
+```
+
+# Listening for Events
+
+The SDK implements the standard DOM `addEventListener` API. The host pushes
+events to your component automatically.
+
+## The `filechange` Event
+
+The most important event is `filechange`. It fires whenever a file in your
+working directory changes — for example, when you or another agent writes a file
+with `files_write_file`.
+
+```jsx
+useEffect(() => {
+  function onFileChange(e) {
+    console.log("File changed:", e.detail.path);
+  }
+
+  window.opalSDK.addEventListener("filechange", onFileChange);
+
+  return () => {
+    window.opalSDK.removeEventListener("filechange", onFileChange);
+  };
+}, []);
+```
+
+The event detail contains:
+
+| Field  | Type     | Description                                        |
+| ------ | -------- | -------------------------------------------------- |
+| `path` | `string` | Workspace-relative path of the file that changed.  |
+
+## Key Points
+
+- Events arrive as standard `CustomEvent` objects.
+- The payload is on `e.detail`.
+- Always clean up listeners in your `useEffect` return function to prevent
+  memory leaks.
+
+# Example: Auto-Refreshing Data Display
+
+Here's a complete component that loads data from a JSON file and automatically
+re-reads it whenever the file changes on disk:
+
+```jsx
+import React, { useState, useEffect, useCallback } from "react";
+
+export default function DataView() {
+  const [data, setData] = useState(null);
+  const [error, setError] = useState(null);
+
+  const loadData = useCallback(async () => {
+    try {
+      const raw = await window.opalSDK.readFile("data.json");
+      setData(JSON.parse(raw));
+      setError(null);
+    } catch (err) {
+      setError(err.message);
+    }
+  }, []);
+
+  // Load initial data.
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  // Re-read when the file changes.
+  useEffect(() => {
+    function onFileChange(e) {
+      if (e.detail.path === "data.json") {
+        loadData();
+      }
+    }
+
+    window.opalSDK.addEventListener("filechange", onFileChange);
+
+    return () => {
+      window.opalSDK.removeEventListener("filechange", onFileChange);
+    };
+  }, [loadData]);
+
+  if (error) return <div>Error: {error}</div>;
+  if (!data) return <div>Loading…</div>;
+
+  return (
+    <div>
+      <h2>{data.title}</h2>
+      <pre>{JSON.stringify(data, null, 2)}</pre>
+    </div>
+  );
+}
+```
+
+This pattern — load once, then listen for changes — is the standard way to
+build reactive components. The host watches the filesystem and pushes
+`filechange` events automatically; your component just needs to re-read the
+files it cares about.
+
+# Rules
+
+## Always use `window.opalSDK`, never `postMessage`
+
+The SDK handles serialization, request IDs, and error propagation for you. Raw
+`postMessage` calls will not be understood by the host.
+
+## All methods are async
+
+Even fire-and-forget methods like `navigateTo` return a Promise. You can `await`
+them or ignore the return value — both work.
+
+## Clean up event listeners
+
+If your component unmounts and re-mounts, stale listeners will fire on the old
+component instance. Always return a cleanup function from `useEffect`.
+
+## Filter `filechange` by path
+
+The `filechange` event fires for every file in the working directory, not just
+yours. Check `e.detail.path` before reacting:
+
+```jsx
+function onFileChange(e) {
+  if (e.detail.path === "my-data.json") {
+    reload();
+  }
+}
+```

--- a/packages/bees/bees/runners/antigravity.py
+++ b/packages/bees/bees/runners/antigravity.py
@@ -38,6 +38,7 @@ from google.antigravity.connections.local.local_connection_config import (
     LocalAgentConfig,
 )
 from google.antigravity.hooks import policy
+from google.antigravity.hooks.hooks import HookContext, PostToolCallHook
 
 from bees.disk_file_system import DiskFileSystem
 from bees.protocols.session import (
@@ -102,30 +103,19 @@ def _translate_step(step: ag_types.Step) -> list[SessionEvent]:
     ):
         events.append({"systemMessage": {"text": step.content_delta}})
 
-    # Tool calls / responses.
-    # The SDK emits TOOL_CALL steps twice per invocation:
-    #   1. status=ACTIVE → the model requested the call (functionCall)
-    #   2. status=DONE   → the tool executed and produced a result (functionResponse)
-    if step.tool_calls:
-        is_response = (
-            step.type == ag_types.StepType.TOOL_CALL
-            and step.status == ag_types.StepStatus.DONE
-        )
+    # Tool calls.
+    # The SDK may emit TOOL_CALL steps more than once per invocation
+    # (ACTIVE → DONE).  We only emit functionCall for the initial
+    # ACTIVE step.  functionResponse events are captured separately
+    # via a PostToolCallHook (see _ToolResultCapture).
+    if step.tool_calls and step.status != ag_types.StepStatus.DONE:
         for tc in step.tool_calls:
             name = tc.name
             if isinstance(name, ag_types.BuiltinTools):
                 name = name.value
-            if is_response:
-                events.append({
-                    "functionResponse": {
-                        "name": name,
-                        "response": tc.args,
-                    },
-                })
-            else:
-                events.append({
-                    "functionCall": {"name": name, "args": tc.args},
-                })
+            events.append(
+                {"functionCall": {"name": name, "args": tc.args}},
+            )
 
     # Usage metadata → usageMetadata event.
     if step.usage_metadata:
@@ -227,6 +217,52 @@ def _assemble_system_instructions(
 
 
 # ---------------------------------------------------------------------------
+# PostToolCallHook — captures tool results for functionResponse events
+# ---------------------------------------------------------------------------
+
+
+class _ToolResultCapture(PostToolCallHook):
+    """Observes tool completions and queues results for event emission.
+
+    Registered as a hook on the Agent so it fires for every tool call
+    — both SDK built-in tools (file ops, shell) and custom host-side
+    tools (agents_*, events_*).  Results are pushed to an asyncio.Queue
+    that the AntigravityStream drains into ``functionResponse`` events.
+    """
+
+    def __init__(self, queue: asyncio.Queue[ag_types.ToolResult]) -> None:
+        self._queue = queue
+
+    async def run(
+        self, context: HookContext, data: ag_types.ToolResult,
+    ) -> None:
+        self._queue.put_nowait(data)
+
+
+def _tool_result_to_event(
+    result: ag_types.ToolResult,
+) -> dict[str, Any]:
+    """Convert a ToolResult into a ``functionResponse`` SessionEvent."""
+    name = result.name
+    if isinstance(name, ag_types.BuiltinTools):
+        name = name.value
+    response = result.result
+    if result.error:
+        response = {"error": result.error}
+    elif response is None:
+        response = {}
+    elif not isinstance(response, dict):
+        # Wrap scalars / lists so the value is always a JSON object.
+        response = {"result": response}
+    return {
+        "functionResponse": {
+            "name": name,
+            "response": response,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
 # AntigravityStream — SessionStream wrapping SDK's step stream
 # ---------------------------------------------------------------------------
 
@@ -274,6 +310,7 @@ class AntigravityStream:
         has_chat: bool = False,
         on_chat_entry: Callable[[str, str], None] | None = None,
         request_config: dict[str, Any] | None = None,
+        tool_result_queue: asyncio.Queue[ag_types.ToolResult] | None = None,
     ) -> None:
         self._agent = agent
         self._exit_stack = exit_stack
@@ -282,6 +319,9 @@ class AntigravityStream:
         self._has_chat = has_chat
         self._on_chat_entry = on_chat_entry
         self._request_config = request_config or {}
+        self._tool_result_queue: asyncio.Queue[ag_types.ToolResult] = (
+            tool_result_queue or asyncio.Queue()
+        )
 
         self._started = False
         self._exhausted = False
@@ -300,6 +340,14 @@ class AntigravityStream:
     async def __anext__(self) -> SessionEvent:
         if self._exhausted:
             raise StopAsyncIteration
+
+        # Drain tool results captured by the PostToolCallHook.
+        # These arrive asynchronously but are ordered correctly:
+        # the hook fires after tool execution completes, which is
+        # always after the ACTIVE step that produced the functionCall.
+        while not self._tool_result_queue.empty():
+            result = self._tool_result_queue.get_nowait()
+            self._pending_events.append(_tool_result_to_event(result))
 
         # Drain any buffered events first.
         if self._pending_events:
@@ -531,19 +579,26 @@ class AntigravityRunner:
             save_dir = tempfile.mkdtemp(prefix="bees-ag-")
         Path(save_dir).mkdir(parents=True, exist_ok=True)
 
-        # 5. Build the LocalAgentConfig.
+        # 5. Build the hook that captures tool results.
+        tool_result_queue: asyncio.Queue[ag_types.ToolResult] = (
+            asyncio.Queue()
+        )
+        tool_result_hook = _ToolResultCapture(tool_result_queue)
+
+        # 6. Build the LocalAgentConfig.
         agent_config = LocalAgentConfig(
             api_key=self._api_key,
             system_instructions=system_instructions,
             capabilities=capabilities,
             tools=custom_tools,
             policies=[policy.allow_all()],
+            hooks=[tool_result_hook],
             workspaces=[workspace],
             save_dir=save_dir,
             conversation_id=None,  # Fresh session.
         )
 
-        # 6. Enter the Agent context.
+        # 7. Enter the Agent context.
         exit_stack = contextlib.AsyncExitStack()
         try:
             agent = await exit_stack.enter_async_context(Agent(agent_config))
@@ -551,10 +606,10 @@ class AntigravityRunner:
             await exit_stack.aclose()
             raise
 
-        # 7. Extract the initial prompt from segments.
+        # 8. Extract the initial prompt from segments.
         initial_prompt = _extract_initial_prompt(config)
 
-        # 8. Detect chat mode from function filter.
+        # 9. Detect chat mode from function filter.
         has_chat = _has_chat_functions(config.function_filter)
 
         request_config = _build_request_config(
@@ -569,6 +624,7 @@ class AntigravityRunner:
             has_chat=has_chat,
             on_chat_entry=config.on_chat_entry,
             request_config=request_config,
+            tool_result_queue=tool_result_queue,
         )
 
     async def resume(
@@ -607,19 +663,26 @@ class AntigravityRunner:
         # 4. Build workspace path.
         workspace = _workspace_path(config)
 
-        # 5. Build the LocalAgentConfig with resume state.
+        # 5. Build the hook that captures tool results.
+        tool_result_queue: asyncio.Queue[ag_types.ToolResult] = (
+            asyncio.Queue()
+        )
+        tool_result_hook = _ToolResultCapture(tool_result_queue)
+
+        # 6. Build the LocalAgentConfig with resume state.
         agent_config = LocalAgentConfig(
             api_key=self._api_key,
             system_instructions=system_instructions,
             capabilities=capabilities,
             tools=custom_tools,
             policies=[policy.allow_all()],
+            hooks=[tool_result_hook],
             workspaces=[workspace],
             save_dir=save_dir,
             conversation_id=conversation_id,
         )
 
-        # 6. Enter the Agent context.
+        # 7. Enter the Agent context.
         exit_stack = contextlib.AsyncExitStack()
         try:
             agent = await exit_stack.enter_async_context(Agent(agent_config))
@@ -627,10 +690,10 @@ class AntigravityRunner:
             await exit_stack.aclose()
             raise
 
-        # 7. Build the resume prompt from the user's response + context.
+        # 8. Build the resume prompt from the user's response + context.
         resume_prompt = _build_resume_prompt(response, context_parts)
 
-        # 8. Detect chat mode from function filter.
+        # 9. Detect chat mode from function filter.
         has_chat = _has_chat_functions(config.function_filter)
 
         request_config = _build_request_config(
@@ -645,6 +708,7 @@ class AntigravityRunner:
             has_chat=has_chat,
             on_chat_entry=config.on_chat_entry,
             request_config=request_config,
+            tool_result_queue=tool_result_queue,
         )
 
 


### PR DESCRIPTION
## What
Uses the Antigravity SDK's `PostToolCallHook` to capture tool execution results and emit `functionResponse` events in the session event stream, making tool results visible in Hivetool's session log.

## Why
Custom host-side tools (agents_*, events_*) flow through the SDK's `_handle_tool_call` path, which never emits a DONE step to the step queue. This meant `functionResponse` events were completely absent from Antigravity session logs. The previous DONE-based detection also had a data-correctness bug: it used `tc.args` (the tool's input arguments) as the response instead of the actual result.

## Changes

### `packages/bees/bees/runners/antigravity.py`
- **`_ToolResultCapture`** — new `PostToolCallHook` subclass that observes every tool completion (built-in and custom) and pushes `ToolResult` objects to an `asyncio.Queue`
- **`_tool_result_to_event`** — converts a `ToolResult` into a `functionResponse` SessionEvent, handling errors, None, scalars, and dict results
- **`_translate_step`** — removed the broken DONE-based `functionResponse` detection; DONE TOOL_CALL steps are now silently skipped since the ACTIVE step already produced the `functionCall`
- **`AntigravityStream.__anext__`** — drains the tool result queue at the top of each iteration, injecting `functionResponse` events into the pending buffer
- **`run()` / `resume()`** — both create a `_ToolResultCapture` hook + queue and wire them into `LocalAgentConfig(hooks=[...])` and `AntigravityStream`

## Testing
Ran the Weather Orchestrator test pattern (`weather-orchestrator` template) end-to-end. Verified `functionResponse` events now appear in `events.jsonl` after each `functionCall`, and Hivetool renders them correctly in the session log.
