### PR TITLE
[bees] Support Dynamic MCP Tools in Antigravity Runner

### DIFF
--- a/hives/antigravity/config/SYSTEM.yaml
+++ b/hives/antigravity/config/SYSTEM.yaml
@@ -2,3 +2,47 @@
 title: Antigravity Test
 description: Test hive for the Antigravity SDK runner
 # root: ag-worker
+mcp:
+  - name: gmail
+    description: Gmail MCP Server
+    url: https://gmailmcp.googleapis.com/mcp/v1
+    oauth:
+      client_id: "${GOOGLE_OAUTH_CLIENT_ID}"
+      client_secret: "${GOOGLE_OAUTH_CLIENT_SECRET}"
+      scopes:
+        - https://www.googleapis.com/auth/gmail.readonly
+        - https://www.googleapis.com/auth/gmail.compose
+
+  - name: drive
+    description: Google Drive MCP Server
+    url: https://drivemcp.googleapis.com/mcp/v1
+    oauth:
+      client_id: "${GOOGLE_OAUTH_CLIENT_ID}"
+      client_secret: "${GOOGLE_OAUTH_CLIENT_SECRET}"
+      scopes:
+        - https://www.googleapis.com/auth/drive.readonly
+        - https://www.googleapis.com/auth/drive.file
+
+  - name: calendar
+    description: Google Calendar MCP Server
+    url: https://calendarmcp.googleapis.com/mcp/v1
+    oauth:
+      client_id: "${GOOGLE_OAUTH_CLIENT_ID}"
+      client_secret: "${GOOGLE_OAUTH_CLIENT_SECRET}"
+      scopes:
+        - https://www.googleapis.com/auth/calendar.calendarlist.readonly
+        - https://www.googleapis.com/auth/calendar.events.freebusy
+        - https://www.googleapis.com/auth/calendar.events.readonly
+
+  - name: gchat
+    description: Google Chat MCP Server
+    url: https://chatmcp.googleapis.com/mcp/v1
+    oauth:
+      client_id: "${GOOGLE_OAUTH_CLIENT_ID}"
+      client_secret: "${GOOGLE_OAUTH_CLIENT_SECRET}"
+      scopes:
+        - https://www.googleapis.com/auth/chat.spaces.readonly
+        - https://www.googleapis.com/auth/chat.memberships.readonly
+        - https://www.googleapis.com/auth/chat.messages.readonly
+        - https://www.googleapis.com/auth/chat.messages.create
+        - https://www.googleapis.com/auth/chat.users.readstate.readonly

--- a/hives/antigravity/config/TEMPLATES.yaml
+++ b/hives/antigravity/config/TEMPLATES.yaml
@@ -64,6 +64,20 @@
     - events.*
     - builtin.search_grounding
 
+- name: workspace-test
+  runner: antigravity
+  title: Test Workspace MCP 2
+  description: Tests workspace MCP integration
+  objective:
+    Chat with the user and fulfill their requests with the tools that you have.
+  functions:
+    - chat.*
+    - drive.*
+    - gchat.*
+    - gmail.*
+    - calendar.*
+    - people.*
+
 - name: ag-worker
   runner: antigravity
   title: AG Worker

--- a/packages/bees/bees/runners/tool_mapping.py
+++ b/packages/bees/bees/runners/tool_mapping.py
@@ -70,8 +70,10 @@ _FILTER_TO_BUILTINS: dict[str, list[ag_types.BuiltinTools]] = {
     ],
 }
 
