### PR TITLE
[bees] Task-State Awareness for Antigravity Orchestrator

### DIFF
--- a/packages/bees/bees/runners/antigravity.py
+++ b/packages/bees/bees/runners/antigravity.py
@@ -368,6 +368,7 @@ class AntigravityStream:
         suspend_queue: asyncio.Queue[SuspendError] | None = None,
         resume_after_step: int = -1,
         file_system: FileSystem | None = None,
+        ticket_dir: Path | None = None,
     ) -> None:
         self._agent = agent
         self._exit_stack = exit_stack
@@ -383,6 +384,7 @@ class AntigravityStream:
             suspend_queue or asyncio.Queue()
         )
         self._file_system = file_system
+        self._ticket_dir = ticket_dir
 
         self._started = False
         self._exhausted = False
@@ -453,6 +455,27 @@ class AntigravityStream:
 
             self._exhausted = True
             if not self._emitted_complete:
+                # Look ahead: check if there are active child tasks.
+                has_active_tasks = False
+                if self._ticket_dir:
+                    from bees.unified_agent_store import UnifiedAgentStore
+                    try:
+                        store = UnifiedAgentStore(self._ticket_dir.parent.parent)
+                        caller_agent_id = self._ticket_dir.name
+                        has_active_tasks = store.has_pending_tasks(caller_agent_id)
+                    except Exception:
+                        logger.warning("Failed to query active tasks in AntigravityStream", exc_info=True)
+
+                if has_active_tasks and not self._pending_suspend:
+                    from bees.protocols.handler_types import WaitForInputEvent
+                    interaction_id = str(uuid.uuid4())
+                    event = WaitForInputEvent(
+                        request_id=interaction_id,
+                        prompt={},
+                        input_type="any",
+                    )
+                    self._pending_suspend = SuspendError(event, {})
+
                 self._emitted_complete = True
 
                 # Priority 1: A tool requested suspension (deferred
@@ -727,6 +750,7 @@ class AntigravityRunner:
             tool_result_queue=tool_result_queue,
             suspend_queue=suspend_queue,
             file_system=config.file_system,
+            ticket_dir=config.ticket_dir,
         )
 
     async def resume(
@@ -817,6 +841,7 @@ class AntigravityRunner:
             suspend_queue=suspend_queue,
             resume_after_step=last_step_index,
             file_system=config.file_system,
+            ticket_dir=config.ticket_dir,
         )
 
 

--- a/packages/bees/bees/runners/tool_mapping.py
+++ b/packages/bees/bees/runners/tool_mapping.py
@@ -280,10 +280,7 @@ def wrap_bees_handler(
                 "result_id": result_id,
                 "message": (
                     "Results are pending and will be delivered "
-                    "asynchronously. Please stop and wait for the "
-                    "response — do not take further action until you "
-                    "receive a <context_update> message with this "
-                    "result_id."
+                    "asynchronously. Now, reply with \"[ack]\" and wait for a " "<context_update> message that will provide the results."
                 ),
             }
 

--- a/packages/bees/bees/unified_agent_store.py
+++ b/packages/bees/bees/unified_agent_store.py
@@ -336,3 +336,12 @@ class UnifiedAgentStore:
             kind="work",
             title=title,
         )
+
+    def has_pending_tasks(self, agent_id: str) -> bool:
+        """Check if an agent has any pending child tasks."""
+        pending_tasks = [
+            t for t in self._task_file_store.query_all()
+            if t.created_by == agent_id
+            and t.status not in ("completed", "failed", "cancelled")
+        ]
+        return len(pending_tasks) > 0

--- a/packages/bees/tests/test_runners/test_antigravity_events.py
+++ b/packages/bees/tests/test_runners/test_antigravity_events.py
@@ -298,3 +298,145 @@ class TestAntigravityBuildCompleteResult:
         asyncio.run(run_test())
 
 
