### PR TITLE
[bees] Fix three AntigravityRunner session bugs

### DIFF
--- a/packages/bees/bees/runners/antigravity.py
+++ b/packages/bees/bees/runners/antigravity.py
@@ -248,6 +248,12 @@ def _tool_result_to_event(
     if isinstance(name, ag_types.BuiltinTools):
         name = name.value
     response = result.result
+    # SDK builtin tools return Pydantic BaseModel instances
+    # (SearchDirectoryResult, EditFileResult, etc.) that aren't
+    # JSON-serializable.  Normalize to plain dicts early so the
+    # downstream isinstance checks and json.dumps work correctly.
+    if hasattr(response, "model_dump"):
+        response = response.model_dump()
     if result.error:
         response = {"error": result.error}
     elif response is None:
@@ -313,6 +319,7 @@ class AntigravityStream:
         request_config: dict[str, Any] | None = None,
         tool_result_queue: asyncio.Queue[ag_types.ToolResult] | None = None,
         suspend_queue: asyncio.Queue[SuspendError] | None = None,
+        resume_after_step: int = -1,
     ) -> None:
         self._agent = agent
         self._exit_stack = exit_stack
@@ -337,6 +344,11 @@ class AntigravityStream:
         self._emitted_complete = False
         self._last_user_text: str = ""
         self._pending_suspend: SuspendError | None = None
+        # On resume, skip steps replayed from the prior trajectory.
+        # Steps with step_index <= this value are old history.
+        self._resume_after_step = resume_after_step
+        # Track highest step_index seen for the resume blob.
+        self._last_step_index: int = -1
 
     # -- async iterator ----------------------------------------------------
 
@@ -380,6 +392,12 @@ class AntigravityStream:
         assert self._step_iter is not None
         try:
             step = await self._step_iter.__anext__()
+            self._last_step_index = max(
+                self._last_step_index, step.step_index,
+            )
+            # On resume, skip steps replayed from prior turns.
+            if step.step_index <= self._resume_after_step:
+                return await self.__anext__()
         except StopAsyncIteration:
             # The SDK turn is done — the agent went idle.
             self._exhausted = True
@@ -455,15 +473,21 @@ class AntigravityStream:
                 self._emitted_complete = True
 
         # Accumulate user-directed text for chat mode suspend prompt.
-        # Reset when a step has no systemMessage — tool calls, user
-        # input replays, etc. clear the accumulator so only the LAST
-        # contiguous model response becomes the suspend prompt.
+        # Reset when a step has active model content (thoughts, tool
+        # calls) but no text — the model switched to non-text work.
+        # Metadata-only steps (usageMetadata, complete) are bookkeeping
+        # and must NOT reset the accumulator, otherwise the greeting
+        # text gets wiped and the chat agent completes instead of
+        # suspending for user input.
         has_model_text = False
+        has_active_content = False
         for event in events:
             if "systemMessage" in event:
                 has_model_text = True
                 self._last_user_text += event["systemMessage"].get("text", "")
-        if not has_model_text:
+            if "functionCall" in event or "thought" in event:
+                has_active_content = True
+        if has_active_content and not has_model_text:
             self._last_user_text = ""
 
         # Check for deferred suspends from tool wrappers.
@@ -534,6 +558,7 @@ class AntigravityStream:
             blob = {
                 "save_dir": self._save_dir,
                 "conversation_id": conversation_id,
+                "last_step_index": self._last_step_index,
             }
             self._resume_blob = json.dumps(
                 blob, ensure_ascii=False,
@@ -673,6 +698,7 @@ class AntigravityRunner:
         resume_data = json.loads(state.decode("utf-8"))
         save_dir = resume_data["save_dir"]
         conversation_id = resume_data["conversation_id"]
+        last_step_index = resume_data.get("last_step_index", -1)
 
         # 2. Map function filter to SDK capabilities (same as run).
         stub_hooks = _StubSessionHooks(config.file_system)
@@ -739,6 +765,7 @@ class AntigravityRunner:
             request_config=request_config,
             tool_result_queue=tool_result_queue,
             suspend_queue=suspend_queue,
+            resume_after_step=last_step_index,
         )
 
 

