### PR TITLE
[eval] Eval Sidecar and Viewer

### DIFF
--- a/packages/visual-editor/eval/graph-editing-eval.ts
+++ b/packages/visual-editor/eval/graph-editing-eval.ts
@@ -160,6 +160,14 @@ class GraphEditingEvalHarness {
         }
       }
 
+      await ensureDir(OUT_DIR);
+      const filename = `${toKebabFilename(this.args.name)}-${toKebabFilename(evalName)}-${timestamp()}`;
+      const harFilename = `${filename}.har`;
+      const logFilename = `${filename}.log.json`;
+      const graphFilename = `${filename}.bgl.json`;
+      const raterFilename = `${filename}.rater.json`;
+      let wroteRater = false;
+
       let score = "SKIPPED";
       let explanation = "";
       let translatedIntent = "";
@@ -167,6 +175,7 @@ class GraphEditingEvalHarness {
       const csvEntry = batchRowMap.get(evalName);
 
       if (isCSVBatch && csvEntry) {
+        let raterOutput: unknown = null;
         try {
           console.log(`[Eval] Evaluating "${evalName}" with gemini-3.5-flash...`);
           const evalResponseSchema: GeminiSchema = {
@@ -270,15 +279,19 @@ class GraphEditingEvalHarness {
             if (typeof evalOutcome === "string") {
               try {
                 parsed = JSON.parse(evalOutcome);
+                raterOutput = parsed;
               } catch {
-                // Ignore parse error.
+                raterOutput = { raw_text: evalOutcome, error: "JSON Parse Failed" };
               }
             } else if (firstPart && typeof firstPart === "object" && "text" in firstPart && typeof firstPart.text === "string") {
               try {
                 parsed = JSON.parse(firstPart.text);
+                raterOutput = parsed;
               } catch {
-                // Ignore parse error.
+                raterOutput = { raw_text: firstPart.text, error: "JSON Parse Failed" };
               }
+            } else {
+              raterOutput = { api_response: evalOutcome, error: "No candidates or text parts in response" };
             }
             
             translatedIntent = parsed?.translated_intent || csvEntry.intent;
@@ -289,11 +302,33 @@ class GraphEditingEvalHarness {
             console.error("[Eval] Gemini evaluation API failed:", errPayload?.$error || "Unknown Error");
             score = "EVAL API ERROR";
             explanation = errPayload?.$error || "Unknown Error";
+            raterOutput = {
+              error: "Gemini evaluation API failed",
+              details: errPayload?.$error || evalOutcome,
+            };
           }
         } catch (e) {
           console.error("[Eval] Exception during Gemini evaluation:", (e as Error).message);
           score = "EVAL EXCEPTION";
           explanation = (e as Error).message;
+          raterOutput = {
+            error: "Exception during Gemini evaluation",
+            details: (e as Error).message,
+          };
+        }
+
+        if (raterOutput) {
+          try {
+            console.log(`[Eval] Writing rater output to "${raterFilename}"...`);
+            await writeFile(
+              join(OUT_DIR, raterFilename),
+              JSON.stringify(raterOutput, null, 2),
+              "utf-8"
+            );
+            wroteRater = true;
+          } catch (writeErr) {
+            console.error("[Eval] Failed to write rater output file:", (writeErr as Error).message);
+          }
         }
 
         batchCSVRows.push({
@@ -307,12 +342,6 @@ class GraphEditingEvalHarness {
       }
 
       const har = run.requestLogger.getHar();
-      await ensureDir(OUT_DIR);
-      const filename = `${toKebabFilename(this.args.name)}-${toKebabFilename(evalName)}-${timestamp()}`;
-      const harFilename = `${filename}.har`;
-      const logFilename = `${filename}.log.json`;
-      const graphFilename = `${filename}.bgl.json`;
-
       await writeFile(
         join(OUT_DIR, `${harFilename}`),
         JSON.stringify(har, null, 2),
@@ -383,6 +412,9 @@ class GraphEditingEvalHarness {
       console.log(`HAR: "${harFilename}"`);
       console.log(`Log: "${logFilename}"`);
       console.log(`Graph: "${graphFilename}"`);
+      if (wroteRater) {
+        console.log(`Rater Output: "${raterFilename}"`);
+      }
       if (driveUrl) {
         console.log(`Drive URL: \x1b[36m${driveUrl}\x1b[0m`);
       }

--- a/packages/visual-editor/eval/viewer/src/filesystem.ts
+++ b/packages/visual-editor/eval/viewer/src/filesystem.ts
@@ -234,14 +234,37 @@ export class FileSystemEvalBackend {
 
     try {
       const queryEntries: ParsedFileMedata[] = [];
+      const raterMap = new Map<string, string>();
+
+      try {
+        for await (const [name, descriptor] of handle.entries()) {
+          if (name.endsWith(".rater.json") && descriptor.kind === "file") {
+            try {
+              const fileBlob = await (descriptor as FileSystemFileHandle).getFile();
+              const text = await fileBlob.text();
+              const parsed = JSON.parse(text);
+              const judgement = parsed?.overall_judgement || (parsed?.error ? 'FAIL' : 'UNKNOWN');
+              const baseName = name.replace(/\.rater\.json$/, "");
+              raterMap.set(baseName, judgement);
+            } catch {
+              // Ignore failure.
+            }
+          }
+        }
+      } catch {
+        // Ignore listing failure.
+      }
+
       for await (const [name] of handle.entries()) {
-        if (!name.endsWith(".json")) {
+        if (!name.endsWith(".log.json")) {
           continue;
         }
 
         const fullPath = this.#getFullFilePath(path, name);
         const parsed = parseFileName(fullPath);
         if (parsed) {
+          const baseName = name.replace(/\.log\.json$/, "");
+          parsed.judgement = raterMap.get(baseName);
           queryEntries.push(parsed);
         }
       }

--- a/packages/visual-editor/eval/viewer/src/inspector.ts
+++ b/packages/visual-editor/eval/viewer/src/inspector.ts
@@ -73,6 +73,9 @@ export class A2UIEvalInspector extends SignalWatcher(LitElement) {
   @state()
   accessor bgl: GraphDescriptor | null = null;
 
+  @state()
+  accessor rater: unknown = null;
+
   @property()
   accessor selectedPath: FileSystemEvalBackendHandle | null = null;
 
@@ -682,6 +685,7 @@ export class A2UIEvalInspector extends SignalWatcher(LitElement) {
         this.contexts = [];
         this.outcome = null;
         this.bgl = null;
+        this.rater = null;
       }
       this.#updateUrl();
     }
@@ -731,6 +735,18 @@ export class A2UIEvalInspector extends SignalWatcher(LitElement) {
       } else {
         this.bgl = null;
       }
+
+      const raterPath = path.replace(/\.log\.json$/, ".rater.json");
+      const raterData = await this.#fileSystem.read(raterPath as FileSystemPath);
+      if (ok(raterData)) {
+        try {
+          this.rater = JSON.parse(raterData);
+        } catch {
+          this.rater = null;
+        }
+      } else {
+        this.rater = null;
+      }
     } catch (err) {
       console.warn(err);
       this.renderMode = "messages";
@@ -763,7 +779,7 @@ export class A2UIEvalInspector extends SignalWatcher(LitElement) {
   #renderContents() {
     if (this.renderMode === "topology") {
       return html`<section id="topology" style="width: 100%; height: 100%;">
-        <bgl-viewer .graph=${this.bgl}></bgl-viewer>
+        <bgl-viewer .graph=${this.bgl} .rater=${this.rater}></bgl-viewer>
       </section>`;
     }
 
@@ -974,14 +990,31 @@ export class A2UIEvalInspector extends SignalWatcher(LitElement) {
                               this.selectedFile = f;
                               this.selectedFilePath = f.path;
                             }}
+                            style="display: flex; align-items: center; justify-content: space-between; width: 100%;"
                           >
-                            ${f.date.toLocaleString(
-                              Intl.DateTimeFormat().resolvedOptions().locale,
-                              {
-                                dateStyle: "short",
-                                timeStyle: "medium",
-                              }
-                            )}
+                            <span style="flex-grow: 1; text-align: left;">
+                              ${f.date.toLocaleString(
+                                Intl.DateTimeFormat().resolvedOptions().locale,
+                                {
+                                  dateStyle: "short",
+                                  timeStyle: "medium",
+                                }
+                              )}
+                            </span>
+                            ${f.judgement ? (() => {
+                              const judgement = f.judgement;
+                              const isPass = judgement === 'PASS';
+                              const isPartial = judgement === 'PARTIAL';
+                              const isFail = judgement === 'FAIL';
+                              const color = isPass ? '#34a853' : (isPartial ? '#fbbc04' : (isFail ? '#ea4335' : 'transparent'));
+                              const icon = isPass ? 'check_circle' : (isPartial ? 'warning' : (isFail ? 'cancel' : ''));
+                              if (!icon) return nothing;
+                              return html`<span 
+                                class="g-icon filled round" 
+                                style="color: ${color}; font-size: 16px; margin-left: 8px; flex-shrink: 0;"
+                                title="Evaluation Judgement: ${judgement}"
+                              >${icon}</span>`;
+                            })() : nothing}
                           </button>
                         </li>`;
                       })}

--- a/packages/visual-editor/eval/viewer/src/parse-file-name.ts
+++ b/packages/visual-editor/eval/viewer/src/parse-file-name.ts
@@ -11,6 +11,7 @@ export type ParsedFileMedata = {
   type: string;
   name: string;
   date: Date;
+  judgement?: string;
 };
 
 export type GroupedByName = {

--- a/packages/visual-editor/eval/viewer/src/ui/bgl-viewer.ts
+++ b/packages/visual-editor/eval/viewer/src/ui/bgl-viewer.ts
@@ -89,6 +89,9 @@ class BGLViewer extends LitElement {
   @property()
   accessor graph: GraphDescriptor | null = null;
 
+  @property()
+  accessor rater: Record<string, unknown> | null = null;
+
   @provide({ context: scaContext })
   accessor sca: any = {
     controller: {
@@ -134,6 +137,7 @@ class BGLViewer extends LitElement {
   accessor #selectedNode: any = null;
 
   #dialogRef: Ref<HTMLDialogElement> = createRef();
+  #raterDialogRef: Ref<HTMLDialogElement> = createRef();
 
   static styles = [
     icons,
@@ -162,9 +166,13 @@ class BGLViewer extends LitElement {
       position: absolute;
       top: var(--bb-grid-size-5);
       left: var(--bb-grid-size-6);
-      z-index: 5;
+      right: var(--bb-grid-size-6);
+      z-index: 10;
       pointer-events: none;
-      max-width: 600px;
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: var(--bb-grid-size-4);
 
       h1 {
         margin: 0 0 var(--bb-grid-size) 0;
@@ -181,6 +189,67 @@ class BGLViewer extends LitElement {
       }
     }
 
+    #rater-indicator {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: var(--bb-grid-size-2);
+      background: var(--light-dark-n-100);
+      padding: var(--bb-grid-size-3) var(--bb-grid-size-4);
+      border-radius: var(--bb-grid-size-4);
+      border: 1px solid var(--border-color);
+      box-shadow: 0 4px 12px oklch(from var(--light-dark-n-10) l c h / 0.1);
+      font-size: 13px;
+      font-weight: 500;
+      color: var(--light-dark-n-0);
+      flex-shrink: 0;
+
+      .status-row {
+        display: flex;
+        align-items: center;
+        gap: var(--bb-grid-size-2);
+        margin-bottom: var(--bb-grid-size);
+      }
+
+      .status-dot {
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
+        flex-shrink: 0;
+
+        &.pass { background: #34a853; }
+        &.fail { background: #ea4335; }
+        &.partial { background: #fbbc04; }
+        &.unknown { background: #9aa0a6; }
+      }
+
+      button {
+        background: var(--light-dark-n-95);
+        color: var(--light-dark-n-10);
+        border: 1px solid var(--border-color);
+        padding: var(--bb-grid-size-2) var(--bb-grid-size-3);
+        border-radius: var(--bb-grid-size-2);
+        cursor: pointer;
+        font-size: 11px;
+        font-weight: 500;
+        transition: background 0.2s, color 0.2s;
+        pointer-events: auto;
+        width: 100%;
+        text-align: center;
+
+        &:hover {
+          background: var(--light-dark-n-90);
+          color: var(--light-dark-n-0);
+        }
+      }
+    }
+
+    dialog[open] {
+      display: flex;
+      flex-direction: column;
+      max-height: 85vh;
+    }
+
     dialog {
       border: none;
       border-radius: var(--bb-grid-size-4);
@@ -190,8 +259,6 @@ class BGLViewer extends LitElement {
       box-shadow: 0 16px 48px oklch(from var(--light-dark-n-10) l c h / 0.3);
       max-width: 720px;
       width: 85vw;
-      max-height: 85vh;
-      overflow: hidden;
       font-family: var(--font-family);
 
       &::backdrop {
@@ -203,7 +270,9 @@ class BGLViewer extends LitElement {
         margin: 0;
         display: flex;
         flex-direction: column;
-        height: 100%;
+        flex-grow: 1;
+        min-height: 0;
+        overflow: hidden;
       }
 
       #dialog-header {
@@ -241,6 +310,51 @@ class BGLViewer extends LitElement {
       #dialog-body {
         overflow-y: auto;
         flex-grow: 1;
+        min-height: 0;
+
+        .dimensions-table {
+          width: 100%;
+          border-collapse: collapse;
+          margin-top: var(--bb-grid-size-2);
+          font-size: 13px;
+          line-height: 1.5;
+          color: var(--light-dark-n-10);
+          background: var(--light-dark-n-98);
+          border-radius: var(--bb-grid-size-2);
+          overflow: hidden;
+
+          th {
+            background: var(--light-dark-n-90);
+            color: var(--light-dark-n-0);
+            text-align: left;
+            font-weight: 600;
+            padding: var(--bb-grid-size-3) var(--bb-grid-size-4);
+            text-transform: uppercase;
+            font-size: 11px;
+            letter-spacing: 0.5px;
+          }
+
+          td {
+            border-bottom: 1px solid var(--border-color);
+            padding: var(--bb-grid-size-3) var(--bb-grid-size-4);
+            vertical-align: top;
+
+            &:first-child {
+              color: var(--light-dark-n-0);
+              white-space: nowrap;
+            }
+
+            &.score-cell {
+              font-weight: 600;
+              white-space: nowrap;
+              color: var(--light-dark-n-0);
+            }
+          }
+
+          tr:last-child td {
+            border-bottom: none;
+          }
+        }
 
         pre {
           background: var(--light-dark-n-95);
@@ -606,6 +720,68 @@ class BGLViewer extends LitElement {
     </dialog>`;
   }
 
+  #showRaterModal() {
+    this.requestUpdate();
+    requestAnimationFrame(() => {
+      this.#raterDialogRef.value?.showModal();
+    });
+  }
+
+  #renderRaterModal() {
+    if (!this.rater) {
+      return nothing;
+    }
+
+    const title = "Evaluation Results";
+
+    return html`<dialog ${ref(this.#raterDialogRef)}>
+      <form method="dialog">
+        <div id="dialog-header">
+          <h2>${title}</h2>
+          <button type="submit" aria-label="Close">
+            <span class="g-icon filled round">close</span>
+          </button>
+        </div>
+        <div id="dialog-body">
+          ${Object.entries(this.rater || {}).map(([key, value]) => {
+            if (key === "dimensions" && typeof value === "object" && value !== null) {
+              return html`<div class="config-item">
+                <h3>Dimensions</h3>
+                <table class="dimensions-table">
+                  <thead>
+                    <tr>
+                      <th>Category</th>
+                      <th>Score</th>
+                      <th>Rationale</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    ${Object.entries(value).map(([dimKey, dimVal]: [string, any]) => {
+                      const category = dimKey.replace(/_/g, " ").replace(/^./, (str) => str.toUpperCase());
+                      const score = dimVal?.score ?? "-";
+                      const rationale = dimVal?.rationale ?? "";
+                      return html`<tr>
+                        <td><strong>${category}</strong></td>
+                        <td class="score-cell">${score}/5</td>
+                        <td>${rationale}</td>
+                      </tr>`;
+                    })}
+                  </tbody>
+                </table>
+              </div>`;
+            }
+            
+            const formattedValue = typeof value === "object" ? JSON.stringify(value, null, 2) : String(value);
+            return html`<div class="config-item">
+              <h3>${key.replace(/_/g, " ").replace(/^./, (str) => str.toUpperCase())}</h3>
+              <pre>${formattedValue}</pre>
+            </div>`;
+          })}
+        </div>
+      </form>
+    </dialog>`;
+  }
+
   render() {
     if (!this.#graphComponent) {
       return html`<div
@@ -618,9 +794,22 @@ class BGLViewer extends LitElement {
     const title = this.graph?.title || "Untitled Topology";
     const description = this.graph?.description || "";
 
-    return html`<div id="bgl-header">
-        <h1>${title}</h1>
-        ${description ? html`<p>${description}</p>` : nothing}
+    const judgement = ((this.rater as any)?.overall_judgement || ((this.rater as any)?.error ? 'FAIL' : 'UNKNOWN')) as string;
+    const statusClass = judgement.toLowerCase();
+
+    return html`
+      <div id="bgl-header">
+        <div style="max-width: calc(100% - 220px);">
+          <h1>${title}</h1>
+          ${description ? html`<p>${description}</p>` : nothing}
+        </div>
+        ${this.rater ? html`<div id="rater-indicator" style="pointer-events: auto;">
+          <div class="status-row">
+            <div class="status-dot ${statusClass}"></div>
+            <span>Eval: ${judgement}</span>
+          </div>
+          <button @click=${() => this.#showRaterModal()}>Show Details</button>
+        </div>` : nothing}
       </div>
       <div
         id="container"
@@ -641,6 +830,7 @@ class BGLViewer extends LitElement {
       >
         ${this.#graphComponent}
       </div>
-      ${this.#renderModal()}`;
+      ${this.#renderModal()}
+      ${this.#renderRaterModal()}`;
   }
 }


### PR DESCRIPTION
## What
Adds a sidecar file mechanism to capture detailed `gemini-3.5-flash` powered evaluator outputs (`*.rater.json`), alongside comprehensive, delight-focused autodetection and visual status badging for the Eval Inspector Viewer UI.

## Why
Enables developers to inspect batch evaluation performance, category-specific scoring, and rationale rationalizations efficiently within their native BGL topology and sidebar navigation contexts.

## Changes
- **packages/visual-editor/eval/graph-editing-eval.ts**: Programmed an immediate sidecar write mechanism capturing full evaluation, API error, and exception details to `*.rater.json` files during batch runs.
- **packages/visual-editor/eval/viewer/src/filesystem.ts**: Upgraded directory walking to proactively collect, parse, and attach rater evaluation judgements to the hierarchy file mapping.
- **packages/visual-editor/eval/viewer/src/parse-file-name.ts**: Augmented the file metadata schemas to incorporate evaluation judgements.
- **packages/visual-editor/eval/viewer/src/inspector.ts**: Implemented sidecar autodetection loading and left sidebar file list badging with color-coded evaluation statuses.
- **packages/visual-editor/eval/viewer/src/ui/bgl-viewer.ts**: Created a portrait, flex-anchored evaluation status indicator for the BGL Topology view, alongside an inner-scrollable details modal mapping evaluation metrics into clean, delight-focused HTML tables.

## Testing
1. Run a batch graph editing evaluation (`npm run eval:graph-editing:batch -w packages/visual-editor`).
2. Boot the Eval Inspector viewer and mount the `out/` directory.
3. Observe color-coded pass/fail icons in the left sidebar hierarchy, click a file to view BGL topology, and click "Show Details" on the indicator widget to inspect metric tables.
