### PR TITLE
[eval] High-Fidelity Agent Session Transcript Sidecar Extraction and Viewer Visualization

### DIFF
--- a/packages/visual-editor/eval/graph-editing-eval.ts
+++ b/packages/visual-editor/eval/graph-editing-eval.ts
@@ -9,6 +9,7 @@ import { mock } from "node:test";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 import { A2ModuleArgs } from "../src/a2/runnable-module-factory.js";
+import { buildHooksFromSink } from "../src/a2/agent/loop-setup.js";
 import { AgentContext } from "../src/a2/agent/agent-context.js";
 import { McpClientManager } from "../src/mcp/index.js";
 import { autoClearingInterval } from "./auto-clearing-interval.js";
@@ -48,6 +49,18 @@ export { graphEditingSession };
 const MODULE_DIR = dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = join(MODULE_DIR, "..", "..", "..");
 const OUT_DIR = join(ROOT_DIR, "out");
+
+type TranscriptEvent =
+  | { type: "objective"; text: string }
+  | { type: "thought"; text: string }
+  | { type: "functionCall"; name: string; args: Record<string, unknown>; callId: string }
+  | { type: "functionResponse"; callId: string; parts: unknown[] }
+  | { type: "usageMetadata"; metadata: unknown };
+
+interface TranscriptTurn {
+  turn: number;
+  events: TranscriptEvent[];
+}
 
 export type GraphEditingEvalHarnessRuntimeArgs = {
   invokeAgent: (prompt: string) => Promise<{
@@ -166,6 +179,7 @@ class GraphEditingEvalHarness {
       const logFilename = `${filename}.log.json`;
       const graphFilename = `${filename}.bgl.json`;
       const raterFilename = `${filename}.rater.json`;
+      const transcriptFilename = `${filename}.transcript.jsonl`;
       let wroteRater = false;
 
       let score = "SKIPPED";
@@ -366,6 +380,18 @@ class GraphEditingEvalHarness {
         "utf-8"
       );
 
+      if (run.transcriptTurns && run.transcriptTurns.length > 0) {
+        console.log(`[Eval] Writing transcript to "${transcriptFilename}"...`);
+        const jsonlContent = run.transcriptTurns
+          .map((turn) => JSON.stringify(turn))
+          .join("\n");
+        await writeFile(
+          join(OUT_DIR, transcriptFilename),
+          jsonlContent,
+          "utf-8"
+        );
+      }
+
       let driveUrl: string | undefined = undefined;
 
       if (this.args.uploadToDrive) {
@@ -416,6 +442,9 @@ class GraphEditingEvalHarness {
       console.log(`HAR: "${harFilename}"`);
       console.log(`Log: "${logFilename}"`);
       console.log(`Graph: "${graphFilename}"`);
+      if (run.transcriptTurns && run.transcriptTurns.length > 0) {
+        console.log(`Transcript: "${transcriptFilename}"`);
+      }
       if (wroteRater) {
         console.log(`Rater Output: "${raterFilename}"`);
       }
@@ -699,6 +728,7 @@ class GraphEditingEvalRun implements EvalLogger {
   };
 
   lastMessage: string = "";
+  readonly transcriptTurns: TranscriptTurn[] = [];
   private readonly translator = new EditingAgentPidginTranslator();
 
   constructor(
@@ -744,6 +774,63 @@ class GraphEditingEvalRun implements EvalLogger {
   }> {
     const consumer = new AgentEventConsumer();
     const sink = new LocalAgentEventBridge(consumer);
+
+    const hooks = buildHooksFromSink(sink);
+
+    let currentTurn: TranscriptTurn = {
+      turn: 1,
+      events: [],
+    };
+
+    const finalizeCurrentTurn = () => {
+      if (currentTurn.events.length > 0) {
+        this.transcriptTurns.push({ ...currentTurn });
+        currentTurn = {
+          turn: this.transcriptTurns.length + 1,
+          events: [],
+        };
+      }
+    };
+
+    consumer.on("start", (payload) => {
+      const text = payload.objective.parts
+        .filter((p): p is { text: string } => "text" in p)
+        .map((p) => p.text)
+        .join("\n");
+      currentTurn.events.push({ type: "objective", text });
+    });
+
+    consumer.on("thought", (payload) => {
+      currentTurn.events.push({ type: "thought", text: payload.text });
+    });
+
+    consumer.on("functionCall", (payload) => {
+      currentTurn.events.push({
+        type: "functionCall",
+        name: payload.name,
+        args: payload.args,
+        callId: payload.callId,
+      });
+    });
+
+    consumer.on("functionResult", (payload) => {
+      currentTurn.events.push({
+        type: "functionResponse",
+        callId: payload.callId,
+        parts: payload.content.parts as unknown[],
+      });
+    });
+
+    consumer.on("usageMetadata", (payload) => {
+      currentTurn.events.push({
+        type: "usageMetadata",
+        metadata: payload.metadata,
+      });
+    });
+
+    consumer.on("turnComplete", () => {
+      finalizeCurrentTurn();
+    });
 
     consumer.on("readGraph", () => {
       return Promise.resolve({ graph: this.graph });
@@ -870,25 +957,29 @@ class GraphEditingEvalRun implements EvalLogger {
       } satisfies OpalShellHostProtocol,
     };
 
-    const outcome = await withRetry(async () => {
-      const res = await invokeGraphEditingAgent(objective, moduleArgs, sink, this.translator);
-      return res;
-    });
+    try {
+      const outcome = await withRetry(async () => {
+        const res = await invokeGraphEditingAgent(objective, moduleArgs, sink, this.translator, hooks);
+        return res;
+      });
 
-    if (!ok(outcome)) {
-      const errPayload = outcome as unknown as { $error?: string; error?: string };
-      if (errPayload.$error === "EVAL_DONE" || errPayload.error === "EVAL_DONE") {
-        return {
-          message: this.lastMessage,
-          graph: this.graph,
-        };
+      if (!ok(outcome)) {
+        const errPayload = outcome as unknown as { $error?: string; error?: string };
+        if (errPayload.$error === "EVAL_DONE" || errPayload.error === "EVAL_DONE") {
+          return {
+            message: this.lastMessage,
+            graph: this.graph,
+          };
+        }
+        throw new Error(`Agent execution failed: ${errPayload.$error ?? errPayload.error}`);
       }
-      throw new Error(`Agent execution failed: ${errPayload.$error ?? errPayload.error}`);
-    }
 
-    return {
-      message: this.lastMessage,
-      graph: this.graph,
-    };
+      return {
+        message: this.lastMessage,
+        graph: this.graph,
+      };
+    } finally {
+      finalizeCurrentTurn();
+    }
   }
 }

--- a/packages/visual-editor/eval/viewer/src/inspector.ts
+++ b/packages/visual-editor/eval/viewer/src/inspector.ts
@@ -76,6 +76,9 @@ export class A2UIEvalInspector extends SignalWatcher(LitElement) {
   @state()
   accessor rater: unknown = null;
 
+  @state()
+  accessor transcript: unknown[] | null = null;
+
   @property()
   accessor selectedPath: FileSystemEvalBackendHandle | null = null;
 
@@ -747,6 +750,19 @@ export class A2UIEvalInspector extends SignalWatcher(LitElement) {
       } else {
         this.rater = null;
       }
+
+      const transcriptPath = path.replace(/\.log\.json$/, ".transcript.jsonl");
+      const transcriptData = await this.#fileSystem.read(transcriptPath as FileSystemPath);
+      if (ok(transcriptData) && typeof transcriptData === "string") {
+        try {
+          const lines = transcriptData.split("\n").filter((l) => l.trim().length > 0);
+          this.transcript = lines.map((l) => JSON.parse(l));
+        } catch {
+          this.transcript = null;
+        }
+      } else {
+        this.transcript = null;
+      }
     } catch (err) {
       console.warn(err);
       this.renderMode = "messages";
@@ -779,7 +795,7 @@ export class A2UIEvalInspector extends SignalWatcher(LitElement) {
   #renderContents() {
     if (this.renderMode === "topology") {
       return html`<section id="topology" style="width: 100%; height: 100%;">
-        <bgl-viewer .graph=${this.bgl} .rater=${this.rater}></bgl-viewer>
+        <bgl-viewer .graph=${this.bgl} .rater=${this.rater} .transcript=${this.transcript}></bgl-viewer>
       </section>`;
     }
 

--- a/packages/visual-editor/eval/viewer/src/ui/bgl-viewer.ts
+++ b/packages/visual-editor/eval/viewer/src/ui/bgl-viewer.ts
@@ -23,6 +23,9 @@ import { provide } from "@lit/context";
 import { scaContext } from "../../../../src/sca/context/context.js";
 import { ok } from "@breadboard-ai/utils";
 import { A2_TOOLS } from "../../../../src/a2/a2-registry.js";
+import "../../../../src/ui/elements/graph-editing-chat/opie-avatar.js";
+import "../../../../src/ui/elements/json-tree/json-tree.js";
+import { parseThought } from "../../../../src/a2/agent/thought-parser.js";
 import {
   A2_COMPONENT_MAP,
   A2_TOOL_MAP,
@@ -93,6 +96,9 @@ class BGLViewer extends LitElement {
   @property()
   accessor rater: Record<string, unknown> | null = null;
 
+  @property()
+  accessor transcript: unknown[] | null = null;
+
   @provide({ context: scaContext })
   accessor sca: any = {
     controller: {
@@ -139,6 +145,7 @@ class BGLViewer extends LitElement {
 
   #dialogRef: Ref<HTMLDialogElement> = createRef();
   #raterDialogRef: Ref<HTMLDialogElement> = createRef();
+  #transcriptDialogRef: Ref<HTMLDialogElement> = createRef();
 
   static styles = [
     icons,
@@ -809,6 +816,85 @@ class BGLViewer extends LitElement {
     </dialog>`;
   }
 
+  #showTranscriptModal() {
+    this.requestUpdate();
+    requestAnimationFrame(() => {
+      this.#transcriptDialogRef.value?.showModal();
+    });
+  }
+
+  #renderTranscriptModal() {
+    if (!this.transcript || this.transcript.length === 0) {
+      return nothing;
+    }
+
+    return html`<dialog ${ref(this.#transcriptDialogRef)}>
+      <form method="dialog">
+        <div id="dialog-header">
+          <h2>Agent Session Transcript</h2>
+          <button type="submit" aria-label="Close">
+            <span class="g-icon filled round">close</span>
+          </button>
+        </div>
+        <div id="dialog-body" style="padding: var(--bb-grid-size-4); display: flex; flex-direction: column; gap: var(--bb-grid-size-4);">
+          ${this.transcript.map((turn: any) => {
+            const eventsHtml = (turn.events || []).map((evt: any) => {
+              if (evt.type === "objective") {
+                return html`<div class="config-item" style="background: var(--light-dark-n-95); padding: var(--bb-grid-size-3); border-radius: var(--bb-grid-size-2); margin-bottom: var(--bb-grid-size-2);">
+                  <h4 style="margin: 0 0 var(--bb-grid-size-2) 0; color: var(--primary);">Objective</h4>
+                  <pre style="white-space: pre-wrap; font-family: monospace; margin: 0; font-size: 12px; color: var(--light-dark-n-20);">${evt.text}</pre>
+                </div>`;
+              }
+              if (evt.type === "thought") {
+                const parsed = parseThought(evt.text);
+                return html`<div style="border-left: 3px solid var(--primary); padding-left: var(--bb-grid-size-3); margin-bottom: var(--bb-grid-size-2);">
+                  <h4 style="margin: 0 0 var(--bb-grid-size-1) 0; color: var(--light-dark-n-40);">${parsed.title || "Thoughts"}</h4>
+                  <div style="font-style: italic; font-size: 13px; color: var(--light-dark-n-40); white-space: pre-wrap;">${parsed.body}</div>
+                </div>`;
+              }
+              if (evt.type === "functionCall") {
+                return html`<div style="background: var(--elevated-background-light); border: 1px solid var(--border-color); border-radius: var(--bb-grid-size-2); padding: var(--bb-grid-size-3); display: flex; flex-direction: column; gap: var(--bb-grid-size-2); margin-bottom: var(--bb-grid-size-2);">
+                  <div style="display: flex; align-items: center; gap: var(--bb-grid-size-2);">
+                    <strong style="font-size: 13px; color: var(--light-dark-n-10);">${evt.name}</strong>
+                    <span style="background: oklch(from var(--primary) l c h / 0.15); color: var(--primary); font-size: 10px; font-weight: 600; text-transform: uppercase; padding: 2px 6px; border-radius: 4px; border: 1px solid oklch(from var(--primary) l c h / 0.25);">call</span>
+                  </div>
+                  <bb-json-tree .json=${evt.args as any} autoExpand></bb-json-tree>
+                </div>`;
+              }
+              if (evt.type === "functionResponse") {
+                const responseData = evt.parts && evt.parts.length > 0 ? (evt.parts[0] as any)?.functionResponse?.response ?? evt.parts : {};
+                const functionName = evt.parts && evt.parts.length > 0 ? (evt.parts[0] as any)?.functionResponse?.name ?? "response" : "response";
+                return html`<div style="background: var(--elevated-background-light); border: 1px solid var(--border-color); border-radius: var(--bb-grid-size-2); padding: var(--bb-grid-size-3); display: flex; flex-direction: column; gap: var(--bb-grid-size-2); margin-bottom: var(--bb-grid-size-2);">
+                  <div style="display: flex; align-items: center; gap: var(--bb-grid-size-2);">
+                    <strong style="font-size: 13px; color: var(--light-dark-n-10);">${functionName}</strong>
+                    <span style="background: oklch(0.75 0.12 150 / 0.15); color: oklch(0.75 0.12 150); font-size: 10px; font-weight: 600; text-transform: uppercase; padding: 2px 6px; border-radius: 4px; border: 1px solid oklch(0.75 0.12 150 / 0.25);">response</span>
+                  </div>
+                  <bb-json-tree .json=${responseData as any}></bb-json-tree>
+                </div>`;
+              }
+              if (evt.type === "usageMetadata") {
+                const meta = evt.metadata || {};
+                return html`<div class="config-item" style="font-size: 11px; color: var(--light-dark-n-50); margin-top: var(--bb-grid-size-2); margin-bottom: var(--bb-grid-size-2);">
+                  <span>Tokens: Prompt: ${meta.promptTokenCount ?? '-'} | Cached: ${meta.cachedContentTokenCount ?? '-'} | Output: ${meta.candidatesTokenCount ?? '-'} | Total: ${meta.totalTokenCount ?? '-'}</span>
+                </div>`;
+              }
+              return nothing;
+            });
+
+            return html`<div class="turn-record" style="padding-bottom: var(--bb-grid-size-4); display: flex; flex-direction: column;">
+              <div style="display: flex; align-items: center; gap: var(--bb-grid-size-3); margin-bottom: var(--bb-grid-size-4); font-size: 11px; font-weight: 600; text-transform: uppercase; color: var(--light-dark-n-60); letter-spacing: 0.5px;">
+                <span>Turn ${turn.turn}</span>
+                <div style="flex-grow: 1; height: 1px; background: var(--light-dark-n-80);"></div>
+              </div>
+              ${eventsHtml}
+            </div>`;
+          })}
+        </div>
+      </form>
+    </dialog>`;
+  }
+
+
   render() {
     if (!this.#graphComponent) {
       return html`<div
@@ -856,8 +942,13 @@ class BGLViewer extends LitElement {
         }}
       >
         ${this.#graphComponent}
+        ${this.transcript && this.transcript.length > 0 ? html`<bb-opie-avatar 
+          style="position: absolute; left: var(--bb-grid-size-5); bottom: var(--bb-grid-size-5); z-index: 100;"
+          @click=${() => this.#showTranscriptModal()}
+        ></bb-opie-avatar>` : nothing}
       </div>
       ${this.#renderModal()}
-      ${this.#renderRaterModal()}`;
+      ${this.#renderRaterModal()}
+      ${this.#renderTranscriptModal()}`;
   }
 }


### PR DESCRIPTION
## What
Added support for extracting, persisting, and visually reviewing high-fidelity, interleaved agent session transcript JSON Lines (`.transcript.jsonl`) sidecar artifacts across evaluations in the Eval Inspector Viewer.

## Why
Enables developers to trace exact sequential interleaving of agent reasoning, objectives, thoughts, function calls, and function responses, rather than relying on noisy, un-interleaved HTTP/HAR pipeline collations.

## Changes
- **Evaluation Harness (`graph-editing-eval.ts`)**: Integrated `buildHooksFromSink` to map low-level agent loop hooks into a sequential `events` array in `TranscriptTurn`, outputting to `${filename}.transcript.jsonl` sidecars with resilient alpha/EVAL_DONE finally-halt triggers.
- **Eval Viewer (`A2UIEvalInspector`)**: Wired JSON Lines fetching and parsing for the transcript sidecar.
- **Visuals & Lit Templates (`BGLViewer`)**: Imported and styled a `<bb-opie-avatar>` trigger, creating an expandable dialog view with OKLCH chips, `parseThought` integration, sequential JSON trees, and subtle turn divider rows.

## Testing
Run `npm run eval:graph-editing:batch -w packages/visual-editor` to generate sidecars, and review via `npm run eval:viewer`.
