### PR TITLE
[opie] Include Selection State in Initial Graph Editing Agent Objective

### DIFF
--- a/packages/visual-editor/src/a2/agent/graph-editing/main.ts
+++ b/packages/visual-editor/src/a2/agent/graph-editing/main.ts
@@ -9,7 +9,8 @@ import { A2ModuleArgs } from "../../runnable-module-factory.js";
 import { Loop, AgentResult } from "../loop.js";
 import { buildGraphEditingFunctionGroups } from "./configurator.js";
 import { EditingAgentPidginTranslator } from "./editing-agent-pidgin-translator.js";
-import { graphOverviewYaml } from "./graph-overview.js";
+import { graphOverviewYaml, describeSelection } from "./graph-overview.js";
+import { bind } from "../../../sca/actions/graph/graph-actions.js";
 import type { LoopHooks } from "../types.js";
 import type { AgentEventSink } from "../agent-event-sink.js";
 import type { ReadGraphResponse } from "./types.js";
@@ -49,9 +50,16 @@ async function invokeGraphEditingAgent(
     translator
   );
 
-  // TODO: Selection info comes from the controller — needs a suspend event
-  // for "readSelection" or similar. For now, skip selection info.
-  const selectionInfo = "";
+  let selectionInfo = "";
+  try {
+    const { controller } = bind;
+    const selectedNodes = controller?.editor?.selection?.selection?.nodes;
+    if (selectedNodes && graph.nodes) {
+      selectionInfo = describeSelection(selectedNodes, graph.nodes, translator);
+    }
+  } catch {
+    // Gracefully fallback if bind hasn’t set the controller yet (e.g. in standalone environments or tests).
+  }
 
   objective = {
     parts: [


### PR DESCRIPTION
## What
Updated the initial graph editing agent invocation to extract and embed the currently selected steps from the canvas directly into the starting conversation objective, mimicking the payload delivered during suspended chat resumption.

## Why
Ensures the graph editing assistant has a full, up-to-date picture of the canvas and selection state from the very start of the session, rather than omitting selection context on the first turn.

## Changes
### Visual Editor (`packages/visual-editor`)
- Updated [main.ts](file:///packages/visual-editor/src/a2/agent/graph-editing/main.ts) in `invokeGraphEditingAgent` to pull node selections from `bind.controller` via `describeSelection`.
- Added defensive `try/catch` wrapping around controller traversal to support headless/test runs gracefully.

## Testing
1. Launch the Visual Editor application.
2. Select one or more steps on the canvas.
3. Click "Start Agent".
4. Verify the initial agent objective text contains the list of selected steps matching the `Selected steps: ...` format.
