### PR TITLE
[ve] Use model aliases for all frontend calls to (Stream)GenerateContent

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -37,6 +37,7 @@ import dejaCodePreferSummarizeLLMContent from "./packages/visual-editor/eslint-r
 import dejaCodePreferFormatError from "./packages/visual-editor/eslint-rules/deja-code-prefer-format-error.js";
 import dejaCodePreferCanParse from "./packages/visual-editor/eslint-rules/deja-code-prefer-can-parse.js";
 import dejaCodePreferRouterNavigate from "./packages/visual-editor/eslint-rules/deja-code-prefer-router-navigate.js";
+import dejaCodePreferModelAlias from "./packages/visual-editor/eslint-rules/deja-code-prefer-model-alias.js";
 
 // Create local rules plugin
 const localRulesPlugin = {
@@ -68,6 +69,7 @@ const localRulesPlugin = {
     "deja-code-prefer-format-error": dejaCodePreferFormatError,
     "deja-code-prefer-can-parse": dejaCodePreferCanParse,
     "deja-code-prefer-router-navigate": dejaCodePreferRouterNavigate,
+    "deja-code-prefer-model-alias": dejaCodePreferModelAlias,
   },
 };
 
@@ -142,6 +144,7 @@ export default tseslint.config(
       "local-rules/deja-code-prefer-format-error": "error",
       "local-rules/deja-code-prefer-can-parse": "error",
       "local-rules/deja-code-prefer-router-navigate": "error",
+      "local-rules/deja-code-prefer-model-alias": "error",
 
       // expect-type rules (requires type information)
       "expect-type/expect": "error",

--- a/packages/visual-editor/eslint-rules/deja-code-prefer-model-alias.js
+++ b/packages/visual-editor/eslint-rules/deja-code-prefer-model-alias.js
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * ESLint rule: deja-code-prefer-model-alias
+ *
+ * Déjà Code — prevents hardcoded Gemini model names in the frontend.
+ *
+ * Pattern:
+ *   modelName: "gemini-3-flash-preview"
+ *   generateContent("gemini-2.5-pro", body, moduleArgs)
+ *   model: "gemini-2.5-flash-image"
+ *
+ * The frontend should use `MODEL_ALIAS_*` constants from `gemini.ts`
+ * instead. The backend remaps aliases to concrete model names, so the
+ * frontend never needs to know the actual model version.
+ *
+ * This rule flags any string literal that looks like a versioned Gemini
+ * or Veo model name (e.g. "gemini-3-flash-preview", "veo-3.1-generate-preview").
+ * It does NOT flag aliases like "alias-text-flash" or UI identifiers like
+ * "gemini-flash".
+ */
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Déjà Code: use MODEL_ALIAS_* constants instead of hardcoded Gemini/Veo model names",
+      recommended: false,
+    },
+    messages: {
+      preferModelAlias:
+        'Déjà Code: don\'t hardcode model name "{{ model }}". ' +
+        "Use a MODEL_ALIAS_* constant from gemini.ts — the backend remaps aliases to concrete models.",
+    },
+    schema: [],
+  },
+
+  create(context) {
+    return {
+      Literal(node) {
+        if (typeof node.value !== "string") return;
+        if (!isHardcodedModelName(node.value)) return;
+
+        context.report({
+          node,
+          messageId: "preferModelAlias",
+          data: { model: node.value },
+        });
+      },
+    };
+  },
+};
+
+/**
+ * Returns true if the string looks like a concrete, versioned model name
+ * that should be replaced with an alias.
+ *
+ * Matches patterns like:
+ *   - gemini-2.5-pro
+ *   - gemini-3-flash-preview
+ *   - gemini-3.1-flash-lite
+ *   - gemini-2.0-flash-exp
+ *   - gemini-1.5-pro-latest
+ *   - veo-3.1-generate-preview
+ *   - learnlm-1.5-pro-experimental
+ *
+ * Does NOT match:
+ *   - alias-text-flash (the aliases themselves)
+ *   - gemini-flash (UI identifiers without version numbers)
+ *   - gemini-prompt (non-model strings)
+ */
+function isHardcodedModelName(value) {
+  return /^(gemini|veo|learnlm)-\d/.test(value);
+}

--- a/packages/visual-editor/src/a2/a2/gemini.ts
+++ b/packages/visual-editor/src/a2/a2/gemini.ts
@@ -79,8 +79,7 @@ async function resolvePrefix(): Promise<string> {
 const STREAM_RETRY_DELAY_MS = 700;
 const STREAM_MAX_RETRIES = 5;
 
-const VALID_MODALITIES = ["Text", "Text and Image", "Audio"] as const;
-type ValidModalities = (typeof VALID_MODALITIES)[number];
+type ValidModalities = "Text" | "Text and Image" | "Audio";
 
 export type HarmBlockThreshold =
   // Content with NEGLIGIBLE will be allowed.

--- a/packages/visual-editor/src/a2/a2/gemini.ts
+++ b/packages/visual-editor/src/a2/a2/gemini.ts
@@ -310,7 +310,6 @@ export type GeminiOutputs =
       context: LLMContent[];
     };
 
