### PR TITLE
[opie] Fit to View upon Item Positioning in Opie

### DIFF
--- a/packages/visual-editor/src/sca/actions/agent/graph-editing-agent-actions.ts
+++ b/packages/visual-editor/src/sca/actions/agent/graph-editing-agent-actions.ts
@@ -180,6 +180,15 @@ function startGraphEditingAgent(firstMessage: string): void {
       if (!result.success) {
         return { success: false, error: "Failed to apply edits" };
       }
+      const isPositioning =
+        (event.label && event.label.startsWith("Position")) ||
+        (event.edits.length > 0 &&
+          event.edits.every(
+            (e) => e.type === "changemetadata" || e.type === "changeassetmetadata"
+          ));
+      if (isPositioning) {
+        controller.editor.canvas.requestFitToView();
+      }
       return { success: true };
     }
 
@@ -215,6 +224,7 @@ function startGraphEditingAgent(firstMessage: string): void {
         case "layoutGraph": {
           const graph = editor.raw();
           await layoutGraph(graph.nodes ?? [], graph.edges ?? []);
+          controller.editor.canvas.requestFitToView();
           return { success: true };
         }
         case "updateGraphProperties": {

--- a/packages/visual-editor/src/sca/controller/subcontrollers/editor/canvas/canvas-controller.ts
+++ b/packages/visual-editor/src/sca/controller/subcontrollers/editor/canvas/canvas-controller.ts
@@ -37,8 +37,19 @@ export class CanvasController extends RootController {
   @field({ deep: true })
   private accessor _assetDimensions: Map<string, StepDimensions> = new Map();
 
+  @field()
+  private accessor _fitToViewTrigger: number = 0;
+
   constructor(controllerId: string, persistenceId: string) {
     super(controllerId, persistenceId);
+  }
+
+  get fitToViewTrigger(): number {
+    return this._fitToViewTrigger;
+  }
+
+  requestFitToView(): void {
+    this._fitToViewTrigger++;
   }
 
   get viewport(): Readonly<Viewport> {

--- a/packages/visual-editor/src/ui/elements/step-editor/renderer.ts
+++ b/packages/visual-editor/src/ui/elements/step-editor/renderer.ts
@@ -266,6 +266,7 @@ export class Renderer extends SignalWatcher(LitElement) {
   #boundsForInteraction = new DOMRect();
   #fitToViewPre = false;
   #fitToViewPost = false;
+  #lastFitToViewTrigger = 0;
   #attemptAdjustToNewBounds = false;
   #firstResize = true;
 
@@ -826,6 +827,21 @@ export class Renderer extends SignalWatcher(LitElement) {
   // check handles skipping redundant inbound pushes instead.
 
   protected willUpdate(changedProperties: PropertyValues<this>): void {
+    const canvasController = this.sca?.controller?.editor?.canvas;
+    if (canvasController) {
+      const currentTrigger = canvasController.fitToViewTrigger;
+      if (currentTrigger > this.#lastFitToViewTrigger) {
+        this.#lastFitToViewTrigger = currentTrigger;
+        let animate = true;
+        if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+          animate = false;
+        }
+        requestAnimationFrame(() => {
+          this.fitToView(animate);
+        });
+      }
+    }
+
     if (this.#fitToViewPre) {
       this.#fitToViewPre = false;
       this.fitToView(false);
@@ -1491,6 +1507,8 @@ export class Renderer extends SignalWatcher(LitElement) {
     if (!this.#graphs || !this.camera) {
       return nothing;
     }
+
+    this.sca?.controller?.editor?.canvas?.fitToViewTrigger;
 
     const inspectableGraph = this.#gc.editor?.inspect("") ?? null;
     const hasNoAssets = (inspectableGraph?.assets() ?? new Map()).size === 0;

--- a/packages/visual-editor/src/ui/elements/step-editor/renderer.ts
+++ b/packages/visual-editor/src/ui/elements/step-editor/renderer.ts
@@ -1508,7 +1508,7 @@ export class Renderer extends SignalWatcher(LitElement) {
       return nothing;
     }
 
-    this.sca?.controller?.editor?.canvas?.fitToViewTrigger;
+    void this.sca?.controller?.editor?.canvas?.fitToViewTrigger;
 
     const inspectableGraph = this.#gc.editor?.inspect("") ?? null;
     const hasNoAssets = (inspectableGraph?.assets() ?? new Map()).size === 0;


### PR DESCRIPTION
## What
Integrate an automated "Fit to Screen" camera adjustment within the Visual Editor renderer whenever Opie (the Graph Editing Agent) updates item positions on the canvas, or initiates a structural layoutGraph transform.

## Why
Ensures that after the agent aligns, organizes, or repositions steps and assets on the 2D visual canvas, the user's viewport dynamically adjusts to display the whole beautifully laid-out graph, providing an exceptional, premium out-of-the-box user experience without requiring manual zoom.

## Changes
### Visual Editor
- **`CanvasController`**: Introduced the reactive `@field` named `fitToViewTrigger` along with an accompanying `requestFitToView()` method to the SCA Canvas controller layer.
- **`GraphEditingAgentActions`**: Intercepts `applyEdits` for `changemetadata`/`changeassetmetadata` as well as `layoutGraph` transforms to invoke `requestFitToView()` safely on the canvas.
- **`Renderer`**: Subscribed to the `fitToViewTrigger` Signal directly, requesting a Settled-DOM frame callback for `fitToView(...)` honoring any operating system `prefers-reduced-motion` settings.

## Testing
1. Have the Visual Editor and Opal Backend Running.
2. Open Opie and ask "layout the graph beautifully" or "organize steps on the canvas".
3. Verify that right after the agent applies the positions, the viewport perfectly fits all steps and assets on the canvas.
