### PR TITLE
[bees] Orient Antigravity Agent Prompts and Clean Host-Side Leakage

### DIFF
--- a/hives/antigravity/config/TEMPLATES.yaml
+++ b/hives/antigravity/config/TEMPLATES.yaml
@@ -7,11 +7,15 @@
   objective: >
     You are a simple test agent. Your job is to:
 
-    1. List the files in your workspace directory. 2. Create a file called
-    "hello.txt" with the content "Hello from Antigravity!". 
+
+    1. List the files in your workspace directory. 
 
 
-    3. Call the "finish" tool with a brief summary of what you did.
+    2. Create a file called "hello.txt" with the content "Hello from
+    Antigravity!". 
+
+
+    Return a brief summary of what you did.
   functions:
     - system.*
     - files.*

--- a/packages/bees/bees/runners/antigravity.py
+++ b/packages/bees/bees/runners/antigravity.py
@@ -206,7 +206,7 @@ async def _translate_step(
 def _build_request_config(
     capabilities: ag_types.CapabilitiesConfig,
     custom_tools: list[Callable[..., Any]],
-    custom_instructions: list[str],
+    system_instructions: ag_types.CustomSystemInstructions,
 ) -> dict[str, Any]:
     """Build the Hivetool-compatible config dict for the sendRequest body.
 
@@ -215,10 +215,8 @@ def _build_request_config(
     """
     result: dict[str, Any] = {}
 
-    # System instruction: join custom tool group instructions.
-    if custom_instructions:
-        text = "\n\n".join(custom_instructions)
-        result["systemInstruction"] = {"parts": [{"text": text}]}
+    if system_instructions:
+        result["systemInstruction"] = {"parts": [{"text": system_instructions.text}]}
 
     # Tools: combine SDK builtins + custom tool names.
     declarations: list[dict[str, str]] = []
@@ -249,27 +247,21 @@ AGENT_IDENTITY = (
 
 
 def _assemble_system_instructions(
-    custom_instructions: list[str],
-) -> ag_types.TemplatedSystemInstructions:
-    """Build SDK system instructions from custom tool group instructions.
+    active_instructions: list[str],
+) -> ag_types.CustomSystemInstructions:
+    """Build SDK system instructions from all active tool group instructions.
 
-    Each custom function group (agents, events, skills) carries an
-    ``instruction`` fragment describing how to use those tools.  These
-    are appended as named sections to the SDK's default template.
-
-    Groups that map to SDK builtins (system, chat, files, sandbox) are
-    excluded — the SDK explains its own tools.
+    Compiles a structured custom system prompt containing the core identity
+    and active tool guidelines/meta-plan. Bypasses harness defaults to maximize
+    context caching and prevent instruction leakage.
     """
-    sections = [
-        ag_types.SystemInstructionSection(
-            content=text, title=f"tools_{i}",
-        )
-        for i, text in enumerate(custom_instructions)
-    ]
-    return ag_types.TemplatedSystemInstructions(
-        identity=AGENT_IDENTITY,
-        sections=sections,
-    )
+    identity_block = f"<identity>\n{AGENT_IDENTITY}\n</identity>"
+
+    instructions_parts = [inst.strip() for inst in active_instructions if inst.strip()]
+    active_text = "\n\n".join(instructions_parts)
+
+    final_prompt = f"{identity_block}\n\n{active_text}"
+    return ag_types.CustomSystemInstructions(text=final_prompt)
 
 
 # ---------------------------------------------------------------------------
@@ -672,7 +664,7 @@ class AntigravityRunner:
             )
         )
 
-        # 2. Assemble system instructions from custom tool groups.
+        # 2. Assemble system instructions from all active tool groups.
         system_instructions = _assemble_system_instructions(
             custom_instructions,
         )
@@ -721,7 +713,7 @@ class AntigravityRunner:
         has_chat = _has_chat_functions(config.function_filter)
 
         request_config = _build_request_config(
-            capabilities, custom_tools, custom_instructions,
+            capabilities, custom_tools, system_instructions,
         )
 
         return AntigravityStream(
@@ -768,7 +760,7 @@ class AntigravityRunner:
             )
         )
 
-        # 3. Assemble system instructions from custom tool groups.
+        # 3. Assemble system instructions from all active tool groups.
         system_instructions = _assemble_system_instructions(
             custom_instructions,
         )
@@ -810,7 +802,7 @@ class AntigravityRunner:
         has_chat = _has_chat_functions(config.function_filter)
 
         request_config = _build_request_config(
-            capabilities, custom_tools, custom_instructions,
+            capabilities, custom_tools, system_instructions,
         )
 
         return AntigravityStream(
@@ -840,6 +832,8 @@ def _extract_initial_prompt(config: SessionConfiguration) -> str:
     and the actual user prompt.  The user prompt is typically the last
     segment with role='user' or the objective text.
     """
+    from datetime import datetime
+
     # Collect all text from segments — the segments form the full
     # context that the Gemini runner would send as the initial request.
     # Since system instructions are handled separately, we extract
@@ -850,7 +844,53 @@ def _extract_initial_prompt(config: SessionConfiguration) -> str:
         if text:
             texts.append(text)
 
-    return "\n\n".join(texts) if texts else "Begin."
+    objective_text = "\n\n".join(texts) if texts else "Begin."
+
+    now = datetime.now().strftime("%B %-d, %Y %-I:%M %p")
+    workspace = _workspace_path(config)
+    metadata_block = f"<metadata>\n<current_date>{now}</current_date>\n<working_directory>{workspace}</working_directory>\n</metadata>"
+
+    # Check if sandbox orientation is needed
+    has_files_or_sandbox = False
+    if config.function_filter is None:
+        has_files_or_sandbox = True
+    else:
+        has_files_or_sandbox = any(
+            pattern.startswith("files") or pattern.startswith("sandbox")
+            for pattern in config.function_filter
+        )
+
+    slug = None
+    if config.ticket_dir and (config.ticket_dir / "metadata.json").is_file():
+        try:
+            mdata = json.loads((config.ticket_dir / "metadata.json").read_text(encoding="utf-8"))
+            slug = mdata.get("slug")
+        except Exception:
+            pass
+
+    if has_files_or_sandbox and "<sandbox_environment>" not in objective_text:
+        if slug:
+            sandbox_block = (
+                "<sandbox_environment>\n"
+                "Your current working directory is the root of the workspace.\n"
+                f"You are assigned to work in the subdirectory: ./{slug}\n"
+                f"CRITICAL: You must prefix all file paths with {slug}/ "
+                "when creating or writing files (e.g., using files_write_file or "
+                "redirection in bash). Writes to the root directory or other "
+                "directories will fail.\n"
+                "You can read files from anywhere in the workspace.\n"
+                "</sandbox_environment>"
+            )
+        else:
+            sandbox_block = (
+                "<sandbox_environment>\n"
+                "Your current working directory is the root of the workspace.\n"
+                "You can read files from anywhere in the workspace.\n"
+                "</sandbox_environment>"
+            )
+        objective_text = f"{objective_text}\n\n{sandbox_block}"
+
+    return f"{metadata_block}\n<objective>{objective_text}</objective>"
 
 
 def _workspace_path(config: SessionConfiguration) -> str:

--- a/packages/bees/bees/runners/tool_mapping.py
+++ b/packages/bees/bees/runners/tool_mapping.py
@@ -158,43 +158,64 @@ def map_function_filter(
           ``AntigravityStream`` so it can detect pending suspends.
     """
     enabled_builtins: set[ag_types.BuiltinTools] = set()
-    custom_tools: list[Callable[..., Any]] = []
-    custom_instructions: list[str] = []
+    active_instructions: list[str] = []
     suspend_queue: asyncio.Queue[SuspendError] = asyncio.Queue()
 
     if function_filter is None:
         # No filter → enable all SDK builtins (except excluded).
         enabled_builtins = set(ag_types.BuiltinTools) - _EXCLUDED_BUILTINS
         # Also instantiate all custom-tool groups.
-        custom_tools, custom_instructions = _extract_custom_tools(
+        custom_tools, _ = _extract_custom_tools(
             function_groups, hooks,
             include_groups=None,
             suspend_queue=suspend_queue,
         )
+        active_group_names = None
     else:
         custom_group_names: set[str] = set()
+        active_group_names = set()
 
         for pattern in function_filter:
             # Check if this pattern maps to SDK builtins.
             matched_builtins = _resolve_builtin_pattern(pattern)
             if matched_builtins is not None:
                 enabled_builtins.update(matched_builtins)
-            else:
-                # Extract the group name from the pattern (e.g. "agents" from
-                # "agents.*" or "agents_assign_task").
-                group_name = pattern.split(".")[0].split("_")[0]
-                if group_name in _CUSTOM_TOOL_GROUPS:
-                    custom_group_names.add(group_name)
+            
+            # Map pattern to group name (e.g. "agents" from "agents.*" or "agents_assign_task").
+            group_name = pattern.split(".")[0].split("_")[0]
+            active_group_names.add(group_name)
+            if group_name in _CUSTOM_TOOL_GROUPS:
+                custom_group_names.add(group_name)
 
         # Remove any excluded builtins that snuck in.
         enabled_builtins -= _EXCLUDED_BUILTINS
 
         # Extract custom tools from matching function groups.
-        custom_tools, custom_instructions = _extract_custom_tools(
+        custom_tools, _ = _extract_custom_tools(
             function_groups, hooks,
             include_groups=custom_group_names,
             suspend_queue=suspend_queue,
         )
+
+    # Collect instructions for all active groups (built-in and custom).
+    for entry in function_groups:
+        if isinstance(entry, FunctionGroup):
+            group = entry
+        elif callable(entry):
+            try:
+                group = entry(hooks)
+            except Exception:
+                continue
+        else:
+            continue
+
+        if group.name:
+            if active_group_names is None or group.name in active_group_names:
+                if group.name in {"system", "files", "chat"}:
+                    continue
+                if group.instruction:
+                    active_instructions.append(group.instruction)
+
 
     finish_schema = None
     if ag_types.BuiltinTools.FINISH in enabled_builtins:
@@ -206,7 +227,7 @@ def map_function_filter(
         finish_tool_schema_json=finish_schema,
     )
 
-    return capabilities, custom_tools, custom_instructions, suspend_queue
+    return capabilities, custom_tools, active_instructions, suspend_queue
 
 
 # ---------------------------------------------------------------------------

--- a/packages/bees/tests/test_runners/test_antigravity_events.py
+++ b/packages/bees/tests/test_runners/test_antigravity_events.py
@@ -133,14 +133,90 @@ class TestAntigravitySystemInstructions:
         )
 
         custom = ["custom note 1", "custom note 2"]
-        templated = _assemble_system_instructions(custom)
+        custom_si = _assemble_system_instructions(custom)
 
-        assert templated.identity == AGENT_IDENTITY
-        assert len(templated.sections) == 2
-        assert templated.sections[0].content == "custom note 1"
-        assert templated.sections[0].title == "tools_0"
-        assert templated.sections[1].content == "custom note 2"
-        assert templated.sections[1].title == "tools_1"
+        assert isinstance(custom_si, ag_types.CustomSystemInstructions)
+        assert "<identity>" in custom_si.text
+        assert AGENT_IDENTITY in custom_si.text
+        assert "custom note 1" in custom_si.text
+        assert "custom note 2" in custom_si.text
+
+
+class TestAntigravityExtractInitialPrompt:
+    """Tests for ``_extract_initial_prompt``."""
+
+    def test_extract_initial_prompt_basic(self) -> None:
+        from pathlib import Path
+        from bees.runners.antigravity import _extract_initial_prompt
+        from bees.protocols.session import SessionConfiguration
+        from bees.disk_file_system import DiskFileSystem
+
+        config = SessionConfiguration(
+            segments=[{"text": "My Objective"}],
+            function_groups=[],
+            function_filter=["agents.*"],
+            model="gemini-2.5-flash",
+            file_system=DiskFileSystem(Path("/tmp")),
+        )
+
+        prompt = _extract_initial_prompt(config)
+        assert "<metadata>" in prompt
+        assert "<current_date>" in prompt
+        assert "<working_directory>/tmp</working_directory>" in prompt
+        assert "<objective>My Objective</objective>" in prompt
+        assert "<sandbox_environment>" not in prompt
+
+    def test_extract_initial_prompt_sandbox(self, tmp_path: Path) -> None:
+        from pathlib import Path
+        from bees.runners.antigravity import _extract_initial_prompt
+        from bees.protocols.session import SessionConfiguration
+        from bees.disk_file_system import DiskFileSystem
+        import json
+
+        # Write metadata.json with a slug
+        metadata = {"slug": "sub/agent/slug"}
+        (tmp_path / "metadata.json").write_text(json.dumps(metadata), encoding="utf-8")
+
+        config = SessionConfiguration(
+            segments=[{"text": "My Subagent Objective"}],
+            function_groups=[],
+            function_filter=["files.*"],
+            model="gemini-2.5-flash",
+            file_system=DiskFileSystem(tmp_path),
+            ticket_dir=tmp_path,
+        )
+
+        prompt = _extract_initial_prompt(config)
+        assert "<metadata>" in prompt
+        assert f"<working_directory>{tmp_path.resolve()}</working_directory>" in prompt
+        assert "<objective>" in prompt
+        assert "My Subagent Objective" in prompt
+        assert "<sandbox_environment>" in prompt
+        assert "subdirectory: ./sub/agent/slug" in prompt
+
+    def test_extract_initial_prompt_root_with_files(self) -> None:
+        from pathlib import Path
+        from bees.runners.antigravity import _extract_initial_prompt
+        from bees.protocols.session import SessionConfiguration
+        from bees.disk_file_system import DiskFileSystem
+
+        config = SessionConfiguration(
+            segments=[{"text": "My Root Objective"}],
+            function_groups=[],
+            function_filter=["files.*"],
+            model="gemini-2.5-flash",
+            file_system=DiskFileSystem(Path("/tmp")),
+        )
+
+        prompt = _extract_initial_prompt(config)
+        assert "<metadata>" in prompt
+        assert "<working_directory>/tmp</working_directory>" in prompt
+        assert "<objective>" in prompt
+        assert "My Root Objective" in prompt
+        assert "<sandbox_environment>" in prompt
+        assert "Your current working directory is the root of the workspace." in prompt
+        assert "You can read files from anywhere in the workspace." in prompt
+        assert "assigned to work in the subdirectory" not in prompt
 
 
 class TestAntigravityBuildCompleteResult:

--- a/packages/bees/tests/test_runners/test_tool_mapping.py
+++ b/packages/bees/tests/test_runners/test_tool_mapping.py
@@ -342,6 +342,14 @@ class TestMapFunctionFilter:
         assert tools == []
         assert instructions == []
 
+    def test_builtin_filter_collects_instructions(self) -> None:
+        """When a builtin group is in filter and groups list, its instructions are collected."""
+        sandbox_group = _make_group("sandbox", instruction="Use sandbox.")
+        caps, tools, instructions, _sq = map_function_filter(
+            ["sandbox.*"], [sandbox_group], _StubHooks(),
+        )
+        assert instructions == ["Use sandbox."]
+
     def test_multiple_builtin_filters(self) -> None:
         """Multiple builtin filters union their tools."""
         caps, _, _, _sq = map_function_filter(


### PR DESCRIPTION
## What
Refactored prompt construction in the `AntigravityRunner` to compile `CustomSystemInstructions` and format initial turn request prompts with structured metadata (date, working directory path) and sandbox bounds. Bypassed host-side tool instructions (`system`, `files`, `chat`) to avoid model confusion with Antigravity SDK built-ins.

## Why
Standardizing system and objective prompts improves prefix caching benefits and prevents host-side instructions (which document tools not present in the Antigravity SDK) from leaking and confusing the model.

## Changes
* **packages/bees/bees/runners/antigravity.py**:
  * Switched system instructions to `CustomSystemInstructions` for single-string prompt compilation.
  * Extracted initial turn prompts with `<metadata>` tags for `<current_date>` and `<working_directory>`.
  * Added conditional `<sandbox_environment>` block mapping for both root agents and subagents whenever files/sandbox capabilities are active.
* **packages/bees/bees/runners/tool_mapping.py**:
  * Bypassed built-in group instructions for `"system"`, `"files"`, and `"chat"` when compiling the system instructions.
* **packages/bees/tests/**:
  * Updated test assertions to check for `<working_directory>` and correct sandbox blocks.
  * Verified mapping filtering behavior and instruction collection in `test_tool_mapping.py` and `test_antigravity_events.py`.

## Testing
* Ran the python test suite: `.venv/bin/python -m pytest tests/ -v` (622 passed, 1 skipped).
