### PR TITLE
[bees] Render Antigravity Trajectories in Hivetool

### DIFF
--- a/packages/bees/hivetool/src/data/agent-store.ts
+++ b/packages/bees/hivetool/src/data/agent-store.ts
@@ -14,7 +14,7 @@
 
 import { Signal } from "signal-polyfill";
 import type { StateAccess } from "./state-access.js";
-import type { AgentData, TaskItemData, SurfaceManifest } from "./types.js";
+import type { AgentData, TaskItemData, SurfaceManifest, TrajectoryData } from "./types.js";
 import { LiveSessionClient } from "./live-session.js";
 
 export { AgentStore };
@@ -33,6 +33,17 @@ class AgentStore {
   readonly agents = new Signal.State<AgentData[]>([]);
   readonly selectedAgentId = new Signal.State<string | null>(null);
   readonly recentlyUpdatedAgent = new Signal.State<{ id: string; at: number } | null>(null);
+
+  readonly trajectories = new Signal.State<TrajectoryData[]>([]);
+  readonly selectedTrajectoryAgentId = new Signal.State<string | null>(null);
+  readonly recentlyUpdatedTrajectory = new Signal.State<{ id: string; at: number } | null>(null);
+
+  readonly selectedTrajectory = new Signal.Computed(() => {
+    const id = this.selectedTrajectoryAgentId.get();
+    if (!id) return null;
+    return this.trajectories.get().find((t) => t.agentId === id) ?? null;
+  });
+
 
   /**
    * Fires when a file inside an agent's workspace directory changes.
@@ -117,6 +128,8 @@ class AgentStore {
     });
 
     this.agents.set(entries);
+
+    await this.#scanTrajectories(entries);
 
     // Detect active live sessions.
     await this.#detectLiveSessions(entries);
@@ -237,6 +250,36 @@ class AgentStore {
     return entries;
   }
 
+  async #scanTrajectories(entries: AgentData[]): Promise<void> {
+    if (!this.#agentsHandle) return;
+    const trajs: TrajectoryData[] = [];
+
+    for (const agent of entries) {
+      try {
+        const agentDir = await this.#agentsHandle.getDirectoryHandle(agent.id);
+        const trajFileHandle = await agentDir.getFileHandle("antigravity_traj.json");
+        const file = await trajFileHandle.getFile();
+        const text = await file.text();
+        const data = JSON.parse(text);
+
+        trajs.push({
+          agentId: agent.id,
+          agentTitle: agent.title ?? `Agent ${agent.id.slice(0, 8)}`,
+          agentStatus: agent.status ?? "unknown",
+          trajectoryId: data.trajectory_id || "",
+          steps: data.steps || [],
+          lastModified: file.lastModified,
+        });
+      } catch {
+        // No trajectory file for this agent, skip.
+      }
+    }
+
+    // Sort by lastModified descending (most recently updated first)
+    trajs.sort((a, b) => b.lastModified - a.lastModified);
+    this.trajectories.set(trajs);
+  }
+
   /**
    * Get task records assigned to a given agent.
    *
@@ -263,6 +306,9 @@ class AgentStore {
     this.selectedAgentId.set(null);
     this.selectedTaskId.set(null);
     this.recentlyUpdatedAgent.set(null);
+    this.trajectories.set([]);
+    this.selectedTrajectoryAgentId.set(null);
+    this.recentlyUpdatedTrajectory.set(null);
     this.filesystemChange.set(null);
     this.activeLiveSessions.set(new Set());
     this.disconnectLiveSession();
@@ -729,6 +775,8 @@ class AgentStore {
               const fsPath = segments.slice(4).join("/");
               if (!fsChanges.has(agentId)) fsChanges.set(agentId, []);
               fsChanges.get(agentId)!.push(fsPath);
+            } else if (segments.length === 2 && segments[1] === "antigravity_traj.json") {
+              this.recentlyUpdatedTrajectory.set({ id: agentId, at: Date.now() });
             }
           }
 

--- a/packages/bees/hivetool/src/data/types.ts
+++ b/packages/bees/hivetool/src/data/types.ts
@@ -182,3 +182,33 @@ export interface SurfaceManifest {
   items: SurfaceItem[];
 }
 
+// ---------------------------------------------------------------------------
+// Antigravity Trajectory types (from antigravity_traj.json)
+// ---------------------------------------------------------------------------
+
+export interface TrajectoryStep {
+  step_index: number;
+  timestamp: string;
+  type: "user_input" | "model_output" | "tool_response" | "complete" | "error" | string;
+  content?: string;
+  thought?: string;
+  tool_calls?: Array<{
+    name: string;
+    arguments?: Record<string, unknown> | string;
+  }>;
+  tool_name?: string;
+  response?: Record<string, unknown> | string;
+  outcome?: Record<string, unknown> | string;
+  error?: string;
+}
+
+export interface TrajectoryData {
+  agentId: string;
+  agentTitle: string;
+  agentStatus: string;
+  trajectoryId: string;
+  steps: TrajectoryStep[];
+  lastModified: number;
+}
+
+

--- a/packages/bees/hivetool/src/ui/agent-pane.ts
+++ b/packages/bees/hivetool/src/ui/agent-pane.ts
@@ -230,6 +230,15 @@ class BeesAgentPane extends SignalWatcher(LitElement) {
       value: sessionVal.slice(0, 8),
       onclick: () => this.navigate("logs", sessionVal),
     });
+    const hasTrajectory = this.agentStore.trajectories.get().some((t) => t.agentId === agent.id);
+    if (hasTrajectory) {
+      identityChips.push({
+        label: "trajectory",
+        value: agent.id.slice(0, 8),
+        cls: "trajectory",
+        onclick: () => this.navigate("trajectories", agent.id),
+      });
+    }
     if (agent.skills && agent.skills.length > 0) {
       const skillDirs = new Set(
         (this.skillStore?.skills.get() ?? []).map((sk) => sk.dirName)

--- a/packages/bees/hivetool/src/ui/app.ts
+++ b/packages/bees/hivetool/src/ui/app.ts
@@ -37,11 +37,13 @@ import "./task-detail.js";
 import "./log-list.js";
 import "./log-detail.js";
 import "./system-detail.js";
+import "./trajectory-list.js";
+import "./trajectory-detail.js";
 import { scrollbarStyles } from "./shared-styles.js";
 
 export { BeesApp };
 
-type TabId = "logs" | "agents" | "tasks" | "templates" | "skills" | "system";
+type TabId = "logs" | "agents" | "tasks" | "templates" | "skills" | "system" | "trajectories";
 
 /** Shared interface for editable detail panels. */
 interface EditablePanel {
@@ -573,6 +575,9 @@ class BeesApp extends SignalWatcher(LitElement) {
       case "skills":
         id = this.skillStore.selectedSkillDir.get();
         break;
+      case "trajectories":
+        id = this.agentStore.selectedTrajectoryAgentId.get();
+        break;
     }
     writeRoute(this.activeTab, id);
   }
@@ -586,6 +591,7 @@ class BeesApp extends SignalWatcher(LitElement) {
       "templates",
       "skills",
       "system",
+      "trajectories",
     ];
     const tab = validTabs.includes(route.tab as TabId)
       ? (route.tab as TabId)
@@ -610,6 +616,9 @@ class BeesApp extends SignalWatcher(LitElement) {
       case "skills":
         if (route.id) this.skillStore.selectSkill(route.id);
         break;
+      case "trajectories":
+        if (route.id) this.agentStore.selectedTrajectoryAgentId.set(route.id);
+        break;
     }
   }
 
