### PR TITLE
[bees] Extract idle resolution state machine, fix Silent Turn Fallthrough

### DIFF
--- a/packages/bees/bees/runners/antigravity.py
+++ b/packages/bees/bees/runners/antigravity.py
@@ -48,6 +48,7 @@ from bees.protocols.session import (
     SessionEvent,
 )
 from bees.protocols.filesystem import FileSystem
+from bees.runners.idle_resolution import IdleInputs, IdleOutcome, resolve_idle
 from bees.runners.tool_mapping import map_function_filter
 
 __all__ = ["AntigravityRunner", "AntigravityStream"]
@@ -479,64 +480,22 @@ class AntigravityStream:
 
             self._exhausted = True
             if not self._emitted_complete:
-                # Look ahead: check if there are active child tasks.
-                has_active_tasks = False
-                if self._ticket_dir:
-                    from bees.unified_agent_store import UnifiedAgentStore
-                    try:
-                        store = UnifiedAgentStore(self._ticket_dir.parent.parent)
-                        caller_agent_id = self._ticket_dir.name
-                        has_active_tasks = store.has_pending_tasks(caller_agent_id)
-                    except Exception:
-                        logger.warning("Failed to query active tasks in AntigravityStream", exc_info=True)
-
-                if has_active_tasks and not self._pending_suspend:
-                    from bees.protocols.handler_types import WaitForInputEvent
-                    interaction_id = str(uuid.uuid4())
-                    event = WaitForInputEvent(
-                        request_id=interaction_id,
-                        prompt={},
-                        input_type="any",
-                    )
-                    self._pending_suspend = SuspendError(event, {})
-
+                idle_inputs = self._build_idle_inputs()
+                outcome, event = resolve_idle(idle_inputs)
                 self._emitted_complete = True
 
-                # Priority 1: A tool requested suspension (deferred
-                # result pattern).  This overrides both chat and
-                # worker idle behavior — the agent MUST suspend.
-                if self._pending_suspend:
-                    await self._cleanup()
-                    return {"waitForInput": {
-                        "requestId": (
-                            self._pending_suspend.interaction_id
-                        ),
-                        "prompt": {},
-                        "inputType": "any",
-                    }}
+                # Side effect: log model text to chat log.
+                if (
+                    outcome == IdleOutcome.SUSPEND_CHAT
+                    and self._last_user_text
+                    and self._on_chat_entry
+                ):
+                    self._on_chat_entry("agent", self._last_user_text)
 
-                # Priority 2: Chat mode — idle without FINISH =
-                # waiting for user input.
-                if self._has_chat and self._last_user_text:
-                    # Log the model's message to the chat log.
-                    if self._on_chat_entry:
-                        self._on_chat_entry("agent", self._last_user_text)
-
-                    await self._cleanup()
-                    return {"waitForInput": {
-                        "requestId": str(uuid.uuid4()),
-                        "prompt": {
-                            "parts": [{"text": self._last_user_text}],
-                        },
-                        "inputType": "text",
-                    }}
-
-                # Default: Worker mode — idle without FINISH = done.
                 await self._cleanup()
-                return {"complete": {"result": {
-                    "success": True,
-                    "outcomes": {"parts": [{"text": ""}]},
-                }}}
+                if outcome == IdleOutcome.ALREADY_COMPLETE:
+                    raise
+                return event
 
             await self._cleanup()
             raise
@@ -646,6 +605,35 @@ class AntigravityStream:
         return self._resume_blob
 
     # -- internal ----------------------------------------------------------
+
+    def _build_idle_inputs(self) -> IdleInputs:
+        """Gather accumulated state for the idle resolution state machine."""
+        has_active_tasks = False
+        if self._ticket_dir:
+            from bees.unified_agent_store import UnifiedAgentStore
+            try:
+                store = UnifiedAgentStore(self._ticket_dir.parent.parent)
+                caller_agent_id = self._ticket_dir.name
+                has_active_tasks = store.has_pending_tasks(caller_agent_id)
+            except Exception:
+                logger.warning(
+                    "Failed to query active tasks in AntigravityStream",
+                    exc_info=True,
+                )
+
+        return IdleInputs(
+            emitted_complete=self._emitted_complete,
+            pending_suspend=self._pending_suspend is not None,
+            suspend_request_id=(
+                self._pending_suspend.interaction_id
+                if self._pending_suspend
+                else ""
+            ),
+            has_active_tasks=has_active_tasks,
+            has_chat=self._has_chat,
+            last_user_text=self._last_user_text,
+        )
+
 
     def _capture_resume_state(self) -> None:
         """Capture resume state from the agent's conversation."""

