### PR TITLE
[bees] Fix 23 test failures in bees test suite

### DIFF
--- a/packages/bees/tests/test_protocols/test_session_configuration.py
+++ b/packages/bees/tests/test_protocols/test_session_configuration.py
@@ -90,6 +90,7 @@ class TestSessionConfigurationConformance(unittest.TestCase):
             "log_path",
             "on_chat_entry",
             "extract_chat_from_context",
+            "persist_events",
             "voice",
         }
         self.assertEqual(field_names, expected)
@@ -186,7 +187,7 @@ class TestSessionStreamConformance(unittest.TestCase):
             async for event in stream:
                 collected.append(event)
 
-        asyncio.get_event_loop().run_until_complete(drain())
+        asyncio.run(drain())
         self.assertEqual(collected, events)
 
     def test_resume_state_none_on_complete(self):

--- a/packages/bees/tests/test_protocols/test_session_runner.py
+++ b/packages/bees/tests/test_protocols/test_session_runner.py
@@ -145,7 +145,7 @@ class TestSessionRunnerConformance(unittest.TestCase):
             self.assertIsInstance(stream, SessionStream)
             self.assertEqual(len(runner.run_calls), 1)
 
-        asyncio.get_event_loop().run_until_complete(check())
+        asyncio.run(check())
 
     def test_resume_returns_stream(self):
         """resume() returns a SessionStream."""
@@ -168,7 +168,7 @@ class TestSessionRunnerConformance(unittest.TestCase):
             self.assertEqual(call["response"], {"text": "hello"})
             self.assertEqual(call["context_parts"], [{"text": "update"}])
 
-        asyncio.get_event_loop().run_until_complete(check())
+        asyncio.run(check())
 
     def test_accessible_from_protocols_package(self):
         """SessionRunner is accessible via bees.protocols."""
@@ -221,7 +221,7 @@ class TestDrainSessionComplete(unittest.TestCase):
             self.assertIsNone(result.error)
             self.assertEqual(result.session_id, "test-123")
 
-        asyncio.get_event_loop().run_until_complete(check())
+        asyncio.run(check())
 
     def test_empty_stream(self):
         """An empty stream produces a completed result with zero events."""
@@ -236,7 +236,7 @@ class TestDrainSessionComplete(unittest.TestCase):
             self.assertEqual(result.events, 0)
             self.assertEqual(result.turns, 0)
 
-        asyncio.get_event_loop().run_until_complete(check())
+        asyncio.run(check())
 
     def test_on_event_callback(self):
         """on_event is called for each event."""
@@ -261,7 +261,7 @@ class TestDrainSessionComplete(unittest.TestCase):
             self.assertEqual(received[0], events[0])
             self.assertEqual(received[1], events[1])
 
-        asyncio.get_event_loop().run_until_complete(check())
+        asyncio.run(check())
 
 
 class TestDrainSessionSuspend(unittest.TestCase):
@@ -288,7 +288,7 @@ class TestDrainSessionSuspend(unittest.TestCase):
             self.assertIsNotNone(result.suspend_event)
             self.assertIn("waitForInput", result.suspend_event)
 
-        asyncio.get_event_loop().run_until_complete(check())
+        asyncio.run(check())
 
     def test_suspend_via_wait_for_choice(self):
         """A waitForChoice event produces a suspended result."""
@@ -308,7 +308,7 @@ class TestDrainSessionSuspend(unittest.TestCase):
             self.assertTrue(result.suspended)
             self.assertEqual(result.status, "suspended")
 
-        asyncio.get_event_loop().run_until_complete(check())
+        asyncio.run(check())
 
 
 class TestDrainSessionPause(unittest.TestCase):
@@ -333,7 +333,7 @@ class TestDrainSessionPause(unittest.TestCase):
             self.assertTrue(result.paused)
             self.assertEqual(result.error, "Rate limit exceeded")
 
-        asyncio.get_event_loop().run_until_complete(check())
+        asyncio.run(check())
 
 
 class TestDrainSessionError(unittest.TestCase):
@@ -354,7 +354,7 @@ class TestDrainSessionError(unittest.TestCase):
             self.assertEqual(result.status, "failed")
             self.assertEqual(result.error, "Model unavailable")
 
-        asyncio.get_event_loop().run_until_complete(check())
+        asyncio.run(check())
 
 
 if __name__ == "__main__":

--- a/packages/bees/tests/test_runners/test_gemini_runner.py
+++ b/packages/bees/tests/test_runners/test_gemini_runner.py
@@ -40,11 +40,14 @@ def _make_queue(events: list[dict[str, Any] | None]) -> asyncio.Queue:
 
 
 def _make_completed_task() -> asyncio.Task:
-    """Create an already-completed asyncio.Task."""
+    """Create an already-completed asyncio.Task.
+
+    Must be called from within a running event loop (i.e. inside an
+    ``async def``).
+    """
     async def noop():
         pass
