### PR TITLE
[ve] Teach Opie Agent to Edit Graph Title, Description, and Themes

### DIFF
--- a/packages/visual-editor/src/a2/agent/agent-event.ts
+++ b/packages/visual-editor/src/a2/agent/agent-event.ts
@@ -26,6 +26,7 @@ export type {
   TransformDescriptor,
   UpdateNodeDescriptor,
   LayoutGraphDescriptor,
+  UpdateGraphPropertiesDescriptor,
   StartPayload,
   ThoughtPayload,
   FunctionCallPayload,
@@ -156,7 +157,18 @@ type ApplyEditsPayload = {
  * reduced to plain `EditSpec[]`. The client instantiates the
  * appropriate transform class and applies it.
  */
-type TransformDescriptor = UpdateNodeDescriptor | LayoutGraphDescriptor;
+type TransformDescriptor =
+  | UpdateNodeDescriptor
+  | LayoutGraphDescriptor
+  | UpdateGraphPropertiesDescriptor;
+
+type UpdateGraphPropertiesDescriptor = {
+  kind: "updateGraphProperties";
+  title?: string;
+  description?: string;
+  themeIntent?: string;
+};
+
 
 type UpdateNodeDescriptor = {
   kind: "updateNode";

--- a/packages/visual-editor/src/a2/agent/function-caller.ts
+++ b/packages/visual-editor/src/a2/agent/function-caller.ts
@@ -77,23 +77,35 @@ class FunctionCallerImpl implements FunctionCaller {
     callId: string,
     part: FunctionCallCapabilityPart,
     statusUpdateCallback: StatusUpdateCallback,
-    reporter: ProgressReporter | null
+    reporter: ProgressReporter | null,
+    onResult?: (callId: string, content: LLMContent) => void
   ): void {
     const name = part.functionCall.name;
     if (this.builtIn.has(name)) {
       this.#functionPromises.push(
         this.#callBuiltIn(part, statusUpdateCallback, reporter).then(
-          (result) => (ok(result) ? { callId, response: result } : result)
+          (result) => {
+            if (ok(result)) {
+              onResult?.(callId, { parts: [result] });
+              return { callId, response: result };
+            }
+            return result;
+          }
         )
       );
     } else {
       this.#functionPromises.push(
-        this.#callCustom(part).then((result) =>
-          ok(result) ? { callId, response: result } : result
-        )
+        this.#callCustom(part).then((result) => {
+          if (ok(result)) {
+            onResult?.(callId, { parts: [result] });
+            return { callId, response: result };
+          }
+          return result;
+        })
       );
     }
   }
+
 
   async getResults(): Promise<
     Outcome<{ combined: LLMContent; results: FunctionCallResult[] } | null>

--- a/packages/visual-editor/src/a2/agent/graph-editing/functions.ts
+++ b/packages/visual-editor/src/a2/agent/graph-editing/functions.ts
@@ -37,6 +37,8 @@ const GRAPH_GET_OVERVIEW = "graph_get_overview";
 const GRAPH_REMOVE_STEP = "graph_remove_step";
 const GRAPH_UPSERT_AGENT_STEP = "upsert_agent_step";
 const GRAPH_UPSERT_LEGACY_STEP = "upsert_legacy_step";