--- a/packages/bees/bees/runners/idle_resolution.py
+++ b/packages/bees/bees/runners/idle_resolution.py
@@ -1,0 +1,137 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Idle resolution state machine for the Antigravity runner.
+
+When the Antigravity SDK's step stream exhausts (``StopAsyncIteration``),
+the runner must decide what terminal event to emit.  This module
+encodes that decision as a pure function: dataclass in, enum + event
+dict out.
+
+The decision priority chain:
+
+1. **Already complete** — the SDK emitted a FINISH step during this
+   turn.  Nothing more to decide.
+2. **Deferred suspend** — a tool (e.g. ``agents_await``) requested
+   suspension via the suspend queue.  The agent MUST suspend so the
+   scheduler can deliver the result asynchronously.
+3. **Active child tasks** — child agents are still running.  Synthesize
+   a deferred suspend so the scheduler keeps the session alive.
+4. **Chat idle** — the session has ``chat.*`` in its function filter and
+   the model produced user-facing text.  Suspend for user input.
+5. **Worker done** — none of the above.  The agent finished its work.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+__all__ = ["IdleInputs", "IdleOutcome", "resolve_idle"]
+
+
+class IdleOutcome(Enum):
+    """Terminal state after an SDK turn ends."""
+
+    ALREADY_COMPLETE = "already_complete"
+    COMPLETE = "complete"
+    SUSPEND_DEFERRED = "suspend_deferred"
+    SUSPEND_CHAT = "suspend_chat"
+
+
+@dataclass
+class IdleInputs:
+    """Accumulated state at SDK turn end.
+
+    Attributes:
+        emitted_complete: The SDK emitted a FINISH step during this turn.
+        pending_suspend: A tool requested deferred suspension.
+        suspend_request_id: Request ID from the pending suspend (empty if none).
+        has_active_tasks: Child agents are still running.
+        has_chat: Session has ``chat.*`` in its function filter.
+        last_user_text: Accumulated model text directed at the user.
+    """
+
+    emitted_complete: bool = False
+    pending_suspend: bool = False
+    suspend_request_id: str = ""
+    has_active_tasks: bool = False
+    has_chat: bool = False
+    last_user_text: str = ""
+
+
+def resolve_idle(inputs: IdleInputs) -> tuple[IdleOutcome, dict[str, Any]]:
+    """Given turn-end state, determine the terminal event to emit.
+
+    Returns a tuple of (outcome, event_dict).  The event_dict is ready
+    to be yielded as a ``SessionEvent``.
+    """
+    # Priority 0: SDK already emitted a FINISH step — nothing to decide.
+    if inputs.emitted_complete:
+        return IdleOutcome.ALREADY_COMPLETE, {}
+
+    # Priority 1: Active child tasks without an existing suspend →
+    # synthesize a deferred suspend so the scheduler keeps us alive.
+    if inputs.has_active_tasks and not inputs.pending_suspend:
+        request_id = str(uuid.uuid4())
+        return IdleOutcome.SUSPEND_DEFERRED, _deferred_event(request_id)
+
+    # Priority 2: A tool requested suspension (deferred result pattern).
+    if inputs.pending_suspend:
+        return IdleOutcome.SUSPEND_DEFERRED, _deferred_event(
+            inputs.suspend_request_id,
+        )
+
+    # Priority 3: Chat mode — idle without FINISH = waiting for user.
+    # The session is infinite; it must always suspend regardless of
+    # whether the model produced text.  The text is presentation data
+    # for the prompt, not a lifecycle gate.
+    if inputs.has_chat:
+        return IdleOutcome.SUSPEND_CHAT, _chat_event(inputs.last_user_text)
+
+    # Default: Worker mode — idle without FINISH = done.
+    return IdleOutcome.COMPLETE, _complete_event()
+
+
+# ---------------------------------------------------------------------------
+# Event constructors
+# ---------------------------------------------------------------------------
+
+
+def _deferred_event(request_id: str) -> dict[str, Any]:
+    """Build a ``waitForInput`` event for deferred/system-initiated suspend."""
+    return {
+        "waitForInput": {
+            "requestId": request_id,
+            "prompt": {},
+            "inputType": "any",
+        },
+    }
+
+
+def _chat_event(user_text: str) -> dict[str, Any]:
+    """Build a ``waitForInput`` event for chat-mode suspend."""
+    prompt: dict[str, Any] = {}
+    if user_text:
+        prompt = {"parts": [{"text": user_text}]}
+    return {
+        "waitForInput": {
+            "requestId": str(uuid.uuid4()),
+            "prompt": prompt,
+            "inputType": "text",
+        },
+    }
+
+
+def _complete_event() -> dict[str, Any]:
+    """Build a ``complete`` event for worker-mode idle."""
+    return {
+        "complete": {
+            "result": {
+                "success": True,
+                "outcomes": {"parts": [{"text": ""}]},
+            },
+        },
+    }

