### PR TITLE
[opie]  Policy-Driven Graph Editing & GraphEditingManager Introduction

### DIFF
--- a/packages/visual-editor/eval/graph-editing-eval.ts
+++ b/packages/visual-editor/eval/graph-editing-eval.ts
@@ -31,13 +31,15 @@ import { getAuthenticatedClient } from "./authenticate.js";
 import { type ConsentController } from "../src/sca/controller/subcontrollers/global/global.js";
 import { AgentService } from "../src/a2/agent/agent-service.js";
 import { invokeGraphEditingAgent } from "../src/a2/agent/graph-editing/main.js";
+import { EditingAgentPidginTranslator } from "../src/a2/agent/graph-editing/editing-agent-pidgin-translator.js";
 import { AgentEventConsumer, LocalAgentEventBridge } from "../src/a2/agent/agent-event-consumer.js";
 import { ok } from "@breadboard-ai/utils";
 import { generateContent, GeminiBody, GeminiSchema } from "../src/a2/a2/gemini.js";
 import { toLLMContent } from "../src/a2/a2/utils.js";
 import { A2_TOOLS } from "../src/a2/a2-registry.js";
-import { LLMContent, NodeConfiguration, EditSpec, GraphDescriptor } from "@breadboard-ai/types";
-import { TransformDescriptor } from "../src/a2/agent/agent-event.js";
+import { HeadlessGraphEditor } from "./headless-graph-editor.js";
+import { GraphEditingManager } from "../src/a2/agent/graph-editing/graph-editing-manager.js";
+import { LLMContent, GraphDescriptor } from "@breadboard-ai/types";
 
 import { GoogleDriveClient } from "@breadboard-ai/utils/google-drive/google-drive-client.js";
 import { GOOGLE_DRIVE_FOLDER_MIME_TYPE, GRAPH_MIME_TYPE } from "../src/ui/utils/google-drive-host-operations.js";
@@ -661,6 +663,7 @@ class GraphEditingEvalRun implements EvalLogger {
   };
 
   lastMessage: string = "";
+  private readonly translator = new EditingAgentPidginTranslator();
 
   constructor(
     private readonly accessToken: string,
@@ -711,15 +714,10 @@ class GraphEditingEvalRun implements EvalLogger {
     });
 
     consumer.on("applyEdits", async (event) => {
-      if (event.edits) {
-        this.applyEditsToGraph(event.edits);
-        return { success: true };
-      }
-      if (event.transform) {
-        this.applyTransformToGraph(event.transform);
-        return { success: true };
-      }
-      return { success: false, error: "Invalid applyEdits payload" };
+      const editor = HeadlessGraphEditor.create(this.graph);
+      const manager = new GraphEditingManager(editor);
+      const result = await manager.applyEdits(event);
+      return result;
     });
 
     consumer.on("waitForInput", (event) => {
@@ -837,7 +835,7 @@ class GraphEditingEvalRun implements EvalLogger {
     };
 
     const outcome = await withRetry(async () => {
-      const res = await invokeGraphEditingAgent(objective, moduleArgs, sink);
+      const res = await invokeGraphEditingAgent(objective, moduleArgs, sink, this.translator);
       return res;
     });
 
@@ -856,46 +854,5 @@ class GraphEditingEvalRun implements EvalLogger {
       message: this.lastMessage,
       graph: this.graph,
     };
-  }
-
-  private applyEditsToGraph(edits: EditSpec[]) {
-    for (const edit of edits) {
-      if (edit.type === "addnode") {
-        this.graph.nodes ??= [];
-        this.graph.nodes.push(edit.node);
-      } else if (edit.type === "removenode") {
-        this.graph.nodes = (this.graph.nodes ?? []).filter((n) => n.id !== edit.id);
-        this.graph.edges = (this.graph.edges ?? []).filter(
-          (e) => e.from !== edit.id && e.to !== edit.id
-        );
-      } else if (edit.type === "changegraphmetadata") {
-        if (edit.title !== undefined) this.graph.title = edit.title;
-        if (edit.description !== undefined) this.graph.description = edit.description;
-        if (edit.metadata !== undefined) this.graph.metadata = edit.metadata;
-      }
-    }
-  }
-
-  private applyTransformToGraph(transform: TransformDescriptor) {
-    if (transform.kind === "updateNode") {
-      const node = this.graph.nodes?.find((n) => n.id === transform.nodeId);
-      if (node) {
-        if (transform.configuration) {
-          node.configuration = {
-            ...(node.configuration ?? {}),
-            ...transform.configuration,
-          } as unknown as NodeConfiguration;
-        }
-        if (transform.metadata) {
-          node.metadata = {
-            ...(node.metadata ?? {}),
-            ...transform.metadata,
-          };
-        }
-      }
-    } else if (transform.kind === "updateGraphProperties") {
-      if (transform.title !== undefined) this.graph.title = transform.title;
-      if (transform.description !== undefined) this.graph.description = transform.description;
-    }
   }
 }

