### PR TITLE
[feedback] Allow framing google.com in the Shell

### DIFF
--- a/packages/unified-server/src/csp.ts
+++ b/packages/unified-server/src/csp.ts
@@ -54,6 +54,7 @@ export const SHELL_CSP = {
   ["frame-src"]: [
     "https://docs.google.com",
     "https://drive.google.com",
+    "https://www.google.com",
     flags.SHELL_GUEST_ORIGIN,
   ],
   ["img-src"]: ["'self'", "https://*.gstatic.com"],


### PR DESCRIPTION
## What
Add `https://www.google.com` to the `frame-src` Content Security Policy directive for the Breadboard Shell.

## Why
This allows the Google Feedback API to submit headless reports (silent feedback flows) without triggering a Content Security Policy violation.

## Changes
- **Unified Server**
  - Updated `SHELL_CSP` `frame-src` in `csp.ts` to permit framing `https://www.google.com`.

## Testing
Verify that triggers invoking headless (flow=submit) feedback via the `FeedbackController` in the Shell no longer emit CSP frame-src framing errors in the console.
