### PR TITLE
[bees] Show per-turn timeline for Antigravity sessions in Hivetool

### DIFF
--- a/packages/bees/hivetool/src/data/session-store-reader.ts
+++ b/packages/bees/hivetool/src/data/session-store-reader.ts
@@ -54,6 +54,10 @@ function compileEventsToSegment(sessionId: string, events: Record<string, unknow
   
   let currentTurnGroup: TurnGroup | null = null;
   let currentTurnIndex = 0;
+  // Set after usageMetadata to split the next content event into a new
+  // turn group.  For Gemini this is a no-op (sendRequest already creates
+  // turns).  For Antigravity it gives per-API-call turn boundaries.
+  let needsNewTurn = false;
 
   for (const event of events) {
     if ("sendRequest" in event) {
@@ -76,6 +80,7 @@ function compileEventsToSegment(sessionId: string, events: Record<string, unknow
       };
       turnGroups.push(currentTurnGroup);
       turnCount++;
+      needsNewTurn = false;
 
       // Parse the incoming user turn / resume turn from sendRequest history
       const contents = body.contents as Array<Record<string, unknown>> || [];
@@ -106,6 +111,24 @@ function compileEventsToSegment(sessionId: string, events: Record<string, unknow
       }
     }
     
+    // After usageMetadata marks the end of a model API call, split
+    // subsequent content into a new turn group.  This fires for
+    // thought, systemMessage, functionCall, and functionResponse —
+    // but NOT for complete (which stays with the final model output).
+    if (needsNewTurn && currentTurnGroup && (
+      "thought" in event || "systemMessage" in event ||
+      "functionCall" in event || "functionResponse" in event
+    )) {
+      currentTurnGroup = {
+        turnIndex: currentTurnIndex++,
+        entries: [],
+        tokenMetadata: null,
+      };
+      turnGroups.push(currentTurnGroup);
+      turnCount++;
+      needsNewTurn = false;
+    }
+
     if (currentTurnGroup) {
       if ("thought" in event) {
         const thought = event.thought as Record<string, unknown> || {};
@@ -176,6 +199,7 @@ function compileEventsToSegment(sessionId: string, events: Record<string, unknow
         totalThoughtsTokens += (metadata.thoughtsTokenCount as number) || 0;
         totalCachedTokens += (metadata.cachedContentTokenCount as number) || 0;
         totalTokens += (metadata.totalTokenCount as number) || 0;
+        needsNewTurn = true;
       }
 
       if ("complete" in event && runnerType !== "generate") {


### PR DESCRIPTION
## What
Adds `usageMetadata`-based turn splitting to `compileEventsToSegment` so Antigravity agent sessions render per-API-call turn groups in Hivetool's log detail view.

## Why
Antigravity sessions emit only a single `sendRequest` at the start of a run, so `compileEventsToSegment` collapsed the entire agentic loop into one giant turn group — no turn headers, no per-turn token bars, no rewind points. The SDK's `usageMetadata` step is the natural per-API-call boundary signal we were missing.

## Changes
### Hivetool — `session-store-reader.ts`
- After processing a `usageMetadata` event, set a `needsNewTurn` flag.
- On the next content event (`thought`, `systemMessage`, `functionCall`, `functionResponse`), create a new `TurnGroup` before processing it.
- `complete` does **not** trigger a split — it stays with the final model output.
- Backward-compatible: Gemini sessions already split on `sendRequest`, so the flag is harmlessly reset before it fires.

## Testing
- Run an Antigravity agent in Hivetool and verify the log detail view shows multiple turns with individual token bars and rewind buttons.
- Verify Gemini agent log rendering is unchanged.