+class TestAntigravityStreamTaskStateAwareness:
+    """Tests for AntigravityStream task state awareness."""
+
+    def test_antigravity_stream_awaits_active_tasks(self, tmp_path) -> None:
+        from unittest.mock import AsyncMock, MagicMock, patch
+        from bees.runners.antigravity import AntigravityStream
+        import asyncio
+
+        async def run_test():
+            # Mock the SDK Agent and its conversation step iterator
+            mock_agent = MagicMock()
+            mock_agent.conversation_id = "test-conversation-id"
+            mock_conversation = MagicMock()
+            mock_conversation.send = AsyncMock()
+            mock_agent.conversation = mock_conversation
+            
+            # Step iterator yields nothing, triggering StopAsyncIteration immediately
+            async def mock_receive_steps():
+                if False:
+                    yield None
+            mock_conversation.receive_steps.return_value = mock_receive_steps()
+            
+            # Create a mock UnifiedAgentStore and set has_pending_tasks to True
+            mock_store = MagicMock()
+            mock_store.has_pending_tasks.return_value = True
+            
+            # Set up a ticket_dir structure: tmp_path / "agents" / "parent-id"
+            agents_dir = tmp_path / "agents"
+            agents_dir.mkdir(parents=True, exist_ok=True)
+            ticket_dir = agents_dir / "parent-id"
+            ticket_dir.mkdir(exist_ok=True)
+            
+            with patch("bees.unified_agent_store.UnifiedAgentStore", return_value=mock_store):
+                stream = AntigravityStream(
+                    agent=mock_agent,
+                    exit_stack=AsyncMock(),
+                    save_dir=str(ticket_dir),
+                    initial_prompt="hello",
+                    ticket_dir=ticket_dir,
+                )
+                
+                # Step 1: Initial sendRequest
+                event1 = await stream.__anext__()
+                assert "sendRequest" in event1
+                
+                # Step 2: The model goes idle, but since tasks are active,
+                # stream should yield waitForInput instead of complete!
+                event2 = await stream.__anext__()
+                assert "waitForInput" in event2
+                assert stream._pending_suspend is not None
+
+        asyncio.run(run_test())
+
+    def test_antigravity_stream_completes_when_no_active_tasks(self, tmp_path) -> None:
+        from unittest.mock import AsyncMock, MagicMock, patch
+        from bees.runners.antigravity import AntigravityStream
+        import asyncio
+
+        async def run_test():
+            mock_agent = MagicMock()
+            mock_agent.conversation_id = "test-conversation-id"
+            mock_conversation = MagicMock()
+            mock_conversation.send = AsyncMock()
+            mock_agent.conversation = mock_conversation
+            
+            async def mock_receive_steps():
+                if False:
+                    yield None
+            mock_conversation.receive_steps.return_value = mock_receive_steps()
+            
+            # Create a mock UnifiedAgentStore and set has_pending_tasks to False
+            mock_store = MagicMock()
+            mock_store.has_pending_tasks.return_value = False
+            
+            agents_dir = tmp_path / "agents"
+            agents_dir.mkdir(parents=True, exist_ok=True)
+            ticket_dir = agents_dir / "parent-id"
+            ticket_dir.mkdir(exist_ok=True)
+            
+            with patch("bees.unified_agent_store.UnifiedAgentStore", return_value=mock_store):
+                stream = AntigravityStream(
+                    agent=mock_agent,
+                    exit_stack=AsyncMock(),
+                    save_dir=str(ticket_dir),
+                    initial_prompt="hello",
+                    ticket_dir=ticket_dir,
+                )
+                
+                event1 = await stream.__anext__()
+                assert "sendRequest" in event1
+                
+                # Since no tasks are active, should complete!
+                event2 = await stream.__anext__()
+                assert "complete" in event2
+
+        asyncio.run(run_test())
+
+    def test_antigravity_stream_awaits_queued_tasks(self, tmp_path) -> None:
+        from unittest.mock import AsyncMock, MagicMock, patch
+        from bees.runners.antigravity import AntigravityStream
+        import asyncio
+
+        async def run_test():
+            mock_agent = MagicMock()
+            mock_agent.conversation_id = "test-conversation-id"
+            mock_conversation = MagicMock()
+            mock_conversation.send = AsyncMock()
+            mock_agent.conversation = mock_conversation
+            
+            async def mock_receive_steps():
+                if False:
+                    yield None
+            mock_conversation.receive_steps.return_value = mock_receive_steps()
+            
+            # Create a mock UnifiedAgentStore and set has_pending_tasks to True
+            mock_store = MagicMock()
+            mock_store.has_pending_tasks.return_value = True
+            
+            agents_dir = tmp_path / "agents"
+            agents_dir.mkdir(parents=True, exist_ok=True)
+            ticket_dir = agents_dir / "parent-id"
+            ticket_dir.mkdir(exist_ok=True)
+            
+            with patch("bees.unified_agent_store.UnifiedAgentStore", return_value=mock_store):
+                stream = AntigravityStream(
+                    agent=mock_agent,
+                    exit_stack=AsyncMock(),
+                    save_dir=str(ticket_dir),
+                    initial_prompt="hello",
+                    ticket_dir=ticket_dir,
+                )
+                
+                event1 = await stream.__anext__()
+                assert "sendRequest" in event1
+                
+                event2 = await stream.__anext__()
+                assert "waitForInput" in event2
+                assert stream._pending_suspend is not None
+
+        asyncio.run(run_test())
+
+

