### PR TITLE
[eval]  Robust Evaluation Viewer

### DIFF
--- a/packages/visual-editor/eval/viewer/src/filesystem.ts
+++ b/packages/visual-editor/eval/viewer/src/filesystem.ts
@@ -240,7 +240,10 @@ export class FileSystemEvalBackend {
         }
 
         const fullPath = this.#getFullFilePath(path, name);
-        queryEntries.push(parseFileName(fullPath));
+        const parsed = parseFileName(fullPath);
+        if (parsed) {
+          queryEntries.push(parsed);
+        }
       }
 
       return buildFileHierarchy(queryEntries);

--- a/packages/visual-editor/eval/viewer/src/parse-file-name.ts
+++ b/packages/visual-editor/eval/viewer/src/parse-file-name.ts
@@ -23,7 +23,7 @@ export type GroupedByType = {
   items: GroupedByName[];
 };
 
-function parseFileName(fullPath: string): ParsedFileMedata {
+function parseFileName(fullPath: string): ParsedFileMedata | null {
   const fileName = fullPath.split("/").at(-1)!;
   const regex =
     /^([^-]+)-(.+)-(\d{4}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2})\.log\.json$/;
@@ -31,7 +31,8 @@ function parseFileName(fullPath: string): ParsedFileMedata {
   const match = fileName.match(regex);
 
   if (!match) {
-    throw new Error(`Invalid file format: ${fileName}`);
+    console.warn(`Invalid file format: ${fileName}`);
+    return null;
   }
 
   const [, type, rawName, dateString] = match;

--- a/packages/visual-editor/eval/viewer/src/ui/contexts-viewer.ts
+++ b/packages/visual-editor/eval/viewer/src/ui/contexts-viewer.ts
@@ -83,9 +83,8 @@ class ContextsViewer extends LitElement {
         context.config?.generationConfig?.responseMimeType ===
         "application/json";
       const { generationConfig, systemInstruction } = context.config || {};
-      const systemInstructionText = (
-        systemInstruction?.parts?.[0] as TextCapabilityPart
-      )?.text;
+      const systemInstructionText =
+        (systemInstruction?.parts?.[0] as TextCapabilityPart)?.text || "";
       return html`<details class="item" ?open=${idx === 0}>
         <summary>
           Context ${idx + 1} (${context.turnCount} turns,


### PR DESCRIPTION
## What
Improved the Evaluation Viewer's robustness to malformed or unrecognized files, and prevented runtime errors when rendering context views.

## Why
Prevents the Evaluation Viewer from throwing uncaught errors and crashing when it encounters unrecognized files (such as `.graph.json` files) within mounted directories, or when a context view lacks system instructions.

## Changes
- **Eval Viewer Filesystem**: Modified `parseFileName` to return `null` instead of throwing an error on invalid formats, and updated `FileSystemEvalBackend.query` to safely ignore unrecognized files.
- **Contexts Viewer UI**: Added an empty string fallback when extracting the `systemInstructionText` within `contexts-viewer.ts` to guarantee type-safety for the markdown rendering directive.

## Testing
1. Mount a directory in the Evaluation Viewer that contains both log and non-log files (e.g., `.graph.json`). The valid logs will render correctly while others are silently skipped.
2. Click the **Contexts** view button for logs that have no configured system instructions. The viewer will load successfully without crashing.