--- a/packages/visual-editor/eval/headless-graph-editor.ts
+++ b/packages/visual-editor/eval/headless-graph-editor.ts
@@ -1,0 +1,177 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  EditableGraph,
+  EditableGraphOptions,
+  GraphDescriptor,
+  GraphIdentifier,
+  GraphStoreArgs,
+  MutableGraph,
+  MutableGraphStore,
+  NodeDescriptor,
+  NodeDescribeSnapshot,
+  RuntimeFlagManager,
+} from "@breadboard-ai/types";
+import { Graph as GraphEditor } from "../src/engine/editor/graph.js";
+import { Graph as InspectableGraphImpl } from "../src/engine/inspector/graph/graph.js";
+import { Node } from "../src/engine/inspector/graph/node.js";
+
+export { HeadlessGraphEditor };
+
+const genericSnapshot: NodeDescribeSnapshot = {
+  current: {
+    inputSchema: { type: "object" },
+    outputSchema: {
+      type: "object",
+      properties: {
+        context: {
+          type: "array",
+          items: { type: "object" },
+          title: "Context out",
+          behavior: ["main-port"],
+        },
+      },
+    },
+  },
+  latest: Promise.resolve({
+    inputSchema: { type: "object" },
+    outputSchema: {
+      type: "object",
+      properties: {
+        context: {
+          type: "array",
+          items: { type: "object" },
+          title: "Context out",
+          behavior: ["main-port"],
+        },
+      },
+    },
+  }),
+  updating: false,
+};
+
+function makeTestGraphStoreArgs(
+  options: EditableGraphOptions = {}
+): GraphStoreArgs {
+  return {
+    sandbox: options.sandbox || {},
+    loader: options.loader || {
+      load() {
+        throw new Error("Do not load graphs in headless mode");
+      },
+    },
+    flags: {
+      env: () => {
+        throw new Error("Do not use flags in headless mode");
+      },
+      overrides: () => {
+        throw new Error("Do not use flags in headless mode");
+      },
+      flags: () => {
+        throw new Error("Do not use flags in headless mode");
+      },
+      override() {
+        throw new Error("Do not use flags in headless mode");
+      },
+      clearOverride() {
+        throw new Error("Do not use flags in headless mode");
+      },
+    } satisfies RuntimeFlagManager,
+  };
+}
+
+function makeTestGraphStore(
+  _args: GraphStoreArgs
+): MutableGraphStore {
+  let mutableGraph: MutableGraph | undefined;
+  const store = {
+    set(graph: MutableGraph): void {
+      mutableGraph = graph;
+    },
+    get(): MutableGraph | undefined {
+      return mutableGraph;
+    },
+  };
+  return store;
+}
+
+function createMutableGraph(
+  graph: GraphDescriptor,
+  store: MutableGraphStore,
+  deps: GraphStoreArgs
+): MutableGraph {
+  function graphNodes(graphId: GraphIdentifier): NodeDescriptor[] {
+    if (!graphId) return mutable.graph.nodes;
+    return mutable.graph.graphs?.[graphId]?.nodes || [];
+  }
+
+  function buildNodeAccessor() {
+    return {
+      get: (id: string, graphId: string) => {
+        const descriptor = graphNodes(graphId).find((n) => n.id === id);
+        return descriptor
+          ? new Node(descriptor, mutable as MutableGraph, graphId)
+          : undefined;
+      },
+      nodes: (graphId: string) =>
+        graphNodes(graphId).map(
+          (n) => new Node(n, mutable as MutableGraph, graphId)
+        ),
+      byType: (type: string, graphId: string) =>
+        graphNodes(graphId)
+          .filter((n) => n.type === type)
+          .map((n) => new Node(n, mutable as MutableGraph, graphId)),
+    };
+  }
+
+  const mutable = {
+    graph,
+    id: crypto.randomUUID(),
+    deps,
+    store,
+    graphs: null! as MutableGraph["graphs"],
+    nodes: null! as MutableGraph["nodes"],
+
+    describeNode(): NodeDescribeSnapshot {
+      return genericSnapshot;
+    },
+
+    update(graph: GraphDescriptor, _visualOnly: boolean): void {
+      mutable.graph = graph;
+    },
+
+    rebuild(graph: GraphDescriptor): void {
+      mutable.graph = graph;
+      mutable.graphs = {
+        get: (id: GraphIdentifier) => new InspectableGraphImpl(id, mutable as MutableGraph),
+        graphs: () =>
+          Object.fromEntries(
+            Object.keys(mutable.graph.graphs || {}).map((id) => [
+              id,
+              new InspectableGraphImpl(id, mutable as MutableGraph),
+            ])
+          ),
+      };
+      mutable.nodes = buildNodeAccessor();
+    },
+  };
+
+  mutable.rebuild(graph);
+  return mutable as MutableGraph;
+}
+
+class HeadlessGraphEditor {
+  static create(
+    graph: GraphDescriptor,
+    options: EditableGraphOptions = {}
+  ): EditableGraph {
+    const args = makeTestGraphStoreArgs(options);
+    const store = makeTestGraphStore(args);
+    const mutable = createMutableGraph(graph, store, args);
+    return new GraphEditor(mutable, options);
+  }
+}

