### PR TITLE
[ve] Expose Legacy Graph Options in Graph Overview

### DIFF
--- a/packages/visual-editor/src/a2/agent/graph-editing/constants.ts
+++ b/packages/visual-editor/src/a2/agent/graph-editing/constants.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * The Generate component URL from A2_COMPONENTS.
+ */
+export const GENERATE_COMPONENT_URL =
+  "embed://a2/generate.bgl.json#module:main";
+
+/**
+ * The User Input component URL from A2_COMPONENTS.
+ */
+export const USER_INPUT_COMPONENT_URL =
+  "embed://a2/a2.bgl.json#21ee02e7-83fa-49d0-964c-0cab10eafc2c";
+
+/**
+ * The Output component URL from A2_COMPONENTS.
+ */
+export const OUTPUT_COMPONENT_URL =
+  "embed://a2/a2.bgl.json#module:render-outputs";
+
+/**
+ * Maps a legacy step type to its configuration properties.
+ */
+export const LEGACY_OPTION_MAP: Record<string, Record<string, string>> = {
+  "user-input": {
+    modality: "p-modality",
+    required: "p-required",
+  },
+  output: {
+    render_mode: "p-render-mode",
+    doc_title: "b-doc-title",
+  },
+  "text-3-flash": {
+    system_instruction: "b-system-instruction",
+  },
+  "text-3-pro": {
+    system_instruction: "b-system-instruction",
+  },
+  image: {
+    system_instruction: "b-system-instruction",
+  },
+  "image-pro": {
+    system_instruction: "b-system-instruction",
+  },
+  audio: {
+    system_instruction: "b-system-instruction",
+  },
+  video: {
+    system_instruction: "b-system-instruction",
+  },
+  music: {
+    system_instruction: "b-system-instruction",
+  },
+};

--- a/packages/visual-editor/src/a2/agent/graph-editing/functions.ts
+++ b/packages/visual-editor/src/a2/agent/graph-editing/functions.ts
@@ -19,6 +19,12 @@ import { defineFunction, mapDefinitions } from "../function-definition.js";
 import type { FunctionGroup } from "../types.js";
 import type { EditingAgentPidginTranslator } from "./editing-agent-pidgin-translator.js";
 import { graphOverviewYaml } from "./graph-overview.js";
+import {
+  GENERATE_COMPONENT_URL,
+  USER_INPUT_COMPONENT_URL,
+  OUTPUT_COMPONENT_URL,
+  LEGACY_OPTION_MAP,
+} from "./constants.js";
 import type { ApplyEditsResponse, ReadGraphResponse } from "./types.js";
 
 export { getGraphEditingFunctionGroup };
@@ -31,22 +37,6 @@ const GRAPH_GET_OVERVIEW = "graph_get_overview";
 const GRAPH_REMOVE_STEP = "graph_remove_step";
 const GRAPH_UPSERT_AGENT_STEP = "upsert_agent_step";
 const GRAPH_UPSERT_LEGACY_STEP = "upsert_legacy_step";
