### PR TITLE
[feedback] Feedback Monitoring Tab in Opal Dev Tools

### DIFF
--- a/packages/visual-editor/src/sca/controller/subcontrollers/global/feedback-controller.ts
+++ b/packages/visual-editor/src/sca/controller/subcontrollers/global/feedback-controller.ts
@@ -58,9 +58,22 @@ function loadGoogleFeedbackApi(): Promise<UserFeedbackApi> {
 // eslint-disable-next-line local-rules/no-exported-types-outside-types-ts
 export type FeedbackStatus = "closed" | "loading" | "open";
 
+// eslint-disable-next-line local-rules/no-exported-types-outside-types-ts
+export type FeedbackLogEntry = {
+  timestamp: number;
+  bucketOverride?: string;
+  productData?: Record<string, string>;
+  flow?: "submit";
+  status: "pending" | "loaded" | "error" | "closed";
+  errorMessage?: string;
+};
+
 export class FeedbackController extends RootController {
   @field()
   accessor status: FeedbackStatus = "closed";
+
+  @field({ deep: false })
+  accessor entries: FeedbackLogEntry[] = [];
 
   readonly #env: Readonly<AppEnvironment>;
 
@@ -71,6 +84,37 @@ export class FeedbackController extends RootController {
   ) {
     super(controllerId, persistenceId);
     this.#env = env;
+
+    if (typeof window !== "undefined") {
+      window.addEventListener("securitypolicyviolation", (event) => {
+        const url = event.blockedURI || "";
+        if (
+          url.includes("google.com/tools/feedback") ||
+          url.includes("support.google.com") ||
+          url.includes("feedback")
+        ) {
+          const lastEntry = this.entries[this.entries.length - 1];
+          if (
+            lastEntry &&
+            (lastEntry.status === "pending" ||
+              lastEntry.status === "loaded" ||
+              lastEntry.status === "closed") // Catch it even if closed callback raced
+          ) {
+            const newEntries = [...this.entries];
+            const idx = newEntries.length - 1;
+            const existingMsg = newEntries[idx].errorMessage
+              ? `${newEntries[idx].errorMessage}\n\n`
+              : "";
+            newEntries[idx] = {
+              ...newEntries[idx],
+              status: "error",
+              errorMessage: `${existingMsg}CSP Violation: Loading '${url}' violates directive '${event.violatedDirective}'.`,
+            };
+            this.entries = newEntries;
+          }
+        }
+      });
+    }
   }
 
   async open(
@@ -85,11 +129,39 @@ export class FeedbackController extends RootController {
       return;
     }
 
+    const entryIndex = this.entries.length;
+    this.entries = [
+      ...this.entries,
+      {
+        timestamp: Date.now(),
+        bucketOverride,
+        productData,
+        flow,
+        status: "pending",
+      },
+    ];
+
+    const updateEntryStatus = (
+      status: FeedbackLogEntry["status"],
+      errorMessage?: string
+    ) => {
+      const newEntries = [...this.entries];
+      if (newEntries[entryIndex]) {
+        newEntries[entryIndex] = {
+          ...newEntries[entryIndex],
+          status,
+          ...(errorMessage ? { errorMessage } : {}),
+        };
+        this.entries = newEntries;
+      }
+    };
+
     if (!this.#env) {
       logger.log(
         Utils.Logging.Formatter.error("No environment was provided."),
         LABEL
       );
+      updateEntryStatus("error", "No environment was provided.");
       return;
     }
     const productId = this.#env.deploymentConfig.GOOGLE_FEEDBACK_PRODUCT_ID;
@@ -100,6 +172,7 @@ export class FeedbackController extends RootController {
         ),
         LABEL
       );
+      updateEntryStatus("error", "No GOOGLE_FEEDBACK_PRODUCT_ID was set in the client deployment configuration.");
       return;
     }
     const bucket = bucketOverride ?? this.#env.deploymentConfig.GOOGLE_FEEDBACK_BUCKET;
@@ -110,6 +183,7 @@ export class FeedbackController extends RootController {
         ),
         LABEL
       );
+      updateEntryStatus("error", "No GOOGLE_FEEDBACK_BUCKET was set in the client deployment configuration.");
       return;
     }
     const { packageJsonVersion: version, gitCommitHash } = this.#env.buildInfo;
