### PR TITLE
[bees] Binary Trajectory Log Decompression and Parsing in Box Watcher

### DIFF
--- a/packages/bees/bees/box.py
+++ b/packages/bees/bees/box.py
@@ -55,6 +55,7 @@ from bees.runners.live import LiveRunner
 from bees.runners.antigravity import AntigravityRunner
 from bees.runners.direct_model import DirectModelRunner
 from bees.agent import Agent
+from bees.trajectory_parser import convert_trajectory_to_json
 from opal_backend.local.backend_client_impl import HttpBackendClient
 
 logger = logging.getLogger("bees.box")
@@ -76,6 +77,9 @@ def classify_change(path: Path, hive_dir: Path) -> ChangeKind:
         ``"mutation"`` for mutation files that need atomic processing,
         ``"ignore"`` for everything else (logs, temp files, etc.).
     """
+    if path.name == "antigravity_traj.json":
+        return "ignore"
+
     try:
         rel = path.relative_to(hive_dir)
     except ValueError:
@@ -213,7 +217,13 @@ async def run(
                 needs_mutation = False
 
                 for _change_type, changed_path in changes:
-                    kind = classify_change(Path(changed_path), hive_dir)
+                    path = Path(changed_path)
+                    # If an antigravity trajectory file changed, write its JSON representation.
+                    if path.name.startswith("traj-") and path.parent.name == "antigravity_state" and path.is_file():
+                        dest_path = path.parent.parent / "antigravity_traj.json"
+                        convert_trajectory_to_json(path, dest_path)
+
+                    kind = classify_change(path, hive_dir)
                     if kind == "config":
                         needs_restart = True
                     elif kind == "task":

--- a/packages/bees/bees/trajectory_parser.py
+++ b/packages/bees/bees/trajectory_parser.py
@@ -1,0 +1,275 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import struct
+import json
+import logging
+import zstandard as zstd
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+logger = logging.getLogger("bees.trajectory_parser")
+
+def read_varint(data: bytes, pos: int) -> Tuple[int, int]:
+    val = 0
+    shift = 0
+    start = pos
+    while pos < len(data):
+        b = data[pos]
+        pos += 1
+        val |= (b & 0x7f) << shift
+        if not (b & 0x80):
+            return val, pos
+        shift += 7
+        if shift >= 64:
+            break
+    return 0, start
+
+def is_readable_string(data: bytes) -> bool:
+    try:
+        s = data.decode('utf-8')
+        if not s:
+            return False
+        for c in s:
+            o = ord(c)
+            if (o < 32 and c not in '\n\r\t') or o == 127 or (128 <= o <= 159):
+                return False
+        return True
+    except Exception:
+        return False
+
+def is_valid_protobuf(data: bytes) -> bool:
+    if not data:
+        return False
+    pos = 0
+    length = len(data)
+    fields_found = 0
+    while pos < length:
+        tag, new_pos = read_varint(data, pos)
+        if new_pos == pos or tag == 0:
+            return False
+        pos = new_pos
+        field_number = tag >> 3
+        wire_type = tag & 0x07
+        
+        if field_number == 0 or field_number > 20000:
+            return False
+        
+        if wire_type == 0:
+            val, new_pos = read_varint(data, pos)
+            if new_pos == pos:
+                return False
+            pos = new_pos
+        elif wire_type == 1:
+            if pos + 8 > length:
+                return False
+            pos += 8
+        elif wire_type == 2:
+            val_len, new_pos = read_varint(data, pos)
+            if new_pos == pos or pos + val_len > length:
+                return False
+            pos = new_pos + val_len
+        elif wire_type == 5:
+            if pos + 4 > length:
+                return False
+            pos += 4
+        else:
+            return False
+        fields_found += 1
+    return pos == length and fields_found > 0
+
+def parse_proto(data: bytes) -> List[Tuple[int, Any]]:
+    fields = []
+    pos = 0
+    length = len(data)
+    while pos < length:
+        tag, new_pos = read_varint(data, pos)
+        if new_pos == pos:
+            break
+        pos = new_pos
+        field_number = tag >> 3
+        wire_type = tag & 0x07
+        
+        if wire_type == 0:
+            val, pos = read_varint(data, pos)
+            fields.append((field_number, val))
+        elif wire_type == 1:
+            if pos + 8 <= length:
+                val = struct.unpack("<Q", data[pos:pos+8])[0]
+                pos += 8
+                fields.append((field_number, val))
+            else:
+                break
+        elif wire_type == 2:
+            val_len, pos = read_varint(data, pos)
+            if pos + val_len <= length:
+                val_data = data[pos:pos+val_len]
+                pos += val_len
+                
+                is_str = is_readable_string(val_data)
+                    
+                if is_str:
+                    fields.append((field_number, val_data.decode('utf-8')))
+                elif is_valid_protobuf(val_data):
+                    fields.append((field_number, parse_proto(val_data)))
+                else:
+                    fields.append((field_number, val_data))
+            else:
+                break
+        elif wire_type == 5:
+            if pos + 4 <= length:
+                val = struct.unpack("<I", data[pos:pos+4])[0]
+                pos += 4
+                fields.append((field_number, val))
+            else:
+                break
+        else:
+            break
+    return fields
+
+def get_field(fields: List[Tuple[int, Any]], num: int) -> Any:
+    for f, v in fields:
+        if f == num:
+            return v
+    return None
+
+def get_fields(fields: List[Tuple[int, Any]], num: int) -> List[Any]:
+    return [v for f, v in fields if f == num]
+
+def format_timestamp(step_fields: List[Tuple[int, Any]]) -> str:
+    field5 = get_field(step_fields, 5)
+    if not isinstance(field5, list):
+        return "Unknown Time"
+    field1 = get_field(field5, 1)
+    if not isinstance(field1, list):
+        return "Unknown Time"
+    seconds = get_field(field1, 1)
+    if seconds is None:
+        return "Unknown Time"
+    try:
+        dt = datetime.fromtimestamp(seconds)
+        return dt.strftime("%Y-%m-%d %H:%M:%S")
+    except Exception:
+        return "Unknown Time"
+
+def trajectory_to_dict(decompressed_data: bytes) -> Dict[str, Any]:
+    parsed = parse_proto(decompressed_data)
+    trajectory_id = get_field(parsed, 1)
+    steps = get_fields(parsed, 2)
+    
+    steps_list = []
+    for i, step in enumerate(steps):
+        step_type_val = get_field(step, 1)
+        time_str = format_timestamp(step)
+        
+        step_dict: Dict[str, Any] = {
+            "step_index": i + 1,
+            "timestamp": time_str,
+        }
+        
+        if step_type_val == 14:
+            step_dict["type"] = "user_input"
+            input_msg = get_field(step, 19)
+            if isinstance(input_msg, list):
+                prompt = get_field(input_msg, 2) or get_field(input_msg, 3)
+                if isinstance(prompt, list):
+                    prompt = get_field(prompt, 1)
+                step_dict["content"] = prompt if isinstance(prompt, str) else ""
+            else:
+                step_dict["content"] = ""
+                
+        elif step_type_val == 15:
+            step_dict["type"] = "model_output"
+            output_msg = get_field(step, 20)
+            if isinstance(output_msg, list):
+                thought = get_field(output_msg, 3)
+                if thought:
+                    step_dict["thought"] = thought.strip()
+                
+                content = get_field(output_msg, 8) or get_field(output_msg, 1)
+                if isinstance(content, str):
+                    step_dict["content"] = content.strip()
+                
+                tool_calls = get_fields(output_msg, 7)
+                tcs_list = []
+                for tc in tool_calls:
+                    if isinstance(tc, list):
+                        name = get_field(tc, 2)
+                        args = get_field(tc, 3)
+                        tc_dict = {"name": name}
+                        if args:
+                            try:
+                                tc_dict["arguments"] = json.loads(args)
+                            except Exception:
+                                tc_dict["arguments"] = args
+                        tcs_list.append(tc_dict)
+                if tcs_list:
+                    step_dict["tool_calls"] = tcs_list
+                    
+        elif step_type_val == 17:
+            step_dict["type"] = "error"
+            error_msg = get_field(step, 24)
+            if isinstance(error_msg, list):
+                f3 = get_field(error_msg, 3)
+                if isinstance(f3, list):
+                    err_txt = get_field(f3, 2) or get_field(f3, 9) or get_field(f3, 1)
+                    if isinstance(err_txt, str):
+                        step_dict["error"] = err_txt
+                else:
+                    err_txt = get_field(error_msg, 9) or get_field(error_msg, 1)
+                    if isinstance(err_txt, str):
+                        step_dict["error"] = err_txt
+        elif step_type_val == 2:
+            step_dict["type"] = "complete"
+            complete_msg = get_field(step, 12)
+            if isinstance(complete_msg, list):
+                outcome_json = get_field(complete_msg, 2)
+                if outcome_json:
+                    try:
+                        step_dict["outcome"] = json.loads(outcome_json)
+                    except Exception:
+                        step_dict["outcome"] = outcome_json
+                    
+        elif step_type_val == 103:
+            step_dict["type"] = "tool_response"
+            tool_resp_msg = get_field(step, 116)
+            if isinstance(tool_resp_msg, list):
+                name = get_field(tool_resp_msg, 2)
+                field4 = get_field(tool_resp_msg, 4)
+                resp_json = None
+                if isinstance(field4, list):
+                    field2 = get_field(field4, 2)
+                    if isinstance(field2, list):
+                        resp_json = get_field(field2, 2)
+                
+                step_dict["tool_name"] = name
+                if resp_json:
+                    try:
+                        step_dict["response"] = json.loads(resp_json)
+                    except Exception:
+                        step_dict["response"] = resp_json
+            else:
+                step_dict["tool_name"] = "unknown"
+        else:
+            step_dict["type"] = f"unknown_{step_type_val}"
+            
+        steps_list.append(step_dict)
+        
+    return {
+        "trajectory_id": trajectory_id if isinstance(trajectory_id, str) else str(trajectory_id),
+        "steps": steps_list,
+    }
+
+def convert_trajectory_to_json(filepath: Path, destpath: Path) -> bool:
+    try:
+        compressed_data = filepath.read_bytes()
+        dctx = zstd.ZstdDecompressor()
+        decompressed_data = dctx.decompress(compressed_data)
+        traj_dict = trajectory_to_dict(decompressed_data)
+        
+        destpath.write_text(json.dumps(traj_dict, indent=2), encoding="utf-8")
+        return True
+    except Exception as e:
+        logger.error("Failed to convert trajectory file %s to JSON: %s", filepath, e, exc_info=True)
+        return False

--- a/packages/bees/tests/test_box.py
+++ b/packages/bees/tests/test_box.py
@@ -99,3 +99,9 @@ class TestClassifyChange:
         assert classify_change(
             HIVE / "mutations" / ".box-active", HIVE
         ) == "ignore"
+
+    def test_trajectory_json_ignored(self):
+        assert classify_change(
+            HIVE / "agents" / "abc-123" / "antigravity_traj.json", HIVE
+        ) == "ignore"
+

--- a/packages/bees/tests/test_trajectory_parser.py
+++ b/packages/bees/tests/test_trajectory_parser.py
@@ -1,0 +1,143 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import zstandard as zstd
+from pathlib import Path
+from bees.trajectory_parser import convert_trajectory_to_json, trajectory_to_dict
+
+def test_trajectory_parsing(tmp_path: Path):
+    # Construct a simple mock trajectory protobuf byte stream.
+    # Outer Message:
+    #   Field 1 (trajectory_id): "mock_traj" (tag 1, wire type 2)
+    #   Field 2 (Step, repeated):
+    #     Step 1:
+    #       Field 1 (type): 14 (User Input, tag 1, wire type 0)
+    #       Field 19 (User message, tag 19, wire type 2) -> contains Field 2 (prompt): "Objective text" (tag 2, wire type 2)
+    #     Step 2:
+    #       Field 1 (type): 15 (Model Output, tag 1, wire type 0)
+    #       Field 20 (Model response, tag 20, wire type 2) -> contains Field 3 (thought): "Thinking..." (tag 3, wire type 2)
+    
+    # 1. Build Step 1 (User Input)
+    # Field 2 (prompt) of Field 19: "Objective text" (tag 2, wire type 2 -> 0x12, length 14 -> 0x0e)
+    prompt_payload = b"\x12\x0eObjective text"
+    # Field 19: tag 19, wire type 2 -> (19 << 3) | 2 = 154 -> 0x9a 0x01, length 16 -> 0x10
+    step1_field19 = b"\x9a\x01\x10" + prompt_payload
+    # Step 1 outer: Field 1 = 14 (tag 1, wire type 0 -> 0x08, value 14 -> 0x0e) + Field 19
+    step1_payload = b"\x08\x0e" + step1_field19
+    # Step 1 wrapped: tag 2, wire type 2 -> 0x12, length 21 -> 0x15
+    step1_wrapped = b"\x12\x15" + step1_payload
+
+    # 2. Build Step 2 (Model Output)
+    # Field 3 (thought) of Field 20: "Thinking..." (tag 3, wire type 2 -> 0x1a, length 11 -> 0x0b)
+    thought_payload = b"\x1a\x0bThinking..."
+    # Field 20: tag 20, wire type 2 -> (20 << 3) | 2 = 162 -> 0xa2 0x01, length 13 -> 0x0d
+    step2_field20 = b"\xa2\x01\x0d" + thought_payload
+    # Step 2 outer: Field 1 = 15 (tag 1, wire type 0 -> 0x08, value 15 -> 0x0f) + Field 20
+    step2_payload = b"\x08\x0f" + step2_field20
+    # Step 2 wrapped: tag 2, wire type 2 -> 0x12, length 18 -> 0x12
+    step2_wrapped = b"\x12\x12" + step2_payload
+
+    # 3. Build Outer Trajectory Message
+    # Field 1 (trajectory_id): "mock_traj" (tag 1, wire type 2 -> 0x0a, length 9 -> 0x09)
+    traj_id_payload = b"\x0a\x09mock_traj"
+    
+    # Combine everything
+    outer_protobuf = traj_id_payload + step1_wrapped + step2_wrapped
+    
+    # Compress using zstd
+    cctx = zstd.ZstdCompressor()
+    compressed = cctx.compress(outer_protobuf)
+    
+    # Write to a temporary file
+    traj_file = tmp_path / "traj-mock"
+    traj_file.write_bytes(compressed)
+    
+    # Convert to JSON
+    dest_json = tmp_path / "antigravity_traj.json"
+    success = convert_trajectory_to_json(traj_file, dest_json)
+    
+    assert success is True
+    assert dest_json.is_file()
+    
+    # Verify the JSON contents
+    data = json.loads(dest_json.read_text(encoding="utf-8"))
+    assert data["trajectory_id"] == "mock_traj"
+    assert len(data["steps"]) == 2
+    
+    step1 = data["steps"][0]
+    assert step1["step_index"] == 1
+    assert step1["type"] == "user_input"
+    assert step1["content"] == "Objective text"
+    
+    step2 = data["steps"][1]
+    assert step2["step_index"] == 2
+    assert step2["type"] == "model_output"
+    assert step2["thought"] == "Thinking..."
+
+def test_enhanced_trajectory_parsing(tmp_path: Path):
+    # 1. Build Step 1 (User Input with non-ASCII weather string)
+    prompt_payload = b"\x12\x13Temperature: 60 \xc2\xb0F"
+    step1_field19 = b"\x9a\x01\x15" + prompt_payload
+    step1_payload = b"\x08\x0e" + step1_field19
+    step1_wrapped = b"\x12\x1a" + step1_payload
+
+    # 2. Build Step 2 (Model Output with Field 8 '[ack]')
+    ack_payload = b"\x42\x05[ack]"
+    step2_field20 = b"\xa2\x01\x07" + ack_payload
+    step2_payload = b"\x08\x0f" + step2_field20
+    step2_wrapped = b"\x12\x0c" + step2_payload
+
+    # 3. Build Step 3 (Error step type 17)
+    err_text_payload = b"\x12\x07timeout"
+    step3_field3 = b"\x1a\x09" + err_text_payload
+    step3_field24 = b"\xc2\x01\x0b" + step3_field3
+    step3_payload = b"\x08\x11" + step3_field24
+    step3_wrapped = b"\x12\x10" + step3_payload
+
+    # 4. Build Step 4 (Complete step type 2)
+    outcome_payload = b'{"objective_outcome":"success"}'
+    step4_field12 = b"\x62\x21\x12\x1f" + outcome_payload
+    step4_payload = b"\x08\x02" + step4_field12
+    step4_wrapped = b"\x12\x25" + step4_payload
+
+    # Outer message
+    traj_id_payload = b"\x0a\x0dmock_enhanced"
+    outer_protobuf = traj_id_payload + step1_wrapped + step2_wrapped + step3_wrapped + step4_wrapped
+
+    cctx = zstd.ZstdCompressor()
+    compressed = cctx.compress(outer_protobuf)
+
+    traj_file = tmp_path / "traj-mock-enhanced"
+    traj_file.write_bytes(compressed)
+
+    dest_json = tmp_path / "antigravity_traj.json"
+    success = convert_trajectory_to_json(traj_file, dest_json)
+
+    assert success is True
+    assert dest_json.is_file()
+
+    data = json.loads(dest_json.read_text(encoding="utf-8"))
+    assert data["trajectory_id"] == "mock_enhanced"
+    assert len(data["steps"]) == 4
+
+    s1 = data["steps"][0]
+    assert s1["step_index"] == 1
+    assert s1["type"] == "user_input"
+    assert s1["content"] == "Temperature: 60 °F"
+
+    s2 = data["steps"][1]
+    assert s2["step_index"] == 2
+    assert s2["type"] == "model_output"
+    assert s2["content"] == "[ack]"
+
+    s3 = data["steps"][2]
+    assert s3["step_index"] == 3
+    assert s3["type"] == "error"
+    assert s3["error"] == "timeout"
+
+    s4 = data["steps"][3]
+    assert s4["step_index"] == 4
+    assert s4["type"] == "complete"
+    assert s4["outcome"] == {"objective_outcome": "success"}
+


### PR DESCRIPTION
## What
Added support for automatic decompression and JSON parsing of binary trajectory files (`traj-*`) generated by the Antigravity SDK. Every time a trajectory changes under `antigravity_state/traj-*`, it is decompressed, parsed, and written as `antigravity_traj.json` in the same directory.

## Why
Enables developers to inspect high-fidelity Antigravity SDK trajectory step logs directly as formatted JSON alongside the agent's run metadata.

## Changes
- **`packages/bees/bees/trajectory_parser.py`**: Implemented `convert_trajectory_to_json` to handle zstd decompression and recursive protobuf wire parsing for Step Types: User Input (`14`), Model Output (`15`), Complete (`2`), and Error (`17`). Implemented `is_readable_string` to validate UTF-8 strings by excluding ASCII/C1 control characters (except `\n\r\t`) so that strings containing characters like the degree symbol (`°`) decode as readable text rather than falling back to binary.
- **`packages/bees/bees/box.py`**: Integrated trajectory change detection in the `awatch` watcher loop. Added loop protection in `classify_change` to ignore generated `antigravity_traj.json` files.
- **`packages/bees/tests/test_trajectory_parser.py`**: Added unit tests covering user inputs, model thought, tool calls, model acknowledgments (`[ack]`), execution errors, and step completions.
- **`packages/bees/tests/test_box.py`**: Added test case ensuring `antigravity_traj.json` is correctly ignored by the file classifier.

## Testing
Verified by running:
```bash
npm run test:python
```
All 646 python tests passed successfully.
