### PR TITLE
[ve] A2 Graph Editing Agent DevTools Telemetry & Session Log Upgrade

### DIFF
--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -157,8 +157,18 @@ class Main extends MainBase {
   render() {
     const renderValues = this.getRenderValues();
 
-    const enableDevTools = this.sca.env.flags.get("enableDevTools");
-    const devToolsOpen = this.sca.controller.editor.devtools.isOpen;
+    const isHydratingDevTools = Utils.Helpers.isHydrating(
+      () => this.sca.env.flags.get("enableDevTools")
+    ) || Utils.Helpers.isHydrating(
+      () => this.sca.controller.editor.devtools.isOpen
+    );
+
+    const enableDevTools = isHydratingDevTools
+      ? false
+      : this.sca.env.flags.get("enableDevTools");
+    const devToolsOpen = isHydratingDevTools
+      ? false
+      : this.sca.controller.editor.devtools.isOpen;
 
     const mainPanel = html`
       ${this.sca.controller.global.main.show.has("TOS") ||

--- a/packages/visual-editor/src/sca/actions/agent/graph-editing-agent-actions.ts
+++ b/packages/visual-editor/src/sca/actions/agent/graph-editing-agent-actions.ts
@@ -19,9 +19,12 @@ import type {
   NodeConfiguration,
   NodeMetadata,
 } from "@breadboard-ai/types";
+
 import { makeAction } from "../binder.js";
 import { buildHooksFromSink } from "../../../a2/agent/loop-setup.js";
 import { invokeGraphEditingAgent } from "../../../a2/agent/graph-editing/main.js";
+import { buildGraphEditingFunctionGroups } from "../../../a2/agent/graph-editing/configurator.js";
+import { EditingAgentPidginTranslator } from "../../../a2/agent/graph-editing/editing-agent-pidgin-translator.js";
 import type { AgentRunHandle } from "../../../a2/agent/agent-service.js";
 import type { LocalAgentRun } from "../../../a2/agent/local-agent-run.js";
 import type { A2ModuleFactory } from "../../../a2/runnable-module-factory.js";
@@ -89,17 +92,46 @@ function startGraphEditingAgent(firstMessage: string): void {
   }) as LocalAgentRun;
   currentRun = handle;
 
-  // Wire consumer handlers to controller mutations
+  const devtools = controller.editor.devtools;
+
+  if (devtools) {
+    const translator = new EditingAgentPidginTranslator();
+    const functionGroups = buildGraphEditingFunctionGroups({
+      sink: handle.sink,
+      translator,
+    });
+    const systemInstruction = functionGroups
+      .map((g) => g.instruction)
+      .filter((ins): ins is string => typeof ins === "string")
+      .join("\n\n");
+    const functionDeclarations = functionGroups.flatMap(
+      (g) => g.declarations
+    );
+
+    devtools.setSystemInstruction(systemInstruction);
+    devtools.setFunctionDeclarations(functionDeclarations);
+    devtools.addObjective(firstMessage);
+  }
+
+
   handle.events
     .on("thought", (event) => {
       agent.addThought(event.text);
+      devtools?.addThought?.(event.text);
     })
     .on("functionCall", (event) => {
       const name = event.name;
       if (name !== "wait_for_user_input") {
         agent.addMessage("system", `${event.title ?? name}…`);
       }
+      devtools?.addCall?.(event.callId, name, event.args);
+    })
+    .on("functionResult", (event) => {
+      devtools?.updateCallResponse?.(event.callId, event.content);
     });
+
+
+
 
   // Build hooks from sink
   const hooks = buildHooksFromSink(handle.sink);

--- a/packages/visual-editor/src/sca/controller/subcontrollers/editor/devtools/devtools-controller.ts
+++ b/packages/visual-editor/src/sca/controller/subcontrollers/editor/devtools/devtools-controller.ts
@@ -1,13 +1,122 @@
-/**
- * @license
- * Copyright 2026 Google LLC
- * SPDX-License-Identifier: Apache-2.0
- */
-
 import { field } from "../../../decorators/field.js";
 import { RootController } from "../../root-controller.js";
+import type { SessionLogEntry } from "../../../../types.js";
+import type { FunctionDeclaration } from "../../../../../a2/a2/gemini.js";
+import type { LLMContent } from "@breadboard-ai/types";
 
 export class DevToolsController extends RootController {
   @field({ persist: "session" })
   accessor isOpen = false;
+
+  @field()
+  private accessor _systemInstruction: string = "";
+
+  @field({ deep: true })
+  private accessor _functionDeclarations: FunctionDeclaration[] = [];
+
+  @field({ deep: true })
+  private accessor _entries: SessionLogEntry[] = [];
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // ACCESSORS
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  get systemInstruction(): string {
+    return this._systemInstruction;
+  }
+
+  get functionDeclarations(): readonly FunctionDeclaration[] {
+    return this._functionDeclarations;
+  }
+
+  get entries(): readonly SessionLogEntry[] {
+    return this._entries;
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // MUTATIONS
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  setSystemInstruction(instruction: string | LLMContent | null | undefined): void {
+    if (!instruction) {
+      this._systemInstruction = "";
+      return;
+    }
+    if (typeof instruction === "string") {
+      this._systemInstruction = instruction;
+    } else if ("parts" in instruction) {
+      this._systemInstruction = instruction.parts
+        .filter((p): p is { text: string } => "text" in p)
+        .map((p) => p.text)
+        .join("\n");
+    }
+  }
+
+  setFunctionDeclarations(declarations: FunctionDeclaration[]): void {
+    this._functionDeclarations = [...declarations];
+  }
+
+  addObjective(request: string): void {
+    const entry: SessionLogEntry = {
+      callId: crypto.randomUUID(),
+      kind: "objective",
+      name: "objective",
+      args: { user_request: request },
+      timestamp: Date.now(),
+    };
+    this._entries = [...this._entries, entry];
+  }
+
+  addThought(text: string): void {
+    const entry: SessionLogEntry = {
+      callId: crypto.randomUUID(),
+      kind: "thought",
+      name: "thought",
+      args: { thought: text },
+      timestamp: Date.now(),
+    };
+    this._entries = [...this._entries, entry];
+  }
+
+  addCall(callId: string, name: string, args: Record<string, unknown>): void {
+    const entry: SessionLogEntry = {
+      callId,
+      kind: "call",
+      name,
+      args,
+      timestamp: Date.now(),
+    };
+    this._entries = [...this._entries, entry];
+  }
+
+  updateCallResponse(callId: string, response: Record<string, unknown> | LLMContent | null | undefined): void {
+    let resolvedResponse: Record<string, unknown> | undefined = undefined;
+    if (response) {
+      if ("parts" in response && Array.isArray((response as LLMContent).parts)) {
+        const firstPart = (response as LLMContent).parts[0];
+        if (firstPart && "functionResponse" in firstPart) {
+          resolvedResponse = firstPart.functionResponse.response as Record<string, unknown>;
+        } else {
+          resolvedResponse = response as unknown as Record<string, unknown>;
+        }
+      } else {
+        resolvedResponse = response as Record<string, unknown>;
+      }
+    }
+
+    this._entries = this._entries.map((entry) => {
+      if (entry.callId === callId) {
+        return { ...entry, response: resolvedResponse };
+      }
+      return entry;
+    });
+  }
+
+  clearLog(): void {
+    this._entries = [];
+    this._systemInstruction = "";
+    this._functionDeclarations = [];
+  }
 }
+
+

--- a/packages/visual-editor/src/sca/types.ts
+++ b/packages/visual-editor/src/sca/types.ts
@@ -613,3 +613,14 @@ export type NodeDescriber = (
   type: NodeTypeIdentifier,
   configuration: NodeConfiguration
 ) => Promise<NodeDescriberResult>;
+
+export type SessionLogEntry = {
+  callId: string;
+  kind: "objective" | "thought" | "call";
+  name: string;
+  args: Record<string, unknown>;
+  response?: Record<string, unknown>;
+  timestamp: number;
+};
+
+

--- a/packages/visual-editor/src/ui/elements/devtools/devtools.ts
+++ b/packages/visual-editor/src/ui/elements/devtools/devtools.ts
@@ -11,6 +11,9 @@ import { consume } from "@lit/context";
 import { scaContext } from "../../../sca/context/context.js";
 import { type SCA } from "../../../sca/sca.js";
 import { icons } from "../../styles/icons.js";
+import { parseThought } from "../../../a2/agent/thought-parser.js";
+import { markdown } from "../../directives/markdown.js";
+import "../json-tree/json-tree.js";
 
 @customElement("bb-devtools")
 export class DevTools extends SignalWatcher(LitElement) {
@@ -29,23 +32,30 @@ export class DevTools extends SignalWatcher(LitElement) {
         flex-direction: column;
         height: 100%;
         width: 100%;
-        background: var(--light-dark-n-100);
+        min-height: 0;
+        overflow: hidden;
+        background: var(--light-dark-n-98);
         border-top: 1px solid var(--light-dark-n-90);
+        color: var(--light-dark-n-10);
+        font-family: var(--bb-font-family, sans-serif);
       }
 
       #devtools-header {
         display: flex;
         align-items: center;
         justify-content: space-between;
-        padding: var(--bb-grid-size-2) var(--bb-grid-size-4);
-        background: var(--light-dark-n-98);
+        padding: var(--bb-grid-size-3) var(--bb-grid-size-4);
+        background: var(--light-dark-n-100);
         border-bottom: 1px solid var(--light-dark-n-90);
 
         & h2 {
           margin: 0;
-          font: 500 var(--bb-label-large) / var(--bb-label-line-height-large)
+          font: 600 var(--bb-label-large) / var(--bb-label-line-height-large)
             var(--bb-font-family);
           color: var(--light-dark-n-10);
+          display: flex;
+          align-items: center;
+          gap: var(--bb-grid-size-2);
         }
 
         & #close-devtools {
@@ -72,28 +82,420 @@ export class DevTools extends SignalWatcher(LitElement) {
       #devtools-content {
         flex: 1;
         padding: var(--bb-grid-size-4);
-        overflow: auto;
+        overflow: hidden;
+        display: flex;
+        flex-direction: row;
+        gap: var(--bb-grid-size-3);
+        min-height: 0;
+      }
+
+      .devtools-column-left {
+        flex: 1;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--bb-grid-size-4);
+        min-height: 0;
+        overflow: hidden;
+      }
+
+      .devtools-column-right {
+        flex: 1.2;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--bb-grid-size-4);
+        overflow-y: auto;
+      }
+
+      .column-inner {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+        overflow: hidden;
+      }
+
+      .scroll-container {
+        flex: 1;
+        overflow-y: auto;
+        padding-right: var(--bb-grid-size);
+      }
+
+      .header-title {
+        display: flex;
+        align-items: center;
+        gap: var(--bb-grid-size);
+      }
+
+      .header-icon {
+        font-size: var(--bb-label-large);
+      }
+
+      .request-pre {
+        white-space: pre-wrap;
+        margin: 0;
         background: var(--light-dark-n-100);
+        border: 1px solid var(--light-dark-n-95);
+        padding: var(--bb-grid-size-3);
+        border-radius: var(--bb-grid-size);
+        font: 400 var(--bb-body-small) / var(--bb-body-line-height-small)
+          var(--bb-font-family-mono, monospace);
+        overflow-x: auto;
+      }
+
+      .waiting-pre {
+        color: var(--light-dark-n-40);
+        font-style: italic;
+        margin: 0;
+        background: var(--light-dark-n-100);
+        border: 1px solid var(--light-dark-n-95);
+        padding: var(--bb-grid-size-3);
+        border-radius: var(--bb-grid-size);
+        font: 400 var(--bb-body-small) / var(--bb-body-line-height-small)
+          var(--bb-font-family-mono, monospace);
+        overflow-x: auto;
+      }
+
+      .function-wrap {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--bb-grid-size);
+      }
+
+      .section {
+        background: var(--light-dark-n-100);
+        border: 1px solid var(--light-dark-n-90);
+        border-radius: var(--bb-grid-size-2);
+        padding: var(--bb-grid-size-4);
+        display: flex;
+        flex-direction: column;
+        gap: var(--bb-grid-size-3);
+
+        & h3 {
+          margin: 0;
+          font: 600 var(--bb-label-medium) / var(--bb-label-line-height-medium)
+            var(--bb-font-family);
+          color: var(--light-dark-n-20);
+          display: flex;
+          align-items: center;
+          gap: var(--bb-grid-size-2);
+          padding-bottom: var(--bb-grid-size-2);
+          border-bottom: 1px solid var(--light-dark-n-95);
+        }
+      }
+
+
+      .si-section {
+        flex: 1;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+      }
+
+      .markdown-container {
+        flex: 1;
+        overflow-y: auto;
+        min-height: 0;
+        padding-right: var(--bb-grid-size);
+      }
+
+      .functions-section {
+        flex-shrink: 0;
+      }
+
+      .markdown-body {
+        font: 400 var(--bb-body-medium) / var(--bb-body-line-height-medium)
+          var(--bb-font-family);
+        color: var(--light-dark-n-15);
+
+
+        & p {
+          margin: 0 0 var(--bb-grid-size-3) 0;
+          &:last-child {
+            margin-bottom: 0;
+          }
+        }
+
+        & code {
+          background: var(--light-dark-n-95);
+          padding: 2px 4px;
+          border-radius: 3px;
+          font-family: var(--bb-font-family-mono, monospace);
+          font-size: var(--bb-body-small);
+        }
+
+        & ul, & ol {
+          margin: 0 0 var(--bb-grid-size-3) 0;
+          padding-left: var(--bb-grid-size-4);
+        }
+
+        & h2, & h3 {
+          margin: var(--bb-grid-size-4) 0 var(--bb-grid-size-2) 0;
+          font-family: var(--bb-font-family);
+          color: var(--light-dark-n-10);
+          border-bottom: none;
+          padding-bottom: 0;
+        }
+
+        & h2 {
+          font: 600 var(--bb-label-large) / var(--bb-label-line-height-large);
+        }
+
+        & h3 {
+          font: 600 var(--bb-label-medium) / var(--bb-label-line-height-medium);
+        }
+      }
+
+      .function-tag {
+        display: inline-flex;
+        align-items: center;
+        background: var(--light-dark-n-90);
+        color: var(--light-dark-n-20);
+        padding: var(--bb-grid-size) var(--bb-grid-size-3);
+        border-radius: var(--bb-grid-size-5);
+
+        font: 500 var(--bb-label-small) / var(--bb-label-line-height-small)
+          var(--bb-font-family-mono, monospace);
+        border: 1px solid var(--light-dark-n-80);
+      }
+
+      .call-log {
+        display: flex;
+        flex-direction: column;
+        gap: var(--bb-grid-size-3);
+      }
+
+      .call-entry {
+        background: var(--light-dark-n-98);
+        border: 1px solid var(--light-dark-n-90);
+        border-radius: var(--bb-grid-size);
+        overflow: hidden;
+
+        &.objective {
+          border-left: 4px solid var(--light-dark-p-40);
+          background: var(--light-dark-n-100);
+          & .call-header {
+            background: var(--light-dark-n-98);
+            color: var(--light-dark-p-20);
+          }
+        }
+
+        &.thought {
+          border-left: 4px solid var(--light-dark-s-40);
+          background: var(--light-dark-n-98);
+          & .call-header {
+            background: var(--light-dark-n-95);
+            color: var(--light-dark-s-20);
+          }
+          & .thought-body {
+            padding: var(--bb-grid-size-3);
+            font: 400 var(--bb-body-medium) / var(--bb-body-line-height-medium)
+              var(--bb-font-family);
+            color: var(--light-dark-n-15);
+          }
+        }
+
+        & .call-header {
+
+          background: var(--light-dark-n-95);
+          padding: var(--bb-grid-size-2) var(--bb-grid-size-3);
+          font: 600 var(--bb-label-small) / var(--bb-label-line-height-small)
+            var(--bb-font-family-mono, monospace);
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          border-bottom: 1px solid var(--light-dark-n-90);
+
+          & .timestamp {
+            font-size: var(--bb-body-small);
+            color: var(--light-dark-n-40);
+            font-weight: 400;
+          }
+        }
+
+        & .call-details {
+          padding: var(--bb-grid-size-3);
+          display: flex;
+          flex-direction: column;
+          gap: var(--bb-grid-size-2);
+
+          & .label {
+            font: 600 var(--bb-label-small) / var(--bb-label-line-height-small)
+              var(--bb-font-family);
+            color: var(--light-dark-n-30);
+            margin-bottom: 2px;
+          }
+
+          & pre, & bb-json-tree {
+            margin: 0;
+            background: var(--light-dark-n-100);
+            border: 1px solid var(--light-dark-n-95);
+            padding: var(--bb-grid-size-3);
+            border-radius: var(--bb-grid-size);
+            font: 400 var(--bb-body-small) / var(--bb-body-line-height-small)
+              var(--bb-font-family-mono, monospace);
+            overflow-x: auto;
+          }
+
+        }
+      }
+
+      .empty-state {
+        color: var(--light-dark-n-50);
+        font: 400 var(--bb-body-medium) / var(--bb-body-line-height-medium)
+          var(--bb-font-family);
+        text-align: center;
+        padding: var(--bb-grid-size-6) 0;
       }
     `,
   ];
 
   render() {
+    const devtools = this.sca.controller.editor.devtools;
+    const systemInstruction = devtools.systemInstruction;
+    const functions = devtools.functionDeclarations;
+    const entries = devtools.entries;
+
     return html`
       <div id="devtools-header">
-        <h2>Dev Tools</h2>
+        <h2><span class="g-icon">developer_board</span> Dev Tools</h2>
         <button
           id="close-devtools"
           @click=${() => {
-            this.sca.controller.editor.devtools.isOpen = false;
+            devtools.isOpen = false;
           }}
         >
           <span class="g-icon">close</span>
         </button>
       </div>
       <div id="devtools-content">
-        <!-- Blank for now -->
+        <div class="devtools-column-left">
+          <div class="section si-section">
+            <h3><span class="g-icon">description</span> System Instruction</h3>
+            ${systemInstruction
+              ? html`<div class="markdown-container">
+                  <div class="markdown-body">${markdown(systemInstruction)}</div>
+                </div>`
+              : html`<div class="empty-state">No system instruction defined yet.</div>`}
+          </div>
+
+          <div class="section functions-section">
+            <h3><span class="g-icon">extension</span> Configured Functions</h3>
+            ${functions && functions.length > 0
+              ? html`
+                  <div class="function-wrap">
+                    ${functions.map(
+                      (fn) =>
+                        html`<span class="function-tag" title=${fn.description || ""}
+                          >${fn.name}</span
+                        >`
+                    )}
+                  </div>
+                `
+              : html`<div class="empty-state">No functions configured yet.</div>`}
+          </div>
+        </div>
+
+        <div class="devtools-column-right">
+          <div class="section column-inner">
+            <h3><span class="g-icon">history</span> Session Log</h3>
+            <div class="scroll-container">
+              ${entries && entries.length > 0
+                ? html`
+                    <div class="call-log">
+                      ${entries
+                        .map((entry) => {
+
+                          const date = new Date(entry.timestamp);
+                          const timeString = date.toLocaleTimeString();
+
+                          if (entry.kind === "thought") {
+                            const rawThought = String(
+                              entry.args.thought || entry.args.text || ""
+                            );
+                            const parsed = parseThought(rawThought);
+
+                            return html`
+                              <div class="call-entry thought">
+                                <div class="call-header">
+                                  <span class="header-title"
+                                    ><span class="g-icon header-icon">spark</span> ${parsed.title
+                                      ? parsed.title
+                                      : "thought"}</span
+                                  >
+                                  <span class="timestamp">${timeString}</span>
+                                </div>
+                                <div class="thought-body">
+                                  ${parsed.body}
+                                </div>
+                              </div>
+                            `;
+                          }
+
+                          if (entry.kind === "objective") {
+                            return html`
+                              <div class="call-entry objective">
+                                <div class="call-header">
+                                  <span class="header-title"
+                                    ><span class="g-icon header-icon">start</span> objective</span>
+                                  <span class="timestamp">${timeString}</span>
+                                </div>
+                                <div class="call-details">
+                                  <div>
+                                    <div class="label">Initial Request:</div>
+                                    <pre class="request-pre">${
+                                      entry.args.user_request ||
+                                      entry.args.request ||
+                                      ""
+                                    }</pre>
+                                  </div>
+                                </div>
+                              </div>
+                            `;
+                          }
+
+                          return html`
+                            <div class="call-entry">
+                              <div class="call-header">
+                                <span class="header-title"
+                                  ><span class="g-icon header-icon">home_repair_service</span> ${entry.name}</span>
+                                <span class="timestamp">${timeString}</span>
+                              </div>
+                              <div class="call-details">
+                                <div>
+                                  <div class="label">Arguments:</div>
+                                  <bb-json-tree
+                                    .json=${entry.args as Record<string, unknown>}
+                                    .autoExpand=${true}
+                                  ></bb-json-tree>
+                                </div>
+                                <div>
+                                  <div class="label">Response:</div>
+                                  ${entry.response
+                                    ? html`<bb-json-tree
+                                        .json=${entry.response as Record<string, unknown>}
+                                        .autoExpand=${true}
+                                      ></bb-json-tree>`
+                                    : html`<pre class="waiting-pre">Waiting for response...</pre>`}
+                                </div>
+                              </div>
+                            </div>
+                          `;
+
+                        })}
+                    </div>
+                  `
+                : html`<div class="empty-state">No entries in session log yet.</div>`}
+
+
+            </div>
+          </div>
+        </div>
       </div>
     `;
   }
 }
