### PR TITLE
[bees] Antigravity Runner Finish Tool and Session Lifecycle Improvements

### DIFF
--- a/hives/antigravity/config/TEMPLATES.yaml
+++ b/hives/antigravity/config/TEMPLATES.yaml
@@ -1,4 +1,4 @@
-# Antigravity test templates
+# Ticket templates — see docs/patterns.md for the field reference.
 
 - name: ag-worker
   runner: antigravity
@@ -8,8 +8,10 @@
     You are a simple test agent. Your job is to:
 
     1. List the files in your workspace directory. 2. Create a file called
-    "hello.txt" with the content "Hello from Antigravity!". 3. Finish with a
-    brief summary of what you did.
+    "hello.txt" with the content "Hello from Antigravity!". 
+
+
+    3. Call the "finish" tool with a brief summary of what you did.
   functions:
     - system.*
     - files.*
@@ -34,8 +36,8 @@
     available agent types, then assign two sequential tasks to a
     "weather-checker" agent with slug "checker".
 
-    - Task 1: Check the weather in San Francisco, CA. Save it to sfo.txt. 
-    - Task 2: Check the weather in London. Save it to lon.txt.
+    - Task 1: Check the weather in San Francisco, CA. Save it to sfo.txt.  -
+    Task 2: Check the weather in London. Save it to lon.txt.
 
     After assigning task 1, don't wait for it to complete, and immediately
     assign task 2 to the same slug and wait for both tasks to complete. When
@@ -61,8 +63,6 @@
     - files.*
     - events.*
     - builtin.search_grounding
-
-## Generators
 
 - name: generate_text
   title: Text Generator
@@ -107,8 +107,7 @@
         - "9:21"
     image_size:
       type: string
-      description:
-        "Target resolution or image size. Valid values: '512', '1K', '2K', '4K'."
+      description: "Target resolution or image size. Valid values: '512', '1K', '2K', '4K'."
       enum:
         - "512"
         - 1K

--- a/packages/bees/bees/runners/antigravity.py
+++ b/packages/bees/bees/runners/antigravity.py
@@ -47,6 +47,7 @@ from bees.protocols.session import (
     SessionConfiguration,
     SessionEvent,
 )
+from bees.protocols.filesystem import FileSystem
 from bees.runners.tool_mapping import map_function_filter
 
 __all__ = ["AntigravityRunner", "AntigravityStream"]
@@ -74,21 +75,61 @@ def _format_usage(usage: ag_types.UsageMetadata) -> dict[str, Any]:
     }
 
 
-def _build_complete_result(step: ag_types.Step) -> dict[str, Any]:
+async def _build_complete_result(
+    step: ag_types.Step,
+    file_system: FileSystem | None = None,
+) -> dict[str, Any]:
     """Build a ``complete`` event result dict from a FINISH step."""
     # The SDK's finish step carries structured_output when configured.
     # Map it to the bees outcome format.
     outcome_text = step.content or ""
+    if step.structured_output and isinstance(step.structured_output, dict):
+        if "objective_outcome" in step.structured_output:
+            outcome_text = step.structured_output["objective_outcome"]
+        elif "user_message" in step.structured_output:
+            outcome_text = step.structured_output["user_message"]
+
+    from typing import cast
+    outcomes: dict[str, Any]
+    if file_system and outcome_text:
+        from bees.pidgin import from_pidgin_string
+        resolved = await from_pidgin_string(outcome_text, file_system)
+        if isinstance(resolved, dict) and "$error" in resolved:
+            # Fall back to raw text if resolution fails
+            outcomes = {"parts": [{"text": outcome_text}]}
+        else:
+            outcomes = cast(dict[str, Any], resolved)
+    else:
+        outcomes = {"parts": [{"text": outcome_text}]}
+
     result: dict[str, Any] = {
         "success": step.status != ag_types.StepStatus.ERROR,
-        "outcomes": {"parts": [{"text": outcome_text}]},
+        "outcomes": outcomes,
     }
     if step.structured_output is not None:
         result["structured_output"] = step.structured_output
