### PR TITLE
[bees] Inject Specialized Files System Instruction in AntigravityRunner

### DIFF
--- a/packages/bees/bees/runners/antigravity.py
+++ b/packages/bees/bees/runners/antigravity.py
@@ -245,9 +245,22 @@ AGENT_IDENTITY = (
     "agent. The outcome is also not visible to the user to the application."
 )
 
+FILES_INSTRUCTION_ANTIGRAVITY = """## Passing around files
+
+You can pass files around using the `<file src="filename.ext" />` syntax.
+
+Use the <file> tag to present the files to the user. 
+
+The post-processing parser replaces each `<file>` tag with the file's
+contents. Make sure your output reads well after the replacement.
+
+Only reference files that you know to exist. Hypothetical file tags they will cause processing errors.
+"""
+
 
 def _assemble_system_instructions(
     active_instructions: list[str],
+    has_files: bool = False,
 ) -> ag_types.CustomSystemInstructions:
     """Build SDK system instructions from all active tool group instructions.
 
@@ -258,6 +271,8 @@ def _assemble_system_instructions(
     identity_block = f"<identity>\n{AGENT_IDENTITY}\n</identity>"
 
     instructions_parts = [inst.strip() for inst in active_instructions if inst.strip()]
+    if has_files:
+        instructions_parts.append(FILES_INSTRUCTION_ANTIGRAVITY.strip())
     active_text = "\n\n".join(instructions_parts)
 
     final_prompt = f"{identity_block}\n\n{active_text}"
@@ -697,8 +712,13 @@ class AntigravityRunner:
         )
 
         # 2. Assemble system instructions from all active tool groups.
+        has_files = (config.function_filter is None) or any(
+            pattern.startswith("files")
+            for pattern in config.function_filter
+        )
         system_instructions = _assemble_system_instructions(
             custom_instructions,
+            has_files=has_files,
         )
 
         # 3. Build workspace path.
@@ -794,8 +814,13 @@ class AntigravityRunner:
         )
 
         # 3. Assemble system instructions from all active tool groups.
+        has_files = (config.function_filter is None) or any(
+            pattern.startswith("files")
+            for pattern in config.function_filter
+        )
         system_instructions = _assemble_system_instructions(
             custom_instructions,
+            has_files=has_files,
         )
 
         # 4. Build workspace path.

--- a/packages/bees/tests/test_runners/test_antigravity_events.py
+++ b/packages/bees/tests/test_runners/test_antigravity_events.py
@@ -141,6 +141,33 @@ class TestAntigravitySystemInstructions:
         assert "custom note 1" in custom_si.text
         assert "custom note 2" in custom_si.text
 
+    def test_assemble_system_instructions_with_files(self) -> None:
+        from bees.runners.antigravity import (
+            _assemble_system_instructions,
+            FILES_INSTRUCTION_ANTIGRAVITY,
+        )
+
+        custom = ["custom note 1"]
+        custom_si = _assemble_system_instructions(custom, has_files=True)
+
+        assert isinstance(custom_si, ag_types.CustomSystemInstructions)
+        assert FILES_INSTRUCTION_ANTIGRAVITY.strip() in custom_si.text
+        # Ensure it has been specialized for Antigravity:
+        assert "Use the <file> tag to present the files to the user" in custom_si.text
+        assert "files_list_files" not in custom_si.text
+
+    def test_assemble_system_instructions_without_files(self) -> None:
+        from bees.runners.antigravity import (
+            _assemble_system_instructions,
+            FILES_INSTRUCTION_ANTIGRAVITY,
+        )
+
+        custom = ["custom note 1"]
+        custom_si = _assemble_system_instructions(custom, has_files=False)
+
+        assert isinstance(custom_si, ag_types.CustomSystemInstructions)
+        assert FILES_INSTRUCTION_ANTIGRAVITY.strip() not in custom_si.text
+
 
 class TestAntigravityExtractInitialPrompt:
     """Tests for ``_extract_initial_prompt``."""


### PR DESCRIPTION
## What
Injects a specialized file-system instruction to the system instructions block when files capabilities are enabled for `AntigravityRunner`.

## Why
Ensures that the Antigravity runner receives proper guidance on using the `<file>` tags for formatting file contents in output while ignoring host-specific instructions and aligning with the runner's tool layout.

## Changes
### packages/bees
- **`bees/runners/antigravity.py`**: Added `FILES_INSTRUCTION_ANTIGRAVITY` constant. Updated `_assemble_system_instructions`, `run`, and `resume` to conditionally append the files instruction when files capabilities are requested (or function filter is empty).
- **`tests/test_runners/test_antigravity_events.py`**: Added unit tests to `TestAntigravitySystemInstructions` to assert correct conditional injection and ensure the prompt content remains specialized and safe.

## Testing
Unit tests in `packages/bees` passed successfully:
```bash
.venv/bin/pytest tests/test_runners/test_antigravity_events.py
```
