### PR TITLE
[opie] Combine DevTools Header and Duration-Based Function Highlighting

### DIFF
--- a/packages/visual-editor/src/ui/elements/devtools/devtools.ts
+++ b/packages/visual-editor/src/ui/elements/devtools/devtools.ts
@@ -57,6 +57,12 @@ export class DevTools extends SignalWatcher(LitElement) {
           gap: var(--bb-grid-size-2);
         }
 
+        & .header-left {
+          display: flex;
+          align-items: center;
+          gap: var(--bb-grid-size-4);
+        }
+
         & #close-devtools {
           background: none;
           border: none;
@@ -81,10 +87,6 @@ export class DevTools extends SignalWatcher(LitElement) {
         align-items: center;
         justify-content: flex-start;
         flex: 0 0 auto;
-        height: var(--bb-grid-size-14);
-        background: var(--light-dark-n-100);
-        border-bottom: 1px solid var(--light-dark-n-90);
-        padding: 0 var(--bb-grid-size-4);
 
         & button {
           display: flex;
@@ -126,16 +128,6 @@ export class DevTools extends SignalWatcher(LitElement) {
         gap: var(--bb-grid-size-3);
         min-height: 0;
       }
-
-      #devtools-content {
-        flex: 1;
-        padding: var(--bb-grid-size-4);
-        overflow: hidden;
-        display: flex;
-        flex-direction: row;
-        gap: var(--bb-grid-size-3);
-        min-height: 0;
-      }
     `,
   ];
 
@@ -148,7 +140,20 @@ export class DevTools extends SignalWatcher(LitElement) {
 
     return html`
       <div id="devtools-header">
-        <h2><span class="g-icon">developer_board</span> Opal Dev Tools</h2>
+        <div class="header-left">
+          <h2><span class="g-icon">developer_board</span> Opal Dev Tools</h2>
+          <div id="devtools-tabs">
+            <button
+              class="sans-flex w-500 round"
+              ?disabled=${devtools.activeTab === "opie"}
+              @click=${() => {
+                devtools.activeTab = "opie";
+              }}
+            >
+              Opie
+            </button>
+          </div>
+        </div>
         <button
           id="close-devtools"
           @click=${() => {
@@ -156,17 +161,6 @@ export class DevTools extends SignalWatcher(LitElement) {
           }}
         >
           <span class="g-icon">close</span>
-        </button>
-      </div>
-      <div id="devtools-tabs">
-        <button
-          class="sans-flex w-500 round"
-          ?disabled=${devtools.activeTab === "opie"}
-          @click=${() => {
-            devtools.activeTab = "opie";
-          }}
-        >
-          Opie
         </button>
       </div>
       <div id="devtools-content">

--- a/packages/visual-editor/src/ui/elements/devtools/opie/opie-panel.ts
+++ b/packages/visual-editor/src/ui/elements/devtools/opie/opie-panel.ts
@@ -4,7 +4,6 @@ import { SignalWatcher } from "@lit-labs/signals";
 import { icons } from "../../../styles/icons.js";
 import { markdown } from "../../../directives/markdown.js";
 import { parseThought } from "../../../../a2/agent/thought-parser.js";
-import { keyed } from "lit/directives/keyed.js";
 import { renderCall } from "./registry.js";
 import type { SessionLogEntry } from "../../../../sca/types.js";
 import type { FunctionDeclaration } from "../../../../a2/a2/gemini.js";
@@ -209,32 +208,17 @@ export class DevToolsOpiePanel extends SignalWatcher(LitElement) {
         font: 500 var(--bb-label-small) / var(--bb-label-line-height-small)
           var(--bb-font-family-mono, monospace);
         border: 1px solid var(--light-dark-n-80);
-        transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
+        transition: background 0.2s cubic-bezier(0, 0, 0.3, 1),
+          color 0.2s cubic-bezier(0, 0, 0.3, 1),
+          border-color 0.2s cubic-bezier(0, 0, 0.3, 1),
+          box-shadow 0.2s cubic-bezier(0, 0, 0.3, 1);
       }
 
-      @keyframes flash-chip {
-        0% {
-          background: var(--light-dark-p-90);
-          color: var(--light-dark-p-20);
-          box-shadow: 0 0 6px oklch(from var(--light-dark-p-40) l c h / 0.2);
-          border-color: var(--light-dark-p-40);
-        }
-        30% {
-          background: var(--light-dark-p-85);
-          color: var(--light-dark-p-15);
-          box-shadow: 0 0 10px oklch(from var(--light-dark-p-40) l c h / 0.3);
-          border-color: var(--light-dark-p-40);
-        }
-        100% {
-          background: var(--light-dark-n-90);
-          color: var(--light-dark-n-20);
-          box-shadow: 0 0 0 transparent;
-          border-color: var(--light-dark-n-80);
-        }
-      }
-
-      .function-tag.flash {
-        animation: flash-chip 1.2s cubic-bezier(0.16, 1, 0.3, 1);
+      .function-tag.active {
+        background: var(--light-dark-p-85);
+        color: var(--light-dark-p-15);
+        box-shadow: 0 0 8px oklch(from var(--light-dark-p-40) l c h / 0.25);
+        border-color: var(--light-dark-p-40);
       }
 
 
@@ -347,19 +331,19 @@ export class DevToolsOpiePanel extends SignalWatcher(LitElement) {
             ? html`
                 <div class="function-wrap">
                   ${functions.map((fn) => {
-                    const lastCallEntry = entries
-                      ? [...entries].reverse().find((e) => e.kind === "call")
-                      : null;
-                    const isLastCall = lastCallEntry && lastCallEntry.name === fn.name;
-                    const lastCallId = isLastCall
-                      ? lastCallEntry.callId || String(lastCallEntry.timestamp)
-                      : "none";
-                    const content = html`<span
-                      class="function-tag ${isLastCall ? "flash" : ""}"
+                    const isActive = entries
+                      ? entries.some(
+                          (e) =>
+                            e.kind === "call" &&
+                            e.name === fn.name &&
+                            !("response" in e)
+                        )
+                      : false;
+                    return html`<span
+                      class="function-tag ${isActive ? "active" : ""}"
                       title=${fn.description || ""}
                       >${fn.name}</span
                     >`;
-                    return isLastCall ? keyed(lastCallId, content) : content;
                   })}
                 </div>
               `


### PR DESCRIPTION
## What
Combines the "Opal Dev Tools" header with the tab strip into a single, space-efficient row, and updates the configured function chips to light up for the exact duration of each function call.

## Why
Improves visual editor UI compactness while giving users clear, real-time visual feedback on which function is actively executing and how long each execution takes.

## Changes
- **Visual Editor**:
  - Grouped the title and tab strip into a `.header-left` flex container in `devtools.ts`.
  - Replaced flash animations in `opie-panel.ts` with a smooth `.active` CSS transition highlight.
  - Replaced the keyed DOM recreation directive with stable Lit rendering tied to the active state of each function's `SessionLogEntry` calls.
  - Removed duplicate CSS definitions for `#devtools-content`.

## Testing
- Invoke tools via Opie and verify function chips highlight for the duration of the call and dim smoothly on response arrival.
- Ensure the header title and tab strip align perfectly on a single row.