+const GRAPH_EDIT_PROPERTIES = "graph_edit_properties";
+
 
 const VALID_LEGACY_STEP_TYPES = [
   "user-input",
@@ -174,7 +176,13 @@ message for you to copy. Want to try that?"
 
 ## Graph Editing
 
-You can inspect, create, edit, and remove steps in the current graph. There are two categories of steps you can add:
+You can update the graph's overall title, description, and theme (\`graph_edit_properties\`), and inspect, create, edit, or remove individual steps in the current graph. 
+
+Be careful to discern whether the user just wants to update the theme splash graphic and only change that. Title, description, and prompts are important: don't change them unless you specifically hear the user request to make the change.
+
+After editing a blank or untitled graph, make it real: add title, description, and a theme that works best with what user has so far. Once that's done, never change the theme without user's specific instruction.
+
+There are two categories of steps you can add:
 
 ### 1. Agentic Steps (\`upsert_agent_step\`)
 An autonomous agent powered by Gemini that interprets its prompt as an objective and uses tools to fulfill it.
@@ -349,8 +357,11 @@ on first run and recall it in subsequent sessions.
 - When creating a step, reference existing steps with <parent> to wire connections.
 - Steps are always created as Generate steps with Agent mode.
 - Write prompts as objectives, not procedures — let the agentic step plan.
+- Use \`graph_edit_properties\` to edit the title, description, or theme of the entire graph when requested.
+
 - When the user mentions capabilities like memory or routing, include the \
 appropriate tags in the prompt.
+
 
 ### Talking to the User
 
@@ -458,6 +469,29 @@ function defineGraphEditingFunctions(
       },
     });
   }
+
+  /**
+   * Applies an updateGraphProperties transform via the suspend mechanism.
+   */
+  async function applyUpdateGraphProperties(
+    title?: string,
+    description?: string,
+    themeIntent?: string
+  ): Promise<ApplyEditsResponse> {
+    return sink.suspend<ApplyEditsResponse>({
+      applyEdits: {
+        requestId: crypto.randomUUID(),
+        label: "Update graph properties",
+        transform: {
+          kind: "updateGraphProperties",
+          title,
+          description,
+          themeIntent,
+        },
+      },
+    });
+  }
+
 
   /**
    * Creates a resolver that looks up node titles from the current graph.
@@ -623,6 +657,60 @@ function defineGraphEditingFunctions(
           return {
             success: false,
             error: `Failed to remove step "${step_id}"`,
+          };
+        }
+
+        return { success: true };
+      }
+    ),
+
+    // =========================================================================
+    // graph_edit_properties
+    // =========================================================================
+    defineFunction(
+      {
+        name: GRAPH_EDIT_PROPERTIES,
+        title: "Updating graph metadata",
+        icon: "edit",
+        description:
+          "Edit the title, description, and theme of the graph. You can provide one, two, or all parameters.",
+        parameters: {
+          title: z
+            .string()
+            .optional()
+            .describe("The new title for the graph"),
+          description: z
+            .string()
+            .optional()
+            .describe("The new description for the graph"),
+          theme_intent: z
+            .string()
+            .optional()
+            .describe(
+              "A description of the theme/vibe to generate for the graph (e.g., 'sunset vibe', 'sleek dark mode')"
+            ),
+        },
+        response: {
+          success: z.boolean(),
+          error: z
+            .string()
+            .optional()
+            .describe(
+              "If an error has occurred, will contain a description of the error"
+            ),
+        },
+      },
+      async ({ title, description, theme_intent }) => {
+        const result = await applyUpdateGraphProperties(
+          title,
+          description,
+          theme_intent
+        );
+
+        if (!result.success) {
+          return {
+            success: false,
+            error: result.error ?? "Failed to update graph properties",
           };
         }
 

--- a/packages/visual-editor/src/a2/agent/graph-editing/graph-overview.ts
+++ b/packages/visual-editor/src/a2/agent/graph-editing/graph-overview.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Edge, LLMContent, NodeDescriptor } from "@breadboard-ai/types";
+import type { Edge, GraphMetadata, LLMContent, NodeDescriptor } from "@breadboard-ai/types";
+
 import type { EditingAgentPidginTranslator } from "./editing-agent-pidgin-translator.js";
 import {
   GENERATE_COMPONENT_URL,
@@ -22,7 +23,11 @@ export { graphOverviewYaml, describeSelection };
  * (converted to pidgin), and an adjacency list of connections.
  */
 function graphOverviewYaml(
-  graph: { title?: string; description?: string },
+  graph: {
+    title?: string;
+    description?: string;
+    metadata?: GraphMetadata;
+  },
   nodes: NodeDescriptor[],
   edges: Edge[],
   translator: EditingAgentPidginTranslator
@@ -38,6 +43,17 @@ function graphOverviewYaml(
   const lines: string[] = [];
   if (graph.title) lines.push(`title: ${graph.title}`);
   if (graph.description) lines.push(`description: ${graph.description}`);
+
+  const presentation = graph.metadata?.visual?.presentation;
+  const themeId = presentation?.theme;
+  const themes = presentation?.themes;
+  const currentTheme =
+    themeId && themes ? themes[themeId] : undefined;
+
+  const isCustom =
+    !!currentTheme?.splashScreen && !currentTheme?.isDefaultTheme;
+  lines.push(`splashImage: ${isCustom ? "present" : "default"}`);
+
 
   lines.push("", "steps:");
   for (const node of nodes) {

--- a/packages/visual-editor/src/a2/agent/loop.ts
+++ b/packages/visual-editor/src/a2/agent/loop.ts
@@ -302,7 +302,8 @@ class Loop {
                 part,
                 (status, opts) =>
                   hooks.onFunctionCallUpdate?.(callId, status, opts),
-                reporter
+                reporter,
+                (cId, content) => hooks.onFunctionResult?.(cId, content)
               );
             }
           }
@@ -318,10 +319,7 @@ class Loop {
           // chance to consider alternatives and fail more gracefully.
           return functionResults;
         }
-        // Report each function result individually
-        for (const { callId, response } of functionResults.results) {
-          hooks.onFunctionResult?.(callId, { parts: [response] });
-        }
+
         contents.push(functionResults.combined);
         hooks.onContent?.(functionResults.combined);
         hooks.onTurnComplete?.();

--- a/packages/visual-editor/src/a2/agent/types.ts
+++ b/packages/visual-editor/src/a2/agent/types.ts
@@ -68,9 +68,11 @@ export type FunctionCaller = {
     callId: string,
     part: FunctionCallCapabilityPart,
     statusUpdateCallback: StatusUpdateCallback,
-    reporter: ProgressReporter | null
+    reporter: ProgressReporter | null,
+    onResult?: (callId: string, content: LLMContent) => void
   ): void;
   getResults(): Promise<
+
     Outcome<{
       combined: LLMContent;
       results: { callId: string; response: FunctionResponseCapabilityPart }[];

--- a/packages/visual-editor/src/sca/actions/agent/graph-editing-agent-actions.ts
+++ b/packages/visual-editor/src/sca/actions/agent/graph-editing-agent-actions.ts
@@ -15,10 +15,17 @@
  */
 
 import type {
+  GraphMetadata,
   LLMContent,
   NodeConfiguration,
   NodeMetadata,
 } from "@breadboard-ai/types";
+import { generateImage, persistTheme } from "../theme/theme-utils.js";
+import { createThemeGenerationPrompt } from "../../../ui/prompts/theme-generation.js";
+
+import { ok } from "@breadboard-ai/utils";
+
+
 
 import { makeAction } from "../binder.js";
 import { buildHooksFromSink } from "../../../a2/agent/loop-setup.js";
@@ -172,7 +179,7 @@ function startGraphEditingAgent(firstMessage: string): void {
 
   // Graph write: apply edits or transforms and return success/failure
   handle.events.on("applyEdits", async (event) => {
-    const { controller } = bind;
+    const { controller, services } = bind;
     const editor = controller.editor.graph.editor;
     if (!editor) {
       return { success: false, error: "No active graph to edit" };
@@ -219,6 +226,81 @@ function startGraphEditingAgent(firstMessage: string): void {
         case "layoutGraph": {
           const graph = editor.raw();
           await layoutGraph(graph.nodes ?? [], graph.edges ?? []);
+          return { success: true };
+        }
+        case "updateGraphProperties": {
+          const { title, description, themeIntent } = transform;
+
+          let metadata: GraphMetadata | undefined;
+
+          if (themeIntent) {
+            const rawGraph = editor.raw();
+            const promptTitle = title ?? rawGraph.title;
+            const promptDesc = description ?? rawGraph.description;
+
+            const appTheme = await generateImage(
+              createThemeGenerationPrompt({
+                random: false,
+                title: promptTitle || "Application",
+                description: promptDesc,
+                userInstruction: themeIntent,
+              }),
+
+              handle.signal,
+              controller,
+              services
+            );
+
+            if (!ok(appTheme)) {
+              return {
+                success: false,
+                error: `Theme generation failed: ${appTheme.$error}`,
+              };
+            }
+
+            const graphThemeResult = await persistTheme(
+              appTheme,
+              controller,
+              services
+            );
+
+            if (!ok(graphThemeResult)) {
+              return {
+                success: false,
+                error: `Failed to persist theme: ${graphThemeResult.$error}`,
+              };
+            }
+
+            metadata = editor.raw().metadata ?? {};
+            metadata.visual ??= {};
+            metadata.visual.presentation ??= {};
+            metadata.visual.presentation.themes ??= {};
+
+            const id = globalThis.crypto.randomUUID();
+            metadata.visual.presentation.themes[id] = graphThemeResult;
+            metadata.visual.presentation.theme = id;
+          }
+
+          const result = await editor.edit(
+            [
+              {
+                type: "changegraphmetadata",
+                title: title ?? undefined,
+                description: description ?? undefined,
+                metadata,
+                graphId: "",
+              },
+            ],
+            "Updating graph properties"
+          );
+
+          if (themeIntent) {
+            controller.editor.theme.updateHash(controller.editor.graph.graph);
+          }
+
+          if (!result.success) {
+            return { success: false, error: result.error };
+          }
           return { success: true };
         }
       }

--- a/packages/visual-editor/src/ui/elements/devtools/opie/registry.ts
+++ b/packages/visual-editor/src/ui/elements/devtools/opie/registry.ts
@@ -6,6 +6,8 @@ import { renderUpsertLegacyStep } from "./renderers/upsert-legacy-step.js";
 import { renderWaitForUserInput } from "./renderers/wait-for-user-input.js";
 import { renderGraphGetOverview } from "./renderers/graph-get-overview.js";
 import { renderGraphRemoveStep } from "./renderers/graph-remove-step.js";
+import { renderGraphEditProperties } from "./renderers/graph-edit-properties.js";
+
 
 export type FunctionRenderer = (
   entry: SessionLogEntry,
@@ -18,6 +20,7 @@ export const FUNCTION_RENDERERS = new Map<string, FunctionRenderer>([
   ["wait_for_user_input", renderWaitForUserInput],
   ["graph_get_overview", renderGraphGetOverview],
   ["graph_remove_step", renderGraphRemoveStep],
+  ["graph_edit_properties", renderGraphEditProperties],
 ]);
 
 export function renderCall(entry: SessionLogEntry, timeString: string): TemplateResult {

--- a/packages/visual-editor/src/ui/elements/devtools/opie/renderers/graph-edit-properties.ts
+++ b/packages/visual-editor/src/ui/elements/devtools/opie/renderers/graph-edit-properties.ts
@@ -1,0 +1,63 @@
+import { html, TemplateResult } from "lit";
+import type { SessionLogEntry } from "../../../../../sca/types.js";
+
+export function renderGraphEditProperties(
+  entry: SessionLogEntry,
+  timeString: string
+): TemplateResult {
+  const args = (entry.args || {}) as Record<string, unknown>;
+  const title = typeof args.title === "string" ? args.title : null;
+  const description =
+    typeof args.description === "string" ? args.description : null;
+  const themeIntent =
+    typeof args.theme_intent === "string" ? args.theme_intent : null;
+
+  return html`
+    <div class="call-entry">
+      <div class="call-header">
+        <span class="header-title"
+          ><span class="g-icon header-icon">edit</span> Edited Graph
+          Properties</span
+        >
+        <span class="timestamp">${timeString}</span>
+      </div>
+      <div class="call-details">
+        ${title
+          ? html`
+              <div>
+                <div class="label">New Title:</div>
+                <code class="thought-body">${title}</code>
+              </div>
+            `
+          : ""}
+        ${description
+          ? html`
+              <div>
+                <div class="label">New Description:</div>
+                <code class="thought-body">${description}</code>
+              </div>
+            `
+          : ""}
+        ${themeIntent
+          ? html`
+              <div>
+                <div class="label">Generated Theme Vibe:</div>
+                <code class="thought-body">${themeIntent}</code>
+              </div>
+            `
+          : ""}
+        ${entry.response
+          ? html`
+              <div>
+                <div class="label">Result:</div>
+                <bb-json-tree
+                  .json=${entry.response as Record<string, unknown>}
+                  .autoExpand=${true}
+                ></bb-json-tree>
+              </div>
+            `
+          : html`<pre class="waiting-pre">Waiting for response...</pre>`}
+      </div>
+    </div>
+  `;
+}

--- a/packages/visual-editor/tests/agent/graph-editing/graph-editing-functions-suspend.test.ts
+++ b/packages/visual-editor/tests/agent/graph-editing/graph-editing-functions-suspend.test.ts
@@ -276,4 +276,55 @@ suite("Graph editing functions suspend/resume", () => {
       `Error should mention not found, got: ${result.error}`
     );
   });
+
+  // ── graph_edit_properties ──────────────────────────────────────────────────
+
+  test("graph_edit_properties emits applyEdits with updateGraphProperties transform", async () => {
+    const consumer = new AgentEventConsumer();
+    const bridge = new LocalAgentEventBridge(consumer);
+    const translator = new EditingAgentPidginTranslator();
+
+    const captured: ApplyEditsPayload[] = [];
+    consumer.on("applyEdits", (payload) => {
+      captured.push(payload);
+      return Promise.resolve({ success: true });
+    });
+
+    const group = getGraphEditingFunctionGroup(bridge, translator);
+    const handler = findHandler(group, "graph_edit_properties");
+    const result = await handler(
+      {
+        title: "Updated Title",
+        description: "Updated Description",
+        theme_intent: "sunset vibe",
+      },
+      noop,
+      null
+    );
+
+    assert.strictEqual(captured.length, 1);
+    assert.ok(captured[0].requestId, "Should have a requestId");
+    assert.ok(captured[0].transform, "Should have a transform");
+    assert.strictEqual(
+      captured[0].transform!.kind,
+      "updateGraphProperties"
+    );
+    if (captured[0].transform!.kind === "updateGraphProperties") {
+      assert.strictEqual(
+        captured[0].transform!.title,
+        "Updated Title"
+      );
+      assert.strictEqual(
+        captured[0].transform!.description,
+        "Updated Description"
+      );
+      assert.strictEqual(
+        captured[0].transform!.themeIntent,
+        "sunset vibe"
+      );
+    }
+
+    assert.strictEqual(result.success, true);
+  });
 });
+

--- a/packages/visual-editor/tests/agent/graph-editing/graph-overview.test.ts
+++ b/packages/visual-editor/tests/agent/graph-editing/graph-overview.test.ts
@@ -80,4 +80,61 @@ describe("graphOverviewYaml", () => {
     ok(yaml.includes("Final result"));
     ok(yaml.includes("Translate hello to French"));
   });
+
+  it("shows splashImage: present when graph has custom splashScreen", () => {
+    const translator = new EditingAgentPidginTranslator();
+    const yaml = graphOverviewYaml(
+      {
+        title: "Test Graph",
+        metadata: {
+          visual: {
+            presentation: {
+              theme: "theme-1",
+              themes: {
+                "theme-1": {
+                  splashScreen: {
+                    storedData: {
+                      handle: "some-handle",
+                      mimeType: "image/png",
+                    },
+                  },
+                  isDefaultTheme: false,
+                },
+              },
+            },
+          },
+        },
+      },
+      [],
+      [],
+      translator
+    );
+    ok(yaml.includes("splashImage: present"));
+  });
+
+  it("shows splashImage: default when graph lacks splashScreen or is default theme", () => {
+    const translator = new EditingAgentPidginTranslator();
+    const yaml = graphOverviewYaml(
+      {
+        title: "Test Graph",
+        metadata: {
+          visual: {
+            presentation: {
+              theme: "theme-1",
+              themes: {
+                "theme-1": {
+                  isDefaultTheme: true,
+                },
+              },
+            },
+          },
+        },
+      },
+      [],
+      [],
+      translator
+    );
+    ok(yaml.includes("splashImage: default"));
+  });
 });
+


### PR DESCRIPTION
## What
Teaches the `graph-editing` A2 agent (Opie) to inspect and edit the current graph's overall title, description, and visual theme via a unified `graph_edit_properties` tool. Concurrently resolves an internal event batching bottleneck to enable real-time function result streaming to the user.

## Why
Enables users to issue conversational requests to Opie to reorganize, rename, or restyle their Opal flows (e.g., "Give this a sunset theme and call it 'My Photo App'"). Additionally ensures the DevTools progress timeline renders responsive, individual function results immediately, avoiding `Promise.all` aggregation delays.

## Changes

### Graph Editing Agent Enhancements
- Added `UpdateGraphPropertiesDescriptor` to the `TransformDescriptor` wire format in [agent-event.ts](file:///packages/visual-editor/src/a2/agent/agent-event.ts).
- Registered the `graph_edit_properties` tool definition and enriched Opie's internal prompt in [functions.ts](file:///packages/visual-editor/src/a2/agent/graph-editing/functions.ts).
- Built and registered a context-aware `UpdateGraphProperties` client handler in [graph-editing-agent-actions.ts](file:///packages/visual-editor/src/sca/actions/agent/graph-editing-agent-actions.ts) that extracts existing application metadata and combines it dynamically to prompt and persist bespoke Gemini splash screen graphics.
- Enriched the YAML overview in [graph-overview.ts](file:///packages/visual-editor/src/a2/agent/graph-editing/graph-overview.ts) to flag the presence of existing custom splash screen assets to the agent.

### Real-Time Telemetry Streaming
- Decoupled `FunctionCallerImpl` in [function-caller.ts](file:///packages/visual-editor/src/a2/agent/function-caller.ts) from `Promise.all` batching, introducing an optional `onResult` completion callback wired directly into the A2 runtime.
- Updated [loop.ts](file:///packages/visual-editor/src/a2/agent/loop.ts) to intercept and stream individual function call outcomes directly to [registry.ts](file:///packages/visual-editor/src/ui/elements/devtools/opie/registry.ts) listeners as they settle.
- Created the [graph-edit-properties.ts](file:///packages/visual-editor/src/ui/elements/devtools/opie/renderers/graph-edit-properties.ts) custom DevTools render shell for rendering property updates.

## Testing
- Extended `graph-editing-functions-suspend.test.ts` to verify the protocol execution of `graph_edit_properties` and metadata transforms.
- Created test cases in `graph-overview.test.ts` asserting high-fidelity Yaml serialization of custom splash theme capabilities.
