### PR TITLE
[feedback] Headless Google Feedback API Integration and Options Refactor

### DIFF
--- a/packages/visual-editor/src/sca/actions/agent/graph-editing-agent-actions.ts
+++ b/packages/visual-editor/src/sca/actions/agent/graph-editing-agent-actions.ts
@@ -413,12 +413,17 @@ export const setOpieReaction = asAction(
 
     if (newReaction !== "none") {
       feedbackTimeoutId = setTimeout(() => {
-        feedbackTimeoutId = null;
+        const conversation = formatConversation(agent.entries, 10);
         const productData = {
           reaction: newReaction,
-          conversation: formatConversation(agent.entries, 10),
+          conversation,
         };
-        controller.global.feedback.open("opie", productData, "submit");
+        controller.global.feedback.open({
+          bucketOverride: "opie",
+          productData,
+          flow: "submit",
+          description: `User sentiment: ${newReaction}`,
+        });
       }, 3000);
     }
   }

--- a/packages/visual-editor/src/sca/controller/subcontrollers/global/feedback-controller.ts
+++ b/packages/visual-editor/src/sca/controller/subcontrollers/global/feedback-controller.ts
@@ -18,6 +18,10 @@ type UserFeedbackApi = {
       bucket?: string;
       productVersion?: string;
       flow?: string;
+      report?: {
+        description: string;
+        [key: string]: unknown;
+      };
       callback?: () => void;
       onLoadCallback?: () => void;
     },
@@ -64,6 +68,7 @@ export type FeedbackLogEntry = {
   bucketOverride?: string;
   productData?: Record<string, string>;
   flow?: "submit";
+  description?: string;
   status: "pending" | "loaded" | "error" | "closed";
   errorMessage?: string;
 };
