### PR TITLE
Deferred Result pattern for Antigravity suspend/resume

### DIFF
--- a/packages/bees/bees/runners/antigravity.py
+++ b/packages/bees/bees/runners/antigravity.py
@@ -41,6 +41,7 @@ from google.antigravity.hooks import policy
 from google.antigravity.hooks.hooks import HookContext, PostToolCallHook
 
 from bees.disk_file_system import DiskFileSystem
+from bees.protocols.handler_types import SuspendError
 from bees.protocols.session import (
     SUSPEND_TYPES,
     SessionConfiguration,
@@ -311,6 +312,7 @@ class AntigravityStream:
         on_chat_entry: Callable[[str, str], None] | None = None,
         request_config: dict[str, Any] | None = None,
         tool_result_queue: asyncio.Queue[ag_types.ToolResult] | None = None,
+        suspend_queue: asyncio.Queue[SuspendError] | None = None,
     ) -> None:
         self._agent = agent
         self._exit_stack = exit_stack
@@ -322,6 +324,9 @@ class AntigravityStream:
         self._tool_result_queue: asyncio.Queue[ag_types.ToolResult] = (
             tool_result_queue or asyncio.Queue()
         )
+        self._suspend_queue: asyncio.Queue[SuspendError] = (
+            suspend_queue or asyncio.Queue()
+        )
 
         self._started = False
         self._exhausted = False
@@ -331,6 +336,7 @@ class AntigravityStream:
         self._emitted_send_request = False
         self._emitted_complete = False
         self._last_user_text: str = ""
+        self._pending_suspend: SuspendError | None = None
 
     # -- async iterator ----------------------------------------------------
 
@@ -340,14 +346,6 @@ class AntigravityStream:
     async def __anext__(self) -> SessionEvent:
         if self._exhausted:
             raise StopAsyncIteration
-
-        # Drain tool results captured by the PostToolCallHook.
-        # These arrive asynchronously but are ordered correctly:
-        # the hook fires after tool execution completes, which is
-        # always after the ACTIVE step that produced the functionCall.
-        while not self._tool_result_queue.empty():
-            result = self._tool_result_queue.get_nowait()
-            self._pending_events.append(_tool_result_to_event(result))
 
         # Drain any buffered events first.
         if self._pending_events:
@@ -390,15 +388,26 @@ class AntigravityStream:
             if not self._emitted_complete:
                 self._emitted_complete = True
 
-                # Chat mode: idle without FINISH = waiting for user input.
+                # Priority 1: A tool requested suspension (deferred
+                # result pattern).  This overrides both chat and
+                # worker idle behavior — the agent MUST suspend.
+                if self._pending_suspend:
+                    await self._cleanup()
+                    return {"waitForInput": {
+                        "requestId": (
+                            self._pending_suspend.interaction_id
+                        ),
+                        "prompt": {},
+                        "inputType": "any",
+                    }}
+
+                # Priority 2: Chat mode — idle without FINISH =
+                # waiting for user input.
                 if self._has_chat and self._last_user_text:
                     # Log the model's message to the chat log.
                     if self._on_chat_entry:
                         self._on_chat_entry("agent", self._last_user_text)
 
-                    # Don't tear down the agent yet — persist state for
-                    # resume, but the cleanup still runs because the
-                    # stream is done from drain_session's perspective.
                     await self._cleanup()
                     return {"waitForInput": {
                         "requestId": str(uuid.uuid4()),
@@ -408,7 +417,7 @@ class AntigravityStream:
                         "inputType": "text",
                     }}
 