+
+    if file_system:
+        # Collect intermediate files.
+        intermediate = []
+        for path in list(file_system.files.keys()):
+            file_parts = await file_system.get(path)
+            if isinstance(file_parts, dict) and "$error" in file_parts:
+                continue
+            if file_parts:
+                intermediate.append({
+                    "path": path,
+                    "content": {"parts": file_parts},
+                })
+        result["intermediate"] = intermediate
+
     return result
 
 
-def _translate_step(step: ag_types.Step) -> list[SessionEvent]:
+async def _translate_step(
+    step: ag_types.Step,
+    file_system: FileSystem | None = None,
+) -> list[SessionEvent]:
     """Translate a single SDK Step into zero or more SessionEvent dicts."""
     events: list[SessionEvent] = []
 
@@ -129,7 +170,8 @@ def _translate_step(step: ag_types.Step) -> list[SessionEvent]:
         step.type == ag_types.StepType.FINISH
         and step.status == ag_types.StepStatus.DONE
     ):
-        events.append({"complete": {"result": _build_complete_result(step)}})
+        complete_result = await _build_complete_result(step, file_system)
+        events.append({"complete": {"result": complete_result}})
 
     # Error → error event (terminal errors only).
     # Tool call errors (policy denials, missing files, etc.) are
@@ -196,6 +238,16 @@ def _build_request_config(
 # ---------------------------------------------------------------------------
 
 
+AGENT_IDENTITY = (
+    "You are an LLM-powered AI agent, orchestrated within an application alongside "
+    "other AI agents. During this session, your job is to fulfill the objective, "
+    "specified at the start of the conversation context. The objective is provided by "
+    "the application and is not visible to the user of the application. Similarly, "
+    "the outcome you produce is delivered by the orchestration system to another "
+    "agent. The outcome is also not visible to the user to the application."
+)
+
+
 def _assemble_system_instructions(
     custom_instructions: list[str],
 ) -> ag_types.TemplatedSystemInstructions:
@@ -214,7 +266,10 @@ def _assemble_system_instructions(
         )
         for i, text in enumerate(custom_instructions)
     ]
-    return ag_types.TemplatedSystemInstructions(sections=sections)
+    return ag_types.TemplatedSystemInstructions(
+        identity=AGENT_IDENTITY,
+        sections=sections,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -320,6 +375,7 @@ class AntigravityStream:
         tool_result_queue: asyncio.Queue[ag_types.ToolResult] | None = None,
         suspend_queue: asyncio.Queue[SuspendError] | None = None,
         resume_after_step: int = -1,
+        file_system: FileSystem | None = None,
     ) -> None:
         self._agent = agent
         self._exit_stack = exit_stack
@@ -334,6 +390,7 @@ class AntigravityStream:
         self._suspend_queue: asyncio.Queue[SuspendError] = (
             suspend_queue or asyncio.Queue()
         )
+        self._file_system = file_system
 
         self._started = False
         self._exhausted = False
@@ -400,9 +457,9 @@ class AntigravityStream:
                 return await self.__anext__()
         except StopAsyncIteration:
             # The SDK turn is done — the agent went idle.
-            self._exhausted = True
             self._capture_resume_state()
 
+            self._exhausted = True
             if not self._emitted_complete:
                 self._emitted_complete = True
 
@@ -450,7 +507,7 @@ class AntigravityStream:
             return {"error": {"message": str(exc)}}
 
         # Translate the step into events.
-        events = _translate_step(step)
+        events = await _translate_step(step, self._file_system)
 
         # Drain tool results captured by the PostToolCallHook.
         # Done here (after step translation) so functionResponse events
@@ -677,6 +734,7 @@ class AntigravityRunner:
             request_config=request_config,
             tool_result_queue=tool_result_queue,
             suspend_queue=suspend_queue,
