### PR TITLE
[opie] Extract Opie Subcontroller for Tab-Based DevTools

### DIFF
--- a/packages/visual-editor/src/sca/actions/agent/graph-editing-agent-actions.ts
+++ b/packages/visual-editor/src/sca/actions/agent/graph-editing-agent-actions.ts
@@ -97,7 +97,7 @@ function startGraphEditingAgent(firstMessage: string): void {
   }) as LocalAgentRun;
   currentRun = handle;
 
-  const devtools = controller.editor.devtools;
+  const devtools = controller.editor.devtools?.opie;
 
   if (devtools) {
     devtools.clearLog();
@@ -122,7 +122,7 @@ function startGraphEditingAgent(firstMessage: string): void {
 
   handle.events
     .on("start", (event) => {
-      const devtools = controller.editor.devtools;
+      const devtools = controller.editor.devtools?.opie;
       if (devtools && event.objective) {
         devtools.addObjective(event.objective);
       }
@@ -364,6 +364,6 @@ export const resetGraphEditingAgent = asAction(
     pendingResolve = null;
     const { controller } = bind;
     controller.editor.graphEditingAgent.reset();
-    controller.editor.devtools?.clearLog();
+    controller.editor.devtools?.opie?.clearLog();
   }
 );

--- a/packages/visual-editor/src/sca/controller/subcontrollers/editor/devtools/devtools-controller.ts
+++ b/packages/visual-editor/src/sca/controller/subcontrollers/editor/devtools/devtools-controller.ts
@@ -1,8 +1,12 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import { field } from "../../../decorators/field.js";
 import { RootController } from "../../root-controller.js";
-import type { SessionLogEntry } from "../../../../types.js";
-import type { FunctionDeclaration } from "../../../../../a2/a2/gemini.js";
-import type { LLMContent } from "@breadboard-ai/types";
+import { OpieController } from "./opie-controller.js";
 
 export class DevToolsController extends RootController {
   @field({ persist: "session" })
@@ -11,138 +15,13 @@ export class DevToolsController extends RootController {
   @field({ persist: "session" })
   accessor activeTab = "opie";
 
-  @field()
-  private accessor _systemInstruction: string = "";
+  public readonly opie: OpieController;
 
-  @field({ deep: true })
-  private accessor _functionDeclarations: FunctionDeclaration[] = [];
-
-  @field({ deep: true })
-  private accessor _entries: SessionLogEntry[] = [];
-
-  // ═══════════════════════════════════════════════════════════════════════════
-  // ACCESSORS
-  // ═══════════════════════════════════════════════════════════════════════════
-
-  get systemInstruction(): string {
-    return this._systemInstruction;
-  }
-
-  get functionDeclarations(): readonly FunctionDeclaration[] {
-    return this._functionDeclarations;
-  }
-
-  get entries(): readonly SessionLogEntry[] {
-    return this._entries;
-  }
-
-  // ═══════════════════════════════════════════════════════════════════════════
-  // MUTATIONS
-  // ═══════════════════════════════════════════════════════════════════════════
-
-  setSystemInstruction(instruction: string | LLMContent | null | undefined): void {
-    if (!instruction) {
-      this._systemInstruction = "";
-      return;
-    }
-    if (typeof instruction === "string") {
-      this._systemInstruction = instruction;
-    } else if ("parts" in instruction) {
-      this._systemInstruction = instruction.parts
-        .filter((p): p is { text: string } => "text" in p)
-        .map((p) => p.text)
-        .join("\n");
-    }
-  }
-
-  setFunctionDeclarations(declarations: FunctionDeclaration[]): void {
-    this._functionDeclarations = [...declarations];
-  }
-
-  addObjective(request: string | LLMContent): void {
-    let resolvedRequest = "";
-    if (typeof request === "string") {
-      resolvedRequest = request;
-    } else if (request && "parts" in request) {
-      resolvedRequest = (request as LLMContent).parts
-        .filter((p): p is { text: string } => "text" in p)
-        .map((p) => p.text)
-        .join("\n");
-    }
-
-    const existingIndex = this._entries.findIndex((e) => e.kind === "objective");
-    if (existingIndex !== -1) {
-      this._entries = this._entries.map((entry, idx) => {
-        if (idx === existingIndex) {
-          return {
-            ...entry,
-            args: { ...entry.args, user_request: resolvedRequest },
-          };
-        }
-        return entry;
-      });
-    } else {
-      const entry: SessionLogEntry = {
-        callId: crypto.randomUUID(),
-        kind: "objective",
-        name: "objective",
-        args: { user_request: resolvedRequest },
-        timestamp: Date.now(),
-      };
-      this._entries = [...this._entries, entry];
-    }
-  }
-
-  addThought(text: string): void {
-    const entry: SessionLogEntry = {
-      callId: crypto.randomUUID(),
-      kind: "thought",
-      name: "thought",
-      args: { thought: text },
-      timestamp: Date.now(),
-    };
-    this._entries = [...this._entries, entry];
-  }
-
-  addCall(callId: string, name: string, args: Record<string, unknown>): void {
-    const entry: SessionLogEntry = {
-      callId,
-      kind: "call",
-      name,
-      args,
-      timestamp: Date.now(),
-    };
-    this._entries = [...this._entries, entry];
-  }
-
-  updateCallResponse(callId: string, response: Record<string, unknown> | LLMContent | null | undefined): void {
-    let resolvedResponse: Record<string, unknown> | undefined = undefined;
-    if (response) {
-      if ("parts" in response && Array.isArray((response as LLMContent).parts)) {
-        const firstPart = (response as LLMContent).parts[0];
-        if (firstPart && "functionResponse" in firstPart) {
-          resolvedResponse = firstPart.functionResponse.response as Record<string, unknown>;
-        } else {
-          resolvedResponse = response as unknown as Record<string, unknown>;
-        }
-      } else {
-        resolvedResponse = response as Record<string, unknown>;
-      }
-    }
-
-    this._entries = this._entries.map((entry) => {
-      if (entry.callId === callId) {
-        return { ...entry, response: resolvedResponse };
-      }
-      return entry;
-    });
-  }
-
-  clearLog(): void {
-    this._entries = [];
-    this._systemInstruction = "";
-    this._functionDeclarations = [];
+  constructor(controllerId: string, persistenceId: string) {
+    super(controllerId, persistenceId);
+    this.opie = new OpieController(
+      `${controllerId}_Opie`,
+      `${persistenceId}_Opie`
+    );
   }
 }
-
-

--- a/packages/visual-editor/src/sca/controller/subcontrollers/editor/devtools/opie-controller.ts
+++ b/packages/visual-editor/src/sca/controller/subcontrollers/editor/devtools/opie-controller.ts
@@ -1,0 +1,146 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { field } from "../../../decorators/field.js";
+import { RootController } from "../../root-controller.js";
+import type { SessionLogEntry } from "../../../../types.js";
+import type { FunctionDeclaration } from "../../../../../a2/a2/gemini.js";
+import type { LLMContent } from "@breadboard-ai/types";
+
+export class OpieController extends RootController {
+  @field()
+  private accessor _systemInstruction: string = "";
+
+  @field({ deep: true })
+  private accessor _functionDeclarations: FunctionDeclaration[] = [];
+
+  @field({ deep: true })
+  private accessor _entries: SessionLogEntry[] = [];
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // ACCESSORS
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  get systemInstruction(): string {
+    return this._systemInstruction;
+  }
+
+  get functionDeclarations(): readonly FunctionDeclaration[] {
+    return this._functionDeclarations;
+  }
+
+  get entries(): readonly SessionLogEntry[] {
+    return this._entries;
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // MUTATIONS
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  setSystemInstruction(instruction: string | LLMContent | null | undefined): void {
+    if (!instruction) {
+      this._systemInstruction = "";
+      return;
+    }
+    if (typeof instruction === "string") {
+      this._systemInstruction = instruction;
+    } else if ("parts" in instruction) {
+      this._systemInstruction = instruction.parts
+        .filter((p): p is { text: string } => "text" in p)
+        .map((p) => p.text)
+        .join("\n");
+    }
+  }
+
+  setFunctionDeclarations(declarations: FunctionDeclaration[]): void {
+    this._functionDeclarations = [...declarations];
+  }
+
+  addObjective(request: string | LLMContent): void {
+    let resolvedRequest = "";
+    if (typeof request === "string") {
+      resolvedRequest = request;
+    } else if (request && "parts" in request) {
+      resolvedRequest = (request as LLMContent).parts
+        .filter((p): p is { text: string } => "text" in p)
+        .map((p) => p.text)
+        .join("\n");
+    }
+
+    const existingIndex = this._entries.findIndex((e) => e.kind === "objective");
+    if (existingIndex !== -1) {
+      this._entries = this._entries.map((entry, idx) => {
+        if (idx === existingIndex) {
+          return {
+            ...entry,
+            args: { ...entry.args, user_request: resolvedRequest },
+          };
+        }
+        return entry;
+      });
+    } else {
+      const entry: SessionLogEntry = {
+        callId: crypto.randomUUID(),
+        kind: "objective",
+        name: "objective",
+        args: { user_request: resolvedRequest },
+        timestamp: Date.now(),
+      };
+      this._entries = [...this._entries, entry];
+    }
+  }
+
+  addThought(text: string): void {
+    const entry: SessionLogEntry = {
+      callId: crypto.randomUUID(),
+      kind: "thought",
+      name: "thought",
+      args: { thought: text },
+      timestamp: Date.now(),
+    };
+    this._entries = [...this._entries, entry];
+  }
+
+  addCall(callId: string, name: string, args: Record<string, unknown>): void {
+    const entry: SessionLogEntry = {
+      callId,
+      kind: "call",
+      name,
+      args,
+      timestamp: Date.now(),
+    };
+    this._entries = [...this._entries, entry];
+  }
+
+  updateCallResponse(callId: string, response: Record<string, unknown> | LLMContent | null | undefined): void {
+    let resolvedResponse: Record<string, unknown> | undefined = undefined;
+    if (response) {
+      if ("parts" in response && Array.isArray((response as LLMContent).parts)) {
+        const firstPart = (response as LLMContent).parts[0];
+        if (firstPart && "functionResponse" in firstPart) {
+          resolvedResponse = firstPart.functionResponse.response as Record<string, unknown>;
+        } else {
+          resolvedResponse = response as unknown as Record<string, unknown>;
+        }
+      } else {
+        resolvedResponse = response as Record<string, unknown>;
+      }
+    }
+
+    this._entries = this._entries.map((entry) => {
+      if (entry.callId === callId) {
+        return { ...entry, response: resolvedResponse };
+      }
+      return entry;
+    });
+  }
+
+  clearLog(): void {
+    this._entries = [];
+    this._systemInstruction = "";
+    this._functionDeclarations = [];
+  }
+}

--- a/packages/visual-editor/src/ui/elements/devtools/devtools.ts
+++ b/packages/visual-editor/src/ui/elements/devtools/devtools.ts
@@ -141,9 +141,10 @@ export class DevTools extends SignalWatcher(LitElement) {
 
   render() {
     const devtools = this.sca.controller.editor.devtools;
-    const systemInstruction = devtools.systemInstruction;
-    const functions = devtools.functionDeclarations;
-    const entries = devtools.entries;
+    const opie = devtools.opie;
+    const systemInstruction = opie.systemInstruction;
+    const functions = opie.functionDeclarations;
+    const entries = opie.entries;
 
     return html`
       <div id="devtools-header">

--- a/packages/visual-editor/tests/sca/actions/agent/graph-editing-agent-actions.test.ts
+++ b/packages/visual-editor/tests/sca/actions/agent/graph-editing-agent-actions.test.ts
@@ -36,6 +36,7 @@ async function makeControllerStub(id: string) {
   );
   await agent.isHydrated;
   await devtools.isHydrated;
+  await devtools.opie.isHydrated;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return { editor: { graphEditingAgent: agent, devtools } } as any;
 }
@@ -92,9 +93,10 @@ suite("graph-editing-agent-actions", () => {
     agent.currentFlow = "flow-1";
     agent.addMessage("user", "Hello");
     const devtools = controller.editor.devtools;
-    devtools.setSystemInstruction("Do this");
-    devtools.setFunctionDeclarations([{ name: "test_func", description: "A test func" }]);
-    devtools.addObjective("Hello");
+    const opie = devtools.opie;
+    opie.setSystemInstruction("Do this");
+    opie.setFunctionDeclarations([{ name: "test_func", description: "A test func" }]);
+    opie.addObjective("Hello");
     await agent.isSettled;
     await devtools.isSettled;
 
@@ -109,9 +111,9 @@ suite("graph-editing-agent-actions", () => {
     assert.strictEqual(agent.processing, false);
     assert.strictEqual(agent.currentFlow, null);
 
-    assert.deepStrictEqual(devtools.entries, []);
-    assert.strictEqual(devtools.systemInstruction, "");
-    assert.deepStrictEqual(devtools.functionDeclarations, []);
+    assert.deepStrictEqual(opie.entries, []);
+    assert.strictEqual(opie.systemInstruction, "");
+    assert.deepStrictEqual(opie.functionDeclarations, []);
   });
 
   test("resetGraphEditingAgent is safe to call multiple times", async () => {

--- a/packages/visual-editor/tests/sca/controller/subcontrollers/editor/devtools/opie-controller.test.ts
+++ b/packages/visual-editor/tests/sca/controller/subcontrollers/editor/devtools/opie-controller.test.ts
@@ -1,0 +1,122 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { suite, test } from "node:test";
+import assert from "node:assert/strict";
+import { OpieController } from "../../../../../../src/sca/controller/subcontrollers/editor/devtools/opie-controller.js";
+import type { LLMContent } from "@breadboard-ai/types";
+
+suite("OpieController", () => {
+  suite("setSystemInstruction", () => {
+    test("sets empty string initially", () => {
+      const ctrl = new OpieController("opie_1", "OpieController");
+      assert.strictEqual(ctrl.systemInstruction, "");
+    });
+
+    test("sets string instruction", () => {
+      const ctrl = new OpieController("opie_2", "OpieController");
+      ctrl.setSystemInstruction("Be helpful");
+      assert.strictEqual(ctrl.systemInstruction, "Be helpful");
+    });
+
+    test("sets null/undefined instruction to empty string", () => {
+      const ctrl = new OpieController("opie_3", "OpieController");
+      ctrl.setSystemInstruction("Help");
+      ctrl.setSystemInstruction(null);
+      assert.strictEqual(ctrl.systemInstruction, "");
+      ctrl.setSystemInstruction("Help");
+      ctrl.setSystemInstruction(undefined);
+      assert.strictEqual(ctrl.systemInstruction, "");
+    });
+
+    test("sets LLMContent instruction", () => {
+      const ctrl = new OpieController("opie_4", "OpieController");
+      const content: LLMContent = {
+        parts: [{ text: "Instruction Part 1" }, { text: "Instruction Part 2" }],
+      };
+      ctrl.setSystemInstruction(content);
+      assert.strictEqual(
+        ctrl.systemInstruction,
+        "Instruction Part 1\nInstruction Part 2"
+      );
+    });
+  });
+
+  suite("addObjective", () => {
+    test("adds string objective", () => {
+      const ctrl = new OpieController("opie_5", "OpieController");
+      ctrl.addObjective("New Request");
+      assert.strictEqual(ctrl.entries.length, 1);
+      assert.strictEqual(ctrl.entries[0].kind, "objective");
+      assert.deepStrictEqual(ctrl.entries[0].args, {
+        user_request: "New Request",
+      });
+    });
+
+    test("adds LLMContent objective", () => {
+      const ctrl = new OpieController("opie_6", "OpieController");
+      const content: LLMContent = {
+        parts: [{ text: "Request Part A" }, { text: "Request Part B" }],
+      };
+      ctrl.addObjective(content);
+      assert.strictEqual(ctrl.entries.length, 1);
+      assert.strictEqual(ctrl.entries[0].kind, "objective");
+      assert.deepStrictEqual(ctrl.entries[0].args, {
+        user_request: "Request Part A\nRequest Part B",
+      });
+    });
+
+    test("updates existing objective", () => {
+      const ctrl = new OpieController("opie_7", "OpieController");
+      ctrl.addObjective("Original Objective");
+      ctrl.addObjective("Updated Objective");
+      assert.strictEqual(ctrl.entries.length, 1);
+      assert.strictEqual(ctrl.entries[0].kind, "objective");
+      assert.deepStrictEqual(ctrl.entries[0].args, {
+        user_request: "Updated Objective",
+      });
+    });
+  });
+
+  suite("updateCallResponse", () => {
+    test("handles functionResponse in LLMContent", () => {
+      const ctrl = new OpieController("opie_8", "OpieController");
+      ctrl.addCall("call-1", "test_func", {});
+      const response: LLMContent = {
+        parts: [
+          {
+            functionResponse: {
+              name: "test_func",
+              response: { result: "Success" },
+            },
+          },
+        ],
+      };
+      ctrl.updateCallResponse("call-1", response);
+      assert.strictEqual(ctrl.entries.length, 1);
+      assert.deepStrictEqual(ctrl.entries[0].response, { result: "Success" });
+    });
+
+    test("handles regular record object", () => {
+      const ctrl = new OpieController("opie_9", "OpieController");
+      ctrl.addCall("call-2", "test_func", {});
+      const response = { status: "OK" };
+      ctrl.updateCallResponse("call-2", response);
+      assert.deepStrictEqual(ctrl.entries[0].response, { status: "OK" });
+    });
+  });
+
+  suite("addCall & addThought", () => {
+    test("adds call and thought entries to log", () => {
+      const ctrl = new OpieController("opie_10", "OpieController");
+      ctrl.addThought("I should check status");
+      ctrl.addCall("c-1", "get_status", { id: 123 });
+      assert.strictEqual(ctrl.entries.length, 2);
+      assert.strictEqual(ctrl.entries[0].kind, "thought");
+      assert.strictEqual(ctrl.entries[1].kind, "call");
+    });
+  });
+});


### PR DESCRIPTION
## What
Extracted Opie-specific state, mutations, and log entries from `DevToolsController` into a dedicated composition-based `OpieController`.

## Why
Supports the recent transition to a tab-based UI where Opie is just one tab among others, ensuring the architectural boundaries and separation of concerns mandated by Breadboard's SCA framework.

## Changes
- **DevTools**:
  - Extracted `OpieController` with properties for system instructions, functions, and session entries.
  - Composed `DevToolsController` to house an `opie` member, initializing it per SCA namespacing protocols.
  - Plumbed action bindings and UI elements to map through `.opie` correctly.

## Testing
- Verified 11 Visual Editor action tests and 10 new subcontroller unit tests pass successfully.
- Boosted line coverage for the extracted `OpieController` to 97%.
