### PR TITLE
[ve] Fix duplicate rendering of shell UI and consent requests in lite mode

### DIFF
--- a/packages/visual-editor/src/index-lite.ts
+++ b/packages/visual-editor/src/index-lite.ts
@@ -729,7 +729,6 @@ export class LiteMain extends MainBase implements LiteEditInputController {
         .isFreshGraph=${isFreshGraph}
       >
       </bb-app-controller>
-      ${this.#renderShellUI()} ${this.renderConsentRequests()}
     </section>`;
   }
 
@@ -837,7 +836,8 @@ export class LiteMain extends MainBase implements LiteEditInputController {
         ${content}
       </section>
       ${this.#renderShellUI()} ${this.#renderSharePanel()}
-      ${this.renderSnackbar()} ${this.renderNotebookLmPicker()} `;
+      ${this.renderSnackbar()} ${this.renderNotebookLmPicker()}
+      ${this.renderConsentRequests()} `;
   }
 
   #onSnackbar(event: BreadboardUI.Events.SnackbarEvent) {


### PR DESCRIPTION
## What
Removed redundant `#renderShellUI()` and `renderConsentRequests()` calls from the nested `#renderApp()` layout in `index-lite.ts`, rendering `renderConsentRequests()` once at the root level instead.

## Why
This resolves a regression introduced in 08b37d79962e57de87c2346526b2cff0fa5b00d2 where the elevated overflow menu was double-rendered in lite mode, causing click events on choices to be swallowed by a race condition with the "outside click" dismissal handler.

## Changes
- **Visual Editor**:
  - Removed `#renderShellUI()` and `renderConsentRequests()` from `#renderApp()` in `index-lite.ts`.
  - Added `renderConsentRequests()` to the root `LiteMain` render method template in `index-lite.ts`.

## Testing
- Verified visually by ensuring the add-asset button menu in lite mode triggers choices without instantly disappearing.
- Ran tests via `npm run test` in `packages/visual-editor` to verify suite integrity.
