### PR TITLE
[bees] Support for Built-in Gemini Tools (Search Grounding & URL Context) in Antigravity Runner

### DIFF
--- a/hives/antigravity/config/TEMPLATES.yaml
+++ b/hives/antigravity/config/TEMPLATES.yaml
@@ -83,6 +83,7 @@
 
 
     Your first task: {{system.context}}
+  runner: antigravity
   functions:
     - files.*
     - events.*

--- a/packages/bees/bees/runners/antigravity.py
+++ b/packages/bees/bees/runners/antigravity.py
@@ -56,6 +56,50 @@ __all__ = ["AntigravityRunner", "AntigravityStream"]
 logger = logging.getLogger(__name__)
 
 
+# --- RUNTIME HACK FOR GOOGLE SEARCH GROUNDING & URL CONTEXT ---
+import contextvars
+import websockets
+
+_hacked_features_var = contextvars.ContextVar("hacked_features", default=frozenset())
+
+try:
+    _orig_ws_connect = websockets.connect
+
+    async def _hacked_ws_connect(uri, *args, **kwargs):
+        ws = await _orig_ws_connect(uri, *args, **kwargs)
+        _orig_send = ws.send
+
+        async def _hacked_send(message, *args, **kwargs):
+            features = _hacked_features_var.get()
+            if isinstance(message, str) and features:
+                try:
+                    data = json.loads(message)
+                    if "config" in data:
+                        gemini_config = data["config"].get("geminiConfig", data["config"].get("gemini_config", {}))
+                        for feature in features:
+                            gemini_config[feature] = True
+                        data["config"]["geminiConfig"] = gemini_config
+                        message = json.dumps(data)
+                except Exception as e:
+                    logger.warning("Failed to inject hacked features into init message: %s", e)
+            return await _orig_send(message, *args, **kwargs)
+
+        ws.send = _hacked_send
+        ws._orig_send = _orig_send
+        return ws
+
+    websockets.connect = _hacked_ws_connect
+except Exception as e:
+    logger.warning("Failed to apply Google Search Grounding runtime hack: %s", e)
+# -------------------------------------------------------------
+
+
+
+
+
+
+
+
 # ---------------------------------------------------------------------------
 # Step → SessionEvent translation
 # ---------------------------------------------------------------------------
@@ -746,11 +790,25 @@ class AntigravityRunner:
 
         # 7. Enter the Agent context.
         exit_stack = contextlib.AsyncExitStack()
+        token = None
+        hacks = []
+        if config.function_filter:
+            if "builtin.search_grounding" in config.function_filter:
+                hacks.append("enable_google_search")
+            if "builtin.url_context" in config.function_filter:
+                hacks.append("enable_url_context")
+        if hacks:
+            token = _hacked_features_var.set(frozenset(hacks))
         try:
             agent = await exit_stack.enter_async_context(Agent(agent_config))
         except Exception:
             await exit_stack.aclose()
             raise
+        finally:
+            if token:
+                _hacked_features_var.reset(token)
+
+
 
         # 8. Extract the initial prompt from segments.
         initial_prompt = _extract_initial_prompt(config)
@@ -841,11 +899,25 @@ class AntigravityRunner:
 
         # 7. Enter the Agent context.
         exit_stack = contextlib.AsyncExitStack()
+        token = None
+        hacks = []
+        if config.function_filter:
+            if "builtin.search_grounding" in config.function_filter:
+                hacks.append("enable_google_search")
+            if "builtin.url_context" in config.function_filter:
+                hacks.append("enable_url_context")
+        if hacks:
+            token = _hacked_features_var.set(frozenset(hacks))
         try:
             agent = await exit_stack.enter_async_context(Agent(agent_config))
         except Exception:
             await exit_stack.aclose()
             raise
+        finally:
+            if token:
+                _hacked_features_var.reset(token)
+
+
 
         # 8. Build the resume prompt from the user's response + context.
         resume_prompt = _build_resume_prompt(response, context_parts)

--- a/packages/bees/tests/test_runners/test_antigravity_events.py
+++ b/packages/bees/tests/test_runners/test_antigravity_events.py
@@ -648,5 +648,86 @@ class TestAntigravityStreamEventOrdering:
         asyncio.run(run_test())
 
 
