### PR TITLE
[feedback] Allow Google Feedback Scripts in Opal Shell CSP

### DIFF
--- a/packages/unified-server/src/csp.ts
+++ b/packages/unified-server/src/csp.ts
@@ -61,6 +61,7 @@ export const SHELL_CSP = {
     "'self'",
     "https://apis.google.com",
     "https://www.googletagmanager.com",
+    "https://www.gstatic.com", // Feedback JS
   ],
   ["style-src"]: [
     "'self'",


### PR DESCRIPTION
## What
Updates the Opal `SHELL_CSP` to safely allow Google Feedback script execution (`www.gstatic.com`) in the host Shell environment.

## Why
Resolves Content Security Policy violations caused when the Google Feedback API (Listnr) escapes the application iframe context to inject its silent submit logic into the top-level Shell document.

## Changes
- **Unified Server**:
  - `packages/unified-server/src/csp.ts`: Extended `SHELL_CSP["script-src"]` to include `"https://www.gstatic.com"`, keeping the rest of the Shell's CSP surface tight and contained.

## Testing
1. Trigger an Opie chat thumbs up/down feedback flow.
2. Verify in the browser dev tools that `submit_flow.js` loads correctly from `www.gstatic.com` without triggering a CSP violation error.