--- a/packages/bees/tests/test_unified_agent_store.py
+++ b/packages/bees/tests/test_unified_agent_store.py
@@ -1,0 +1,68 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for UnifiedAgentStore operations."""
+
+from __future__ import annotations
+
+import pytest
+from pathlib import Path
+
+from bees.unified_agent_store import UnifiedAgentStore
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> UnifiedAgentStore:
+    """Create a UnifiedAgentStore backed by a temp directory."""
+    return UnifiedAgentStore(tmp_path)
+
+
+class TestHasPendingTasks:
+    def test_no_tasks(self, store: UnifiedAgentStore) -> None:
+        assert store.has_pending_tasks("agent-1") is False
+
+    def test_with_pending_tasks(self, store: UnifiedAgentStore) -> None:
+        # Create an in_progress task created by agent-1
+        store._task_file_store.create(
+            objective="Do task 1",
+            assignee="agent-2",
+            created_by="agent-1",
+        )
+        # Create a queued task created by agent-1
+        task2 = store._task_file_store.create(
+            objective="Do task 2",
+            assignee="agent-3",
+            created_by="agent-1",
+        )
+        task2.status = "queued"
+        store._task_file_store.save(task2)
+
+        # Check has_pending_tasks
+        assert store.has_pending_tasks("agent-1") is True
+
+    def test_with_only_completed_or_terminal_tasks(self, store: UnifiedAgentStore) -> None:
+        # Create completed and cancelled tasks created by agent-1
+        task1 = store._task_file_store.create(
+            objective="Do task 1",
+            assignee="agent-2",
+            created_by="agent-1",
+        )
+        task1.status = "completed"
+        store._task_file_store.save(task1)
+
+        task2 = store._task_file_store.create(
+            objective="Do task 2",
+            assignee="agent-3",
+            created_by="agent-1",
+        )
+        task2.status = "cancelled"
+        store._task_file_store.save(task2)
+
+        # Other agent has active task
+        store._task_file_store.create(
+            objective="Do task 3",
+            assignee="agent-4",
+            created_by="agent-other",
+        )
+
+        assert store.has_pending_tasks("agent-1") is False


### PR DESCRIPTION
## What
Implemented look-ahead task verification in the Antigravity session runner and encapsulated task queries in the store. This suspends the agent session instead of completing prematurely if child tasks are still active.

## Why
Prevents orchestrator/coordinator agents from completing prematurely and leaving spawned sub-tasks orphaned when the orchestrator's LLM trajectory goes idle.

## Changes
- **unified_agent_store.py**: Added generic `has_pending_tasks(agent_id)` query helper.
- **runners/antigravity.py**: Modified stream iterator StopAsyncIteration block to check `store.has_pending_tasks()` and yield a suspend (`waitForInput`) event when child tasks are running or queued. Passed `ticket_dir` down to `AntigravityStream`.
- **test_unified_agent_store.py**: Added unit tests covering store task query scenarios.
- **test_runners/test_antigravity_events.py**: Added stream lifecycle tests asserting state-aware suspension and completion logic.

## Testing
Verify by running python unit tests:
```bash
npm run test:python
```
