### PR TITLE
[opie]  Teaching Opie Canvas Layout Awareness

### DIFF
--- a/packages/visual-editor/src/a2/agent/graph-editing/graph-overview.ts
+++ b/packages/visual-editor/src/a2/agent/graph-editing/graph-overview.ts
@@ -14,6 +14,7 @@ import type {
 } from "@breadboard-ai/types";
 
 import type { EditingAgentPidginTranslator } from "./editing-agent-pidgin-translator.js";
+import type { CanvasController } from "../../../sca/controller/subcontrollers/editor/canvas/canvas-controller.js";
 import {
   GENERATE_COMPONENT_URL,
   USER_INPUT_COMPONENT_URL,
@@ -38,7 +39,8 @@ function graphOverviewYaml(
   },
   nodes: NodeDescriptor[],
   edges: Edge[],
-  translator: EditingAgentPidginTranslator
+  translator: EditingAgentPidginTranslator,
+  canvas?: CanvasController
 ): string {
   // Register all nodes with the translator to get stable pidgin handles.
   const handleMap = new Map<string, string>();
@@ -62,6 +64,14 @@ function graphOverviewYaml(
     !!currentTheme?.splashScreen && !currentTheme?.isDefaultTheme;
   lines.push(`splashImage: ${isCustom ? "present" : "default"}`);
 
+  if (canvas && canvas.viewport && canvas.viewport.width > 0) {
+    lines.push("", "viewport:");
+    lines.push(`  left: ${Math.round(canvas.viewport.left)}`);
+    lines.push(`  top: ${Math.round(canvas.viewport.top)}`);
+    lines.push(`  width: ${Math.round(canvas.viewport.width)}`);
+    lines.push(`  height: ${Math.round(canvas.viewport.height)}`);
+  }
+
   if (graph.assets && Object.keys(graph.assets).length > 0) {
     lines.push("", "assets:");
     for (const [path, asset] of Object.entries(graph.assets)) {
@@ -70,11 +80,22 @@ function graphOverviewYaml(
       lines.push(`  ${path}:`);
       lines.push(`    title: ${title}`);
       lines.push(`    type: ${type}`);
+
+      const visual = (asset.metadata?.visual ?? {}) as Record<string, unknown>;
+      if (typeof visual.x === "number" && typeof visual.y === "number") {
+        lines.push(`    x: ${Math.round(visual.x)}`);
+        lines.push(`    y: ${Math.round(visual.y)}`);
+      }
+
+      if (canvas && typeof canvas.getAssetDimensions === "function") {
+        const dims = canvas.getAssetDimensions(path);
+        if (dims && dims.height > 0) {
+          lines.push(`    width: ${Math.round(dims.width)}`);
+          lines.push(`    height: ${Math.round(dims.height)}`);
+        }
+      }
     }
   }
-
-
-
 
   lines.push("", "steps:");
   for (const node of nodes) {
@@ -82,6 +103,20 @@ function graphOverviewYaml(
     const title = node.metadata?.title ?? "(untitled)";
     lines.push(`  ${handle}:`);
     lines.push(`    title: ${title}`);
+
+    const visual = (node.metadata?.visual ?? {}) as Record<string, unknown>;
+    if (typeof visual.x === "number" && typeof visual.y === "number") {
+      lines.push(`    x: ${Math.round(visual.x)}`);
+      lines.push(`    y: ${Math.round(visual.y)}`);
+    }
+
+    if (canvas && typeof canvas.getStepDimensions === "function") {
+      const dims = canvas.getStepDimensions(node.id);
+      if (dims && dims.height > 0) {
+        lines.push(`    width: ${Math.round(dims.width)}`);
+        lines.push(`    height: ${Math.round(dims.height)}`);
+      }
+    }
 
     const config = node.configuration as Record<string, unknown> | undefined;
 

--- a/packages/visual-editor/src/a2/agent/graph-editing/main.ts
+++ b/packages/visual-editor/src/a2/agent/graph-editing/main.ts
@@ -43,22 +43,32 @@ async function invokeGraphEditingAgent(
     },
   });
 
-  const overview = graphOverviewYaml(
-    graph,
-    graph.nodes ?? [],
-    graph.edges ?? [],
-    translator
-  );
-
+  let overview = "";
   let selectionInfo = "";
   try {
     const { controller } = bind;
+    const canvas = controller?.editor?.canvas;
+    
+    overview = graphOverviewYaml(
+      graph,
+      graph.nodes ?? [],
+      graph.edges ?? [],
+      translator,
+      canvas
+    );
+
     const selectedNodes = controller?.editor?.selection?.selection?.nodes;
     if (selectedNodes && graph.nodes) {
       selectionInfo = describeSelection(selectedNodes, graph.nodes, translator);
     }
   } catch {
-    // Gracefully fallback if bind hasn’t set the controller yet (e.g. in standalone environments or tests).
+    // Gracefully fallback if bind hasn’t set the controller yet
+    overview = graphOverviewYaml(
+      graph,
+      graph.nodes ?? [],
+      graph.edges ?? [],
+      translator
+    );
   }
 
   objective = {

--- a/packages/visual-editor/src/sca/controller/controller.ts
+++ b/packages/visual-editor/src/sca/controller/controller.ts
@@ -88,6 +88,10 @@ class Controller implements AppController {
         "Editor_DevTools",
         "DevToolsController"
       ),
+      canvas: new Editor.Canvas.CanvasController(
+        "Editor_Canvas",
+        "CanvasController"
+      ),
     };
 
     this.home = {
@@ -255,6 +259,7 @@ export interface AppController extends DebuggableAppController {
     graphEditingAgent: Editor.GraphEditingAgent.GraphEditingAgentController;
     notebookLmPicker: Editor.NotebookLmPicker.NotebookLmPickerController;
     devtools: Editor.DevTools.DevToolsController;
+    canvas: Editor.Canvas.CanvasController;
   };
   home: {
     recent: Home.RecentBoardsController;

--- a/packages/visual-editor/src/sca/controller/subcontrollers/editor/canvas/canvas-controller.ts
+++ b/packages/visual-editor/src/sca/controller/subcontrollers/editor/canvas/canvas-controller.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { NodeIdentifier } from "@breadboard-ai/types";
+import { field } from "../../../decorators/field.js";
+import { RootController } from "../../root-controller.js";
+
+export type { Viewport, StepDimensions };
+
+interface Viewport {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
+interface StepDimensions {
+  width: number;
+  height: number;
+}
+
+export class CanvasController extends RootController {
+  @field({ deep: true })
+  private accessor _viewport: Viewport = {
+    left: 0,
+    top: 0,
+    width: 0,
+    height: 0,
+  };
+
+  @field({ deep: true })
+  private accessor _stepDimensions: Map<NodeIdentifier, StepDimensions> = new Map();
+
+  @field({ deep: true })
+  private accessor _assetDimensions: Map<string, StepDimensions> = new Map();
+
+  constructor(controllerId: string, persistenceId: string) {
+    super(controllerId, persistenceId);
+  }
+
+  get viewport(): Readonly<Viewport> {
+    return this._viewport;
+  }
+
+  setViewport(viewport: Viewport): void {
+    this._viewport = viewport;
+  }
+
+  getStepDimensions(nodeId: NodeIdentifier): Readonly<StepDimensions> {
+    return this._stepDimensions.get(nodeId) || { width: 300, height: 0 };
+  }
+
+  setStepDimensions(nodeId: NodeIdentifier, dimensions: StepDimensions): void {
+    this._stepDimensions.set(nodeId, dimensions);
+  }
+
+  getAssetDimensions(assetPath: string): Readonly<StepDimensions> {
+    return this._assetDimensions.get(assetPath) || { width: 300, height: 0 };
+  }
+
+  setAssetDimensions(assetPath: string, dimensions: StepDimensions): void {
+    this._assetDimensions.set(assetPath, dimensions);
+  }
+
+  get stepDimensions(): ReadonlyMap<NodeIdentifier, StepDimensions> {
+    return this._stepDimensions;
+  }
+
+  get assetDimensions(): ReadonlyMap<string, StepDimensions> {
+    return this._assetDimensions;
+  }
+
+  clearStepDimensions(): void {
+    this._stepDimensions.clear();
+  }
+
+  removeStepDimensions(nodeId: NodeIdentifier): void {
+    this._stepDimensions.delete(nodeId);
+  }
+}

--- a/packages/visual-editor/src/sca/controller/subcontrollers/editor/canvas/canvas.ts
+++ b/packages/visual-editor/src/sca/controller/subcontrollers/editor/canvas/canvas.ts
@@ -1,0 +1,7 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from "./canvas-controller.js";

--- a/packages/visual-editor/src/sca/controller/subcontrollers/editor/editor.ts
+++ b/packages/visual-editor/src/sca/controller/subcontrollers/editor/editor.ts
@@ -16,3 +16,4 @@ export * as Integrations from "./integrations/integrations.js";
 export * as GraphEditingAgent from "./graph-editing-agent-controller.js";
 export * as NotebookLmPicker from "./notebooklm-picker-controller.js";
 export * as DevTools from "./devtools/devtools-controller.js";
+export * as Canvas from "./canvas/canvas.js";

--- a/packages/visual-editor/src/ui/elements/step-editor/graph-asset.ts
+++ b/packages/visual-editor/src/ui/elements/step-editor/graph-asset.ts
@@ -281,6 +281,15 @@ export class GraphAsset
       this.#containerRef.value.offsetHeight
     );
 
+    try {
+      this.sca?.controller?.editor?.canvas?.setAssetDimensions(this.assetPath, {
+        width: this.#containerRef.value.offsetWidth,
+        height: this.#containerRef.value.offsetHeight,
+      });
+    } catch {
+      // Gracefully handle fallback
+    }
+
     this.dispatchEvent(new NodeBoundsUpdateRequestEvent());
   });
 

--- a/packages/visual-editor/src/ui/elements/step-editor/graph-node.ts
+++ b/packages/visual-editor/src/ui/elements/step-editor/graph-node.ts
@@ -607,6 +607,15 @@ export class GraphNode extends Box implements DragConnectorReceiver {
       this.#containerRef.value.offsetWidth,
       this.#containerRef.value.offsetHeight
     );
+
+    try {
+      this.sca?.controller?.editor?.canvas?.setStepDimensions(this.nodeId, {
+        width: this.#containerRef.value.offsetWidth,
+        height: this.#containerRef.value.offsetHeight,
+      });
+    } catch {
+      // Gracefully handle if sca is not hydrated or available
+    }
   }
 
   #watchingResize = false;

--- a/packages/visual-editor/src/ui/elements/step-editor/renderer.ts
+++ b/packages/visual-editor/src/ui/elements/step-editor/renderer.ts
@@ -974,6 +974,26 @@ export class Renderer extends SignalWatcher(LitElement) {
       for (const graph of this.#graphs.values()) {
         graph.updateEntity(inverseCameraMatrix);
 
+        if (graph.graphId === MAIN_BOARD_ID) {
+          try {
+            const inverseMatrix = graph.worldTransform.inverse();
+            const ptTopLeft = new DOMPoint(0, 0).matrixTransform(inverseMatrix);
+            const ptBottomRight = new DOMPoint(
+              this.#boundsForInteraction.width,
+              this.#boundsForInteraction.height
+            ).matrixTransform(inverseMatrix);
+
+            this.sca.controller.editor.canvas.setViewport({
+              left: ptTopLeft.x,
+              top: ptTopLeft.y,
+              width: ptBottomRight.x - ptTopLeft.x,
+              height: ptBottomRight.y - ptTopLeft.y,
+            });
+          } catch {
+            // Gracefully handle if worldTransform inverse fails (e.g. scale is 0)
+          }
+        }
+
         if (this.interactionMode === "selection") {
           // Drag-select.
           if (this.#dragRect) {


### PR DESCRIPTION
## What
Added real-time 2D visual layout and viewport awareness to Opie (the Graph Editing Agent), exposing the current screen viewport bounds in graph space, dynamic step rendering heights, and dynamic asset bounding boxes through a decoupled SCA Signal infrastructure.

## Why
Enables Opie to comprehend the active view and geometry of the active canvas to layout new nodes intelligently, avoid overlap, and arrange elements perfectly inside available empty screen space.

## Changes
### Visual Editor Frontend
- **CanvasController**: Created a reactive subcontroller in the SCA tree storing Signal-backed viewport dimensions and step/asset dimensional metadata.
- **Renderer & Graph Nodes**: Anchored geometry observers translating DOM boundaries continuously into graph world-space and pushing metrics into the Signal engine.
- **Opie Overview YAML**: Upgraded schema to map `viewport`, `x`, `y`, `width`, and `height` coordinates elegantly for steps and assets.

## Testing
1. Load a multi-step graph into the Visual Editor.
2. Open Opie's editing chat console.
3. Inspect Opie's initial objective prompt YAML context to verify presence of `viewport:`, `steps.width/height`, and `assets.x/y/width/height`.
