### PR TITLE
[ve] Fix renderer jump

### DIFF
--- a/packages/visual-editor/src/ui/elements/step-editor/renderer.ts
+++ b/packages/visual-editor/src/ui/elements/step-editor/renderer.ts
@@ -1084,6 +1084,7 @@ export class Renderer extends SignalWatcher(LitElement) {
   #updateCamera(animated = false, targetMatrix: DOMMatrix) {
     if (!animated) {
       this.camera.transform = targetMatrix;
+      this.tick++;
     } else {
       this.#addEffect("camera", () => {
         if (!this.camera) {


### PR DESCRIPTION
## What
Add `tick++` to the non-animated camera update path in `#updateCamera`, ensuring the renderer re-renders entity positions whenever the camera transform changes.

## Why
When a graph loads, the renderer is recreated inside the splitter layout. A deferred `fitToView` (via `requestAnimationFrame`) fires after async node content loads and produces a new camera matrix — but the non-animated path only set `camera.transform` without incrementing `tick`. Since the entity position update in `willUpdate` is gated on `tick` changing, the new camera position was silently stored but never applied to entities. The next user interaction (e.g., a click) incremented `tick`, causing entities to snap to the updated camera position — visible as an ~80px vertical jump.

The animated camera path already incremented `tick` on every frame. This makes the non-animated path consistent.

## Changes
- **`packages/visual-editor/src/ui/elements/step-editor/renderer.ts`**: Add `this.tick++` after `this.camera.transform = targetMatrix` in the non-animated branch of `#updateCamera`.

## Testing
1. Open any graph with at least one step
2. Wait for the graph to fully load and settle
3. Click on the canvas or a node
4. Verify there is no jump/snap in node position on first interaction