--- a/packages/bees/tests/test_runners/test_antigravity_events.py
+++ b/packages/bees/tests/test_runners/test_antigravity_events.py
@@ -1,0 +1,115 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for antigravity event translation helpers.
+
+Covers ``_tool_result_to_event`` — specifically the Pydantic model
+serialization that caused the SearchDirectoryResult crash.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pydantic
+import pytest
+
+from google.antigravity import types as ag_types
+
+from bees.runners.antigravity import _tool_result_to_event
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeResult(pydantic.BaseModel):
+    """Simulates an SDK builtin tool result (Pydantic BaseModel)."""
+
+    count: int = 0
+    message: str = "ok"
+
+
+# ---------------------------------------------------------------------------
+# _tool_result_to_event
+# ---------------------------------------------------------------------------
+
+
+class TestToolResultToEvent:
+    """Tests for ``_tool_result_to_event``."""
+
+    def test_pydantic_model_is_serializable(self) -> None:
+        """Pydantic BaseModel results are converted to JSON-safe dicts."""
+        result = ag_types.ToolResult(
+            name="search_directory",
+            result=_FakeResult(count=3, message="found"),
+        )
+        event = _tool_result_to_event(result)
+
+        # Must not raise — this is the exact codepath that crashed.
+        serialized = json.dumps(event, ensure_ascii=False)
+        parsed = json.loads(serialized)
+
+        assert parsed["functionResponse"]["name"] == "search_directory"
+        assert parsed["functionResponse"]["response"] == {
+            "count": 3,
+            "message": "found",
+        }
+
+    def test_pydantic_model_via_builtin_enum(self) -> None:
+        """BuiltinTools enum names are converted to strings."""
+        result = ag_types.ToolResult(
+            name=ag_types.BuiltinTools.SEARCH_DIR,
+            result=_FakeResult(count=0),
+        )
+        event = _tool_result_to_event(result)
+        serialized = json.dumps(event)
+
+        parsed = json.loads(serialized)
+        assert parsed["functionResponse"]["name"] == ag_types.BuiltinTools.SEARCH_DIR.value
+
+    def test_dict_result_passes_through(self) -> None:
+        """Plain dict results are used as-is."""
+        result = ag_types.ToolResult(
+            name="my_tool",
+            result={"status": "ok", "data": [1, 2, 3]},
+        )
+        event = _tool_result_to_event(result)
+        assert event["functionResponse"]["response"] == {
+            "status": "ok",
+            "data": [1, 2, 3],
+        }
+
+    def test_none_result_becomes_empty_dict(self) -> None:
+        """None results are normalized to empty dicts."""
+        result = ag_types.ToolResult(name="my_tool", result=None)
+        event = _tool_result_to_event(result)
+        assert event["functionResponse"]["response"] == {}
+
+    def test_error_result_overrides_value(self) -> None:
+        """When error is set, response becomes the error dict."""
+        result = ag_types.ToolResult(
+            name="my_tool",
+            result=_FakeResult(count=1),
+            error="Something went wrong",
+        )
+        event = _tool_result_to_event(result)
+        assert event["functionResponse"]["response"] == {
+            "error": "Something went wrong",
+        }
+
+    def test_scalar_result_wrapped(self) -> None:
+        """Scalar values are wrapped in a dict."""
+        result = ag_types.ToolResult(name="my_tool", result=42)
+        event = _tool_result_to_event(result)
+        assert event["functionResponse"]["response"] == {"result": 42}
+
+    def test_list_result_wrapped(self) -> None:
+        """List values are wrapped in a dict."""
+        result = ag_types.ToolResult(name="my_tool", result=["a", "b"])
+        event = _tool_result_to_event(result)
+        assert event["functionResponse"]["response"] == {
+            "result": ["a", "b"],
+        }


### PR DESCRIPTION
## What
Fixes three bugs in `AntigravityRunner` that caused sessions to crash, silently complete instead of suspending, or replay duplicate content on resume.

## Why
The AG-chat interactive agent was unusable: builtin tool calls crashed with JSON serialization errors, the model's greeting was lost before the suspend check, and every resume replayed the entire prior conversation.

## Changes

### `packages/bees/bees/runners/antigravity.py`
- **Pydantic serialization**: `_tool_result_to_event()` now calls `model_dump()` on SDK builtin tool results (e.g. `SearchDirectoryResult`) before embedding them in `functionResponse` events, preventing `json.dumps` crashes
- **Chat suspend logic**: Text accumulator reset now only triggers on active model content (thoughts, function calls), not metadata-only steps like `usageMetadata` — fixes chat agents completing instead of emitting `waitForInput`
- **Resume deduplication**: Track `last_step_index` in the resume blob and skip replayed steps on resume, eliminating duplicate events from the SDK's trajectory replay

### `packages/bees/tests/test_runners/test_antigravity_events.py` [NEW]
- Tests for `_tool_result_to_event` covering Pydantic models, dicts, None, errors, scalars, and lists

## Testing
- `pytest tests/test_runners/test_antigravity_events.py` — 7/7 pass
- Manual: ran `dev:box` with `ag-chat` template, verified suspend works on greeting, resume produces only new-turn events, and builtin tools no longer crash