+            file_system=config.file_system,
         )
 
     async def resume(
@@ -766,6 +824,7 @@ class AntigravityRunner:
             tool_result_queue=tool_result_queue,
             suspend_queue=suspend_queue,
             resume_after_step=last_step_index,
+            file_system=config.file_system,
         )
 
 

--- a/packages/bees/bees/runners/tool_mapping.py
+++ b/packages/bees/bees/runners/tool_mapping.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import asyncio
 import fnmatch
+import json
 import logging
 from typing import Any, Callable
 
@@ -77,6 +78,42 @@ _EXCLUDED_BUILTINS = {
     ag_types.BuiltinTools.GENERATE_IMAGE,
     ag_types.BuiltinTools.START_SUBAGENT,
 }
+
+
+DEFAULT_FINISH_SCHEMA = json.dumps({
+    "type": "object",
+    "properties": {
+        "objective_outcome": {
+            "type": "string",
+            "description": "Your return value: the content of the fulfilled objective."
+        }
+    },
+    "required": ["objective_outcome"],
+    "additionalProperties": False,
+})
+
+
+def _find_finish_schema(
+    function_groups: list[FunctionGroupFactory],
+    hooks: SessionHooks,
+) -> str | None:
+    """Find the parametersJsonSchema of system_objective_fulfilled in system group."""
+    for entry in function_groups:
+        group = None
+        if isinstance(entry, FunctionGroup):
+            group = entry
+        elif callable(entry):
+            try:
+                group = entry(hooks)
+            except Exception:
+                continue
+        if group and group.name == "system":
+            for name, func_def in group.definitions:
+                if name == "system_objective_fulfilled":
+                    schema = func_def.parameters_json_schema
+                    if schema:
+                        return json.dumps(schema)
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -159,9 +196,14 @@ def map_function_filter(
             suspend_queue=suspend_queue,
         )
 
+    finish_schema = None
+    if ag_types.BuiltinTools.FINISH in enabled_builtins:
+        finish_schema = _find_finish_schema(function_groups, hooks) or DEFAULT_FINISH_SCHEMA
+
     capabilities = ag_types.CapabilitiesConfig(
         enabled_tools=sorted(enabled_builtins, key=lambda t: t.value),
         enable_subagents=False,  # Bees manages its own agent hierarchy.
+        finish_tool_schema_json=finish_schema,
     )
 
     return capabilities, custom_tools, custom_instructions, suspend_queue

