### PR TITLE
[bees] Session-Level Antigravity State and Hivetool UI Links

### DIFF
--- a/packages/bees/bees/runners/antigravity.py
+++ b/packages/bees/bees/runners/antigravity.py
@@ -763,7 +763,9 @@ class AntigravityRunner:
         workspace = _workspace_path(config)
 
         # 4. Create a save_dir for session persistence.
-        if config.ticket_dir:
+        if config.ticket_dir and config.session_id:
+            save_dir = str(config.ticket_dir / "sessions" / config.session_id / "antigravity_state")
+        elif config.ticket_dir:
             save_dir = str(config.ticket_dir / "antigravity_state")
         else:
             save_dir = tempfile.mkdtemp(prefix="bees-ag-")

--- a/packages/bees/bees/trajectory_parser.py
+++ b/packages/bees/bees/trajectory_parser.py
@@ -153,7 +153,7 @@ def format_timestamp(step_fields: List[Tuple[int, Any]]) -> str:
     except Exception:
         return "Unknown Time"
 
-def trajectory_to_dict(decompressed_data: bytes) -> Dict[str, Any]:
+def trajectory_to_dict(decompressed_data: bytes, session_id: str | None = None) -> Dict[str, Any]:
     parsed = parse_proto(decompressed_data)
     trajectory_id = get_field(parsed, 1)
     steps = get_fields(parsed, 2)
@@ -256,17 +256,25 @@ def trajectory_to_dict(decompressed_data: bytes) -> Dict[str, Any]:
             
         steps_list.append(step_dict)
         