--- a/packages/bees/tests/test_runners/test_antigravity_events.py
+++ b/packages/bees/tests/test_runners/test_antigravity_events.py
@@ -374,7 +374,6 @@ class TestAntigravityStreamTaskStateAwareness:
                 # stream should yield waitForInput instead of complete!
                 event2 = await stream.__anext__()
                 assert "waitForInput" in event2
-                assert stream._pending_suspend is not None
 
         asyncio.run(run_test())
 
@@ -462,7 +461,6 @@ class TestAntigravityStreamTaskStateAwareness:
                 
                 event2 = await stream.__anext__()
                 assert "waitForInput" in event2
-                assert stream._pending_suspend is not None
 
         asyncio.run(run_test())
 

--- a/packages/bees/tests/test_runners/test_idle_resolution.py
+++ b/packages/bees/tests/test_runners/test_idle_resolution.py
@@ -1,0 +1,145 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the idle resolution state machine.
+
+Covers all branches of ``resolve_idle`` and documents the expected
+behavior for each combination of inputs.  The "silent turn" test
+documents the correct behavior (should suspend) and will FAIL
+against the initial extraction until the bug is fixed.
+"""
+
+from __future__ import annotations
+
+from bees.runners.idle_resolution import IdleInputs, IdleOutcome, resolve_idle
+
+
+# ---------------------------------------------------------------------------
+# Worker mode (has_chat=False)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkerMode:
+    """Worker-mode sessions complete when idle without a FINISH step."""
+
+    def test_completes_when_sdk_emitted_finish(self) -> None:
+        """ALREADY_COMPLETE when the SDK already said we're done."""
+        inputs = IdleInputs(emitted_complete=True)
+        outcome, event = resolve_idle(inputs)
+        assert outcome == IdleOutcome.ALREADY_COMPLETE
+        assert event == {}
+
+    def test_completes_when_idle_no_finish(self) -> None:
+        """Worker idle without FINISH = done."""
+        inputs = IdleInputs(has_chat=False)
+        outcome, event = resolve_idle(inputs)
+        assert outcome == IdleOutcome.COMPLETE
+        assert "complete" in event
+        assert event["complete"]["result"]["success"] is True
+
+    def test_suspends_on_deferred_result(self) -> None:
+        """A tool requested deferred suspension via suspend queue."""
+        inputs = IdleInputs(
+            pending_suspend=True,
+            suspend_request_id="req-123",
+        )
+        outcome, event = resolve_idle(inputs)
+        assert outcome == IdleOutcome.SUSPEND_DEFERRED
+        assert "waitForInput" in event
+        assert event["waitForInput"]["requestId"] == "req-123"
+        assert event["waitForInput"]["inputType"] == "any"
+
+    def test_suspends_when_active_child_tasks(self) -> None:
+        """Active child tasks synthesize a deferred suspend."""
+        inputs = IdleInputs(has_active_tasks=True)
+        outcome, event = resolve_idle(inputs)
+        assert outcome == IdleOutcome.SUSPEND_DEFERRED
+        assert "waitForInput" in event
+        assert event["waitForInput"]["inputType"] == "any"
+        # Request ID is auto-generated.
+        assert event["waitForInput"]["requestId"]
+
+
+# ---------------------------------------------------------------------------
+# Chat mode (has_chat=True)
+# ---------------------------------------------------------------------------
+
+
+class TestChatMode:
+    """Chat-mode sessions suspend when idle — they never complete."""
+
+    def test_suspends_with_prompt_when_model_produced_text(self) -> None:
+        """Normal chat turn: model responds, session suspends for user."""
+        inputs = IdleInputs(has_chat=True, last_user_text="Hello!")
+        outcome, event = resolve_idle(inputs)
+        assert outcome == IdleOutcome.SUSPEND_CHAT
+        assert "waitForInput" in event
+        assert event["waitForInput"]["inputType"] == "text"
+        assert event["waitForInput"]["prompt"] == {
+            "parts": [{"text": "Hello!"}],
+        }
+
+    def test_suspends_on_silent_turn(self) -> None:
+        """Silent Turn Fallthrough: chat session resumed with a context
+        update, model processes silently (no user-facing text).
+
+        The session MUST still suspend — it is infinite.
+        """
+        inputs = IdleInputs(has_chat=True, last_user_text="")
+        outcome, event = resolve_idle(inputs)
+        assert outcome == IdleOutcome.SUSPEND_CHAT, (
+            f"Expected SUSPEND_CHAT but got {outcome}. "
+            "Chat sessions must suspend even when the model is silent."
+        )
+        assert "waitForInput" in event
+        assert event["waitForInput"]["inputType"] == "text"
+
+
+# ---------------------------------------------------------------------------
+# Priority ordering
+# ---------------------------------------------------------------------------
+
+
+class TestPriorityOrdering:
+    """Verify the priority chain when multiple conditions are true."""
+
+    def test_deferred_suspend_beats_chat(self) -> None:
+        inputs = IdleInputs(
+            pending_suspend=True,
+            suspend_request_id="req-456",
+            has_chat=True,
+            last_user_text="Hi there",
+        )
+        outcome, event = resolve_idle(inputs)
+        assert outcome == IdleOutcome.SUSPEND_DEFERRED
+        assert event["waitForInput"]["requestId"] == "req-456"
+
+    def test_active_tasks_beat_chat(self) -> None:
+        inputs = IdleInputs(
+            has_active_tasks=True,
+            has_chat=True,
+            last_user_text="Working on it...",
+        )
+        outcome, event = resolve_idle(inputs)
+        assert outcome == IdleOutcome.SUSPEND_DEFERRED
+
+    def test_deferred_suspend_beats_active_tasks(self) -> None:
+        """When both are set, the tool's request ID is used."""
+        inputs = IdleInputs(
+            pending_suspend=True,
+            suspend_request_id="req-789",
+            has_active_tasks=True,
+        )
+        outcome, event = resolve_idle(inputs)
+        assert outcome == IdleOutcome.SUSPEND_DEFERRED
+        assert event["waitForInput"]["requestId"] == "req-789"
+
+    def test_already_complete_takes_absolute_precedence(self) -> None:
+        inputs = IdleInputs(
+            emitted_complete=True,
+            pending_suspend=True,
+            has_chat=True,
+            last_user_text="Hello",
+        )
+        outcome, event = resolve_idle(inputs)
+        assert outcome == IdleOutcome.ALREADY_COMPLETE


