### PR TITLE
[ve] Clean up Opie DevTools when Graph Editing Agent is Torn Down

### DIFF
--- a/packages/visual-editor/src/sca/actions/agent/graph-editing-agent-actions.ts
+++ b/packages/visual-editor/src/sca/actions/agent/graph-editing-agent-actions.ts
@@ -24,9 +24,8 @@ import { generateImage, persistTheme } from "../theme/theme-utils.js";
 import { createThemeGenerationPrompt } from "../../../ui/prompts/theme-generation.js";
 
 import { ok } from "@breadboard-ai/utils";
-
-
-
+import { asAction, ActionMode } from "../../coordination.js";
+import { onGraphUrlChange } from "./triggers.js";
 import { makeAction } from "../binder.js";
 import { buildHooksFromSink } from "../../../a2/agent/loop-setup.js";
 import { invokeGraphEditingAgent } from "../../../a2/agent/graph-editing/main.js";
@@ -44,7 +43,6 @@ export {
   bind,
   startGraphEditingAgent,
   resolveGraphEditingInput,
-  resetGraphEditingAgent,
 };
 
 const bind = makeAction();
@@ -354,10 +352,18 @@ function resolveGraphEditingInput(text: string): boolean {
 /**
  * Abort the current loop and reset all state.
  */
-function resetGraphEditingAgent(): void {
-  currentRun?.abort();
-  currentRun = null;
-  pendingResolve = null;
-  const { controller } = bind;
-  controller.editor.graphEditingAgent.reset();
-}
+export const resetGraphEditingAgent = asAction(
+  "GraphEditingAgent.reset",
+  {
+    mode: ActionMode.Immediate,
+    triggeredBy: () => onGraphUrlChange(bind),
+  },
+  async (): Promise<void> => {
+    currentRun?.abort();
+    currentRun = null;
+    pendingResolve = null;
+    const { controller } = bind;
+    controller.editor.graphEditingAgent.reset();
+    controller.editor.devtools?.clearLog();
+  }
+);

--- a/packages/visual-editor/tests/sca/actions/agent/graph-editing-agent-actions.test.ts
+++ b/packages/visual-editor/tests/sca/actions/agent/graph-editing-agent-actions.test.ts
@@ -16,6 +16,7 @@ import {
   GraphEditingAgentController,
   type ChatEntry,
 } from "../../../../src/sca/controller/subcontrollers/editor/graph-editing-agent-controller.js";
+import { DevToolsController } from "../../../../src/sca/controller/subcontrollers/editor/devtools/devtools-controller.js";
 import { AgentService } from "../../../../src/a2/agent/agent-service.js";
 import type { WaitForInputPayload } from "../../../../src/a2/agent/agent-event.js";
 import { setDOM, unsetDOM } from "../../../fake-dom.js";
@@ -29,9 +30,14 @@ async function makeControllerStub(id: string) {
     id,
     "GraphEditingAgentController"
   );
+  const devtools = new DevToolsController(
+    `${id}_dt`,
+    "DevToolsController"
+  );
   await agent.isHydrated;
+  await devtools.isHydrated;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return { editor: { graphEditingAgent: agent } } as any;
+  return { editor: { graphEditingAgent: agent, devtools } } as any;
 }
 
 function makeServicesStub() {
@@ -85,10 +91,16 @@ suite("graph-editing-agent-actions", () => {
     agent.processing = true;
     agent.currentFlow = "flow-1";
     agent.addMessage("user", "Hello");
+    const devtools = controller.editor.devtools;
+    devtools.setSystemInstruction("Do this");
+    devtools.setFunctionDeclarations([{ name: "test_func", description: "A test func" }]);
+    devtools.addObjective("Hello");
     await agent.isSettled;
+    await devtools.isSettled;
 
     resetGraphEditingAgent();
     await agent.isSettled;
+    await devtools.isSettled;
 
     assert.deepStrictEqual(agent.entries, []);
     assert.strictEqual(agent.open, false);
@@ -96,6 +108,10 @@ suite("graph-editing-agent-actions", () => {
     assert.strictEqual(agent.waiting, false);
     assert.strictEqual(agent.processing, false);
     assert.strictEqual(agent.currentFlow, null);
+
+    assert.deepStrictEqual(devtools.entries, []);
+    assert.strictEqual(devtools.systemInstruction, "");
+    assert.deepStrictEqual(devtools.functionDeclarations, []);
   });
 
   test("resetGraphEditingAgent is safe to call multiple times", async () => {


### PR DESCRIPTION
## What
Refactored `resetGraphEditingAgent` into a canonical SCA Action orchestrated by the `onGraphUrlChange` signal trigger. It ensures the DevTools Opie panel gracefully cleans up its session log entries, system instructions, and functions on teardown.

## Why
When a user transitioned from a graph back to the Home page, the graph UI element returned early and skipped conditional agent reset logic. By elevating agent reset into a triggered SCA action, the agent and its DevTools dashboard are reliably cleaned up during all graph exits and switches.

## Changes
- **SCA Actions**
  - Updated [graph-editing-agent-actions.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/src/sca/actions/agent/graph-editing-agent-actions.ts): Converted `resetGraphEditingAgent` to an `asAction` bound to the `onGraphUrlChange` trigger and invoking `devtools.clearLog()`.
- **Tests**
  - Enhanced [graph-editing-agent-actions.test.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/tests/sca/actions/agent/graph-editing-agent-actions.test.ts) to verify that DevTools controller state is effectively cleared during resets.

## Testing
1. Navigate to an Opal graph.
2. Observe the DevTools Opie panel populated with logs and function metadata.
3. Navigate back to Home or open another Opal.
4. Verify the Opie panel and agent loop are gracefully reset.