--- a/packages/visual-editor/src/a2/agent/graph-editing/graph-editing-manager.ts
+++ b/packages/visual-editor/src/a2/agent/graph-editing/graph-editing-manager.ts
@@ -1,0 +1,202 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  EditableGraph,
+  GraphMetadata,
+  NodeConfiguration,
+  NodeMetadata,
+  Outcome,
+} from "@breadboard-ai/types";
+import { UpdateNode } from "../../../ui/transforms/update-node.js";
+import { computePositions } from "./layout-graph.js";
+import type { InPort } from "../../../ui/transforms/autowire-in-ports.js";
+import type { ApplyEditsResponse } from "./types.js";
+import type { TransformDescriptor } from "../agent-event.js";
+import type { EditSpec } from "@breadboard-ai/types";
+
+export { GraphEditingManager };
+export type { GraphThemeGenerationContext, GraphThemeGenerator };
+
+type GraphThemeGenerationContext = {
+  title: string;
+  description: string;
+  userInstruction: string;
+  signal?: AbortSignal;
+};
+
+type GraphThemeGenerator = (
+  context: GraphThemeGenerationContext
+) => Promise<Outcome<unknown>>;
+
+/**
+ * Encapsulates policy-driven Graph Editing for both production and evaluation.
+ * Decouples the mutation policy from UI/SCA and environment-specific triggers.
+ */
+class GraphEditingManager {
+  constructor(
+    private readonly editor: EditableGraph,
+    private readonly themeGenerator?: GraphThemeGenerator
+  ) {}
+
+  async applyEdits(
+    payload: {
+      edits?: EditSpec[];
+      transform?: TransformDescriptor;
+      label?: string;
+    },
+    options?: {
+      signal?: AbortSignal;
+      onNodeConfigChanged?: (config: {
+        nodeId: string;
+        graphId: string;
+        configuration: NodeConfiguration;
+        titleUserModified: boolean;
+      }) => void;
+      onThemeUpdated?: (metadata: GraphMetadata) => void;
+    }
+  ): Promise<ApplyEditsResponse> {
+    const { editor, themeGenerator } = this;
+    const { edits, transform, label } = payload;
+
+    if (edits) {
+      const result = await editor.edit(edits, label || "Apply Edits");
+      if (!result.success) {
+        return { success: false, error: result.error };
+      }
+      return { success: true };
+    }
+
+    if (transform) {
+      switch (transform.kind) {
+        case "updateNode": {
+          const t = new UpdateNode(
+            transform.nodeId,
+            transform.graphId,
+            transform.configuration as NodeConfiguration | null,
+            transform.metadata as NodeMetadata | null,
+            transform.portsToAutowire as InPort[] | null
+          );
+          const result = await editor.apply(t);
+
+          if (result.success && transform.configuration && options?.onNodeConfigChanged) {
+            options.onNodeConfigChanged({
+              nodeId: transform.nodeId,
+              graphId: transform.graphId,
+              configuration: transform.configuration as NodeConfiguration,
+              titleUserModified: t.titleUserModified,
+            });
+          }
+
+          if (!result.success) {
+            return { success: false, error: result.error };
+          }
+          return { success: true };
+        }
+
+        case "layoutGraph": {
+          const graph = editor.raw();
+          const positions = computePositions(graph.nodes ?? [], graph.edges ?? []);
+          const edits: EditSpec[] = [];
+          for (const [nodeId, { x, y }] of positions) {
+            const node = graph.nodes?.find((n) => n.id === nodeId);
+            const existingMetadata = node?.metadata ?? {};
+            const existingVisual = (existingMetadata.visual ?? {}) as Record<string, unknown>;
+            edits.push({
+              type: "changemetadata",
+              id: nodeId,
+              graphId: "",
+              metadata: {
+                ...existingMetadata,
+                visual: { ...existingVisual, x, y },
+              },
+            });
+          }
+          if (edits.length > 0) {
+            const result = await editor.edit(edits, "Layout graph");
+            if (!result.success) {
+              return { success: false, error: result.error };
+            }
+          }
+          return { success: true };
+        }
+
+        case "updateGraphProperties": {
+          const { title, description, themeIntent } = transform;
+          let metadata: GraphMetadata | undefined;
+
+          if (themeIntent && themeGenerator) {
+            const rawGraph = editor.raw();
+            const promptTitle = title ?? rawGraph.title ?? "Application";
+            const promptDesc = description ?? rawGraph.description ?? "";
+
+            const appThemeResult = await themeGenerator({
+              title: promptTitle,
+              description: promptDesc,
+              userInstruction: themeIntent,
+              signal: options?.signal,
+            });
+
+            const errPayload = appThemeResult as Record<string, unknown>;
+            if (
+              errPayload &&
+              typeof errPayload === "object" &&
+              "$error" in errPayload &&
+              typeof errPayload.$error === "string"
+            ) {
+              return {
+                success: false,
+                error: `Theme generation failed: ${errPayload.$error}`,
+              };
+            }
+
+            metadata = editor.raw().metadata ?? {};
+            metadata.visual ??= {};
+            metadata.visual.presentation ??= {};
+            metadata.visual.presentation.themes ??= {};
+
+            const id = globalThis.crypto.randomUUID();
+            const themes = metadata.visual.presentation.themes as Record<string, unknown>;
+            themes[id] = appThemeResult;
+            metadata.visual.presentation.theme = id;
+
+            if (options?.onThemeUpdated) {
+              options.onThemeUpdated(metadata);
+            }
+          }
+
+          const result = await editor.edit(
+            [
+              {
+                type: "changegraphmetadata",
+                title: title ?? undefined,
+                description: description ?? undefined,
+                metadata,
+                graphId: "",
+              },
+            ],
+            "Updating graph properties"
+          );
+
+          if (!result.success) {
+            return { success: false, error: result.error };
+          }
+          return { success: true };
+        }
+
+        default: {
+          const kind = (transform as { kind: string }).kind ?? "unknown";
+          return {
+            success: false,
+            error: `Unsupported transform kind: ${kind}`,
+          };
+        }
+      }
+    }
+
+    return { success: false, error: "Invalid applyEdits payload" };
+  }
+}