@@ -118,12 +123,19 @@ export class FeedbackController extends RootController {
   }
 
   async open(
-    bucketOverride?: string,
-    productData?: Record<string, string>,
-    flow?: "submit"
+    options: {
+      bucketOverride?: string;
+      productData?: Record<string, string>;
+    } & (
+      | { flow?: undefined; description?: never }
+      | { flow: "submit"; description: string }
+    ) = {}
   ) {
     const LABEL = "Feedback.open";
     const logger = Utils.Logging.getLogger();
+
+    const { bucketOverride, productData, flow } = options;
+    const description = "description" in options ? options.description : undefined;
 
     if (this.status !== "closed") {
       return;
@@ -137,14 +149,15 @@ export class FeedbackController extends RootController {
         bucketOverride,
         productData,
         flow,
+        description,
         status: "pending",
       },
     ];
 
-    const updateEntryStatus = (
+    const updateEntryStatus: (
       status: FeedbackLogEntry["status"],
       errorMessage?: string
-    ) => {
+    ) => void = (status, errorMessage) => {
       const newEntries = [...this.entries];
       if (newEntries[entryIndex]) {
         newEntries[entryIndex] = {
@@ -229,6 +242,17 @@ export class FeedbackController extends RootController {
       bucket,
       productVersion: `${version} (${gitCommitHash})`,
     };
+
+    if (isSilent && (!description || description.trim() === "")) {
+      const msg = "Headless feedback submission requires a valid 'description'.";
+      logger.log(Utils.Logging.Formatter.error(msg), LABEL);
+      updateEntryStatus("error", msg);
+      return;
+    }
+
+    if (description) {
+      config.report = { description };
+    }
 
     if (isSilent) {
       config.flow = "submit";

--- a/packages/visual-editor/src/ui/elements/devtools/feedback/feedback-panel.ts
+++ b/packages/visual-editor/src/ui/elements/devtools/feedback/feedback-panel.ts
@@ -216,10 +216,19 @@ export class DevToolsFeedbackPanel extends SignalWatcher(LitElement) {
                               </div>`
                             : ""}
 
+                          ${entry.description
+                            ? html`<div>
+                                <div class="label">Report Payload (Headless Submission):</div>
+                                <bb-json-tree
+                                  .json=${{ description: entry.description }}
+                                ></bb-json-tree>
+                              </div>`
+                            : ""}
+
                           ${entry.productData &&
                           Object.keys(entry.productData).length > 0
                             ? html`<div>
-                                <div class="label">Product Data (Payload):</div>
+                                <div class="label">Product Data (PSD):</div>
                                 <bb-json-tree
                                   .json=${entry.productData}
                                 ></bb-json-tree>

--- a/packages/visual-editor/tests/sca/controller/subcontrollers/global/feedback-controller.test.ts
+++ b/packages/visual-editor/tests/sca/controller/subcontrollers/global/feedback-controller.test.ts
@@ -22,6 +22,11 @@ type UserFeedbackConfig = {
   productId: string;
   bucket?: string;
   productVersion?: string;
+  flow?: string;
+  report?: {
+    description: string;
+    [key: string]: unknown;
+  };
   callback?: () => void;
   onLoadCallback?: () => void;
 };
@@ -168,5 +173,36 @@ suite("FeedbackController", () => {
     const openPromise2 = controller.open();
     await Promise.all([openPromise, openPromise2]);
     assert.strictEqual(controller.status, "open");
+  });
+
+  test("open() with flow='submit' and explicit description configures api correctly", async () => {
+    const description = "Test Headless Feedback";
+    const productData = { foo: "bar" };
+    await controller.open({
+      productData,
+      flow: "submit",
+      description,
+    });
+
+    assert.strictEqual(providedConfig.flow, "submit");
+    assert.deepStrictEqual(providedConfig.report, { description });
+    assert.strictEqual(controller.entries[controller.entries.length - 1].status, "loaded");
+  });
+
+  test("open() with flow='submit' triggers an error status if description is missing", async () => {
+    const productData = { foo: "bar", baz: "qux" };
+    
+    // Reset spy captured config
+    providedConfig = undefined as unknown as UserFeedbackConfig;
+    
+    await controller.open({
+      productData,
+      flow: "submit",
+    } as unknown as Parameters<FeedbackController["open"]>[0]);
+
+    assert.strictEqual(providedConfig, undefined); // API not called
+    const lastEntry = controller.entries[controller.entries.length - 1];
+    assert.strictEqual(lastEntry.status, "error");
+    assert.match(lastEntry.errorMessage || "", /Headless feedback submission requires a valid 'description'/);
   });
 });


### PR DESCRIPTION
## What
Refactored the Google Feedback API integration to support headless (silent) submissions correctly. Migrated the API to use a strictly-typed Discriminated Union Options interface that mandates a feedback description for headless submission requests.

## Why
The Google Feedback API expects a programmatic `report.description` payload for silent submissions. Bypassing or omitting this payload causes headless submissions to fail to save properly to the Listnr backend.

## Changes
### Visual Editor
- **SCA Controller (`feedback-controller.ts`)**: Updated the `FeedbackController.open()` method signature to use a strict Discriminated Union payload object. Introduced runtime and compiler-level safeguards ensuring a `description` is provided on all `submit` flows.
- **SCA Actions (`graph-editing-agent-actions.ts`)**: Migrated the `setOpieReaction` action to the refined options API payload.
- **DevTools Panel (`feedback-panel.ts`)**: Updated the Feedback log payload inspector to extract and render headless submission descriptions directly.
- **Unit Tests (`feedback-controller.test.ts`)**: Extended the test suite with Discriminated Union configuration validation and strict early-error assertion scenarios.

## Testing
1. Run the test suite: `npm run test:file -- './dist/tsc/tests/sca/controller/subcontrollers/global/feedback-controller.test.js'`
2. Trigger the "thumbs up/thumbs down" buttons inside the Opie agent chat UI and confirm headless request entries generate seamlessly inside the Feedback DevTools inspector tab.