-
-/**
- * The Generate component URL from A2_COMPONENTS.
- */
-const GENERATE_COMPONENT_URL = "embed://a2/generate.bgl.json#module:main";
-
-/**
- * The User Input component URL from A2_COMPONENTS.
- */
-const USER_INPUT_COMPONENT_URL =
-  "embed://a2/a2.bgl.json#21ee02e7-83fa-49d0-964c-0cab10eafc2c";
-
-/**
- * The Output component URL from A2_COMPONENTS.
- */
-const OUTPUT_COMPONENT_URL = "embed://a2/a2.bgl.json#module:render-outputs";
 
 const VALID_LEGACY_STEP_TYPES = [
   "user-input",
@@ -808,37 +798,7 @@ function defineGraphEditingFunctions(
 
         let stepId: string;
 
-        const LEGACY_OPTION_MAP: Record<string, Record<string, string>> = {
-          "user-input": {
-            modality: "p-modality",
-            required: "p-required",
-          },
-          output: {
-            render_mode: "p-render-mode",
-            doc_title: "b-doc-title",
-          },
-          "text-3-flash": {
-            system_instruction: "b-system-instruction",
-          },
-          "text-3-pro": {
-            system_instruction: "b-system-instruction",
-          },
-          image: {
-            system_instruction: "b-system-instruction",
-          },
-          "image-pro": {
-            system_instruction: "b-system-instruction",
-          },
-          audio: {
-            system_instruction: "b-system-instruction",
-          },
-          video: {
-            system_instruction: "b-system-instruction",
-          },
-          music: {
-            system_instruction: "b-system-instruction",
-          },
-        };
+
 
         if (step_id) {
           const resolved = await resolveAndValidateNode(step_id, translator);

--- a/packages/visual-editor/src/a2/agent/graph-editing/graph-overview.ts
+++ b/packages/visual-editor/src/a2/agent/graph-editing/graph-overview.ts
@@ -6,6 +6,12 @@
 
 import type { Edge, LLMContent, NodeDescriptor } from "@breadboard-ai/types";
 import type { EditingAgentPidginTranslator } from "./editing-agent-pidgin-translator.js";
+import {
+  GENERATE_COMPONENT_URL,
+  USER_INPUT_COMPONENT_URL,
+  OUTPUT_COMPONENT_URL,
+  LEGACY_OPTION_MAP,
+} from "./constants.js";
 
 export { graphOverviewYaml, describeSelection };
 
@@ -40,8 +46,14 @@ function graphOverviewYaml(
     lines.push(`  ${handle}:`);
     lines.push(`    title: ${title}`);
 
+    const config = node.configuration as Record<string, unknown> | undefined;
+
     // Convert prompt back to pidgin for readability
-    const prompt = node.configuration?.["config$prompt"];
+    const prompt =
+      config?.["config$prompt"] ||
+      config?.["description"] ||
+      config?.["text"];
+
     if (prompt && typeof prompt === "object") {
       const pidgin = translator.toPidgin(prompt as LLMContent);
       if (pidgin.text) {
@@ -52,6 +64,49 @@ function graphOverviewYaml(
           .join("\n");
         lines.push(`    prompt: |`);
         lines.push(indented);
+      }
+    }
+
+    let inferredStepType: string | undefined;
+    if (node.type === USER_INPUT_COMPONENT_URL) {
+      inferredStepType = "user-input";
+    } else if (node.type === OUTPUT_COMPONENT_URL) {
+      inferredStepType = "output";
+    } else if (node.type === GENERATE_COMPONENT_URL) {
+      const genMode =
+        config &&
+        typeof config === "object" &&
+        "generation-mode" in config
+          ? (config["generation-mode"] as string)
+          : undefined;
+      inferredStepType = genMode || "text-3-flash";
+    }
+
+    const options: Record<string, unknown> = {};
+    if (inferredStepType && LEGACY_OPTION_MAP[inferredStepType]) {
+      const optionMap = LEGACY_OPTION_MAP[inferredStepType];
+      if (config && typeof config === "object") {
+        for (const [optKey, targetKey] of Object.entries(optionMap)) {
+          if (targetKey in config && config[targetKey] !== undefined) {
+            options[optKey] = config[targetKey];
+          }
+        }
+      }
+    }
+
+    if (Object.keys(options).length > 0) {
+      lines.push(`    options:`);
+      for (const [key, val] of Object.entries(options)) {
+        if (typeof val === "string" && val.includes("\n")) {
+          const indentedVal = val
+            .split("\n")
+            .map((l) => `        ${l}`)
+            .join("\n");
+          lines.push(`      ${key}: |`);
+          lines.push(indentedVal);
+        } else {
+          lines.push(`      ${key}: ${JSON.stringify(val)}`);
+        }
       }
     }
   }

--- a/packages/visual-editor/tests/agent/graph-editing/graph-overview.test.ts
+++ b/packages/visual-editor/tests/agent/graph-editing/graph-overview.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from "node:test";
+import { ok } from "node:assert";
+import { graphOverviewYaml } from "../../../src/a2/agent/graph-editing/graph-overview.js";
+import { EditingAgentPidginTranslator } from "../../../src/a2/agent/graph-editing/editing-agent-pidgin-translator.js";
+import type { NodeDescriptor, Edge } from "@breadboard-ai/types";
+
+const GENERATE_COMPONENT_URL = "embed://a2/generate.bgl.json#module:main";
+const USER_INPUT_COMPONENT_URL =
+  "embed://a2/a2.bgl.json#21ee02e7-83fa-49d0-964c-0cab10eafc2c";
+const OUTPUT_COMPONENT_URL =
+  "embed://a2/a2.bgl.json#module:render-outputs";
+
+describe("graphOverviewYaml", () => {
+  it("shows options for legacy step types", () => {
+    const translator = new EditingAgentPidginTranslator();
+    const nodes: NodeDescriptor[] = [
+      {
+        id: "node-in",
+        type: USER_INPUT_COMPONENT_URL,
+        metadata: { title: "My User Input" },
+        configuration: {
+          description: {
+            parts: [{ text: "Enter your prompt" }],
+            role: "user",
+          },
+          "p-modality": "Image",
+          "p-required": true,
+        },
+      },
+      {
+        id: "node-out",
+        type: OUTPUT_COMPONENT_URL,
+        metadata: { title: "My Output" },
+        configuration: {
+          text: {
+            parts: [{ text: "Final result" }],
+            role: "user",
+          },
+          "p-render-mode": "google-doc",
+          "b-doc-title": "My Doc Title",
+        },
+      },
+      {
+        id: "node-flash",
+        type: GENERATE_COMPONENT_URL,
+        metadata: { title: "My Flash Generation" },
+        configuration: {
+          "generation-mode": "text-3-flash",
+          config$prompt: {
+            parts: [{ text: "Translate hello to French" }],
+            role: "user",
+          },
+          "b-system-instruction": "Always respond in French",
+        },
+      },
+    ];
+
+    const edges: Edge[] = [];
+
+    const yaml = graphOverviewYaml(
+      { title: "Test Graph", description: "This is a test description" },
+      nodes,
+      edges,
+      translator
+    );
+
+    ok(yaml.includes("options:"));
+    ok(yaml.includes('modality: "Image"'));
+    ok(yaml.includes("required: true"));
+    ok(yaml.includes('render_mode: "google-doc"'));
+    ok(yaml.includes('doc_title: "My Doc Title"'));
+    ok(yaml.includes('system_instruction: "Always respond in French"'));
+    ok(yaml.includes("Enter your prompt"));
+    ok(yaml.includes("Final result"));
+    ok(yaml.includes("Translate hello to French"));
+  });
+});


### PR DESCRIPTION
## What
Added support for extracting and displaying legacy configuration options and prompt fallbacks for user-input, output, and generation steps inside the YAML graph overview for the A2 Agent. Consolidated the configuration URLs and mapping to a central source of truth.

## Why
This allows the editing agent to see the current graph configurations alongside their handles, empowering it to know the exact values of current graph options and accurately identify when it has changed them.

## Changes
### `packages/visual-editor`
- Created [constants.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/src/a2/agent/graph-editing/constants.ts) to define component URLs and `LEGACY_OPTION_MAP` to avoid duplicated code.
- Updated [graph-overview.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/src/a2/agent/graph-editing/graph-overview.ts) to read fallback `description` and `text` prompt content for legacy steps, and mapped configuration options into the output YAML.
- Replaced duplicated constants in [functions.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/src/a2/agent/graph-editing/functions.ts) with imports from `constants.js`.

## Testing
- Verified implementation with a new test suite in [graph-overview.test.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/tests/agent/graph-editing/graph-overview.test.ts) covering all legacy step types.
- Ran TypeScript compilation checks cleanly with `npm run build:tsc`.