+class TestAntigravitySearchGroundingHack:
+    """Tests for the runtime monkeypatch enabling Google Search Grounding and URL Context."""
+
+    @pytest.mark.asyncio
+    async def test_search_grounding_hacked_websocket_send(self) -> None:
+        import websockets
+        import json
+        import unittest.mock
+        from unittest.mock import AsyncMock, MagicMock
+        from bees.runners.antigravity import _hacked_features_var
+        import bees.runners.antigravity as ag_runner
+
+        # Create a mock websocket
+        mock_ws_instance = MagicMock()
+        mock_ws_instance.send = AsyncMock()
+
+        # Mock the original ws connect reference within the module to prevent actual connection,
+        # but let the monkeypatched connect wrapper execute.
+        with unittest.mock.patch.object(ag_runner, "_orig_ws_connect", AsyncMock(return_value=mock_ws_instance)):
+            ws = await websockets.connect("ws://localhost:8000")
+
+            # Set the contextvar to contain search grounding and url context
+            token = _hacked_features_var.set(frozenset(["enable_google_search", "enable_url_context"]))
+            try:
+                # Send a sample initialization message
+                init_msg = json.dumps({
+                    "config": {
+                        "geminiConfig": {
+                            "modelName": "gemini-3.5-flash"
+                        }
+                    }
+                })
+                await ws.send(init_msg)
+            finally:
+                _hacked_features_var.reset(token)
+
+            # Verify that the message sent has the features injected!
+            sent_msg = ws._orig_send.call_args[0][0]
+            data = json.loads(sent_msg)
+            assert data["config"]["geminiConfig"]["enable_google_search"] is True
+            assert data["config"]["geminiConfig"]["enable_url_context"] is True
+
+    @pytest.mark.asyncio
+    async def test_search_grounding_disabled_by_default(self) -> None:
+        import websockets
+        import json
+        import unittest.mock
+        from unittest.mock import AsyncMock, MagicMock
+        from bees.runners.antigravity import _hacked_features_var
+        import bees.runners.antigravity as ag_runner
+
+        mock_ws_instance = MagicMock()
+        mock_ws_instance.send = AsyncMock()
+
+        with unittest.mock.patch.object(ag_runner, "_orig_ws_connect", AsyncMock(return_value=mock_ws_instance)):
+            ws = await websockets.connect("ws://localhost:8000")
+
+            # Contextvar is empty/default
+            init_msg = json.dumps({
+                "config": {
+                    "geminiConfig": {
+                        "modelName": "gemini-3.5-flash"
+                    }
+                }
+            })
+            await ws.send(init_msg)
+
+            # Verify that the message sent does NOT have the features injected!
+            sent_msg = ws._orig_send.call_args[0][0]
+            data = json.loads(sent_msg)
+            assert "enable_google_search" not in data["config"]["geminiConfig"]
+            assert "enable_url_context" not in data["config"]["geminiConfig"]
+
+
+
+
+
+
+
+
+
 
 


### PR DESCRIPTION
## What
Added support for Gemini API's built-in tools (`builtin.search_grounding` and `builtin.url_context`) in the Antigravity runner via a unified runtime monkeypatch of `websockets.connect`.

## Why
The pre-compiled Go `localharness` binary packaged within the SDK wheel doesn't expose these options in its Python-side descriptor schemas, but does support them natively in the underlying Go server. Intercepting the raw websocket initialization payload bypasses this schema limitation and enables both search grounding and URL context in the local development environment.

## Changes

### Antigravity Runner (`packages/bees`)
- **[antigravity.py](file:///Users/dimitriglazkov/Documents/code/breadboard/packages/bees/bees/runners/antigravity.py)**:
  - Monkeypatched `websockets.connect` to wrap the connection's `send` method.
  - Added a `_hacked_features_var` `ContextVar` that intercepts the initialization JSON payload to inject `enable_google_search: true` and/or `enable_url_context: true` depending on the active session's function filter.
  - Integrated this hack into both `run` and `resume` methods of the `AntigravityRunner`.

### Configuration (`hives`)
- **[TEMPLATES.yaml](file:///Users/dimitriglazkov/Documents/code/breadboard/hives/antigravity/config/TEMPLATES.yaml)**:
  - Updated the template config to use the `antigravity` runner.

### Tests
- **[test_antigravity_events.py](file:///Users/dimitriglazkov/Documents/code/breadboard/packages/bees/tests/test_runners/test_antigravity_events.py)**:
  - Added unit tests verifying that both features are correctly injected when active, and left unmodified by default.

## Testing
- Ran python test suite:
  ```bash
  npm run test:python
  ```
  All 650 unit tests successfully pass.
