### PR TITLE
[ve] Extensible Opal Dev Tools Dashboard & Spaghetti-Proof Telemetry

### DIFF
--- a/packages/visual-editor/src/sca/actions/agent/graph-editing-agent-actions.ts
+++ b/packages/visual-editor/src/sca/actions/agent/graph-editing-agent-actions.ts
@@ -95,6 +95,7 @@ function startGraphEditingAgent(firstMessage: string): void {
   const devtools = controller.editor.devtools;
 
   if (devtools) {
+    devtools.clearLog();
     const translator = new EditingAgentPidginTranslator();
     const functionGroups = buildGraphEditingFunctionGroups({
       sink: handle.sink,
@@ -115,6 +116,12 @@ function startGraphEditingAgent(firstMessage: string): void {
 
 
   handle.events
+    .on("start", (event) => {
+      const devtools = controller.editor.devtools;
+      if (devtools && event.objective) {
+        devtools.addObjective(event.objective);
+      }
+    })
     .on("thought", (event) => {
       agent.addThought(event.text);
       devtools?.addThought?.(event.text);

--- a/packages/visual-editor/src/sca/controller/subcontrollers/editor/devtools/devtools-controller.ts
+++ b/packages/visual-editor/src/sca/controller/subcontrollers/editor/devtools/devtools-controller.ts
@@ -8,6 +8,9 @@ export class DevToolsController extends RootController {
   @field({ persist: "session" })
   accessor isOpen = false;
 
+  @field({ persist: "session" })
+  accessor activeTab = "opie";
+
   @field()
   private accessor _systemInstruction: string = "";
 
@@ -56,15 +59,38 @@ export class DevToolsController extends RootController {
     this._functionDeclarations = [...declarations];
   }
 
-  addObjective(request: string): void {
-    const entry: SessionLogEntry = {
-      callId: crypto.randomUUID(),
-      kind: "objective",
-      name: "objective",
-      args: { user_request: request },
-      timestamp: Date.now(),
-    };
-    this._entries = [...this._entries, entry];
+  addObjective(request: string | LLMContent): void {
+    let resolvedRequest = "";
+    if (typeof request === "string") {
+      resolvedRequest = request;
+    } else if (request && "parts" in request) {
+      resolvedRequest = (request as LLMContent).parts
+        .filter((p): p is { text: string } => "text" in p)
+        .map((p) => p.text)
+        .join("\n");
+    }
+
+    const existingIndex = this._entries.findIndex((e) => e.kind === "objective");
+    if (existingIndex !== -1) {
+      this._entries = this._entries.map((entry, idx) => {
+        if (idx === existingIndex) {
+          return {
+            ...entry,
+            args: { ...entry.args, user_request: resolvedRequest },
+          };
+        }
+        return entry;
+      });
+    } else {
+      const entry: SessionLogEntry = {
+        callId: crypto.randomUUID(),
+        kind: "objective",
+        name: "objective",
+        args: { user_request: resolvedRequest },
+        timestamp: Date.now(),
+      };
+      this._entries = [...this._entries, entry];
+    }
   }
 
   addThought(text: string): void {

--- a/packages/visual-editor/src/ui/elements/devtools/devtools.ts
+++ b/packages/visual-editor/src/ui/elements/devtools/devtools.ts
@@ -11,9 +11,8 @@ import { consume } from "@lit/context";
 import { scaContext } from "../../../sca/context/context.js";
 import { type SCA } from "../../../sca/sca.js";
 import { icons } from "../../styles/icons.js";
-import { parseThought } from "../../../a2/agent/thought-parser.js";
-import { markdown } from "../../directives/markdown.js";
 import "../json-tree/json-tree.js";
+import "./opie/opie-panel.js";
 
 @customElement("bb-devtools")
 export class DevTools extends SignalWatcher(LitElement) {
@@ -62,19 +61,58 @@ export class DevTools extends SignalWatcher(LitElement) {
           background: none;
           border: none;
           cursor: pointer;
-          padding: var(--bb-grid-size);
-          border-radius: 50%;
+          color: var(--light-dark-n-40);
           display: flex;
           align-items: center;
           justify-content: center;
-          color: var(--light-dark-n-40);
-          transition: background-color 0.2s cubic-bezier(0, 0, 0.3, 1),
-                      color 0.2s cubic-bezier(0, 0, 0.3, 1);
+          padding: var(--bb-grid-size);
+          border-radius: 50%;
+          transition: background 0.2s;
 
-          &:hover,
-          &:focus {
+          &:hover {
             background: var(--light-dark-n-90);
             color: var(--light-dark-n-10);
+          }
+        }
+      }
+
+      #devtools-tabs {
+        display: flex;
+        align-items: center;
+        justify-content: flex-start;
+        flex: 0 0 auto;
+        height: var(--bb-grid-size-14);
+        background: var(--light-dark-n-100);
+        border-bottom: 1px solid var(--light-dark-n-90);
+        padding: 0 var(--bb-grid-size-4);
+
+        & button {
+          display: flex;
+          align-items: center;
+          border-radius: var(--bb-grid-size-16);
+          font-size: 12px;
+          font-weight: 500;
+          background: none;
+          color: var(--light-dark-n-15);
+          height: 32px;
+          border: none;
+          margin: 0 var(--bb-grid-size-2);
+          padding: 0 var(--bb-grid-size-3);
+          position: relative;
+          cursor: pointer;
+          white-space: nowrap;
+          transition:
+            background 0.2s cubic-bezier(0, 0, 0.3, 1),
+            color 0.2s cubic-bezier(0, 0, 0.3, 1);
+
+          &:hover,
+          &[disabled] {
+            color: var(--light-dark-p-20);
+            background: var(--light-dark-n-95);
+          }
+
+          &[disabled] {
+            cursor: auto;
           }
         }
       }
@@ -89,265 +127,14 @@ export class DevTools extends SignalWatcher(LitElement) {
         min-height: 0;
       }
 
-      .devtools-column-left {
+      #devtools-content {
         flex: 1;
-        min-width: 0;
-        display: flex;
-        flex-direction: column;
-        gap: var(--bb-grid-size-4);
-        min-height: 0;
-        overflow: hidden;
-      }
-
-      .devtools-column-right {
-        flex: 1.2;
-        min-width: 0;
-        display: flex;
-        flex-direction: column;
-        gap: var(--bb-grid-size-4);
-        overflow-y: auto;
-      }
-
-      .column-inner {
-        flex: 1;
-        display: flex;
-        flex-direction: column;
-        min-height: 0;
-        overflow: hidden;
-      }
-
-      .scroll-container {
-        flex: 1;
-        overflow-y: auto;
-        padding-right: var(--bb-grid-size);
-      }
-
-      .header-title {
-        display: flex;
-        align-items: center;
-        gap: var(--bb-grid-size);
-      }
-
-      .header-icon {
-        font-size: var(--bb-label-large);
-      }
-
-      .request-pre {
-        white-space: pre-wrap;
-        margin: 0;
-        background: var(--light-dark-n-100);
-        border: 1px solid var(--light-dark-n-95);
-        padding: var(--bb-grid-size-3);
-        border-radius: var(--bb-grid-size);
-        font: 400 var(--bb-body-small) / var(--bb-body-line-height-small)
-          var(--bb-font-family-mono, monospace);
-        overflow-x: auto;
-      }
-
-      .waiting-pre {
-        color: var(--light-dark-n-40);
-        font-style: italic;
-        margin: 0;
-        background: var(--light-dark-n-100);
-        border: 1px solid var(--light-dark-n-95);
-        padding: var(--bb-grid-size-3);
-        border-radius: var(--bb-grid-size);
-        font: 400 var(--bb-body-small) / var(--bb-body-line-height-small)
-          var(--bb-font-family-mono, monospace);
-        overflow-x: auto;
-      }
-
-      .function-wrap {
-        display: flex;
-        flex-wrap: wrap;
-        gap: var(--bb-grid-size);
-      }
-
-      .section {
-        background: var(--light-dark-n-100);
-        border: 1px solid var(--light-dark-n-90);
-        border-radius: var(--bb-grid-size-2);
         padding: var(--bb-grid-size-4);
-        display: flex;
-        flex-direction: column;
-        gap: var(--bb-grid-size-3);
-
-        & h3 {
-          margin: 0;
-          font: 600 var(--bb-label-medium) / var(--bb-label-line-height-medium)
-            var(--bb-font-family);
-          color: var(--light-dark-n-20);
-          display: flex;
-          align-items: center;
-          gap: var(--bb-grid-size-2);
-          padding-bottom: var(--bb-grid-size-2);
-          border-bottom: 1px solid var(--light-dark-n-95);
-        }
-      }
-
-
-      .si-section {
-        flex: 1;
-        min-height: 0;
-        display: flex;
-        flex-direction: column;
         overflow: hidden;
-      }
-
-      .markdown-container {
-        flex: 1;
-        overflow-y: auto;
-        min-height: 0;
-        padding-right: var(--bb-grid-size);
-      }
-
-      .functions-section {
-        flex-shrink: 0;
-      }
-
-      .markdown-body {
-        font: 400 var(--bb-body-medium) / var(--bb-body-line-height-medium)
-          var(--bb-font-family);
-        color: var(--light-dark-n-15);
-
-
-        & p {
-          margin: 0 0 var(--bb-grid-size-3) 0;
-          &:last-child {
-            margin-bottom: 0;
-          }
-        }
-
-        & code {
-          background: var(--light-dark-n-95);
-          padding: 2px 4px;
-          border-radius: 3px;
-          font-family: var(--bb-font-family-mono, monospace);
-          font-size: var(--bb-body-small);
-        }
-
-        & ul, & ol {
-          margin: 0 0 var(--bb-grid-size-3) 0;
-          padding-left: var(--bb-grid-size-4);
-        }
-
-        & h2, & h3 {
-          margin: var(--bb-grid-size-4) 0 var(--bb-grid-size-2) 0;
-          font-family: var(--bb-font-family);
-          color: var(--light-dark-n-10);
-          border-bottom: none;
-          padding-bottom: 0;
-        }
-
-        & h2 {
-          font: 600 var(--bb-label-large) / var(--bb-label-line-height-large);
-        }
-
-        & h3 {
-          font: 600 var(--bb-label-medium) / var(--bb-label-line-height-medium);
-        }
-      }
-
-      .function-tag {
-        display: inline-flex;
-        align-items: center;
-        background: var(--light-dark-n-90);
-        color: var(--light-dark-n-20);
-        padding: var(--bb-grid-size) var(--bb-grid-size-3);
-        border-radius: var(--bb-grid-size-5);
-
-        font: 500 var(--bb-label-small) / var(--bb-label-line-height-small)
-          var(--bb-font-family-mono, monospace);
-        border: 1px solid var(--light-dark-n-80);
-      }
-
-      .call-log {
         display: flex;
-        flex-direction: column;
+        flex-direction: row;
         gap: var(--bb-grid-size-3);
-      }
-
-      .call-entry {
-        background: var(--light-dark-n-98);
-        border: 1px solid var(--light-dark-n-90);
-        border-radius: var(--bb-grid-size);
-        overflow: hidden;
-
-        &.objective {
-          border-left: 4px solid var(--light-dark-p-40);
-          background: var(--light-dark-n-100);
-          & .call-header {
-            background: var(--light-dark-n-98);
-            color: var(--light-dark-p-20);
-          }
-        }
-
-        &.thought {
-          border-left: 4px solid var(--light-dark-s-40);
-          background: var(--light-dark-n-98);
-          & .call-header {
-            background: var(--light-dark-n-95);
-            color: var(--light-dark-s-20);
-          }
-          & .thought-body {
-            padding: var(--bb-grid-size-3);
-            font: 400 var(--bb-body-medium) / var(--bb-body-line-height-medium)
-              var(--bb-font-family);
-            color: var(--light-dark-n-15);
-          }
-        }
-
-        & .call-header {
-
-          background: var(--light-dark-n-95);
-          padding: var(--bb-grid-size-2) var(--bb-grid-size-3);
-          font: 600 var(--bb-label-small) / var(--bb-label-line-height-small)
-            var(--bb-font-family-mono, monospace);
-          display: flex;
-          justify-content: space-between;
-          align-items: center;
-          border-bottom: 1px solid var(--light-dark-n-90);
-
-          & .timestamp {
-            font-size: var(--bb-body-small);
-            color: var(--light-dark-n-40);
-            font-weight: 400;
-          }
-        }
-
-        & .call-details {
-          padding: var(--bb-grid-size-3);
-          display: flex;
-          flex-direction: column;
-          gap: var(--bb-grid-size-2);
-
-          & .label {
-            font: 600 var(--bb-label-small) / var(--bb-label-line-height-small)
-              var(--bb-font-family);
-            color: var(--light-dark-n-30);
-            margin-bottom: 2px;
-          }
-
-          & pre, & bb-json-tree {
-            margin: 0;
-            background: var(--light-dark-n-100);
-            border: 1px solid var(--light-dark-n-95);
-            padding: var(--bb-grid-size-3);
-            border-radius: var(--bb-grid-size);
-            font: 400 var(--bb-body-small) / var(--bb-body-line-height-small)
-              var(--bb-font-family-mono, monospace);
-            overflow-x: auto;
-          }
-
-        }
-      }
-
-      .empty-state {
-        color: var(--light-dark-n-50);
-        font: 400 var(--bb-body-medium) / var(--bb-body-line-height-medium)
-          var(--bb-font-family);
-        text-align: center;
-        padding: var(--bb-grid-size-6) 0;
+        min-height: 0;
       }
     `,
   ];
@@ -360,7 +147,7 @@ export class DevTools extends SignalWatcher(LitElement) {
 
     return html`
       <div id="devtools-header">
-        <h2><span class="g-icon">developer_board</span> Dev Tools</h2>
+        <h2><span class="g-icon">developer_board</span> Opal Dev Tools</h2>
         <button
           id="close-devtools"
           @click=${() => {
@@ -370,129 +157,27 @@ export class DevTools extends SignalWatcher(LitElement) {
           <span class="g-icon">close</span>
         </button>
       </div>
+      <div id="devtools-tabs">
+        <button
+          class="sans-flex w-500 round"
+          ?disabled=${devtools.activeTab === "opie"}
+          @click=${() => {
+            devtools.activeTab = "opie";
+          }}
+        >
+          Opie
+        </button>
+      </div>
       <div id="devtools-content">
-        <div class="devtools-column-left">
-          <div class="section si-section">
-            <h3><span class="g-icon">description</span> System Instruction</h3>
-            ${systemInstruction
-              ? html`<div class="markdown-container">
-                  <div class="markdown-body">${markdown(systemInstruction)}</div>
-                </div>`
-              : html`<div class="empty-state">No system instruction defined yet.</div>`}
-          </div>
-
-          <div class="section functions-section">
-            <h3><span class="g-icon">extension</span> Configured Functions</h3>
-            ${functions && functions.length > 0
-              ? html`
-                  <div class="function-wrap">
-                    ${functions.map(
-                      (fn) =>
-                        html`<span class="function-tag" title=${fn.description || ""}
-                          >${fn.name}</span
-                        >`
-                    )}
-                  </div>
-                `
-              : html`<div class="empty-state">No functions configured yet.</div>`}
-          </div>
-        </div>
-
-        <div class="devtools-column-right">
-          <div class="section column-inner">
-            <h3><span class="g-icon">history</span> Session Log</h3>
-            <div class="scroll-container">
-              ${entries && entries.length > 0
-                ? html`
-                    <div class="call-log">
-                      ${entries
-                        .map((entry) => {
-
-                          const date = new Date(entry.timestamp);
-                          const timeString = date.toLocaleTimeString();
-
-                          if (entry.kind === "thought") {
-                            const rawThought = String(
-                              entry.args.thought || entry.args.text || ""
-                            );
-                            const parsed = parseThought(rawThought);
-
-                            return html`
-                              <div class="call-entry thought">
-                                <div class="call-header">
-                                  <span class="header-title"
-                                    ><span class="g-icon header-icon">spark</span> ${parsed.title
-                                      ? parsed.title
-                                      : "thought"}</span
-                                  >
-                                  <span class="timestamp">${timeString}</span>
-                                </div>
-                                <div class="thought-body">
-                                  ${parsed.body}
-                                </div>
-                              </div>
-                            `;
-                          }
-
-                          if (entry.kind === "objective") {
-                            return html`
-                              <div class="call-entry objective">
-                                <div class="call-header">
-                                  <span class="header-title"
-                                    ><span class="g-icon header-icon">start</span> objective</span>
-                                  <span class="timestamp">${timeString}</span>
-                                </div>
-                                <div class="call-details">
-                                  <div>
-                                    <div class="label">Initial Request:</div>
-                                    <pre class="request-pre">${
-                                      entry.args.user_request ||
-                                      entry.args.request ||
-                                      ""
-                                    }</pre>
-                                  </div>
-                                </div>
-                              </div>
-                            `;
-                          }
-
-                          return html`
-                            <div class="call-entry">
-                              <div class="call-header">
-                                <span class="header-title"
-                                  ><span class="g-icon header-icon">home_repair_service</span> ${entry.name}</span>
-                                <span class="timestamp">${timeString}</span>
-                              </div>
-                              <div class="call-details">
-                                <div>
-                                  <div class="label">Arguments:</div>
-                                  <bb-json-tree
-                                    .json=${entry.args as Record<string, unknown>}
-                                    .autoExpand=${true}
-                                  ></bb-json-tree>
-                                </div>
-                                <div>
-                                  <div class="label">Response:</div>
-                                  ${entry.response
-                                    ? html`<bb-json-tree
-                                        .json=${entry.response as Record<string, unknown>}
-                                        .autoExpand=${true}
-                                      ></bb-json-tree>`
-                                    : html`<pre class="waiting-pre">Waiting for response...</pre>`}
-                                </div>
-                              </div>
-                            </div>
-                          `;
-
-                        })}
-                    </div>
-                  `
-                : html`<div class="empty-state">No entries in session log yet.</div>`}
-
-
-            </div>
-          </div>
-        </div>
+        ${devtools.activeTab === "opie"
+          ? html`
+              <bb-devtools-opie-panel
+                .entries=${entries}
+                .systemInstruction=${systemInstruction}
+                .functions=${functions}
+              ></bb-devtools-opie-panel>
+            `
+          : ""}
       </div>
     `;
   }

--- a/packages/visual-editor/src/ui/elements/devtools/opie/opie-panel.ts
+++ b/packages/visual-editor/src/ui/elements/devtools/opie/opie-panel.ts
@@ -1,0 +1,406 @@
+import { LitElement, html, css, TemplateResult } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { SignalWatcher } from "@lit-labs/signals";
+import { icons } from "../../../styles/icons.js";
+import { markdown } from "../../../directives/markdown.js";
+import { parseThought } from "../../../../a2/agent/thought-parser.js";
+import { renderCall } from "./registry.js";
+import type { SessionLogEntry } from "../../../../sca/types.js";
+import type { FunctionDeclaration } from "../../../../a2/a2/gemini.js";
+import "../../json-tree/json-tree.js";
+
+@customElement("bb-devtools-opie-panel")
+export class DevToolsOpiePanel extends SignalWatcher(LitElement) {
+  @property({ type: Array })
+  accessor entries: readonly SessionLogEntry[] = [];
+
+  @property({ type: String })
+  accessor systemInstruction = "";
+
+  @property({ type: Array })
+  accessor functions: readonly FunctionDeclaration[] = [];
+
+  static styles = [
+    icons,
+    css`
+      * {
+        box-sizing: border-box;
+      }
+
+      :host {
+        display: flex;
+        flex-direction: row;
+        width: 100%;
+        height: 100%;
+        min-height: 0;
+        gap: var(--bb-grid-size-3);
+        overflow: hidden;
+        font-family: var(--bb-font-family, sans-serif);
+        color: var(--light-dark-n-10);
+      }
+
+      .devtools-column-left {
+        flex: 1;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--bb-grid-size-4);
+        min-height: 0;
+        overflow: hidden;
+      }
+
+      .devtools-column-right {
+        flex: 1.2;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--bb-grid-size-4);
+        overflow-y: auto;
+      }
+
+      .column-inner {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+        overflow: hidden;
+      }
+
+      .scroll-container {
+        flex: 1;
+        overflow-y: auto;
+        padding-right: var(--bb-grid-size);
+      }
+
+      .header-title {
+        display: flex;
+        align-items: center;
+        gap: var(--bb-grid-size);
+      }
+
+      .header-icon {
+        font-size: var(--bb-label-large);
+      }
+
+      .request-pre {
+        white-space: pre-wrap;
+        margin: 0;
+        background: var(--light-dark-n-100);
+        border: 1px solid var(--light-dark-n-95);
+        padding: var(--bb-grid-size-3);
+        border-radius: var(--bb-grid-size);
+        font: 400 var(--bb-body-small) / var(--bb-body-line-height-small)
+          var(--bb-font-family-mono, monospace);
+        overflow-x: auto;
+      }
+
+      .waiting-pre {
+        color: var(--light-dark-n-40);
+        font-style: italic;
+        margin: 0;
+        background: var(--light-dark-n-100);
+        border: 1px solid var(--light-dark-n-95);
+        padding: var(--bb-grid-size-3);
+        border-radius: var(--bb-grid-size);
+        font: 400 var(--bb-body-small) / var(--bb-body-line-height-small)
+          var(--bb-font-family-mono, monospace);
+        overflow-x: auto;
+      }
+
+      .function-wrap {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--bb-grid-size);
+      }
+
+      .section {
+        background: var(--light-dark-n-100);
+        border: 1px solid var(--light-dark-n-90);
+        border-radius: var(--bb-grid-size-2);
+        padding: var(--bb-grid-size-4);
+        display: flex;
+        flex-direction: column;
+        gap: var(--bb-grid-size-3);
+
+        & h3 {
+          margin: 0;
+          font: 600 var(--bb-label-medium) / var(--bb-label-line-height-medium)
+            var(--bb-font-family);
+          color: var(--light-dark-n-20);
+          display: flex;
+          align-items: center;
+          gap: var(--bb-grid-size-2);
+          padding-bottom: var(--bb-grid-size-2);
+          border-bottom: 1px solid var(--light-dark-n-95);
+        }
+      }
+
+      .si-section {
+        flex: 1;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+      }
+
+      .markdown-container {
+        flex: 1;
+        overflow-y: auto;
+        min-height: 0;
+        padding-right: var(--bb-grid-size);
+      }
+
+      .functions-section {
+        flex-shrink: 0;
+      }
+
+      .markdown-body {
+        font: 400 var(--bb-body-medium) / var(--bb-body-line-height-medium)
+          var(--bb-font-family);
+        color: var(--light-dark-n-15);
+
+        & p {
+          margin: 0 0 var(--bb-grid-size-3) 0;
+          &:last-child {
+            margin-bottom: 0;
+          }
+        }
+
+        & code {
+          background: var(--light-dark-n-95);
+          padding: 2px 4px;
+          border-radius: 3px;
+          font-family: var(--bb-font-family-mono, monospace);
+          font-size: var(--bb-body-small);
+        }
+
+        & ul,
+        & ol {
+          margin: 0 0 var(--bb-grid-size-3) 0;
+          padding-left: var(--bb-grid-size-4);
+        }
+
+        & h2,
+        & h3 {
+          margin: var(--bb-grid-size-4) 0 var(--bb-grid-size-2) 0;
+          font-family: var(--bb-font-family);
+          color: var(--light-dark-n-10);
+          border-bottom: none;
+          padding-bottom: 0;
+        }
+
+        & h2 {
+          font: 600 var(--bb-label-large) / var(--bb-label-line-height-large);
+        }
+
+        & h3 {
+          font: 600 var(--bb-label-medium) / var(--bb-label-line-height-medium);
+        }
+      }
+
+      .function-tag {
+        display: inline-flex;
+        align-items: center;
+        background: var(--light-dark-n-90);
+        color: var(--light-dark-n-20);
+        padding: var(--bb-grid-size) var(--bb-grid-size-3);
+        border-radius: var(--bb-grid-size-5);
+        font: 500 var(--bb-label-small) / var(--bb-label-line-height-small)
+          var(--bb-font-family-mono, monospace);
+        border: 1px solid var(--light-dark-n-80);
+      }
+
+      .call-log {
+        display: flex;
+        flex-direction: column;
+        gap: var(--bb-grid-size-3);
+      }
+
+      .call-entry {
+        background: var(--light-dark-n-98);
+        border: 1px solid var(--light-dark-n-90);
+        border-radius: var(--bb-grid-size);
+        overflow: hidden;
+
+        &.objective {
+          border-left: 4px solid var(--light-dark-p-40);
+          background: var(--light-dark-n-100);
+          & .call-header {
+            background: var(--light-dark-n-98);
+            color: var(--light-dark-p-20);
+          }
+        }
+
+        &.thought {
+          border-left: 4px solid var(--light-dark-s-40);
+          background: var(--light-dark-n-98);
+          & .call-header {
+            background: var(--light-dark-n-95);
+            color: var(--light-dark-s-20);
+          }
+          & .thought-body {
+            padding: var(--bb-grid-size-3);
+            font: 400 var(--bb-body-medium) / var(--bb-body-line-height-medium)
+              var(--bb-font-family);
+            color: var(--light-dark-n-15);
+          }
+        }
+
+        & .call-header {
+          background: var(--light-dark-n-95);
+          padding: var(--bb-grid-size-2) var(--bb-grid-size-3);
+          font: 600 var(--bb-label-small) / var(--bb-label-line-height-small)
+            var(--bb-font-family-mono, monospace);
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          border-bottom: 1px solid var(--light-dark-n-90);
+
+          & .timestamp {
+            font-size: var(--bb-body-small);
+            color: var(--light-dark-n-40);
+            font-weight: 400;
+          }
+        }
+
+        & .call-details {
+          padding: var(--bb-grid-size-3);
+          display: flex;
+          flex-direction: column;
+          gap: var(--bb-grid-size-2);
+
+          & .label {
+            font: 600 var(--bb-label-small) / var(--bb-label-line-height-small)
+              var(--bb-font-family);
+            color: var(--light-dark-n-30);
+            margin-bottom: 2px;
+          }
+
+          & pre,
+          & bb-json-tree {
+            margin: 0;
+            background: var(--light-dark-n-100);
+            border: 1px solid var(--light-dark-n-95);
+            padding: var(--bb-grid-size-3);
+            border-radius: var(--bb-grid-size);
+            font: 400 var(--bb-body-small) / var(--bb-body-line-height-small)
+              var(--bb-font-family-mono, monospace);
+            overflow-x: auto;
+          }
+        }
+      }
+
+      .empty-state {
+        color: var(--light-dark-n-50);
+        font: 400 var(--bb-body-medium) / var(--bb-body-line-height-medium)
+          var(--bb-font-family);
+        text-align: center;
+        padding: var(--bb-grid-size-6) 0;
+      }
+    `,
+  ];
+
+  render(): TemplateResult {
+    const { entries, systemInstruction, functions } = this;
+    return html`
+      <div class="devtools-column-left">
+        <div class="section si-section">
+          <h3><span class="g-icon">description</span> System Instruction</h3>
+          ${systemInstruction
+            ? html`<div class="markdown-container">
+                <div class="markdown-body">${markdown(systemInstruction)}</div>
+              </div>`
+            : html`<div class="empty-state">No system instruction defined yet.</div>`}
+        </div>
+
+        <div class="section functions-section">
+          <h3><span class="g-icon">extension</span> Configured Functions</h3>
+          ${functions && functions.length > 0
+            ? html`
+                <div class="function-wrap">
+                  ${functions.map(
+                    (fn) =>
+                      html`<span class="function-tag" title=${fn.description || ""}
+                        >${fn.name}</span
+                      >`
+                  )}
+                </div>
+              `
+            : html`<div class="empty-state">No functions configured yet.</div>`}
+        </div>
+      </div>
+
+      <div class="devtools-column-right">
+        <div class="section column-inner">
+          <h3><span class="g-icon">history</span> Session Log</h3>
+          <div class="scroll-container">
+            ${entries && entries.length > 0
+              ? html`
+                  <div class="call-log">
+                    ${entries.map((entry) => {
+                      const date = new Date(entry.timestamp);
+                      const timeString = date.toLocaleTimeString();
+
+                      if (entry.kind === "thought") {
+                        const rawThought = String(
+                          entry.args.thought || entry.args.text || ""
+                        );
+                        const parsed = parseThought(rawThought);
+
+                        return html`
+                          <div class="call-entry thought">
+                            <div class="call-header">
+                              <span class="header-title"
+                                ><span class="g-icon header-icon">spark</span> ${parsed.title
+                                  ? parsed.title
+                                  : "thought"}</span
+                              >
+                              <span class="timestamp">${timeString}</span>
+                            </div>
+                            <div class="thought-body markdown-body">
+                              ${markdown(parsed.body)}
+                            </div>
+                          </div>
+                        `;
+                      }
+
+                      if (entry.kind === "objective") {
+                        return html`
+                          <div class="call-entry objective">
+                            <div class="call-header">
+                              <span class="header-title"
+                                ><span class="g-icon header-icon">start</span> objective</span
+                              >
+                              <span class="timestamp">${timeString}</span>
+                            </div>
+                            <div class="call-details">
+                              <div>
+                                <div class="label">Initial Request:</div>
+                                <pre class="request-pre">${
+                                  entry.args.user_request ||
+                                  entry.args.request ||
+                                  ""
+                                }</pre>
+                              </div>
+                            </div>
+                          </div>
+                        `;
+                      }
+
+                      return renderCall(entry, timeString);
+                    })}
+                  </div>
+                `
+              : html`<div class="empty-state">No entries in session log yet.</div>`}
+          </div>
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "bb-devtools-opie-panel": DevToolsOpiePanel;
+  }
+}

--- a/packages/visual-editor/src/ui/elements/devtools/opie/registry.ts
+++ b/packages/visual-editor/src/ui/elements/devtools/opie/registry.ts
@@ -1,0 +1,24 @@
+import { TemplateResult } from "lit";
+import type { SessionLogEntry } from "../../../../sca/types.js";
+import { renderDefaultCall } from "./renderers/default-call.js";
+import { renderUpsertAgentStep } from "./renderers/upsert-agent-step.js";
+import { renderWaitForUserInput } from "./renderers/wait-for-user-input.js";
+import { renderGraphGetOverview } from "./renderers/graph-get-overview.js";
+import { renderGraphRemoveStep } from "./renderers/graph-remove-step.js";
+
+export type FunctionRenderer = (
+  entry: SessionLogEntry,
+  timeString: string
+) => TemplateResult;
+
+export const FUNCTION_RENDERERS = new Map<string, FunctionRenderer>([
+  ["upsert_agent_step", renderUpsertAgentStep],
+  ["wait_for_user_input", renderWaitForUserInput],
+  ["graph_get_overview", renderGraphGetOverview],
+  ["graph_remove_step", renderGraphRemoveStep],
+]);
+
+export function renderCall(entry: SessionLogEntry, timeString: string): TemplateResult {
+  const renderer = FUNCTION_RENDERERS.get(entry.name) || renderDefaultCall;
+  return renderer(entry, timeString);
+}

--- a/packages/visual-editor/src/ui/elements/devtools/opie/renderers/default-call.ts
+++ b/packages/visual-editor/src/ui/elements/devtools/opie/renderers/default-call.ts
@@ -1,0 +1,33 @@
+import { html, TemplateResult } from "lit";
+import type { SessionLogEntry } from "../../../../../sca/types.js";
+
+export function renderDefaultCall(entry: SessionLogEntry, timeString: string): TemplateResult {
+  return html`
+    <div class="call-entry">
+      <div class="call-header">
+        <span class="header-title"
+          ><span class="g-icon header-icon">home_repair_service</span> ${entry.name}</span
+        >
+        <span class="timestamp">${timeString}</span>
+      </div>
+      <div class="call-details">
+        <div>
+          <div class="label">Arguments:</div>
+          <bb-json-tree
+            .json=${entry.args as Record<string, unknown>}
+            .autoExpand=${true}
+          ></bb-json-tree>
+        </div>
+        <div>
+          <div class="label">Response:</div>
+          ${entry.response
+            ? html`<bb-json-tree
+                .json=${entry.response as Record<string, unknown>}
+                .autoExpand=${true}
+              ></bb-json-tree>`
+            : html`<pre class="waiting-pre">Waiting for response...</pre>`}
+        </div>
+      </div>
+    </div>
+  `;
+}

--- a/packages/visual-editor/src/ui/elements/devtools/opie/renderers/graph-get-overview.ts
+++ b/packages/visual-editor/src/ui/elements/devtools/opie/renderers/graph-get-overview.ts
@@ -1,0 +1,28 @@
+import { html, TemplateResult } from "lit";
+import type { SessionLogEntry } from "../../../../../sca/types.js";
+
+export function renderGraphGetOverview(entry: SessionLogEntry, timeString: string): TemplateResult {
+  const response = (entry.response || {}) as Record<string, unknown>;
+  const overview = typeof response.overview === "string" ? response.overview : "";
+
+  return html`
+    <div class="call-entry">
+      <div class="call-header">
+        <span class="header-title"
+          ><span class="g-icon header-icon">preview</span> Inspected Graph Overview</span
+        >
+        <span class="timestamp">${timeString}</span>
+      </div>
+      <div class="call-details">
+        ${overview
+          ? html`
+              <div>
+                <div class="label">YAML Overview:</div>
+                <pre class="request-pre">${overview}</pre>
+              </div>
+            `
+          : html`<pre class="waiting-pre">Waiting for response...</pre>`}
+      </div>
+    </div>
+  `;
+}

--- a/packages/visual-editor/src/ui/elements/devtools/opie/renderers/graph-remove-step.ts
+++ b/packages/visual-editor/src/ui/elements/devtools/opie/renderers/graph-remove-step.ts
@@ -1,0 +1,35 @@
+import { html, TemplateResult } from "lit";
+import type { SessionLogEntry } from "../../../../../sca/types.js";
+
+export function renderGraphRemoveStep(entry: SessionLogEntry, timeString: string): TemplateResult {
+  const args = (entry.args || {}) as Record<string, unknown>;
+  const stepId = typeof args.step_id === "string" ? args.step_id : "unknown";
+
+  return html`
+    <div class="call-entry">
+      <div class="call-header">
+        <span class="header-title"
+          ><span class="g-icon header-icon">delete</span> Removed Step</span
+        >
+        <span class="timestamp">${timeString}</span>
+      </div>
+      <div class="call-details">
+        <div>
+          <div class="label">Target Step:</div>
+          <code class="thought-body">${stepId}</code>
+        </div>
+        ${entry.response
+          ? html`
+              <div>
+                <div class="label">Result:</div>
+                <bb-json-tree
+                  .json=${entry.response as Record<string, unknown>}
+                  .autoExpand=${true}
+                ></bb-json-tree>
+              </div>
+            `
+          : html`<pre class="waiting-pre">Waiting for response...</pre>`}
+      </div>
+    </div>
+  `;
+}

--- a/packages/visual-editor/src/ui/elements/devtools/opie/renderers/upsert-agent-step.ts
+++ b/packages/visual-editor/src/ui/elements/devtools/opie/renderers/upsert-agent-step.ts
@@ -1,0 +1,51 @@
+import { html, TemplateResult } from "lit";
+import type { SessionLogEntry } from "../../../../../sca/types.js";
+
+export function renderUpsertAgentStep(entry: SessionLogEntry, timeString: string): TemplateResult {
+  const args = (entry.args || {}) as Record<string, unknown>;
+  const stepId = typeof args.step_id === "string" ? args.step_id : "New Step";
+  const title = typeof args.title === "string" ? args.title : "";
+  const prompt = typeof args.prompt === "string" ? args.prompt : "";
+
+  return html`
+    <div class="call-entry">
+      <div class="call-header">
+        <span class="header-title"
+          ><span class="g-icon header-icon">edit</span> Upsert Step: ${stepId}</span
+        >
+        <span class="timestamp">${timeString}</span>
+      </div>
+      <div class="call-details">
+        ${title
+          ? html`
+              <div>
+                <div class="label">Step Title:</div>
+                <div class="thought-body" style="padding: var(--bb-grid-size); background: var(--light-dark-n-95); border-radius: var(--bb-grid-size); margin-bottom: var(--bb-grid-size-2);">
+                  <strong>${title}</strong>
+                </div>
+              </div>
+            `
+          : ""}
+        ${prompt
+          ? html`
+              <div>
+                <div class="label">Prompt:</div>
+                <pre class="request-pre">${prompt}</pre>
+              </div>
+            `
+          : ""}
+        ${entry.response
+          ? html`
+              <div>
+                <div class="label">Result:</div>
+                <bb-json-tree
+                  .json=${entry.response as Record<string, unknown>}
+                  .autoExpand=${true}
+                ></bb-json-tree>
+              </div>
+            `
+          : html`<pre class="waiting-pre">Waiting for response...</pre>`}
+      </div>
+    </div>
+  `;
+}

--- a/packages/visual-editor/src/ui/elements/devtools/opie/renderers/wait-for-user-input.ts
+++ b/packages/visual-editor/src/ui/elements/devtools/opie/renderers/wait-for-user-input.ts
@@ -1,0 +1,66 @@
+import { html, TemplateResult } from "lit";
+import type { SessionLogEntry } from "../../../../../sca/types.js";
+import { markdown } from "../../../../directives/markdown.js";
+
+export function renderWaitForUserInput(entry: SessionLogEntry, timeString: string): TemplateResult {
+  const args = (entry.args || {}) as Record<string, unknown>;
+  const message = typeof args.message === "string" ? args.message : "";
+  const response = (entry.response || {}) as Record<string, unknown>;
+  const userMessage = typeof response.user_message === "string" ? response.user_message : "";
+  const currentGraph = typeof response.current_graph === "string" ? response.current_graph : "";
+  const selectedSteps = typeof response.selected_steps === "string" ? response.selected_steps : "";
+  const graphChanges = typeof response.graph_changes === "string" ? response.graph_changes : "";
+
+  return html`
+    <div class="call-entry thought">
+      <div class="call-header">
+        <span class="header-title"
+          ><span class="g-icon header-icon">pending</span> Waiting for User Input</span
+        >
+        <span class="timestamp">${timeString}</span>
+      </div>
+      <div class="call-details">
+        ${message
+          ? html`
+              <div>
+                <div class="label">Agent Message:</div>
+                <div class="thought-body markdown-body">${markdown(message)}</div>
+              </div>
+            `
+          : ""}
+        ${userMessage
+          ? html`
+              <div>
+                <div class="label">User Response:</div>
+                <pre class="request-pre">${userMessage}</pre>
+              </div>
+            `
+          : html`<pre class="waiting-pre">Waiting for response...</pre>`}
+        ${graphChanges
+          ? html`
+              <div>
+                <div class="label">Graph Changes:</div>
+                <div class="thought-body markdown-body">${markdown(graphChanges)}</div>
+              </div>
+            `
+          : ""}
+        ${selectedSteps
+          ? html`
+              <div>
+                <div class="label">Selected Steps:</div>
+                <div class="thought-body markdown-body">${markdown(selectedSteps)}</div>
+              </div>
+            `
+          : ""}
+        ${currentGraph
+          ? html`
+              <div>
+                <div class="label">Current Graph:</div>
+                <pre class="request-pre">${currentGraph}</pre>
+              </div>
+            `
+          : ""}
+      </div>
+    </div>
+  `;
+}


### PR DESCRIPTION
## What
Refactored the `<bb-devtools>` user interface into a premium, Spaghetti-proof architectural workspace. Introduces a dynamic, Google Material allowlisted Tab Strip atop the dashboard, extracts Opie-specific graph editing logs into an encapsulated, Shadow DOM-isolated `<bb-devtools-opie-panel>` LitElement, and maps A2 Function invocation responses via a lightweight registry dispatcher for flexible telemetry representation.

## Why
Decouples visual editor domain telemetry from generic view scaffolding. Ensures each future debug tab (e.g., Performance, Execution) can reside independently in its own stylesheet and module, while ensuring graph context, prompt wrappers, and initial responses update and display in real-time.

## Changes
### Visual Editor (UI)
- Upgraded `<bb-devtools>` with a premium horizontal `.devtools-tabs` strip supporting `@state()` transitions and a title rebranding to "Opal Dev Tools".
- Created `<bb-devtools-opie-panel>` (`opie-panel.ts`) to encapsulate all graph editing agent layout structures, YAML overviews, and markdown rendering.
- Replaced monolithic template logic in `<bb-devtools>` with a centralized dispatcher registry (`registry.ts`) mapping A2 Function names to function-specific Lit templates (`wait-for-user-input.ts`, `upsert-agent-step.ts`, `graph-get-overview.ts`).

### SCA Architecture & A2 Infrastructure
- Augmented `DevToolsController.addObjective` to support `LLMContent` payload handling and in-place application objective tracking.
- Wired the `"start"` listener in `graph-editing-agent-actions.ts` to capture true augmented graph context and diff schemas dispatched by the A2 loop.
- Purged leaked styles, stale components, and deprecated decorators to maintain strict SCA component boundary hygiene.

## Testing
1. Run `bbu` to verify TypeScript builds and test suite execution.
2. Open the newly titled **Opal Dev Tools** panel.
3. Observe the "Opie" Tab Strip activate chronologically.
4. Interact with the A2 agent and verify the right-side Session Log expands YAML blocks, selected steps, and graph changes seamlessly.