-                # Worker mode: idle without FINISH = done.
+                # Default: Worker mode — idle without FINISH = done.
                 await self._cleanup()
                 return {"complete": {"result": {
                     "success": True,
@@ -424,6 +433,14 @@ class AntigravityStream:
 
         # Translate the step into events.
         events = _translate_step(step)
+
+        # Drain tool results captured by the PostToolCallHook.
+        # Done here (after step translation) so functionResponse events
+        # appear adjacent to the step that produced them, rather than
+        # being spliced into the next text chunk.
+        while not self._tool_result_queue.empty():
+            result = self._tool_result_queue.get_nowait()
+            events.append(_tool_result_to_event(result))
 
         if not events:
             # Step produced no translatable events — skip to next.
@@ -448,6 +465,13 @@ class AntigravityStream:
                 self._last_user_text += event["systemMessage"].get("text", "")
         if not has_model_text:
             self._last_user_text = ""
+
+        # Check for deferred suspends from tool wrappers.
+        if not self._pending_suspend:
+            try:
+                self._pending_suspend = self._suspend_queue.get_nowait()
+            except asyncio.QueueEmpty:
+                pass
 
         # Check for suspend events — capture resume state eagerly.
         for event in events:
@@ -558,10 +582,12 @@ class AntigravityRunner:
         """
         # 1. Map function filter to SDK capabilities.
         stub_hooks = _StubSessionHooks(config.file_system)
-        capabilities, custom_tools, custom_instructions = map_function_filter(
-            config.function_filter,
-            config.function_groups,
-            stub_hooks,
+        capabilities, custom_tools, custom_instructions, suspend_queue = (
+            map_function_filter(
+                config.function_filter,
+                config.function_groups,
+                stub_hooks,
+            )
         )
 
         # 2. Assemble system instructions from custom tool groups.
@@ -625,6 +651,7 @@ class AntigravityRunner:
             on_chat_entry=config.on_chat_entry,
             request_config=request_config,
             tool_result_queue=tool_result_queue,
+            suspend_queue=suspend_queue,
         )
 
     async def resume(
@@ -649,10 +676,12 @@ class AntigravityRunner:
 
         # 2. Map function filter to SDK capabilities (same as run).
         stub_hooks = _StubSessionHooks(config.file_system)
-        capabilities, custom_tools, custom_instructions = map_function_filter(
-            config.function_filter,
-            config.function_groups,
-            stub_hooks,
+        capabilities, custom_tools, custom_instructions, suspend_queue = (
+            map_function_filter(
+                config.function_filter,
+                config.function_groups,
+                stub_hooks,
+            )
         )
 
         # 3. Assemble system instructions from custom tool groups.
@@ -709,6 +738,7 @@ class AntigravityRunner:
             on_chat_entry=config.on_chat_entry,
             request_config=request_config,
             tool_result_queue=tool_result_queue,
+            suspend_queue=suspend_queue,
         )
 
 

--- a/packages/bees/bees/runners/tool_mapping.py
+++ b/packages/bees/bees/runners/tool_mapping.py
@@ -22,6 +22,7 @@ own agent hierarchy and the direct_model subagent is more capable).
 
 from __future__ import annotations
 
+import asyncio
 import fnmatch
 import logging
 from typing import Any, Callable
@@ -35,6 +36,7 @@ from bees.protocols.functions import (
     FunctionGroupFactory,
     SessionHooks,
 )
+from bees.protocols.handler_types import SuspendError
 from bees.disk_file_system import DiskFileSystem
 
 __all__ = ["map_function_filter", "wrap_bees_handler"]
@@ -86,7 +88,12 @@ def map_function_filter(
     function_filter: list[str] | None,
     function_groups: list[FunctionGroupFactory],
     hooks: SessionHooks,
-) -> tuple[ag_types.CapabilitiesConfig, list[Callable[..., Any]], list[str]]:
+) -> tuple[
+    ag_types.CapabilitiesConfig,
+    list[Callable[..., Any]],
+    list[str],
+    asyncio.Queue[SuspendError],
+]:
     """Map bees function filters to SDK capabilities and custom tools.
 
     Args:
@@ -98,7 +105,8 @@ def map_function_filter(
         hooks: Session hooks for late-binding function group factories.
 
     Returns:
-        A ``(capabilities, custom_tools, custom_instructions)`` tuple:
+        A ``(capabilities, custom_tools, custom_instructions, suspend_queue)``
+        tuple:
 
         - ``capabilities``: SDK ``CapabilitiesConfig`` with the appropriate
           ``enabled_tools`` list.
@@ -108,17 +116,23 @@ def map_function_filter(
           custom tool groups (e.g. agents, events, skills).  Groups
           that map to SDK builtins are excluded — the SDK explains
           its own tools.
+        - ``suspend_queue``: Queue that receives ``SuspendError`` instances
+          intercepted by custom tool wrappers.  Pass to
+          ``AntigravityStream`` so it can detect pending suspends.
     """
     enabled_builtins: set[ag_types.BuiltinTools] = set()
     custom_tools: list[Callable[..., Any]] = []
     custom_instructions: list[str] = []
+    suspend_queue: asyncio.Queue[SuspendError] = asyncio.Queue()
 
     if function_filter is None:
         # No filter → enable all SDK builtins (except excluded).
         enabled_builtins = set(ag_types.BuiltinTools) - _EXCLUDED_BUILTINS
         # Also instantiate all custom-tool groups.
         custom_tools, custom_instructions = _extract_custom_tools(
-            function_groups, hooks, include_groups=None,
+            function_groups, hooks,
+            include_groups=None,
+            suspend_queue=suspend_queue,
         )
     else:
         custom_group_names: set[str] = set()
@@ -140,7 +154,9 @@ def map_function_filter(
 
         # Extract custom tools from matching function groups.
         custom_tools, custom_instructions = _extract_custom_tools(
-            function_groups, hooks, include_groups=custom_group_names,
+            function_groups, hooks,
+            include_groups=custom_group_names,
+            suspend_queue=suspend_queue,
         )
 
     capabilities = ag_types.CapabilitiesConfig(
@@ -148,7 +164,7 @@ def map_function_filter(
         enable_subagents=False,  # Bees manages its own agent hierarchy.
     )
 
-    return capabilities, custom_tools, custom_instructions
+    return capabilities, custom_tools, custom_instructions, suspend_queue
 
 
 # ---------------------------------------------------------------------------
@@ -158,12 +174,21 @@ def map_function_filter(
 
 def wrap_bees_handler(
     func_def: FunctionDefinition,
+    *,
+    suspend_queue: asyncio.Queue[SuspendError] | None = None,
 ) -> Callable[..., Any]:
     """Wrap a bees ``FunctionDefinition`` as an SDK-compatible Python tool.
 
     The SDK's tool runner calls Python tools with ``**kwargs`` and expects
     a return value.  Bees handlers have the signature
     ``(args: dict, status_cb) -> dict``.  This wrapper bridges the two.
+
+    When a handler raises ``SuspendError`` (e.g. ``agents_await``,
+    ``events_yield``), the exception is intercepted and converted to a
+    **deferred result** — a normal response that tells the model to go
+    idle and wait for an asynchronous delivery.  The ``SuspendError`` is
+    pushed onto ``suspend_queue`` so ``AntigravityStream`` can detect
+    the pending suspend and emit ``waitForInput`` when the model idles.
 
     Returns a ``ToolWithSchema`` so the SDK's ``callable_to_tool_proto``
     serializes the explicit JSON Schema directly, bypassing signature
@@ -172,9 +197,32 @@ def wrap_bees_handler(
     handler = func_def.handler
 
     async def tool_fn(**kwargs: Any) -> Any:
-        # Bees handlers expect (args_dict, status_callback).
-        result = await handler(kwargs, _noop_status_cb)
-        return result
+        try:
+            # Bees handlers expect (args_dict, status_callback).
+            result = await handler(kwargs, _noop_status_cb)
+            return result
+        except SuspendError as e:
+            # The SDK's tool runner would swallow SuspendError as a
+            # generic tool error.  Instead, return a deferred result
+            # and signal the stream to suspend when the model idles.
+            result_id = e.interaction_id
+            if suspend_queue:
+                await suspend_queue.put(e)
+            logger.info(
+                "Deferred suspend for %s (result_id=%s)",
+                func_def.name, result_id[:8],
+            )
+            return {
+                "status": "pending",
+                "result_id": result_id,
+                "message": (
+                    "Results are pending and will be delivered "
+                    "asynchronously. Please stop and wait for the "
+                    "response — do not take further action until you "
+                    "receive a <context_update> message with this "
+                    "result_id."
+                ),
+            }
 
     # The SDK uses __name__ and __doc__ for tool registration.
     tool_fn.__name__ = func_def.name
@@ -219,6 +267,7 @@ def _extract_custom_tools(
     hooks: SessionHooks,
     *,
     include_groups: set[str] | None,
+    suspend_queue: asyncio.Queue[SuspendError] | None = None,
 ) -> tuple[list[Callable[..., Any]], list[str]]:
     """Instantiate function groups and wrap their definitions as custom tools.
 
@@ -228,6 +277,8 @@ def _extract_custom_tools(
         include_groups: If not None, only include groups whose ``name``
             is in this set.  If None, include all groups that map to
             custom tools.
+        suspend_queue: Queue to pass to ``wrap_bees_handler`` for
+            intercepting ``SuspendError``.
 
     Returns:
         A ``(tools, instructions)`` tuple.  ``instructions`` contains
@@ -265,7 +316,9 @@ def _extract_custom_tools(
             continue
 
         for _name, func_def in group.definitions:
-            tools.append(wrap_bees_handler(func_def))
+            tools.append(wrap_bees_handler(
+                func_def, suspend_queue=suspend_queue,
+            ))
 
         if group.instruction:
             instructions.append(group.instruction)

--- a/packages/bees/tests/test_runners/test_tool_mapping.py
+++ b/packages/bees/tests/test_runners/test_tool_mapping.py
@@ -311,7 +311,7 @@ class TestMapFunctionFilter:
 
     def test_none_filter_enables_all_builtins(self) -> None:
         """None filter enables all SDK builtins except excluded ones."""
-        caps, tools, instructions = map_function_filter(
+        caps, tools, instructions, _sq, _rq = map_function_filter(
             None, [], _StubHooks(),
         )
         enabled = set(caps.enabled_tools)
@@ -324,7 +324,7 @@ class TestMapFunctionFilter:
         fd = _make_func_def(name="agents_list")
         group = _make_group("agents", [fd], instruction="Agents.")
 
-        _caps, tools, instructions = map_function_filter(
+        _caps, tools, instructions, _sq, _rq = map_function_filter(
             None, [group], _StubHooks(),
         )
         assert len(tools) == 1
@@ -333,7 +333,7 @@ class TestMapFunctionFilter:
 
     def test_builtin_filter_enables_correct_tools(self) -> None:
         """'files.*' enables exactly the file-related builtins."""
-        caps, tools, instructions = map_function_filter(
+        caps, tools, instructions, _sq, _rq = map_function_filter(
             ["files.*"], [], _StubHooks(),
         )
         enabled = set(caps.enabled_tools)
@@ -344,7 +344,7 @@ class TestMapFunctionFilter:
 
     def test_multiple_builtin_filters(self) -> None:
         """Multiple builtin filters union their tools."""
-        caps, _, _ = map_function_filter(
+        caps, _, _, _sq, _rq = map_function_filter(
             ["files.*", "sandbox.*"], [], _StubHooks(),
         )
         enabled = set(caps.enabled_tools)
@@ -358,7 +358,7 @@ class TestMapFunctionFilter:
         fd = _make_func_def(name="agents_list")
         group = _make_group("agents", [fd], instruction="Agents.")
 
-        caps, tools, instructions = map_function_filter(
+        caps, tools, instructions, _sq, _rq = map_function_filter(
             ["agents.*"], [group], _StubHooks(),
         )
         # No builtins for agents.
@@ -372,7 +372,7 @@ class TestMapFunctionFilter:
         fd = _make_func_def(name="agents_list")
         group = _make_group("agents", [fd])
 
-        caps, tools, _ = map_function_filter(
+        caps, tools, _, _sq, _rq = map_function_filter(
             ["files.*", "system.*", "agents.*"], [group], _StubHooks(),
         )
         enabled = set(caps.enabled_tools)
@@ -384,24 +384,24 @@ class TestMapFunctionFilter:
 
     def test_excluded_builtins_never_enabled(self) -> None:
         """GENERATE_IMAGE and START_SUBAGENT are never enabled."""
-        caps, _, _ = map_function_filter(None, [], _StubHooks())
+        caps, _, _, _sq, _rq = map_function_filter(None, [], _StubHooks())
         enabled = set(caps.enabled_tools)
         for excluded in _EXCLUDED_BUILTINS:
             assert excluded not in enabled
 
     def test_subagents_always_disabled(self) -> None:
         """enable_subagents is always False."""
-        caps, _, _ = map_function_filter(None, [], _StubHooks())
+        caps, _, _, _sq, _rq = map_function_filter(None, [], _StubHooks())
         assert caps.enable_subagents is False
 
-        caps2, _, _ = map_function_filter(
+        caps2, _, _, _sq, _rq = map_function_filter(
             ["files.*"], [], _StubHooks(),
         )
         assert caps2.enable_subagents is False
 
     def test_enabled_tools_sorted(self) -> None:
         """enabled_tools are sorted by enum value for deterministic output."""
-        caps, _, _ = map_function_filter(None, [], _StubHooks())
+        caps, _, _, _sq, _rq = map_function_filter(None, [], _StubHooks())
         values = [t.value for t in caps.enabled_tools]
         assert values == sorted(values)
 
@@ -410,7 +410,7 @@ class TestMapFunctionFilter:
         fd = _make_func_def(name="agents_assign_task")
         group = _make_group("agents", [fd])
 
-        _caps, tools, _ = map_function_filter(
+        _caps, tools, _, _sq, _rq = map_function_filter(
             ["agents_assign_task"], [group], _StubHooks(),
         )
         assert len(tools) == 1
@@ -418,7 +418,7 @@ class TestMapFunctionFilter:
 
     def test_empty_filter_enables_nothing(self) -> None:
         """An empty filter list enables no builtins and no custom tools."""
-        caps, tools, instructions = map_function_filter(
+        caps, tools, instructions, _sq, _rq = map_function_filter(
             [], [], _StubHooks(),
         )
         assert set(caps.enabled_tools) == set()
@@ -427,7 +427,7 @@ class TestMapFunctionFilter:
 
     def test_unknown_filter_ignored(self) -> None:
         """Unknown filter patterns are silently ignored."""
-        caps, tools, instructions = map_function_filter(
+        caps, tools, instructions, _sq, _rq = map_function_filter(
             ["unknown.*", "nope"], [], _StubHooks(),
         )
         assert set(caps.enabled_tools) == set()
@@ -443,7 +443,7 @@ class TestMapFunctionFilter:
         fd = _make_func_def(name="agents_cancel", schema=schema)
         group = _make_group("agents", [fd])
 
-        _caps, tools, _ = map_function_filter(
+        _caps, tools, _, _sq, _rq = map_function_filter(
             ["agents.*"], [group], _StubHooks(),
         )
         assert len(tools) == 1


### PR DESCRIPTION
## What
Enables `SuspendError`-raising tools (`agents_await`, `events_yield`) to correctly suspend Antigravity sessions by intercepting the exception in the tool wrapper and returning a deferred result instead of letting the SDK swallow it as a tool error.

## Why
The Antigravity SDK's tool runner catches all exceptions from custom tools and feeds them back to the model as error responses. Tools that raise `SuspendError` (to request session suspension) were being silently swallowed — the model would see an error, shrug, and keep going, burning tokens while accomplishing nothing.

## Changes

### `bees/runners/tool_mapping.py`
- `wrap_bees_handler` catches `SuspendError` and returns `{"status": "pending", "result_id": "..."}` — a legitimate response that tells the model to go idle
- Pushes the intercepted `SuspendError` onto a shared `asyncio.Queue` so the stream knows a suspend was requested
- `map_function_filter` creates and returns the `suspend_queue` as a 4th tuple element
- `_extract_custom_tools` threads the queue into each tool wrapper

### `bees/runners/antigravity.py`
- `AntigravityStream` accepts a `suspend_queue` and checks it after each step
- Pending suspend overrides idle behavior: when the model goes idle with a pending suspend, the stream emits `waitForInput` regardless of `has_chat` mode
- Fixed `functionResponse` event interleaving — tool results now drain after step translation (adjacent to their tool calls) instead of at the top of `__anext__` (spliced into the next text chunk)

### `tests/test_runners/test_tool_mapping.py`
- Updated all 14 `map_function_filter` call sites for the new 4-element return tuple

## Testing
- All 604 existing tests pass
- Smoke tested with `weather-orchestrator` template: parent agent assigns two tasks, calls `agents_await`, correctly suspends (twice), resumes with context updates, and completes
