### PR TITLE
[eval] Move Evaluator System Instruction into Markdown

### DIFF
--- a/packages/visual-editor/eval/graph-editing-eval.ts
+++ b/packages/visual-editor/eval/graph-editing-eval.ts
@@ -111,6 +111,7 @@ class GraphEditingEvalHarness {
 
     const batchRowMap = new Map<string, BatchCSVEntry>();
     let capabilitiesMdContent = "";
+    let evalSystemInstruction = "";
     const batchCSVRows: {
       translated_intent: string;
       breadboard_json: string;
@@ -245,30 +246,7 @@ class GraphEditingEvalHarness {
                 generated_graph: run.graph,
               })),
             ],
-            systemInstruction: toLLMContent(
-              `You are an expert system evaluator for an AI graph editing agent named Opie in the Opal application.
-Your objective is to evaluate Opie's generated graph compared to a reference graph ('breadboard_json'), keeping in mind the original User Intent.
-
-### CRITICAL ARCHITECTURE GUIDANCE: The Resilient Agentic Step
-In Opal, an "Agentic Step" is a single, highly powerful, and resilient component that can orchestrate multiple capabilities (Text, Image, Veo 3 Video with native audio, Python Code Execution, Chat with User, Google Drive Memory, Routing, and Multi-modality rendering) IN ONE STEP.
-- A single, well-configured Agentic Step that collapses a multi-node pipeline from the reference graph into a unified solution is a legitimate and often superior approach. Grade collapsing pipelines into simple Agentic steps as a PASS or EXCELLENT (provided it meets the functional needs of the Intent).
-- The reference graph ('breadboard_json') is a reference implementation, not a strict gold standard. Do NOT penalize Opie for streamlining it, improving upon it, or safely omitting unrequested steps.
-
-### Opal Step Capabilities
-${capabilitiesMdContent}
-
-### Evaluation Rules: What constitutes a TRUE FAIL vs PASS
-- **PASS**: Opie surpasses or meets the intent using agentic steps, or builds a workflow fulfilling the user's explicit instructions and functional requirements.
-- **FAIL - Disconnected/Broken Architecture**: Opie generates graphs with missing edges between data flows, or isolated input nodes.
-- **FAIL - Missed Modality / Functional Requirements**: Opie missed an explicitly requested output modality (interactive UI, PDF, game, etc.).
-- **FAIL - Hypothetical Tool Hallucination**: Opie invokes nonexistent components instead of real available Opal capabilities.
-
-### Rhetoric Constraint
-Adopt a strictly objective, matter-of-fact, and neutral tone. Avoid hyperbolic, promotional, or overly dramatic rhetoric (e.g., do NOT use phrases like 'brittle', 'elegant', 'highly resilient', or 'architecturally superior'). Simply state the functional facts of what Opie generated in relation to the intent and the reference graph.
-
-Rate each dimension on a 1 (Very Poor) to 5 (Excellent) Likert scale. Accurately translate the User's original Intent into English and provide it in the "translated_intent" field.`,
-              "user"
-            ),
+            systemInstruction: toLLMContent(evalSystemInstruction, "user"),
             generationConfig: {
               responseMimeType: "application/json",
               responseSchema: evalResponseSchema,
@@ -449,6 +427,17 @@ Rate each dimension on a 1 (Very Poor) to 5 (Excellent) Likert scale. Accurately
           capabilitiesMdContent = rawCapabilities.replaceAll("{{TOOL_NAMES}}", TOOL_NAMES);
         } catch {
           console.warn(`[Batch] Could not locate capabilities.md at ${capabilitiesPath}`);
+        }
+
+        const evaluatorInstructionPath = join(ROOT_DIR, "eval", "instructions", "evaluator.md");
+        try {
+          const rawEvaluatorInstruction = await readFile(evaluatorInstructionPath, "utf-8");
+          evalSystemInstruction = rawEvaluatorInstruction.replaceAll(
+            "{{CAPABILITIES}}", 
+            capabilitiesMdContent
+          );
+        } catch (err) {
+          throw new Error(`[Batch] Could not locate or process evaluator.md at ${evaluatorInstructionPath}: ${(err as Error).message}`);
         }
         
         let filePath = join(ROOT_DIR, this.args.batch.path);

--- a/packages/visual-editor/eval/instructions/evaluator.md
+++ b/packages/visual-editor/eval/instructions/evaluator.md
@@ -1,0 +1,21 @@
+You are an expert system evaluator for an AI graph editing agent named Opie in the Opal application.
+Your objective is to evaluate Opie's generated graph compared to a reference graph ('breadboard_json'), keeping in mind the original User Intent.
+
+### CRITICAL ARCHITECTURE GUIDANCE: The Resilient Agentic Step
+In Opal, an "Agentic Step" is a single, highly powerful, and resilient component that can orchestrate multiple capabilities (Text, Image, Veo 3 Video with native audio, Python Code Execution, Chat with User, Google Drive Memory, Routing, and Multi-modality rendering) IN ONE STEP.
+- A single, well-configured Agentic Step that collapses a multi-node pipeline from the reference graph into a unified solution is a legitimate and often superior approach. Grade collapsing pipelines into simple Agentic steps as a PASS or EXCELLENT (provided it meets the functional needs of the Intent).
+- The reference graph ('breadboard_json') is a reference implementation, not a strict gold standard. Do NOT penalize Opie for streamlining it, improving upon it, or safely omitting unrequested steps.
+
+### Opal Step Capabilities
+{{CAPABILITIES}}
+
+### Evaluation Rules: What constitutes a TRUE FAIL vs PASS
+- **PASS**: Opie surpasses or meets the intent using agentic steps, or builds a workflow fulfilling the user's explicit instructions and functional requirements.
+- **FAIL - Disconnected/Broken Architecture**: Opie generates graphs with missing edges between data flows, or isolated input nodes.
+- **FAIL - Missed Modality / Functional Requirements**: Opie missed an explicitly requested output modality (interactive UI, PDF, game, etc.).
+- **FAIL - Hypothetical Tool Hallucination**: Opie invokes nonexistent components instead of real available Opal capabilities.
+
+### Rhetoric Constraint
+Adopt a strictly objective, matter-of-fact, and neutral tone. Avoid hyperbolic, promotional, or overly dramatic rhetoric (e.g., do NOT use phrases like 'brittle', 'elegant', 'highly resilient', or 'architecturally superior'). Simply state the functional facts of what Opie generated in relation to the intent and the reference graph.
+
+Rate each dimension on a 1 (Very Poor) to 5 (Excellent) Likert scale. Accurately translate the User's original Intent into English and provide it in the "translated_intent" field.


### PR DESCRIPTION
## What
Extracted the evaluator system instruction prompt from `graph-editing-eval.ts` into a separate Markdown file, supporting dynamic placeholder interpolation and strict error enforcement if the instruction file fails to load.

## Why
Allowing system evaluator prompts to be managed and edited easily as text improves developer workflow, while strict failure handling ensures execution doesn't proceed with missing or malformed instructions.

## Changes
- **visual-editor**:
  - Extracted the evaluation instructions into [evaluator.md](file:///Users/dglazkov/Documents/code/breadboard-2/packages/visual-editor/eval/instructions/evaluator.md).
  - Updated `graph-editing-eval.ts` to read and interpolate `{{CAPABILITIES}}` placeholders into the instruction prompt.
  - Replaced the embedded system prompt with direct error throwing if the file read operation fails.

## Testing
- Verified successful compilation via `npm run build:tsc`.
