### PR TITLE
Enable enhanced private mode for embedded Youtube videos

### DIFF
--- a/packages/unified-server/src/csp.ts
+++ b/packages/unified-server/src/csp.ts
@@ -121,6 +121,7 @@ export const MAIN_APP_CSP = {
     "https://drive.google.com",
     "https://www.google.com",
     "https://www.youtube.com",
+    "https://www.youtube-nocookie.com",
     "https://feedback-pa.clients6.google.com",
     "https://accounts.google.com",
   ],

--- a/packages/visual-editor/landing/index.html
+++ b/packages/visual-editor/landing/index.html
@@ -108,7 +108,7 @@
             id="video-player"
             width="100%"
             height="100%"
-            src="https://www.youtube.com/embed/g9RBGnz-vqk"
+            src="https://www.youtube-nocookie.com/embed/g9RBGnz-vqk"
             title="Bring your app ideas to life with Opal"
             frameborder="0"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"


### PR DESCRIPTION
## Changes
* switched to youtube-nocookie.com
* updated content security policy to allowlist the new domain.

> [Official Documentation](https://support.google.com/youtube/answer/171780)