### PR TITLE
[bees] Improve SuspendError Handling in Chat-Enabled Agents

### DIFF
--- a/hives/antigravity/config/TEMPLATES.yaml
+++ b/hives/antigravity/config/TEMPLATES.yaml
@@ -41,6 +41,8 @@
     You are a friendly assistant. Greet the user and ask how you can help. When
     the user asks you to do something, do it and then ask if there's anything
     else.
+
+    Never call `agents_await`: your job is to stay responsive to the user.
   functions:
     - chat.*
     - files.*

--- a/packages/bees/bees/runners/idle_resolution.py
+++ b/packages/bees/bees/runners/idle_resolution.py
@@ -72,24 +72,22 @@ def resolve_idle(inputs: IdleInputs) -> tuple[IdleOutcome, dict[str, Any]]:
     if inputs.emitted_complete:
         return IdleOutcome.ALREADY_COMPLETE, {}
 
-    # Priority 1: Active child tasks without an existing suspend →
+    # Priority 1: Chat mode — chat sessions are infinite and always suspend
+    # for user input, even if there are pending tool suspends or active child tasks.
+    if inputs.has_chat:
+        return IdleOutcome.SUSPEND_CHAT, _chat_event(inputs.last_user_text)
+
+    # Priority 2: Active child tasks without an existing suspend →
     # synthesize a deferred suspend so the scheduler keeps us alive.
     if inputs.has_active_tasks and not inputs.pending_suspend:
         request_id = str(uuid.uuid4())
         return IdleOutcome.SUSPEND_DEFERRED, _deferred_event(request_id)
 
-    # Priority 2: A tool requested suspension (deferred result pattern).
+    # Priority 3: A tool requested suspension (deferred result pattern).
     if inputs.pending_suspend:
         return IdleOutcome.SUSPEND_DEFERRED, _deferred_event(
             inputs.suspend_request_id,
         )
-
-    # Priority 3: Chat mode — idle without FINISH = waiting for user.
-    # The session is infinite; it must always suspend regardless of
-    # whether the model produced text.  The text is presentation data
-    # for the prompt, not a lifecycle gate.
-    if inputs.has_chat:
-        return IdleOutcome.SUSPEND_CHAT, _chat_event(inputs.last_user_text)
 
     # Default: Worker mode — idle without FINISH = done.
     return IdleOutcome.COMPLETE, _complete_event()