-const MODEL_ALIASES: Record<string, string> = {};
 
 const MODELS: readonly string[] = [
   MODEL_ALIAS_TEXT_LITE,
@@ -743,9 +742,6 @@ async function generateContent(
   body: GeminiBody,
   moduleArgs: A2ModuleArgs
 ): Promise<Outcome<GeminiAPIOutputs>> {
-  if (MODEL_ALIASES[model]) {
-    model = MODEL_ALIASES[model];
-  }
   const { fetchWithCreds, context } = moduleArgs;
   try {
     const prefix = await resolvePrefix();
@@ -800,9 +796,6 @@ async function streamGenerateContent(
   body: GeminiBody,
   moduleArgs: A2ModuleArgs
 ): Promise<Outcome<AsyncIterable<GeminiAPIOutputs>>> {
-  if (MODEL_ALIASES[model]) {
-    model = MODEL_ALIASES[model];
-  }
   const { fetchWithCreds, context } = moduleArgs;
   const prefix = await resolvePrefix();
   for (let attempt = 0; attempt < STREAM_MAX_RETRIES; attempt++) {
@@ -920,9 +913,6 @@ async function invoke(
     return validatingInputs;
   }
   let { model } = inputs;
-  if (model && MODEL_ALIASES[model]) {
-    model = MODEL_ALIASES[model];
-  }
   if (!model) {
     model = MODELS[0];
   }

--- a/packages/visual-editor/src/a2/a2/gemini.ts
+++ b/packages/visual-editor/src/a2/a2/gemini.ts
@@ -32,7 +32,14 @@ export {
   generateContent,
   streamGenerateContent,
   conformBody as conformGeminiBody,
+  MODEL_ALIAS_TEXT_LITE,
+  MODEL_ALIAS_TEXT_FLASH,
+  MODEL_ALIAS_TEXT_PRO,
 };
+
+const MODEL_ALIAS_TEXT_LITE = "alias-text-lite";
+const MODEL_ALIAS_TEXT_FLASH = "alias-text-flash";
+const MODEL_ALIAS_TEXT_PRO = "alias-text-pro";
 
 const defaultSafetySettings = (): SafetySetting[] => [
   {
@@ -303,37 +310,12 @@ export type GeminiOutputs =
       context: LLMContent[];
     };
 
-const MODEL_ALIASES: Record<string, string> = {
-  "gemini-2.5-flash": "gemini-3.1-flash-lite",
-};
+const MODEL_ALIASES: Record<string, string> = {};
 
 const MODELS: readonly string[] = [
-  "gemini-3.1-flash-lite",
-  "gemini-3-flash-preview",
-  "gemini-2.5-flash",
-  "gemini-2.5-flash-lite",
-  "gemini-2.5-pro",
-  "gemini-2.0-flash",
-  "gemini-2.0-flash-001",
-  "gemini-2.0-flash-lite-preview-02-05",
-  "gemini-2.0-flash-exp",
-  "gemini-2.0-flash-thinking-exp",
-  "gemini-2.0-flash-thinking-exp-01-21",
-  "gemini-2.0-pro-exp-02-05",
-  "gemini-1.5-flash-latest",
-  "gemini-1.5-pro-latest",
-  "gemini-exp-1206",
-  "gemini-exp-1121",
-  "learnlm-1.5-pro-experimental",
-  "gemini-1.5-pro-001",
-  "gemini-1.5-pro-002",
-  "gemini-1.5-pro-exp-0801",
-  "gemini-1.5-pro-exp-0827",
-  "gemini-1.5-flash-001",
-  "gemini-1.5-flash-002",
-  "gemini-1.5-flash-8b-exp-0924",
-  "gemini-1.5-flash-8b-exp-0827",
-  "gemini-1.5-flash-exp-0827",
+  MODEL_ALIAS_TEXT_LITE,
+  MODEL_ALIAS_TEXT_FLASH,
+  MODEL_ALIAS_TEXT_PRO,
 ];
 
 /**
@@ -341,9 +323,8 @@ const MODELS: readonly string[] = [
  * Maps a model to its fallback chain (ordered by preference).
  */
 const MODEL_FALLBACKS: Record<string, readonly string[]> = {
-  "gemini-3-pro": ["gemini-3-flash-preview", "gemini-2.5-pro"],
-  "gemini-2.5-pro": ["gemini-3-flash-preview"],
-  "gemini-3-flash-preview": ["gemini-3.1-flash-lite"],
+  [MODEL_ALIAS_TEXT_PRO]: [MODEL_ALIAS_TEXT_FLASH, MODEL_ALIAS_TEXT_LITE],
+  [MODEL_ALIAS_TEXT_FLASH]: [MODEL_ALIAS_TEXT_LITE],
 };
 
 const NO_RETRY_CODES: readonly number[] = [400, 429, 404, 403];
@@ -495,12 +476,10 @@ async function conformBody(
 
 function calculateDuration(model: string) {
   switch (model) {
-    case "gemini-3.1-flash-lite":
-    case "gemini-2.5-flash":
-      return 20;
-    case "gemini-2.5-pro":
-    case "gemini-3-pro":
+    case MODEL_ALIAS_TEXT_PRO:
       return 50;
+    case MODEL_ALIAS_TEXT_FLASH:
+    case MODEL_ALIAS_TEXT_LITE:
     default:
       return 20;
   }
@@ -1012,42 +991,11 @@ async function invoke(
 
 type DescribeInputs = {
   inputs: {
-    modality?: ValidModalities;
     model: string;
   };
 };
 
-async function describe({ inputs }: DescribeInputs) {
-  const canHaveModalities = inputs.model === "gemini-2.0-flash-exp";
-  const canHaveSystemInstruction =
-    !canHaveModalities || (canHaveModalities && inputs.modality == "Text");
-  const maybeAddSystemInstruction: Schema["properties"] =
-    canHaveSystemInstruction
-      ? {
-          systemInstruction: {
-            type: "object",
-            behavior: ["llm-content", "config"],
-            title: "System Instruction",
-            default: '{"role":"user","parts":[{"text":""}]}',
-            description:
-              "(Optional) Give the model additional context on what to do," +
-              "like specific rules/guidelines to adhere to or specify behavior" +
-              "separate from the provided context",
-          },
-        }
-      : {};
-  const maybeAddModalities: Schema["properties"] = canHaveModalities
-    ? {
-        modality: {
-          type: "string",
-          enum: [...VALID_MODALITIES],
-          title: "Output Modality",
-          behavior: ["config"],
-          description:
-            "(Optional) Tell the model what kind of output you're looking for.",
-        },
-      }
-    : {};
+async function describe(_describeInputs: DescribeInputs) {
   return {
     inputSchema: {
       type: "object",
@@ -1067,8 +1015,16 @@ async function describe({ inputs }: DescribeInputs) {
           description:
             "(Optional) A prompt. Will be added to the end of the the conversation context.",
         },
-        ...maybeAddSystemInstruction,
-        ...maybeAddModalities,
+        systemInstruction: {
+          type: "object",
+          behavior: ["llm-content", "config"],
+          title: "System Instruction",
+          default: '{"role":"user","parts":[{"text":""}]}',
+          description:
+            "(Optional) Give the model additional context on what to do," +
+            "like specific rules/guidelines to adhere to or specify behavior" +
+            "separate from the provided context",
+        },
         context: {
           type: "array",
           items: {

--- a/packages/visual-editor/src/a2/a2/gemini.ts
+++ b/packages/visual-editor/src/a2/a2/gemini.ts
@@ -35,11 +35,15 @@ export {
   MODEL_ALIAS_TEXT_LITE,
   MODEL_ALIAS_TEXT_FLASH,
   MODEL_ALIAS_TEXT_PRO,
+  MODEL_ALIAS_IMAGE_FLASH,
+  MODEL_ALIAS_IMAGE_PRO,
 };
 
 const MODEL_ALIAS_TEXT_LITE = "alias-text-lite";
 const MODEL_ALIAS_TEXT_FLASH = "alias-text-flash";
 const MODEL_ALIAS_TEXT_PRO = "alias-text-pro";
+const MODEL_ALIAS_IMAGE_FLASH = "alias-image-flash";
+const MODEL_ALIAS_IMAGE_PRO = "alias-image-pro";
 
 const defaultSafetySettings = (): SafetySetting[] => [
   {

--- a/packages/visual-editor/src/a2/a2/generate-webpage-stream.ts
+++ b/packages/visual-editor/src/a2/a2/generate-webpage-stream.ts
@@ -54,7 +54,6 @@ type StreamingRequestPart = {
 
 type StreamingRequestBody = {
   intent: string;
-  modelName: string;
   userInstruction: string;
   contents: Array<{
     parts: StreamingRequestPart[];
@@ -73,8 +72,7 @@ type StreamingRequestBody = {
  */
 function buildStreamingRequestBody(
   instruction: string,
-  content: LLMContent[],
-  modelName: string
+  content: LLMContent[]
 ): StreamingRequestBody {
   const contents: StreamingRequestBody["contents"] = [];
   const driveResourceKeys: StreamingRequestBody["driveResourceKeys"] = {};
@@ -139,7 +137,6 @@ function buildStreamingRequestBody(
 
   const requestBody: StreamingRequestBody = {
     intent: "",
-    modelName,
     userInstruction: instruction,
     contents,
   };
@@ -188,18 +185,17 @@ function parseStoredDataUrl(handle: string): string {
 async function executeWebpageStream(
   moduleArgs: A2ModuleArgs,
   instruction: string,
-  content: LLMContent[],
-  modelName: string
+  content: LLMContent[]
 ): Promise<Outcome<LLMContent>> {
   const reporter = createReporter(moduleArgs, {
-    title: `Generating webpage with ${modelName}`,
+    title: `Generating webpage`,
     icon: "web",
   });
 
   const { appScreen } = getCurrentStepState(moduleArgs);
 
   try {
-    reporter.addJson("Preparing request", { modelName }, "upload");
+    reporter.addJson("Preparing request", {}, "upload");
 
     if (appScreen) appScreen.progress = "Generating HTML";
 
@@ -209,8 +205,7 @@ async function executeWebpageStream(
 
     const requestBody = buildStreamingRequestBody(
       instruction,
-      content,
-      modelName
+      content
     );
 
     const response = await moduleArgs.fetchWithCreds(url.toString(), {

--- a/packages/visual-editor/src/a2/a2/html-generator.ts
+++ b/packages/visual-editor/src/a2/a2/html-generator.ts
@@ -16,8 +16,7 @@ async function callGenWebpage(
   moduleArgs: A2ModuleArgs,
   instruction: string,
   content: LLMContent[],
-  _renderMode: string,
-  modelName: string
+  _renderMode: string
 ): Promise<Outcome<LLMContent>> {
   // If the content already contains HTML inlineData, pass it through
   // without invoking webpage generation.
@@ -29,5 +28,5 @@ async function callGenWebpage(
     }
   }
 
-  return executeWebpageStream(moduleArgs, instruction, content, modelName);
+  return executeWebpageStream(moduleArgs, instruction, content);
 }

--- a/packages/visual-editor/src/a2/a2/render-consistent-ui.ts
+++ b/packages/visual-editor/src/a2/a2/render-consistent-ui.ts
@@ -13,6 +13,7 @@ import {
 } from "@breadboard-ai/types";
 import { isStoredData, ok } from "@breadboard-ai/utils";
 import { A2ModuleArgs } from "../runnable-module-factory.js";
+import { MODEL_ALIAS_TEXT_LITE } from "./gemini.js";
 import { A2UI_SCHEMA } from "./au2ui-schema.js";
 import { GeminiPrompt } from "./gemini-prompt.js";
 import { createReporter } from "../agent/progress-work-item.js";
@@ -177,7 +178,7 @@ async function renderConsistentUI(
   });
 
   const prompt = new GeminiPrompt(moduleArgs, {
-    model: "gemini-3.1-flash-lite",
+    model: MODEL_ALIAS_TEXT_LITE,
     body: {
       contents: [data],
       systemInstruction: createFullSystemInstruction(systemInstruction),

--- a/packages/visual-editor/src/a2/a2/render-outputs.ts
+++ b/packages/visual-editor/src/a2/a2/render-outputs.ts
@@ -18,11 +18,7 @@ import { renderConsistentUI } from "./render-consistent-ui.js";
 import { A2ModuleArgs } from "../runnable-module-factory.js";
 import { Params } from "./common.js";
 import { isLLMContent, isLLMContentArray } from "../../data/common.js";
-import {
-  MODEL_ALIAS_TEXT_LITE,
-  MODEL_ALIAS_TEXT_FLASH,
-  MODEL_ALIAS_TEXT_PRO,
-} from "./gemini.js";
+
 import {
   DocEditMode,
   DocOutputName,
@@ -38,8 +34,6 @@ import {
 export { invoke as default, describe };
 
 const MANUAL_MODE = "Manual layout";
-const FLASH_MODE = "Webpage with auto-layout by 2.5 Flash";
-const PRO_MODE = "Webpage with auto-layout by 2.5 Pro";
 
 const THROW_ERROR_MARKER = "throw_error ";
 
@@ -59,33 +53,6 @@ type Mode = {
   icon: string;
 };
 
-type Model = {
-  id: string;
-  title: string;
-  description: string;
-  modelName: string;
-};
-
-const MODELS: Model[] = [
-  {
-    id: "gemini-flash",
-    title: "Gemini 3.0 Flash",
-    description: "Best for coding simple, static displays",
-    modelName: MODEL_ALIAS_TEXT_FLASH,
-  },
-  {
-    id: "gemini-flash-lite",
-    title: "Gemini 3.1 Flash Lite",
-    description: "Best for simple speedy displays",
-    modelName: MODEL_ALIAS_TEXT_LITE,
-  },
-  {
-    id: "gemini-pro",
-    title: "Gemini 3.1 Pro",
-    description: "Best for coding complex or interactive displays",
-    modelName: MODEL_ALIAS_TEXT_PRO,
-  },
-];
 
 const MODES: Mode[] = [
   {
@@ -138,11 +105,6 @@ function getMode(modeId: string | undefined): Mode {
   return renderModeMap.get(modeId || "Manual") || MODES[0];
 }
 
-const modelMap = new Map(MODELS.map((model) => [model.id, model]));
-
-function getModel(modelType: string | undefined): Model {
-  return modelMap.get(modelType || "gemini-flash") || MODELS[0];
-}
 
 function defaultSystemInstruction(): LLMContent {
   return llm`You are a skilled web developer specializing in creating intuitive and visually appealing HTML web pages based on user instructions and data. Your task is to generate a valid HTML webpage that will be rendered in an iframe. The generated code must be valid and functional HTML with JavaScript and CSS embedded inline within <script> and <style> tags respectively. Return only the code, and open the HTML codeblock with the literal string '\`\`\`html'. Render content as a clean, well-structured webpage, paying careful attention to user instructions. Use a responsive or mobile-friendly layout whenever possible and minimize unnecessary padding or margins.`.asContent();
@@ -152,7 +114,6 @@ type InvokeInputs = {
   text?: LLMContent;
   "p-render-mode": string;
   "b-system-instruction"?: LLMContent;
-  "b-render-model-name": string;
   "b-doc-title"?: string;
   [DocOutputName.EditMode]?: DocEditMode;
   [DocOutputName.WriteMode]?: DocWriteMode;
@@ -329,7 +290,6 @@ async function invoke(
     text,
     "p-render-mode": renderMode,
     "b-system-instruction": systemInstruction,
-    "b-render-model-name": modelType,
     "b-doc-title": googleDocTitle,
     [DocOutputName.EditMode]: docEditMode,
     [DocOutputName.WriteMode]: docWriteMode,
@@ -341,7 +301,6 @@ async function invoke(
   }: InvokeInputs,
   moduleArgs: A2ModuleArgs
 ): Promise<Outcome<InvokeOutputs>> {
-  let { modelName } = getModel(modelType);
   const { renderType } = getMode(renderMode);
 
   if (!text) {
@@ -355,14 +314,7 @@ async function invoke(
   }
 
   const context = mergeContent([substituting], "user");
-  // If the step uses one of the deprecated modes that encodes model, trust this.
-  if (renderMode == FLASH_MODE) {
-    modelName = MODEL_ALIAS_TEXT_LITE;
-  } else if (renderMode == PRO_MODE) {
-    modelName = MODEL_ALIAS_TEXT_PRO;
-  }
   console.log("Rendering with mode: ", renderType);
-  console.log("Rendering with model: ", modelName);
   let out = context;
   switch (renderType) {
     case "Manual": {
@@ -386,8 +338,7 @@ async function invoke(
         moduleArgs,
         systemText,
         [context],
-        renderType,
-        modelName
+        renderType
       );
       if (!ok(webPage)) {
         console.warn(
@@ -464,13 +415,6 @@ function advancedSettings(
           behavior: ["llm-content", "config", "hint-advanced"],
           title: "System Instruction",
           description: "The system instruction used for auto-layout",
-        },
-        "b-render-model-name": {
-          type: "string",
-          enum: MODELS,
-          behavior: ["llm-content", "config", "hint-advanced"],
-          title: "Model",
-          description: "The model to use for auto-generating display code",
         },
       };
     case "GoogleDoc": {

--- a/packages/visual-editor/src/a2/a2/render-outputs.ts
+++ b/packages/visual-editor/src/a2/a2/render-outputs.ts
@@ -19,6 +19,11 @@ import { A2ModuleArgs } from "../runnable-module-factory.js";
 import { Params } from "./common.js";
 import { isLLMContent, isLLMContentArray } from "../../data/common.js";
 import {
+  MODEL_ALIAS_TEXT_LITE,
+  MODEL_ALIAS_TEXT_FLASH,
+  MODEL_ALIAS_TEXT_PRO,
+} from "./gemini.js";
+import {
   DocEditMode,
   DocOutputName,
   DocWriteMode,
@@ -66,19 +71,19 @@ const MODELS: Model[] = [
     id: "gemini-flash",
     title: "Gemini 3.0 Flash",
     description: "Best for coding simple, static displays",
-    modelName: "gemini-3-flash-preview",
+    modelName: MODEL_ALIAS_TEXT_FLASH,
   },
   {
     id: "gemini-flash-lite",
     title: "Gemini 3.1 Flash Lite",
     description: "Best for simple speedy displays",
-    modelName: "gemini-3.1-flash-lite",
+    modelName: MODEL_ALIAS_TEXT_LITE,
   },
   {
     id: "gemini-pro",
     title: "Gemini 3.1 Pro",
     description: "Best for coding complex or interactive displays",
-    modelName: "gemini-3.1-pro-preview",
+    modelName: MODEL_ALIAS_TEXT_PRO,
   },
 ];
 
@@ -352,9 +357,9 @@ async function invoke(
   const context = mergeContent([substituting], "user");
   // If the step uses one of the deprecated modes that encodes model, trust this.
   if (renderMode == FLASH_MODE) {
-    modelName = "gemini-3.1-flash-lite";
+    modelName = MODEL_ALIAS_TEXT_LITE;
   } else if (renderMode == PRO_MODE) {
-    modelName = "gemini-2.5-pro";
+    modelName = MODEL_ALIAS_TEXT_PRO;
   }
   console.log("Rendering with mode: ", renderType);
   console.log("Rendering with model: ", modelName);

--- a/packages/visual-editor/src/a2/agent/a2ui/generate-output.ts
+++ b/packages/visual-editor/src/a2/agent/a2ui/generate-output.ts
@@ -10,6 +10,7 @@ import {
   GeminiSchema,
   generateContent,
   GenerationConfig,
+  MODEL_ALIAS_TEXT_FLASH,
 } from "../../a2/gemini.js";
 import { llm } from "../../a2/utils.js";
 import { A2ModuleArgs } from "../../runnable-module-factory.js";
@@ -57,7 +58,7 @@ ${commonInstruction}`.asContent();
   });
   if (!ok(body)) return body;
   const generating = await generateContent(
-    "gemini-flash-latest",
+    MODEL_ALIAS_TEXT_FLASH,
     body,
     moduleArgs
   );
@@ -97,7 +98,7 @@ ${commonInstruction}`.asContent();
   });
   if (!ok(body)) return body;
   const generating = await generateContent(
-    "gemini-flash-latest",
+    MODEL_ALIAS_TEXT_FLASH,
     body,
     moduleArgs
   );

--- a/packages/visual-editor/src/a2/agent/a2ui/smart-layout-pipeline.ts
+++ b/packages/visual-editor/src/a2/agent/a2ui/smart-layout-pipeline.ts
@@ -20,8 +20,10 @@ import { A2UIRenderer } from "../types.js";
 
 export { SmartLayoutPipeline };
 
-const SPEC_MODEL = "gemini-3-flash-preview";
-const TEMPLATE_MODEL = "gemini-3-flash-preview";
+import { MODEL_ALIAS_TEXT_FLASH } from "../../a2/gemini.js";
+
+const SPEC_MODEL = MODEL_ALIAS_TEXT_FLASH;
+const TEMPLATE_MODEL = MODEL_ALIAS_TEXT_FLASH;
 
 export type SmartLayoutPipelineArgs = {
   moduleArgs: A2ModuleArgs;

--- a/packages/visual-editor/src/a2/agent/functions/generate.ts
+++ b/packages/visual-editor/src/a2/agent/functions/generate.ts
@@ -16,6 +16,8 @@ import {
   MODEL_ALIAS_TEXT_LITE,
   MODEL_ALIAS_TEXT_FLASH,
   MODEL_ALIAS_TEXT_PRO,
+  MODEL_ALIAS_IMAGE_FLASH,
+  MODEL_ALIAS_IMAGE_PRO,
 } from "../../a2/gemini.js";
 import { type ExecuteStepArgs } from "../../a2/step-executor.js";
 import { A2ModuleArgs } from "../../runnable-module-factory.js";
@@ -53,12 +55,9 @@ export { getGenerateFunctionGroup, GENERATE_TEXT_FUNCTION };
 
 const GENERATE_TEXT_FUNCTION = "generate_text";
 
-const VIDEO_MODEL_NAME = "veo-3.1-generate-preview";
 
 const CODE_GENERATION_MODEL_NAME = MODEL_ALIAS_TEXT_FLASH;
 
-const IMAGE_FLASH_MODEL_NAME = "gemini-2.5-flash-image";
-const IMAGE_PRO_MODEL_NAME = "gemini-3-pro-image-preview";
 
 export type ModelConstraint =
   | "none"
@@ -111,7 +110,7 @@ function getGenerateFunctionGroup(args: GenerateFunctionArgs): FunctionGroup {
       if (!ok(imageParts)) return { error: imageParts.$error };
 
       const modelName =
-        model == "pro" ? IMAGE_PRO_MODEL_NAME : IMAGE_FLASH_MODEL_NAME;
+        model == "pro" ? MODEL_ALIAS_IMAGE_PRO : MODEL_ALIAS_IMAGE_FLASH;
 
       // Use provided reporter if available, otherwise create one
       const effectiveReporter =
@@ -277,11 +276,10 @@ function getGenerateFunctionGroup(args: GenerateFunctionArgs): FunctionGroup {
         prompt,
         imageParts.map((part) => ({ parts: [part] })),
         false,
-        aspect_ratio ?? "16:9",
-        VIDEO_MODEL_NAME
+        aspect_ratio ?? "16:9"
       );
       if (!ok(generating))
-        return toErrorOrResponse(expandVeoError(generating, VIDEO_MODEL_NAME));
+        return toErrorOrResponse(expandVeoError(generating));
       const dataPart = generating.parts.at(0);
       if (!dataPart || !("storedData" in dataPart)) {
         return { error: `No video was generated` };

--- a/packages/visual-editor/src/a2/agent/functions/generate.ts
+++ b/packages/visual-editor/src/a2/agent/functions/generate.ts
@@ -10,7 +10,13 @@ import {
   TextCapabilityPart,
 } from "@breadboard-ai/types";
 import { ok } from "@breadboard-ai/utils";
-import { GenerationConfig, Tool } from "../../a2/gemini.js";
+import {
+  type GenerationConfig,
+  type Tool,
+  MODEL_ALIAS_TEXT_LITE,
+  MODEL_ALIAS_TEXT_FLASH,
+  MODEL_ALIAS_TEXT_PRO,
+} from "../../a2/gemini.js";
 import { type ExecuteStepArgs } from "../../a2/step-executor.js";
 import { A2ModuleArgs } from "../../runnable-module-factory.js";
 import { AgentFileSystem } from "../file-system.js";
@@ -49,10 +55,10 @@ const GENERATE_TEXT_FUNCTION = "generate_text";
 
 const VIDEO_MODEL_NAME = "veo-3.1-generate-preview";
 
-const FLASH_MODEL_NAME = "gemini-3-flash-preview";
-const CODE_GENERATION_MODEL_NAME = "gemini-3-flash-preview";
-const PRO_MODEL_NAME = "gemini-3.1-pro-preview";
-const LITE_MODEL_NAME = "gemini-2.5-flash-lite";
+const FLASH_MODEL_NAME = MODEL_ALIAS_TEXT_FLASH;
+const CODE_GENERATION_MODEL_NAME = MODEL_ALIAS_TEXT_FLASH;
+const PRO_MODEL_NAME = MODEL_ALIAS_TEXT_PRO;
+const LITE_MODEL_NAME = MODEL_ALIAS_TEXT_LITE;
 
 const IMAGE_FLASH_MODEL_NAME = "gemini-2.5-flash-image";
 const IMAGE_PRO_MODEL_NAME = "gemini-3-pro-image-preview";

--- a/packages/visual-editor/src/a2/agent/functions/generate.ts
+++ b/packages/visual-editor/src/a2/agent/functions/generate.ts
@@ -55,10 +55,7 @@ const GENERATE_TEXT_FUNCTION = "generate_text";
 
 const VIDEO_MODEL_NAME = "veo-3.1-generate-preview";
 
-const FLASH_MODEL_NAME = MODEL_ALIAS_TEXT_FLASH;
 const CODE_GENERATION_MODEL_NAME = MODEL_ALIAS_TEXT_FLASH;
-const PRO_MODEL_NAME = MODEL_ALIAS_TEXT_PRO;
-const LITE_MODEL_NAME = MODEL_ALIAS_TEXT_LITE;
 
 const IMAGE_FLASH_MODEL_NAME = "gemini-2.5-flash-image";
 const IMAGE_PRO_MODEL_NAME = "gemini-3-pro-image-preview";
@@ -470,11 +467,11 @@ DO NOT start with "Okay", or "Alright" or any preambles. Just the output, please
 function resolveTextModel(model: "pro" | "lite" | "flash"): string {
   switch (model) {
     case "pro":
-      return PRO_MODEL_NAME;
+      return MODEL_ALIAS_TEXT_PRO;
     case "flash":
-      return FLASH_MODEL_NAME;
+      return MODEL_ALIAS_TEXT_FLASH;
     default:
-      return LITE_MODEL_NAME;
+      return MODEL_ALIAS_TEXT_LITE;
   }
 }
 

--- a/packages/visual-editor/src/a2/agent/loop.ts
+++ b/packages/visual-editor/src/a2/agent/loop.ts
@@ -13,6 +13,7 @@ import {
   streamGenerateContent,
   Tool,
   UsageMetadata,
+  MODEL_ALIAS_TEXT_FLASH,
 } from "../a2/gemini.js";
 import { llm } from "../a2/utils.js";
 import { A2ModuleArgs } from "../runnable-module-factory.js";
@@ -80,7 +81,7 @@ type FileData = {
   content: LLMContent;
 };
 
-const AGENT_MODEL = "gemini-3-flash-preview";
+const AGENT_MODEL = MODEL_ALIAS_TEXT_FLASH;
 
 /**
  * When uncached tokens exceed this threshold, create a new cache

--- a/packages/visual-editor/src/a2/autoname/main.ts
+++ b/packages/visual-editor/src/a2/autoname/main.ts
@@ -5,7 +5,7 @@
  */
 
 import { GeminiPrompt } from "../a2/gemini-prompt.js";
-import { defaultSafetySettings } from "../a2/gemini.js";
+import { defaultSafetySettings, MODEL_ALIAS_TEXT_LITE } from "../a2/gemini.js";
 import { err, ok } from "../a2/utils.js";
 
 import type { AutonameMode, Arguments } from "./types.js";
@@ -54,7 +54,7 @@ async function invoke(
     return { context: cantAutoname() };
   }
   const naming = await new GeminiPrompt(moduleArgs, {
-    model: "gemini-2.5-flash-lite",
+    model: MODEL_ALIAS_TEXT_LITE,
     body: {
       contents: modeHandler.prompt(),
       safetySettings: defaultSafetySettings(),

--- a/packages/visual-editor/src/a2/deep-research/main.ts
+++ b/packages/visual-editor/src/a2/deep-research/main.ts
@@ -9,6 +9,7 @@ import invokeGemini, {
   type GeminiInputs,
   type Tool,
   defaultSafetySettings,
+  MODEL_ALIAS_TEXT_LITE,
 } from "../a2/gemini.js";
 import { ArgumentNameGenerator } from "../a2/introducer.js";
 import { report } from "../a2/output.js";
@@ -48,7 +49,7 @@ const RESEARCH_TOOLS: DefaultToolDescriptor[] = [
   },
 ];
 
-const RESEARCH_MODEL = "gemini-3.1-flash-lite";
+const RESEARCH_MODEL = MODEL_ALIAS_TEXT_LITE;
 
 const MAX_ITERATIONS = 7;
 

--- a/packages/visual-editor/src/a2/generate/main.ts
+++ b/packages/visual-editor/src/a2/generate/main.ts
@@ -43,6 +43,7 @@ import {
   MODEL_ALIAS_TEXT_LITE,
   MODEL_ALIAS_TEXT_FLASH,
   MODEL_ALIAS_TEXT_PRO,
+  MODEL_ALIAS_IMAGE_PRO,
 } from "../a2/gemini.js";
 
 export { invoke as default, describe };
@@ -282,7 +283,7 @@ const ALL_MODES: Mode[] = [
     title: "Nano Banana Pro",
     description: "For complex visuals with text",
     icon: "photo_spark",
-    modelName: "gemini-3-pro-image-preview",
+    modelName: MODEL_ALIAS_IMAGE_PRO,
     promptPlaceholderText:
       "Type your image prompt here. Use @ to include other content.",
     info: `Image ${LIMIT_MSG}`,

--- a/packages/visual-editor/src/a2/generate/main.ts
+++ b/packages/visual-editor/src/a2/generate/main.ts
@@ -39,6 +39,11 @@ import musicGenerator, {
   describe as describeMusicGenerator,
 } from "../music-generator/main.js";
 import type { ModelConstraint } from "../agent/functions/generate.js";
+import {
+  MODEL_ALIAS_TEXT_LITE,
+  MODEL_ALIAS_TEXT_FLASH,
+  MODEL_ALIAS_TEXT_PRO,
+} from "../a2/gemini.js";
 
 export { invoke as default, describe };
 
@@ -99,7 +104,7 @@ const PROMPT_PORT = "config$prompt";
 
 const LIMIT_MSG = "generation has a daily limit";
 
-const DEPRECATED_TEXT_MODEL_FALLBACK = 'gemini-3.1-flash-lite';
+const DEPRECATED_TEXT_MODEL_FALLBACK = MODEL_ALIAS_TEXT_LITE;
 
 const ALL_MODES: Mode[] = [
   {
@@ -109,7 +114,7 @@ const ALL_MODES: Mode[] = [
     title: "Agent",
     description: "Agent can use any models",
     icon: "button_magic",
-    modelName: "gemini-3-flash-preview",
+    modelName: MODEL_ALIAS_TEXT_FLASH,
     promptPlaceholderText:
       "Type your prompt here. Use @ to include other content.",
     portMap: new Map([[PROMPT_PORT, "description"]]),
@@ -143,7 +148,7 @@ const ALL_MODES: Mode[] = [
     title: "Gemini 3 Flash",
     description: "Best for everyday tasks",
     icon: "text_analysis",
-    modelName: "gemini-3-flash-preview",
+    modelName: MODEL_ALIAS_TEXT_FLASH,
     promptPlaceholderText:
       "Type your prompt here. Use @ to include other content.",
     portMap: new Map([[PROMPT_PORT, "description"]]),
@@ -193,7 +198,7 @@ const ALL_MODES: Mode[] = [
     title: "Gemini 3.1 Pro",
     description: "Best for complex tasks",
     icon: "text_analysis",
-    modelName: "gemini-3.1-pro-preview",
+    modelName: MODEL_ALIAS_TEXT_PRO,
     promptPlaceholderText:
       "Type your prompt here. Use @ to include other content.",
     portMap: new Map([[PROMPT_PORT, "description"]]),

--- a/packages/visual-editor/src/a2/generate/main.ts
+++ b/packages/visual-editor/src/a2/generate/main.ts
@@ -99,6 +99,8 @@ const PROMPT_PORT = "config$prompt";
 
 const LIMIT_MSG = "generation has a daily limit";
 
+const DEPRECATED_TEXT_MODEL_FALLBACK = 'gemini-3.1-flash-lite';
+
 const ALL_MODES: Mode[] = [
   {
     id: "agent",
@@ -117,6 +119,7 @@ const ALL_MODES: Mode[] = [
     describe: describeGenerateText,
   },
   {
+    // DEPRECATED (included in HIDDEN_MODE_IDS); fallback to DEPRECATED_TEXT_MODEL_FALLBACK
     id: "text-2.0-flash",
     type: "text",
     url: "embed://a2/generate-text.bgl.json#daf082ca-c1aa-4aff-b2c8-abeb984ab66c",
@@ -124,7 +127,7 @@ const ALL_MODES: Mode[] = [
     description: "Older model, use sparingly",
     hidden: true,
     icon: "text_analysis",
-    modelName: "gemini-2.0-flash",
+    modelName: DEPRECATED_TEXT_MODEL_FALLBACK,
     promptPlaceholderText:
       "Type your prompt here. Use @ to include other content.",
     portMap: new Map([[PROMPT_PORT, "description"]]),
@@ -150,13 +153,14 @@ const ALL_MODES: Mode[] = [
     describe: describeGenerateText,
   },
   {
+    // DEPRECATED (included in HIDDEN_MODE_IDS); fallback to DEPRECATED_TEXT_MODEL_FALLBACK
     id: "text",
     type: "text",
     url: "embed://a2/generate-text.bgl.json#daf082ca-c1aa-4aff-b2c8-abeb984ab66c",
     title: "Gemini 3.1 Flash Lite",
     description: "Good model for everyday tasks",
     icon: "text_analysis",
-    modelName: "gemini-3.1-flash-lite",
+    modelName: DEPRECATED_TEXT_MODEL_FALLBACK,
     promptPlaceholderText:
       "Type your prompt here. Use @ to include other content.",
     portMap: new Map([[PROMPT_PORT, "description"]]),
@@ -166,13 +170,14 @@ const ALL_MODES: Mode[] = [
     describe: describeGenerateText,
   },
   {
+    // DEPRECATED (included in HIDDEN_MODE_IDS); fallback to DEPRECATED_TEXT_MODEL_FALLBACK
     id: "text-2.5-pro",
     type: "text",
     url: "embed://a2/generate-text.bgl.json#daf082ca-c1aa-4aff-b2c8-abeb984ab66c",
     title: "Gemini 2.5 Pro",
     description: "Good model for complex tasks",
     icon: "text_analysis",
-    modelName: "gemini-2.5-pro",
+    modelName: DEPRECATED_TEXT_MODEL_FALLBACK,
     promptPlaceholderText:
       "Type your prompt here. Use @ to include other content.",
     portMap: new Map([[PROMPT_PORT, "description"]]),
@@ -198,13 +203,14 @@ const ALL_MODES: Mode[] = [
     describe: describeGenerateText,
   },
   {
+    // DEPRECATED (included in HIDDEN_MODE_IDS); fallback to DEPRECATED_TEXT_MODEL_FALLBACK
     id: "think",
     type: "think",
     url: "embed://a2/go-over-list.bgl.json#module:main",
     title: "Plan and Execute with Gemini 3.1 Flash Lite",
     description: "Plans and executes complex tasks",
     icon: "spark",
-    modelName: "gemini-3.1-flash-lite",
+    modelName: DEPRECATED_TEXT_MODEL_FALLBACK,
     promptPlaceholderText:
       "Type your goal here. Use @ to include other content.",
     portMap: new Map([[PROMPT_PORT, "plan"]]),
@@ -214,13 +220,14 @@ const ALL_MODES: Mode[] = [
     describe: describeGoOverList,
   },
   {
+    // DEPRECATED (included in HIDDEN_MODE_IDS); fallback to DEPRECATED_TEXT_MODEL_FALLBACK
     id: "deep-research",
     type: "deep-research",
     url: "embed://a2/deep-research.bgl.json#module:main",
     title: "Deep Research with Gemini 3.1 Flash Lite",
     description: "In-depth research on your topic",
     icon: "spark",
-    modelName: "gemini-3.1-flash-lite",
+    modelName: DEPRECATED_TEXT_MODEL_FALLBACK,
     promptPlaceholderText:
       "Type your research query here. Use @ to include other content.",
     portMap: new Map([[PROMPT_PORT, "query"]]),
@@ -230,6 +237,7 @@ const ALL_MODES: Mode[] = [
     describe: describeDeepResearch,
   },
   {
+    // DEPRECATED (included in HIDDEN_MODE_IDS)
     id: "image-gen",
     type: "image-gen",
     url: "embed://a2/a2.bgl.json#module:image-generator",

--- a/packages/visual-editor/src/a2/video-generator/main.ts
+++ b/packages/visual-editor/src/a2/video-generator/main.ts
@@ -38,48 +38,14 @@ import { A2ModuleArgs } from "../runnable-module-factory.js";
 import { driveFileToBlob, toGcsAwareChunk } from "../a2/data-transforms.js";
 import { createReporter } from "../agent/progress-work-item.js";
 
-type Model = {
-  id: string;
-  title: string;
-  description: string;
-  modelName: string;
-};
-
 const ASPECT_RATIOS = ["16:9", "9:16"];
 const OUTPUT_NAME = "generated_video";
-const MODELS: Model[] = [
-  {
-    id: "veo-3",
-    title: "Veo 3",
-    description: "State of the art video generation with audio",
-    modelName: "veo-3.0-generate-preview",
-  },
-  {
-    id: "veo-3.1",
-    title: "Veo 3.1",
-    description: "Latest state of the art video generation with audio",
-    modelName: "veo-3.1-generate-preview",
-  },
-  {
-    id: "veo-2",
-    title: "Veo 2",
-    description: "Faster video generation, no audio",
-    modelName: "veo-2.0-generate-001",
-  },
-];
-
-const modelMap = new Map(MODELS.map((model) => [model.id, model]));
-
-function getModel(modelId: string | undefined): Model {
-  return modelMap.get(modelId || "veo-3") || MODELS[0];
-}
 
 type VideoGeneratorInputs = {
   context: LLMContent[];
   instruction?: LLMContent;
   "p-disable-prompt-rewrite": boolean;
   "p-aspect-ratio": string;
-  "b-model-name": string;
 };
 
 type VideoGeneratorOutputs = {
@@ -107,8 +73,7 @@ async function callVideoGen(
   prompt: string,
   imageContent: LLMContent[],
   disablePromptRewrite: boolean,
-  aspectRatio: string,
-  modelName: string
+  aspectRatio: string
 ): Promise<Outcome<LLMContent>> {
   const executionInputs: ContentMap = {};
   executionInputs["text_instruction"] = {
@@ -168,7 +133,6 @@ async function callVideoGen(
       output: OUTPUT_NAME,
       options: {
         disablePromptRewrite,
-        modelName,
       },
     },
     execution_inputs: executionInputs,
@@ -189,12 +153,10 @@ async function invoke(
     instruction,
     "p-disable-prompt-rewrite": disablePromptRewrite,
     "p-aspect-ratio": aspectRatio,
-    "b-model-name": modelId,
     ...params
   }: VideoGeneratorInputs,
   moduleArgs: A2ModuleArgs
 ): Promise<Outcome<VideoGeneratorOutputs>> {
-  const { modelName } = getModel(modelId);
   context ??= [];
   let instructionText = "";
   if (instruction) {
@@ -250,7 +212,7 @@ async function invoke(
     });
   }
 
-  console.log(`PROMPT(${modelName}): ${combinedInstruction}`);
+  console.log(`PROMPT: ${combinedInstruction}`);
 
   // 2) Call backend to generate video.
   const reporter = createReporter(moduleArgs, {
@@ -263,10 +225,9 @@ async function invoke(
     combinedInstruction,
     imageContext,
     disablePromptRewrite,
-    aspectRatio,
-    modelName
+    aspectRatio
   );
-  if (!ok(content)) return expandVeoError(content, modelName);
+  if (!ok(content)) return expandVeoError(content);
   return { context: [content] };
 }
 
@@ -316,8 +277,7 @@ const SUPPORT_CODES = new Map<number, ErrorReason>([
 ]);
 
 function expandVeoError(
-  e: ErrorWithMetadata,
-  model: string
+  e: ErrorWithMetadata
 ): ErrorWithMetadata {
   const match = e.$error.match(/Support codes: (\d+(?:, \d+)*)/);
   const reasons = new Set<ErrorReason>();
@@ -336,7 +296,7 @@ function expandVeoError(
         origin: "server",
         kind: "safety",
         reasons: Array.from(reasons.values()),
-        model,
+        model: "veo",
       },
     };
   }
@@ -378,13 +338,6 @@ async function describe({ inputs: { instruction } }: DescribeInputs) {
           enum: ASPECT_RATIOS,
           description: "The aspect ratio of the generated video",
           default: ASPECT_RATIOS[0],
-        },
-        "b-model-name": {
-          type: "string",
-          enum: MODELS,
-          behavior: ["llm-content", "config", "hint-advanced"],
-          title: "Model Version",
-          description: "The Veo version to use",
         },
         ...template.schemas(),
       },

--- a/packages/visual-editor/src/sca/actions/theme/theme-utils.ts
+++ b/packages/visual-editor/src/sca/actions/theme/theme-utils.ts
@@ -21,9 +21,11 @@ import type { AppController } from "../../controller/controller.js";
 import type { AppServices } from "../../services/services.js";
 import { Utils } from "../../utils.js";
 
+import { MODEL_ALIAS_IMAGE_FLASH } from "../../../a2/a2/gemini.js";
+
 export { generateImage, persistTheme };
 
-const IMAGE_GENERATOR = "gemini-2.5-flash-image";
+const IMAGE_GENERATOR = MODEL_ALIAS_IMAGE_FLASH;
 
 function endpointURL(model: string) {
   return `${geminiApiPrefix()}/${encodeURIComponent(model)}:generateContent`;


### PR DESCRIPTION
## What
Replaces all hardcoded Gemini text model names in the frontend with `MODEL_ALIAS_*` constants, removes frontend model selection UI and logic for video and webpage generation (the backend now decides), and adds an ESLint rule to prevent hardcoded model names from creeping back in.

## Why
Hardcoded model names like `gemini-2.5-flash` scattered across the frontend are fragile — every model version bump requires a multi-file find-and-replace. Model aliases (`alias-text-flash`, `alias-text-pro`, etc.) let the backend remap to concrete models, so the frontend never needs to change when models are updated (n.b.: technically we _may_ need to update the frontend human readable model descriptions in e.g. the model selector when model upgrades occur, but that's not as critical to keep things from _breaking_ when model changes are necessary). Additionally, the backend now handles model selection for video and webpage generation, so the frontend model selectors are dead UI.

## Changes

### Model aliases (`gemini.ts`)
- Remove `MODEL_ALIASES` map (no longer used)
- Remove `VALID_MODALITIES` (was only used as a type)
- Define `MODEL_ALIAS_TEXT_LITE`, `MODEL_ALIAS_TEXT_FLASH`, `MODEL_ALIAS_TEXT_PRO`, `MODEL_ALIAS_IMAGE_FLASH`, `MODEL_ALIAS_IMAGE_PRO`
- Replace all hardcoded `gemini-*` text model strings across 10 files with the appropriate alias constant

### Remove frontend model selectors
- **Video nodes**: Remove `b-model-name` from the describe schema, remove `Model` type / `MODELS` array / `getModel()` / `modelMap`, remove `modelName` from `callVideoGen()` and `ExecuteStep` request body
- **Webpage / Auto layout nodes**: Remove `b-render-model-name` from the describe schema, remove `Model` type / `MODELS` array / `getModel()`, remove `modelName` from `callGenWebpage()` → `executeWebpageStream()` → `StreamingRequestBody`
- **Agent generate_video**: Remove `VIDEO_MODEL_NAME` constant
- Preserve `model: "veo"` in `expandVeoError` metadata so `mediumFromModel()` still selects the correct error medium

### ESLint rule
- New `deja-code-prefer-model-alias` rule flags any string literal matching `(gemini|veo|learnlm)-\d` — catches versioned model names that should use aliases
- Registered in `eslint.config.js` as an error for all visual-editor source

## Testing
- `npm run build:tsc` passes
- `npm run test` passes (all existing tests)
- ESLint rule fires on hardcoded model names and passes on alias constants