@@ -126,6 +200,7 @@ export class FeedbackController extends RootController {
       api = await loadGoogleFeedbackApi();
     } catch (e) {
       /* c8 ignore next 4 */
+      const msg = e instanceof Error ? e.message : String(e);
       logger.log(
         Utils.Logging.Formatter.error(
           "Error loading Google Feedback script:",
@@ -133,6 +208,7 @@ export class FeedbackController extends RootController {
         ),
         LABEL
       );
+      updateEntryStatus("error", `Error loading Google Feedback script: ${msg}`);
       if (!isSilent) {
         this.status = "closed";
         this.#env.shellHost.setOneGoogleBarVisible(true);
@@ -144,6 +220,7 @@ export class FeedbackController extends RootController {
       /* c8 ignore next 4 */
       // The user might have pressed Escape on the loading panel in the
       // meantime.
+      updateEntryStatus("closed", "Cancelled by user during load.");
       return;
     }
 
@@ -155,24 +232,42 @@ export class FeedbackController extends RootController {
 
     if (isSilent) {
       config.flow = "submit";
+      updateEntryStatus("loaded");
     } else {
       config.onLoadCallback = () => {
         // Note that the API we loaded earlier is very tiny. This startFeedback
         // call is what actually loads most of the JavaScript, so we want to
         // keep the loading indicator visible until this callback fires.
         this.status = "open";
+        updateEntryStatus("loaded");
       };
       config.callback = () => {
         this.status = "closed";
         this.#env.shellHost.setOneGoogleBarVisible(true);
+        updateEntryStatus("closed");
       };
     }
 
-    api.startFeedback(config, productData);
+    try {
+      api.startFeedback(config, productData);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      updateEntryStatus("error", `Error starting feedback: ${msg}`);
+    }
   }
 
   close() {
     this.status = "closed";
     this.#env.shellHost.setOneGoogleBarVisible(true);
+    // Find the last pending/loaded entry and mark it closed
+    const lastEntry = this.entries[this.entries.length - 1];
+    if (lastEntry && (lastEntry.status === "pending" || lastEntry.status === "loaded")) {
+      const newEntries = [...this.entries];
+      newEntries[newEntries.length - 1] = {
+        ...lastEntry,
+        status: "closed",
+      };
+      this.entries = newEntries;
+    }
   }
 }

--- a/packages/visual-editor/src/ui/elements/devtools/devtools.ts
+++ b/packages/visual-editor/src/ui/elements/devtools/devtools.ts
@@ -13,6 +13,7 @@ import { type SCA } from "../../../sca/sca.js";
 import { icons } from "../../styles/icons.js";
 import "../json-tree/json-tree.js";
 import "./opie/opie-panel.js";
+import "./feedback/feedback-panel.js";
 
 @customElement("bb-devtools")
 export class DevTools extends SignalWatcher(LitElement) {
@@ -137,6 +138,7 @@ export class DevTools extends SignalWatcher(LitElement) {
     const systemInstruction = opie.systemInstruction;
     const functions = opie.functionDeclarations;
     const entries = opie.entries;
+    const feedbackEntries = this.sca.controller.global.feedback.entries;
 
     return html`
       <div id="devtools-header">
@@ -151,6 +153,15 @@ export class DevTools extends SignalWatcher(LitElement) {
               }}
             >
               Opie
+            </button>
+            <button
+              class="sans-flex w-500 round"
+              ?disabled=${devtools.activeTab === "feedback"}
+              @click=${() => {
+                devtools.activeTab = "feedback";
+              }}
+            >
+              Feedback
             </button>
           </div>
         </div>
@@ -171,6 +182,13 @@ export class DevTools extends SignalWatcher(LitElement) {
                 .systemInstruction=${systemInstruction}
                 .functions=${functions}
               ></bb-devtools-opie-panel>
+            `
+          : ""}
+        ${devtools.activeTab === "feedback"
+          ? html`
+              <bb-devtools-feedback-panel
+                .entries=${feedbackEntries}
+              ></bb-devtools-feedback-panel>
             `
           : ""}
       </div>

--- a/packages/visual-editor/src/ui/elements/devtools/feedback/feedback-panel.ts
+++ b/packages/visual-editor/src/ui/elements/devtools/feedback/feedback-panel.ts
@@ -1,0 +1,248 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { LitElement, html, css, TemplateResult } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { SignalWatcher } from "@lit-labs/signals";
+import { icons } from "../../../styles/icons.js";
+import type { FeedbackLogEntry } from "../../../../sca/controller/subcontrollers/global/feedback-controller.js";
+import "../../json-tree/json-tree.js";
+
+@customElement("bb-devtools-feedback-panel")
+export class DevToolsFeedbackPanel extends SignalWatcher(LitElement) {
+  @property({ type: Array })
+  accessor entries: readonly FeedbackLogEntry[] = [];
+
+  static styles = [
+    icons,
+    css`
+      * {
+        box-sizing: border-box;
+      }
+
+      :host {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+        height: 100%;
+        min-height: 0;
+        gap: var(--bb-grid-size-3);
+        overflow: hidden;
+        font-family: var(--bb-font-family, sans-serif);
+        color: var(--light-dark-n-10);
+      }
+
+      .scroll-container {
+        flex: 1;
+        overflow-y: auto;
+        padding-right: var(--bb-grid-size);
+      }
+
+      .section {
+        background: var(--light-dark-n-100);
+        border: 1px solid var(--light-dark-n-90);
+        border-radius: var(--bb-grid-size-2);
+        padding: var(--bb-grid-size-4);
+        display: flex;
+        flex-direction: column;
+        gap: var(--bb-grid-size-3);
+        height: 100%;
+
+        & h3 {
+          margin: 0;
+          font: 600 var(--bb-label-medium) / var(--bb-label-line-height-medium)
+            var(--bb-font-family);
+          color: var(--light-dark-n-20);
+          display: flex;
+          align-items: center;
+          gap: var(--bb-grid-size-2);
+          padding-bottom: var(--bb-grid-size-2);
+          border-bottom: 1px solid var(--light-dark-n-95);
+        }
+      }
+
+      .call-log {
+        display: flex;
+        flex-direction: column;
+        gap: var(--bb-grid-size-3);
+      }
+
+      .call-entry {
+        background: var(--light-dark-n-98);
+        border: 1px solid var(--light-dark-n-90);
+        border-radius: var(--bb-grid-size);
+        overflow: hidden;
+
+        &.pending {
+          border-left: 4px solid var(--light-dark-p-40);
+        }
+
+        &.loaded {
+          border-left: 4px solid var(--light-dark-s-40);
+        }
+
+        &.error {
+          border-left: 4px solid var(--light-dark-e-40, var(--bb-error-color));
+        }
+
+        &.closed {
+          border-left: 4px solid var(--light-dark-n-50);
+        }
+
+        & .call-header {
+          background: var(--light-dark-n-95);
+          padding: var(--bb-grid-size-2) var(--bb-grid-size-3);
+          font: 600 var(--bb-label-small) / var(--bb-label-line-height-small)
+            var(--bb-font-family-mono, monospace);
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          border-bottom: 1px solid var(--light-dark-n-90);
+
+          & .header-title {
+            display: flex;
+            align-items: center;
+            gap: var(--bb-grid-size);
+          }
+
+          & .timestamp {
+            font-size: var(--bb-body-small);
+            color: var(--light-dark-n-40);
+            font-weight: 400;
+          }
+        }
+
+        & .call-details {
+          padding: var(--bb-grid-size-3);
+          display: flex;
+          flex-direction: column;
+          gap: var(--bb-grid-size-2);
+
+          & .label {
+            font: 600 var(--bb-label-small) / var(--bb-label-line-height-small)
+              var(--bb-font-family);
+            color: var(--light-dark-n-30);
+            margin-bottom: 2px;
+          }
+
+          & .meta-row {
+            display: flex;
+            gap: var(--bb-grid-size-4);
+            font: 400 var(--bb-body-small) / var(--bb-body-line-height-small)
+              var(--bb-font-family);
+            color: var(--light-dark-n-20);
+          }
+
+          & .error-message {
+            color: var(--light-dark-e-40, var(--bb-error-color));
+            background: var(--light-dark-e-95);
+            padding: var(--bb-grid-size-2);
+            border-radius: var(--bb-grid-size);
+            font: 400 var(--bb-body-small) / var(--bb-body-line-height-small)
+              var(--bb-font-family-mono, monospace);
+            border: 1px solid var(--light-dark-e-80);
+          }
+
+          & pre,
+          & bb-json-tree {
+            margin: 0;
+            background: var(--light-dark-n-100);
+            border: 1px solid var(--light-dark-n-95);
+            padding: var(--bb-grid-size-3);
+            border-radius: var(--bb-grid-size);
+            font: 400 var(--bb-body-small) / var(--bb-body-line-height-small)
+              var(--bb-font-family-mono, monospace);
+            overflow-x: auto;
+          }
+        }
+      }
+
+      .empty-state {
+        color: var(--light-dark-n-50);
+        font: 400 var(--bb-body-medium) / var(--bb-body-line-height-medium)
+          var(--bb-font-family);
+        text-align: center;
+        padding: var(--bb-grid-size-6) 0;
+      }
+    `,
+  ];
+
+  render(): TemplateResult {
+    const { entries } = this;
+    return html`
+      <div class="section">
+        <h3><span class="g-icon">history</span> Feedback Log</h3>
+        <div class="scroll-container">
+          ${entries && entries.length > 0
+            ? html`
+                <div class="call-log">
+                  ${entries.map((entry) => {
+                    const date = new Date(entry.timestamp);
+                    const timeString = date.toLocaleTimeString();
+                    const statusClass = entry.status;
+                    let statusIcon = "pending";
+                    if (entry.status === "loaded") statusIcon = "check_circle";
+                    if (entry.status === "error") statusIcon = "error";
+                    if (entry.status === "closed") statusIcon = "cancel";
+
+                    return html`
+                      <div class="call-entry ${statusClass}">
+                        <div class="call-header">
+                          <span class="header-title">
+                            <span class="g-icon header-icon">${statusIcon}</span>
+                            Feedback Request (${entry.flow === "submit" ? "Silent" : "Interactive"})
+                          </span>
+                          <span class="timestamp">${timeString}</span>
+                        </div>
+                        <div class="call-details">
+                          <div class="meta-row">
+                            <div>
+                              <span class="label">Status:</span> ${entry.status}
+                            </div>
+                            ${entry.bucketOverride
+                              ? html`<div>
+                                  <span class="label">Bucket Override:</span>
+                                  ${entry.bucketOverride}
+                                </div>`
+                              : ""}
+                          </div>
+
+                          ${entry.errorMessage
+                            ? html`<div class="error-message">
+                                ${entry.errorMessage}
+                              </div>`
+                            : ""}
+
+                          ${entry.productData &&
+                          Object.keys(entry.productData).length > 0
+                            ? html`<div>
+                                <div class="label">Product Data (Payload):</div>
+                                <bb-json-tree
+                                  .json=${entry.productData}
+                                ></bb-json-tree>
+                              </div>`
+                            : html`<div>
+                                <div class="label">Product Data:</div>
+                                <div class="empty-state" style="padding: var(--bb-grid-size-2);">No product data included.</div>
+                              </div>`}
+                        </div>
+                      </div>
+                    `;
+                  })}
+                </div>
+              `
+            : html`<div class="empty-state">No feedback sent yet in this session.</div>`}
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "bb-devtools-feedback-panel": DevToolsFeedbackPanel;
+  }
+}


### PR DESCRIPTION
## What
Added a dedicated "Feedback" monitoring tab to the Opal Developer Tools UI, giving developers a direct, live view into data payloads, lifecycle events, and errors emitted by the `FeedbackController`.

## Why
Enhances the debuggability of feedback routing flows across both interactive and silent submission modes, ensuring payloads (such as Opie chat data) and runtime errors (like Content Security Policy violations) are surfaced visibly and structured correctly.

## Changes
- **SCA Subcontrollers**:
  - `FeedbackController`: Added a reactive `@field({ deep: false })` `entries` log. Integrated asynchronous lifecycle state tracking (`pending`, `loaded`, `error`, `closed`). Implemented global `securitypolicyviolation` DOM listeners to detect and log CSP failures natively.
- **Visual Editor UI Components**:
  - `bb-devtools`: Added UI tabs, clicks orchestration, and component conditional render mappings for the new "Feedback" panel.
  - `bb-devtools-feedback-panel`: Created a responsive list-view renderer for entries, displaying timestamped statuses and payloads leveraging `<bb-json-tree>` and design system color tokens.

## Testing
1. Boot up the fake server and enable Dev Tools.
2. Open Dev Tools and navigate to the new "Feedback" tab.
3. Trigger a feedback submission (e.g., thumbs down on Opie or Help -> Feedback).
4. Verify the operation's lifecycle updates in the tab and that the JSON tree perfectly renders the payload.
