### PR TITLE
[ve] Introduce ENABLE_DEV_TOOLS Flag and Modular bb-devtools Panel

### DIFF
--- a/packages/types/src/flags.ts
+++ b/packages/types/src/flags.ts
@@ -63,6 +63,11 @@ export type RuntimeFlags = {
   enableGraphEditorAgent: boolean;
 
   /**
+   * Enable Development Tools
+   */
+  enableDevTools: boolean;
+
+  /**
    * Use the remix text editor (model-driven, Lit-rendered)
    */
   textEditorRemix: boolean;
@@ -195,6 +200,11 @@ export const RUNTIME_FLAG_META: Record<keyof RuntimeFlags, RuntimeFlagMeta> = {
   enableGraphEditorAgent: {
     title: "Graph Editor Agent",
     description: "Enable conversational graph building",
+    visibility: "experimental",
+  },
+  enableDevTools: {
+    title: "Enable Development Tools",
+    description: "Enable Development Tools",
     visibility: "experimental",
   },
   textEditorRemix: {

--- a/packages/unified-server/src/config.ts
+++ b/packages/unified-server/src/config.ts
@@ -74,6 +74,7 @@ export async function createClientConfig(opts: {
       enableNotebookLm: flags.ENABLE_NOTEBOOK_LM,
       enableResumeAgentRun: flags.ENABLE_RESUME_AGENT_RUN,
       enableGraphEditorAgent: flags.ENABLE_GRAPH_EDITOR_AGENT,
+      enableDevTools: flags.ENABLE_DEV_TOOLS,
       textEditorRemix: flags.ENABLE_TEXT_EDITOR_REMIX,
       showTokenCounter: flags.ENABLE_SHOW_TOKEN_COUNTER,
       enableOpalBackend: flags.ENABLE_OPAL_BACKEND,

--- a/packages/unified-server/src/flags.ts
+++ b/packages/unified-server/src/flags.ts
@@ -42,6 +42,8 @@ export const ENABLE_BACKEND_CLIENT = getBoolean("ENABLE_BACKEND_CLIENT");
 
 export const ENABLE_CONSISTENT_UI = getBoolean("ENABLE_CONSISTENT_UI");
 
+export const ENABLE_DEV_TOOLS = getBoolean("ENABLE_DEV_TOOLS");
+
 export const ENABLE_FORCE_2D_GRAPH = getBoolean("ENABLE_FORCE_2D_GRAPH");
 
 export const ENABLE_GOOGLE_DRIVE_TOOLS = getBoolean(

--- a/packages/visual-editor/src/a2/agent/graph-editing/functions.ts
+++ b/packages/visual-editor/src/a2/agent/graph-editing/functions.ts
@@ -5,18 +5,19 @@
  */
 
 import type {
+  EditSpec,
   GraphDescriptor,
   NodeDescriptor,
   NodeValue,
 } from "@breadboard-ai/types";
-import type { InPort } from "../../../ui/transforms/autowire-in-ports.js";
 import z from "zod";
+import type { InPort } from "../../../ui/transforms/autowire-in-ports.js";
+import { A2_TOOLS } from "../../a2-registry.js";
+import type { AgentEventSink } from "../agent-event-sink.js";
 import { defineFunction, mapDefinitions } from "../function-definition.js";
 import type { FunctionGroup } from "../types.js";
-import { A2_TOOLS } from "../../a2-registry.js";
 import type { EditingAgentPidginTranslator } from "./editing-agent-pidgin-translator.js";
 import { graphOverviewYaml } from "./graph-overview.js";
-import type { AgentEventSink } from "../agent-event-sink.js";
 import type { ApplyEditsResponse, ReadGraphResponse } from "./types.js";
 
 export { getGraphEditingFunctionGroup };
@@ -369,7 +370,7 @@ function defineGraphEditingFunctions(
    * Applies edits via the suspend mechanism, waiting for confirmation.
    */
   async function applyEdits(
-    edits: import("@breadboard-ai/types").EditSpec[],
+    edits: EditSpec[],
     label: string
   ): Promise<ApplyEditsResponse> {
     return sink.suspend<ApplyEditsResponse>({

--- a/packages/visual-editor/src/index.styles.ts
+++ b/packages/visual-editor/src/index.styles.ts
@@ -707,5 +707,49 @@ export const styles = [
         opacity: 1;
       }
     }
+
+    #open-devtools {
+      position: absolute;
+      bottom: var(--bb-grid-size-4);
+      right: var(--bb-grid-size-4);
+      z-index: 1000;
+      width: 56px;
+      height: 56px;
+      border-radius: 50%;
+      border: none;
+      background: var(--light-dark-p-50);
+      color: white;
+      box-shadow: var(--bb-elevation-3);
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      transition: background-color 0.2s cubic-bezier(0, 0, 0.3, 1);
+
+      &:hover,
+      &:focus {
+        background-color: var(--light-dark-p-30);
+      }
+
+      & .g-icon {
+        font-size: 24px;
+      }
+    }
+
+    .devtools-split {
+      height: 100%;
+      width: 100%;
+
+      & [slot="slot-0"] {
+        height: 100%;
+        position: relative;
+        display: flex;
+        flex-direction: column;
+      }
+
+      & [slot="slot-1"] {
+        height: 100%;
+      }
+    }
   `,
 ] as CSSResultGroup;

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -19,6 +19,8 @@ import { CheckAppAccessResult } from "@breadboard-ai/types/opal-shell-protocol.j
 import { MakeUrlInit } from "./sca/types.js";
 import { repeat } from "lit/directives/repeat.js";
 import { Utils } from "./sca/utils.js";
+import "./ui/elements/splitter/splitter.js";
+import "./ui/elements/devtools/devtools.js";
 
 // Build constant.
 declare const ENABLE_DEBUG_TOOLING: boolean;
@@ -139,14 +141,26 @@ class Main extends MainBase {
     }
   }
 
+  #renderFloatingDevToolsButton() {
+    return html`
+      <button
+        id="open-devtools"
+        @click=${() => {
+          this.sca.controller.editor.devtools.isOpen = true;
+        }}
+      >
+        <span class="g-icon">developer_board</span>
+      </button>
+    `;
+  }
+
   render() {
     const renderValues = this.getRenderValues();
 
-    const content = html`<div
-      id="content"
-      ?inert=${renderValues.showingOverlay ||
-      this.sca.controller.global.main.blockingAction}
-    >
+    const enableDevTools = this.sca.env.flags.get("enableDevTools");
+    const devToolsOpen = this.sca.controller.editor.devtools.isOpen;
+
+    const mainPanel = html`
       ${this.sca.controller.global.main.show.has("TOS") ||
       this.sca.controller.global.main.show.has("MissingShare")
         ? nothing
@@ -158,6 +172,36 @@ class Main extends MainBase {
               ? this.#renderStatusUpdateBar()
               : nothing,
           ]}
+    `;
+
+    let body;
+    if (enableDevTools && devToolsOpen) {
+      body = html`
+        <bb-splitter
+          direction="vertical"
+          name="devtools-splitter"
+          .split=${[0.67, 0.33]}
+          class="devtools-split"
+        >
+          <div slot="slot-0">
+            ${mainPanel}
+          </div>
+          <bb-devtools slot="slot-1"></bb-devtools>
+        </bb-splitter>
+      `;
+    } else {
+      body = html`
+        ${mainPanel}
+        ${enableDevTools && !devToolsOpen ? this.#renderFloatingDevToolsButton() : nothing}
+      `;
+    }
+
+    const content = html`<div
+      id="content"
+      ?inert=${renderValues.showingOverlay ||
+      this.sca.controller.global.main.blockingAction}
+    >
+      ${body}
     </div>`;
 
     /**

--- a/packages/visual-editor/src/sca/controller/controller.ts
+++ b/packages/visual-editor/src/sca/controller/controller.ts
@@ -84,6 +84,10 @@ class Controller implements AppController {
         "Editor_NotebookLmPicker",
         "NotebookLmPickerController"
       ),
+      devtools: new Editor.DevTools.DevToolsController(
+        "Editor_DevTools",
+        "DevToolsController"
+      ),
     };
 
     this.home = {
@@ -250,6 +254,7 @@ export interface AppController extends DebuggableAppController {
     integrations: Editor.Integrations.IntegrationsController;
     graphEditingAgent: Editor.GraphEditingAgent.GraphEditingAgentController;
     notebookLmPicker: Editor.NotebookLmPicker.NotebookLmPickerController;
+    devtools: Editor.DevTools.DevToolsController;
   };
   home: {
     recent: Home.RecentBoardsController;

--- a/packages/visual-editor/src/sca/controller/subcontrollers/editor/devtools/devtools-controller.ts
+++ b/packages/visual-editor/src/sca/controller/subcontrollers/editor/devtools/devtools-controller.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { field } from "../../../decorators/field.js";
+import { RootController } from "../../root-controller.js";
+
+export class DevToolsController extends RootController {
+  @field({ persist: "session" })
+  accessor isOpen = false;
+}

--- a/packages/visual-editor/src/sca/controller/subcontrollers/editor/editor.ts
+++ b/packages/visual-editor/src/sca/controller/subcontrollers/editor/editor.ts
@@ -15,3 +15,4 @@ export * as FastAccess from "./fast-access/fast-access.js";
 export * as Integrations from "./integrations/integrations.js";
 export * as GraphEditingAgent from "./graph-editing-agent-controller.js";
 export * as NotebookLmPicker from "./notebooklm-picker-controller.js";
+export * as DevTools from "./devtools/devtools-controller.js";

--- a/packages/visual-editor/src/ui/config/client-deployment-configuration.ts
+++ b/packages/visual-editor/src/ui/config/client-deployment-configuration.ts
@@ -25,6 +25,7 @@ const DEFAULT_FLAG_VALUES: RuntimeFlags = {
   enableResumeAgentRun: false,
   enableNotebookLm: false,
   enableGraphEditorAgent: false,
+  enableDevTools: false,
   textEditorRemix: false,
   showTokenCounter: false,
   enableOpalBackend: false,

--- a/packages/visual-editor/src/ui/elements/devtools/devtools.ts
+++ b/packages/visual-editor/src/ui/elements/devtools/devtools.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { LitElement, html, css } from "lit";
+import { customElement } from "lit/decorators.js";
+import { SignalWatcher } from "@lit-labs/signals";
+import { consume } from "@lit/context";
+import { scaContext } from "../../../sca/context/context.js";
+import { type SCA } from "../../../sca/sca.js";
+import { icons } from "../../styles/icons.js";
+
+@customElement("bb-devtools")
+export class DevTools extends SignalWatcher(LitElement) {
+  @consume({ context: scaContext })
+  accessor sca!: SCA;
+
+  static styles = [
+    icons,
+    css`
+      * {
+        box-sizing: border-box;
+      }
+
+      :host {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        width: 100%;
+        background: var(--light-dark-n-100);
+        border-top: 1px solid var(--light-dark-n-90);
+      }
+
+      #devtools-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: var(--bb-grid-size-2) var(--bb-grid-size-4);
+        background: var(--light-dark-n-98);
+        border-bottom: 1px solid var(--light-dark-n-90);
+
+        & h2 {
+          margin: 0;
+          font: 500 var(--bb-label-large) / var(--bb-label-line-height-large)
+            var(--bb-font-family);
+          color: var(--light-dark-n-10);
+        }
+
+        & #close-devtools {
+          background: none;
+          border: none;
+          cursor: pointer;
+          padding: var(--bb-grid-size);
+          border-radius: 50%;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          color: var(--light-dark-n-40);
+          transition: background-color 0.2s cubic-bezier(0, 0, 0.3, 1),
+                      color 0.2s cubic-bezier(0, 0, 0.3, 1);
+
+          &:hover,
+          &:focus {
+            background: var(--light-dark-n-90);
+            color: var(--light-dark-n-10);
+          }
+        }
+      }
+
+      #devtools-content {
+        flex: 1;
+        padding: var(--bb-grid-size-4);
+        overflow: auto;
+        background: var(--light-dark-n-100);
+      }
+    `,
+  ];
+
+  render() {
+    return html`
+      <div id="devtools-header">
+        <h2>Dev Tools</h2>
+        <button
+          id="close-devtools"
+          @click=${() => {
+            this.sca.controller.editor.devtools.isOpen = false;
+          }}
+        >
+          <span class="g-icon">close</span>
+        </button>
+      </div>
+      <div id="devtools-content">
+        <!-- Blank for now -->
+      </div>
+    `;
+  }
+}

--- a/packages/visual-editor/src/ui/elements/elements.ts
+++ b/packages/visual-editor/src/ui/elements/elements.ts
@@ -71,6 +71,7 @@ export { Toast } from "./toast/toast.js";
 export { Tooltip } from "./tooltip/tooltip.js";
 export { OnboardingTooltip } from "./tooltip/onboarding-tooltip.js";
 export { AppSandbox } from "../../app-sandbox/app-sandbox-element.js";
+export { DevTools } from "./devtools/devtools.js";
 
 // Flowgen.
 export { FlowgenEditorInput } from "../flow-gen/flowgen-editor-input.js";

--- a/packages/visual-editor/tests/sca/controller/data/default-flags.ts
+++ b/packages/visual-editor/tests/sca/controller/data/default-flags.ts
@@ -17,6 +17,7 @@ export const defaultRuntimeFlags: RuntimeFlags = {
   enableNotebookLm: false,
   enableResumeAgentRun: false,
   enableGraphEditorAgent: false,
+  enableDevTools: false,
   textEditorRemix: false,
   showTokenCounter: false,
   enableOpalBackend: false,

--- a/packages/visual-editor/tests/sca/environment/environment.test.ts
+++ b/packages/visual-editor/tests/sca/environment/environment.test.ts
@@ -45,6 +45,7 @@ function makeRuntimeConfig(
         enableResumeAgentRun: false,
         enableNotebookLm: false,
         enableGraphEditorAgent: false,
+        enableDevTools: false,
         textEditorRemix: false,
         showTokenCounter: false,
 
@@ -78,6 +79,7 @@ const testFlags: RuntimeFlags = {
   enableResumeAgentRun: false,
   enableNotebookLm: false,
   enableGraphEditorAgent: false,
+  enableDevTools: false,
   textEditorRemix: false,
   showTokenCounter: false,
 

--- a/packages/visual-editor/tests/sca/helpers/mock-controller.ts
+++ b/packages/visual-editor/tests/sca/helpers/mock-controller.ts
@@ -175,6 +175,9 @@ export function makeTestController(options: TestControllerOptions = {}) {
       theme: {
         status: "idle" as string,
       },
+      devtools: {
+        isOpen: false,
+      },
     },
   } as unknown as AppController;
 


### PR DESCRIPTION
## What
Introduces the `ENABLE_DEV_TOOLS` runtime feature flag ("Enable Development Tools") and implements a corresponding modular resizable `<bb-devtools>` panel at the bottom third of the application page when the flag is enabled.

## Why
Provides a framework for launching development tools in-app. The panel starts out closed with a floating action button in the bottom right corner; clicking it opens a resizable panel while hiding the button, and clicking the close button on the panel restores the floating button.

## Changes

### Unified Server & Types
- **`packages/unified-server/`**: Added `ENABLE_DEV_TOOLS` environment check in [flags.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/unified-server/src/flags.ts) and mapped it to client config in [config.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/unified-server/src/config.ts).
- **`packages/types/`**: Defined `enableDevTools` in `RuntimeFlags` and mapped title/description in `RUNTIME_FLAG_META` in [flags.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/types/src/flags.ts).

### Frontend State & Layout (SCA)
- **`packages/visual-editor/`**:
  - Registered `DevToolsController` to track `isOpen` state in [controller.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/src/sca/controller/controller.ts).
  - Created and registered modular `<bb-devtools>` component in [devtools.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/src/ui/elements/devtools/devtools.ts).
  - Wired vertical `<bb-splitter>` and floating button layout inside [index.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/src/index.ts).
  - Added clean layout/FAB styles under `.devtools-split` and `#open-devtools` inside [index.styles.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/src/index.styles.ts).
  - Added default configuration values in [client-deployment-configuration.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/src/ui/config/client-deployment-configuration.ts).

### Tests
- **`packages/visual-editor/tests/`**: Updated test flags, mocks, and environment setup in [default-flags.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/tests/sca/controller/data/default-flags.ts), [environment.test.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/tests/sca/environment/environment.test.ts), and [mock-controller.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/tests/sca/helpers/mock-controller.ts).

## Testing
- Verified that all workspace test suites pass successfully with `npm run test -w packages/visual-editor`.
- Verified that unit tests for environment creations pass with `npm run test:file -w packages/visual-editor -- './dist/tsc/tests/sca/environment/environment.test.js'`.
