### PR TITLE
[bees] Fix incorrect imageSize mapping in image adapter

### DIFF
--- a/packages/bees/bees/runners/adapters/image.py
+++ b/packages/bees/bees/runners/adapters/image.py
@@ -140,15 +140,6 @@ class ImageAdapter:
 # within generationConfig.  See:
 # https://ai.google.dev/gemini-api/docs/image-generation
 
-_IMAGE_SIZE_MAP: dict[str, str] = {
-    "512": "512",
-    "1K": "1024",
-    "1k": "1024",
-    "2K": "2048",
-    "2k": "2048",
-    "4K": "4096",
-    "4k": "4096",
-}
 
 
 def _build_generation_config(
@@ -169,8 +160,7 @@ def _build_generation_config(
 
     image_size = options.get("image_size")
     if image_size:
-        mapped = _IMAGE_SIZE_MAP.get(str(image_size), str(image_size))
-        image_config["imageSize"] = mapped
+        image_config["imageSize"] = str(image_size)
 
     person_generation = options.get("person_generation")
     if person_generation:


### PR DESCRIPTION
## What
Removed `_IMAGE_SIZE_MAP` from the image generation adapter that was incorrectly converting image size values (e.g. `"1K"` → `"1024"`).

## Why
The Gemini `ImageConfig.imageSize` field accepts plain strings like `"512"`, `"1K"`, `"2K"`, `"4K"` — not pixel counts. The mapping was producing values the API doesn't recognize, which was a likely cause of 400 errors during image generation.

## Changes
- **`packages/bees/bees/runners/adapters/image.py`**
  - Deleted `_IMAGE_SIZE_MAP` dictionary
  - Pass `image_size` option through directly to `imageConfig.imageSize`

## Testing
Verify image generation with `image_size: "1K"` no longer produces 400 errors from the Gemini API.