--- a/packages/bees/bees/runners/tool_mapping.py
+++ b/packages/bees/bees/runners/tool_mapping.py
@@ -161,6 +161,10 @@ def map_function_filter(
     active_instructions: list[str] = []
     suspend_queue: asyncio.Queue[SuspendError] = asyncio.Queue()
 
+    has_chat = False
+    if function_filter is not None:
+        has_chat = any(pattern.startswith("chat.") for pattern in function_filter)
+
     if function_filter is None:
         # No filter → enable all SDK builtins (except excluded).
         enabled_builtins = set(ag_types.BuiltinTools) - _EXCLUDED_BUILTINS
@@ -169,6 +173,7 @@ def map_function_filter(
             function_groups, hooks,
             include_groups=None,
             suspend_queue=suspend_queue,
+            has_chat=has_chat,
         )
         active_group_names = None
     else:
@@ -195,6 +200,7 @@ def map_function_filter(
             function_groups, hooks,
             include_groups=custom_group_names,
             suspend_queue=suspend_queue,
+            has_chat=has_chat,
         )
 
     # Collect instructions for all active groups (built-in and custom).
@@ -239,6 +245,7 @@ def wrap_bees_handler(
     func_def: FunctionDefinition,
     *,
     suspend_queue: asyncio.Queue[SuspendError] | None = None,
+    has_chat: bool = False,
 ) -> Callable[..., Any]:
     """Wrap a bees ``FunctionDefinition`` as an SDK-compatible Python tool.
 
@@ -275,13 +282,18 @@ def wrap_bees_handler(
                 "Deferred suspend for %s (result_id=%s)",
                 func_def.name, result_id[:8],
             )
+            message = "Results are pending and will be delivered asynchronously."
+            if has_chat:
+                message += " Continue conversing with the user. The <context_update> message will arrive as soon as the task completes."
+            else:
+                message += (
+                    " Now, reply with \"[ack]\" and wait for a "
+                    "<context_update> message that will provide the results."
+                )
             return {
                 "status": "pending",
                 "result_id": result_id,
-                "message": (
-                    "Results are pending and will be delivered "
-                    "asynchronously. Now, reply with \"[ack]\" and wait for a " "<context_update> message that will provide the results."
-                ),
+                "message": message,
             }
 
     # The SDK uses __name__ and __doc__ for tool registration.
@@ -328,6 +340,7 @@ def _extract_custom_tools(
     *,
     include_groups: set[str] | None,
     suspend_queue: asyncio.Queue[SuspendError] | None = None,
+    has_chat: bool = False,
 ) -> tuple[list[Callable[..., Any]], list[str]]:
     """Instantiate function groups and wrap their definitions as custom tools.
 
@@ -339,6 +352,7 @@ def _extract_custom_tools(
             custom tools.
         suspend_queue: Queue to pass to ``wrap_bees_handler`` for
             intercepting ``SuspendError``.
+        has_chat: True if the session has chat functions enabled.
 
     Returns:
         A ``(tools, instructions)`` tuple.  ``instructions`` contains
@@ -377,7 +391,7 @@ def _extract_custom_tools(
 
         for _name, func_def in group.definitions:
             tools.append(wrap_bees_handler(
-                func_def, suspend_queue=suspend_queue,
+                func_def, suspend_queue=suspend_queue, has_chat=has_chat,
             ))
 
         if group.instruction:

--- a/packages/bees/tests/test_runners/test_idle_resolution.py
+++ b/packages/bees/tests/test_runners/test_idle_resolution.py
@@ -103,7 +103,7 @@ class TestChatMode:
 class TestPriorityOrdering:
     """Verify the priority chain when multiple conditions are true."""
 
-    def test_deferred_suspend_beats_chat(self) -> None:
+    def test_chat_beats_deferred_suspend(self) -> None:
         inputs = IdleInputs(
             pending_suspend=True,
             suspend_request_id="req-456",
@@ -111,17 +111,24 @@ class TestPriorityOrdering:
             last_user_text="Hi there",
         )
         outcome, event = resolve_idle(inputs)
-        assert outcome == IdleOutcome.SUSPEND_DEFERRED
-        assert event["waitForInput"]["requestId"] == "req-456"
+        assert outcome == IdleOutcome.SUSPEND_CHAT
+        assert event["waitForInput"]["inputType"] == "text"
+        assert event["waitForInput"]["prompt"] == {
+            "parts": [{"text": "Hi there"}],
+        }
 
-    def test_active_tasks_beat_chat(self) -> None:
+    def test_chat_beats_active_tasks(self) -> None:
         inputs = IdleInputs(
             has_active_tasks=True,
             has_chat=True,
             last_user_text="Working on it...",
         )
         outcome, event = resolve_idle(inputs)
-        assert outcome == IdleOutcome.SUSPEND_DEFERRED
+        assert outcome == IdleOutcome.SUSPEND_CHAT
+        assert event["waitForInput"]["inputType"] == "text"
+        assert event["waitForInput"]["prompt"] == {
+            "parts": [{"text": "Working on it..."}],
+        }
 
     def test_deferred_suspend_beats_active_tasks(self) -> None:
         """When both are set, the tool's request ID is used."""

--- a/packages/bees/tests/test_runners/test_tool_mapping.py
+++ b/packages/bees/tests/test_runners/test_tool_mapping.py
@@ -151,6 +151,41 @@ class TestWrapBeesHandler:
         result = asyncio.run(tool())
         assert result == {"echo": {}}
 
+    def test_handler_suspend_error_non_chat(self) -> None:
+        """When a handler raises SuspendError and has_chat is False, it instructs the agent to say [ack]."""
+        from bees.protocols.handler_types import SuspendError, WaitForInputEvent
+        async def suspend_handler(args: dict[str, Any], status_cb: Any) -> dict[str, Any]:
+            event = WaitForInputEvent(request_id="req-1", prompt={}, input_type="any")
+            raise SuspendError(event, {"functionCall": {"name": "test_fn", "args": args}})
+            
+        func_def = FunctionDefinition(
+            name="test_fn",
+            description="Suspends",
+            handler=suspend_handler,
+        )
+        tool = wrap_bees_handler(func_def, has_chat=False)
+        result = asyncio.run(tool())
+        assert result["status"] == "pending"
+        assert "[ack]" in result["message"]
+
+    def test_handler_suspend_error_chat(self) -> None:
+        """When a handler raises SuspendError and has_chat is True, it instructs the agent to converse with the user."""
+        from bees.protocols.handler_types import SuspendError, WaitForInputEvent
+        async def suspend_handler(args: dict[str, Any], status_cb: Any) -> dict[str, Any]:
+            event = WaitForInputEvent(request_id="req-1", prompt={}, input_type="any")
+            raise SuspendError(event, {"functionCall": {"name": "test_fn", "args": args}})
+            
+        func_def = FunctionDefinition(
+            name="test_fn",
+            description="Suspends",
+            handler=suspend_handler,
+        )
+        tool = wrap_bees_handler(func_def, has_chat=True)
+        result = asyncio.run(tool())
+        assert result["status"] == "pending"
+        assert "[ack]" not in result["message"]
+        assert "continue conversing" in result["message"].lower()
+
 
 # ---------------------------------------------------------------------------
 # _resolve_builtin_pattern


### PR DESCRIPTION
## What
Modified `wrap_bees_handler` to avoid advising chat-enabled agents to reply with `[ack]` when a `SuspendError` is raised. Changed idle resolution to prioritize `SUSPEND_CHAT` over deferred system suspension when chat is enabled.

## Why
Allows chat-enabled agents to continue conversing with the user while waiting for background tasks (e.g., subagent completions) instead of forcing them to output `[ack]` and stop conversing.

## Changes
- **`packages/bees/bees/runners/tool_mapping.py`**:
  - Propagated `has_chat` boolean based on the presence of `chat.*` in the function filter.
  - Updated the wrapper return message when `SuspendError` is raised in chat mode to instruct the model to continue conversing with the user while waiting.
- **`packages/bees/bees/runners/idle_resolution.py`**:
  - Prioritized `SUSPEND_CHAT` over deferred system-initiated suspends in `resolve_idle`.
- **`packages/bees/tests/test_runners/test_idle_resolution.py`**:
  - Adjusted tests to assert chat-mode resolution when deferred suspends/active tasks are present.
- **`packages/bees/tests/test_runners/test_tool_mapping.py`**:
  - Added test cases checking `SuspendError` instruction messages for chat vs non-chat tools.

## Testing
- Ran Python unit tests using `npm run test:python -w packages/bees` (all 648 tests pass).