+
+


### PR DESCRIPTION
## What
Implemented real-time developer tooling for the A2 Graph Editing Agent inside `<bb-devtools>`. Introduces a beautiful two-column layout housing System Instructions (rendered with Markdown), Configured Function pills, and a chronological, independently scrollable Session Log capturing objectives, thoughts, and JSON-tree-formatted function call/response pairs.

## Why
Exposes the agent's internal reasoning, environment capabilities, and data exchange visually for developers in real-time, bridging the architectural reality of prefix-cached API bodies with a complete, user-facing telemetry viewer.

## Changes
### Visual Editor (UI)
- Upgraded `<bb-devtools>` to support a premium two-column CSS layout.
- Integrated the `markdown` and `isHydrating` directives for robust, safe UI rendering.
- Replaced pre-formatted text with interactive `<bb-json-tree>` components supporting first-level auto-expansion.
- Added Google Material icons allowlist integration (`developer_board`, `description`, `spark`, `home_repair_service`).

### SCA Architecture
- Added `SessionLogEntry` schema for unified, kind-based (`objective` | `thought` | `call`) chronological state tracking in `DevToolsController`.
- Handled edge cases regarding Gemini Prefix Caching in `graph-editing-agent-actions` via direct static extraction.

## Testing
1. Run `bbu` and open the DevTools panel.
2. Send a prompt to the A2 Graph Editing agent.
3. Observe the Session Log populate chronologically with the objective at the top, followed by parsed reasoning thoughts and expanded interactive JSON tree logs for any dispatched function calls.