@@ -620,7 +629,7 @@ class BeesApp extends SignalWatcher(LitElement) {
   private handleNavigate(e: CustomEvent) {
     const { id } = e.detail;
     // Normalize: log-detail emits "agent" (singular).
-    const tab = e.detail.tab === "agent" ? "agents" : e.detail.tab;
+    const tab = e.detail.tab === "agent" ? "agents" : (e.detail.tab === "trajectory" ? "trajectories" : e.detail.tab);
     this.activeTab = tab;
 
     switch (tab) {
@@ -638,6 +647,9 @@ class BeesApp extends SignalWatcher(LitElement) {
         break;
       case "tasks":
         this.agentStore.selectedTaskId.set(id);
+        break;
+      case "trajectories":
+        this.agentStore.selectedTrajectoryAgentId.set(id);
         break;
     }
 
@@ -770,6 +782,27 @@ class BeesApp extends SignalWatcher(LitElement) {
         ? recentLogUpdate.id
         : null;
 
+    const recentTrajUpdate = this.agentStore.recentlyUpdatedTrajectory.get();
+    const flashTrajId =
+      recentTrajUpdate && Date.now() - recentTrajUpdate.at < 15000
+        ? recentTrajUpdate.id
+        : null;
+
+    const hasTrajectories = this.agentStore.trajectories.get().length > 0;
+    const tabs: Array<[TabId, string, string | null]> = [
+      ["agents", "Agents", flashAgentId],
+      ["logs", "Sessions", flashLogId],
+      ["tasks", "Tasks", null],
+    ];
+    if (hasTrajectories) {
+      tabs.push(["trajectories", "Trajectories", flashTrajId]);
+    }
+    tabs.push(
+      ["templates", "Templates", null],
+      ["skills", "Skills", null],
+      ["system", "System", null]
+    );
+
     return html`
       ${this.maximized ? nothing : html`
       <div class="top-bar">
@@ -793,16 +826,7 @@ class BeesApp extends SignalWatcher(LitElement) {
           </div>
         </div>
         <div class="top-bar-tabs">
-          ${(
-            [
-              ["agents", "Agents", flashAgentId],
-              ["logs", "Sessions", flashLogId],
-              ["tasks", "Tasks", null],
-              ["templates", "Templates", null],
-              ["skills", "Skills", null],
-              ["system", "System", null],
-            ] as const
-          ).map(
+          ${tabs.map(
             ([id, label, flash]) => html`
               <div
                 class="sidebar-tab ${this.activeTab === id
@@ -825,7 +849,7 @@ class BeesApp extends SignalWatcher(LitElement) {
       >
         ${this.maximized ? nothing : html`
         <div class="sidebar">
-          ${this.renderSidebar(flashAgentId, flashLogId)}
+          ${this.renderSidebar(flashAgentId, flashLogId, flashTrajId)}
         </div>
         `}
         <div class="main">${this.renderMain(flashAgentId)}</div>
@@ -897,7 +921,8 @@ class BeesApp extends SignalWatcher(LitElement) {
 
   private renderSidebar(
     flashAgentId: string | null,
-    flashLogId: string | null
+    flashLogId: string | null,
+    flashTrajId: string | null
   ) {
     switch (this.activeTab) {
       case "agents":
@@ -926,6 +951,15 @@ class BeesApp extends SignalWatcher(LitElement) {
             this.syncHash();
           }}
         ></bees-log-list>`;
+      case "trajectories":
+        return html`<bees-trajectory-list
+          .store=${this.agentStore}
+          .flashTrajId=${flashTrajId}
+          @select=${(e: CustomEvent) => {
+            this.agentStore.selectedTrajectoryAgentId.set(e.detail.agentId);
+            this.syncHash();
+          }}
+        ></bees-trajectory-list>`;
       case "templates":
         return html`<bees-template-list
           .store=${this.templateStore}
@@ -987,6 +1021,11 @@ class BeesApp extends SignalWatcher(LitElement) {
           .mutationClient=${this.mutationClient}
           .sessionId=${this.logStore.selectedSessionId.get()}
         ></bees-log-detail>`;
+      case "trajectories":
+        return html`<bees-trajectory-detail
+          .agentStore=${this.agentStore}
+          .agentId=${this.agentStore.selectedTrajectoryAgentId.get()}
+        ></bees-trajectory-detail>`;
       case "templates":
         return html`<bees-template-detail
           .templateStore=${this.templateStore}

--- a/packages/bees/hivetool/src/ui/shared-styles.ts
+++ b/packages/bees/hivetool/src/ui/shared-styles.ts
@@ -348,6 +348,12 @@ const sharedStyles = css`
     border-color: #1e3a5c;
   }
 
+  .identity-chip.trajectory {
+    background: #2d122d22;
+    color: #f472b6;
+    border-color: #5c1e5c;
+  }
+
   .identity-label {
     font-size: 0.6rem;
     font-weight: 700;

--- a/packages/bees/hivetool/src/ui/trajectory-detail.ts
+++ b/packages/bees/hivetool/src/ui/trajectory-detail.ts
@@ -1,0 +1,353 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SignalWatcher } from "@lit-labs/signals";
+import { LitElement, html, css, nothing } from "lit";
+import { customElement, property } from "lit/decorators.js";
+
+import {
+  renderJson,
+  renderExpandButton,
+} from "./json-tree.js";
+import type { AgentStore } from "../data/agent-store.js";
+import type { TrajectoryStep, TrajectoryData } from "../data/types.js";
+import { logDetailStyles } from "./log-detail.styles.js";
+
+export { BeesTrajectoryDetail };
+
+const CONTEXT_UPDATE_RE = /^<context_update>([\s\S]*)<\/context_update>$/;
+
+@customElement("bees-trajectory-detail")
+class BeesTrajectoryDetail extends SignalWatcher(LitElement) {
+  @property({ attribute: false })
+  accessor agentStore: AgentStore | null = null;
+
+  @property({ type: String })
+  accessor agentId: string | null = null;
+
+  static styles = [
+    ...logDetailStyles,
+    css`
+      .turn.error {
+        background: #2d1616;
+        border: 1px solid #5c1e1e;
+      }
+      .turn.error .turn-role {
+        color: #f87171;
+      }
+      .role-chip.error {
+        background: #7f1d1d;
+        color: #fca5a5;
+      }
+      .part-error {
+        color: #fca5a5;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+      .objective-block {
+        background: #11141a;
+        border: 1px solid #1e293b;
+        border-radius: 6px;
+        padding: 10px 12px;
+        margin-top: 6px;
+      }
+      .metadata-block {
+        font-size: 0.75rem;
+        color: #64748b;
+        margin-top: 4px;
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+      }
+      .metadata-block code {
+        background: #1e293b;
+        padding: 1px 4px;
+        border-radius: 3px;
+        color: #e2e8f0;
+        word-break: break-all;
+      }
+    `,
+  ];
+
+  render() {
+    if (!this.agentStore || !this.agentId) {
+      return html`<div class="empty">Select a trajectory to inspect.</div>`;
+    }
+
+    const trajs = this.agentStore.trajectories.get();
+    const traj = trajs.find((t) => t.agentId === this.agentId);
+
+    if (!traj) {
+      return html`<div class="empty">Trajectory not found.</div>`;
+    }
+
+    return html`
+      ${this.renderHeader(traj)}
+      <div class="conversation">
+        ${traj.steps.map((step) => html`
+          ${this.renderStepHeader(step)}
+          ${this.renderStep(step)}
+        `)}
+      </div>
+    `;
+  }
+
+  private renderStepHeader(step: TrajectoryStep) {
+    return html`
+      <div class="turn-header">
+        <span class="turn-header-label">step ${step.step_index}</span>
+        ${step.timestamp ? html`<span class="mono" style="font-size: 0.65rem; color: #475569; margin-left: 8px;">${step.timestamp}</span>` : nothing}
+        <div style="flex: 1; height: 1px; background: #1e293b; margin-left: 8px;"></div>
+      </div>
+    `;
+  }
+
+  private renderHeader(t: TrajectoryData) {
+    const started = t.steps[0]?.timestamp;
+    return html`
+      <div class="header">
+        <div class="header-top">
+          <h2>
+            Trajectory
+            <code class="mono">${t.trajectoryId.slice(0, 13)}…</code>
+          </h2>
+          <span
+            class="link-chip"
+            @click=${() => this.#dispatchNavigate("agent", t.agentId)}
+          >
+            <span class="link-chip-label">agent</span>
+            ${t.agentId.slice(0, 8)}
+          </span>
+        </div>
+        <div class="header-meta">
+          <span>${started ? started : "—"}</span>
+          <span>${t.steps.length} step${t.steps.length !== 1 ? "s" : ""}</span>
+          <span>Status: ${t.agentStatus}</span>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderStep(step: TrajectoryStep) {
+    const type = step.type || "unknown";
+
+    switch (type) {
+      case "user_input":
+        return this.renderUserInputStep(step);
+      case "model_output":
+        return this.renderModelOutputStep(step);
+      case "tool_response":
+        return this.renderToolResponseStep(step);
+      case "complete":
+        return this.renderCompleteStep(step);
+      case "error":
+        return this.renderErrorStep(step);
+      default:
+        return this.renderUnknownStep(step);
+    }
+  }
+
+  private renderUserInputStep(step: TrajectoryStep) {
+    const content = step.content || "";
+
+    // 1. Check for context_update
+    const cuMatch = content.match(CONTEXT_UPDATE_RE);
+    if (cuMatch) {
+      const label = html`<span class="role-chip context-update">context update</span>`;
+      return html`
+        <div class="turn context-update">
+          <div class="turn-role">${label}</div>
+          <div class="turn-parts">
+            <div class="part-text">${cuMatch[1].trim()}</div>
+          </div>
+        </div>
+      `;
+    }
+
+    // 2. Parse initial prompt metadata / objective
+    const objMatch = content.match(/<objective>([\s\S]*?)<\/objective>/);
+    const wdMatch = content.match(/<working_directory>([\s\S]*?)<\/working_directory>/);
+    const dateMatch = content.match(/<current_date>([\s\S]*?)<\/current_date>/);
+
+    const label = html`<span class="role-chip user">user</span>`;
+
+    if (objMatch) {
+      return html`
+        <div class="turn user">
+          <div class="turn-role">${label}</div>
+          <div class="turn-parts">
+            <div class="objective-block">
+              <strong>Objective:</strong>
+              <div style="white-space: pre-wrap; margin-top: 4px;">${objMatch[1].trim()}</div>
+            </div>
+            ${wdMatch || dateMatch
+              ? html`
+                  <div class="metadata-block">
+                    ${dateMatch ? html`<span><strong>Date:</strong> ${dateMatch[1].trim()}</span>` : nothing}
+                    ${wdMatch ? html`<span><strong>Workspace:</strong> <code class="mono">${wdMatch[1].trim()}</code></span>` : nothing}
+                  </div>
+                `
+              : nothing}
+          </div>
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="turn user">
+        <div class="turn-role">${label}</div>
+        <div class="turn-parts">
+          <div class="part-text">${content}</div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderModelOutputStep(step: TrajectoryStep) {
+    const templates = [];
+
+    // Render thoughts if present
+    if (step.thought) {
+      const { title, body } = this.#parseThought(step.thought);
+      const label = title
+        ? html`<span class="role-chip thought">thought</span> ${title}`
+        : html`<span class="role-chip thought">thought</span>`;
+      const isLong = body.length > 300;
+
+      templates.push(html`
+        <div class="turn thought">
+          <div class="turn-role">${label}</div>
+          <div class="turn-parts">
+            <div class="part-thought ${isLong ? "long" : ""}">${body}${isLong ? renderExpandButton() : nothing}</div>
+          </div>
+        </div>
+      `);
+    }
+
+    // Render tool calls if present
+    if (step.tool_calls && step.tool_calls.length > 0) {
+      for (const tc of step.tool_calls) {
+        const label = html`<span class="role-chip call">call</span> ${tc.name}`;
+        templates.push(html`
+          <div class="turn call">
+            <div class="turn-role">${label}</div>
+            <div class="turn-parts">
+              <div class="json-tree">${renderJson(tc.arguments)}</div>
+            </div>
+          </div>
+        `);
+      }
+    }
+
+    // Render plain text content if present (and not already shown as thought/calls)
+    if (step.content && step.content.trim() !== "") {
+      const isLong = step.content.length > 500;
+      templates.push(html`
+        <div class="turn model">
+          <div class="turn-role"><span class="role-chip model">model</span></div>
+          <div class="turn-parts">
+            <div class="part-text ${isLong ? "long" : ""}">${step.content}${isLong ? renderExpandButton() : nothing}</div>
+          </div>
+        </div>
+      `);
+    }
+
+    return html`${templates}`;
+  }
+
+  private renderToolResponseStep(step: TrajectoryStep) {
+    const name = step.tool_name || "unknown";
+    const label = html`<span class="role-chip response">response</span> ${name}`;
+    return html`
+      <div class="turn system">
+        <div class="turn-role">${label}</div>
+        <div class="turn-parts">
+          <div class="part-function-response">
+            <div class="json-tree">${renderJson(step.response)}</div>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderCompleteStep(step: TrajectoryStep) {
+    const label = html`<span class="role-chip system-message">system</span>`;
+    const outcome = step.outcome;
+
+    if (outcome && typeof outcome === "object") {
+      const objOutcome = (outcome as Record<string, unknown>).objective_outcome;
+      if (typeof objOutcome === "string") {
+        return html`
+          <div class="turn system-message">
+            <div class="turn-role">${label}</div>
+            <div class="turn-parts">
+              <div class="part-system-message">${objOutcome}</div>
+            </div>
+          </div>
+        `;
+      }
+    }
+
+    return html`
+      <div class="turn system-message">
+        <div class="turn-role">${label}</div>
+        <div class="turn-parts">
+          <div class="part-system-message">
+            <div class="json-tree">${renderJson(outcome)}</div>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderErrorStep(step: TrajectoryStep) {
+    const label = html`<span class="role-chip error">error</span>`;
+    return html`
+      <div class="turn error">
+        <div class="turn-role">${label}</div>
+        <div class="turn-parts">
+          <div class="part-error">${step.error || "An error occurred."}</div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderUnknownStep(step: TrajectoryStep) {
+    const label = html`<span class="role-chip inherited">step</span>`;
+    return html`
+      <div class="turn inherited">
+        <div class="turn-role">${label} ${step.type}</div>
+        <div class="turn-parts">
+          <div class="json-tree">${renderJson(step)}</div>
+        </div>
+      </div>
+    `;
+  }
+
+  #parseThought(text: string): { title: string | null; body: string } {
+    const match = text.match(/\*\*(.+?)\*\*/);
+    if (!match) return { title: null, body: text };
+    const title = match[1];
+    const body = text.replace(match[0], "").trim();
+    return { title, body };
+  }
+
+  #dispatchNavigate(tab: string, id: string) {
+    this.dispatchEvent(
+      new CustomEvent("navigate", {
+        detail: { tab, id },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "bees-trajectory-detail": BeesTrajectoryDetail;
+  }
+}

--- a/packages/bees/hivetool/src/ui/trajectory-list.ts
+++ b/packages/bees/hivetool/src/ui/trajectory-list.ts
@@ -1,0 +1,207 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SignalWatcher } from "@lit-labs/signals";
+import { LitElement, html, css, nothing } from "lit";
+import { customElement, property } from "lit/decorators.js";
+
+import type { AgentStore } from "../data/agent-store.js";
+import { getRelativeTime } from "../utils.js";
+import { sharedStyles } from "./shared-styles.js";
+
+export { BeesTrajectoryList };
+
+@customElement("bees-trajectory-list")
+class BeesTrajectoryList extends SignalWatcher(LitElement) {
+  static styles = [
+    sharedStyles,
+    css`
+      :host {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        overflow: hidden;
+      }
+
+      .trajectories-container {
+        flex: 1;
+        overflow-y: auto;
+        display: flex;
+        flex-direction: column;
+        gap: 16px;
+        padding: 12px 16px;
+      }
+
+      .section-header {
+        font-size: 0.7rem;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: #64748b;
+        margin-bottom: 8px;
+      }
+
+      .trajectory-list {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+
+      /* Individual trajectory card */
+      .trajectory-card {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        padding: 10px 12px;
+        border-radius: 6px;
+        cursor: pointer;
+        background: transparent;
+        border: 1px solid transparent;
+        transition: all 0.15s ease;
+      }
+
+      .trajectory-card:hover {
+        background: #13161c;
+      }
+
+      .trajectory-card.selected {
+        background: #1e3a5f33;
+        border-color: #3b82f644;
+      }
+
+      .trajectory-card-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+
+      .agent-title {
+        font-size: 0.75rem;
+        font-weight: 600;
+        color: #cbd5e1;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 180px;
+      }
+
+      .trajectory-card.selected .agent-title {
+        color: #60a5fa;
+      }
+
+      .status-badge {
+        font-size: 0.6rem;
+        font-weight: 600;
+        padding: 1px 6px;
+        border-radius: 999px;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+      }
+
+      .status-badge.running {
+        background: #1d4ed822;
+        color: #60a5fa;
+        border: 1px solid #1d4ed866;
+      }
+
+      .status-badge.suspended {
+        background: #92400e22;
+        color: #fbbf24;
+        border: 1px solid #92400e66;
+      }
+
+      .status-badge.completed {
+        background: #064e3b22;
+        color: #34d399;
+        border: 1px solid #064e3b66;
+      }
+
+      .status-badge.failed {
+        background: #7f1d1d22;
+        color: #f87171;
+        border: 1px solid #7f1d1d66;
+      }
+
+      .trajectory-meta {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        font-size: 0.65rem;
+        color: #64748b;
+      }
+
+      .traj-id {
+        font-family: "Google Mono", "Roboto Mono", monospace;
+        color: #475569;
+      }
+    `,
+  ];
+
+  @property({ attribute: false })
+  accessor store: AgentStore | null = null;
+
+  @property({ attribute: false })
+  accessor flashTrajId: string | null = null;
+
+  render() {
+    if (!this.store) return nothing;
+    const trajs = this.store.trajectories.get();
+    const selectedId = this.store.selectedTrajectoryAgentId.get();
+
+    if (trajs.length === 0) {
+      return html`<div class="empty-state">No trajectories found.</div>`;
+    }
+
+    return html`
+      <div class="trajectories-container">
+        <div class="section-header">Trajectories</div>
+        <div class="trajectory-list">
+          ${trajs.map((traj) => {
+            const isSelected = selectedId === traj.agentId;
+            const isFlash = this.flashTrajId === traj.agentId;
+            const stepLabel = `${traj.steps.length} step${traj.steps.length !== 1 ? "s" : ""}`;
+            const timeLabel = traj.lastModified
+              ? getRelativeTime(new Date(traj.lastModified).toISOString())
+              : "";
+
+            return html`
+              <div
+                class="trajectory-card ${isSelected ? "selected" : ""} ${isFlash ? "lightning-flash" : ""}"
+                @click=${() => this.handleSelect(traj.agentId)}
+              >
+                <div class="trajectory-card-header">
+                  <span class="agent-title" title="${traj.agentTitle}">
+                    ${traj.agentTitle}
+                  </span>
+                  <span class="status-badge ${traj.agentStatus}">${traj.agentStatus}</span>
+                </div>
+                <div class="trajectory-meta">
+                  <span>${stepLabel}</span>
+                  <span class="traj-id" title="Trajectory ID: ${traj.trajectoryId}">
+                    ${traj.trajectoryId.slice(0, 8)}...
+                  </span>
+                  <span>${timeLabel}</span>
+                </div>
+              </div>
+            `;
+          })}
+        </div>
+      </div>
+    `;
+  }
+
+  private handleSelect(agentId: string) {
+    this.dispatchEvent(
+      new CustomEvent("select", { detail: { agentId }, bubbles: true })
+    );
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "bees-trajectory-list": BeesTrajectoryList;
+  }
+}


### PR DESCRIPTION
## What
Adds rendering of Antigravity agent trajectory JSON logs (`antigravity_traj.json`) to Hivetool in a new "Trajectories" tab and links back to it from the agent pane header.

## Why
Enables developers to inspect the sequential step-by-step execution trajectory of Antigravity agents in real-time, matching the existing visual and structural layout of conversation sessions.

## Changes
- **Types**: Added `TrajectoryStep` and `TrajectoryData` interface definitions to `packages/bees/hivetool/src/data/types.ts`.
- **Store & Observer**: Updated `AgentStore` in `packages/bees/hivetool/src/data/agent-store.ts` to scan each agent directory for `antigravity_traj.json` and reused the global `FileSystemObserver` on the `agents/` directory to listen for file updates reactively.
- **Top Tab Navigation**: Modified `BeesApp` in `packages/bees/hivetool/src/ui/app.ts` to conditionally display the "Trajectories" tab, configure routing, and handle navigation events.
- **Sidebar & Detail Components**:
  - Created `<bees-trajectory-list>` in `packages/bees/hivetool/src/ui/trajectory-list.ts` to list agents with trajectories, showing step counts and status.
  - Created `<bees-trajectory-detail>` in `packages/bees/hivetool/src/ui/trajectory-detail.ts` to display steps with step headers (delineation) and cards for User Input, Model Output (collapsible thoughts, tool calls), Tool Responses, Completion and Errors.
- **Link back chip**: Added a `trajectory` backlink identity chip in `packages/bees/hivetool/src/ui/agent-pane.ts` to navigate to an agent's trajectory from the Agents pane header, and added CSS rule in `packages/bees/hivetool/src/ui/shared-styles.ts`.

## Testing
- Open a hive directory (e.g. `hives/antigravity`) with trajectories.
- Verify that the "Trajectories" tab appears in the top-bar and displays the list of trajectories in the sidebar.
- Verify step delineation ("step 1", "step 2") and correct rendering of thoughts, tool calls/responses, outcomes, and errors.
- Click the pink `trajectory` chip in the Agent Pane header to navigate directly to the agent's trajectory.
- Ensure compilation is successful (running `dev:hivetool` dev server does not show errors).