-# Function group names that produce custom tools rather than SDK builtins.
-_CUSTOM_TOOL_GROUPS = {"agents", "events", "skills"}
+# Function group names that map directly to SDK built-in capabilities.
+# All other groups are custom Python tools.
+_SDK_BUILTIN_GROUPS = {"files", "sandbox", "chat", "system"}
+
 
 # SDK tools we never enable, regardless of filter.
 _EXCLUDED_BUILTINS = {
@@ -189,7 +191,7 @@ def map_function_filter(
             # Map pattern to group name (e.g. "agents" from "agents.*" or "agents_assign_task").
             group_name = pattern.split(".")[0].split("_")[0]
             active_group_names.add(group_name)
-            if group_name in _CUSTOM_TOOL_GROUPS:
+            if group_name not in _SDK_BUILTIN_GROUPS:
                 custom_group_names.add(group_name)
 
         # Remove any excluded builtins that snuck in.
@@ -381,8 +383,7 @@ def _extract_custom_tools(
 
         group_name = group.name or ""
 
-        # Skip groups that map to SDK builtins.
-        if group_name and group_name not in _CUSTOM_TOOL_GROUPS:
+        if group_name in _SDK_BUILTIN_GROUPS:
             continue
 
         # Skip groups not in the include set (when filtering).

--- a/packages/bees/tests/test_runners/test_tool_mapping.py
+++ b/packages/bees/tests/test_runners/test_tool_mapping.py
@@ -28,7 +28,6 @@ from bees.protocols.functions import (
     SessionHooks,
 )
 from bees.runners.tool_mapping import (
-    _CUSTOM_TOOL_GROUPS,
     _EXCLUDED_BUILTINS,
     _FILTER_TO_BUILTINS,
     _extract_custom_tools,
@@ -409,6 +408,35 @@ class TestMapFunctionFilter:
         assert len(tools) == 1
         assert tools[0].__name__ == "agents_list"
         assert instructions == ["Agents."]
+
+    def test_mcp_filter_extracts_tools(self) -> None:
+        """'weather.*' enables the weather MCP custom tool group."""
+        fd = _make_func_def(name="weather_get_forecast")
+        group = _make_group("weather", [fd], instruction="Weather tools.")
+
+        caps, tools, instructions, _sq = map_function_filter(
+            ["weather.*"], [group], _StubHooks(),
+        )
+        assert set(caps.enabled_tools) == set()
+        assert len(tools) == 1
+        assert tools[0].__name__ == "weather_get_forecast"
+        assert instructions == ["Weather tools."]
+
+    def test_none_filter_extracts_all_custom_groups(self) -> None:
+        """None filter extracts tools from both standard and MCP custom groups."""
+        fd1 = _make_func_def(name="agents_list")
+        group1 = _make_group("agents", [fd1], instruction="Agents.")
+        fd2 = _make_func_def(name="weather_get_forecast")
+        group2 = _make_group("weather", [fd2], instruction="Weather.")
+
+        _caps, tools, instructions, _sq = map_function_filter(
+            None, [group1, group2], _StubHooks(),
+        )
+        assert len(tools) == 2
+        names = {t.__name__ for t in tools}
+        assert names == {"agents_list", "weather_get_forecast"}
+        assert set(instructions) == {"Agents.", "Weather."}
+
 
     def test_mixed_filter(self) -> None:
         """Builtin + custom filters work together."""


### PR DESCRIPTION
## What
Refactored the Antigravity runner's tool mapping logic to dynamically classify custom tool groups instead of matching against a static hardcoded set, enabling dynamic MCP server tools to be correctly registered and exposed to the Antigravity SDK.

## Why
Previously, MCP server tool groups (e.g. `weather`) were ignored by the Antigravity runner because their names were not listed in the static `_CUSTOM_TOOL_GROUPS` set, meaning the runner could not receive or execute MCP tools unlike the Gemini runner.

## Changes
- **bees package**:
  - Replaced the static `_CUSTOM_TOOL_GROUPS` set in [tool_mapping.py](file:///Users/dimitriglazkov/Documents/code/breadboard/packages/bees/bees/runners/tool_mapping.py) with `_SDK_BUILTIN_GROUPS` (`{"files", "sandbox", "chat", "system"}`).
  - Modified mapping logic to dynamically treat any tool group *not* in `_SDK_BUILTIN_GROUPS` as a custom Python tool group.
  - Removed unused `_CUSTOM_TOOL_GROUPS` import from [test_tool_mapping.py](file:///Users/dimitriglazkov/Documents/code/breadboard/packages/bees/tests/test_runners/test_tool_mapping.py).
  - Added unit test coverage for specific MCP tool groups and when no filter is provided.

## Testing
- Verified via existing and new unit tests in `packages/bees/tests/test_runners/test_tool_mapping.py`. All tests passed.