-    loop = asyncio.get_event_loop()
-    return loop.create_task(noop())
+    return asyncio.ensure_future(noop())
 
 
 def _make_mock_interaction_store(
@@ -90,16 +93,19 @@ class TestGeminiStreamConformance(unittest.TestCase):
         from bees.protocols.session import SessionStream
         from bees.runners.gemini import GeminiStream
 
-        task = _make_completed_task()
-        stream = GeminiStream(
-            queue=asyncio.Queue(),
-            task=task,
-            context_queue=asyncio.Queue(),
-            session_id="test",
-            session_store=MagicMock(),
-            interaction_store=MagicMock(),
-        )
-        self.assertIsInstance(stream, SessionStream)
+        async def check():
+            task = _make_completed_task()
+            stream = GeminiStream(
+                queue=asyncio.Queue(),
+                task=task,
+                context_queue=asyncio.Queue(),
+                session_id="test",
+                session_store=MagicMock(),
+                interaction_store=MagicMock(),
+            )
+            self.assertIsInstance(stream, SessionStream)
+
+        asyncio.run(check())
 
 
 class TestGeminiRunnerConformance(unittest.TestCase):
@@ -150,7 +156,7 @@ class TestGeminiStreamIteration(unittest.TestCase):
 
             self.assertEqual(received, events)
 
-        asyncio.get_event_loop().run_until_complete(check())
+        asyncio.run(check())
 
     def test_empty_stream(self):
         """A stream with only None yields no events."""
@@ -174,7 +180,7 @@ class TestGeminiStreamIteration(unittest.TestCase):
 
             self.assertEqual(received, [])
 
-        asyncio.get_event_loop().run_until_complete(check())
+        asyncio.run(check())
 
     def test_double_iteration_raises(self):
         """Iterating an exhausted stream yields nothing."""
@@ -202,7 +208,7 @@ class TestGeminiStreamIteration(unittest.TestCase):
                 received.append(event)
             self.assertEqual(received, [])
 
-        asyncio.get_event_loop().run_until_complete(check())
+        asyncio.run(check())
 
 
 # ---------------------------------------------------------------------------
@@ -237,7 +243,7 @@ class TestGeminiStreamResumeState(unittest.TestCase):
 
             self.assertIsNone(stream.resume_state())
 
-        asyncio.get_event_loop().run_until_complete(check())
+        asyncio.run(check())
 
     def test_suspended_session_captures_state(self):
         """A suspended session captures resume state as JSON bytes."""
@@ -284,7 +290,7 @@ class TestGeminiStreamResumeState(unittest.TestCase):
             self.assertEqual(data["interaction_state"], state_dict)
             self.assertEqual(data["function_name"], "request_user_input")
 
-        asyncio.get_event_loop().run_until_complete(check())
+        asyncio.run(check())
 
     def test_paused_session_captures_state(self):
         """A paused session captures resume state."""
@@ -324,7 +330,7 @@ class TestGeminiStreamResumeState(unittest.TestCase):
             self.assertEqual(data["session_id"], "s-paused")
             self.assertEqual(data["interaction_id"], interaction_id)
 
-        asyncio.get_event_loop().run_until_complete(check())
+        asyncio.run(check())
 
     def test_function_name_omitted_when_absent(self):
         """If InteractionState has no function_call_part, function_name
@@ -362,7 +368,7 @@ class TestGeminiStreamResumeState(unittest.TestCase):
             data = json.loads(blob)
             self.assertNotIn("function_name", data)
 
-        asyncio.get_event_loop().run_until_complete(check())
+        asyncio.run(check())
 
     def test_fallback_to_session_store_resume_id(self):
         """If the suspend event lacks interactionId, falls back to
@@ -399,7 +405,7 @@ class TestGeminiStreamResumeState(unittest.TestCase):
             data = json.loads(blob)
             self.assertEqual(data["interaction_id"], "i-from-store")
 
-        asyncio.get_event_loop().run_until_complete(check())
+        asyncio.run(check())
 
 
 # ---------------------------------------------------------------------------
@@ -432,7 +438,7 @@ class TestGeminiStreamBackChannel(unittest.TestCase):
             self.assertFalse(ctx_queue.empty())
             self.assertEqual(ctx_queue.get_nowait(), parts)
 
-        asyncio.get_event_loop().run_until_complete(check())
+        asyncio.run(check())
 
     def test_send_tool_response_is_noop(self):
         """send_tool_response() does not raise."""
@@ -452,7 +458,7 @@ class TestGeminiStreamBackChannel(unittest.TestCase):
             # Should not raise.
             await stream.send_tool_response([{"result": "ok"}])
 
-        asyncio.get_event_loop().run_until_complete(check())
+        asyncio.run(check())
 
 
 # ---------------------------------------------------------------------------
@@ -508,7 +514,7 @@ class TestResumeStateBlobFormat(unittest.TestCase):
             self.assertIn("interaction_state", data)
             self.assertEqual(data["function_name"], "test_fn")
 
-        asyncio.get_event_loop().run_until_complete(check())
+        asyncio.run(check())
 
 
 class TestGeminiRunnerForkPrehydration(unittest.TestCase):


### PR DESCRIPTION
## What
Fix all 23 test failures in `packages/bees` caused by deprecated `asyncio.get_event_loop()` usage on Python 3.12 and a stale field-name assertion.

## Why
Python 3.12 removed the implicit event loop auto-creation from `asyncio.get_event_loop()`, causing it to raise `RuntimeError` when called without a running loop. The test suite had 22 call sites using the deprecated pattern. A separate test also failed because `persist_events` was added to `SessionConfiguration` without updating the field-name conformance test.

## Changes

### `tests/test_protocols/test_session_configuration.py`
- Add `"persist_events"` to the expected field set in `test_field_names`
- Replace `asyncio.get_event_loop().run_until_complete()` → `asyncio.run()`

### `tests/test_protocols/test_session_runner.py`
- Replace all 10 `asyncio.get_event_loop().run_until_complete()` → `asyncio.run()`

### `tests/test_runners/test_gemini_runner.py`
- Replace `_make_completed_task()` to use `asyncio.ensure_future()` (requires a running loop, so all call sites are now inside `async def` contexts)
- Wrap `test_satisfies_session_stream` in `asyncio.run()` since it was the only sync call site for `_make_completed_task()`
- Replace all 11 `asyncio.get_event_loop().run_until_complete()` → `asyncio.run()`

## Testing
```
npm run test:python -w bees
# 604 passed, 1 skipped
```