### PR DESCRIPTION
## What
Extracted the idle-detection logic from `AntigravityStream.__anext__` into a pure-function state machine (`resolve_idle`) and fixed a bug where infinite chat sessions could complete instead of suspending.

## Why
When an antigravity chat session was resumed with a context update (e.g. subagent completion) and the model processed it without producing user-facing text, the session fell through to worker-mode completion. The root cause: the chat-suspend gate was `if has_chat and last_user_text`, making suspension conditional on model output — but each resume creates a fresh stream, so `last_user_text` starts empty.

## Changes

### `packages/bees/bees/runners/`
- **[NEW] `idle_resolution.py`** — Pure-function state machine. `IdleInputs` dataclass → `(IdleOutcome, event_dict)`. Encodes the priority chain: ALREADY_COMPLETE > SUSPEND_DEFERRED > SUSPEND_CHAT > COMPLETE.
- **`antigravity.py`** — Replaced 64-line inline `if` cascade with delegation to `resolve_idle`. Added `_build_idle_inputs()` to gather stream state. Side effects (chat log, cleanup) remain in the stream.

### `packages/bees/tests/test_runners/`
- **[NEW] `test_idle_resolution.py`** — 10 tests covering all branches and priority orderings, including `test_suspends_on_silent_turn` which reproduces the bug.
- **`test_antigravity_events.py`** — Removed 2 assertions on `stream._pending_suspend` (implementation detail that no longer exists; the behavior was already asserted via the emitted event).

## Testing
```bash
cd packages/bees && .venv/bin/python -m pytest tests/test_runners/ -v
# 104 passed
```