-    return {
+    result = {
         "trajectory_id": trajectory_id if isinstance(trajectory_id, str) else str(trajectory_id),
         "steps": steps_list,
     }
+    if session_id:
+        result["session_id"] = session_id
+    return result
 
 def convert_trajectory_to_json(filepath: Path, destpath: Path) -> bool:
     try:
         compressed_data = filepath.read_bytes()
         dctx = zstd.ZstdDecompressor()
         decompressed_data = dctx.decompress(compressed_data)
-        traj_dict = trajectory_to_dict(decompressed_data)
+        
+        session_id = None
+        if filepath.parent.name == "antigravity_state" and filepath.parent.parent.parent.name == "sessions":
+            session_id = filepath.parent.parent.name
+            
+        traj_dict = trajectory_to_dict(decompressed_data, session_id=session_id)
         
         destpath.write_text(json.dumps(traj_dict, indent=2), encoding="utf-8")
         return True

--- a/packages/bees/hivetool/src/data/agent-store.ts
+++ b/packages/bees/hivetool/src/data/agent-store.ts
@@ -257,7 +257,19 @@ class AgentStore {
     for (const agent of entries) {
       try {
         const agentDir = await this.#agentsHandle.getDirectoryHandle(agent.id);
-        const trajFileHandle = await agentDir.getFileHandle("antigravity_traj.json");
+        let trajFileHandle: FileSystemFileHandle | null = null;
+        if (agent.active_session) {
+          try {
+            const sessionsDir = await agentDir.getDirectoryHandle("sessions");
+            const sessionDir = await sessionsDir.getDirectoryHandle(agent.active_session);
+            trajFileHandle = await sessionDir.getFileHandle("antigravity_traj.json");
+          } catch {
+            // Fall through to agent-level root
+          }
+        }
+        if (!trajFileHandle) {
+          trajFileHandle = await agentDir.getFileHandle("antigravity_traj.json");
+        }
         const file = await trajFileHandle.getFile();
         const text = await file.text();
         const data = JSON.parse(text);
@@ -267,6 +279,7 @@ class AgentStore {
           agentTitle: agent.title ?? `Agent ${agent.id.slice(0, 8)}`,
           agentStatus: agent.status ?? "unknown",
           trajectoryId: data.trajectory_id || "",
+          sessionId: data.session_id || agent.active_session,
           steps: data.steps || [],
           lastModified: file.lastModified,
         });
@@ -775,7 +788,10 @@ class AgentStore {
               const fsPath = segments.slice(4).join("/");
               if (!fsChanges.has(agentId)) fsChanges.set(agentId, []);
               fsChanges.get(agentId)!.push(fsPath);
-            } else if (segments.length === 2 && segments[1] === "antigravity_traj.json") {
+            } else if (
+              (segments.length === 2 && segments[1] === "antigravity_traj.json") ||
+              (segments.length === 4 && segments[1] === "sessions" && segments[3] === "antigravity_traj.json")
+            ) {
               this.recentlyUpdatedTrajectory.set({ id: agentId, at: Date.now() });
             }
           }

--- a/packages/bees/hivetool/src/data/types.ts
+++ b/packages/bees/hivetool/src/data/types.ts
@@ -207,6 +207,7 @@ export interface TrajectoryData {
   agentTitle: string;
   agentStatus: string;
   trajectoryId: string;
+  sessionId?: string;
   steps: TrajectoryStep[];
   lastModified: number;
 }

--- a/packages/bees/hivetool/src/ui/trajectory-detail.ts
+++ b/packages/bees/hivetool/src/ui/trajectory-detail.ts
@@ -69,6 +69,9 @@ class BeesTrajectoryDetail extends SignalWatcher(LitElement) {
         color: #e2e8f0;
         word-break: break-all;
       }
+      .link-chip + .link-chip {
+        margin-left: 0;
+      }
     `,
   ];
 
@@ -121,6 +124,15 @@ class BeesTrajectoryDetail extends SignalWatcher(LitElement) {
             <span class="link-chip-label">agent</span>
             ${t.agentId.slice(0, 8)}
           </span>
+          ${t.sessionId ? html`
+            <span
+              class="link-chip"
+              @click=${() => this.#dispatchNavigate("logs", t.sessionId!)}
+            >
+              <span class="link-chip-label">session</span>
+              ${t.sessionId.slice(0, 8)}
+            </span>
+          ` : nothing}
         </div>
         <div class="header-meta">
           <span>${started ? started : "—"}</span>

--- a/packages/bees/tests/test_box.py
+++ b/packages/bees/tests/test_box.py
@@ -105,3 +105,8 @@ class TestClassifyChange:
             HIVE / "agents" / "abc-123" / "antigravity_traj.json", HIVE
         ) == "ignore"
 
+    def test_session_trajectory_json_ignored(self):
+        assert classify_change(
+            HIVE / "agents" / "abc-123" / "sessions" / "session-xyz" / "antigravity_traj.json", HIVE
+        ) == "ignore"
+

--- a/packages/bees/tests/test_trajectory_parser.py
+++ b/packages/bees/tests/test_trajectory_parser.py
@@ -141,3 +141,23 @@ def test_enhanced_trajectory_parsing(tmp_path: Path):
     assert s4["type"] == "complete"
     assert s4["outcome"] == {"objective_outcome": "success"}
 
+def test_trajectory_parsing_with_session(tmp_path: Path):
+    sessions_dir = tmp_path / "sessions" / "session-123" / "antigravity_state"
+    sessions_dir.mkdir(parents=True)
+    traj_file = sessions_dir / "traj-mock"
+    
+    traj_id_payload = b"\x0a\x09mock_traj"
+    cctx = zstd.ZstdCompressor()
+    compressed = cctx.compress(traj_id_payload)
+    traj_file.write_bytes(compressed)
+    
+    dest_json = sessions_dir.parent / "antigravity_traj.json"
+    success = convert_trajectory_to_json(traj_file, dest_json)
+    
+    assert success is True
+    assert dest_json.is_file()
+    
+    data = json.loads(dest_json.read_text(encoding="utf-8"))
+    assert data["trajectory_id"] == "mock_traj"
+    assert data["session_id"] == "session-123"
+


### PR DESCRIPTION
## What
Moved the Antigravity runner state directory from the agent level down into the session directory, and updated the trajectory parser and Hivetool UI to scan, load, and link trajectories on a per-session basis.

## Why
Storing state at the session level instead of the agent level prevents state pollution between consecutive sessions, and provides clean tracking and visual linking of execution trajectories to specific session runs.

## Changes

### Bees Runner & Parser (Python)
- **`packages/bees/bees/runners/antigravity.py`**: Changed the Antigravity runner state `save_dir` to `sessions/<session_id>/antigravity_state`.
- **`packages/bees/bees/trajectory_parser.py`**: Updated `convert_trajectory_to_json` to extract `session_id` from the file path and include it in `antigravity_traj.json`.
- **`packages/bees/tests/test_trajectory_parser.py`**: Added unit test to verify `session_id` extraction.
- **`packages/bees/tests/test_box.py`**: Added unit test verifying that session-level trajectory JSON file changes are classified as `"ignore"`.

### Hivetool UI (TypeScript)
- **`packages/bees/hivetool/src/data/types.ts`**: Added `sessionId` field to the `TrajectoryData` interface.
- **`packages/bees/hivetool/src/data/agent-store.ts`**: Updated `#scanTrajectories` to look inside `sessions/{active_session}` for the trajectory file first, populating `sessionId` in `TrajectoryData`, and adjusted `#startObserver` to watch session-level trajectory files.
- **`packages/bees/hivetool/src/ui/trajectory-detail.ts`**: Added a session link chip in the header for navigation to session logs and styled it to align next to the agent link chip on the right.

## Testing
- Ran all Python tests: `npm run test:python -w packages/bees` (all passed).
- Built Hivetool client: `npm run build -w packages/bees/hivetool` (compiled cleanly).