--- a/packages/bees/bees/session.py
+++ b/packages/bees/bees/session.py
@@ -527,6 +527,8 @@ async def drain_session(
     else:
         status = "completed"
 
+    await session_store.set_status(session_id, status)
+
     return SessionResult(
         session_id=ticket_id or "",
         status=status,

--- a/packages/bees/tests/test_runners/test_antigravity_events.py
+++ b/packages/bees/tests/test_runners/test_antigravity_events.py
@@ -113,3 +113,112 @@ class TestToolResultToEvent:
         assert event["functionResponse"]["response"] == {
             "result": ["a", "b"],
         }
+
+
+
+
+
+# ---------------------------------------------------------------------------
+# System instruction assembly tests
+# ---------------------------------------------------------------------------
+
+
+class TestAntigravitySystemInstructions:
+    """Tests for ``_assemble_system_instructions``."""
+
+    def test_assemble_system_instructions(self) -> None:
+        from bees.runners.antigravity import (
+            _assemble_system_instructions,
+            AGENT_IDENTITY,
+        )
+
+        custom = ["custom note 1", "custom note 2"]
+        templated = _assemble_system_instructions(custom)
+
+        assert templated.identity == AGENT_IDENTITY
+        assert len(templated.sections) == 2
+        assert templated.sections[0].content == "custom note 1"
+        assert templated.sections[0].title == "tools_0"
+        assert templated.sections[1].content == "custom note 2"
+        assert templated.sections[1].title == "tools_1"
+
+
+class TestAntigravityBuildCompleteResult:
+    """Tests for ``_build_complete_result``."""
+
+    def test_build_complete_result_basic(self) -> None:
+        from bees.runners.antigravity import _build_complete_result
+        import asyncio
+
+        async def run_test():
+            step = ag_types.Step(
+                id="step-1",
+                step_index=0,
+                type=ag_types.StepType.FINISH,
+                status=ag_types.StepStatus.DONE,
+                source=ag_types.StepSource.MODEL,
+                target=ag_types.StepTarget.USER,
+                content="Finished normally",
+            )
+            res = await _build_complete_result(step)
+            assert res["success"] is True
+            assert res["outcomes"] == {"parts": [{"text": "Finished normally"}]}
+
+        asyncio.run(run_test())
+
+    def test_build_complete_result_structured(self) -> None:
+        from bees.runners.antigravity import _build_complete_result
+        import asyncio
+
+        async def run_test():
+            step = ag_types.Step(
+                id="step-1",
+                step_index=0,
+                type=ag_types.StepType.FINISH,
+                status=ag_types.StepStatus.DONE,
+                source=ag_types.StepSource.MODEL,
+                target=ag_types.StepTarget.USER,
+                structured_output={"objective_outcome": "The task was successfully completed!"},
+            )
+            res = await _build_complete_result(step)
+            assert res["success"] is True
+            assert res["outcomes"] == {"parts": [{"text": "The task was successfully completed!"}]}
+            assert res["structured_output"] == {"objective_outcome": "The task was successfully completed!"}
+
+        asyncio.run(run_test())
+
+    def test_build_complete_result_pidgin_and_intermediate(self) -> None:
+        from bees.runners.antigravity import _build_complete_result
+        from bees.disk_file_system import DiskFileSystem
+        import asyncio
+        import tempfile
+        from pathlib import Path
+
+        async def run_test():
+            with tempfile.TemporaryDirectory() as tmpdir:
+                fs = DiskFileSystem(Path(tmpdir))
+                fs.write("result.txt", "Some important output data")
+
+                step = ag_types.Step(
+                    id="step-1",
+                    step_index=0,
+                    type=ag_types.StepType.FINISH,
+                    status=ag_types.StepStatus.DONE,
+                    source=ag_types.StepSource.MODEL,
+                    target=ag_types.StepTarget.USER,
+                    structured_output={"objective_outcome": "See <file src=\"result.txt\" /> for the output."},
+                )
+                res = await _build_complete_result(step, file_system=fs)
+                assert res["success"] is True
+                # outcome_text is resolved via pidgin
+                assert res["outcomes"]["parts"] == [
+                    {"text": "See \nSome important output data\n for the output."}
+                ]
+                # intermediate files are collected
+                assert len(res["intermediate"]) == 1
+                assert res["intermediate"][0]["path"] == "result.txt"
+                assert res["intermediate"][0]["content"]["parts"] == [{"text": "Some important output data"}]
+
+        asyncio.run(run_test())
+
+

--- a/packages/bees/tests/test_runners/test_tool_mapping.py
+++ b/packages/bees/tests/test_runners/test_tool_mapping.py
@@ -311,7 +311,7 @@ class TestMapFunctionFilter:
 
     def test_none_filter_enables_all_builtins(self) -> None:
         """None filter enables all SDK builtins except excluded ones."""
-        caps, tools, instructions, _sq, _rq = map_function_filter(
+        caps, tools, instructions, _sq = map_function_filter(
             None, [], _StubHooks(),
         )
         enabled = set(caps.enabled_tools)
@@ -324,7 +324,7 @@ class TestMapFunctionFilter:
         fd = _make_func_def(name="agents_list")
         group = _make_group("agents", [fd], instruction="Agents.")
 
-        _caps, tools, instructions, _sq, _rq = map_function_filter(
+        _caps, tools, instructions, _sq = map_function_filter(
             None, [group], _StubHooks(),
         )
         assert len(tools) == 1
@@ -333,7 +333,7 @@ class TestMapFunctionFilter:
 
     def test_builtin_filter_enables_correct_tools(self) -> None:
         """'files.*' enables exactly the file-related builtins."""
-        caps, tools, instructions, _sq, _rq = map_function_filter(
+        caps, tools, instructions, _sq = map_function_filter(
             ["files.*"], [], _StubHooks(),
         )
         enabled = set(caps.enabled_tools)
@@ -344,7 +344,7 @@ class TestMapFunctionFilter:
 
     def test_multiple_builtin_filters(self) -> None:
         """Multiple builtin filters union their tools."""
-        caps, _, _, _sq, _rq = map_function_filter(
+        caps, _, _, _sq = map_function_filter(
             ["files.*", "sandbox.*"], [], _StubHooks(),
         )
         enabled = set(caps.enabled_tools)
@@ -358,7 +358,7 @@ class TestMapFunctionFilter:
         fd = _make_func_def(name="agents_list")
         group = _make_group("agents", [fd], instruction="Agents.")
 
-        caps, tools, instructions, _sq, _rq = map_function_filter(
+        caps, tools, instructions, _sq = map_function_filter(
             ["agents.*"], [group], _StubHooks(),
         )
         # No builtins for agents.
@@ -372,7 +372,7 @@ class TestMapFunctionFilter:
         fd = _make_func_def(name="agents_list")
         group = _make_group("agents", [fd])
 
-        caps, tools, _, _sq, _rq = map_function_filter(
+        caps, tools, _, _sq = map_function_filter(
             ["files.*", "system.*", "agents.*"], [group], _StubHooks(),
         )
         enabled = set(caps.enabled_tools)
@@ -384,24 +384,24 @@ class TestMapFunctionFilter:
 
     def test_excluded_builtins_never_enabled(self) -> None:
         """GENERATE_IMAGE and START_SUBAGENT are never enabled."""
-        caps, _, _, _sq, _rq = map_function_filter(None, [], _StubHooks())
+        caps, _, _, _sq = map_function_filter(None, [], _StubHooks())
         enabled = set(caps.enabled_tools)
         for excluded in _EXCLUDED_BUILTINS:
             assert excluded not in enabled
 
     def test_subagents_always_disabled(self) -> None:
         """enable_subagents is always False."""
-        caps, _, _, _sq, _rq = map_function_filter(None, [], _StubHooks())
+        caps, _, _, _sq = map_function_filter(None, [], _StubHooks())
         assert caps.enable_subagents is False
 
-        caps2, _, _, _sq, _rq = map_function_filter(
+        caps2, _, _, _sq = map_function_filter(
             ["files.*"], [], _StubHooks(),
         )
         assert caps2.enable_subagents is False
 
     def test_enabled_tools_sorted(self) -> None:
         """enabled_tools are sorted by enum value for deterministic output."""
-        caps, _, _, _sq, _rq = map_function_filter(None, [], _StubHooks())
+        caps, _, _, _sq = map_function_filter(None, [], _StubHooks())
         values = [t.value for t in caps.enabled_tools]
         assert values == sorted(values)
 
@@ -410,7 +410,7 @@ class TestMapFunctionFilter:
         fd = _make_func_def(name="agents_assign_task")
         group = _make_group("agents", [fd])
 
-        _caps, tools, _, _sq, _rq = map_function_filter(
+        _caps, tools, _, _sq = map_function_filter(
             ["agents_assign_task"], [group], _StubHooks(),
         )
         assert len(tools) == 1
@@ -418,7 +418,7 @@ class TestMapFunctionFilter:
 
     def test_empty_filter_enables_nothing(self) -> None:
         """An empty filter list enables no builtins and no custom tools."""
-        caps, tools, instructions, _sq, _rq = map_function_filter(
+        caps, tools, instructions, _sq = map_function_filter(
             [], [], _StubHooks(),
         )
         assert set(caps.enabled_tools) == set()
@@ -427,7 +427,7 @@ class TestMapFunctionFilter:
 
     def test_unknown_filter_ignored(self) -> None:
         """Unknown filter patterns are silently ignored."""
-        caps, tools, instructions, _sq, _rq = map_function_filter(
+        caps, tools, instructions, _sq = map_function_filter(
             ["unknown.*", "nope"], [], _StubHooks(),
         )
         assert set(caps.enabled_tools) == set()
@@ -443,9 +443,41 @@ class TestMapFunctionFilter:
         fd = _make_func_def(name="agents_cancel", schema=schema)
         group = _make_group("agents", [fd])
 
-        _caps, tools, _, _sq, _rq = map_function_filter(
+        _caps, tools, _, _sq = map_function_filter(
             ["agents.*"], [group], _StubHooks(),
         )
         assert len(tools) == 1
         assert isinstance(tools[0], ToolWithSchema)
         assert tools[0].input_schema == schema
+
+    def test_finish_tool_schema_resolved_from_system_group(self) -> None:
+        """When system.* is in filter, finish_tool_schema_json is extracted from system group."""
+        schema = {
+            "type": "object",
+            "properties": {"objective_outcome": {"type": "string"}},
+            "required": ["objective_outcome"],
+        }
+        fd = _make_func_def(name="system_objective_fulfilled", schema=schema)
+        group = _make_group("system", [fd])
+
+        caps, _, _, _sq = map_function_filter(
+            ["system.*"], [group], _StubHooks(),
+        )
+        import json
+        assert caps.finish_tool_schema_json == json.dumps(schema)
+
+    def test_finish_tool_schema_fallback(self) -> None:
+        """When system.* is in filter but no group matches, it falls back to DEFAULT_FINISH_SCHEMA."""
+        caps, _, _, _sq = map_function_filter(
+            ["system.*"], [], _StubHooks(),
+        )
+        from bees.runners.tool_mapping import DEFAULT_FINISH_SCHEMA
+        assert caps.finish_tool_schema_json == DEFAULT_FINISH_SCHEMA
+
+    def test_finish_tool_schema_none_when_disabled(self) -> None:
+        """When system.* is not in filter, finish_tool_schema_json is None."""
+        caps, _, _, _sq = map_function_filter(
+            ["files.*"], [], _StubHooks(),
+        )
+        assert caps.finish_tool_schema_json is None
+


### PR DESCRIPTION
## What
Ensures the `finish` tool is visible to the Gemini model in `AntigravityRunner` sessions, resolves the stuck "running" status for finished sessions, and maps structured outcomes (including pidgin tag resolution and intermediate workspace file collection) correctly upon session completion.

## Why
Antigravity sessions were missing the `finish` tool declaration because `finish_tool_schema_json` was not populated. Additionally, sessions were remaining stuck in the "running" state in the persistent store because `drain_session` never set the final status on the store, and the resulting outcome texts were not parsing structured payloads.

## Changes
- **packages/bees/bees/runners/tool_mapping.py**:
  - Implemented `_find_finish_schema` helper to locate and extract the schema for `system_objective_fulfilled` from function groups.
  - Set `capabilities.finish_tool_schema_json` to make the `finish` tool visible to the Gemini model.
- **packages/bees/bees/session.py**:
  - Transitioned the session status in the session store to the final derived status at the end of `drain_session`.
- **packages/bees/bees/runners/antigravity.py**:
  - Refactored `_translate_step` and `_build_complete_result` to be async.
  - Passed `file_system` to `AntigravityStream` and updated `_build_complete_result` to extract structured outcomes, resolve pidgin tags, and collect intermediate files.
- **packages/bees/tests/test_runners/**:
  - Added schema visibility tests to `test_tool_mapping.py`.
  - Added structured outcome, pidgin resolution, and intermediate file tests to `test_antigravity_events.py`.

## Testing
Verify that all python tests run and pass successfully:
```bash
.venv/bin/pytest tests/
```