--- a/packages/visual-editor/src/a2/agent/graph-editing/main.ts
+++ b/packages/visual-editor/src/a2/agent/graph-editing/main.ts
@@ -28,9 +28,9 @@ async function invokeGraphEditingAgent(
   objective: LLMContent,
   moduleArgs: A2ModuleArgs,
   sink: AgentEventSink,
+  translator: EditingAgentPidginTranslator,
   hooks?: LoopHooks
 ): Promise<Outcome<AgentResult>> {
-  const translator = new EditingAgentPidginTranslator();
   const functionGroups = buildGraphEditingFunctionGroups({
     sink,
     translator,

--- a/packages/visual-editor/src/sca/actions/agent/graph-editing-agent-actions.ts
+++ b/packages/visual-editor/src/sca/actions/agent/graph-editing-agent-actions.ts
@@ -15,10 +15,7 @@
  */
 
 import type {
-  GraphMetadata,
   LLMContent,
-  NodeConfiguration,
-  NodeMetadata,
 } from "@breadboard-ai/types";
 import { generateImage, persistTheme } from "../theme/theme-utils.js";
 import { createThemeGenerationPrompt } from "../../../ui/prompts/theme-generation.js";
@@ -35,9 +32,7 @@ import type { AgentRunHandle } from "../../../a2/agent/agent-service.js";
 import type { LocalAgentRun } from "../../../a2/agent/local-agent-run.js";
 import type { A2ModuleFactory } from "../../../a2/runnable-module-factory.js";
 import type { ChatResponse } from "../../../a2/agent/types.js";
-import { UpdateNode } from "../../../ui/transforms/update-node.js";
-import { layoutGraph } from "../../../a2/agent/graph-editing/layout-graph.js";
-import type { InPort } from "../../../ui/transforms/autowire-in-ports.js";
+import { GraphEditingManager, GraphThemeGenerator } from "../../../a2/agent/graph-editing/graph-editing-manager.js";
 import type { ChatEntry } from "../../types.js";
 
 export { bind, startGraphEditingAgent, resolveGraphEditingInput };
@@ -95,10 +90,10 @@ function startGraphEditingAgent(firstMessage: string): void {
   currentRun = handle;
 
   const devtools = controller.editor.devtools?.opie;
+  const translator = new EditingAgentPidginTranslator();
 
   if (devtools) {
     devtools.clearLog();
-    const translator = new EditingAgentPidginTranslator();
     const functionGroups = buildGraphEditingFunctionGroups({
       sink: handle.sink,
       translator,
@@ -174,138 +169,57 @@ function startGraphEditingAgent(firstMessage: string): void {
       return { success: false, error: "No active graph to edit" };
     }
 
-    if (event.edits) {
-      // Raw EditSpec[] — apply directly
-      const result = await editor.edit(event.edits, event.label);
-      if (!result.success) {
-        return { success: false, error: "Failed to apply edits" };
+    const themeGenerator: GraphThemeGenerator = async (ctx) => {
+      const appTheme = await generateImage(
+        createThemeGenerationPrompt({
+          random: false,
+          title: ctx.title,
+          description: ctx.description,
+          userInstruction: ctx.userInstruction,
+        }),
+        ctx.signal || handle.signal,
+        controller,
+        services
+      );
+
+      if (!ok(appTheme)) {
+        return appTheme;
       }
-      const isPositioning =
-        (event.label && event.label.startsWith("Position")) ||
-        (event.edits.length > 0 &&
-          event.edits.every(
-            (e) => e.type === "changemetadata" || e.type === "changeassetmetadata"
-          ));
-      if (isPositioning) {
-        controller.editor.canvas.requestFitToView();
-      }
-      return { success: true };
+
+      const graphThemeResult = await persistTheme(
+        appTheme,
+        controller,
+        services
+      );
+
+      return graphThemeResult;
+    };
+
+    const manager = new GraphEditingManager(editor, themeGenerator);
+    const result = await manager.applyEdits(event, {
+      signal: handle.signal,
+      onNodeConfigChanged: (ctx) => {
+        controller.editor.graph.lastNodeConfigChange = ctx;
+      },
+      onThemeUpdated: () => {
+        controller.editor.theme.updateHash(controller.editor.graph.graph);
+      },
+    });
+
+    const isPositioning =
+      (event.label && event.label.startsWith("Position")) ||
+      (event.edits &&
+        event.edits.length > 0 &&
+        event.edits.every(
+          (e) => e.type === "changemetadata" || e.type === "changeassetmetadata"
+        )) ||
+      (event.transform && event.transform.kind === "layoutGraph");
+
+    if (result.success && isPositioning) {
+      controller.editor.canvas.requestFitToView();
     }
 
-    if (event.transform) {
-      // Transform descriptor — instantiate and apply
-      const { transform } = event;
-      switch (transform.kind) {
-        case "updateNode": {
-          const t = new UpdateNode(
-            transform.nodeId,
-            transform.graphId,
-            transform.configuration as NodeConfiguration | null,
-            transform.metadata as NodeMetadata | null,
-            transform.portsToAutowire as InPort[] | null
-          );
-          const result = await editor.apply(t);
-
-          // Side effect: trigger autoname if config changed
-          if (transform.configuration) {
-            controller.editor.graph.lastNodeConfigChange = {
-              nodeId: transform.nodeId,
-              graphId: transform.graphId,
-              configuration: transform.configuration as NodeConfiguration,
-              titleUserModified: t.titleUserModified,
-            };
-          }
-
-          if (!result.success) {
-            return { success: false, error: result.error };
-          }
-          return { success: true };
-        }
-        case "layoutGraph": {
-          const graph = editor.raw();
-          await layoutGraph(graph.nodes ?? [], graph.edges ?? []);
-          controller.editor.canvas.requestFitToView();
-          return { success: true };
-        }
-        case "updateGraphProperties": {
-          const { title, description, themeIntent } = transform;
-
-          let metadata: GraphMetadata | undefined;
-
-          if (themeIntent) {
-            const rawGraph = editor.raw();
-            const promptTitle = title ?? rawGraph.title;
-            const promptDesc = description ?? rawGraph.description;
-
-            const appTheme = await generateImage(
-              createThemeGenerationPrompt({
-                random: false,
-                title: promptTitle || "Application",
-                description: promptDesc,
-                userInstruction: themeIntent,
-              }),
-
-              handle.signal,
-              controller,
-              services
-            );
-
-            if (!ok(appTheme)) {
-              return {
-                success: false,
-                error: `Theme generation failed: ${appTheme.$error}`,
-              };
-            }
-
-            const graphThemeResult = await persistTheme(
-              appTheme,
-              controller,
-              services
-            );
-
-            if (!ok(graphThemeResult)) {
-              return {
-                success: false,
-                error: `Failed to persist theme: ${graphThemeResult.$error}`,
-              };
-            }
-
-            metadata = editor.raw().metadata ?? {};
-            metadata.visual ??= {};
-            metadata.visual.presentation ??= {};
-            metadata.visual.presentation.themes ??= {};
-
-            const id = globalThis.crypto.randomUUID();
-            metadata.visual.presentation.themes[id] = graphThemeResult;
-            metadata.visual.presentation.theme = id;
-          }
-
-          const result = await editor.edit(
-            [
-              {
-                type: "changegraphmetadata",
-                title: title ?? undefined,
-                description: description ?? undefined,
-                metadata,
-                graphId: "",
-              },
-            ],
-            "Updating graph properties"
-          );
-
-          if (themeIntent) {
-            controller.editor.theme.updateHash(controller.editor.graph.graph);
-          }
-
-          if (!result.success) {
-            return { success: false, error: result.error };
-          }
-          return { success: true };
-        }
-      }
-    }
-
-    return { success: false, error: "Invalid applyEdits event" };
+    return result;
   });
 
   const context = {
@@ -316,7 +230,7 @@ function startGraphEditingAgent(firstMessage: string): void {
 
   const moduleArgs = factory.createModuleArgs(context);
 
-  invokeGraphEditingAgent(objective, moduleArgs, handle.sink, hooks)
+  invokeGraphEditingAgent(objective, moduleArgs, handle.sink, translator, hooks)
     .then((result) => {
       agent.loopRunning = false;
       agent.processing = false;

--- a/packages/visual-editor/tests/a2/agent/graph-editing/graph-editing-manager.test.ts
+++ b/packages/visual-editor/tests/a2/agent/graph-editing/graph-editing-manager.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from "node:assert";
+import { GENERATE_COMPONENT_URL } from "../../../../src/a2/agent/graph-editing/constants.js";
+import { describe, it } from "node:test";
+import type { GraphDescriptor } from "@breadboard-ai/types";
+import { HeadlessGraphEditor } from "../../../../eval/headless-graph-editor.js";
+import { GraphEditingManager } from "../../../../src/a2/agent/graph-editing/graph-editing-manager.js";
+
+describe("GraphEditingManager", () => {
+  it("executes addnode and addedge edit specs perfectly", async () => {
+    const graph: GraphDescriptor = {
+      nodes: [],
+      edges: [],
+    };
+
+    const editor = HeadlessGraphEditor.create(graph);
+    const manager = new GraphEditingManager(editor);
+
+    const result = await manager.applyEdits({
+      edits: [
+        {
+          type: "addnode",
+          graphId: "",
+          node: {
+            id: "node-1",
+            type: GENERATE_COMPONENT_URL,
+          },
+        },
+        {
+          type: "addnode",
+          graphId: "",
+          node: {
+            id: "node-2",
+            type: GENERATE_COMPONENT_URL,
+          },
+        },
+      ],
+      label: "Add steps",
+    });
+
+    if (!result.success) {
+      console.log("MUTATION ERROR:", result.error);
+    }
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(editor.raw().nodes?.length, 2);
+
+    const edgeResult = await manager.applyEdits({
+      edits: [
+        {
+          type: "addedge",
+          graphId: "",
+          edge: {
+            from: "node-1",
+            to: "node-2",
+            out: "text",
+            in: "p-z-node-1",
+          },
+        },
+      ],
+      label: "Wire steps",
+    });
+
+    assert.strictEqual(edgeResult.success, true);
+    assert.strictEqual(editor.raw().edges?.length, 1);
+    assert.strictEqual(editor.raw().edges?.[0].from, "node-1");
+  });
+});


### PR DESCRIPTION
## What
Introduces `GraphEditingManager` to encapsulate and centralize policy-driven Graph Editing operations, removing direct dependencies on local UI/SCA environments from the eval system and production orchestration. Unifies the `applyEdits` logic in both production action handlers and evaluation run environments.

## Why
Decouples mutation policy orchestration from the Lit context and runtime-dependent action handlers, providing a consistent operational base for editing graphs headless during evaluation and in production workflows.

## Changes
- **visual-editor**:
  - Implemented `GraphEditingManager` covering `edit` specs, `updateNode` transforms, `layoutGraph`, and `updateGraphProperties` including theme generation.
  - Refactored `graph-editing-agent-actions.ts` to utilize `GraphEditingManager` for the `applyEdits` bridge.
  - Updated `graph-editing-eval.ts` to use `GraphEditingManager` paired with the newly introduced `HeadlessGraphEditor`, eliminating complex legacy local graph-mutation logic.
  - Promoted `EditingAgentPidginTranslator` instantiation to the `startGraphEditingAgent` orchestration level and evaluation runs.

## Testing
Verified with `npm run eval:graph-editing:batch -w packages/visual-editor`.
