### PR TITLE
Heartstone: Server-Side Graph Execution (Pre-Phase through Phase 7)

### DIFF
--- a/packages/opal-backend/AGENT.md
+++ b/packages/opal-backend/AGENT.md
@@ -36,25 +36,29 @@ imports. Only Python stdlib + typing.
 
 All transport is injected through protocols:
 
-| Protocol           | File                   | What it abstracts                   |
-| ------------------ | ---------------------- | ----------------------------------- |
-| `BackendClient`    | `backend_client.py`    | One Platform ops + Gemini streaming |
-| `InteractionStore` | `interaction_store.py` | Suspend/resume state persistence    |
-| `EventBus`         | `event_bus.py`         | Live event delivery to SSE clients  |
+| Protocol              | File                      | What it abstracts                   |
+| --------------------- | ------------------------- | ----------------------------------- |
+| `BackendClient`       | `backend_client.py`       | One Platform ops + Gemini streaming |
+| `InteractionStore`    | `interaction_store.py`    | Suspend/resume state persistence    |
+| `EventBus`            | `event_bus.py`            | Live event delivery to SSE clients  |
+| `GraphSessionStore`   | `graph_session_store.py`  | Graph execution state coordination  |
+| `TaskScheduler`       | `task_scheduler.py`       | Node task dispatch abstraction      |
 
 Implementations live in `local/`:
 
 - `HttpBackendClient` → `local/backend_client_impl.py`
 - `InMemoryInteractionStore` → `local/interaction_store_impl.py`
 - `InMemoryEventBus` → `local/event_bus_impl.py`
+- `InMemoryGraphSessionStore` → `local/graph_session_store_impl.py`
+- `LocalTaskScheduler` → `local/task_scheduler_impl.py`
 
 ## Entry Points
 
-The public API is two async generators in `run.py`:
+The agent loop API is two async generators in `run.py`:
 
 ```python
-# Start a new run
-async for event in opal_backend.run(
+# Start a new agent run (renamed from run() in Heartstone)
+async for event in opal_backend.run_agent(
     objective=objective,
     backend=backend_client,
     store=interaction_store,
@@ -62,8 +66,8 @@ async for event in opal_backend.run(
 ):
     yield event
 
-# Resume a suspended run
-async for event in opal_backend.resume(
+# Resume a suspended agent run (renamed from resume())
+async for event in opal_backend.resume_agent(
     interaction_id=interaction_id,
     response=user_response,
     backend=backend_client,
@@ -71,6 +75,9 @@ async for event in opal_backend.resume(
 ):
     yield event
 ```
+
+> **Note:** `run` and `resume` are still available as backward-compatible
+> aliases.
 
 These create all internal state (file system, task tree, function groups, loop)
 and yield typed `AgentEvent` instances. Callers provide only what varies by

--- a/packages/opal-backend/AGENT.md
+++ b/packages/opal-backend/AGENT.md
@@ -34,17 +34,19 @@ your change. The how-to checklists below include these reminders explicitly.
 external dependencies.** No `httpx`, `fastapi`, `pydantic`, or `sse_starlette`
 imports. Only Python stdlib + typing.
 
-All transport is injected through two protocols:
+All transport is injected through protocols:
 
 | Protocol           | File                   | What it abstracts                   |
 | ------------------ | ---------------------- | ----------------------------------- |
 | `BackendClient`    | `backend_client.py`    | One Platform ops + Gemini streaming |
 | `InteractionStore` | `interaction_store.py` | Suspend/resume state persistence    |
+| `EventBus`         | `event_bus.py`         | Live event delivery to SSE clients  |
 
 Implementations live in `local/`:
 
 - `HttpBackendClient` → `local/backend_client_impl.py`
 - `InMemoryInteractionStore` → `local/interaction_store_impl.py`
+- `InMemoryEventBus` → `local/event_bus_impl.py`
 
 ## Entry Points
 

--- a/packages/opal-backend/opal_backend/__init__.py
+++ b/packages/opal-backend/opal_backend/__init__.py
@@ -1,6 +1,6 @@
 # Copyright 2026 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-from .run import run, resume
+from .run import run_agent, resume_agent, run, resume
 
-__all__ = ["run", "resume"]
+__all__ = ["run_agent", "resume_agent", "run", "resume"]

--- a/packages/opal-backend/opal_backend/dev/main.py
+++ b/packages/opal-backend/opal_backend/dev/main.py
@@ -37,10 +37,11 @@ from opal_backend.local.drive_operations_client_impl import (
 )
 
 from opal_backend.local.interaction_store_impl import InMemoryInteractionStore
+from opal_backend.local.event_bus_impl import InMemoryEventBus
 from opal_backend.sessions.in_memory_store import InMemorySessionStore
 from opal_backend.local.session_router import SessionDeps, create_session_router
 from opal_backend.sessions.api import (
-    Subscribers, new_session, register_task, start_session,
+    new_session, register_task, start_session,
     resume_session as resume_session_fn, update_context,
 )
 from opal_backend.sessions.store import SessionStatus
@@ -75,7 +76,7 @@ _interaction_store = InMemoryInteractionStore()
 
 # In-memory store for sessions (dev only).
 _session_store = InMemorySessionStore()
-_subscribers = Subscribers()
+_event_bus = InMemoryEventBus()
 _session_deps = SessionDeps(
     backend_factory=lambda token, origin: HttpBackendClient(
         upstream_base=UPSTREAM_BASE,
@@ -91,7 +92,7 @@ _session_deps = SessionDeps(
     interaction_store=_interaction_store,
 )
 _session_router = create_session_router(
-    _session_store, _subscribers, deps=_session_deps,
+    _session_store, _event_bus, deps=_session_deps,
 )
 
 
@@ -230,13 +231,13 @@ class DevAgentBackend:
         )
 
         # Subscribe BEFORE starting the loop so we don't miss events.
-        queue = _subscribers.subscribe(session_id)
+        queue = _event_bus.subscribe(session_id)
 
         task = asyncio.create_task(
             start_session(
                 session_id=session_id,
                 store=_session_store,
-                subscribers=_subscribers,
+                event_bus=_event_bus,
             ),
             name=f"shim-{session_id}",
         )
@@ -280,14 +281,14 @@ class DevAgentBackend:
         )
 
         # Subscribe BEFORE resuming.
-        queue = _subscribers.subscribe(session_id)
+        queue = _event_bus.subscribe(session_id)
 
         task = asyncio.create_task(
             resume_session_fn(
                 session_id=session_id,
                 response=response,
                 store=_session_store,
-                subscribers=_subscribers,
+                event_bus=_event_bus,
             ),
             name=f"shim-resume-{session_id}",
         )
@@ -296,18 +297,15 @@ class DevAgentBackend:
         return self._stream_queue(session_id, queue)
 
     def _stream_queue(
-        self, session_id: str, queue: asyncio.Queue,
+        self, session_id: str, queue,
     ) -> EventSourceResponse:
-        """Stream events from a subscriber queue as SSE."""
+        """Stream events from an EventBus subscription as SSE."""
         async def stream():
             try:
-                while True:
-                    item = await queue.get()
-                    if item is None:
-                        break  # Session ended.
+                async for item in queue:
                     yield {"data": json.dumps(item)}
             finally:
-                _subscribers.unsubscribe(session_id, queue)
+                _event_bus.unsubscribe(session_id, queue)
         return EventSourceResponse(content=stream())
 
 

--- a/packages/opal-backend/opal_backend/dev/main.py
+++ b/packages/opal-backend/opal_backend/dev/main.py
@@ -43,6 +43,7 @@ from opal_backend.local.graph_session_router import create_graph_session_router
 from opal_backend.local.task_scheduler_impl import LocalTaskScheduler
 from opal_backend.graph_runner import GraphRunner
 from opal_backend.run import run_agent as run_agent_fn
+from opal_backend.run import resume_agent as resume_agent_fn
 from opal_backend.sessions.in_memory_store import InMemorySessionStore
 from opal_backend.local.session_router import SessionDeps, create_session_router
 from opal_backend.sessions.api import (
@@ -113,6 +114,7 @@ _graph_runner = GraphRunner(
     backend_factory=_make_backend,
     interaction_store=_interaction_store,
     run_agent_fn=run_agent_fn,
+    resume_agent_fn=resume_agent_fn,
 )
 _graph_scheduler = LocalTaskScheduler(run_fn=_graph_runner.run_node)
 _graph_runner._scheduler = _graph_scheduler

--- a/packages/opal-backend/opal_backend/dev/main.py
+++ b/packages/opal-backend/opal_backend/dev/main.py
@@ -38,6 +38,10 @@ from opal_backend.local.drive_operations_client_impl import (
 
 from opal_backend.local.interaction_store_impl import InMemoryInteractionStore
 from opal_backend.local.event_bus_impl import InMemoryEventBus
+from opal_backend.local.graph_session_store_impl import InMemoryGraphSessionStore
+from opal_backend.local.graph_session_router import create_graph_session_router
+from opal_backend.local.task_scheduler_impl import LocalTaskScheduler
+from opal_backend.graph_runner import GraphRunner
 from opal_backend.sessions.in_memory_store import InMemorySessionStore
 from opal_backend.local.session_router import SessionDeps, create_session_router
 from opal_backend.sessions.api import (
@@ -93,6 +97,22 @@ _session_deps = SessionDeps(
 )
 _session_router = create_session_router(
     _session_store, _event_bus, deps=_session_deps,
+)
+
+# Graph session infrastructure (Heartstone).
+_graph_session_store = InMemoryGraphSessionStore()
+_graph_runner = GraphRunner(
+    store=_graph_session_store,
+    event_bus=_event_bus,
+    scheduler=None,  # Set below — circular dep.
+)
+_graph_scheduler = LocalTaskScheduler(run_fn=_graph_runner.run_node)
+_graph_runner._scheduler = _graph_scheduler
+_graph_session_router = create_graph_session_router(
+    store=_graph_session_store,
+    event_bus=_event_bus,
+    runner=_graph_runner,
+    scheduler=_graph_scheduler,
 )
 
 
@@ -541,6 +561,7 @@ router = create_api_router(
     proxy=_proxy,
     agent=_agent,
     sessions=_session_router,
+    graph_sessions=_graph_session_router,
 )
 app.include_router(router)
 

--- a/packages/opal-backend/opal_backend/dev/main.py
+++ b/packages/opal-backend/opal_backend/dev/main.py
@@ -42,6 +42,7 @@ from opal_backend.local.graph_session_store_impl import InMemoryGraphSessionStor
 from opal_backend.local.graph_session_router import create_graph_session_router
 from opal_backend.local.task_scheduler_impl import LocalTaskScheduler
 from opal_backend.graph_runner import GraphRunner
+from opal_backend.run import run_agent as run_agent_fn
 from opal_backend.sessions.in_memory_store import InMemorySessionStore
 from opal_backend.local.session_router import SessionDeps, create_session_router
 from opal_backend.sessions.api import (
@@ -74,6 +75,16 @@ UPSTREAM_BASE = os.environ.get(
 
 # Persistent HTTP client for proxying (raw httpx — proxy needs full request control).
 _proxy_client = httpx.AsyncClient(timeout=120.0)
+# Shared backend factory — used by both session and graph runners.
+def _make_backend(token: str, origin: str = "") -> HttpBackendClient:
+    return HttpBackendClient(
+        upstream_base=UPSTREAM_BASE,
+        httpx_client=httpx.AsyncClient(timeout=120.0),
+        access_token=token,
+        origin=origin,
+        gemini_key=GEMINI_KEY,
+    )
+
 
 # In-memory store for suspended interactions (dev only).
 _interaction_store = InMemoryInteractionStore()
@@ -82,13 +93,7 @@ _interaction_store = InMemoryInteractionStore()
 _session_store = InMemorySessionStore()
 _event_bus = InMemoryEventBus()
 _session_deps = SessionDeps(
-    backend_factory=lambda token, origin: HttpBackendClient(
-        upstream_base=UPSTREAM_BASE,
-        httpx_client=httpx.AsyncClient(timeout=120.0),
-        access_token=token,
-        origin=origin,
-        gemini_key=GEMINI_KEY,
-    ),
+    backend_factory=_make_backend,
     drive_factory=lambda token: HttpDriveOperationsClient(
         httpx_client=httpx.AsyncClient(timeout=120.0),
         access_token=token,
@@ -105,6 +110,9 @@ _graph_runner = GraphRunner(
     store=_graph_session_store,
     event_bus=_event_bus,
     scheduler=None,  # Set below — circular dep.
+    backend_factory=_make_backend,
+    interaction_store=_interaction_store,
+    run_agent_fn=run_agent_fn,
 )
 _graph_scheduler = LocalTaskScheduler(run_fn=_graph_runner.run_node)
 _graph_runner._scheduler = _graph_scheduler

--- a/packages/opal-backend/opal_backend/event_bus.py
+++ b/packages/opal-backend/opal_backend/event_bus.py
@@ -1,0 +1,69 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""EventBus protocol — live event delivery from background tasks to clients.
+
+Extracted from the concrete ``Subscribers`` class that was previously
+embedded in ``sessions/api.py``. This protocol enables injectable
+implementations:
+
+- ``InMemoryEventBus`` (``local/event_bus_impl.py``) — asyncio.Queue,
+  single-process. Used by the dev and fake servers.
+- Production — database change streams or pub/sub for cross-server
+  delivery.
+
+Both agent sessions and graph sessions share this protocol for live
+event delivery to SSE streams.
+"""
+
+from __future__ import annotations
+
+from typing import Any, AsyncIterator, Protocol, runtime_checkable
+
+__all__ = ["EventBus"]
+
+
+@runtime_checkable
+class EventBus(Protocol):
+    """Live event delivery from background tasks to clients.
+
+    Each session has zero or more subscribers. ``publish()`` fans out
+    events to all subscribers. ``subscribe()`` returns an async
+    iterator that yields events as they arrive. ``close()`` sends an
+    end-of-stream sentinel to all subscribers.
+
+    ``unsubscribe()`` removes a single subscription (returned by
+    ``subscribe()``) before the stream ends naturally.
+    """
+
+    def subscribe(
+        self, session_id: str,
+    ) -> AsyncIterator[dict[str, Any] | None]:
+        """Subscribe to live events for a session.
+
+        Returns an async iterator that yields event dicts. A ``None``
+        value is the end-of-stream sentinel — no more events will
+        follow for this session.
+        """
+        ...
+
+    async def publish(
+        self, session_id: str, event: dict[str, Any],
+    ) -> None:
+        """Publish an event to all subscribers of a session."""
+        ...
+
+    async def close(self, session_id: str) -> None:
+        """Signal end-of-stream to all subscribers and clean up."""
+        ...
+
+    def unsubscribe(
+        self, session_id: str, subscription: AsyncIterator[dict[str, Any] | None],
+    ) -> None:
+        """Remove a subscription before the stream ends naturally.
+
+        Called in ``finally`` blocks to clean up when clients
+        disconnect early. Safe to call after the stream has already
+        ended.
+        """
+        ...

--- a/packages/opal-backend/opal_backend/graph_condense.py
+++ b/packages/opal-backend/opal_backend/graph_condense.py
@@ -1,0 +1,258 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Graph condensation — Tarjan SCC + subgraph folding.
+
+Port of ``condense.ts`` and ``nodes-to-subgraph.ts`` from the
+visual-editor. Given a ``GraphDescriptor``, replaces every
+strongly connected component (cycle) with a single node whose
+type points at a subgraph (``#<subgraph_id>``).
+
+The subgraph contains:
+- An ``input`` node capturing incoming edge ports.
+- An ``output`` node capturing outgoing edge ports.
+- The original cycle nodes and their internal edges.
+
+After condensation the graph is guaranteed to be a DAG, suitable
+for topological sorting via ``create_plan()``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .graph_types import Edge, GraphDescriptor, NodeDescriptor
+
+__all__ = ["condense"]
+
+
+def condense(graph: GraphDescriptor) -> GraphDescriptor:
+    """Condense a graph by folding SCCs into subgraph nodes.
+
+    Returns the original graph unchanged if no cycles exist.
+    """
+    if not graph.nodes or not graph.edges:
+        return graph
+
+    sccs = _find_sccs(graph)
+    if not sccs:
+        return graph
+
+    return _create_condensed_graph(graph, sccs)
+
+
+# ---------------------------------------------------------------------------
+# Tarjan's SCC algorithm
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _TarjanState:
+    index: int
+    lowlink: int
+    on_stack: bool
+
+
+def _find_sccs(graph: GraphDescriptor) -> list[list[str]]:
+    """Find all strongly connected components using Tarjan's algorithm.
+
+    Returns only non-trivial SCCs (size > 1, or single node with
+    self-loop).
+    """
+    node_states: dict[str, _TarjanState] = {}
+    stack: list[str] = []
+    sccs: list[list[str]] = []
+    counter = [0]  # Mutable counter for nested function.
+
+    # Pre-compute adjacency.
+    successors: dict[str, list[str]] = {}
+    for edge in graph.edges:
+        successors.setdefault(edge.from_node, []).append(edge.to_node)
+
+    def strong_connect(node_id: str) -> None:
+        state = _TarjanState(
+            index=counter[0], lowlink=counter[0], on_stack=True,
+        )
+        node_states[node_id] = state
+        counter[0] += 1
+        stack.append(node_id)
+
+        for successor_id in successors.get(node_id, []):
+            successor_state = node_states.get(successor_id)
+            if successor_state is None:
+                strong_connect(successor_id)
+                updated = node_states[successor_id]
+                state.lowlink = min(state.lowlink, updated.lowlink)
+            elif successor_state.on_stack:
+                state.lowlink = min(state.lowlink, successor_state.index)
+
+        if state.lowlink == state.index:
+            scc: list[str] = []
+            while True:
+                popped = stack.pop()
+                node_states[popped].on_stack = False
+                scc.append(popped)
+                if popped == node_id:
+                    break
+            sccs.append(scc)
+
+    for node in graph.nodes:
+        if node.id not in node_states:
+            strong_connect(node.id)
+
+    # Filter trivial SCCs.
+    self_loop_nodes = {
+        e.from_node for e in graph.edges if e.from_node == e.to_node
+    }
+    return [
+        scc for scc in sccs
+        if len(scc) > 1 or scc[0] in self_loop_nodes
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Condensed graph creation
+# ---------------------------------------------------------------------------
+
+
+def _create_condensed_graph(
+    graph: GraphDescriptor, sccs: list[list[str]],
+) -> GraphDescriptor:
+    """Create a new graph with SCCs folded into subgraph nodes."""
+    condensed = GraphDescriptor(
+        nodes=list(graph.nodes),
+        edges=list(graph.edges),
+        graphs=dict(graph.graphs) if graph.graphs else {},
+        title=graph.title,
+        description=graph.description,
+    )
+
+    for i, scc in enumerate(sccs):
+        subgraph_id = f"scc_{i}"
+        _nodes_to_subgraph(
+            condensed, scc, subgraph_id,
+            title=f"SCC Subgraph {subgraph_id}",
+            description="Subgraph containing strongly connected component",
+        )
+
+    return condensed
+
+
+def _nodes_to_subgraph(
+    graph: GraphDescriptor,
+    node_group: list[str],
+    subgraph_id: str,
+    title: str | None = None,
+    description: str | None = None,
+) -> None:
+    """Move a group of nodes into a subgraph, mutating *graph*.
+
+    Port of ``nodesToSubgraph()`` from ``nodes-to-subgraph.ts``.
+    """
+    node_set = set(node_group)
+
+    # Classify edges.
+    internal: list[Edge] = []
+    incoming: list[Edge] = []
+    outgoing: list[Edge] = []
+
+    for edge in graph.edges:
+        f_in = edge.from_node in node_set
+        t_in = edge.to_node in node_set
+        if f_in and t_in:
+            internal.append(edge)
+        elif not f_in and t_in:
+            incoming.append(edge)
+        elif f_in and not t_in:
+            outgoing.append(edge)
+
+    # Group nodes.
+    group_nodes = [n for n in graph.nodes if n.id in node_set]
+
+    # Create input/output boundary nodes.
+    input_node = NodeDescriptor(
+        id=f"input_{subgraph_id}",
+        type="input",
+        metadata={
+            "title": "Subgraph Input",
+            "description": "Captures incoming edges to the subgraph",
+        },
+    )
+    output_node = NodeDescriptor(
+        id=f"output_{subgraph_id}",
+        type="output",
+        metadata={
+            "title": "Subgraph Output",
+            "description": "Captures outgoing edges from the subgraph",
+        },
+    )
+
+    # Build subgraph edges.
+    subgraph_edges = list(internal)
+
+    for edge in incoming:
+        subgraph_edges.append(Edge(
+            from_node=f"input_{subgraph_id}",
+            to_node=edge.to_node,
+            in_port=edge.in_port,
+            out_port=edge.in_port or "out",
+        ))
+
+    for edge in outgoing:
+        subgraph_edges.append(Edge(
+            from_node=edge.from_node,
+            to_node=f"output_{subgraph_id}",
+            in_port=edge.out_port or "in",
+            out_port=edge.out_port,
+        ))
+
+    subgraph = GraphDescriptor(
+        title=title or f"Subgraph {subgraph_id}",
+        description=description or f"Subgraph containing {len(node_group)} nodes",
+        nodes=[input_node, *group_nodes, output_node],
+        edges=subgraph_edges,
+    )
+
+    # Store subgraph.
+    if graph.graphs is None:
+        graph.graphs = {}
+    graph.graphs[subgraph_id] = subgraph
+
+    # Replace folded nodes with a single subgraph node.
+    replacement = NodeDescriptor(
+        id=subgraph_id,
+        type=f"#{subgraph_id}",
+        metadata={"title": f'Subgraph "{subgraph_id}"', "tags": ["folded"]},
+    )
+    graph.nodes = [n for n in graph.nodes if n.id not in node_set]
+    graph.nodes.append(replacement)
+
+    # Rewrite cross-boundary edges.
+    new_edges: list[Edge] = []
+    for edge in graph.edges:
+        f_in = edge.from_node in node_set
+        t_in = edge.to_node in node_set
+
+        if f_in and t_in:
+            continue  # Internal — now in subgraph.
+        if f_in and not t_in:
+            new_edges.append(Edge(
+                from_node=subgraph_id,
+                to_node=edge.to_node,
+                out_port=edge.out_port,
+                in_port=edge.in_port,
+                optional=edge.optional,
+                constant=edge.constant,
+            ))
+        elif not f_in and t_in:
+            new_edges.append(Edge(
+                from_node=edge.from_node,
+                to_node=subgraph_id,
+                out_port=edge.out_port,
+                in_port=edge.in_port,
+                optional=edge.optional,
+                constant=edge.constant,
+            ))
+        else:
+            new_edges.append(edge)
+    graph.edges = new_edges

--- a/packages/opal-backend/opal_backend/graph_plan.py
+++ b/packages/opal-backend/opal_backend/graph_plan.py
@@ -1,0 +1,118 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Graph plan creation — Kahn's topological sort.
+
+Port of ``create-plan.ts`` from the visual-editor. Given a
+condensed (acyclic) ``GraphDescriptor``, produces a ``GraphPlan``
+of stages. Each stage is a group of nodes that can execute in
+parallel. Stage *n* must complete before stage *n+1* begins.
+
+Standalone nodes (no outgoing edges, in-degree 0) are handled
+specially:
+- If ALL entry nodes are standalone, pick only the first one.
+- If some are standalone and some connected, ignore standalone.
+- If none are standalone, start from all entry nodes.
+"""
+
+from __future__ import annotations
+
+from .graph_types import Edge, GraphDescriptor, GraphPlan, PlanNodeInfo
+
+__all__ = ["create_plan"]
+
+
+def create_plan(graph: GraphDescriptor) -> GraphPlan:
+    """Create a staged execution plan from a condensed graph.
+
+    The input graph must be a DAG (run ``condense()`` first if it
+    may contain cycles).
+    """
+    if not graph.nodes:
+        return GraphPlan(stages=[])
+
+    node_map = {node.id: node for node in graph.nodes}
+
+    # Compute in-degree and adjacency.
+    in_degree: dict[str, int] = {n.id: 0 for n in graph.nodes}
+    out_edges: dict[str, list[Edge]] = {n.id: [] for n in graph.nodes}
+    in_edges: dict[str, list[Edge]] = {n.id: [] for n in graph.nodes}
+
+    for edge in graph.edges:
+        in_degree[edge.to_node] = in_degree.get(edge.to_node, 0) + 1
+        out_edges.setdefault(edge.from_node, []).append(Edge(
+            from_node=edge.from_node,
+            to_node=edge.to_node,
+            out_port=edge.out_port,
+            in_port=edge.in_port,
+            optional=edge.optional,
+            constant=edge.constant,
+        ))
+        in_edges.setdefault(edge.to_node, []).append(Edge(
+            from_node=edge.from_node,
+            to_node=edge.to_node,
+            out_port=edge.out_port,
+            in_port=edge.in_port,
+            optional=edge.optional,
+            constant=edge.constant,
+        ))
+
+    # Entry nodes = in-degree 0.
+    entries = [n for n in graph.nodes if in_degree.get(n.id, 0) == 0]
+
+    # Separate standalone (no outgoing edges) from connected.
+    standalone = []
+    connected = []
+    only_standalone = True
+
+    for node in entries:
+        if not out_edges.get(node.id):
+            standalone.append(node)
+        else:
+            only_standalone = False
+            connected.append(node)
+
+    if not standalone:
+        queue = list(entries)
+    elif only_standalone:
+        # All isolated — just pick the first one.
+        queue = [standalone[0]]
+    else:
+        # Mix of standalone and connected — ignore standalone.
+        queue = list(connected)
+
+    # Kahn's algorithm — level-by-level BFS.
+    stages: list[list[PlanNodeInfo]] = []
+    processed: set[str] = set()
+
+    while queue:
+        stage_nodes: list[PlanNodeInfo] = []
+        next_queue = []
+
+        for node in queue:
+            if node.id in processed:
+                continue
+            processed.add(node.id)
+
+            info = PlanNodeInfo(
+                node=node_map[node.id],
+                downstream=out_edges.get(node.id, []),
+                upstream=in_edges.get(node.id, []),
+            )
+            stage_nodes.append(info)
+
+            for edge in out_edges.get(node.id, []):
+                deg = in_degree.get(edge.to_node, 0)
+                if deg > 0:
+                    in_degree[edge.to_node] = deg - 1
+                    if deg == 1:
+                        target = node_map.get(edge.to_node)
+                        if target:
+                            next_queue.append(target)
+
+        if stage_nodes:
+            stages.append(stage_nodes)
+
+        queue = next_queue
+
+    return GraphPlan(stages=stages)

--- a/packages/opal-backend/opal_backend/graph_runner.py
+++ b/packages/opal-backend/opal_backend/graph_runner.py
@@ -7,11 +7,14 @@ Orchestrates the full lifecycle of a single node task:
 1. Emit ``nodeStart`` event
 2. Load inputs from ``GraphSessionStore``
 3. Load config from the stored plan
-4. Run the appropriate handler
+4. Run the appropriate handler (with agent event forwarding)
 5. Save outputs via ``complete_node()``
 6. Schedule newly-ready downstream nodes
 7. Check if graph is complete → emit ``graphComplete``
 8. Emit ``nodeEnd`` event
+
+Handles ``NodeSuspended`` — saves node state and emits
+``inputRequired`` without completing the node.
 
 Only stdlib + typing — no external deps (synced to production).
 """
@@ -19,11 +22,15 @@ Only stdlib + typing — no external deps (synced to production).
 from __future__ import annotations
 
 import traceback
-from typing import Any
+import uuid
+from typing import Any, AsyncIterator, Callable
 
+from .backend_client import BackendClient
 from .event_bus import EventBus
-from .graph_session_store import GraphSessionStore
-from .node_handlers import dispatch_handler
+from .events import AgentEvent
+from .graph_session_store import GraphSessionStore, SuspendedNodeState
+from .interaction_store import InteractionStore
+from .node_handlers import NodeHandlerDeps, NodeSuspended, dispatch_handler
 from .task_scheduler import TaskScheduler
 
 __all__ = ["GraphRunner"]
@@ -33,8 +40,8 @@ class GraphRunner:
     """Runs individual node tasks and coordinates the graph lifecycle.
 
     Wired together by the server entry point (``dev/main.py`` or
-    ``fake/main.py``) with concrete implementations of the three
-    protocol dependencies.
+    ``fake/main.py``) with concrete implementations of the protocol
+    dependencies.
     """
 
     def __init__(
@@ -42,18 +49,37 @@ class GraphRunner:
         store: GraphSessionStore,
         event_bus: EventBus,
         scheduler: TaskScheduler,
+        *,
+        backend_factory: Callable[[str, str], BackendClient] | None = None,
+        interaction_store: InteractionStore | None = None,
+        run_agent_fn: Callable[..., AsyncIterator[AgentEvent]] | None = None,
     ) -> None:
         self._store = store
         self._event_bus = event_bus
         self._scheduler = scheduler
+        self._backend_factory = backend_factory
+        self._interaction_store = interaction_store
+        self._run_agent_fn = run_agent_fn
+        # Per-session auth context, set by start_graph().
+        self._session_auth: dict[str, tuple[str, str]] = {}
 
     async def start_graph(
         self, session_id: str,
+        *,
+        access_token: str = "",
+        origin: str = "",
     ) -> None:
         """Start execution by scheduling all initially-ready nodes.
 
         Called once after ``store.create()`` has stored the plan.
+
+        Args:
+            access_token: User's OAuth token for backend API calls.
+            origin: Request origin header for backend API calls.
         """
+        # Store auth context so node tasks can create authenticated clients.
+        self._session_auth[session_id] = (access_token, origin)
+
         plan = await self._store.get_plan(session_id)
         if not plan:
             return
@@ -82,6 +108,11 @@ class GraphRunner:
         """
         try:
             await self._run_node_inner(session_id, node_id)
+        except NodeSuspended as suspended:
+            # Node needs user input — save state, emit event, end task.
+            await self._handle_suspend(
+                session_id, node_id, suspended,
+            )
         except Exception as exc:
             # Node failed — mark it and skip dependents.
             error_msg = f"{type(exc).__name__}: {exc}"
@@ -91,6 +122,57 @@ class GraphRunner:
             )
             for nid in newly_ready:
                 await self._scheduler.schedule(session_id, nid)
+            await self._check_graph_complete(session_id)
+
+    async def resume_node(
+        self, session_id: str, interaction_id: str,
+        response: dict[str, Any],
+    ) -> None:
+        """Resume a suspended node after user input.
+
+        Loads the suspended node state, provides the response as
+        input, re-runs the handler, and completes the node normally.
+        """
+        loaded = await self._store.load_suspended_node(
+            session_id, interaction_id,
+        )
+        if not loaded:
+            raise ValueError(
+                f"No suspended node for interaction {interaction_id}",
+            )
+
+        node_id, suspended_state = loaded
+
+        # Resume: provide the response as the node's output.
+        # For agent nodes, we'd resume the agent loop here.
+        # For now, treat the response as node outputs directly.
+        outputs = {"context": [response]} if response else {"context": []}
+
+        try:
+            newly_ready = await self._store.complete_node(
+                session_id, node_id, outputs,
+            )
+
+            # Emit nodeEnd.
+            await self._store.append_event(session_id, {
+                "type": "nodeEnd", "nodeId": node_id,
+            })
+            await self._event_bus.publish(session_id, {
+                "type": "nodeEnd", "nodeId": node_id,
+            })
+
+            # Schedule downstream.
+            for nid in newly_ready:
+                await self._scheduler.schedule(session_id, nid)
+
+            await self._check_graph_complete(session_id)
+
+        except Exception as exc:
+            error_msg = f"{type(exc).__name__}: {exc}"
+            await self._emit_node_error(session_id, node_id, error_msg)
+            await self._store.mark_node_failed(
+                session_id, node_id, error_msg,
+            )
             await self._check_graph_complete(session_id)
 
     async def _run_node_inner(
@@ -111,16 +193,19 @@ class GraphRunner:
         # 3. Load node config.
         config = await self._store.get_node_config(session_id, node_id)
 
-        # 4. Determine node type and dispatch.
-        node_type = await self._get_node_type(session_id, node_id)
-        outputs = await dispatch_handler(node_type, inputs, config)
+        # 4. Build handler deps.
+        deps = self._build_handler_deps(session_id, node_id)
 
-        # 5. Save outputs and get newly-ready downstream nodes.
+        # 5. Determine node type and dispatch.
+        node_type = await self._get_node_type(session_id, node_id)
+        outputs = await dispatch_handler(node_type, inputs, config, deps)
+
+        # 6. Save outputs and get newly-ready downstream nodes.
         newly_ready = await self._store.complete_node(
             session_id, node_id, outputs,
         )
 
-        # 6. Emit nodeEnd.
+        # 7. Emit nodeEnd.
         await self._store.append_event(session_id, {
             "type": "nodeEnd", "nodeId": node_id,
         })
@@ -128,12 +213,61 @@ class GraphRunner:
             "type": "nodeEnd", "nodeId": node_id,
         })
 
-        # 7. Schedule downstream.
+        # 8. Schedule downstream.
         for nid in newly_ready:
             await self._scheduler.schedule(session_id, nid)
 
-        # 8. Check if graph is complete.
+        # 9. Check if graph is complete.
         await self._check_graph_complete(session_id)
+
+    def _build_handler_deps(
+        self, session_id: str, node_id: str,
+    ) -> NodeHandlerDeps:
+        """Build handler dependencies for the current node."""
+
+        async def on_agent_event(event_dict: dict[str, Any]) -> None:
+            """Forward agent events wrapped with nodeId."""
+            wrapped = {
+                "type": "agentEvent",
+                "nodeId": node_id,
+                "event": event_dict,
+            }
+            await self._store.append_event(session_id, wrapped)
+            await self._event_bus.publish(session_id, wrapped)
+
+        token, origin = self._session_auth.get(session_id, ("", ""))
+        return NodeHandlerDeps(
+            on_agent_event=on_agent_event,
+            run_agent_fn=self._run_agent_fn,
+            backend=self._backend_factory(token, origin) if self._backend_factory else None,
+            interaction_store=self._interaction_store,
+        )
+
+    async def _handle_suspend(
+        self, session_id: str, node_id: str,
+        suspended: NodeSuspended,
+    ) -> None:
+        """Handle a NodeSuspended exception from a handler."""
+        state = SuspendedNodeState(
+            node_id=node_id,
+            interaction_id=suspended.interaction_id,
+            context=suspended.context,
+        )
+        await self._store.suspend_node(
+            session_id, node_id,
+            suspended.interaction_id, state,
+        )
+        await self._store.set_status(session_id, "suspended")
+
+        # Emit inputRequired event.
+        event = {
+            "type": "inputRequired",
+            "nodeId": node_id,
+            "interactionId": suspended.interaction_id,
+            "suspendEvent": suspended.suspend_event,
+        }
+        await self._store.append_event(session_id, event)
+        await self._event_bus.publish(session_id, event)
 
     async def _get_node_type(
         self, session_id: str, node_id: str,

--- a/packages/opal-backend/opal_backend/graph_runner.py
+++ b/packages/opal-backend/opal_backend/graph_runner.py
@@ -1,0 +1,179 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Graph runner — per-node task execution logic.
+
+Orchestrates the full lifecycle of a single node task:
+1. Emit ``nodeStart`` event
+2. Load inputs from ``GraphSessionStore``
+3. Load config from the stored plan
+4. Run the appropriate handler
+5. Save outputs via ``complete_node()``
+6. Schedule newly-ready downstream nodes
+7. Check if graph is complete → emit ``graphComplete``
+8. Emit ``nodeEnd`` event
+
+Only stdlib + typing — no external deps (synced to production).
+"""
+
+from __future__ import annotations
+
+import traceback
+from typing import Any
+
+from .event_bus import EventBus
+from .graph_session_store import GraphSessionStore
+from .node_handlers import dispatch_handler
+from .task_scheduler import TaskScheduler
+
+__all__ = ["GraphRunner"]
+
+
+class GraphRunner:
+    """Runs individual node tasks and coordinates the graph lifecycle.
+
+    Wired together by the server entry point (``dev/main.py`` or
+    ``fake/main.py``) with concrete implementations of the three
+    protocol dependencies.
+    """
+
+    def __init__(
+        self,
+        store: GraphSessionStore,
+        event_bus: EventBus,
+        scheduler: TaskScheduler,
+    ) -> None:
+        self._store = store
+        self._event_bus = event_bus
+        self._scheduler = scheduler
+
+    async def start_graph(
+        self, session_id: str,
+    ) -> None:
+        """Start execution by scheduling all initially-ready nodes.
+
+        Called once after ``store.create()`` has stored the plan.
+        """
+        plan = await self._store.get_plan(session_id)
+        if not plan:
+            return
+
+        # Emit graphStart event.
+        await self._store.append_event(session_id, {
+            "type": "graphStart",
+            "sessionId": session_id,
+        })
+        await self._event_bus.publish(session_id, {
+            "type": "graphStart",
+            "sessionId": session_id,
+        })
+
+        # Schedule all entry nodes (stage 0 — pending_deps == 0).
+        if plan.stages:
+            for info in plan.stages[0]:
+                await self._scheduler.schedule(session_id, info.node.id)
+
+    async def run_node(
+        self, session_id: str, node_id: str,
+    ) -> None:
+        """Execute a single node task (full lifecycle).
+
+        This is the callback passed to ``LocalTaskScheduler``.
+        """
+        try:
+            await self._run_node_inner(session_id, node_id)
+        except Exception as exc:
+            # Node failed — mark it and skip dependents.
+            error_msg = f"{type(exc).__name__}: {exc}"
+            await self._emit_node_error(session_id, node_id, error_msg)
+            newly_ready = await self._store.mark_node_failed(
+                session_id, node_id, error_msg,
+            )
+            for nid in newly_ready:
+                await self._scheduler.schedule(session_id, nid)
+            await self._check_graph_complete(session_id)
+
+    async def _run_node_inner(
+        self, session_id: str, node_id: str,
+    ) -> None:
+        """Inner node execution — no error handling."""
+        # 1. Emit nodeStart.
+        await self._store.append_event(session_id, {
+            "type": "nodeStart", "nodeId": node_id,
+        })
+        await self._event_bus.publish(session_id, {
+            "type": "nodeStart", "nodeId": node_id,
+        })
+
+        # 2. Load inputs from upstream outputs.
+        inputs = await self._store.get_node_inputs(session_id, node_id)
+
+        # 3. Load node config.
+        config = await self._store.get_node_config(session_id, node_id)
+
+        # 4. Determine node type and dispatch.
+        node_type = await self._get_node_type(session_id, node_id)
+        outputs = await dispatch_handler(node_type, inputs, config)
+
+        # 5. Save outputs and get newly-ready downstream nodes.
+        newly_ready = await self._store.complete_node(
+            session_id, node_id, outputs,
+        )
+
+        # 6. Emit nodeEnd.
+        await self._store.append_event(session_id, {
+            "type": "nodeEnd", "nodeId": node_id,
+        })
+        await self._event_bus.publish(session_id, {
+            "type": "nodeEnd", "nodeId": node_id,
+        })
+
+        # 7. Schedule downstream.
+        for nid in newly_ready:
+            await self._scheduler.schedule(session_id, nid)
+
+        # 8. Check if graph is complete.
+        await self._check_graph_complete(session_id)
+
+    async def _get_node_type(
+        self, session_id: str, node_id: str,
+    ) -> str:
+        """Look up node type from the stored plan."""
+        plan = await self._store.get_plan(session_id)
+        if plan:
+            for stage in plan.stages:
+                for info in stage:
+                    if info.node.id == node_id:
+                        return info.node.type
+        return "unknown"
+
+    async def _check_graph_complete(
+        self, session_id: str,
+    ) -> None:
+        """Emit graphComplete if all nodes are done."""
+        if await self._store.is_graph_complete(session_id):
+            outputs = await self._store.get_graph_outputs(session_id)
+            await self._store.set_status(session_id, "completed")
+            await self._store.append_event(session_id, {
+                "type": "graphComplete",
+                "sessionId": session_id,
+                "outputs": outputs,
+            })
+            await self._event_bus.publish(session_id, {
+                "type": "graphComplete",
+                "sessionId": session_id,
+                "outputs": outputs,
+            })
+            # Close the event bus for this session.
+            await self._event_bus.close(session_id)
+
+    async def _emit_node_error(
+        self, session_id: str, node_id: str, error: str,
+    ) -> None:
+        """Emit nodeError event."""
+        await self._store.append_event(session_id, {
+            "type": "nodeError", "nodeId": node_id, "error": error,
+        })
+        await self._event_bus.publish(session_id, {
+            "type": "nodeError", "nodeId": node_id, "error": error,
+        })

--- a/packages/opal-backend/opal_backend/graph_runner.py
+++ b/packages/opal-backend/opal_backend/graph_runner.py
@@ -21,8 +21,6 @@ Only stdlib + typing — no external deps (synced to production).
 
 from __future__ import annotations
 
-import traceback
-import uuid
 from typing import Any, AsyncIterator, Callable
 
 from .backend_client import BackendClient
@@ -30,7 +28,12 @@ from .event_bus import EventBus
 from .events import AgentEvent
 from .graph_session_store import GraphSessionStore, SuspendedNodeState
 from .interaction_store import InteractionStore
-from .node_handlers import NodeHandlerDeps, NodeSuspended, dispatch_handler
+from .node_handlers import (
+    NodeHandlerDeps,
+    NodeSuspended,
+    consume_agent_events,
+    dispatch_handler,
+)
 from .task_scheduler import TaskScheduler
 
 __all__ = ["GraphRunner"]
@@ -53,6 +56,7 @@ class GraphRunner:
         backend_factory: Callable[[str, str], BackendClient] | None = None,
         interaction_store: InteractionStore | None = None,
         run_agent_fn: Callable[..., AsyncIterator[AgentEvent]] | None = None,
+        resume_agent_fn: Callable[..., AsyncIterator[AgentEvent]] | None = None,
     ) -> None:
         self._store = store
         self._event_bus = event_bus
@@ -60,6 +64,7 @@ class GraphRunner:
         self._backend_factory = backend_factory
         self._interaction_store = interaction_store
         self._run_agent_fn = run_agent_fn
+        self._resume_agent_fn = resume_agent_fn
         # Per-session auth context, set by start_graph().
         self._session_auth: dict[str, tuple[str, str]] = {}
 
@@ -109,20 +114,9 @@ class GraphRunner:
         try:
             await self._run_node_inner(session_id, node_id)
         except NodeSuspended as suspended:
-            # Node needs user input — save state, emit event, end task.
-            await self._handle_suspend(
-                session_id, node_id, suspended,
-            )
+            await self._handle_suspend(session_id, node_id, suspended)
         except Exception as exc:
-            # Node failed — mark it and skip dependents.
-            error_msg = f"{type(exc).__name__}: {exc}"
-            await self._emit_node_error(session_id, node_id, error_msg)
-            newly_ready = await self._store.mark_node_failed(
-                session_id, node_id, error_msg,
-            )
-            for nid in newly_ready:
-                await self._scheduler.schedule(session_id, nid)
-            await self._check_graph_complete(session_id)
+            await self._handle_node_error(session_id, node_id, exc)
 
     async def resume_node(
         self, session_id: str, interaction_id: str,
@@ -130,8 +124,10 @@ class GraphRunner:
     ) -> None:
         """Resume a suspended node after user input.
 
-        Loads the suspended node state, provides the response as
-        input, re-runs the handler, and completes the node normally.
+        Loads the suspended node state, re-runs the agent via
+        ``resume_agent_fn``, and completes the node normally. If the
+        agent suspends again, saves state and emits a new
+        ``inputRequired``.
         """
         loaded = await self._store.load_suspended_node(
             session_id, interaction_id,
@@ -142,38 +138,54 @@ class GraphRunner:
             )
 
         node_id, suspended_state = loaded
+        await self._store.set_status(session_id, "running")
 
-        # Resume: provide the response as the node's output.
-        # For agent nodes, we'd resume the agent loop here.
-        # For now, treat the response as node outputs directly.
-        outputs = {"context": [response]} if response else {"context": []}
+        # Input nodes save context={"inputs": ..., "config": ...} and
+        # don't use the agent InteractionStore. Complete them directly
+        # with the user's response as the node output.
+        is_input_node = "inputs" in suspended_state.context
+
+        if is_input_node or not self._resume_agent_fn:
+            # The response is form data keyed by schema property names,
+            # e.g. {"request": {"role": "user", "parts": [...]}}. The
+            # downstream node expects context: [LLMContent], so extract
+            # the values — mirrors the TS askUser() which does
+            # `const request = response.request as LLMContent`.
+            context: list[Any] = []
+            if response:
+                for value in response.values():
+                    if isinstance(value, dict) and "parts" in value:
+                        context.append(value)
+                    elif value is not None:
+                        context.append(value)
+            outputs = {"context": context}
+            try:
+                await self._complete_node(session_id, node_id, outputs)
+            except Exception as exc:
+                await self._handle_node_error(session_id, node_id, exc)
+            return
+
+        deps = self._build_handler_deps(session_id, node_id)
 
         try:
-            newly_ready = await self._store.complete_node(
-                session_id, node_id, outputs,
+            agent_iter = self._resume_agent_fn(
+                interaction_id=interaction_id,
+                response=response,
+                backend=deps.backend,
+                store=self._interaction_store,
             )
-
-            # Emit nodeEnd.
-            await self._store.append_event(session_id, {
-                "type": "nodeEnd", "nodeId": node_id,
-            })
-            await self._event_bus.publish(session_id, {
-                "type": "nodeEnd", "nodeId": node_id,
-            })
-
-            # Schedule downstream.
-            for nid in newly_ready:
-                await self._scheduler.schedule(session_id, nid)
-
-            await self._check_graph_complete(session_id)
-
+            outputs = await consume_agent_events(
+                agent_iter, deps, suspend_context=suspended_state.context,
+            )
+            await self._complete_node(session_id, node_id, outputs)
+        except NodeSuspended as suspended:
+            await self._handle_suspend(session_id, node_id, suspended)
         except Exception as exc:
-            error_msg = f"{type(exc).__name__}: {exc}"
-            await self._emit_node_error(session_id, node_id, error_msg)
-            await self._store.mark_node_failed(
-                session_id, node_id, error_msg,
-            )
-            await self._check_graph_complete(session_id)
+            await self._handle_node_error(session_id, node_id, exc)
+
+    # -------------------------------------------------------------------
+    # Internal helpers
+    # -------------------------------------------------------------------
 
     async def _run_node_inner(
         self, session_id: str, node_id: str,
@@ -200,12 +212,18 @@ class GraphRunner:
         node_type = await self._get_node_type(session_id, node_id)
         outputs = await dispatch_handler(node_type, inputs, config, deps)
 
-        # 6. Save outputs and get newly-ready downstream nodes.
+        # 6. Complete node (save outputs, emit nodeEnd, schedule, check).
+        await self._complete_node(session_id, node_id, outputs)
+
+    async def _complete_node(
+        self, session_id: str, node_id: str,
+        outputs: dict[str, Any],
+    ) -> None:
+        """Save outputs, emit nodeEnd, schedule downstream, check done."""
         newly_ready = await self._store.complete_node(
             session_id, node_id, outputs,
         )
 
-        # 7. Emit nodeEnd.
         await self._store.append_event(session_id, {
             "type": "nodeEnd", "nodeId": node_id,
         })
@@ -213,11 +231,23 @@ class GraphRunner:
             "type": "nodeEnd", "nodeId": node_id,
         })
 
-        # 8. Schedule downstream.
         for nid in newly_ready:
             await self._scheduler.schedule(session_id, nid)
 
-        # 9. Check if graph is complete.
+        await self._check_graph_complete(session_id)
+
+    async def _handle_node_error(
+        self, session_id: str, node_id: str,
+        exc: Exception,
+    ) -> None:
+        """Emit error, mark failed, schedule dependents, check done."""
+        error_msg = f"{type(exc).__name__}: {exc}"
+        await self._emit_node_error(session_id, node_id, error_msg)
+        newly_ready = await self._store.mark_node_failed(
+            session_id, node_id, error_msg,
+        )
+        for nid in newly_ready:
+            await self._scheduler.schedule(session_id, nid)
         await self._check_graph_complete(session_id)
 
     def _build_handler_deps(
@@ -311,3 +341,4 @@ class GraphRunner:
         await self._event_bus.publish(session_id, {
             "type": "nodeError", "nodeId": node_id, "error": error,
         })
+

--- a/packages/opal-backend/opal_backend/graph_session_store.py
+++ b/packages/opal-backend/opal_backend/graph_session_store.py
@@ -1,0 +1,163 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""GraphSessionStore protocol — graph execution state coordination.
+
+Stores graph execution state and coordinates node scheduling.
+This is separate from ``SessionStore`` (agent sessions). Graph
+sessions use task-per-node coordination; agent sessions use the
+existing ``sessions/api.py`` flow. Both share ``EventBus`` for
+live event delivery.
+
+Only stdlib + typing — no external deps (synced to production).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+from .graph_types import GraphPlan
+
+__all__ = [
+    "GraphSessionStore",
+    "SuspendedNodeState",
+]
+
+
+@dataclass
+class SuspendedNodeState:
+    """State saved when a node suspends (waiting for user input).
+
+    Attributes:
+        node_id: The suspended node.
+        interaction_id: Unique ID for this suspend/resume cycle.
+        context: Opaque state the node handler needs on resume.
+    """
+
+    node_id: str
+    interaction_id: str
+    context: dict[str, Any] = field(default_factory=dict)
+
+
+@runtime_checkable
+class GraphSessionStore(Protocol):
+    """Graph execution state and node scheduling coordination.
+
+    Implementations:
+    - ``InMemoryGraphSessionStore`` (``local/``) — dict-backed, dev server
+    - Production — database with atomic operations
+    """
+
+    # ── Plan Storage ──
+
+    async def create(
+        self, session_id: str, plan: GraphPlan,
+    ) -> None:
+        """Store plan with initial dependency counts."""
+        ...
+
+    async def get_plan(
+        self, session_id: str,
+    ) -> GraphPlan | None:
+        """Load the stored plan."""
+        ...
+
+    # ── Node Lifecycle ──
+
+    async def complete_node(
+        self, session_id: str, node_id: str, outputs: dict[str, Any],
+    ) -> list[str]:
+        """Atomically mark node complete, return newly-ready node IDs.
+
+        This is THE coordination point. Must guarantee:
+        - Outputs are persisted before downstream checks
+        - When concurrent nodes complete, each downstream is
+          triggered exactly once (when its last dep completes)
+        """
+        ...
+
+    async def get_node_inputs(
+        self, session_id: str, node_id: str,
+    ) -> dict[str, list[Any]]:
+        """Load upstream node outputs that are this node's inputs.
+
+        Returns a dict mapping input port → values gathered from
+        upstream node outputs connected to this port.
+        """
+        ...
+
+    async def get_node_config(
+        self, session_id: str, node_id: str,
+    ) -> dict[str, Any]:
+        """Load node configuration from the stored plan."""
+        ...
+
+    # ── Suspend / Resume ──
+
+    async def suspend_node(
+        self, session_id: str, node_id: str,
+        interaction_id: str,
+        state: SuspendedNodeState,
+    ) -> None:
+        """Save suspended node state. Task ends after this."""
+        ...
+
+    async def load_suspended_node(
+        self, session_id: str, interaction_id: str,
+    ) -> tuple[str, SuspendedNodeState] | None:
+        """Load suspended node by interaction ID. Returns (nodeId, state)."""
+        ...
+
+    # ── Graph Lifecycle ──
+
+    async def is_graph_complete(
+        self, session_id: str,
+    ) -> bool:
+        """True when all nodes are completed (or skipped)."""
+        ...
+
+    async def get_graph_outputs(
+        self, session_id: str,
+    ) -> dict[str, Any]:
+        """Load final outputs from all completed nodes."""
+        ...
+
+    async def mark_node_failed(
+        self, session_id: str, node_id: str, error: str,
+    ) -> list[str]:
+        """Mark node failed, skip dependents, return newly-ready nodes.
+
+        When a node fails, dependents that have no other path are
+        marked as skipped. Dependents that have alternative completed
+        paths may still become ready.
+        """
+        ...
+
+    # ── Event Log ──
+
+    async def append_event(
+        self, session_id: str, event: dict[str, Any],
+    ) -> int:
+        """Append event to the session log. Returns event index."""
+        ...
+
+    async def get_events(
+        self, session_id: str, *, after: int = -1,
+    ) -> list[dict[str, Any]]:
+        """Return events with index > after."""
+        ...
+
+    # ── Status ──
+
+    async def get_status(
+        self, session_id: str,
+    ) -> str | None:
+        """Return session status (running, suspended, completed, etc.)."""
+        ...
+
+    async def set_status(
+        self, session_id: str, status: str,
+    ) -> None:
+        """Set session status."""
+        ...

--- a/packages/opal-backend/opal_backend/graph_types.py
+++ b/packages/opal-backend/opal_backend/graph_types.py
@@ -1,0 +1,196 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Graph types for server-side graph execution (Project Heartstone).
+
+Mirrors the subset of ``@breadboard-ai/types`` needed for graph
+planning and execution. Only stdlib + typing — no external deps.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+__all__ = [
+    "Edge",
+    "NodeDescriptor",
+    "GraphDescriptor",
+    "PlanNodeInfo",
+    "GraphPlan",
+    "NodeLifecycleState",
+]
+
+
+# ---------------------------------------------------------------------------
+# Graph descriptor types (mirrors @breadboard-ai/types)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Edge:
+    """An edge in a graph, connecting two nodes via named ports.
+
+    Attributes:
+        from_node: Source node id (``from`` in the TS type).
+        to_node: Target node id (``to`` in the TS type).
+        out_port: Output port name on the source node.
+        in_port: Input port name on the target node.
+        optional: If true, this edge is not a required input.
+        constant: If true, data persists after consumption.
+    """
+
+    from_node: str
+    to_node: str
+    out_port: str | None = None
+    in_port: str | None = None
+    optional: bool = False
+    constant: bool = False
+
+    @staticmethod
+    def from_dict(d: dict[str, Any]) -> Edge:
+        """Create an Edge from a BGL JSON dict."""
+        return Edge(
+            from_node=d["from"],
+            to_node=d["to"],
+            out_port=d.get("out"),
+            in_port=d.get("in"),
+            optional=d.get("optional", False),
+            constant=d.get("constant", False),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to BGL JSON dict."""
+        d: dict[str, Any] = {"from": self.from_node, "to": self.to_node}
+        if self.out_port is not None:
+            d["out"] = self.out_port
+        if self.in_port is not None:
+            d["in"] = self.in_port
+        if self.optional:
+            d["optional"] = True
+        if self.constant:
+            d["constant"] = True
+        return d
+
+
+@dataclass
+class NodeDescriptor:
+    """A node in a graph.
+
+    Attributes:
+        id: Unique node identifier.
+        type: Node type identifier (handler lookup key).
+        configuration: Static configuration values.
+        metadata: Display metadata (title, tags, visual, etc.).
+    """
+
+    id: str
+    type: str
+    configuration: dict[str, Any] | None = None
+    metadata: dict[str, Any] | None = None
+
+    @staticmethod
+    def from_dict(d: dict[str, Any]) -> NodeDescriptor:
+        """Create a NodeDescriptor from a BGL JSON dict."""
+        return NodeDescriptor(
+            id=d["id"],
+            type=d["type"],
+            configuration=d.get("configuration"),
+            metadata=d.get("metadata"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to BGL JSON dict."""
+        d: dict[str, Any] = {"id": self.id, "type": self.type}
+        if self.configuration is not None:
+            d["configuration"] = self.configuration
+        if self.metadata is not None:
+            d["metadata"] = self.metadata
+        return d
+
+
+@dataclass
+class GraphDescriptor:
+    """A graph: nodes, edges, optional sub-graphs.
+
+    Mirrors the shape of a ``.bgl.json`` file. Only the fields
+    needed for planning and execution are included.
+    """
+
+    nodes: list[NodeDescriptor] = field(default_factory=list)
+    edges: list[Edge] = field(default_factory=list)
+    graphs: dict[str, GraphDescriptor] | None = None
+    title: str | None = None
+    description: str | None = None
+
+    @staticmethod
+    def from_dict(d: dict[str, Any]) -> GraphDescriptor:
+        """Create a GraphDescriptor from a BGL JSON dict."""
+        graphs = None
+        if "graphs" in d and d["graphs"]:
+            graphs = {
+                k: GraphDescriptor.from_dict(v)
+                for k, v in d["graphs"].items()
+            }
+        return GraphDescriptor(
+            nodes=[NodeDescriptor.from_dict(n) for n in d.get("nodes", [])],
+            edges=[Edge.from_dict(e) for e in d.get("edges", [])],
+            graphs=graphs,
+            title=d.get("title"),
+            description=d.get("description"),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to BGL JSON dict."""
+        d: dict[str, Any] = {
+            "nodes": [n.to_dict() for n in self.nodes],
+            "edges": [e.to_dict() for e in self.edges],
+        }
+        if self.graphs:
+            d["graphs"] = {k: v.to_dict() for k, v in self.graphs.items()}
+        if self.title is not None:
+            d["title"] = self.title
+        if self.description is not None:
+            d["description"] = self.description
+        return d
+
+
+# ---------------------------------------------------------------------------
+# Execution plan types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PlanNodeInfo:
+    """Detailed information computed during plan creation.
+
+    Attributes:
+        node: The node descriptor.
+        downstream: Edges to nodes in later stages.
+        upstream: Edges from nodes in earlier stages.
+    """
+
+    node: NodeDescriptor
+    downstream: list[Edge] = field(default_factory=list)
+    upstream: list[Edge] = field(default_factory=list)
+
+
+@dataclass
+class GraphPlan:
+    """A staged execution plan for a condensed graph.
+
+    Each stage is a group of nodes that can execute in parallel.
+    Stages are ordered by dependency — all nodes in stage *n*
+    must complete before any node in stage *n+1* begins.
+    """
+
+    stages: list[list[PlanNodeInfo]] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Node lifecycle state
+# ---------------------------------------------------------------------------
+
+NodeLifecycleState = str
+"""One of: inactive, ready, working, waiting, succeeded, failed, skipped,
+interrupted. Kept as a string literal union for serialization simplicity."""

--- a/packages/opal-backend/opal_backend/local/README.md
+++ b/packages/opal-backend/opal_backend/local/README.md
@@ -11,10 +11,12 @@ Everything outside this directory IS synced to production.
 | Module                      | Purpose                                                                         |
 | --------------------------- | ------------------------------------------------------------------------------- |
 | `api_surface.py`            | FastAPI router factory + `AgentBackend`/`ProxyBackend` protocols                |
-| `backend_client_impl.py`    | `HttpBackendClient` — HTTP-based `BackendClient` (POSTs to OP + streams Gemini) |
-| `event_bus_impl.py`         | `InMemoryEventBus` — asyncio.Queue-based `EventBus` for live event delivery     |
-| `interaction_store_impl.py` | `InMemoryInteractionStore` — dict-based `InteractionStore`                      |
-| `pending_requests.py`       | `PendingRequestMap` — asyncio futures for fake server suspend/resume            |
+| `backend_client_impl.py`         | `HttpBackendClient` — HTTP-based `BackendClient` (POSTs to OP + streams Gemini) |
+| `event_bus_impl.py`              | `InMemoryEventBus` — asyncio.Queue-based `EventBus` for live event delivery     |
+| `graph_session_store_impl.py`    | `InMemoryGraphSessionStore` — dict-backed graph execution state                 |
+| `interaction_store_impl.py`      | `InMemoryInteractionStore` — dict-based `InteractionStore`                      |
+| `pending_requests.py`            | `PendingRequestMap` — asyncio futures for fake server suspend/resume            |
+| `task_scheduler_impl.py`         | `LocalTaskScheduler` — asyncio.create_task-based task dispatch                  |
 | `session_router.py`         | FastAPI router factory + `SessionDeps` for session REST endpoints                |
 | `sse_sink.py`               | `SSEAgentEventSink` — bridges `AgentEvent` → SSE strings for fake server        |
 
@@ -37,8 +39,10 @@ Body (resume): {"interactionId": "...", "response": {...}}
 
 ## Protocol → Implementation Mapping
 
-| Protocol (synced)  | Implementation (local)                                   |
-| ------------------ | -------------------------------------------------------- |
-| `BackendClient`    | `HttpBackendClient` (`backend_client_impl.py`)           |
-| `EventBus`         | `InMemoryEventBus` (`event_bus_impl.py`)                 |
-| `InteractionStore` | `InMemoryInteractionStore` (`interaction_store_impl.py`) |
+| Protocol (synced)    | Implementation (local)                                          |
+| -------------------- | --------------------------------------------------------------- |
+| `BackendClient`      | `HttpBackendClient` (`backend_client_impl.py`)                  |
+| `EventBus`           | `InMemoryEventBus` (`event_bus_impl.py`)                        |
+| `GraphSessionStore`  | `InMemoryGraphSessionStore` (`graph_session_store_impl.py`)     |
+| `InteractionStore`   | `InMemoryInteractionStore` (`interaction_store_impl.py`)        |
+| `TaskScheduler`      | `LocalTaskScheduler` (`task_scheduler_impl.py`)                 |

--- a/packages/opal-backend/opal_backend/local/README.md
+++ b/packages/opal-backend/opal_backend/local/README.md
@@ -13,6 +13,7 @@ Everything outside this directory IS synced to production.
 | `api_surface.py`            | FastAPI router factory + `AgentBackend`/`ProxyBackend` protocols                |
 | `backend_client_impl.py`         | `HttpBackendClient` — HTTP-based `BackendClient` (POSTs to OP + streams Gemini) |
 | `event_bus_impl.py`              | `InMemoryEventBus` — asyncio.Queue-based `EventBus` for live event delivery     |
+| `graph_session_router.py`        | FastAPI router for graph session REST endpoints (Heartstone)                     |
 | `graph_session_store_impl.py`    | `InMemoryGraphSessionStore` — dict-backed graph execution state                 |
 | `interaction_store_impl.py`      | `InMemoryInteractionStore` — dict-based `InteractionStore`                      |
 | `pending_requests.py`            | `PendingRequestMap` — asyncio futures for fake server suspend/resume            |

--- a/packages/opal-backend/opal_backend/local/README.md
+++ b/packages/opal-backend/opal_backend/local/README.md
@@ -12,6 +12,7 @@ Everything outside this directory IS synced to production.
 | --------------------------- | ------------------------------------------------------------------------------- |
 | `api_surface.py`            | FastAPI router factory + `AgentBackend`/`ProxyBackend` protocols                |
 | `backend_client_impl.py`    | `HttpBackendClient` — HTTP-based `BackendClient` (POSTs to OP + streams Gemini) |
+| `event_bus_impl.py`         | `InMemoryEventBus` — asyncio.Queue-based `EventBus` for live event delivery     |
 | `interaction_store_impl.py` | `InMemoryInteractionStore` — dict-based `InteractionStore`                      |
 | `pending_requests.py`       | `PendingRequestMap` — asyncio futures for fake server suspend/resume            |
 | `session_router.py`         | FastAPI router factory + `SessionDeps` for session REST endpoints                |
@@ -39,4 +40,5 @@ Body (resume): {"interactionId": "...", "response": {...}}
 | Protocol (synced)  | Implementation (local)                                   |
 | ------------------ | -------------------------------------------------------- |
 | `BackendClient`    | `HttpBackendClient` (`backend_client_impl.py`)           |
+| `EventBus`         | `InMemoryEventBus` (`event_bus_impl.py`)                 |
 | `InteractionStore` | `InMemoryInteractionStore` (`interaction_store_impl.py`) |

--- a/packages/opal-backend/opal_backend/local/api_surface.py
+++ b/packages/opal-backend/opal_backend/local/api_surface.py
@@ -63,6 +63,7 @@ def create_api_router(
     *,
     agent: AgentBackend | None = None,
     sessions: APIRouter | None = None,
+    graph_sessions: APIRouter | None = None,
     proxy: ProxyBackend | None = None,
 ) -> APIRouter:
     """Create a FastAPI router with the shared Opal API surface.
@@ -70,6 +71,7 @@ def create_api_router(
     Args:
         agent: Handler for POST /v1beta1/streamRunAgent (optional).
         sessions: Router for session endpoints (optional).
+        graph_sessions: Router for graph session endpoints (optional).
         proxy: Handler for v1beta1/* proxy endpoints (optional).
     """
     router = APIRouter()
@@ -85,6 +87,10 @@ def create_api_router(
     if sessions is not None:
         router.include_router(sessions)
 
+    # ----- Graph session endpoints (must come before catch-all proxy) -----
+    if graph_sessions is not None:
+        router.include_router(graph_sessions)
+
     # ----- Proxy endpoints -----
     if proxy is not None:
 
@@ -96,3 +102,4 @@ def create_api_router(
             return await proxy.proxy(request)
 
     return router
+

--- a/packages/opal-backend/opal_backend/local/event_bus_impl.py
+++ b/packages/opal-backend/opal_backend/local/event_bus_impl.py
@@ -1,0 +1,98 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""In-memory EventBus implementation for the dev and fake servers.
+
+Uses ``asyncio.Queue`` per subscriber — the same mechanism that the
+old ``Subscribers`` class used, now behind the ``EventBus`` protocol.
+
+Since asyncio is single-threaded, there are no race conditions. The
+production implementation would use a pub/sub system for cross-server
+delivery.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, AsyncIterator
+
+from ..event_bus import EventBus
+
+__all__ = ["InMemoryEventBus"]
+
+
+class InMemoryEventBus:
+    """EventBus backed by asyncio.Queue — single-process only.
+
+    Each call to ``subscribe()`` creates a new queue. ``publish()``
+    fans out to all queues. ``close()`` sends a ``None`` sentinel
+    and removes all queues for the session.
+
+    Satisfies the ``EventBus`` protocol.
+    """
+
+    def __init__(self) -> None:
+        self._queues: dict[str, list[asyncio.Queue]] = {}
+
+    def subscribe(
+        self, session_id: str,
+    ) -> AsyncIterator[dict[str, Any] | None]:
+        """Create and register a subscriber for a session.
+
+        Returns an async iterator backed by an asyncio.Queue. The
+        iterator yields event dicts until a ``None`` sentinel arrives.
+        """
+        queue: asyncio.Queue = asyncio.Queue()
+        self._queues.setdefault(session_id, []).append(queue)
+        return _QueueIterator(queue, self, session_id)
+
+    async def publish(
+        self, session_id: str, event: dict[str, Any],
+    ) -> None:
+        """Push an event dict to all subscriber queues."""
+        for queue in self._queues.get(session_id, []):
+            await queue.put(event)
+
+    async def close(self, session_id: str) -> None:
+        """Send sentinel to all subscribers and clean up."""
+        for queue in self._queues.get(session_id, []):
+            await queue.put(None)
+        self._queues.pop(session_id, None)
+
+    def unsubscribe(
+        self, session_id: str,
+        subscription: AsyncIterator[dict[str, Any] | None],
+    ) -> None:
+        """Remove a subscription's underlying queue."""
+        if not isinstance(subscription, _QueueIterator):
+            return
+        queues = self._queues.get(session_id, [])
+        if subscription._queue in queues:
+            queues.remove(subscription._queue)
+
+
+class _QueueIterator:
+    """Async iterator wrapper around an asyncio.Queue.
+
+    Yields event dicts until a ``None`` sentinel is received, then
+    stops iteration.
+    """
+
+    def __init__(
+        self,
+        queue: asyncio.Queue,
+        bus: InMemoryEventBus,
+        session_id: str,
+    ) -> None:
+        self._queue = queue
+        self._bus = bus
+        self._session_id = session_id
+
+    def __aiter__(self) -> AsyncIterator[dict[str, Any] | None]:
+        return self
+
+    async def __anext__(self) -> dict[str, Any] | None:
+        item = await self._queue.get()
+        if item is None:
+            raise StopAsyncIteration
+        return item

--- a/packages/opal-backend/opal_backend/local/graph_session_router.py
+++ b/packages/opal-backend/opal_backend/local/graph_session_router.py
@@ -115,10 +115,11 @@ def create_graph_session_router(
             events = await store.get_events(session_id, after=after)
             next_index = after + 1
             for i, event in enumerate(events):
+                idx = next_index + i
                 yield {
                     "event": "event",
-                    "id": str(next_index + i),
-                    "data": json.dumps(event),
+                    "id": str(idx),
+                    "data": json.dumps({**event, "index": idx}),
                 }
             next_index += len(events)
 
@@ -131,7 +132,9 @@ def create_graph_session_router(
                         yield {
                             "event": "event",
                             "id": str(next_index),
-                            "data": json.dumps(item),
+                            "data": json.dumps(
+                                {**item, "index": next_index},
+                            ),
                         }
                         next_index += 1
                 finally:

--- a/packages/opal-backend/opal_backend/local/graph_session_router.py
+++ b/packages/opal-backend/opal_backend/local/graph_session_router.py
@@ -1,0 +1,172 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Graph session REST API endpoints (FastAPI transport layer).
+
+Parallel to ``session_router.py`` for agent sessions. This module
+provides the HTTP endpoints for graph execution:
+
+    POST /v1beta1/graphSessions/new    → start a graph run
+    GET  /v1beta1/graphSessions/{id}   → SSE stream (replay + live)
+    GET  /v1beta1/graphSessions/{id}/status → lightweight status
+    POST /v1beta1/graphSessions/{id}:cancel → cancel running tasks
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+from sse_starlette.sse import EventSourceResponse
+
+from ..event_bus import EventBus
+from ..graph_condense import condense
+from ..graph_plan import create_plan
+from ..graph_runner import GraphRunner
+from ..graph_session_store import GraphSessionStore
+from ..graph_types import GraphDescriptor
+from ..task_scheduler import TaskScheduler
+
+__all__ = ["create_graph_session_router"]
+
+
+def create_graph_session_router(
+    *,
+    store: GraphSessionStore,
+    event_bus: EventBus,
+    runner: GraphRunner,
+    scheduler: TaskScheduler,
+) -> APIRouter:
+    """Create a FastAPI router with graph session endpoints.
+
+    Args:
+        store: GraphSessionStore for graph execution state.
+        event_bus: EventBus for live SSE event delivery.
+        runner: GraphRunner for node task execution.
+        scheduler: TaskScheduler for cancellation support.
+    """
+    router = APIRouter(prefix="/v1beta1/graphSessions")
+
+    @router.post("/new")
+    async def create_graph_session(request: Request) -> JSONResponse:
+        """Start a new graph run.
+
+        Body: {graph: GraphDescriptor, mode?: str, inputs?: dict,
+               accessToken?: str}
+        """
+        body = await request.json()
+        graph_data = body.get("graph")
+        if not graph_data:
+            return JSONResponse(
+                {"error": "Missing 'graph' in request body"},
+                status_code=400,
+            )
+
+        # Parse, condense (break cycles), and plan.
+        graph = GraphDescriptor.from_dict(graph_data)
+        condensed = condense(graph)
+        plan = create_plan(condensed)
+
+        if not plan.stages:
+            return JSONResponse(
+                {"error": "Graph has no executable nodes"},
+                status_code=400,
+            )
+
+        session_id = str(uuid.uuid4())
+
+        # Store the plan and kick off initial tasks.
+        await store.create(session_id, plan)
+        await runner.start_graph(session_id)
+
+        return JSONResponse({"sessionId": session_id})
+
+    @router.get("/{session_id}")
+    async def stream_graph_events(
+        request: Request, session_id: str, after: int = -1,
+    ) -> EventSourceResponse:
+        """SSE stream: replay stored events, then live events.
+
+        Query params:
+            after: Only return events with index > this value.
+                   Default -1 means all events.
+        """
+        status = await store.get_status(session_id)
+        if status is None:
+            return JSONResponse(
+                {"error": "Graph session not found"}, status_code=404,
+            )
+
+        async def event_generator():
+            yield {
+                "event": "start",
+                "data": json.dumps({"sessionId": session_id}),
+            }
+
+            # Phase 1: replay stored events.
+            events = await store.get_events(session_id, after=after)
+            next_index = after + 1
+            for i, event in enumerate(events):
+                yield {
+                    "event": "event",
+                    "id": str(next_index + i),
+                    "data": json.dumps(event),
+                }
+            next_index += len(events)
+
+            # Phase 2: subscribe for live events if still running.
+            current_status = await store.get_status(session_id)
+            if current_status in ("running", "suspended"):
+                subscription = event_bus.subscribe(session_id)
+                try:
+                    async for item in subscription:
+                        yield {
+                            "event": "event",
+                            "id": str(next_index),
+                            "data": json.dumps(item),
+                        }
+                        next_index += 1
+                finally:
+                    event_bus.unsubscribe(session_id, subscription)
+
+            yield {"event": "done", "data": "{}"}
+
+        return EventSourceResponse(
+            content=event_generator(),
+            media_type="text/event-stream",
+        )
+
+    @router.get("/{session_id}/status")
+    async def get_graph_status(session_id: str) -> JSONResponse:
+        """Lightweight status check."""
+        status = await store.get_status(session_id)
+        if status is None:
+            return JSONResponse(
+                {"error": "Graph session not found"}, status_code=404,
+            )
+        return JSONResponse({"sessionId": session_id, "status": status})
+
+    @router.post("/{session_id}:cancel")
+    async def cancel_graph_session(session_id: str) -> JSONResponse:
+        """Cancel all running node tasks in the session."""
+        status = await store.get_status(session_id)
+        if status is None:
+            return JSONResponse(
+                {"error": "Graph session not found"}, status_code=404,
+            )
+
+        await scheduler.cancel(session_id)
+        await store.set_status(session_id, "cancelled")
+        await event_bus.publish(session_id, {
+            "type": "graphCancelled", "sessionId": session_id,
+        })
+        await event_bus.close(session_id)
+
+        return JSONResponse({
+            "sessionId": session_id, "status": "cancelled",
+        })
+
+    return router

--- a/packages/opal-backend/opal_backend/local/graph_session_router.py
+++ b/packages/opal-backend/opal_backend/local/graph_session_router.py
@@ -174,4 +174,41 @@ def create_graph_session_router(
             "sessionId": session_id, "status": "cancelled",
         })
 
+    @router.post("/{session_id}:resume")
+    async def resume_graph_session(
+        request: Request, session_id: str,
+    ) -> JSONResponse:
+        """Resume a suspended node after user input.
+
+        Body: {interactionId: str, response: dict}
+        """
+        status = await store.get_status(session_id)
+        if status is None:
+            return JSONResponse(
+                {"error": "Graph session not found"}, status_code=404,
+            )
+
+        body = await request.json()
+        interaction_id = body.get("interactionId")
+        if not interaction_id:
+            return JSONResponse(
+                {"error": "Missing 'interactionId' in request body"},
+                status_code=400,
+            )
+
+        response = body.get("response", {})
+
+        try:
+            await runner.resume_node(
+                session_id, interaction_id, response,
+            )
+        except ValueError as exc:
+            return JSONResponse(
+                {"error": str(exc)}, status_code=404,
+            )
+
+        return JSONResponse({
+            "sessionId": session_id, "status": "running",
+        })
+
     return router

--- a/packages/opal-backend/opal_backend/local/graph_session_router.py
+++ b/packages/opal-backend/opal_backend/local/graph_session_router.py
@@ -54,8 +54,7 @@ def create_graph_session_router(
     async def create_graph_session(request: Request) -> JSONResponse:
         """Start a new graph run.
 
-        Body: {graph: GraphDescriptor, mode?: str, inputs?: dict,
-               accessToken?: str}
+        Body: {graph: GraphDescriptor, accessToken?: str}
         """
         body = await request.json()
         graph_data = body.get("graph")
@@ -64,6 +63,10 @@ def create_graph_session_router(
                 {"error": "Missing 'graph' in request body"},
                 status_code=400,
             )
+
+        # Extract user's OAuth token (same pattern as session_router).
+        access_token = body.get("accessToken", "")
+        origin = request.headers.get("origin", "")
 
         # Parse, condense (break cycles), and plan.
         graph = GraphDescriptor.from_dict(graph_data)
@@ -80,7 +83,9 @@ def create_graph_session_router(
 
         # Store the plan and kick off initial tasks.
         await store.create(session_id, plan)
-        await runner.start_graph(session_id)
+        await runner.start_graph(
+            session_id, access_token=access_token, origin=origin,
+        )
 
         return JSONResponse({"sessionId": session_id})
 

--- a/packages/opal-backend/opal_backend/local/graph_session_store_impl.py
+++ b/packages/opal-backend/opal_backend/local/graph_session_store_impl.py
@@ -178,12 +178,12 @@ class InMemoryGraphSessionStore:
     async def is_graph_complete(
         self, session_id: str,
     ) -> bool:
-        """True when all nodes are completed or skipped."""
+        """True when all nodes are in a terminal state."""
         state = self._sessions.get(session_id)
         if not state:
             return False
         return all(
-            ns.status in ("completed", "skipped")
+            ns.status in ("completed", "skipped", "failed")
             for ns in state.nodes.values()
         )
 

--- a/packages/opal-backend/opal_backend/local/graph_session_store_impl.py
+++ b/packages/opal-backend/opal_backend/local/graph_session_store_impl.py
@@ -1,0 +1,298 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""InMemoryGraphSessionStore — dict-backed GraphSessionStore for dev server.
+
+Stores all graph execution state in plain Python dicts. Single-process,
+no concurrency hazards (asyncio cooperative multitasking = no races).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from ..graph_types import GraphPlan
+from ..graph_session_store import SuspendedNodeState
+
+__all__ = ["InMemoryGraphSessionStore"]
+
+
+@dataclass
+class _NodeState:
+    """Per-node mutable state within a graph session."""
+
+    pending_deps: int = 0
+    outputs: dict[str, Any] | None = None
+    status: str = "inactive"  # inactive | ready | running | completed | failed | skipped
+    error: str | None = None
+
+
+@dataclass
+class _SessionState:
+    """All state for a single graph session."""
+
+    plan: GraphPlan
+    nodes: dict[str, _NodeState] = field(default_factory=dict)
+    events: list[dict[str, Any]] = field(default_factory=list)
+    status: str = "running"
+    suspended: dict[str, SuspendedNodeState] = field(default_factory=dict)
+    # interaction_id → node_id
+    interaction_index: dict[str, str] = field(default_factory=dict)
+
+
+class InMemoryGraphSessionStore:
+    """Dict-backed implementation of GraphSessionStore.
+
+    Suitable for dev / fake server use. All operations are O(nodes)
+    at worst. No external dependencies.
+    """
+
+    def __init__(self) -> None:
+        self._sessions: dict[str, _SessionState] = {}
+
+    # ── Plan Storage ──
+
+    async def create(
+        self, session_id: str, plan: GraphPlan,
+    ) -> None:
+        """Store plan with initial dependency counts."""
+        state = _SessionState(plan=plan)
+
+        # Compute per-node pending dep counts from plan stages.
+        for stage in plan.stages:
+            for info in stage:
+                ns = _NodeState(
+                    pending_deps=len(info.upstream),
+                )
+                # Entry nodes (no upstream) are immediately ready.
+                if ns.pending_deps == 0:
+                    ns.status = "ready"
+                state.nodes[info.node.id] = ns
+
+        self._sessions[session_id] = state
+
+    async def get_plan(
+        self, session_id: str,
+    ) -> GraphPlan | None:
+        """Load the stored plan."""
+        s = self._sessions.get(session_id)
+        return s.plan if s else None
+
+    # ── Node Lifecycle ──
+
+    async def complete_node(
+        self, session_id: str, node_id: str, outputs: dict[str, Any],
+    ) -> list[str]:
+        """Mark node complete, decrement downstream deps, return newly-ready."""
+        state = self._sessions[session_id]
+        ns = state.nodes[node_id]
+        ns.outputs = outputs
+        ns.status = "completed"
+
+        # Find downstream nodes from plan and decrement.
+        newly_ready: list[str] = []
+        for stage in state.plan.stages:
+            for info in stage:
+                if info.node.id != node_id:
+                    continue
+                for edge in info.downstream:
+                    target_id = edge.to_node
+                    target_ns = state.nodes.get(target_id)
+                    if target_ns and target_ns.pending_deps > 0:
+                        target_ns.pending_deps -= 1
+                        if target_ns.pending_deps == 0:
+                            target_ns.status = "ready"
+                            newly_ready.append(target_id)
+                break  # Node only appears once in the plan.
+
+        return newly_ready
+
+    async def get_node_inputs(
+        self, session_id: str, node_id: str,
+    ) -> dict[str, list[Any]]:
+        """Gather upstream outputs connected to this node's input ports."""
+        state = self._sessions[session_id]
+        inputs: dict[str, list[Any]] = {}
+
+        # Walk the plan to find upstream edges for this node.
+        for stage in state.plan.stages:
+            for info in stage:
+                if info.node.id != node_id:
+                    continue
+                for edge in info.upstream:
+                    upstream_ns = state.nodes.get(edge.from_node)
+                    if not upstream_ns or upstream_ns.outputs is None:
+                        continue
+                    in_port = edge.in_port or "input"
+                    out_port = edge.out_port or "output"
+                    value = upstream_ns.outputs.get(out_port)
+                    if value is not None:
+                        inputs.setdefault(in_port, []).append(value)
+                return inputs
+
+        return inputs
+
+    async def get_node_config(
+        self, session_id: str, node_id: str,
+    ) -> dict[str, Any]:
+        """Load node configuration from the stored plan."""
+        state = self._sessions[session_id]
+        for stage in state.plan.stages:
+            for info in stage:
+                if info.node.id == node_id:
+                    return info.node.configuration or {}
+        return {}
+
+    # ── Suspend / Resume ──
+
+    async def suspend_node(
+        self, session_id: str, node_id: str,
+        interaction_id: str,
+        suspended_state: SuspendedNodeState,
+    ) -> None:
+        """Save suspended node state."""
+        state = self._sessions[session_id]
+        ns = state.nodes[node_id]
+        ns.status = "suspended"
+        state.suspended[node_id] = suspended_state
+        state.interaction_index[interaction_id] = node_id
+
+    async def load_suspended_node(
+        self, session_id: str, interaction_id: str,
+    ) -> tuple[str, SuspendedNodeState] | None:
+        """Load suspended node by interaction ID."""
+        state = self._sessions.get(session_id)
+        if not state:
+            return None
+        node_id = state.interaction_index.get(interaction_id)
+        if not node_id:
+            return None
+        suspended = state.suspended.get(node_id)
+        if not suspended:
+            return None
+        return (node_id, suspended)
+
+    # ── Graph Lifecycle ──
+
+    async def is_graph_complete(
+        self, session_id: str,
+    ) -> bool:
+        """True when all nodes are completed or skipped."""
+        state = self._sessions.get(session_id)
+        if not state:
+            return False
+        return all(
+            ns.status in ("completed", "skipped")
+            for ns in state.nodes.values()
+        )
+
+    async def get_graph_outputs(
+        self, session_id: str,
+    ) -> dict[str, Any]:
+        """Load outputs from all completed nodes."""
+        state = self._sessions.get(session_id)
+        if not state:
+            return {}
+        result: dict[str, Any] = {}
+        for node_id, ns in state.nodes.items():
+            if ns.outputs is not None:
+                result[node_id] = ns.outputs
+        return result
+
+    async def mark_node_failed(
+        self, session_id: str, node_id: str, error: str,
+    ) -> list[str]:
+        """Mark node failed, skip dependents without alternative paths."""
+        state = self._sessions[session_id]
+        ns = state.nodes[node_id]
+        ns.status = "failed"
+        ns.error = error
+
+        # Find and skip downstream dependents that have no other path.
+        skipped: list[str] = []
+        to_skip = [node_id]
+        while to_skip:
+            current = to_skip.pop()
+            for stage in state.plan.stages:
+                for info in stage:
+                    if info.node.id != current:
+                        continue
+                    for edge in info.downstream:
+                        target_id = edge.to_node
+                        target_ns = state.nodes.get(target_id)
+                        if not target_ns:
+                            continue
+                        if target_ns.status in ("completed", "failed", "skipped"):
+                            continue
+                        # Check if target has any OTHER completed upstream.
+                        has_alt = self._has_alternative_path(
+                            state, target_id, node_id,
+                        )
+                        if not has_alt:
+                            target_ns.status = "skipped"
+                            skipped.append(target_id)
+                            to_skip.append(target_id)
+
+        # Return any nodes that are now newly ready (from other paths).
+        newly_ready: list[str] = []
+        for nid, nstate in state.nodes.items():
+            if nstate.status == "ready" and nid not in skipped:
+                newly_ready.append(nid)
+
+        return newly_ready
+
+    def _has_alternative_path(
+        self, state: _SessionState, target_id: str, failed_id: str,
+    ) -> bool:
+        """Check if target has any completed upstream other than failed_id."""
+        for stage in state.plan.stages:
+            for info in stage:
+                if info.node.id != target_id:
+                    continue
+                for edge in info.upstream:
+                    if edge.from_node == failed_id:
+                        continue
+                    upstream_ns = state.nodes.get(edge.from_node)
+                    if upstream_ns and upstream_ns.status == "completed":
+                        return True
+                return False
+        return False
+
+    # ── Event Log ──
+
+    async def append_event(
+        self, session_id: str, event: dict[str, Any],
+    ) -> int:
+        """Append event to session log. Returns event index."""
+        state = self._sessions[session_id]
+        idx = len(state.events)
+        event_with_idx = {**event, "index": idx}
+        state.events.append(event_with_idx)
+        return idx
+
+    async def get_events(
+        self, session_id: str, *, after: int = -1,
+    ) -> list[dict[str, Any]]:
+        """Return events with index > after."""
+        state = self._sessions.get(session_id)
+        if not state:
+            return []
+        return [e for e in state.events if e.get("index", 0) > after]
+
+    # ── Status ──
+
+    async def get_status(
+        self, session_id: str,
+    ) -> str | None:
+        """Return session status."""
+        state = self._sessions.get(session_id)
+        return state.status if state else None
+
+    async def set_status(
+        self, session_id: str, status: str,
+    ) -> None:
+        """Set session status."""
+        state = self._sessions.get(session_id)
+        if state:
+            state.status = status

--- a/packages/opal-backend/opal_backend/local/session_router.py
+++ b/packages/opal-backend/opal_backend/local/session_router.py
@@ -23,9 +23,10 @@ from sse_starlette.sse import EventSourceResponse
 
 from ..backend_client import BackendClient
 from ..drive_operations_client import DriveOperationsClient
+from ..event_bus import EventBus
 from ..interaction_store import InteractionStore
 from ..sessions.api import (
-    Subscribers, cancel_session_task, new_session, register_task,
+    cancel_session_task, new_session, register_task,
     resume_session, start_session, update_context,
 )
 from ..sessions.store import SessionStatus, SessionStore
@@ -54,14 +55,14 @@ class SessionDeps:
 
 def create_session_router(
     store: SessionStore,
-    subscribers: Subscribers,
+    event_bus: EventBus,
     deps: SessionDeps | None = None,
 ) -> APIRouter:
     """Create a FastAPI router with all session endpoints.
 
     Args:
         store: SessionStore implementation (e.g. InMemorySessionStore).
-        subscribers: Subscriber queue manager for live SSE delivery.
+        event_bus: EventBus for live SSE event delivery.
         deps: Per-request dependency factories. If None, endpoints
               return stub responses (Phase 1 behavior).
     """
@@ -119,7 +120,7 @@ def create_session_router(
             start_session(
                 session_id=session_id,
                 store=store,
-                subscribers=subscribers,
+                event_bus=event_bus,
             ),
             name=f"session-{session_id}",
         )
@@ -164,12 +165,9 @@ def create_session_router(
                 deps is not None
                 and current_status in (SessionStatus.RUNNING, SessionStatus.SUSPENDED)
             ):
-                queue = subscribers.subscribe(session_id)
+                subscription = event_bus.subscribe(session_id)
                 try:
-                    while True:
-                        item = await queue.get()
-                        if item is None:
-                            break  # Session ended.
+                    async for item in subscription:
                         yield {
                             "event": "event",
                             "id": str(next_index),
@@ -177,7 +175,7 @@ def create_session_router(
                         }
                         next_index += 1
                 finally:
-                    subscribers.unsubscribe(session_id, queue)
+                    event_bus.unsubscribe(session_id, subscription)
 
             yield {"event": "done", "data": "{}"}
 
@@ -235,7 +233,7 @@ def create_session_router(
                 session_id=session_id,
                 response=body,
                 store=store,
-                subscribers=subscribers,
+                event_bus=event_bus,
             ),
             name=f"resume-{session_id}",
         )

--- a/packages/opal-backend/opal_backend/local/task_scheduler_impl.py
+++ b/packages/opal-backend/opal_backend/local/task_scheduler_impl.py
@@ -1,0 +1,61 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""LocalTaskScheduler — asyncio.create_task-based TaskScheduler.
+
+Runs node tasks as asyncio tasks in the same process. Tracks
+tasks for cancellation support.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Callable, Coroutine
+
+__all__ = ["LocalTaskScheduler"]
+
+
+class LocalTaskScheduler:
+    """Runs node tasks as asyncio tasks in the same process.
+
+    The ``run_fn`` callback receives ``(session_id, node_id)`` and
+    is responsible for the full node lifecycle (load inputs, run
+    handler, complete node, schedule downstream).
+    """
+
+    def __init__(
+        self,
+        run_fn: Callable[[str, str], Coroutine[Any, Any, None]],
+    ) -> None:
+        self._run_fn = run_fn
+        self._tasks: dict[str, asyncio.Task[None]] = {}
+
+    async def schedule(
+        self, session_id: str, node_id: str,
+    ) -> None:
+        """Dispatch a node task as an asyncio.Task."""
+        task = asyncio.create_task(
+            self._run_fn(session_id, node_id),
+            name=f"node-{session_id}-{node_id}",
+        )
+        key = f"{session_id}:{node_id}"
+        self._tasks[key] = task
+        # Auto-cleanup when task completes.
+        task.add_done_callback(lambda _: self._tasks.pop(key, None))
+
+    async def cancel(
+        self, session_id: str, node_id: str | None = None,
+    ) -> None:
+        """Cancel a running node task (or all tasks in a session)."""
+        if node_id:
+            key = f"{session_id}:{node_id}"
+            task = self._tasks.pop(key, None)
+            if task and not task.done():
+                task.cancel()
+        else:
+            prefix = f"{session_id}:"
+            for key in list(self._tasks):
+                if key.startswith(prefix):
+                    task = self._tasks.pop(key)
+                    if not task.done():
+                        task.cancel()

--- a/packages/opal-backend/opal_backend/node_handlers.py
+++ b/packages/opal-backend/opal_backend/node_handlers.py
@@ -17,6 +17,8 @@ Handler types by phase:
 
 from __future__ import annotations
 
+import json
+import re
 import uuid
 from dataclasses import dataclass, field
 from typing import Any, AsyncIterator, Callable, Coroutine
@@ -25,6 +27,7 @@ from .events import SUSPEND_TYPES, AgentEvent
 
 __all__ = [
     "NodeSuspended",
+    "consume_agent_events",
     "dispatch_handler",
     "passthrough_handler",
     "text_gen_handler",
@@ -212,21 +215,82 @@ async def passthrough_handler(
     return outputs
 
 
+# Maps input node modality config → format icon for the frontend.
+# Mirrors ICONS in packages/visual-editor/src/a2/ask-user/main.ts.
+_MODALITY_ICONS: dict[str, str] = {
+    "Any": "asterisk",
+    "Audio": "mic",
+    "Video": "videocam",
+    "Image": "image",
+    "Upload File": "upload",
+    "Text": "edit_note",
+}
+
+
+def _extract_title(description: Any) -> str:
+    """Extract plain text from an LLMContent description value.
+
+    Returns empty string if no meaningful text is found — the
+    frontend falls back to the node's metadata title.
+    """
+    if isinstance(description, dict):
+        parts = description.get("parts", [])
+        texts = [p.get("text", "") for p in parts if isinstance(p, dict)]
+        if texts:
+            result = " ".join(t for t in texts if t)
+            if result:
+                return result
+    if isinstance(description, str) and description:
+        return description
+    return ""
+
+
+def _build_input_schema(config: dict[str, Any]) -> dict[str, Any]:
+    """Build the UI input schema from node config.
+
+    Mirrors ``createInputSchema()`` in the TypeScript ask-user module.
+    """
+    title = _extract_title(config.get("description"))
+    modality = config.get("p-modality")
+    required = config.get("p-required", False)
+
+    behavior = ["transient", "llm-content"]
+    if required:
+        behavior.append("hint-required")
+
+    icon = _MODALITY_ICONS.get(modality or "", "asterisk")
+
+    return {
+        "type": "object",
+        "properties": {
+            "request": {
+                "type": "object",
+                "title": title,
+                "behavior": behavior,
+                "examples": [
+                    '{"parts":[{"text":""}],"role":"user"}',
+                ],
+                "format": icon,
+            },
+        },
+    }
+
+
 async def input_handler(
     inputs: dict[str, list[Any]],
     config: dict[str, Any],
 ) -> dict[str, Any]:
     """Suspend the node to request user input.
 
-    Raises ``NodeSuspended`` with the node's input schema so the
-    graph runner can emit an ``inputRequired`` event. The resume
-    endpoint later provides the user's input as the node output.
+    Raises ``NodeSuspended`` with a schema built from the node's
+    configuration (description, modality, required). The frontend
+    uses this schema to render the appropriate input form. The
+    resume endpoint later provides the user's input as the node
+    output.
     """
     interaction_id = str(uuid.uuid4())
 
-    # Build the suspend event payload from config.
-    schema = config.get("schema", {})
-    prompt_text = config.get("prompt", "Please provide input")
+    schema = _build_input_schema(config)
 
     raise NodeSuspended(
         interaction_id=interaction_id,
@@ -234,7 +298,6 @@ async def input_handler(
         suspend_event={
             "inputNode": {
                 "schema": schema,
-                "prompt": prompt_text,
             },
         },
     )
@@ -278,10 +341,6 @@ async def agent_handler(
     # Build segments from inputs.
     segments = _build_segments_from_inputs(inputs, config)
 
-    # Run the agent loop.
-    last_event = None
-    result_content: list[dict[str, Any]] = []
-
     agent_iter = deps.run_agent_fn(
         segments=segments,
         backend=deps.backend,
@@ -289,9 +348,29 @@ async def agent_handler(
         graph=deps.graph_info or {},
     )
 
+    return await consume_agent_events(
+        agent_iter, deps, suspend_context={"segments": segments},
+    )
+
+
+async def consume_agent_events(
+    agent_iter: AsyncIterator[AgentEvent],
+    deps: NodeHandlerDeps,
+    suspend_context: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Consume an agent event iterator, forwarding events and collecting output.
+
+    Shared by ``agent_handler`` (initial run) and ``GraphRunner.resume_node``
+    (resumed run). Both iterate the same event stream and need the same
+    forward/suspend/accumulate logic.
+
+    Returns node outputs on completion. Raises ``NodeSuspended`` if
+    the agent needs more input.
+    """
+    result_content: list[dict[str, Any]] = []
+
     async for event in agent_iter:
         event_dict = event.to_dict()
-        last_event = event
 
         # Forward to SSE stream.
         if deps.on_agent_event:
@@ -304,7 +383,7 @@ async def agent_handler(
                 interaction_id = str(uuid.uuid4())
             raise NodeSuspended(
                 interaction_id=interaction_id,
-                context={"segments": segments},
+                context=suspend_context or {},
                 suspend_event=event_dict,
             )
 
@@ -314,18 +393,10 @@ async def agent_handler(
             if content:
                 result_content.append(content)
 
-    # Agent completed — build outputs.
     if result_content:
         return {"context": result_content}
 
-    return {
-        "context": [
-            {
-                "role": "model",
-                "parts": [{"text": "[agent completed]"}],
-            }
-        ],
-    }
+    return {"context": []}
 
 
 def _build_segments_from_inputs(
@@ -350,10 +421,16 @@ def _build_segments_from_inputs(
     # Initial prompt from config (real Breadboard config$prompt).
     prompt = _get_prompt(config)
     if prompt:
+        # Substitute template placeholders with upstream input values.
+        prompt = _substitute_template(prompt, inputs)
         segments.append({"type": "text", "text": prompt})
 
     # Input context from upstream nodes — extract text from LLMContent.
-    for _port, values in inputs.items():
+    # Only include ports that were NOT consumed by template substitution.
+    consumed_ports = _template_consumed_ports(config)
+    for port, values in inputs.items():
+        if port in consumed_ports:
+            continue
         for value in values:
             if isinstance(value, list):
                 # List of LLMContent dicts.
@@ -371,3 +448,109 @@ def _build_segments_from_inputs(
 
     return segments
 
+
+# ---------------------------------------------------------------------------
+# Template substitution — port of Template.substitute() from template.ts
+# ---------------------------------------------------------------------------
+
+# Matches {{...}} where the inner {...} is JSON.
+# Mirrors PARSING_REGEX in template.ts:
+#   /{(?<json>{(?:.*?)})}/gim
+_TEMPLATE_RE = re.compile(r"\{(\{(?:.*?)\})\}", re.IGNORECASE | re.DOTALL)
+
+
+def _substitute_template(
+    text: str,
+    inputs: dict[str, list[Any]],
+) -> str:
+    """Replace template placeholders in prompt text with input values.
+
+    Mirrors ``Template.substitute()`` + ``#replaceParam()`` from
+    ``template.ts``. For ``{"type": "in", "path": "<node-id>"}``
+    placeholders, looks up the input port ``p-z-<node-id>`` and
+    substitutes the text content of the upstream node's output.
+    """
+    def replace_match(m: re.Match[str]) -> str:
+        inner_json = m.group(1)
+        try:
+            param = json.loads(inner_json)
+        except (json.JSONDecodeError, TypeError):
+            return m.group(0)  # Not valid JSON — leave as-is.
+
+        if not isinstance(param, dict) or param.get("type") != "in":
+            return m.group(0)  # Not an "in" param — leave as-is.
+
+        path = param.get("path", "")
+        title = param.get("title", "")
+        port_name = f"p-z-{path}"
+
+        if port_name not in inputs:
+            # Fallback to title, same as TS #replaceParam.
+            return title
+
+        return _extract_input_text(inputs[port_name])
+
+    return _TEMPLATE_RE.sub(replace_match, text)
+
+
+def _template_consumed_ports(
+    config: dict[str, Any],
+) -> set[str]:
+    """Return the set of input port names consumed by template placeholders.
+
+    These ports are inlined into the prompt text and should not also
+    be appended as separate context segments.
+    """
+    prompt = config.get("config$prompt")
+    if not isinstance(prompt, dict):
+        return set()
+
+    text = _extract_text_from_content(prompt)
+    consumed: set[str] = set()
+    for m in _TEMPLATE_RE.finditer(text):
+        try:
+            param = json.loads(m.group(1))
+            if isinstance(param, dict) and param.get("type") == "in":
+                consumed.add(f"p-z-{param.get('path', '')}")
+        except (json.JSONDecodeError, TypeError):
+            continue
+    return consumed
+
+
+def _extract_input_text(values: list[Any]) -> str:
+    """Extract text from an input port's values for template substitution.
+
+    Mirrors the value-type handling in ``Template.substitute()``:
+    - string → use directly
+    - LLMContent (dict with parts) → extract text from parts
+    - LLMContent[] (list) → get last non-$metadata item's text
+    """
+    if not values:
+        return ""
+
+    value = values[0]
+
+    if isinstance(value, str):
+        return value
+
+    if isinstance(value, dict):
+        return _extract_text_from_content(value)
+
+    if isinstance(value, list):
+        # LLMContent[] — get last non-metadata item.
+        last = _get_last_non_metadata(value)
+        if last:
+            return _extract_text_from_content(last)
+
+    return json.dumps(value) if value is not None else ""
+
+
+def _get_last_non_metadata(items: list[Any]) -> dict[str, Any] | None:
+    """Get the last non-$metadata LLMContent from a list.
+
+    Mirrors ``Template.#getLastNonMetadata()`` in template.ts.
+    """
+    for item in reversed(items):
+        if isinstance(item, dict) and item.get("role") != "$metadata":
+            return item
+    return None

--- a/packages/opal-backend/opal_backend/node_handlers.py
+++ b/packages/opal-backend/opal_backend/node_handlers.py
@@ -3,38 +3,82 @@
 
 """Node handlers — per-node-type execution logic.
 
-Each handler receives inputs and config; returns outputs.
+Each handler receives inputs, config, and optional dependencies;
+returns either outputs (complete) or raises ``NodeSuspended`` to
+signal that the node needs user input.
+
 Only stdlib + typing — no external deps (synced to production).
 
-Phase 2 scope:
+Handler types by phase:
 - ``passthrough_handler`` — returns inputs as outputs (output nodes)
 - ``text_gen_handler`` — stub for direct Gemini text generation
-
-Later phases will add:
 - ``agent_handler`` — full agent loop via ``run_agent()``
-- ``asset_handler`` — resolve storedData/fileData
-- ``input_handler`` — emit inputRequired, save state
 """
 
 from __future__ import annotations
 
-from typing import Any
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, AsyncIterator, Callable, Coroutine
+
+from .events import SUSPEND_TYPES, AgentEvent
 
 __all__ = [
+    "NodeSuspended",
     "dispatch_handler",
     "passthrough_handler",
     "text_gen_handler",
+    "agent_handler",
 ]
+
+
+@dataclass
+class NodeSuspended(Exception):
+    """Raised by a handler when the node needs user input.
+
+    The graph runner catches this and calls
+    ``GraphSessionStore.suspend_node()``.
+    """
+
+    interaction_id: str
+    context: dict[str, Any] = field(default_factory=dict)
+    suspend_event: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class NodeHandlerDeps:
+    """Dependencies injected into handlers that need external services.
+
+    Optional — passthrough and stub handlers don't need these.
+    ``GraphRunner`` populates this from its own injected deps.
+    """
+
+    # Called for each agent event during agent node execution.
+    # Signature: (event_dict) -> None
+    on_agent_event: Callable[
+        [dict[str, Any]], Coroutine[Any, Any, None],
+    ] | None = None
+
+    # Agent runner — async iterator factory.
+    # Returns an async iterator of AgentEvent.
+    run_agent_fn: Callable[..., AsyncIterator[AgentEvent]] | None = None
+
+    # For building agent run kwargs.
+    backend: Any = None
+    interaction_store: Any = None
+    graph_info: dict[str, Any] | None = None
 
 
 async def dispatch_handler(
     node_type: str,
     inputs: dict[str, list[Any]],
     config: dict[str, Any],
+    deps: NodeHandlerDeps | None = None,
 ) -> dict[str, Any]:
     """Dispatch to the appropriate handler based on node type.
 
-    Returns node outputs.
+    Returns node outputs. May raise ``NodeSuspended`` if the node
+    needs user input.
     """
     # Subgraph nodes (type starts with "#") are passthrough for now.
     if node_type.startswith("#"):
@@ -46,6 +90,9 @@ async def dispatch_handler(
         case "input":
             return await passthrough_handler(inputs, config)
         case "generate":
+            mode = config.get("mode", "text")
+            if mode == "agent" and deps and deps.run_agent_fn:
+                return await agent_handler(inputs, config, deps)
             return await text_gen_handler(inputs, config)
         case _:
             # Default passthrough for unknown types.
@@ -76,18 +123,9 @@ async def text_gen_handler(
 ) -> dict[str, Any]:
     """Stub text generation handler.
 
-    Phase 2 scope: returns a mock response. Full implementation in
-    Phase 4 will call ``BackendClient.stream_generate_content()``.
+    Returns a mock response. Full implementation will call
+    ``BackendClient.stream_generate_content()``.
     """
-    # For Phase 2 testing, produce a deterministic output.
-    context_parts = []
-    for port, values in inputs.items():
-        for value in values:
-            if isinstance(value, list):
-                context_parts.extend(value)
-            elif isinstance(value, dict):
-                context_parts.append(value)
-
     return {
         "context": [
             {
@@ -96,3 +134,116 @@ async def text_gen_handler(
             }
         ],
     }
+
+
+async def agent_handler(
+    inputs: dict[str, list[Any]],
+    config: dict[str, Any],
+    deps: NodeHandlerDeps,
+) -> dict[str, Any]:
+    """Run the agent loop for a generate node in agent mode.
+
+    Streams ``AgentEvent`` objects from ``run_agent()``, forwarding
+    each one via ``deps.on_agent_event()`` wrapped with the node ID.
+    If the agent yields a suspend event (waitForInput, etc.), raises
+    ``NodeSuspended`` so the graph runner can save state.
+
+    On completion, extracts the agent's final output.
+    """
+    if not deps.run_agent_fn:
+        raise RuntimeError("agent_handler requires run_agent_fn in deps")
+
+    # Build segments from inputs.
+    segments = _build_segments_from_inputs(inputs, config)
+
+    # Run the agent loop.
+    last_event = None
+    result_content: list[dict[str, Any]] = []
+
+    agent_iter = deps.run_agent_fn(
+        segments=segments,
+        backend=deps.backend,
+        store=deps.interaction_store,
+        graph=deps.graph_info or {},
+    )
+
+    async for event in agent_iter:
+        event_dict = event.to_dict()
+        last_event = event
+
+        # Forward to SSE stream.
+        if deps.on_agent_event:
+            await deps.on_agent_event(event_dict)
+
+        # Check for suspend events.
+        if event.type in SUSPEND_TYPES:
+            interaction_id = getattr(event, "interaction_id", None)
+            if not interaction_id:
+                interaction_id = str(uuid.uuid4())
+            raise NodeSuspended(
+                interaction_id=interaction_id,
+                context={"segments": segments},
+                suspend_event=event_dict,
+            )
+
+        # Accumulate content events for final output.
+        if event.type == "content":
+            content = getattr(event, "content", None)
+            if content:
+                result_content.append(content)
+
+    # Agent completed — build outputs.
+    if result_content:
+        return {"context": result_content}
+
+    return {
+        "context": [
+            {
+                "role": "model",
+                "parts": [{"text": "[agent completed]"}],
+            }
+        ],
+    }
+
+
+def _build_segments_from_inputs(
+    inputs: dict[str, list[Any]],
+    config: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Build agent segments from node inputs and config.
+
+    Converts upstream outputs into the ``segments`` format that
+    ``run_agent()`` expects.
+    """
+    segments: list[dict[str, Any]] = []
+
+    # System instruction from config.
+    system_instruction = config.get("systemInstruction")
+    if system_instruction:
+        segments.append({
+            "kind": "text",
+            "parts": [{"text": system_instruction}],
+        })
+
+    # Input context from upstream nodes.
+    for port, values in inputs.items():
+        for value in values:
+            if isinstance(value, list):
+                # Already a list of LLMContent.
+                for item in value:
+                    segments.append({
+                        "kind": "text",
+                        "parts": item.get("parts", []) if isinstance(item, dict) else [],
+                    })
+            elif isinstance(value, dict):
+                segments.append({
+                    "kind": "text",
+                    "parts": value.get("parts", []),
+                })
+            elif isinstance(value, str):
+                segments.append({
+                    "kind": "text",
+                    "parts": [{"text": value}],
+                })
+
+    return segments

--- a/packages/opal-backend/opal_backend/node_handlers.py
+++ b/packages/opal-backend/opal_backend/node_handlers.py
@@ -28,6 +28,7 @@ __all__ = [
     "dispatch_handler",
     "passthrough_handler",
     "text_gen_handler",
+    "input_handler",
     "agent_handler",
 ]
 
@@ -88,7 +89,7 @@ async def dispatch_handler(
         case "output" | "render-outputs":
             return await passthrough_handler(inputs, config)
         case "input":
-            return await passthrough_handler(inputs, config)
+            return await input_handler(inputs, config)
         case "generate":
             mode = config.get("mode", "text")
             if mode == "agent" and deps and deps.run_agent_fn:
@@ -116,6 +117,33 @@ async def passthrough_handler(
             outputs[port] = values
     return outputs
 
+
+async def input_handler(
+    inputs: dict[str, list[Any]],
+    config: dict[str, Any],
+) -> dict[str, Any]:
+    """Suspend the node to request user input.
+
+    Raises ``NodeSuspended`` with the node's input schema so the
+    graph runner can emit an ``inputRequired`` event. The resume
+    endpoint later provides the user's input as the node output.
+    """
+    interaction_id = str(uuid.uuid4())
+
+    # Build the suspend event payload from config.
+    schema = config.get("schema", {})
+    prompt_text = config.get("prompt", "Please provide input")
+
+    raise NodeSuspended(
+        interaction_id=interaction_id,
+        context={"inputs": inputs, "config": config},
+        suspend_event={
+            "inputNode": {
+                "schema": schema,
+                "prompt": prompt_text,
+            },
+        },
+    )
 
 async def text_gen_handler(
     inputs: dict[str, list[Any]],

--- a/packages/opal-backend/opal_backend/node_handlers.py
+++ b/packages/opal-backend/opal_backend/node_handlers.py
@@ -70,6 +70,100 @@ class NodeHandlerDeps:
     graph_info: dict[str, Any] | None = None
 
 
+def _extract_text_from_content(content: dict[str, Any]) -> str:
+    """Extract plain text from an LLMContent dict."""
+    parts = content.get("parts", [])
+    texts = []
+    for part in parts:
+        if isinstance(part, dict) and "text" in part:
+            texts.append(part["text"])
+    return "\n".join(texts)
+
+# ---------------------------------------------------------------------------
+# Config normalization helpers
+# ---------------------------------------------------------------------------
+
+# Explicit map of known Breadboard embed URLs to canonical node types.
+# The URL structure isn't guaranteed to be semantic, so we map each one
+# explicitly rather than parsing the path.
+_EMBED_URL_MAP: dict[str, str] = {
+    "embed://a2/generate.bgl.json#module:main": "generate",
+    "embed://a2/generate-text.bgl.json#daf082ca-c1aa-4aff-b2c8-abeb984ab66c": "generate",
+    "embed://a2/a2.bgl.json#21ee02e7-83fa-49d0-964c-0cab10eafc2c": "input",
+    "embed://a2/ask-user.bgl.json#module:main": "input",
+    "embed://a2/a2.bgl.json#module:render-outputs": "output",
+    # Media generators — generate nodes with specialized output types.
+    "embed://a2/a2.bgl.json#module:image-generator": "generate",
+    "embed://a2/a2.bgl.json#module:image-editor": "generate",
+    "embed://a2/audio-generator.bgl.json#module:main": "generate",
+    "embed://a2/video-generator.bgl.json#module:main": "generate",
+    "embed://a2/music-generator.bgl.json#module:main": "generate",
+    # Compound nodes — run as subgraphs.
+    "embed://a2/go-over-list.bgl.json#module:main": "generate",
+    "embed://a2/deep-research.bgl.json#module:main": "generate",
+}
+
+
+def _effective_node_type(raw_type: str) -> str:
+    """Map a raw node type to a canonical handler type.
+
+    Real Breadboard graphs use embed URLs like
+    ``embed://a2/generate.bgl.json#module:main``.  Subgraph nodes
+    start with ``#``.  Simple types like ``"generate"`` pass through.
+    """
+    # Subgraph nodes.
+    if raw_type.startswith("#"):
+        return "subgraph"
+
+    # Explicit URL lookup.
+    if raw_type in _EMBED_URL_MAP:
+        return _EMBED_URL_MAP[raw_type]
+
+    return raw_type
+
+
+def _get_mode(config: dict[str, Any]) -> str:
+    """Read the generation mode from config.
+
+    Real Breadboard uses ``generation-mode``; simplified test format
+    uses ``mode``.
+    """
+    return config.get("generation-mode", config.get("mode", "text"))
+
+
+def _get_system_instruction(config: dict[str, Any]) -> str:
+    """Extract system instruction text from config.
+
+    Handles both:
+    - Simple string: ``{"systemInstruction": "Be helpful"}``
+    - LLMContent: ``{"b-system-instruction": {"parts": [{"text": "..."}]}}``
+    """
+    # Simple string format.
+    simple = config.get("systemInstruction")
+    if isinstance(simple, str):
+        return simple
+
+    # Real Breadboard LLMContent format.
+    llm_content = config.get("b-system-instruction")
+    if isinstance(llm_content, dict):
+        return _extract_text_from_content(llm_content)
+
+    return ""
+
+
+def _get_prompt(config: dict[str, Any]) -> str:
+    """Extract the initial prompt text from config.
+
+    Real Breadboard uses ``config$prompt`` (LLMContent format).
+    """
+    prompt = config.get("config$prompt")
+    if isinstance(prompt, dict):
+        return _extract_text_from_content(prompt)
+    if isinstance(prompt, str):
+        return prompt
+    return ""
+
+
 async def dispatch_handler(
     node_type: str,
     inputs: dict[str, list[Any]],
@@ -81,17 +175,17 @@ async def dispatch_handler(
     Returns node outputs. May raise ``NodeSuspended`` if the node
     needs user input.
     """
-    # Subgraph nodes (type starts with "#") are passthrough for now.
-    if node_type.startswith("#"):
-        return await passthrough_handler(inputs, config)
+    # Normalize node type — real Breadboard embeds use URLs like
+    # "embed://a2/generate.bgl.json#module:main".
+    effective_type = _effective_node_type(node_type)
 
-    match node_type:
+    match effective_type:
         case "output" | "render-outputs":
             return await passthrough_handler(inputs, config)
         case "input":
             return await input_handler(inputs, config)
         case "generate":
-            mode = config.get("mode", "text")
+            mode = _get_mode(config)
             if mode == "agent" and deps and deps.run_agent_fn:
                 return await agent_handler(inputs, config, deps)
             return await text_gen_handler(inputs, config)
@@ -241,37 +335,39 @@ def _build_segments_from_inputs(
     """Build agent segments from node inputs and config.
 
     Converts upstream outputs into the ``segments`` format that
-    ``run_agent()`` expects.
+    ``run_agent()`` → ``to_pidgin()`` expects.
+
+    Wire format (flat):  ``{"type": "text", "text": "hello"}``
     """
     segments: list[dict[str, Any]] = []
 
-    # System instruction from config.
-    system_instruction = config.get("systemInstruction")
+    # System instruction from config (supports both simple string
+    # and real Breadboard LLMContent format).
+    system_instruction = _get_system_instruction(config)
     if system_instruction:
-        segments.append({
-            "kind": "text",
-            "parts": [{"text": system_instruction}],
-        })
+        segments.append({"type": "text", "text": system_instruction})
 
-    # Input context from upstream nodes.
-    for port, values in inputs.items():
+    # Initial prompt from config (real Breadboard config$prompt).
+    prompt = _get_prompt(config)
+    if prompt:
+        segments.append({"type": "text", "text": prompt})
+
+    # Input context from upstream nodes — extract text from LLMContent.
+    for _port, values in inputs.items():
         for value in values:
             if isinstance(value, list):
-                # Already a list of LLMContent.
+                # List of LLMContent dicts.
                 for item in value:
-                    segments.append({
-                        "kind": "text",
-                        "parts": item.get("parts", []) if isinstance(item, dict) else [],
-                    })
+                    if isinstance(item, dict):
+                        text = _extract_text_from_content(item)
+                        if text:
+                            segments.append({"type": "text", "text": text})
             elif isinstance(value, dict):
-                segments.append({
-                    "kind": "text",
-                    "parts": value.get("parts", []),
-                })
+                text = _extract_text_from_content(value)
+                if text:
+                    segments.append({"type": "text", "text": text})
             elif isinstance(value, str):
-                segments.append({
-                    "kind": "text",
-                    "parts": [{"text": value}],
-                })
+                segments.append({"type": "text", "text": value})
 
     return segments
+

--- a/packages/opal-backend/opal_backend/node_handlers.py
+++ b/packages/opal-backend/opal_backend/node_handlers.py
@@ -1,0 +1,98 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Node handlers — per-node-type execution logic.
+
+Each handler receives inputs and config; returns outputs.
+Only stdlib + typing — no external deps (synced to production).
+
+Phase 2 scope:
+- ``passthrough_handler`` — returns inputs as outputs (output nodes)
+- ``text_gen_handler`` — stub for direct Gemini text generation
+
+Later phases will add:
+- ``agent_handler`` — full agent loop via ``run_agent()``
+- ``asset_handler`` — resolve storedData/fileData
+- ``input_handler`` — emit inputRequired, save state
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = [
+    "dispatch_handler",
+    "passthrough_handler",
+    "text_gen_handler",
+]
+
+
+async def dispatch_handler(
+    node_type: str,
+    inputs: dict[str, list[Any]],
+    config: dict[str, Any],
+) -> dict[str, Any]:
+    """Dispatch to the appropriate handler based on node type.
+
+    Returns node outputs.
+    """
+    # Subgraph nodes (type starts with "#") are passthrough for now.
+    if node_type.startswith("#"):
+        return await passthrough_handler(inputs, config)
+
+    match node_type:
+        case "output" | "render-outputs":
+            return await passthrough_handler(inputs, config)
+        case "input":
+            return await passthrough_handler(inputs, config)
+        case "generate":
+            return await text_gen_handler(inputs, config)
+        case _:
+            # Default passthrough for unknown types.
+            return await passthrough_handler(inputs, config)
+
+
+async def passthrough_handler(
+    inputs: dict[str, list[Any]],
+    config: dict[str, Any],
+) -> dict[str, Any]:
+    """Return inputs as outputs.
+
+    Flattens multi-value input ports: if a port has a single value,
+    unwrap it. This is the behavior for output/render-outputs nodes.
+    """
+    outputs: dict[str, Any] = {}
+    for port, values in inputs.items():
+        if len(values) == 1:
+            outputs[port] = values[0]
+        else:
+            outputs[port] = values
+    return outputs
+
+
+async def text_gen_handler(
+    inputs: dict[str, list[Any]],
+    config: dict[str, Any],
+) -> dict[str, Any]:
+    """Stub text generation handler.
+
+    Phase 2 scope: returns a mock response. Full implementation in
+    Phase 4 will call ``BackendClient.stream_generate_content()``.
+    """
+    # For Phase 2 testing, produce a deterministic output.
+    context_parts = []
+    for port, values in inputs.items():
+        for value in values:
+            if isinstance(value, list):
+                context_parts.extend(value)
+            elif isinstance(value, dict):
+                context_parts.append(value)
+
+    return {
+        "context": [
+            {
+                "role": "model",
+                "parts": [{"text": "[generated response]"}],
+            }
+        ],
+    }

--- a/packages/opal-backend/opal_backend/run.py
+++ b/packages/opal-backend/opal_backend/run.py
@@ -152,7 +152,7 @@ def _extract_builtin_tools(
 # ---------------------------------------------------------------------------
 
 
-async def run(
+async def run_agent(
     *,
     segments: list[dict[str, Any]],
     backend: BackendClient,
@@ -329,7 +329,7 @@ async def run(
 
 
 
-async def resume(
+async def resume_agent(
     *,
     interaction_id: str,
     response: dict[str, Any],
@@ -976,3 +976,8 @@ async def _stream_loop(
     finally:
         if not loop_task.done():
             loop_task.cancel()
+
+
+# Backward-compatible aliases.
+run = run_agent
+resume = resume_agent

--- a/packages/opal-backend/opal_backend/sessions/api.py
+++ b/packages/opal-backend/opal_backend/sessions/api.py
@@ -5,7 +5,7 @@
 Session API — high-level functions for session-based agent execution.
 
 Wraps the existing ``run()`` async iterator with event teeing to a
-``SessionStore`` and live delivery via subscriber queues.
+``SessionStore`` and live delivery via an ``EventBus``.
 """
 
 from __future__ import annotations
@@ -29,58 +29,19 @@ from ..events import (
 )
 from ..backend_client import BackendClient
 from ..drive_operations_client import DriveOperationsClient
+from ..event_bus import EventBus
 from ..interaction_store import InteractionStore
 from ..run import run as run_agent, resume as resume_agent
 from .store import SessionStatus, SessionStore
 
 __all__ = [
     "new_session", "start_session", "resume_session",
-    "cancel_session_task", "update_context", "Subscribers",
+    "cancel_session_task", "update_context",
 ]
 
 logger = logging.getLogger(__name__)
 
 
-# ---------------------------------------------------------------------------
-# Subscriber management — live event delivery to SSE clients
-# ---------------------------------------------------------------------------
-
-
-class Subscribers:
-    """Per-session subscriber queues for live event delivery.
-
-    Each SSE connection subscribes to a session. ``start_session()``
-    publishes each event to all subscriber queues. When the session
-    ends, all queues receive a ``None`` sentinel.
-    """
-
-    def __init__(self) -> None:
-        self._queues: dict[str, list[asyncio.Queue]] = {}
-
-    def subscribe(self, session_id: str) -> asyncio.Queue:
-        """Create and register a subscriber queue for a session."""
-        queue: asyncio.Queue = asyncio.Queue()
-        self._queues.setdefault(session_id, []).append(queue)
-        return queue
-
-    def unsubscribe(self, session_id: str, queue: asyncio.Queue) -> None:
-        """Remove a subscriber queue."""
-        queues = self._queues.get(session_id, [])
-        if queue in queues:
-            queues.remove(queue)
-
-    async def publish(
-        self, session_id: str, event: dict[str, Any],
-    ) -> None:
-        """Push an event dict to all subscriber queues."""
-        for queue in self._queues.get(session_id, []):
-            await queue.put(event)
-
-    async def close(self, session_id: str) -> None:
-        """Send sentinel to all subscribers and clean up."""
-        for queue in self._queues.get(session_id, []):
-            await queue.put(None)
-        self._queues.pop(session_id, None)
 
 
 # ---------------------------------------------------------------------------
@@ -211,7 +172,7 @@ async def start_session(
     *,
     session_id: str,
     store: SessionStore,
-    subscribers: Subscribers,
+    event_bus: EventBus,
 ) -> None:
     """Run the agent loop for a session, teeing events to store + subscribers.
 
@@ -242,7 +203,7 @@ async def start_session(
             session_id=session_id,
         ),
         store=store,
-        subscribers=subscribers,
+        event_bus=event_bus,
         ctx=ctx,
     )
 
@@ -252,7 +213,7 @@ async def resume_session(
     session_id: str,
     response: dict[str, Any],
     store: SessionStore,
-    subscribers: Subscribers,
+    event_bus: EventBus,
     context_parts: list[dict[str, Any]] | None = None,
 ) -> None:
     """Resume a suspended session.
@@ -294,7 +255,7 @@ async def resume_session(
             context_queue=ctx.context_queue,
         ),
         store=store,
-        subscribers=subscribers,
+        event_bus=event_bus,
         ctx=ctx,
     )
 
@@ -309,13 +270,13 @@ async def _tee_events(
     session_id: str,
     events: AsyncIterator[AgentEvent],
     store: SessionStore,
-    subscribers: Subscribers,
+    event_bus: EventBus,
     ctx: _SessionContext,
 ) -> None:
     """Shared event-tee loop for start_session and resume_session.
 
     Iterates the event stream, pushes each event to the store and
-    subscribers, detects terminal/suspend events, and sets final status.
+    event bus, detects terminal/suspend events, and sets final status.
     On suspend, re-stashes the context and the interaction_id so the
     next resume_session call can pick them up.
     """
@@ -325,7 +286,7 @@ async def _tee_events(
         async for event in events:
             event_dict = event.to_dict()
             await store.append_event(session_id, event_dict)
-            await subscribers.publish(session_id, event_dict)
+            await event_bus.publish(session_id, event_dict)
 
             # Detect terminal events to set the right status.
             if isinstance(event, CompleteEvent):
@@ -356,12 +317,12 @@ async def _tee_events(
     except Exception as e:
         logger.exception("Session %s failed", session_id)
         await store.append_event(session_id, {"error": {"message": str(e)}})
-        await subscribers.publish(session_id, {"error": {"message": str(e)}})
+        await event_bus.publish(session_id, {"error": {"message": str(e)}})
         terminal_status = SessionStatus.FAILED
 
     finally:
         await store.set_status(session_id, terminal_status)
-        await subscribers.close(session_id)
+        await event_bus.close(session_id)
         _tasks.pop(session_id, None)
 
 

--- a/packages/opal-backend/opal_backend/task_scheduler.py
+++ b/packages/opal-backend/opal_backend/task_scheduler.py
@@ -1,0 +1,50 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""TaskScheduler protocol — node task dispatch abstraction.
+
+Abstracts HOW a node task is started. The graph runner calls
+``schedule()`` whenever a node becomes ready; the implementation
+decides where and how the task runs.
+
+Only stdlib + typing — no external deps (synced to production).
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+__all__ = ["TaskScheduler"]
+
+
+@runtime_checkable
+class TaskScheduler(Protocol):
+    """Protocol for dispatching node tasks.
+
+    Implementations:
+    - ``LocalTaskScheduler`` (``local/task_scheduler_impl.py``)
+      — ``asyncio.create_task()`` in the same process.
+    - Production — enqueues an RPC to a load-balanced task worker.
+    """
+
+    async def schedule(
+        self, session_id: str, node_id: str,
+    ) -> None:
+        """Dispatch a node task for execution.
+
+        The implementation is responsible for:
+        1. Loading node inputs from GraphSessionStore
+        2. Running the node handler
+        3. Calling complete_node() on completion
+        4. Scheduling newly-ready downstream nodes
+
+        Or alternatively, just enqueuing the work for a worker
+        that does all of the above.
+        """
+        ...
+
+    async def cancel(
+        self, session_id: str, node_id: str | None = None,
+    ) -> None:
+        """Cancel a running node task (or all tasks in a session)."""
+        ...

--- a/packages/opal-backend/tests/test_agent_integration.py
+++ b/packages/opal-backend/tests/test_agent_integration.py
@@ -1,0 +1,271 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for agent mode integration (Phase 4).
+
+Verifies that:
+- Agent nodes stream events wrapped with nodeId
+- Agent suspend → node suspend → inputRequired event
+- Agent resume → node resume → downstream triggered
+- Agent error → node failed → dependents skipped
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any, AsyncIterator
+
+import pytest
+
+from opal_backend.events import (
+    ContentEvent,
+    CompleteEvent,
+    StartEvent,
+    WaitForInputEvent,
+    ErrorEvent,
+    AgentEvent,
+)
+from opal_backend.graph_runner import GraphRunner
+from opal_backend.graph_types import Edge, GraphPlan, NodeDescriptor, PlanNodeInfo
+from opal_backend.local.event_bus_impl import InMemoryEventBus
+from opal_backend.local.graph_session_store_impl import InMemoryGraphSessionStore
+from opal_backend.local.task_scheduler_impl import LocalTaskScheduler
+
+
+def _agent_plan() -> GraphPlan:
+    """Single agent node (generate in agent mode)."""
+    gen = NodeDescriptor(
+        id="agent1", type="generate",
+        configuration={"mode": "agent", "systemInstruction": "Be helpful"},
+    )
+    out = NodeDescriptor(id="out", type="output")
+    e = Edge(from_node="agent1", to_node="out", out_port="context", in_port="result")
+
+    return GraphPlan(stages=[
+        [PlanNodeInfo(node=gen, downstream=[e], upstream=[])],
+        [PlanNodeInfo(node=out, downstream=[], upstream=[e])],
+    ])
+
+
+def _make_fake_run_agent(events: list[AgentEvent]):
+    """Create a fake run_agent that yields the given events."""
+
+    async def fake_run_agent(**kwargs) -> AsyncIterator[AgentEvent]:
+        for event in events:
+            yield event
+
+    return fake_run_agent
+
+
+class TestAgentEventsStreaming:
+    """Phase 4 🎯: agent events stream with nodeId envelope."""
+
+    @pytest.mark.asyncio
+    async def test_agent_events_forwarded(self):
+        store = InMemoryGraphSessionStore()
+        bus = InMemoryEventBus()
+
+        fake_agent = _make_fake_run_agent([
+            StartEvent(objective={"parts": [{"text": "test"}]}),
+            ContentEvent(
+                content={"role": "model", "parts": [{"text": "Hello!"}]},
+            ),
+            CompleteEvent(),
+        ])
+
+        runner = GraphRunner(
+            store=store, event_bus=bus, scheduler=None,
+            run_agent_fn=fake_agent,
+        )
+        scheduler = LocalTaskScheduler(run_fn=runner.run_node)
+        runner._scheduler = scheduler
+
+        plan = _agent_plan()
+        await store.create("s1", plan)
+
+        events: list[dict] = []
+        subscriber = bus.subscribe("s1")
+        await runner.start_graph("s1")
+
+        async for event in subscriber:
+            events.append(event)
+            if event.get("type") == "graphComplete":
+                break
+
+        # Check that agent events are wrapped with nodeId.
+        agent_events = [e for e in events if e["type"] == "agentEvent"]
+        assert len(agent_events) >= 2  # start + content at minimum
+        for ae in agent_events:
+            assert ae["nodeId"] == "agent1"
+            assert "event" in ae
+
+    @pytest.mark.asyncio
+    async def test_agent_output_flows_downstream(self):
+        store = InMemoryGraphSessionStore()
+        bus = InMemoryEventBus()
+
+        fake_agent = _make_fake_run_agent([
+            ContentEvent(
+                content={"role": "model", "parts": [{"text": "Result!"}]},
+            ),
+            CompleteEvent(),
+        ])
+
+        runner = GraphRunner(
+            store=store, event_bus=bus, scheduler=None,
+            run_agent_fn=fake_agent,
+        )
+        scheduler = LocalTaskScheduler(run_fn=runner.run_node)
+        runner._scheduler = scheduler
+
+        plan = _agent_plan()
+        await store.create("s1", plan)
+
+        subscriber = bus.subscribe("s1")
+        await runner.start_graph("s1")
+
+        async for event in subscriber:
+            if event.get("type") == "graphComplete":
+                break
+
+        outputs = await store.get_graph_outputs("s1")
+        assert "agent1" in outputs
+        assert "out" in outputs
+
+
+class TestAgentSuspendResume:
+    """Agent suspend → inputRequired, resume → downstream."""
+
+    @pytest.mark.asyncio
+    async def test_suspend_emits_input_required(self):
+        store = InMemoryGraphSessionStore()
+        bus = InMemoryEventBus()
+
+        fake_agent = _make_fake_run_agent([
+            StartEvent(objective={"parts": [{"text": "test"}]}),
+            WaitForInputEvent(
+                request_id="req-1",
+                prompt={"parts": [{"text": "What next?"}]},
+                input_type="text",
+                interaction_id="int-123",
+            ),
+        ])
+
+        runner = GraphRunner(
+            store=store, event_bus=bus, scheduler=None,
+            run_agent_fn=fake_agent,
+        )
+        scheduler = LocalTaskScheduler(run_fn=runner.run_node)
+        runner._scheduler = scheduler
+
+        plan = _agent_plan()
+        await store.create("s1", plan)
+
+        events: list[dict] = []
+        subscriber = bus.subscribe("s1")
+        await runner.start_graph("s1")
+
+        # Collect events until inputRequired.
+        async for event in subscriber:
+            events.append(event)
+            if event.get("type") == "inputRequired":
+                break
+
+        # Verify inputRequired event.
+        input_req = [e for e in events if e["type"] == "inputRequired"]
+        assert len(input_req) == 1
+        assert input_req[0]["nodeId"] == "agent1"
+        assert input_req[0]["interactionId"] == "int-123"
+
+        # Status should be suspended.
+        assert await store.get_status("s1") == "suspended"
+
+    @pytest.mark.asyncio
+    async def test_resume_completes_graph(self):
+        store = InMemoryGraphSessionStore()
+        bus = InMemoryEventBus()
+
+        fake_agent = _make_fake_run_agent([
+            WaitForInputEvent(
+                request_id="req-1",
+                prompt={"parts": [{"text": "What next?"}]},
+                interaction_id="int-456",
+            ),
+        ])
+
+        runner = GraphRunner(
+            store=store, event_bus=bus, scheduler=None,
+            run_agent_fn=fake_agent,
+        )
+        scheduler = LocalTaskScheduler(run_fn=runner.run_node)
+        runner._scheduler = scheduler
+
+        plan = _agent_plan()
+        await store.create("s1", plan)
+
+        # Start and wait for suspend.
+        subscriber = bus.subscribe("s1")
+        await runner.start_graph("s1")
+
+        async for event in subscriber:
+            if event.get("type") == "inputRequired":
+                break
+
+        # Resume the node.
+        await runner.resume_node(
+            "s1", "int-456",
+            {"role": "user", "parts": [{"text": "Continue!"}]},
+        )
+
+        # Wait for completion.
+        subscriber2 = bus.subscribe("s1")
+        async for event in subscriber2:
+            if event.get("type") == "graphComplete":
+                break
+
+        assert await store.is_graph_complete("s1")
+        assert await store.get_status("s1") == "completed"
+
+
+class TestAgentError:
+    """Agent error → node failed → dependents skipped."""
+
+    @pytest.mark.asyncio
+    async def test_agent_error_marks_node_failed(self):
+        store = InMemoryGraphSessionStore()
+        bus = InMemoryEventBus()
+
+        async def failing_agent(**kwargs):
+            yield StartEvent(objective={"parts": [{"text": "test"}]})
+            raise RuntimeError("Agent crashed")
+
+        runner = GraphRunner(
+            store=store, event_bus=bus, scheduler=None,
+            run_agent_fn=failing_agent,
+        )
+        scheduler = LocalTaskScheduler(run_fn=runner.run_node)
+        runner._scheduler = scheduler
+
+        plan = _agent_plan()
+        await store.create("s1", plan)
+
+        events: list[dict] = []
+        subscriber = bus.subscribe("s1")
+        await runner.start_graph("s1")
+
+        # Graph should complete (with failures) and close the bus.
+        async for event in subscriber:
+            events.append(event)
+            if event.get("type") == "graphComplete":
+                break
+
+        # Agent node should be failed, output skipped.
+        state = store._sessions["s1"]
+        assert state.nodes["agent1"].status == "failed"
+        assert state.nodes["out"].status == "skipped"
+
+        # Verify nodeError event was emitted.
+        error_events = [e for e in events if e["type"] == "nodeError"]
+        assert len(error_events) == 1
+        assert "Agent crashed" in error_events[0]["error"]

--- a/packages/opal-backend/tests/test_dev_access_token.py
+++ b/packages/opal-backend/tests/test_dev_access_token.py
@@ -19,7 +19,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from opal_backend.dev.main import app, _subscribers
+from opal_backend.dev.main import app, _event_bus
 
 
 @pytest.fixture
@@ -41,9 +41,9 @@ def _start_body(**extra):
 
 
 async def _close_subscribers(**kwargs):
-    """Mock start_session that closes subscribers so the SSE stream ends."""
+    """Mock start_session that closes event bus so the SSE stream ends."""
     session_id = kwargs.get("session_id", "")
-    await _subscribers.close(session_id)
+    await _event_bus.close(session_id)
 
 
 class TestAccessTokenExtraction:

--- a/packages/opal-backend/tests/test_graph_condense.py
+++ b/packages/opal-backend/tests/test_graph_condense.py
@@ -1,0 +1,220 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for graph condensation (Tarjan SCC + subgraph folding).
+
+Ported from visual-editor/tests/runtime/condense.ts.
+"""
+
+import pytest
+
+from opal_backend.graph_condense import condense
+from opal_backend.graph_types import Edge, GraphDescriptor, NodeDescriptor
+
+
+def _graph(
+    nodes: list[dict], edges: list[dict],
+) -> GraphDescriptor:
+    """Build a GraphDescriptor from compact dicts."""
+    return GraphDescriptor(
+        nodes=[NodeDescriptor(id=n["id"], type=n.get("type", "process"))
+               for n in nodes],
+        edges=[Edge(
+            from_node=e["from"], to_node=e["to"],
+            out_port=e.get("out"), in_port=e.get("in"),
+        ) for e in edges],
+    )
+
+
+# ── basic functionality ──
+
+
+class TestBasicFunctionality:
+    def test_empty_graph(self):
+        g = GraphDescriptor(nodes=[], edges=[])
+        assert condense(g) is g
+
+    def test_no_cycles(self):
+        g = _graph(
+            [{"id": "a"}, {"id": "b"}, {"id": "c"}],
+            [{"from": "a", "to": "b", "out": "value", "in": "input"},
+             {"from": "b", "to": "c", "out": "result", "in": "data"}],
+        )
+        result = condense(g)
+        assert result is g  # No SCCs → same object.
+
+
+# ── simple SCCs ──
+
+
+class TestSimpleSCCs:
+    def test_2_node_cycle(self):
+        g = _graph(
+            [{"id": "a"}, {"id": "b"}, {"id": "c"}],
+            [{"from": "a", "to": "b", "out": "data", "in": "input"},
+             {"from": "b", "to": "a", "out": "feedback", "in": "previous"},
+             {"from": "b", "to": "c", "out": "result", "in": "final"}],
+        )
+        result = condense(g)
+
+        assert len(result.nodes) == 2
+        ids = {n.id for n in result.nodes}
+        assert "c" in ids
+        assert "scc_0" in ids
+
+        assert result.graphs is not None
+        sub = result.graphs["scc_0"]
+        assert len(sub.nodes) == 4  # input, a, b, output
+        sub_ids = {n.id for n in sub.nodes}
+        assert "input_scc_0" in sub_ids
+        assert "output_scc_0" in sub_ids
+        assert "a" in sub_ids
+        assert "b" in sub_ids
+
+    def test_3_node_cycle(self):
+        g = _graph(
+            [{"id": "a"}, {"id": "b"}, {"id": "c"}],
+            [{"from": "a", "to": "b", "out": "s1", "in": "input"},
+             {"from": "b", "to": "c", "out": "s2", "in": "data"},
+             {"from": "c", "to": "a", "out": "s3", "in": "loop"}],
+        )
+        result = condense(g)
+        assert len(result.nodes) == 1
+        assert result.nodes[0].id == "scc_0"
+        assert result.nodes[0].type == "#scc_0"
+
+        sub = result.graphs["scc_0"]
+        assert len(sub.nodes) == 5  # input, a, b, c, output
+
+    def test_self_loop(self):
+        g = _graph(
+            [{"id": "a"}, {"id": "b"}],
+            [{"from": "a", "to": "a", "out": "state", "in": "previous"},
+             {"from": "a", "to": "b", "out": "result", "in": "final"}],
+        )
+        result = condense(g)
+        assert len(result.nodes) == 2
+        ids = {n.id for n in result.nodes}
+        assert "scc_0" in ids
+        assert "b" in ids
+
+        sub = result.graphs["scc_0"]
+        assert any(n.id == "a" for n in sub.nodes)
+
+
+# ── complex SCCs ──
+
+
+class TestComplexSCCs:
+    def test_multiple_separate_sccs(self):
+        g = _graph(
+            [{"id": "a"}, {"id": "b"}, {"id": "c"},
+             {"id": "d"}, {"id": "e"}],
+            [{"from": "a", "to": "b", "out": "d1", "in": "i1"},
+             {"from": "b", "to": "a", "out": "f1", "in": "p1"},
+             {"from": "c", "to": "d", "out": "d2", "in": "i2"},
+             {"from": "d", "to": "c", "out": "f2", "in": "p2"},
+             {"from": "b", "to": "c", "out": "connect", "in": "bridge"},
+             {"from": "d", "to": "e", "out": "final", "in": "result"}],
+        )
+        result = condense(g)
+        assert len(result.nodes) == 3  # 2 condensed + e
+        assert result.graphs is not None
+        assert "scc_0" in result.graphs
+        assert "scc_1" in result.graphs
+
+    def test_scc_with_external_connections(self):
+        g = _graph(
+            [{"id": "start", "type": "input"},
+             {"id": "a"}, {"id": "b"}, {"id": "c"},
+             {"id": "end", "type": "output"}],
+            [{"from": "start", "to": "a", "out": "initial", "in": "seed"},
+             {"from": "a", "to": "b", "out": "s1", "in": "input"},
+             {"from": "b", "to": "c", "out": "s2", "in": "data"},
+             {"from": "c", "to": "a", "out": "s3", "in": "loop"},
+             {"from": "b", "to": "end", "out": "output", "in": "result"}],
+        )
+        result = condense(g)
+        assert len(result.nodes) == 3  # start, scc_0, end
+        ids = {n.id for n in result.nodes}
+        assert {"start", "scc_0", "end"} == ids
+
+        # Edge connections should be preserved.
+        assert any(e.from_node == "start" and e.to_node == "scc_0"
+                    for e in result.edges)
+        assert any(e.from_node == "scc_0" and e.to_node == "end"
+                    for e in result.edges)
+
+
+# ── edge handling ──
+
+
+class TestEdgeHandling:
+    def test_preserve_edge_metadata(self):
+        g = _graph(
+            [{"id": "a"}, {"id": "b"}, {"id": "c"}],
+            [{"from": "a", "to": "b", "out": "output", "in": "input"},
+             {"from": "b", "to": "a", "out": "result", "in": "feedback"},
+             {"from": "b", "to": "c", "out": "data", "in": "final"}],
+        )
+        result = condense(g)
+        ext = [e for e in result.edges if e.to_node == "c"]
+        assert len(ext) == 1
+        assert ext[0].from_node == "scc_0"
+        assert ext[0].out_port == "data"
+        assert ext[0].in_port == "final"
+
+    def test_port_names_in_subgraph(self):
+        g = _graph(
+            [{"id": "a"}, {"id": "b"}],
+            [{"from": "a", "to": "b", "out": "primary", "in": "input"},
+             {"from": "b", "to": "a", "out": "secondary", "in": "feedback"}],
+        )
+        result = condense(g)
+        assert len(result.nodes) == 1
+        sub = result.graphs["scc_0"]
+        internal = [e for e in sub.edges
+                     if e.from_node in ("a", "b") and e.to_node in ("a", "b")]
+        assert any(e.out_port == "primary" and e.in_port == "input"
+                    for e in internal)
+
+
+# ── port mapping ──
+
+
+class TestPortMapping:
+    def test_incoming_ports_mapped_to_input_node(self):
+        g = _graph(
+            [{"id": "ext1", "type": "input"}, {"id": "ext2", "type": "input"},
+             {"id": "a"}, {"id": "b"}, {"id": "out", "type": "output"}],
+            [{"from": "ext1", "to": "a", "out": "data1", "in": "input1"},
+             {"from": "ext2", "to": "b", "out": "data2", "in": "input2"},
+             {"from": "a", "to": "b", "out": "s1", "in": "process"},
+             {"from": "b", "to": "a", "out": "s2", "in": "feedback"},
+             {"from": "b", "to": "out", "out": "result", "in": "final"}],
+        )
+        result = condense(g)
+        sub = result.graphs["scc_0"]
+        input_edges = [e for e in sub.edges if e.from_node == "input_scc_0"]
+        assert any(e.to_node == "a" and e.in_port == "input1"
+                    for e in input_edges)
+        assert any(e.to_node == "b" and e.in_port == "input2"
+                    for e in input_edges)
+
+    def test_outgoing_ports_mapped_to_output_node(self):
+        g = _graph(
+            [{"id": "inp", "type": "input"}, {"id": "a"}, {"id": "b"},
+             {"id": "ext1", "type": "output"}, {"id": "ext2", "type": "output"}],
+            [{"from": "inp", "to": "a", "out": "seed", "in": "initial"},
+             {"from": "a", "to": "b", "out": "s1", "in": "process"},
+             {"from": "b", "to": "a", "out": "s2", "in": "feedback"},
+             {"from": "a", "to": "ext1", "out": "result1", "in": "data1"},
+             {"from": "b", "to": "ext2", "out": "result2", "in": "data2"}],
+        )
+        result = condense(g)
+        sub = result.graphs["scc_0"]
+        output_edges = [e for e in sub.edges if e.to_node == "output_scc_0"]
+        assert any(e.from_node == "a" and e.out_port == "result1"
+                    for e in output_edges)
+        assert any(e.from_node == "b" and e.out_port == "result2"
+                    for e in output_edges)

--- a/packages/opal-backend/tests/test_graph_plan.py
+++ b/packages/opal-backend/tests/test_graph_plan.py
@@ -1,0 +1,256 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for graph plan creation (Kahn's topological sort).
+
+Ported from visual-editor/tests/runtime/create-plan.ts.
+"""
+
+import pytest
+
+from opal_backend.graph_plan import create_plan
+from opal_backend.graph_types import Edge, GraphDescriptor, NodeDescriptor
+
+
+def _graph(
+    nodes: list[dict], edges: list[dict],
+) -> GraphDescriptor:
+    """Build a GraphDescriptor from compact dicts."""
+    return GraphDescriptor(
+        nodes=[NodeDescriptor(id=n["id"], type=n.get("type", "process"))
+               for n in nodes],
+        edges=[Edge(
+            from_node=e["from"], to_node=e["to"],
+            out_port=e.get("out"), in_port=e.get("in"),
+        ) for e in edges],
+    )
+
+
+# ── basic functionality ──
+
+
+class TestBasicFunctionality:
+    def test_empty_graph(self):
+        g = GraphDescriptor(nodes=[], edges=[])
+        plan = create_plan(g)
+        assert plan.stages == []
+
+    def test_single_node_no_edges(self):
+        g = _graph([{"id": "a"}], [])
+        plan = create_plan(g)
+        assert len(plan.stages) == 1
+        assert len(plan.stages[0]) == 1
+        assert plan.stages[0][0].node.id == "a"
+
+    def test_multiple_standalone_nodes(self):
+        g = _graph(
+            [{"id": "a", "type": "input"},
+             {"id": "b", "type": "process"},
+             {"id": "c", "type": "output"}],
+            [],
+        )
+        plan = create_plan(g)
+        # All standalone — pick only the first one.
+        assert len(plan.stages) == 1
+        assert len(plan.stages[0]) == 1
+        assert plan.stages[0][0].node.id == "a"
+
+
+# ── linear graphs ──
+
+
+class TestLinearGraphs:
+    def test_sequential_stages(self):
+        g = _graph(
+            [{"id": "a", "type": "input"},
+             {"id": "b", "type": "process"},
+             {"id": "c", "type": "output"}],
+            [{"from": "a", "to": "b", "out": "data", "in": "input"},
+             {"from": "b", "to": "c", "out": "result", "in": "final"}],
+        )
+        plan = create_plan(g)
+        assert len(plan.stages) == 3
+        assert plan.stages[0][0].node.id == "a"
+        assert plan.stages[1][0].node.id == "b"
+        assert plan.stages[2][0].node.id == "c"
+
+    def test_longer_linear_chain(self):
+        g = _graph(
+            [{"id": f"n{i}"} for i in range(1, 6)],
+            [{"from": f"n{i}", "to": f"n{i+1}", "out": f"s{i}", "in": "input"}
+             for i in range(1, 5)],
+        )
+        plan = create_plan(g)
+        assert len(plan.stages) == 5
+        for i, stage in enumerate(plan.stages):
+            assert len(stage) == 1
+            assert stage[0].node.id == f"n{i + 1}"
+
+
+# ── parallel graphs ──
+
+
+class TestParallelGraphs:
+    def test_independent_branches(self):
+        g = _graph(
+            [{"id": "start", "type": "input"},
+             {"id": "branch1"}, {"id": "branch2"},
+             {"id": "end", "type": "output"}],
+            [{"from": "start", "to": "branch1", "out": "data", "in": "input1"},
+             {"from": "start", "to": "branch2", "out": "data", "in": "input2"},
+             {"from": "branch1", "to": "end", "out": "r1", "in": "merge1"},
+             {"from": "branch2", "to": "end", "out": "r2", "in": "merge2"}],
+        )
+        plan = create_plan(g)
+        assert len(plan.stages) == 3
+
+        assert plan.stages[0][0].node.id == "start"
+
+        # Parallel stage.
+        stage1_ids = {n.node.id for n in plan.stages[1]}
+        assert stage1_ids == {"branch1", "branch2"}
+
+        assert plan.stages[2][0].node.id == "end"
+
+    def test_four_parallel_branches(self):
+        g = _graph(
+            [{"id": "input", "type": "input"},
+             {"id": "p1"}, {"id": "p2"}, {"id": "p3"}, {"id": "p4"},
+             {"id": "output", "type": "output"}],
+            [{"from": "input", "to": f"p{i}", "out": "data", "in": f"input{i}"}
+             for i in range(1, 5)]
+            + [{"from": f"p{i}", "to": "output", "out": f"r{i}", "in": f"merge{i}"}
+               for i in range(1, 5)],
+        )
+        plan = create_plan(g)
+        assert len(plan.stages) == 3
+        assert len(plan.stages[1]) == 4
+        stage1_ids = {n.node.id for n in plan.stages[1]}
+        assert stage1_ids == {"p1", "p2", "p3", "p4"}
+
+
+# ── complex graphs ──
+
+
+class TestComplexGraphs:
+    def test_diamond_shaped(self):
+        g = _graph(
+            [{"id": "start", "type": "input"},
+             {"id": "left"}, {"id": "right"},
+             {"id": "merge", "type": "output"}],
+            [{"from": "start", "to": "left", "out": "data", "in": "i1"},
+             {"from": "start", "to": "right", "out": "data", "in": "i2"},
+             {"from": "left", "to": "merge", "out": "r1", "in": "c1"},
+             {"from": "right", "to": "merge", "out": "r2", "in": "c2"}],
+        )
+        plan = create_plan(g)
+        assert len(plan.stages) == 3
+        assert len(plan.stages[1]) == 2
+        stage1_ids = {n.node.id for n in plan.stages[1]}
+        assert stage1_ids == {"left", "right"}
+
+    def test_multi_stage_parallel(self):
+        g = _graph(
+            [{"id": "input", "type": "input"},
+             {"id": "s1a"}, {"id": "s1b"},
+             {"id": "s2"},
+             {"id": "s3a"}, {"id": "s3b"},
+             {"id": "output", "type": "output"}],
+            [{"from": "input", "to": "s1a", "out": "d", "in": "i1"},
+             {"from": "input", "to": "s1b", "out": "d", "in": "i2"},
+             {"from": "s1a", "to": "s2", "out": "r1", "in": "c1"},
+             {"from": "s1b", "to": "s2", "out": "r2", "in": "c2"},
+             {"from": "s2", "to": "s3a", "out": "p", "in": "i3"},
+             {"from": "s2", "to": "s3b", "out": "p", "in": "i4"},
+             {"from": "s3a", "to": "output", "out": "f1", "in": "m1"},
+             {"from": "s3b", "to": "output", "out": "f2", "in": "m2"}],
+        )
+        plan = create_plan(g)
+        assert len(plan.stages) == 5
+        sizes = [len(s) for s in plan.stages]
+        assert sizes == [1, 2, 1, 2, 1]
+
+
+# ── node information ──
+
+
+class TestNodeInfo:
+    def test_downstream_populated(self):
+        g = _graph(
+            [{"id": "a", "type": "input"},
+             {"id": "b"}, {"id": "c", "type": "output"}],
+            [{"from": "a", "to": "b", "out": "data", "in": "input"},
+             {"from": "b", "to": "c", "out": "result", "in": "final"}],
+        )
+        plan = create_plan(g)
+        node_a = plan.stages[0][0]
+        assert node_a.node.id == "a"
+        assert len(node_a.downstream) == 1
+        assert node_a.downstream[0].out_port == "data"
+
+    def test_upstream_populated(self):
+        g = _graph(
+            [{"id": "a", "type": "input"},
+             {"id": "b"}, {"id": "c", "type": "output"}],
+            [{"from": "a", "to": "b", "out": "data", "in": "input"},
+             {"from": "b", "to": "c", "out": "result", "in": "final"}],
+        )
+        plan = create_plan(g)
+        node_b = plan.stages[1][0]
+        assert node_b.node.id == "b"
+        assert len(node_b.upstream) == 1
+        assert node_b.upstream[0].in_port == "input"
+
+    def test_multiple_dependencies(self):
+        g = _graph(
+            [{"id": "a", "type": "input"}, {"id": "b", "type": "input"},
+             {"id": "c"}, {"id": "d", "type": "output"},
+             {"id": "e", "type": "output"}],
+            [{"from": "a", "to": "c", "out": "d1", "in": "i1"},
+             {"from": "b", "to": "c", "out": "d2", "in": "i2"},
+             {"from": "c", "to": "d", "out": "r1", "in": "f1"},
+             {"from": "c", "to": "e", "out": "r2", "in": "f2"}],
+        )
+        plan = create_plan(g)
+        node_c = plan.stages[1][0]
+        assert node_c.node.id == "c"
+        assert len(node_c.upstream) == 2
+        assert len(node_c.downstream) == 2
+
+
+# ── edge cases ──
+
+
+class TestEdgeCases:
+    def test_disconnected_components(self):
+        g = _graph(
+            [{"id": "a", "type": "input"}, {"id": "b"},
+             {"id": "c", "type": "input"}, {"id": "d", "type": "output"}],
+            [{"from": "a", "to": "b", "out": "d1", "in": "i1"},
+             {"from": "c", "to": "d", "out": "d2", "in": "i2"}],
+        )
+        plan = create_plan(g)
+        assert len(plan.stages) == 2
+        stage0_ids = {n.node.id for n in plan.stages[0]}
+        assert stage0_ids == {"a", "c"}
+        stage1_ids = {n.node.id for n in plan.stages[1]}
+        assert stage1_ids == {"b", "d"}
+
+
+# ── port handling ──
+
+
+class TestPortHandling:
+    def test_port_names_preserved(self):
+        g = _graph(
+            [{"id": "llm", "type": "llm"},
+             {"id": "transform", "type": "transform"}],
+            [{"from": "llm", "to": "transform",
+              "out": "completion", "in": "text"}],
+        )
+        plan = create_plan(g)
+        llm = plan.stages[0][0]
+        assert llm.downstream[0].out_port == "completion"
+
+        transform = plan.stages[1][0]
+        assert transform.upstream[0].in_port == "text"

--- a/packages/opal-backend/tests/test_graph_runner.py
+++ b/packages/opal-backend/tests/test_graph_runner.py
@@ -281,3 +281,165 @@ class TestEventLog:
         assert "nodeStart" in types
         assert "nodeEnd" in types
         assert "graphComplete" in types
+
+
+# ---------------------------------------------------------------------------
+# Phase 6: Concurrent Nodes
+# ---------------------------------------------------------------------------
+
+
+def _fan_out_plan() -> GraphPlan:
+    """root → out1, root → out2 (fan-out, both start when root completes)."""
+    root = NodeDescriptor(id="root", type="generate")
+    out1 = NodeDescriptor(id="out1", type="output")
+    out2 = NodeDescriptor(id="out2", type="output")
+
+    e1 = Edge(from_node="root", to_node="out1", out_port="context", in_port="r1")
+    e2 = Edge(from_node="root", to_node="out2", out_port="context", in_port="r2")
+
+    return GraphPlan(stages=[
+        [PlanNodeInfo(node=root, downstream=[e1, e2], upstream=[])],
+        [PlanNodeInfo(node=out1, downstream=[], upstream=[e1]),
+         PlanNodeInfo(node=out2, downstream=[], upstream=[e2])],
+    ])
+
+
+def _mixed_plan() -> GraphPlan:
+    """Sequential then parallel: A → (B, C) → D.
+
+    A runs first, then B and C run concurrently, then D runs.
+    """
+    a = NodeDescriptor(id="a", type="generate")
+    b = NodeDescriptor(id="b", type="generate")
+    c = NodeDescriptor(id="c", type="generate")
+    d = NodeDescriptor(id="d", type="output")
+
+    e_ab = Edge(from_node="a", to_node="b", out_port="context", in_port="i1")
+    e_ac = Edge(from_node="a", to_node="c", out_port="context", in_port="i2")
+    e_bd = Edge(from_node="b", to_node="d", out_port="context", in_port="r1")
+    e_cd = Edge(from_node="c", to_node="d", out_port="context", in_port="r2")
+
+    return GraphPlan(stages=[
+        [PlanNodeInfo(node=a, downstream=[e_ab, e_ac], upstream=[])],
+        [PlanNodeInfo(node=b, downstream=[e_bd], upstream=[e_ab]),
+         PlanNodeInfo(node=c, downstream=[e_cd], upstream=[e_ac])],
+        [PlanNodeInfo(node=d, downstream=[], upstream=[e_bd, e_cd])],
+    ])
+
+
+class TestFanOutGraph:
+    """Phase 6: fan-out — both outputs start when root completes."""
+
+    @pytest.mark.asyncio
+    async def test_fan_out_both_start(self):
+        store = InMemoryGraphSessionStore()
+        bus = InMemoryEventBus()
+        runner = GraphRunner(store=store, event_bus=bus, scheduler=None)
+        scheduler = LocalTaskScheduler(run_fn=runner.run_node)
+        runner._scheduler = scheduler
+
+        plan = _fan_out_plan()
+        await store.create("s1", plan)
+
+        events: list[dict] = []
+        subscriber = bus.subscribe("s1")
+        await runner.start_graph("s1")
+
+        async for event in subscriber:
+            events.append(event)
+            if event.get("type") == "graphComplete":
+                break
+
+        # All 3 nodes should have started.
+        node_starts = [e for e in events if e["type"] == "nodeStart"]
+        assert len(node_starts) == 3
+
+        # Both outputs should start after root ends.
+        root_end_idx = next(
+            i for i, e in enumerate(events)
+            if e["type"] == "nodeEnd" and e["nodeId"] == "root"
+        )
+        for out_id in ("out1", "out2"):
+            out_start_idx = next(
+                i for i, e in enumerate(events)
+                if e["type"] == "nodeStart" and e["nodeId"] == out_id
+            )
+            assert out_start_idx > root_end_idx
+
+        assert await store.is_graph_complete("s1")
+
+
+class TestMixedGraph:
+    """Phase 6: A → (B, C) → D — sequential then parallel then merge."""
+
+    @pytest.mark.asyncio
+    async def test_mixed_execution_order(self):
+        store = InMemoryGraphSessionStore()
+        bus = InMemoryEventBus()
+        runner = GraphRunner(store=store, event_bus=bus, scheduler=None)
+        scheduler = LocalTaskScheduler(run_fn=runner.run_node)
+        runner._scheduler = scheduler
+
+        plan = _mixed_plan()
+        await store.create("s1", plan)
+
+        events: list[dict] = []
+        subscriber = bus.subscribe("s1")
+        await runner.start_graph("s1")
+
+        async for event in subscriber:
+            events.append(event)
+            if event.get("type") == "graphComplete":
+                break
+
+        # All 4 nodes should execute.
+        node_starts = [e for e in events if e["type"] == "nodeStart"]
+        assert len(node_starts) == 4
+
+        # A before B and C.
+        a_end = next(
+            i for i, e in enumerate(events)
+            if e["type"] == "nodeEnd" and e["nodeId"] == "a"
+        )
+        for nid in ("b", "c"):
+            start = next(
+                i for i, e in enumerate(events)
+                if e["type"] == "nodeStart" and e["nodeId"] == nid
+            )
+            assert start > a_end, f"{nid} should start after A ends"
+
+        # D after both B and C.
+        d_start = next(
+            i for i, e in enumerate(events)
+            if e["type"] == "nodeStart" and e["nodeId"] == "d"
+        )
+        for nid in ("b", "c"):
+            end = next(
+                i for i, e in enumerate(events)
+                if e["type"] == "nodeEnd" and e["nodeId"] == nid
+            )
+            assert d_start > end, f"D should start after {nid} ends"
+
+        assert await store.is_graph_complete("s1")
+
+    @pytest.mark.asyncio
+    async def test_mixed_outputs_propagate(self):
+        store = InMemoryGraphSessionStore()
+        bus = InMemoryEventBus()
+        runner = GraphRunner(store=store, event_bus=bus, scheduler=None)
+        scheduler = LocalTaskScheduler(run_fn=runner.run_node)
+        runner._scheduler = scheduler
+
+        plan = _mixed_plan()
+        await store.create("s1", plan)
+
+        subscriber = bus.subscribe("s1")
+        await runner.start_graph("s1")
+
+        async for event in subscriber:
+            if event.get("type") == "graphComplete":
+                break
+
+        outputs = await store.get_graph_outputs("s1")
+        assert set(outputs.keys()) == {"a", "b", "c", "d"}
+

--- a/packages/opal-backend/tests/test_graph_runner.py
+++ b/packages/opal-backend/tests/test_graph_runner.py
@@ -1,0 +1,283 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for GraphRunner — end-to-end node task execution.
+
+Phase 2 🎯 objective: a two-node linear graph (text gen → output)
+runs via task-per-node, events emitted correctly.
+"""
+
+import asyncio
+
+import pytest
+
+from opal_backend.graph_types import Edge, GraphPlan, NodeDescriptor, PlanNodeInfo
+from opal_backend.graph_runner import GraphRunner
+from opal_backend.local.event_bus_impl import InMemoryEventBus
+from opal_backend.local.graph_session_store_impl import InMemoryGraphSessionStore
+from opal_backend.local.task_scheduler_impl import LocalTaskScheduler
+
+
+def _two_node_plan() -> GraphPlan:
+    """gen → output (two-node linear plan)."""
+    gen = NodeDescriptor(id="gen", type="generate")
+    out = NodeDescriptor(id="out", type="output")
+
+    e = Edge(from_node="gen", to_node="out", out_port="context", in_port="result")
+
+    return GraphPlan(stages=[
+        [PlanNodeInfo(node=gen, downstream=[e], upstream=[])],
+        [PlanNodeInfo(node=out, downstream=[], upstream=[e])],
+    ])
+
+
+def _three_node_plan() -> GraphPlan:
+    """input → gen → output (three-node linear plan)."""
+    inp = NodeDescriptor(id="inp", type="input")
+    gen = NodeDescriptor(id="gen", type="generate")
+    out = NodeDescriptor(id="out", type="output")
+
+    e1 = Edge(from_node="inp", to_node="gen", out_port="data", in_port="input")
+    e2 = Edge(from_node="gen", to_node="out", out_port="context", in_port="result")
+
+    return GraphPlan(stages=[
+        [PlanNodeInfo(node=inp, downstream=[e1], upstream=[])],
+        [PlanNodeInfo(node=gen, downstream=[e2], upstream=[e1])],
+        [PlanNodeInfo(node=out, downstream=[], upstream=[e2])],
+    ])
+
+
+def _diamond_plan() -> GraphPlan:
+    """input → (gen1, gen2) → output."""
+    inp = NodeDescriptor(id="inp", type="input")
+    gen1 = NodeDescriptor(id="gen1", type="generate")
+    gen2 = NodeDescriptor(id="gen2", type="generate")
+    out = NodeDescriptor(id="out", type="output")
+
+    e1 = Edge(from_node="inp", to_node="gen1", out_port="data", in_port="i1")
+    e2 = Edge(from_node="inp", to_node="gen2", out_port="data", in_port="i2")
+    e3 = Edge(from_node="gen1", to_node="out", out_port="context", in_port="c1")
+    e4 = Edge(from_node="gen2", to_node="out", out_port="context", in_port="c2")
+
+    return GraphPlan(stages=[
+        [PlanNodeInfo(node=inp, downstream=[e1, e2], upstream=[])],
+        [PlanNodeInfo(node=gen1, downstream=[e3], upstream=[e1]),
+         PlanNodeInfo(node=gen2, downstream=[e4], upstream=[e2])],
+        [PlanNodeInfo(node=out, downstream=[], upstream=[e3, e4])],
+    ])
+
+
+class TestTwoNodeLinear:
+    """Phase 2 🎯: two-node linear graph runs via task-per-node."""
+
+    @pytest.mark.asyncio
+    async def test_events_emitted_in_order(self):
+        store = InMemoryGraphSessionStore()
+        bus = InMemoryEventBus()
+        runner = GraphRunner(store=store, event_bus=bus, scheduler=None)
+        scheduler = LocalTaskScheduler(run_fn=runner.run_node)
+        runner._scheduler = scheduler
+
+        plan = _two_node_plan()
+        await store.create("s1", plan)
+
+        # Collect events via subscriber.
+        events: list[dict] = []
+        subscriber = bus.subscribe("s1")
+
+        # Start the graph.
+        await runner.start_graph("s1")
+
+        # Wait for graph completion.
+        async for event in subscriber:
+            events.append(event)
+            if event.get("type") == "graphComplete":
+                break
+
+        # Verify event order.
+        types = [e["type"] for e in events]
+        assert "graphStart" in types
+        assert "graphComplete" in types
+
+        # nodeStart/nodeEnd pairs for both nodes.
+        node_starts = [e for e in events if e["type"] == "nodeStart"]
+        node_ends = [e for e in events if e["type"] == "nodeEnd"]
+        assert len(node_starts) == 2
+        assert len(node_ends) == 2
+
+        # gen should start before out.
+        gen_start_idx = next(
+            i for i, e in enumerate(events)
+            if e["type"] == "nodeStart" and e["nodeId"] == "gen"
+        )
+        out_start_idx = next(
+            i for i, e in enumerate(events)
+            if e["type"] == "nodeStart" and e["nodeId"] == "out"
+        )
+        assert gen_start_idx < out_start_idx
+
+    @pytest.mark.asyncio
+    async def test_graph_completes(self):
+        store = InMemoryGraphSessionStore()
+        bus = InMemoryEventBus()
+        runner = GraphRunner(store=store, event_bus=bus, scheduler=None)
+        scheduler = LocalTaskScheduler(run_fn=runner.run_node)
+        runner._scheduler = scheduler
+
+        plan = _two_node_plan()
+        await store.create("s1", plan)
+        await runner.start_graph("s1")
+
+        # Wait for completion.
+        subscriber = bus.subscribe("s1")
+        async for event in subscriber:
+            if event.get("type") == "graphComplete":
+                break
+
+        assert await store.is_graph_complete("s1")
+        assert await store.get_status("s1") == "completed"
+
+    @pytest.mark.asyncio
+    async def test_outputs_flow_downstream(self):
+        store = InMemoryGraphSessionStore()
+        bus = InMemoryEventBus()
+        runner = GraphRunner(store=store, event_bus=bus, scheduler=None)
+        scheduler = LocalTaskScheduler(run_fn=runner.run_node)
+        runner._scheduler = scheduler
+
+        plan = _two_node_plan()
+        await store.create("s1", plan)
+        await runner.start_graph("s1")
+
+        subscriber = bus.subscribe("s1")
+        async for event in subscriber:
+            if event.get("type") == "graphComplete":
+                break
+
+        # gen node should produce output.
+        outputs = await store.get_graph_outputs("s1")
+        assert "gen" in outputs
+        assert "out" in outputs
+
+
+class TestThreeNodeLinear:
+    @pytest.mark.asyncio
+    async def test_three_stage_execution(self):
+        store = InMemoryGraphSessionStore()
+        bus = InMemoryEventBus()
+        runner = GraphRunner(store=store, event_bus=bus, scheduler=None)
+        scheduler = LocalTaskScheduler(run_fn=runner.run_node)
+        runner._scheduler = scheduler
+
+        plan = _three_node_plan()
+        await store.create("s1", plan)
+
+        events: list[dict] = []
+        subscriber = bus.subscribe("s1")
+
+        await runner.start_graph("s1")
+
+        async for event in subscriber:
+            events.append(event)
+            if event.get("type") == "graphComplete":
+                break
+
+        node_starts = [e for e in events if e["type"] == "nodeStart"]
+        assert len(node_starts) == 3
+
+        # Verify ordering: inp before gen before out.
+        start_ids = [e["nodeId"] for e in node_starts]
+        assert start_ids.index("inp") < start_ids.index("gen")
+        assert start_ids.index("gen") < start_ids.index("out")
+
+
+class TestDiamondGraph:
+    @pytest.mark.asyncio
+    async def test_parallel_branches(self):
+        store = InMemoryGraphSessionStore()
+        bus = InMemoryEventBus()
+        runner = GraphRunner(store=store, event_bus=bus, scheduler=None)
+        scheduler = LocalTaskScheduler(run_fn=runner.run_node)
+        runner._scheduler = scheduler
+
+        plan = _diamond_plan()
+        await store.create("s1", plan)
+
+        events: list[dict] = []
+        subscriber = bus.subscribe("s1")
+
+        await runner.start_graph("s1")
+
+        async for event in subscriber:
+            events.append(event)
+            if event.get("type") == "graphComplete":
+                break
+
+        node_starts = [e for e in events if e["type"] == "nodeStart"]
+        assert len(node_starts) == 4  # inp, gen1, gen2, out
+
+        assert await store.is_graph_complete("s1")
+
+    @pytest.mark.asyncio
+    async def test_merge_waits_for_both_branches(self):
+        store = InMemoryGraphSessionStore()
+        bus = InMemoryEventBus()
+        runner = GraphRunner(store=store, event_bus=bus, scheduler=None)
+        scheduler = LocalTaskScheduler(run_fn=runner.run_node)
+        runner._scheduler = scheduler
+
+        plan = _diamond_plan()
+        await store.create("s1", plan)
+
+        events: list[dict] = []
+        subscriber = bus.subscribe("s1")
+
+        await runner.start_graph("s1")
+
+        async for event in subscriber:
+            events.append(event)
+            if event.get("type") == "graphComplete":
+                break
+
+        # out should start after both gen1 and gen2 end.
+        out_start_idx = next(
+            i for i, e in enumerate(events)
+            if e["type"] == "nodeStart" and e["nodeId"] == "out"
+        )
+        gen1_end_idx = next(
+            i for i, e in enumerate(events)
+            if e["type"] == "nodeEnd" and e["nodeId"] == "gen1"
+        )
+        gen2_end_idx = next(
+            i for i, e in enumerate(events)
+            if e["type"] == "nodeEnd" and e["nodeId"] == "gen2"
+        )
+        assert out_start_idx > gen1_end_idx
+        assert out_start_idx > gen2_end_idx
+
+
+class TestEventLog:
+    @pytest.mark.asyncio
+    async def test_events_stored_in_store(self):
+        store = InMemoryGraphSessionStore()
+        bus = InMemoryEventBus()
+        runner = GraphRunner(store=store, event_bus=bus, scheduler=None)
+        scheduler = LocalTaskScheduler(run_fn=runner.run_node)
+        runner._scheduler = scheduler
+
+        plan = _two_node_plan()
+        await store.create("s1", plan)
+
+        subscriber = bus.subscribe("s1")
+        await runner.start_graph("s1")
+
+        async for event in subscriber:
+            if event.get("type") == "graphComplete":
+                break
+
+        stored_events = await store.get_events("s1")
+        types = [e["type"] for e in stored_events]
+        assert "graphStart" in types
+        assert "nodeStart" in types
+        assert "nodeEnd" in types
+        assert "graphComplete" in types

--- a/packages/opal-backend/tests/test_graph_runner.py
+++ b/packages/opal-backend/tests/test_graph_runner.py
@@ -32,35 +32,35 @@ def _two_node_plan() -> GraphPlan:
 
 
 def _three_node_plan() -> GraphPlan:
-    """input → gen → output (three-node linear plan)."""
-    inp = NodeDescriptor(id="inp", type="input")
-    gen = NodeDescriptor(id="gen", type="generate")
+    """gen1 → gen2 → output (three-node linear plan)."""
+    gen1 = NodeDescriptor(id="gen1", type="generate")
+    gen2 = NodeDescriptor(id="gen2", type="generate")
     out = NodeDescriptor(id="out", type="output")
 
-    e1 = Edge(from_node="inp", to_node="gen", out_port="data", in_port="input")
-    e2 = Edge(from_node="gen", to_node="out", out_port="context", in_port="result")
+    e1 = Edge(from_node="gen1", to_node="gen2", out_port="context", in_port="input")
+    e2 = Edge(from_node="gen2", to_node="out", out_port="context", in_port="result")
 
     return GraphPlan(stages=[
-        [PlanNodeInfo(node=inp, downstream=[e1], upstream=[])],
-        [PlanNodeInfo(node=gen, downstream=[e2], upstream=[e1])],
+        [PlanNodeInfo(node=gen1, downstream=[e1], upstream=[])],
+        [PlanNodeInfo(node=gen2, downstream=[e2], upstream=[e1])],
         [PlanNodeInfo(node=out, downstream=[], upstream=[e2])],
     ])
 
 
 def _diamond_plan() -> GraphPlan:
-    """input → (gen1, gen2) → output."""
-    inp = NodeDescriptor(id="inp", type="input")
+    """root → (gen1, gen2) → output."""
+    root = NodeDescriptor(id="root", type="generate")
     gen1 = NodeDescriptor(id="gen1", type="generate")
     gen2 = NodeDescriptor(id="gen2", type="generate")
     out = NodeDescriptor(id="out", type="output")
 
-    e1 = Edge(from_node="inp", to_node="gen1", out_port="data", in_port="i1")
-    e2 = Edge(from_node="inp", to_node="gen2", out_port="data", in_port="i2")
+    e1 = Edge(from_node="root", to_node="gen1", out_port="context", in_port="i1")
+    e2 = Edge(from_node="root", to_node="gen2", out_port="context", in_port="i2")
     e3 = Edge(from_node="gen1", to_node="out", out_port="context", in_port="c1")
     e4 = Edge(from_node="gen2", to_node="out", out_port="context", in_port="c2")
 
     return GraphPlan(stages=[
-        [PlanNodeInfo(node=inp, downstream=[e1, e2], upstream=[])],
+        [PlanNodeInfo(node=root, downstream=[e1, e2], upstream=[])],
         [PlanNodeInfo(node=gen1, downstream=[e3], upstream=[e1]),
          PlanNodeInfo(node=gen2, downstream=[e4], upstream=[e2])],
         [PlanNodeInfo(node=out, downstream=[], upstream=[e3, e4])],
@@ -185,10 +185,10 @@ class TestThreeNodeLinear:
         node_starts = [e for e in events if e["type"] == "nodeStart"]
         assert len(node_starts) == 3
 
-        # Verify ordering: inp before gen before out.
+        # Verify ordering: gen1 before gen2 before out.
         start_ids = [e["nodeId"] for e in node_starts]
-        assert start_ids.index("inp") < start_ids.index("gen")
-        assert start_ids.index("gen") < start_ids.index("out")
+        assert start_ids.index("gen1") < start_ids.index("gen2")
+        assert start_ids.index("gen2") < start_ids.index("out")
 
 
 class TestDiamondGraph:

--- a/packages/opal-backend/tests/test_graph_session_router.py
+++ b/packages/opal-backend/tests/test_graph_session_router.py
@@ -55,16 +55,16 @@ def _simple_graph() -> dict:
 
 
 def _three_node_graph() -> dict:
-    """input → generate → output."""
+    """generate → generate → output."""
     return {
         "nodes": [
-            {"id": "inp", "type": "input"},
-            {"id": "gen", "type": "generate"},
+            {"id": "gen1", "type": "generate"},
+            {"id": "gen2", "type": "generate"},
             {"id": "out", "type": "output"},
         ],
         "edges": [
-            {"from": "inp", "to": "gen", "out": "data", "in": "input"},
-            {"from": "gen", "to": "out", "out": "context", "in": "result"},
+            {"from": "gen1", "to": "gen2", "out": "context", "in": "input"},
+            {"from": "gen2", "to": "out", "out": "context", "in": "result"},
         ],
     }
 
@@ -228,6 +228,102 @@ class TestCancelEndpoint:
         assert resp.status_code == 404
 
 
+def _input_output_graph() -> dict:
+    """An input → output graph that will suspend at input."""
+    return {
+        "nodes": [
+            {"id": "inp", "type": "input", "configuration": {
+                "prompt": "Enter something",
+            }},
+            {"id": "out", "type": "output"},
+        ],
+        "edges": [
+            {"from": "inp", "to": "out", "out": "data", "in": "result"},
+        ],
+    }
+
+
+class TestResumeEndpoint:
+    def test_resume_completes_suspended_graph(self):
+        app, store, bus = _create_app()
+        client = TestClient(app)
+
+        # Create — will suspend at input.
+        resp = client.post(
+            "/v1beta1/graphSessions/new",
+            json={"graph": _input_output_graph()},
+        )
+        session_id = resp.json()["sessionId"]
+
+        # Verify suspended.
+        resp = client.get(f"/v1beta1/graphSessions/{session_id}/status")
+        assert resp.json()["status"] == "suspended"
+
+        # Get interaction ID from stored events.
+        state = store._sessions[session_id]
+        input_req = next(
+            e for e in state.events if e.get("type") == "inputRequired"
+        )
+        interaction_id = input_req["interactionId"]
+
+        # Resume.
+        resp = client.post(
+            f"/v1beta1/graphSessions/{session_id}:resume",
+            json={
+                "interactionId": interaction_id,
+                "response": {"text": "Hello!"},
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "running"
+
+        # Verify completed.
+        resp = client.get(f"/v1beta1/graphSessions/{session_id}/status")
+        assert resp.json()["status"] == "completed"
+
+    def test_resume_missing_interaction_id(self):
+        app, *_ = _create_app()
+        client = TestClient(app)
+
+        resp = client.post(
+            "/v1beta1/graphSessions/new",
+            json={"graph": _input_output_graph()},
+        )
+        session_id = resp.json()["sessionId"]
+
+        resp = client.post(
+            f"/v1beta1/graphSessions/{session_id}:resume",
+            json={"response": {}},
+        )
+        assert resp.status_code == 400
+
+    def test_resume_invalid_interaction_id(self):
+        app, *_ = _create_app()
+        client = TestClient(app)
+
+        resp = client.post(
+            "/v1beta1/graphSessions/new",
+            json={"graph": _input_output_graph()},
+        )
+        session_id = resp.json()["sessionId"]
+
+        resp = client.post(
+            f"/v1beta1/graphSessions/{session_id}:resume",
+            json={"interactionId": "bogus", "response": {}},
+        )
+        assert resp.status_code == 404
+
+    def test_resume_not_found_session(self):
+        app, *_ = _create_app()
+        client = TestClient(app)
+
+        resp = client.post(
+            "/v1beta1/graphSessions/missing:resume",
+            json={"interactionId": "x", "response": {}},
+        )
+        assert resp.status_code == 404
+
+
 # ── helpers ──
 
 
@@ -244,3 +340,4 @@ def _parse_sse_events(raw: str) -> list[dict]:
                 except json.JSONDecodeError:
                     pass
     return events
+

--- a/packages/opal-backend/tests/test_graph_session_router.py
+++ b/packages/opal-backend/tests/test_graph_session_router.py
@@ -1,0 +1,246 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for graph session router — integration tests using FastAPI TestClient.
+
+Phase 3 🎯: curl starts a graph run, receives SSE events for each node.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from opal_backend.graph_runner import GraphRunner
+from opal_backend.local.event_bus_impl import InMemoryEventBus
+from opal_backend.local.graph_session_router import create_graph_session_router
+from opal_backend.local.graph_session_store_impl import InMemoryGraphSessionStore
+from opal_backend.local.task_scheduler_impl import LocalTaskScheduler
+
+
+def _create_app():
+    """Create a FastAPI app with graph session router wired up."""
+    store = InMemoryGraphSessionStore()
+    bus = InMemoryEventBus()
+    runner = GraphRunner(store=store, event_bus=bus, scheduler=None)
+    scheduler = LocalTaskScheduler(run_fn=runner.run_node)
+    runner._scheduler = scheduler
+
+    router = create_graph_session_router(
+        store=store, event_bus=bus, runner=runner, scheduler=scheduler,
+    )
+
+    app = FastAPI()
+    app.include_router(router)
+    return app, store, bus
+
+
+def _simple_graph() -> dict:
+    """A two-node inline graph (generate → output)."""
+    return {
+        "nodes": [
+            {"id": "gen", "type": "generate"},
+            {"id": "out", "type": "output"},
+        ],
+        "edges": [
+            {
+                "from": "gen", "to": "out",
+                "out": "context", "in": "result",
+            },
+        ],
+    }
+
+
+def _three_node_graph() -> dict:
+    """input → generate → output."""
+    return {
+        "nodes": [
+            {"id": "inp", "type": "input"},
+            {"id": "gen", "type": "generate"},
+            {"id": "out", "type": "output"},
+        ],
+        "edges": [
+            {"from": "inp", "to": "gen", "out": "data", "in": "input"},
+            {"from": "gen", "to": "out", "out": "context", "in": "result"},
+        ],
+    }
+
+
+class TestCreateGraphSession:
+    def test_creates_session(self):
+        app, *_ = _create_app()
+        client = TestClient(app)
+        resp = client.post(
+            "/v1beta1/graphSessions/new",
+            json={"graph": _simple_graph()},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "sessionId" in data
+
+    def test_missing_graph_returns_400(self):
+        app, *_ = _create_app()
+        client = TestClient(app)
+        resp = client.post(
+            "/v1beta1/graphSessions/new", json={},
+        )
+        assert resp.status_code == 400
+        assert "Missing" in resp.json()["error"]
+
+    def test_empty_graph_returns_400(self):
+        app, *_ = _create_app()
+        client = TestClient(app)
+        resp = client.post(
+            "/v1beta1/graphSessions/new",
+            json={"graph": {"nodes": [], "edges": []}},
+        )
+        assert resp.status_code == 400
+
+
+class TestStreamGraphEvents:
+    def test_sse_stream_has_events(self):
+        app, store, bus = _create_app()
+        client = TestClient(app)
+
+        # Create session.
+        resp = client.post(
+            "/v1beta1/graphSessions/new",
+            json={"graph": _simple_graph()},
+        )
+        session_id = resp.json()["sessionId"]
+
+        # Stream events (graph should complete synchronously during POST).
+        with client.stream(
+            "GET", f"/v1beta1/graphSessions/{session_id}",
+        ) as sse_resp:
+            assert sse_resp.status_code == 200
+            raw = sse_resp.read().decode()
+
+        # Parse SSE data events.
+        events = _parse_sse_events(raw)
+        types = [e.get("type") for e in events if "type" in e]
+        assert "graphStart" in types
+        assert "nodeStart" in types
+        assert "nodeEnd" in types
+        assert "graphComplete" in types
+
+    def test_three_node_sse_stream(self):
+        app, *_ = _create_app()
+        client = TestClient(app)
+
+        resp = client.post(
+            "/v1beta1/graphSessions/new",
+            json={"graph": _three_node_graph()},
+        )
+        session_id = resp.json()["sessionId"]
+
+        with client.stream(
+            "GET", f"/v1beta1/graphSessions/{session_id}",
+        ) as sse_resp:
+            raw = sse_resp.read().decode()
+
+        events = _parse_sse_events(raw)
+        node_starts = [
+            e for e in events if e.get("type") == "nodeStart"
+        ]
+        assert len(node_starts) == 3
+
+    def test_stream_not_found(self):
+        app, *_ = _create_app()
+        client = TestClient(app)
+        resp = client.get("/v1beta1/graphSessions/missing")
+        assert resp.status_code == 404
+
+    def test_replay_with_after_parameter(self):
+        app, store, bus = _create_app()
+        client = TestClient(app)
+
+        resp = client.post(
+            "/v1beta1/graphSessions/new",
+            json={"graph": _simple_graph()},
+        )
+        session_id = resp.json()["sessionId"]
+
+        # Get all events first.
+        with client.stream(
+            "GET", f"/v1beta1/graphSessions/{session_id}",
+        ) as sse_resp:
+            all_raw = sse_resp.read().decode()
+        all_events = _parse_sse_events(all_raw)
+
+        # Now request with after=2 to skip some.
+        with client.stream(
+            "GET", f"/v1beta1/graphSessions/{session_id}?after=2",
+        ) as sse_resp:
+            partial_raw = sse_resp.read().decode()
+        partial_events = _parse_sse_events(partial_raw)
+
+        assert len(partial_events) < len(all_events)
+
+
+class TestStatusEndpoint:
+    def test_status_completed(self):
+        app, *_ = _create_app()
+        client = TestClient(app)
+
+        resp = client.post(
+            "/v1beta1/graphSessions/new",
+            json={"graph": _simple_graph()},
+        )
+        session_id = resp.json()["sessionId"]
+
+        resp = client.get(f"/v1beta1/graphSessions/{session_id}/status")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["sessionId"] == session_id
+        assert data["status"] == "completed"
+
+    def test_status_not_found(self):
+        app, *_ = _create_app()
+        client = TestClient(app)
+        resp = client.get("/v1beta1/graphSessions/missing/status")
+        assert resp.status_code == 404
+
+
+class TestCancelEndpoint:
+    def test_cancel_session(self):
+        app, *_ = _create_app()
+        client = TestClient(app)
+
+        resp = client.post(
+            "/v1beta1/graphSessions/new",
+            json={"graph": _simple_graph()},
+        )
+        session_id = resp.json()["sessionId"]
+
+        resp = client.post(f"/v1beta1/graphSessions/{session_id}:cancel")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "cancelled"
+
+    def test_cancel_not_found(self):
+        app, *_ = _create_app()
+        client = TestClient(app)
+        resp = client.post("/v1beta1/graphSessions/missing:cancel")
+        assert resp.status_code == 404
+
+
+# ── helpers ──
+
+
+def _parse_sse_events(raw: str) -> list[dict]:
+    """Parse SSE text into a list of JSON event dicts."""
+    events = []
+    for line in raw.split("\n"):
+        line = line.strip()
+        if line.startswith("data:"):
+            data_str = line[5:].strip()
+            if data_str and data_str != "{}":
+                try:
+                    events.append(json.loads(data_str))
+                except json.JSONDecodeError:
+                    pass
+    return events

--- a/packages/opal-backend/tests/test_graph_session_store.py
+++ b/packages/opal-backend/tests/test_graph_session_store.py
@@ -1,0 +1,295 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for InMemoryGraphSessionStore."""
+
+import pytest
+
+from opal_backend.graph_types import (
+    Edge, GraphDescriptor, GraphPlan, NodeDescriptor, PlanNodeInfo,
+)
+from opal_backend.graph_session_store import SuspendedNodeState
+from opal_backend.local.graph_session_store_impl import InMemoryGraphSessionStore
+
+
+def _linear_plan() -> GraphPlan:
+    """a → b → c (linear three-node plan)."""
+    a = NodeDescriptor(id="a", type="input")
+    b = NodeDescriptor(id="b", type="generate")
+    c = NodeDescriptor(id="c", type="output")
+
+    e_ab = Edge(from_node="a", to_node="b", out_port="data", in_port="input")
+    e_bc = Edge(from_node="b", to_node="c", out_port="context", in_port="result")
+
+    return GraphPlan(stages=[
+        [PlanNodeInfo(node=a, downstream=[e_ab], upstream=[])],
+        [PlanNodeInfo(node=b, downstream=[e_bc], upstream=[e_ab])],
+        [PlanNodeInfo(node=c, downstream=[], upstream=[e_bc])],
+    ])
+
+
+def _diamond_plan() -> GraphPlan:
+    """start → (left, right) → merge."""
+    start = NodeDescriptor(id="start", type="input")
+    left = NodeDescriptor(id="left", type="generate")
+    right = NodeDescriptor(id="right", type="generate")
+    merge = NodeDescriptor(id="merge", type="output")
+
+    e_sl = Edge(from_node="start", to_node="left", out_port="data", in_port="i1")
+    e_sr = Edge(from_node="start", to_node="right", out_port="data", in_port="i2")
+    e_lm = Edge(from_node="left", to_node="merge", out_port="r1", in_port="c1")
+    e_rm = Edge(from_node="right", to_node="merge", out_port="r2", in_port="c2")
+
+    return GraphPlan(stages=[
+        [PlanNodeInfo(node=start, downstream=[e_sl, e_sr], upstream=[])],
+        [PlanNodeInfo(node=left, downstream=[e_lm], upstream=[e_sl]),
+         PlanNodeInfo(node=right, downstream=[e_rm], upstream=[e_sr])],
+        [PlanNodeInfo(node=merge, downstream=[], upstream=[e_lm, e_rm])],
+    ])
+
+
+class TestCreateAndGetPlan:
+    @pytest.mark.asyncio
+    async def test_create_stores_plan(self):
+        store = InMemoryGraphSessionStore()
+        plan = _linear_plan()
+        await store.create("s1", plan)
+        result = await store.get_plan("s1")
+        assert result is plan
+
+    @pytest.mark.asyncio
+    async def test_get_plan_missing_session(self):
+        store = InMemoryGraphSessionStore()
+        assert await store.get_plan("missing") is None
+
+    @pytest.mark.asyncio
+    async def test_initial_node_status(self):
+        store = InMemoryGraphSessionStore()
+        await store.create("s1", _linear_plan())
+        # Entry node "a" should be ready (no upstream).
+        state = store._sessions["s1"]
+        assert state.nodes["a"].status == "ready"
+        assert state.nodes["a"].pending_deps == 0
+        # "b" should be inactive (1 upstream dep).
+        assert state.nodes["b"].status == "inactive"
+        assert state.nodes["b"].pending_deps == 1
+
+
+class TestCompleteNode:
+    @pytest.mark.asyncio
+    async def test_complete_returns_newly_ready(self):
+        store = InMemoryGraphSessionStore()
+        await store.create("s1", _linear_plan())
+
+        newly_ready = await store.complete_node(
+            "s1", "a", {"data": "hello"},
+        )
+        assert newly_ready == ["b"]
+
+    @pytest.mark.asyncio
+    async def test_complete_chain(self):
+        store = InMemoryGraphSessionStore()
+        await store.create("s1", _linear_plan())
+
+        await store.complete_node("s1", "a", {"data": "hello"})
+        newly_ready = await store.complete_node(
+            "s1", "b", {"context": [{"role": "model", "parts": []}]},
+        )
+        assert newly_ready == ["c"]
+
+    @pytest.mark.asyncio
+    async def test_diamond_both_deps_needed(self):
+        store = InMemoryGraphSessionStore()
+        await store.create("s1", _diamond_plan())
+
+        # Complete start → left and right become ready.
+        newly = await store.complete_node("s1", "start", {"data": "x"})
+        assert set(newly) == {"left", "right"}
+
+        # Complete only left — merge still not ready.
+        newly = await store.complete_node("s1", "left", {"r1": "a"})
+        assert newly == []
+
+        # Complete right → merge becomes ready.
+        newly = await store.complete_node("s1", "right", {"r2": "b"})
+        assert newly == ["merge"]
+
+
+class TestGetNodeInputs:
+    @pytest.mark.asyncio
+    async def test_gathers_upstream_outputs(self):
+        store = InMemoryGraphSessionStore()
+        await store.create("s1", _linear_plan())
+
+        await store.complete_node("s1", "a", {"data": "hello"})
+        inputs = await store.get_node_inputs("s1", "b")
+        assert inputs == {"input": ["hello"]}
+
+    @pytest.mark.asyncio
+    async def test_diamond_gathers_from_both_upstreams(self):
+        store = InMemoryGraphSessionStore()
+        await store.create("s1", _diamond_plan())
+
+        await store.complete_node("s1", "start", {"data": "x"})
+        await store.complete_node("s1", "left", {"r1": "left_val"})
+        await store.complete_node("s1", "right", {"r2": "right_val"})
+
+        inputs = await store.get_node_inputs("s1", "merge")
+        assert "c1" in inputs
+        assert "c2" in inputs
+        assert inputs["c1"] == ["left_val"]
+        assert inputs["c2"] == ["right_val"]
+
+
+class TestGetNodeConfig:
+    @pytest.mark.asyncio
+    async def test_returns_config(self):
+        plan = GraphPlan(stages=[[
+            PlanNodeInfo(
+                node=NodeDescriptor(
+                    id="gen", type="generate",
+                    configuration={"model": "gemini-3"},
+                ),
+                downstream=[], upstream=[],
+            ),
+        ]])
+        store = InMemoryGraphSessionStore()
+        await store.create("s1", plan)
+
+        config = await store.get_node_config("s1", "gen")
+        assert config == {"model": "gemini-3"}
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_if_no_config(self):
+        plan = GraphPlan(stages=[[
+            PlanNodeInfo(
+                node=NodeDescriptor(id="n", type="process"),
+                downstream=[], upstream=[],
+            ),
+        ]])
+        store = InMemoryGraphSessionStore()
+        await store.create("s1", plan)
+        assert await store.get_node_config("s1", "n") == {}
+
+
+class TestSuspendResume:
+    @pytest.mark.asyncio
+    async def test_suspend_and_load(self):
+        store = InMemoryGraphSessionStore()
+        await store.create("s1", _linear_plan())
+
+        state = SuspendedNodeState(
+            node_id="b", interaction_id="int-1",
+            context={"cursor": 42},
+        )
+        await store.suspend_node("s1", "b", "int-1", state)
+
+        loaded = await store.load_suspended_node("s1", "int-1")
+        assert loaded is not None
+        node_id, loaded_state = loaded
+        assert node_id == "b"
+        assert loaded_state.context == {"cursor": 42}
+
+    @pytest.mark.asyncio
+    async def test_load_missing_returns_none(self):
+        store = InMemoryGraphSessionStore()
+        assert await store.load_suspended_node("s1", "missing") is None
+
+
+class TestGraphLifecycle:
+    @pytest.mark.asyncio
+    async def test_is_graph_complete_false_initially(self):
+        store = InMemoryGraphSessionStore()
+        await store.create("s1", _linear_plan())
+        assert not await store.is_graph_complete("s1")
+
+    @pytest.mark.asyncio
+    async def test_is_graph_complete_true_when_all_done(self):
+        store = InMemoryGraphSessionStore()
+        await store.create("s1", _linear_plan())
+        await store.complete_node("s1", "a", {})
+        await store.complete_node("s1", "b", {})
+        await store.complete_node("s1", "c", {})
+        assert await store.is_graph_complete("s1")
+
+    @pytest.mark.asyncio
+    async def test_get_graph_outputs(self):
+        store = InMemoryGraphSessionStore()
+        await store.create("s1", _linear_plan())
+        await store.complete_node("s1", "a", {"data": "x"})
+        await store.complete_node("s1", "b", {"context": "y"})
+
+        outputs = await store.get_graph_outputs("s1")
+        assert outputs["a"] == {"data": "x"}
+        assert outputs["b"] == {"context": "y"}
+
+
+class TestMarkNodeFailed:
+    @pytest.mark.asyncio
+    async def test_marks_node_failed(self):
+        store = InMemoryGraphSessionStore()
+        await store.create("s1", _linear_plan())
+        await store.complete_node("s1", "a", {"data": "x"})
+
+        await store.mark_node_failed("s1", "b", "some error")
+        state = store._sessions["s1"]
+        assert state.nodes["b"].status == "failed"
+        assert state.nodes["b"].error == "some error"
+
+    @pytest.mark.asyncio
+    async def test_skips_dependents(self):
+        store = InMemoryGraphSessionStore()
+        await store.create("s1", _linear_plan())
+        await store.complete_node("s1", "a", {"data": "x"})
+
+        await store.mark_node_failed("s1", "b", "error")
+        state = store._sessions["s1"]
+        assert state.nodes["c"].status == "skipped"
+
+
+class TestEventLog:
+    @pytest.mark.asyncio
+    async def test_append_and_get_events(self):
+        store = InMemoryGraphSessionStore()
+        await store.create("s1", _linear_plan())
+
+        idx0 = await store.append_event("s1", {"type": "graphStart"})
+        idx1 = await store.append_event("s1", {"type": "nodeStart", "nodeId": "a"})
+        assert idx0 == 0
+        assert idx1 == 1
+
+        events = await store.get_events("s1")
+        assert len(events) == 2
+        assert events[0]["type"] == "graphStart"
+
+    @pytest.mark.asyncio
+    async def test_get_events_after_index(self):
+        store = InMemoryGraphSessionStore()
+        await store.create("s1", _linear_plan())
+        await store.append_event("s1", {"type": "a"})
+        await store.append_event("s1", {"type": "b"})
+        await store.append_event("s1", {"type": "c"})
+
+        events = await store.get_events("s1", after=0)
+        assert len(events) == 2
+        assert events[0]["type"] == "b"
+
+
+class TestStatus:
+    @pytest.mark.asyncio
+    async def test_default_status(self):
+        store = InMemoryGraphSessionStore()
+        await store.create("s1", _linear_plan())
+        assert await store.get_status("s1") == "running"
+
+    @pytest.mark.asyncio
+    async def test_set_status(self):
+        store = InMemoryGraphSessionStore()
+        await store.create("s1", _linear_plan())
+        await store.set_status("s1", "completed")
+        assert await store.get_status("s1") == "completed"
+
+    @pytest.mark.asyncio
+    async def test_missing_session_status(self):
+        store = InMemoryGraphSessionStore()
+        assert await store.get_status("missing") is None

--- a/packages/opal-backend/tests/test_input_suspend_resume.py
+++ b/packages/opal-backend/tests/test_input_suspend_resume.py
@@ -1,0 +1,238 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for input node suspend/resume (Phase 5).
+
+🎯 Input → Generate → Output works interactively via RPC.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from opal_backend.graph_runner import GraphRunner
+from opal_backend.graph_types import Edge, GraphPlan, NodeDescriptor, PlanNodeInfo
+from opal_backend.local.event_bus_impl import InMemoryEventBus
+from opal_backend.local.graph_session_store_impl import InMemoryGraphSessionStore
+from opal_backend.local.task_scheduler_impl import LocalTaskScheduler
+
+
+def _input_gen_output_plan() -> GraphPlan:
+    """input → generate → output."""
+    inp = NodeDescriptor(
+        id="inp", type="input",
+        configuration={"prompt": "What is your name?", "schema": {"type": "string"}},
+    )
+    gen = NodeDescriptor(id="gen", type="generate")
+    out = NodeDescriptor(id="out", type="output")
+    e1 = Edge(from_node="inp", to_node="gen", out_port="data", in_port="input")
+    e2 = Edge(from_node="gen", to_node="out", out_port="context", in_port="result")
+    return GraphPlan(stages=[
+        [PlanNodeInfo(node=inp, downstream=[e1], upstream=[])],
+        [PlanNodeInfo(node=gen, downstream=[e2], upstream=[e1])],
+        [PlanNodeInfo(node=out, downstream=[], upstream=[e2])],
+    ])
+
+
+def _two_input_plan() -> GraphPlan:
+    """Two independent inputs → output."""
+    inp1 = NodeDescriptor(
+        id="inp1", type="input", configuration={"prompt": "First"},
+    )
+    inp2 = NodeDescriptor(
+        id="inp2", type="input", configuration={"prompt": "Second"},
+    )
+    out = NodeDescriptor(id="out", type="output")
+    e1 = Edge(from_node="inp1", to_node="out", out_port="data", in_port="r1")
+    e2 = Edge(from_node="inp2", to_node="out", out_port="data", in_port="r2")
+    return GraphPlan(stages=[
+        [
+            PlanNodeInfo(node=inp1, downstream=[e1], upstream=[]),
+            PlanNodeInfo(node=inp2, downstream=[e2], upstream=[]),
+        ],
+        [PlanNodeInfo(node=out, downstream=[], upstream=[e1, e2])],
+    ])
+
+
+class TestInputSuspend:
+    """Input nodes suspend and emit inputRequired."""
+
+    @pytest.mark.asyncio
+    async def test_input_node_suspends(self):
+        store = InMemoryGraphSessionStore()
+        bus = InMemoryEventBus()
+        runner = GraphRunner(store=store, event_bus=bus, scheduler=None)
+        scheduler = LocalTaskScheduler(run_fn=runner.run_node)
+        runner._scheduler = scheduler
+
+        plan = _input_gen_output_plan()
+        await store.create("s1", plan)
+
+        events: list[dict] = []
+        subscriber = bus.subscribe("s1")
+        await runner.start_graph("s1")
+
+        # Collect events until inputRequired.
+        async for event in subscriber:
+            events.append(event)
+            if event.get("type") == "inputRequired":
+                break
+
+        # Verify inputRequired event.
+        input_req = [e for e in events if e["type"] == "inputRequired"]
+        assert len(input_req) == 1
+        assert input_req[0]["nodeId"] == "inp"
+        assert "interactionId" in input_req[0]
+
+        # Status should be suspended.
+        assert await store.get_status("s1") == "suspended"
+
+        # Generate and output should still be inactive.
+        state = store._sessions["s1"]
+        assert state.nodes["gen"].status == "inactive"
+        assert state.nodes["out"].status == "inactive"
+
+
+class TestInputResumeFlow:
+    """Full interactive flow: input → generate → output."""
+
+    @pytest.mark.asyncio
+    async def test_resume_completes_graph(self):
+        store = InMemoryGraphSessionStore()
+        bus = InMemoryEventBus()
+        runner = GraphRunner(store=store, event_bus=bus, scheduler=None)
+        scheduler = LocalTaskScheduler(run_fn=runner.run_node)
+        runner._scheduler = scheduler
+
+        plan = _input_gen_output_plan()
+        await store.create("s1", plan)
+
+        # Start — will suspend at input.
+        subscriber = bus.subscribe("s1")
+        await runner.start_graph("s1")
+
+        interaction_id = None
+        async for event in subscriber:
+            if event.get("type") == "inputRequired":
+                interaction_id = event["interactionId"]
+                break
+
+        assert interaction_id is not None
+
+        # Resume with user input.
+        await runner.resume_node(
+            "s1", interaction_id,
+            {"role": "user", "parts": [{"text": "Kevin"}]},
+        )
+
+        # Graph should complete — collect remaining events.
+        subscriber2 = bus.subscribe("s1")
+        async for event in subscriber2:
+            if event.get("type") == "graphComplete":
+                break
+
+        assert await store.is_graph_complete("s1")
+        assert await store.get_status("s1") == "completed"
+
+        # Verify outputs exist.
+        outputs = await store.get_graph_outputs("s1")
+        assert "inp" in outputs
+        assert "gen" in outputs
+        assert "out" in outputs
+
+
+class TestResumeErrors:
+    """Error cases for resume."""
+
+    @pytest.mark.asyncio
+    async def test_invalid_interaction_id(self):
+        store = InMemoryGraphSessionStore()
+        bus = InMemoryEventBus()
+        runner = GraphRunner(store=store, event_bus=bus, scheduler=None)
+        scheduler = LocalTaskScheduler(run_fn=runner.run_node)
+        runner._scheduler = scheduler
+
+        plan = _input_gen_output_plan()
+        await store.create("s1", plan)
+        await runner.start_graph("s1")
+
+        with pytest.raises(ValueError, match="No suspended node"):
+            await runner.resume_node("s1", "bogus", {})
+
+
+class TestMultipleInputNodes:
+    """Two independent input nodes: each suspends independently."""
+
+    @pytest.mark.asyncio
+    async def test_two_inputs_both_suspend(self):
+        store = InMemoryGraphSessionStore()
+        bus = InMemoryEventBus()
+        runner = GraphRunner(store=store, event_bus=bus, scheduler=None)
+        scheduler = LocalTaskScheduler(run_fn=runner.run_node)
+        runner._scheduler = scheduler
+
+        plan = _two_input_plan()
+        await store.create("s1", plan)
+
+        events: list[dict] = []
+        subscriber = bus.subscribe("s1")
+        await runner.start_graph("s1")
+
+        # Both inputs are in stage 0, so both get scheduled.
+        # Collect until we have 2 inputRequired events.
+        input_count = 0
+        async for event in subscriber:
+            events.append(event)
+            if event.get("type") == "inputRequired":
+                input_count += 1
+                if input_count == 2:
+                    break
+
+        input_reqs = [e for e in events if e["type"] == "inputRequired"]
+        assert len(input_reqs) == 2
+        node_ids = {e["nodeId"] for e in input_reqs}
+        assert node_ids == {"inp1", "inp2"}
+
+    @pytest.mark.asyncio
+    async def test_resume_both_inputs_completes(self):
+        store = InMemoryGraphSessionStore()
+        bus = InMemoryEventBus()
+        runner = GraphRunner(store=store, event_bus=bus, scheduler=None)
+        scheduler = LocalTaskScheduler(run_fn=runner.run_node)
+        runner._scheduler = scheduler
+
+        plan = _two_input_plan()
+        await store.create("s1", plan)
+
+        events: list[dict] = []
+        subscriber = bus.subscribe("s1")
+        await runner.start_graph("s1")
+
+        # Collect both inputRequired events.
+        input_count = 0
+        async for event in subscriber:
+            events.append(event)
+            if event.get("type") == "inputRequired":
+                input_count += 1
+                if input_count == 2:
+                    break
+
+        input_reqs = [e for e in events if e["type"] == "inputRequired"]
+
+        # Resume both.
+        for req in input_reqs:
+            await runner.resume_node(
+                "s1", req["interactionId"],
+                {"text": f"value for {req['nodeId']}"},
+            )
+
+        # Graph should complete.
+        subscriber2 = bus.subscribe("s1")
+        async for event in subscriber2:
+            if event.get("type") == "graphComplete":
+                break
+
+        assert await store.is_graph_complete("s1")
+        assert await store.get_status("s1") == "completed"

--- a/packages/opal-backend/tests/test_session_api.py
+++ b/packages/opal-backend/tests/test_session_api.py
@@ -1,7 +1,7 @@
 # Copyright 2026 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for session API (new_session, start_session, Subscribers)."""
+"""Unit tests for session API (new_session, start_session, EventBus)."""
 
 import asyncio
 
@@ -15,11 +15,11 @@ from opal_backend.events import (
     AgentResult,
 )
 from opal_backend.sessions.api import (
-    Subscribers,
     new_session,
     start_session,
     _contexts,
 )
+from opal_backend.local.event_bus_impl import InMemoryEventBus
 from opal_backend.sessions.in_memory_store import InMemorySessionStore
 from opal_backend.sessions.store import SessionStatus
 
@@ -30,53 +30,58 @@ def store():
 
 
 @pytest.fixture
-def subscribers():
-    return Subscribers()
+def event_bus():
+    return InMemoryEventBus()
 
 
-# ── Subscribers ──
+# ── InMemoryEventBus ──
 
 
 @pytest.mark.asyncio
 async def test_subscribe_and_publish():
-    subs = Subscribers()
-    q = subs.subscribe("sess-1")
+    bus = InMemoryEventBus()
+    subscription = bus.subscribe("sess-1")
 
-    await subs.publish("sess-1", {"type": "start"})
-    item = await asyncio.wait_for(q.get(), timeout=1.0)
+    await bus.publish("sess-1", {"type": "start"})
+    item = await asyncio.wait_for(subscription.__anext__(), timeout=1.0)
     assert item == {"type": "start"}
 
 
 @pytest.mark.asyncio
 async def test_unsubscribe():
-    subs = Subscribers()
-    q = subs.subscribe("sess-1")
-    subs.unsubscribe("sess-1", q)
+    bus = InMemoryEventBus()
+    subscription = bus.subscribe("sess-1")
+    bus.unsubscribe("sess-1", subscription)
 
     # Should not raise even with no subscribers.
-    await subs.publish("sess-1", {"type": "start"})
+    await bus.publish("sess-1", {"type": "start"})
 
 
 @pytest.mark.asyncio
 async def test_close_sends_sentinel():
-    subs = Subscribers()
-    q = subs.subscribe("sess-1")
+    bus = InMemoryEventBus()
+    subscription = bus.subscribe("sess-1")
 
-    await subs.close("sess-1")
-    item = await asyncio.wait_for(q.get(), timeout=1.0)
-    assert item is None
+    await bus.close("sess-1")
+    # The async iterator raises StopAsyncIteration on close.
+    items = [item async for item in subscription]
+    assert items == []
 
 
 @pytest.mark.asyncio
 async def test_multiple_subscribers():
-    subs = Subscribers()
-    q1 = subs.subscribe("sess-1")
-    q2 = subs.subscribe("sess-1")
+    bus = InMemoryEventBus()
+    sub1 = bus.subscribe("sess-1")
+    sub2 = bus.subscribe("sess-1")
 
-    await subs.publish("sess-1", {"type": "event"})
+    await bus.publish("sess-1", {"type": "event"})
+    # Close so iteration terminates after the published event.
+    await bus.close("sess-1")
 
-    assert await asyncio.wait_for(q1.get(), timeout=1.0) == {"type": "event"}
-    assert await asyncio.wait_for(q2.get(), timeout=1.0) == {"type": "event"}
+    items1 = [item async for item in sub1]
+    items2 = [item async for item in sub2]
+    assert items1 == [{"type": "event"}]
+    assert items2 == [{"type": "event"}]
 
 
 # ── new_session ──
@@ -117,19 +122,19 @@ async def test_new_session_stashes_context(store):
 
 
 @pytest.mark.asyncio
-async def test_start_session_no_context(store, subscribers):
+async def test_start_session_no_context(store, event_bus):
     """start_session with missing context sets FAILED status."""
     await store.create("sess-missing")
     await start_session(
         session_id="sess-missing",
         store=store,
-        subscribers=subscribers,
+        event_bus=event_bus,
     )
     assert await store.get_status("sess-missing") == SessionStatus.FAILED
 
 
 @pytest.mark.asyncio
-async def test_start_session_tees_events(store, subscribers, monkeypatch):
+async def test_start_session_tees_events(store, event_bus, monkeypatch):
     """Events from run() appear in the store and subscriber queue."""
     # Mock run() to yield a known sequence.
     async def fake_run(**kwargs):
@@ -151,12 +156,12 @@ async def test_start_session_tees_events(store, subscribers, monkeypatch):
     await store.create("sess-tee")
 
     # Subscribe before starting.
-    q = subscribers.subscribe("sess-tee")
+    q = event_bus.subscribe("sess-tee")
 
     await start_session(
         session_id="sess-tee",
         store=store,
-        subscribers=subscribers,
+        event_bus=event_bus,
     )
 
     # Events should be in the store.
@@ -169,16 +174,13 @@ async def test_start_session_tees_events(store, subscribers, monkeypatch):
     # Status should be COMPLETED.
     assert await store.get_status("sess-tee") == SessionStatus.COMPLETED
 
-    # Subscriber queue should have all events + sentinel.
-    received = []
-    while not q.empty():
-        received.append(await q.get())
-    assert len(received) == 4  # 3 events + None sentinel
-    assert received[-1] is None
+    # Subscriber should have received all events.
+    received = [item async for item in q]
+    assert len(received) == 3
 
 
 @pytest.mark.asyncio
-async def test_start_session_failed_status(store, subscribers, monkeypatch):
+async def test_start_session_failed_status(store, event_bus, monkeypatch):
     """CompleteEvent with success=False sets FAILED status."""
     async def fake_run(**kwargs):
         yield CompleteEvent(result=AgentResult(success=False))
@@ -192,14 +194,14 @@ async def test_start_session_failed_status(store, subscribers, monkeypatch):
     await store.create("sess-fail")
 
     await start_session(
-        session_id="sess-fail", store=store, subscribers=subscribers,
+        session_id="sess-fail", store=store, event_bus=event_bus,
     )
 
     assert await store.get_status("sess-fail") == SessionStatus.FAILED
 
 
 @pytest.mark.asyncio
-async def test_start_session_exception_sets_failed(store, subscribers, monkeypatch):
+async def test_start_session_exception_sets_failed(store, event_bus, monkeypatch):
     """Exception during run() sets FAILED status and stores error event."""
     async def fake_run(**kwargs):
         yield StartEvent(objective="test")
@@ -214,7 +216,7 @@ async def test_start_session_exception_sets_failed(store, subscribers, monkeypat
     await store.create("sess-err")
 
     await start_session(
-        session_id="sess-err", store=store, subscribers=subscribers,
+        session_id="sess-err", store=store, event_bus=event_bus,
     )
 
     assert await store.get_status("sess-err") == SessionStatus.FAILED
@@ -229,7 +231,7 @@ async def test_start_session_exception_sets_failed(store, subscribers, monkeypat
 
 @pytest.mark.asyncio
 async def test_start_session_suspend_stashes_resume_id(
-    store, subscribers, monkeypatch,
+    store, event_bus, monkeypatch,
 ):
     """Suspend event → SUSPENDED status, interaction_id stashed."""
     from opal_backend.events import WaitForInputEvent
@@ -252,7 +254,7 @@ async def test_start_session_suspend_stashes_resume_id(
     await store.create("sess-sus")
 
     await start_session(
-        session_id="sess-sus", store=store, subscribers=subscribers,
+        session_id="sess-sus", store=store, event_bus=event_bus,
     )
 
     assert await store.get_status("sess-sus") == SessionStatus.SUSPENDED
@@ -263,7 +265,7 @@ async def test_start_session_suspend_stashes_resume_id(
 
 
 @pytest.mark.asyncio
-async def test_resume_session_lifecycle(store, subscribers, monkeypatch):
+async def test_resume_session_lifecycle(store, event_bus, monkeypatch):
     """Full lifecycle: start (suspend) → resume → complete."""
     from opal_backend.events import WaitForInputEvent
     from opal_backend.sessions.api import _SessionContext, resume_session
@@ -283,7 +285,7 @@ async def test_resume_session_lifecycle(store, subscribers, monkeypatch):
     await store.create("sess-resume")
 
     await start_session(
-        session_id="sess-resume", store=store, subscribers=subscribers,
+        session_id="sess-resume", store=store, event_bus=event_bus,
     )
 
     assert await store.get_status("sess-resume") == SessionStatus.SUSPENDED
@@ -300,7 +302,7 @@ async def test_resume_session_lifecycle(store, subscribers, monkeypatch):
         session_id="sess-resume",
         response={"input": {"role": "user", "parts": [{"text": "Dimitri"}]}},
         store=store,
-        subscribers=subscribers,
+        event_bus=event_bus,
     )
 
     assert await store.get_status("sess-resume") == SessionStatus.COMPLETED
@@ -310,7 +312,7 @@ async def test_resume_session_lifecycle(store, subscribers, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_resume_session_no_context(store, subscribers):
+async def test_resume_session_no_context(store, event_bus):
     """resume_session with missing context sets FAILED."""
     from opal_backend.sessions.api import resume_session
 
@@ -321,7 +323,7 @@ async def test_resume_session_no_context(store, subscribers):
         session_id="sess-no-ctx",
         response={},
         store=store,
-        subscribers=subscribers,
+        event_bus=event_bus,
     )
     assert await store.get_status("sess-no-ctx") == SessionStatus.FAILED
 
@@ -347,7 +349,7 @@ async def test_new_session_stashes_model(store):
 
 
 @pytest.mark.asyncio
-async def test_start_session_passes_model_to_run(store, subscribers, monkeypatch):
+async def test_start_session_passes_model_to_run(store, event_bus, monkeypatch):
     """start_session forwards model from context to run_agent."""
     captured_kwargs = {}
 
@@ -369,7 +371,7 @@ async def test_start_session_passes_model_to_run(store, subscribers, monkeypatch
     await start_session(
         session_id="sess-model-run",
         store=store,
-        subscribers=subscribers,
+        event_bus=event_bus,
     )
 
     assert captured_kwargs.get("model") == "gemini-2.5-pro"
@@ -379,7 +381,7 @@ async def test_start_session_passes_model_to_run(store, subscribers, monkeypatch
 
 
 @pytest.mark.asyncio
-async def test_start_session_paused_status(store, subscribers, monkeypatch):
+async def test_start_session_paused_status(store, event_bus, monkeypatch):
     """PausedEvent → PAUSED status, context re-stashed for resume."""
     from opal_backend.events import PausedEvent
     from opal_backend.sessions.api import _SessionContext
@@ -399,7 +401,7 @@ async def test_start_session_paused_status(store, subscribers, monkeypatch):
     await store.create("sess-pause")
 
     await start_session(
-        session_id="sess-pause", store=store, subscribers=subscribers,
+        session_id="sess-pause", store=store, event_bus=event_bus,
     )
 
     assert await store.get_status("sess-pause") == SessionStatus.PAUSED
@@ -410,7 +412,7 @@ async def test_start_session_paused_status(store, subscribers, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_paused_event_stores_resume_id(store, subscribers, monkeypatch):
+async def test_paused_event_stores_resume_id(store, event_bus, monkeypatch):
     """PausedEvent interaction_id is stashed via set_resume_id."""
     from opal_backend.events import PausedEvent
     from opal_backend.sessions.api import _SessionContext
@@ -430,7 +432,7 @@ async def test_paused_event_stores_resume_id(store, subscribers, monkeypatch):
     await store.create("sess-pause-rid")
 
     await start_session(
-        session_id="sess-pause-rid", store=store, subscribers=subscribers,
+        session_id="sess-pause-rid", store=store, event_bus=event_bus,
     )
 
     # Resume ID should match the PausedEvent's interaction_id.

--- a/packages/opal-backend/tests/test_session_endpoints.py
+++ b/packages/opal-backend/tests/test_session_endpoints.py
@@ -9,7 +9,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from opal_backend.sessions.api import Subscribers
+from opal_backend.local.event_bus_impl import InMemoryEventBus
 from opal_backend.local.session_router import create_session_router
 from opal_backend.sessions.in_memory_store import InMemorySessionStore
 from opal_backend.sessions.store import SessionStatus
@@ -23,7 +23,7 @@ def store():
 @pytest.fixture
 def client(store):
     app = FastAPI()
-    app.include_router(create_session_router(store, Subscribers()))
+    app.include_router(create_session_router(store, InMemoryEventBus()))
     return TestClient(app)
 
 

--- a/packages/types/src/flags.ts
+++ b/packages/types/src/flags.ts
@@ -97,6 +97,12 @@ export type RuntimeFlags = {
    * Show the asset access consent dialog when running a shared Opal.
    */
   enableAssetAccessConsent: boolean;
+
+  /**
+   * Route graph execution through the backend graph runner
+   * instead of in-process PlanRunner.
+   */
+  enableBackendGraphRunner: boolean;
 };
 
 /**
@@ -238,6 +244,12 @@ export const RUNTIME_FLAG_META: Record<keyof RuntimeFlags, RuntimeFlagMeta> = {
     title: "Asset Access Consent",
     description:
       "Show the asset access consent dialog when running a shared Opal.",
+    visibility: "experimental",
+  },
+  enableBackendGraphRunner: {
+    title: "Backend Graph Runner",
+    description:
+      "Route graph execution through the backend instead of in-process",
     visibility: "experimental",
   },
 };

--- a/packages/unified-server/src/config.ts
+++ b/packages/unified-server/src/config.ts
@@ -81,6 +81,7 @@ export async function createClientConfig(opts: {
       enableSessionsBackend: flags.ENABLE_SESSIONS_BACKEND,
       enableSingletonPrefixCache: flags.ENABLE_SINGLETON_PREFIX_CACHE,
       enableAssetAccessConsent: flags.ENABLE_ASSET_ACCESS_CONSENT,
+      enableBackendGraphRunner: flags.ENABLE_BACKEND_GRAPH_RUNNER,
     },
   };
 }

--- a/packages/unified-server/src/flags.ts
+++ b/packages/unified-server/src/flags.ts
@@ -84,6 +84,10 @@ export const ENABLE_ASSET_ACCESS_CONSENT = getBoolean(
   "ENABLE_ASSET_ACCESS_CONSENT"
 );
 
+export const ENABLE_BACKEND_GRAPH_RUNNER = getBoolean(
+  "ENABLE_BACKEND_GRAPH_RUNNER"
+);
+
 export const ENVIRONMENT_NAME = getString("ENVIRONMENT_NAME");
 
 export const FAKE_DRIVE_PORT = Number(process.env["FAKE_DRIVE_PORT"] || 3110);

--- a/packages/visual-editor/src/a2/agent/main.ts
+++ b/packages/visual-editor/src/a2/agent/main.ts
@@ -19,6 +19,7 @@ import { A2UIInteraction } from "./a2ui-interaction.js";
 import { ChoicePresenter } from "./choice-presenter.js";
 import { Params } from "../a2/common.js";
 import type { ProgressReporter } from "./types.js";
+import { registerProgressHandlers } from "./register-progress-handlers.js";
 import { Template } from "../a2/template.js";
 import { A2ModuleArgs } from "../runnable-module-factory.js";
 import { buildAgentRun } from "./loop-setup.js";
@@ -310,68 +311,24 @@ async function invokeRemoteAgent(
   const { consoleEntry, appScreen } = getCurrentStepState(moduleArgs);
   const progress = new ConsoleProgressManager(consoleEntry, appScreen);
 
-  const callIdMap = new Map<string, string>();
-  const reporterMap = new Map<string, ProgressReporter>();
-
   // The `complete` event carries the final AgentResult with outcomes.
   // This mirrors `loop.run()` returning `controller.result` in local mode.
   let remoteResult: { success: boolean; outcomes?: LLMContent } | undefined;
   let remoteError: string | undefined;
 
+  // Register the standard fire-and-forget progress handlers (shared with
+  // the Heartstone backend path).
+  registerProgressHandlers(handle.events, progress, {
+    onComplete: (result) => {
+      remoteResult = result;
+    },
+    onError: (msg) => {
+      remoteError = msg;
+    },
+  });
+
+  // Suspend handlers — these depend on moduleArgs and are path-specific.
   handle.events
-    .on("start", (event) => {
-      progress.startAgent(event.objective);
-    })
-    .on("finish", () => {
-      progress.finish();
-    })
-    .on("complete", (event) => {
-      remoteResult = event.result;
-    })
-    .on("error", (event) => {
-      remoteError = event.message;
-    })
-    .on("thought", (event) => {
-      progress.thought(event.text);
-    })
-    .on("functionCall", (event) => {
-      const { callId: progressCallId, reporter } = progress.functionCall(
-        { functionCall: { name: event.name, args: event.args } },
-        event.icon,
-        event.title
-      );
-      callIdMap.set(event.callId, progressCallId);
-      if (reporter) {
-        reporterMap.set(event.callId, reporter);
-      }
-    })
-    .on("functionCallUpdate", (event) => {
-      const progressCallId = callIdMap.get(event.callId) ?? event.callId;
-      progress.functionCallUpdate(progressCallId, event.status, event.opts);
-    })
-    .on("functionResult", (event) => {
-      const progressCallId = callIdMap.get(event.callId) ?? event.callId;
-      progress.functionResult(progressCallId, event.content);
-      callIdMap.delete(event.callId);
-      reporterMap.delete(event.callId);
-    })
-    .on("sendRequest", (event) => {
-      progress.sendRequest(event.model, event.body);
-    })
-    .on("usageMetadata", (event) => {
-      progress.usageMetadata(event.metadata);
-    })
-    .on("subagentAddJson", (event) => {
-      reporterMap
-        .get(event.callId)
-        ?.addJson(event.title, event.data, event.icon);
-    })
-    .on("subagentError", (event) => {
-      reporterMap.get(event.callId)?.addError(event.error);
-    })
-    .on("subagentFinish", (event) => {
-      reporterMap.get(event.callId)?.finish();
-    })
     .on("waitForInput", (event) => {
       // Display the prompt as a chat output.
       addChatOutput(event.prompt, consoleEntry, appScreen);

--- a/packages/visual-editor/src/a2/agent/register-progress-handlers.ts
+++ b/packages/visual-editor/src/a2/agent/register-progress-handlers.ts
@@ -1,0 +1,122 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview
+ *
+ * Registers the standard set of agent event handlers on an
+ * {@link AgentEventConsumer}. Extracted from `invokeRemoteAgent()`
+ * so both the sessions-backend path and the Heartstone graph-runner
+ * path can share the same handler wiring.
+ *
+ * Covers fire-and-forget progress handlers (start, finish, thought,
+ * functionCall, etc.) and per-path callbacks for `complete`/`error`.
+ */
+
+import type { LLMContent } from "@breadboard-ai/types";
+import type { AgentEventConsumer } from "./agent-event-consumer.js";
+import type { ConsoleProgressManager } from "./console-progress-manager.js";
+import type { ProgressReporter } from "./types.js";
+
+export { registerProgressHandlers };
+export type { ProgressCallbacks };
+
+/**
+ * Path-specific callbacks for events that are handled differently
+ * depending on the caller (sessions-backend vs. Heartstone).
+ */
+interface ProgressCallbacks {
+  /** Called when the agent emits a `complete` event with the result. */
+  onComplete?: (result: { success: boolean; outcomes?: LLMContent }) => void;
+  /** Called when the agent emits an `error` event. */
+  onError?: (message: string) => void;
+}
+
+/**
+ * Register the standard set of agent progress handlers on a consumer.
+ *
+ * This wires up all fire-and-forget agent event types to a
+ * {@link ConsoleProgressManager}, which updates the console entry's
+ * work items and the app screen in the UI.
+ *
+ * Used by:
+ * - `invokeRemoteAgent()` in `main.ts` (sessions-backend path)
+ * - `processEvent()` in `backend-run-action.ts` (Heartstone path)
+ *
+ * @param consumer The AgentEventConsumer to register handlers on.
+ * @param progress The ConsoleProgressManager for UI updates.
+ * @param callbacks Path-specific callbacks for complete/error.
+ * @returns Maps for tracking function call IDs and reporters,
+ *          needed if the caller wants to access them.
+ */
+function registerProgressHandlers(
+  consumer: AgentEventConsumer,
+  progress: ConsoleProgressManager,
+  callbacks?: ProgressCallbacks
+): {
+  callIdMap: Map<string, string>;
+  reporterMap: Map<string, ProgressReporter>;
+} {
+  const callIdMap = new Map<string, string>();
+  const reporterMap = new Map<string, ProgressReporter>();
+
+  consumer
+    .on("start", (event) => {
+      progress.startAgent(event.objective);
+    })
+    .on("finish", () => {
+      progress.finish();
+    })
+    .on("complete", (event) => {
+      callbacks?.onComplete?.(event.result);
+    })
+    .on("error", (event) => {
+      callbacks?.onError?.(event.message);
+    })
+    .on("thought", (event) => {
+      progress.thought(event.text);
+    })
+    .on("functionCall", (event) => {
+      const { callId: progressCallId, reporter } = progress.functionCall(
+        { functionCall: { name: event.name, args: event.args } },
+        event.icon,
+        event.title
+      );
+      callIdMap.set(event.callId, progressCallId);
+      if (reporter) {
+        reporterMap.set(event.callId, reporter);
+      }
+    })
+    .on("functionCallUpdate", (event) => {
+      const progressCallId = callIdMap.get(event.callId) ?? event.callId;
+      progress.functionCallUpdate(progressCallId, event.status, event.opts);
+    })
+    .on("functionResult", (event) => {
+      const progressCallId = callIdMap.get(event.callId) ?? event.callId;
+      progress.functionResult(progressCallId, event.content);
+      callIdMap.delete(event.callId);
+      reporterMap.delete(event.callId);
+    })
+    .on("sendRequest", (event) => {
+      progress.sendRequest(event.model, event.body);
+    })
+    .on("usageMetadata", (event) => {
+      progress.usageMetadata(event.metadata);
+    })
+    .on("subagentAddJson", (event) => {
+      reporterMap
+        .get(event.callId)
+        ?.addJson(event.title, event.data, event.icon);
+    })
+    .on("subagentError", (event) => {
+      reporterMap.get(event.callId)?.addError(event.error);
+    })
+    .on("subagentFinish", (event) => {
+      reporterMap.get(event.callId)?.finish();
+    });
+
+  return { callIdMap, reporterMap };
+}

--- a/packages/visual-editor/src/sca/actions/actions.ts
+++ b/packages/visual-editor/src/sca/actions/actions.ts
@@ -20,6 +20,7 @@ import * as Node from "./node/node-actions.js";
 import * as NotebookLmPicker from "./notebooklm/notebooklm-picker-actions.js";
 import * as Router from "./router/router-actions.js";
 import * as Run from "./run/run-actions.js";
+import * as BackendRun from "./run/backend-run-action.js";
 import * as ScreenSize from "./screen-size/screen-size-actions.js";
 import * as Share from "./share/share-actions.js";
 import * as Shell from "./shell/shell-actions.js";
@@ -74,6 +75,7 @@ export function actions(
     NotebookLmPicker.bind({ controller, services, env });
     Router.bind({ controller, services, env });
     Run.bind({ controller, services, env });
+    BackendRun.bind({ controller, services, env });
     ScreenSize.bind({ controller, services, env });
     Share.bind({ controller, services, env });
     Shell.bind({ controller, services, env });

--- a/packages/visual-editor/src/sca/actions/board/board-actions.ts
+++ b/packages/visual-editor/src/sca/actions/board/board-actions.ts
@@ -34,6 +34,7 @@ import {
   onSaveShortcut,
 } from "./triggers.js";
 import { forSection } from "../../../ui/strings/helper.js";
+import { startBackendRun } from "../run/backend-run-action.js";
 
 const Strings = forSection("Global");
 
@@ -1023,9 +1024,6 @@ async function runBoard(): Promise<void> {
 
   // Backend graph runner: delegate to Heartstone backend.
   if (services.graphRunService.enabled) {
-    const { startBackendRun } = await import(
-      "../run/backend-run-action.js"
-    );
     await startBackendRun();
     return;
   }

--- a/packages/visual-editor/src/sca/actions/board/board-actions.ts
+++ b/packages/visual-editor/src/sca/actions/board/board-actions.ts
@@ -1021,6 +1021,15 @@ async function runBoard(): Promise<void> {
     }
   }
 
+  // Backend graph runner: delegate to Heartstone backend.
+  if (services.graphRunService.enabled) {
+    const { startBackendRun } = await import(
+      "../run/backend-run-action.js"
+    );
+    await startBackendRun();
+    return;
+  }
+
   controller.run.main.runner.start();
 }
 

--- a/packages/visual-editor/src/sca/actions/run/backend-run-action.ts
+++ b/packages/visual-editor/src/sca/actions/run/backend-run-action.ts
@@ -426,11 +426,10 @@ function processEvent(
           const inspectable = controller.editor.graph.get()?.graphs.get("");
           const node = inspectable?.nodeById(nodeId);
           const outputSchema = node?.currentDescribe()?.outputSchema;
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const output = {
-            output: { context: [bridge.outcomes] },
+          const output: AppScreenOutput = {
+            output: { context: [bridge.outcomes] } as OutputValues,
             schema: outputSchema,
-          } as any as AppScreenOutput;
+          };
           screen.outputs.set(nodeId, output);
           screen.last = output;
         }

--- a/packages/visual-editor/src/sca/actions/run/backend-run-action.ts
+++ b/packages/visual-editor/src/sca/actions/run/backend-run-action.ts
@@ -1,0 +1,561 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @fileoverview
+ *
+ * Backend graph run action — consumes Heartstone SSE events and
+ * maps them to the same RunController / RendererController state
+ * that the in-process PlanRunner would set.
+ *
+ * On suspend (`inputRequired`), the SSE stream is closed.
+ * After the user provides input, `:resume` is POSTed and a new
+ * stream is opened — mirroring the sessions-backend pattern.
+ *
+ * Agent events are piped through per-node bridges that reuse the
+ * same {@link registerProgressHandlers} shared with the sessions-
+ * backend path in `invokeRemoteAgent()`.
+ */
+
+import type {
+  AppScreen,
+  AppScreenOutput,
+  BehaviorSchema,
+  ConsoleEntry,
+  LLMContent,
+  OutputValues,
+  Schema,
+} from "@breadboard-ai/types";
+import type { GraphRunEvent } from "../../services/graph-run-service.js";
+import { AgentEventConsumer } from "../../../a2/agent/agent-event-consumer.js";
+import { addChatOutput } from "../../../a2/agent/chat-output.js";
+import { ConsoleProgressManager } from "../../../a2/agent/console-progress-manager.js";
+import { registerProgressHandlers } from "../../../a2/agent/register-progress-handlers.js";
+import { RunController } from "../../controller/subcontrollers/run/run-controller.js";
+import { STATUS } from "../../types.js";
+import { getStepIcon } from "../../../ui/utils/get-step-icon.js";
+import {
+  createAppScreen,
+  tickScreenProgress,
+} from "../../utils/app-screen.js";
+import { makeAction } from "../binder.js";
+import { Utils } from "../../utils.js";
+import {
+  handleInputRequested,
+} from "./helpers/input-queue.js";
+
+const LABEL = "Backend Run";
+
+export { startBackendRun };
+
+export const bind = makeAction();
+
+// ---------------------------------------------------------------------------
+// Abort-aware promise racing
+// ---------------------------------------------------------------------------
+
+/**
+ * Races a promise against an AbortSignal. Rejects with an AbortError
+ * if the signal fires before the promise settles. This ensures input
+ * waits (which never reject on their own) don't hang the run forever
+ * when the user clicks Stop/Restart.
+ */
+function raceAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) {
+    return Promise.reject(new DOMException("Aborted", "AbortError"));
+  }
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(new DOMException("Aborted", "AbortError"));
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (v) => { signal.removeEventListener("abort", onAbort); resolve(v); },
+      (e) => { signal.removeEventListener("abort", onAbort); reject(e); },
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Per-node agent bridge
+// ---------------------------------------------------------------------------
+
+/**
+ * Tracks the AgentEventConsumer and progress state for a single node
+ * so we can dispatch agent events to the correct consumer.
+ *
+ * Also captures the agent's `outcomes` from the `complete` event so
+ * that `nodeEnd` can populate the console entry's output map.
+ *
+ * For input handling, `pendingInput` holds a Promise that resolves
+ * when the user provides input via the UI. This bridges the gap
+ * between the `waitForInput` agent event (which shows the UI) and
+ * the `inputRequired` graph event (which triggers the resume flow).
+ */
+interface NodeAgentBridge {
+  consumer: AgentEventConsumer;
+  progress: ConsoleProgressManager;
+  /** Captured from the `complete` agent event — the agent's final output. */
+  outcomes?: LLMContent;
+  /** Resolves with user input when `waitForInput` UI is completed. */
+  pendingInput?: Promise<OutputValues>;
+}
+
+// ---------------------------------------------------------------------------
+// Main action
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs the current graph on the Heartstone backend via SSE.
+ *
+ * Lifecycle:
+ * 1. POST graph → get session
+ * 2. Open SSE stream → iterate events
+ * 3. On `inputRequired`: close stream, wait for user input, POST :resume,
+ *    reconnect
+ * 4. Repeat until `graphComplete` or `graphError`
+ *
+ * Called from `runBoard()` in board-actions.ts, which is already inside
+ * the `Board.onRun` Exclusive action. This is a plain function — NOT an
+ * asAction — to avoid nested-exclusive deadlocks (same pattern as
+ * `runner.start()`).
+ */
+async function startBackendRun(): Promise<void> {
+  const { controller, services } = bind;
+  const graphRunService = services.graphRunService;
+
+  // Get the graph descriptor from the editor.
+  const graph = controller.editor.graph.editor?.raw();
+  if (!graph) {
+    Utils.Logging.getLogger(controller).log(
+      Utils.Logging.Formatter.warning("No graph to run"),
+      LABEL
+    );
+    return;
+  }
+
+  // Reset state before starting.
+  controller.run.main.reset();
+  controller.run.renderer.reset();
+  controller.run.screen.reset();
+  controller.run.main.setStatus(STATUS.RUNNING);
+
+  // Wire input lifecycle: when a console entry calls requestInputForNode,
+  // notify the input queue to show the UI — same wiring as run-actions.ts.
+  controller.run.main.onInputRequested = (id, schema, skipLabel) =>
+    handleInputRequested(id, schema, controller.run, skipLabel);
+
+  // Start ticking progress every 250ms — same as onRunnerStart.
+  const progressTickerHandle = setInterval(() => {
+    for (const screen of controller.run.screen.screens.values()) {
+      tickScreenProgress(screen);
+    }
+  }, 250);
+
+  const abortController = new AbortController();
+  controller.run.main.abortController = abortController;
+
+  // Per-node agent bridges for dispatching agent events.
+  const bridges = new Map<string, NodeAgentBridge>();
+
+  try {
+    const session = await graphRunService.createSession(
+      graph,
+      abortController.signal
+    );
+    Utils.Logging.getLogger(controller).log(
+      Utils.Logging.Formatter.verbose(
+        `Session created: ${session.sessionId}`
+      ),
+      LABEL
+    );
+
+    // Main stream-consume loop — reconnects on suspend.
+    let running = true;
+    while (running) {
+      const events = session.openStream(abortController.signal);
+
+      for await (const event of events) {
+        if (abortController.signal.aborted) {
+          running = false;
+          break;
+        }
+
+        const result = processEvent(event, controller, bridges);
+
+        if (result === "done") {
+          running = false;
+          break;
+        }
+
+        if (result === "suspend") {
+          // The `waitForInput` agent event (which arrived before this
+          // `inputRequired` graph event) has already shown the input UI
+          // and created a Promise on the bridge. We now:
+          // 1. Wait for the user's response
+          // 2. POST :resume with the response
+          // 3. Break the inner loop so the outer loop reconnects
+
+          const inputEvent = event as Extract<
+            GraphRunEvent,
+            { type: "inputRequired" }
+          >;
+          const bridge = bridges.get(inputEvent.nodeId);
+
+          if (bridge?.pendingInput) {
+            // Agent node path — the `waitForInput` handler already
+            // showed the input UI and created a Promise on the bridge.
+            Utils.Logging.getLogger(controller).log(
+              Utils.Logging.Formatter.verbose(
+                `Waiting for user input on node ${inputEvent.nodeId}`
+              ),
+              LABEL
+            );
+
+            const userInput = await raceAbort(
+              bridge.pendingInput, abortController.signal
+            );
+            bridge.pendingInput = undefined;
+
+            controller.run.main.setStatus(STATUS.RUNNING);
+            await session.resume(inputEvent.interactionId, userInput);
+
+            Utils.Logging.getLogger(controller).log(
+              Utils.Logging.Formatter.verbose(
+                `Resumed session after input on node ${inputEvent.nodeId}`
+              ),
+              LABEL
+            );
+          } else if (inputEvent.suspendEvent?.inputNode) {
+            // Input node path — no agent involved. The backend built
+            // the schema from the node's config (description, modality,
+            // required). Use it directly.
+            const inputNode = inputEvent.suspendEvent.inputNode as {
+              schema?: Schema;
+            };
+            const schema: Schema = inputNode.schema &&
+              (inputNode.schema as Schema).properties
+              ? (inputNode.schema as Schema)
+              : {
+                  type: "object",
+                  properties: {
+                    request: {
+                      type: "object",
+                      title: "Please provide input",
+                      behavior: [
+                        "transient",
+                        "llm-content",
+                      ] as BehaviorSchema[],
+                      format: "asterisk",
+                    },
+                  },
+                };
+
+            // If the schema's request title is empty or the generic
+            // fallback, use the node's metadata title instead
+            // (e.g. "Topic").
+            const requestProp = schema.properties?.request;
+            if (requestProp && !requestProp.title) {
+              const inspectable = controller.editor.graph
+                .get()
+                ?.graphs.get("");
+              const node = inspectable?.nodeById(inputEvent.nodeId);
+              requestProp.title = node?.title() ?? "Please provide input";
+            }
+
+            const entry = controller.run.main.console.get(
+              inputEvent.nodeId
+            );
+            if (entry) {
+              // Show the prompt text as a chat bubble above the input
+              // form — mirrors the `report()` call in the TS ask-user
+              // module. The floating-input component doesn't render
+              // the schema title itself.
+              const promptTitle =
+                schema.properties?.request?.title || "Please provide input";
+              const appScreen = controller.run.screen.screens.get(
+                inputEvent.nodeId
+              );
+              addChatOutput(
+                { role: "model", parts: [{ text: promptTitle }] },
+                entry,
+                appScreen
+              );
+
+              Utils.Logging.getLogger(controller).log(
+                Utils.Logging.Formatter.verbose(
+                  `Input node ${inputEvent.nodeId} requesting input`
+                ),
+                LABEL
+              );
+
+              controller.run.main.setStatus(STATUS.PAUSED);
+              const userInput = await raceAbort(
+                entry.requestInput(schema), abortController.signal
+              );
+
+              controller.run.main.setStatus(STATUS.RUNNING);
+              await session.resume(inputEvent.interactionId, userInput);
+
+              Utils.Logging.getLogger(controller).log(
+                Utils.Logging.Formatter.verbose(
+                  `Resumed session after input node ${inputEvent.nodeId}`
+                ),
+                LABEL
+              );
+            } else {
+              Utils.Logging.getLogger(controller).log(
+                Utils.Logging.Formatter.warning(
+                  `inputRequired for input node ${inputEvent.nodeId} but no console entry`
+                ),
+                LABEL
+              );
+              running = false;
+            }
+          } else {
+            // Unknown suspend type — log and stop gracefully.
+            Utils.Logging.getLogger(controller).log(
+              Utils.Logging.Formatter.warning(
+                `inputRequired but no handler for node ${inputEvent.nodeId}`
+              ),
+              LABEL
+            );
+            running = false;
+          }
+
+          // Break inner loop to reconnect stream.
+          break;
+        }
+      }
+    }
+  } catch (error) {
+    if (abortController.signal.aborted) {
+      Utils.Logging.getLogger(controller).log(
+        Utils.Logging.Formatter.verbose("Run aborted"),
+        LABEL
+      );
+    } else {
+      Utils.Logging.getLogger(controller).log(
+        Utils.Logging.Formatter.warning(`Run failed: ${String(error)}`),
+        LABEL
+      );
+      controller.run.main.setError({
+        message: String(error),
+      });
+    }
+  } finally {
+    // Cleanup — mirrors onRunnerEnd.
+    clearInterval(progressTickerHandle);
+    bridges.clear();
+    controller.run.main.clearInput();
+    controller.run.main.setStatus(STATUS.STOPPED);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Event processing
+// ---------------------------------------------------------------------------
+
+type ProcessResult = "continue" | "done" | "suspend";
+
+/**
+ * Maps a single Heartstone SSE event to controller state updates.
+ * Returns a control signal for the main loop.
+ */
+function processEvent(
+  event: GraphRunEvent,
+  controller: typeof bind.controller,
+  bridges: Map<string, NodeAgentBridge>
+): ProcessResult {
+  switch (event.type) {
+    case "nodeStart": {
+      const { nodeId } = event;
+      const inspectable = controller.editor.graph.get()?.graphs.get("");
+      const node = inspectable?.nodeById(nodeId);
+      const title = node?.title() ?? nodeId;
+      const metadata = node?.currentDescribe()?.metadata ?? {};
+
+      // Create console entry — same as handleNodeStart in run-actions.ts.
+      const entry = RunController.createConsoleEntry(title, "working", {
+        icon: getStepIcon(metadata.icon, node?.currentPorts()),
+        tags: metadata.tags,
+        id: nodeId,
+        controller: controller.run.main,
+      });
+      controller.run.main.setConsoleEntry(nodeId, entry);
+      controller.run.renderer.setNodeState(nodeId, { status: "working" });
+
+      // Create app screen for this node.
+      const outputSchema = node?.currentDescribe()?.outputSchema;
+      const screen = createAppScreen(title, outputSchema);
+      controller.run.screen.setScreen(nodeId, screen);
+
+      // Create per-node agent bridge.
+      const consoleEntry = controller.run.main.console.get(nodeId);
+      const appScreen = controller.run.screen.screens.get(nodeId);
+      createBridge(nodeId, consoleEntry, appScreen, controller, bridges);
+
+      return "continue";
+    }
+
+    case "nodeEnd": {
+      const { nodeId } = event;
+      const bridge = bridges.get(nodeId);
+      const existing = controller.run.main.console.get(nodeId);
+
+      // Populate outputs from the captured agent outcomes.
+      if (existing && bridge?.outcomes) {
+        existing.output.set("context", bridge.outcomes);
+      }
+
+      if (existing) {
+        controller.run.main.setConsoleEntry(nodeId, {
+          ...existing,
+          status: { status: "succeeded" },
+          completed: true,
+        });
+      }
+      controller.run.renderer.setNodeState(nodeId, { status: "succeeded" });
+
+      // Finalize the screen — populate outputs and set status to
+      // "complete", same as handleNodeEnd in run-actions.ts.
+      const screen = controller.run.screen.screens.get(nodeId);
+      if (screen) {
+        if (bridge?.outcomes) {
+          const inspectable = controller.editor.graph.get()?.graphs.get("");
+          const node = inspectable?.nodeById(nodeId);
+          const outputSchema = node?.currentDescribe()?.outputSchema;
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const output = {
+            output: { context: [bridge.outcomes] },
+            schema: outputSchema,
+          } as any as AppScreenOutput;
+          screen.outputs.set(nodeId, output);
+          screen.last = output;
+        }
+        screen.status = "complete";
+      }
+
+      // Clean up bridge.
+      bridges.delete(nodeId);
+      return "continue";
+    }
+
+    case "agentEvent": {
+      const bridge = bridges.get(event.nodeId);
+      if (bridge) {
+        // Dispatch the unwrapped AgentEvent through the consumer.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        bridge.consumer.handle(event.event as any);
+      }
+      return "continue";
+    }
+
+    case "inputRequired": {
+      // Signal the main loop to suspend and handle input.
+      return "suspend";
+    }
+
+    case "graphComplete": {
+      Utils.Logging.getLogger(controller).log(
+        Utils.Logging.Formatter.verbose(
+          `Graph complete: ${event.sessionId}`
+        ),
+        LABEL
+      );
+      return "done";
+    }
+
+    case "graphError": {
+      Utils.Logging.getLogger(controller).log(
+        Utils.Logging.Formatter.warning(`Graph error: ${event.error}`),
+        LABEL
+      );
+      controller.run.main.setError({
+        message: event.error,
+      });
+      return "done";
+    }
+
+    default:
+      return "continue";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-node bridge management
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a per-node agent bridge and registers progress handlers.
+ *
+ * Also registers a `waitForInput` handler that bridges the frontend
+ * input UI to the backend suspend/resume flow. When the agent emits
+ * `waitForInput`, this handler:
+ * 1. Calls `entry.requestInput(schema)` to show the input UI
+ * 2. Stores the resulting Promise on the bridge as `pendingInput`
+ * 3. When `inputRequired` arrives, the main loop awaits `pendingInput`,
+ *    then POSTs `:resume` with the user's response
+ */
+function createBridge(
+  nodeId: string,
+  consoleEntry: ConsoleEntry | undefined,
+  appScreen: AppScreen | undefined,
+  controller: typeof bind.controller,
+  bridges: Map<string, NodeAgentBridge>
+): void {
+  const consumer = new AgentEventConsumer();
+  const progress = new ConsoleProgressManager(consoleEntry, appScreen);
+
+  const bridge: NodeAgentBridge = { consumer, progress };
+
+  registerProgressHandlers(consumer, progress, {
+    onComplete: (result) => {
+      // Capture outcomes for nodeEnd to use.
+      bridge.outcomes = result.outcomes;
+    },
+    onError: (message) => {
+      Utils.Logging.getLogger().log(
+        Utils.Logging.Formatter.warning(
+          `Agent error for ${nodeId}: ${message}`
+        ),
+        LABEL
+      );
+    },
+  });
+
+  // Register the waitForInput handler — this bridges the UI input
+  // flow to the backend suspend/resume protocol.
+  consumer.on("waitForInput", (event) => {
+    const behaviors: BehaviorSchema[] = ["transient", "llm-content"];
+    if (!event.skipLabel) {
+      behaviors.push("hint-required");
+    }
+    const schema: Schema = {
+      properties: {
+        input: {
+          type: "object",
+          behavior: behaviors,
+          format: event.inputType,
+        },
+      },
+    };
+
+    // Show the agent's prompt text in the console and app screen.
+    addChatOutput(event.prompt, consoleEntry, appScreen);
+
+    // requestInput shows the input UI and returns a Promise that
+    // resolves when the user submits. Store it on the bridge for
+    // the main loop to await when inputRequired arrives.
+    const entry = controller.run.main.console.get(nodeId);
+    if (entry) {
+      bridge.pendingInput = entry.requestInput(schema, event.skipLabel);
+    }
+
+    // Return the Promise so the consumer knows this is a suspend event.
+    return bridge.pendingInput;
+  });
+
+  bridges.set(nodeId, bridge);
+}

--- a/packages/visual-editor/src/sca/services/graph-run-service.ts
+++ b/packages/visual-editor/src/sca/services/graph-run-service.ts
@@ -1,0 +1,230 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Service for running graphs on the Heartstone backend via SSE.
+ *
+ * Follows the same service pattern as {@link AgentService}: eagerly
+ * configured with URL + fetch + flag predicate; the flag is read at
+ * `startRun()` time so toggling it in Settings takes effect immediately.
+ *
+ * Protocol:
+ * 1. `POST /v1beta1/graphSessions/new`  → `{ sessionId }`
+ * 2. `GET  /v1beta1/graphSessions/{id}` → SSE stream of graph events
+ * 3. `POST /v1beta1/graphSessions/{id}:resume` → inject input response
+ * 4. `POST /v1beta1/graphSessions/{id}:cancel` → cancel session
+ *
+ * The SSE stream is designed for disconnect/reconnect: on suspend
+ * (e.g. `inputRequired`), the client closes the stream, collects
+ * user input, POSTs `:resume`, then opens a new stream to the same
+ * session. The backend keeps the session alive across connections.
+ */
+
+import { iteratorFromStream } from "@breadboard-ai/utils";
+
+export { GraphRunService };
+export type { GraphRunEvent, GraphRunSession };
+
+// ---------------------------------------------------------------------------
+// Event types emitted by the Heartstone backend SSE stream
+// ---------------------------------------------------------------------------
+
+/**
+ * Common base for all SSE events — the backend assigns a monotonic
+ * `index` to every event so the client can reconnect with `?after=N`.
+ */
+interface GraphRunEventBase {
+  index?: number;
+}
+
+/** Union of all event types the backend emits on the SSE stream. */
+type GraphRunEvent = GraphRunEventBase &
+  (
+    | { type: "graphStart"; sessionId: string }
+    | { type: "nodeStart"; nodeId: string }
+    | { type: "nodeEnd"; nodeId: string }
+    | {
+        type: "agentEvent";
+        nodeId: string;
+        event: Record<string, unknown>;
+      }
+    | {
+        type: "inputRequired";
+        nodeId: string;
+        interactionId: string;
+        suspendEvent?: Record<string, unknown>;
+      }
+    | {
+        type: "graphComplete";
+        sessionId: string;
+        outputs: Record<string, Record<string, unknown>>;
+      }
+    | { type: "graphError"; sessionId: string; error: string }
+  );
+
+/**
+ * Handle for a running graph session. Separates session lifecycle
+ * from stream lifecycle to support disconnect/reconnect on suspend.
+ */
+interface GraphRunSession {
+  /** The backend session ID. */
+  readonly sessionId: string;
+
+  /**
+   * Open (or reconnect) the SSE event stream.
+   *
+   * Returns an async iterable over events. The iterable ends when:
+   * - The stream closes normally (backend done)
+   * - The caller aborts the signal
+   *
+   * Call this again after resume to reconnect.
+   */
+  openStream(signal?: AbortSignal): AsyncIterable<GraphRunEvent>;
+
+  /** Resume a suspended node (graph-level or agent-level input). */
+  resume(interactionId: string, response: unknown): Promise<void>;
+
+  /** Cancel the backend session (best-effort). */
+  cancel(): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Service
+// ---------------------------------------------------------------------------
+
+class GraphRunService {
+  #baseUrl = "";
+  #fetchFn: typeof fetch = fetch;
+  #isEnabled: () => boolean = () => false;
+
+  /**
+   * Configure the backend connection. Called once at app startup.
+   *
+   * @param baseUrl  — e.g. `"http://localhost:8080"` or production URL.
+   * @param fetchFn  — authenticated fetch (usually `fetchWithCreds`).
+   * @param isEnabled — predicate reading the flag at call time.
+   */
+  configureRemote(
+    baseUrl: string,
+    fetchFn: typeof fetch,
+    isEnabled: () => boolean
+  ): void {
+    this.#baseUrl = baseUrl;
+    this.#fetchFn = fetchFn;
+    this.#isEnabled = isEnabled;
+  }
+
+  /** Whether the backend graph runner is enabled right now. */
+  get enabled(): boolean {
+    return this.#isEnabled();
+  }
+
+  /**
+   * Create a graph session on the backend and return a session handle.
+   *
+   * The session handle supports disconnect/reconnect: call
+   * `openStream()` to consume events, close the stream on suspend,
+   * call `resume()`, then call `openStream()` again.
+   */
+  async createSession(
+    graph: Record<string, unknown>,
+    signal?: AbortSignal
+  ): Promise<GraphRunSession> {
+    const createUrl = `${this.#baseUrl}/v1beta1/graphSessions/new`;
+    const createResp = await this.#fetchFn(createUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ graph }),
+      signal,
+    });
+
+    if (!createResp.ok) {
+      throw new Error(
+        `Graph session creation failed: ${createResp.status} ${createResp.statusText}`
+      );
+    }
+
+    const { sessionId } = (await createResp.json()) as { sessionId: string };
+    const fetchFn = this.#fetchFn;
+    const baseUrl = this.#baseUrl;
+
+    // Cursor: the highest event index we've seen. Used to avoid
+    // replaying old events on reconnect.
+    let cursor = -1;
+
+    return {
+      sessionId,
+
+      openStream(signal?: AbortSignal): AsyncIterable<GraphRunEvent> {
+        // Include ?after=N to skip events we've already processed.
+        const streamUrl =
+          `${baseUrl}/v1beta1/graphSessions/${sessionId}?after=${cursor}`;
+        // Return an async iterable that lazily opens the stream.
+        return {
+          [Symbol.asyncIterator]() {
+            let started = false;
+            let iterator: AsyncIterator<GraphRunEvent> | null = null;
+
+            return {
+              async next(): Promise<IteratorResult<GraphRunEvent>> {
+                if (!started) {
+                  started = true;
+                  const resp = await fetchFn(streamUrl, { signal });
+                  if (!resp.ok) {
+                    throw new Error(
+                      `Graph SSE stream failed: ${resp.status} ${resp.statusText}`
+                    );
+                  }
+                  if (!resp.body) {
+                    throw new Error("Graph SSE response has no body");
+                  }
+                  const iterable =
+                    iteratorFromStream<GraphRunEvent>(resp.body);
+                  iterator = iterable[Symbol.asyncIterator]();
+                }
+                const result = await iterator!.next();
+                // Track the cursor for reconnection.
+                if (!result.done && typeof result.value.index === "number") {
+                  cursor = Math.max(cursor, result.value.index);
+                }
+                return result;
+              },
+            };
+          },
+        };
+      },
+
+      async resume(
+        interactionId: string,
+        response: unknown
+      ): Promise<void> {
+        const url = `${baseUrl}/v1beta1/graphSessions/${sessionId}:resume`;
+        const resp = await fetchFn(url, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ interactionId, response }),
+        });
+        if (!resp.ok) {
+          throw new Error(
+            `Resume failed: ${resp.status} ${resp.statusText}`
+          );
+        }
+      },
+
+      async cancel(): Promise<void> {
+        const url = `${baseUrl}/v1beta1/graphSessions/${sessionId}:cancel`;
+        try {
+          await fetchFn(url, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+          });
+        } catch {
+          // Best-effort — signal may have already killed the fetch.
+        }
+      },
+    };
+  }
+}

--- a/packages/visual-editor/src/sca/services/services.ts
+++ b/packages/visual-editor/src/sca/services/services.ts
@@ -41,6 +41,7 @@ import { getLogger, Formatter } from "../utils/logging/logger.js";
 import { NotebookLmApiClient } from "./notebooklm-api-client.js";
 import type { OAuthScope } from "../../ui/connection/oauth-scopes.js";
 import { AgentService } from "../../a2/agent/agent-service.js";
+import { GraphRunService } from "./graph-run-service.js";
 
 // eslint-disable-next-line local-rules/no-exported-types-outside-types-ts
 export interface AppServices {
@@ -69,6 +70,7 @@ export interface AppServices {
   integrationManagers: IntegrationManagerService;
   notebookLmApiClient: NotebookLmApiClient;
   runService: RunService;
+  graphRunService: GraphRunService;
   agentService: AgentService;
   sandbox: A2ModuleFactory;
   signinAdapter: SigninAdapter;
@@ -147,6 +149,13 @@ export function services(
       () => env.flags.get("enableSessionsBackend")
     );
 
+    const graphRunService = new GraphRunService();
+    graphRunService.configureRemote(
+      OPAL_BACKEND_API_PREFIX,
+      fetchWithCreds,
+      () => env.flags.get("enableBackendGraphRunner")
+    );
+
     const sandbox = createA2ModuleFactory({
       mcpClientManager: mcpClientManager,
       fetchWithCreds: fetchWithCreds,
@@ -197,6 +206,7 @@ export function services(
       mcpClientManager,
       notebookLmApiClient,
       runService: new RunService(),
+      graphRunService: graphRunService,
       agentService,
       sandbox,
       signinAdapter,

--- a/packages/visual-editor/src/ui/config/client-deployment-configuration.ts
+++ b/packages/visual-editor/src/ui/config/client-deployment-configuration.ts
@@ -32,6 +32,7 @@ const DEFAULT_FLAG_VALUES: RuntimeFlags = {
   enableSessionsBackend: false,
   enableSingletonPrefixCache: false,
   enableAssetAccessConsent: false,
+  enableBackendGraphRunner: false,
 };
 
 function populateFlags<T extends Partial<ClientDeploymentConfiguration>>(

--- a/packages/visual-editor/tests/sca/actions/board/board-route-actions.test.ts
+++ b/packages/visual-editor/tests/sca/actions/board/board-route-actions.test.ts
@@ -149,6 +149,9 @@ function makeMockServices(
     embedHandler: {
       sendToEmbedder: mock.fn(),
     },
+    graphRunService: {
+      enabled: false,
+    },
   } as unknown as AppServices;
 }
 

--- a/packages/visual-editor/tests/sca/controller/data/default-flags.ts
+++ b/packages/visual-editor/tests/sca/controller/data/default-flags.ts
@@ -24,4 +24,5 @@ export const defaultRuntimeFlags: RuntimeFlags = {
   enableSessionsBackend: false,
   enableSingletonPrefixCache: false,
   enableAssetAccessConsent: false,
+  enableBackendGraphRunner: false,
 };

--- a/packages/visual-editor/tests/sca/environment/environment.test.ts
+++ b/packages/visual-editor/tests/sca/environment/environment.test.ts
@@ -87,6 +87,7 @@ const testFlags: RuntimeFlags = {
   enableSessionsBackend: false,
   enableSingletonPrefixCache: false,
   enableAssetAccessConsent: false,
+  enableBackendGraphRunner: false,
 };
 
 suite("createEnvironment", () => {

--- a/projects/heartstone/PROJECT.md
+++ b/projects/heartstone/PROJECT.md
@@ -666,7 +666,7 @@ POST /v1beta1/graphSessions/{id}:cancel
 |-----------|-----------|-------------|
 | `condense()` | `condense.ts` | `graph_condense.py` |
 | `createPlan()` | `create-plan.ts` | `graph_plan.py` |
-| Control flow | `control.ts` | `graph_control.py` |
+| Node lifecycle | `orchestrator.ts` | Replaced by `GraphSessionStore.complete_node()` |
 | Graph types | `@breadboard-ai/types` | `graph_types.py` |
 | Docs/Sheets/Slides save | `connector-save.ts` | `output_actions.py` |
 


### PR DESCRIPTION
# Heartstone: Server-Side Graph Execution (Pre-Phase through Phase 7)

> Moving graph execution from the browser to the backend, enabling both
> headed (interactive) and headless (scheduled/triggered) graph runs.

## Summary

This PR implements the first seven phases of Project Heartstone — a task-per-node
graph execution engine in the Python backend. Each node runs as an independent
short-lived task. When a task completes, it saves outputs and atomically checks
which downstream nodes are now ready. No long-lived orchestrator thread.

**44 files changed, +5643 / −218**

Behind the `enableBackendGraphRunner` flag. With the flag on, the "Run" button
executes graphs on the backend with live UI updates via SSE, including
interactive input (both agent `waitForInput` and standalone input nodes) with
suspend/resume.

---

## Commits

### Pre-Phase: EventBus Extraction (`724b5552`)

> *🎯 Objective: Existing agent sessions work identically, but `Subscribers` is now
> injected via the `EventBus` protocol.*

Extracts the concrete `Subscribers` class from `sessions/api.py` into the
`EventBus` protocol — a prerequisite that fixes an existing abstraction
boundary violation (`Subscribers` was an in-memory-only implementation living in
synced code).

- **`event_bus.py`** — `EventBus` protocol (subscribe, publish, close)
- **`local/event_bus_impl.py`** — `InMemoryEventBus` (asyncio.Queue, single-process)
- Refactored `sessions/api.py` and `session_router.py` to consume `EventBus`

---

### Phase 1: Core Library — Graph Planning (`2b17dfeb`)

> *🎯 Objective: Given a `GraphDescriptor`, produce a correct dependency graph
> with `pending_deps` counts.*

Ports `condense.ts` (Tarjan SCC + subgraph folding) and `create-plan.ts`
(Kahn topological sort) from the visual-editor to the Python backend.

- **`graph_types.py`** — `Edge`, `NodeDescriptor`, `GraphDescriptor`, `PlanNodeInfo`, `GraphPlan` (with JSON round-trip)
- **`graph_condense.py`** — Tarjan SCC + subgraph folding
- **`graph_plan.py`** — Kahn topological sort → staged plan
- **`tests/test_graph_condense.py`** — 11 tests
- **`tests/test_graph_plan.py`** — 14 tests

---

### Phase 2: GraphSessionStore + Node Task Runner (`6c2d2da8`)

> *🎯 Objective: A two-node linear graph (text gen → output) runs via
> task-per-node, events emitted correctly.*

Creates the `GraphSessionStore` protocol and `InMemoryGraphSessionStore`. Builds
the node task runner: load inputs → execute → save outputs → trigger downstream.

- **`graph_session_store.py`** — `GraphSessionStore` protocol
- **`task_scheduler.py`** — `TaskScheduler` protocol
- **`node_handlers.py`** — handler dispatch + stubs (passthrough, text gen)
- **`graph_runner.py`** — per-node task lifecycle (`GraphRunner`)
- **`local/graph_session_store_impl.py`** — `InMemoryGraphSessionStore`
- **`local/task_scheduler_impl.py`** — `LocalTaskScheduler`
- Renames `run()` → `run_agent()`, `resume()` → `resume_agent()` with backward-compatible aliases
- **`tests/test_graph_session_store.py`** — 22 tests
- **`tests/test_graph_runner.py`** — 7 end-to-end tests

---

### Phase 3: Graph Session RPC + SSE Endpoints (`228d1c24`)

> *🎯 Objective: `curl` starts a graph run, receives SSE events for each node.*

Four endpoints:

| Method | Path | Purpose |
|--------|------|---------|
| POST | `/v1beta1/graphSessions/new` | condense → plan → start |
| GET | `/v1beta1/graphSessions/{id}` | SSE stream (replay + live) |
| GET | `/v1beta1/graphSessions/{id}/status` | Lightweight status check |
| POST | `/v1beta1/graphSessions/{id}:cancel` | Cancel running tasks |

- **`local/graph_session_router.py`** — FastAPI endpoints
- Wired into `dev/main.py` via `create_api_router(graph_sessions=...)`
- **`tests/test_graph_session_router.py`** — 11 integration tests

---

### Phase 4: Agent Mode Integration (`b5f108de`)

> *🎯 Objective: A graph with an Agent node runs via backend with agent events
> streaming, including `waitForInput` suspend/resume.*

Wires generate nodes in agent mode to call `run_agent()`. Agent events stream
wrapped with `nodeId` envelope. `NodeSuspended` exception bridges agent
suspend → node suspend → `inputRequired` event.

- **`node_handlers.py`**: `NodeSuspended`, `NodeHandlerDeps`, `agent_handler`, mode-aware dispatch
- **`graph_runner.py`**: `backend_factory(token, origin)` injection, per-session auth context, `resume_node()`, `_handle_suspend()`
- **`graph_session_router.py`**: access token extraction, auth threading
- **`tests/test_agent_integration.py`** — 5 tests (event streaming, output flow, suspend/resume, error handling)

---

### Phase 5: Input Node Suspend/Resume (`ecdb0711`)

> *🎯 Objective: Input → Generate → Output works interactively via RPC.*

Input nodes emit `inputRequired` and end their task. Resume endpoint loads
state, provides input as node output, triggers downstream execution.

- **`node_handlers.py`**: `input_handler` raises `NodeSuspended` with schema and prompt from config
- **`graph_session_router.py`**: POST `/{id}:resume` endpoint loads suspended node, resumes
- **`tests/test_input_suspend_resume.py`** — 5 new tests (suspend, full resume flow, error cases, concurrent inputs)
- **`tests/test_graph_session_router.py`** — 4 new resume endpoint HTTP tests

---

### Phase 5.5: Fix Node Handlers for Real Graphs (`8a1a48e1`)

Three fixes discovered during manual testing with real Breadboard graphs:

1. **Segment format**: `_build_segments_from_inputs` was producing `{kind: 'text', parts: [...]}` but `to_pidgin` expects `{type: 'text', text: '...'}`
2. **Node type dispatch**: Real Breadboard uses embed URLs (`embed://a2/generate.bgl.json#module:main`). Added `_EMBED_URL_MAP` for all known component URLs
3. **Config key mapping**: Real Breadboard uses `generation-mode`, `b-system-instruction` (LLMContent), `config$prompt` (LLMContent). Added helpers for both real and simplified formats

---

### Phase 6: Concurrent Nodes (`42ae8707`)

> *🎯 Objective: A graph with two independent Generate nodes runs both
> concurrently, correct events, correct downstream triggering.*

Verifies that `LocalTaskScheduler` correctly handles fan-out and mixed
sequential/parallel topologies. Complements the existing diamond graph tests.

- **`tests/test_graph_runner.py`** — 3 new tests (fan-out, mixed graph, output propagation)

---

### Phase 6.5: Backend Graph Runner Flag (`9ca0d972`)

Added `enableBackendGraphRunner` flag to all four locations:

- `packages/types/src/flags.ts` (type + metadata)
- `packages/unified-server/src/flags.ts` (env var)
- `packages/unified-server/src/config.ts` (server→client mapping)
- `packages/visual-editor/.../client-deployment-configuration.ts` (default)

---

### Phase 7: Frontend ↔ Backend Integration (`5e03d582`)

> *🎯 Objective: With flag on, "Run" button executes a simple graph on the
> backend with live UI updates.*

The largest commit — wires the frontend to the backend graph runner:

**SSE stream + event processing:**
- **`graph-run-service.ts`** — SSE client with cursor tracking for reconnect-after-suspend. Uses `iteratorFromStream`, follows `AgentService` pattern
- **`backend-run-action.ts`** — SCA action that consumes the SSE stream and maps events to `RunController`/`RendererController` state. Per-node `AgentEventConsumer` bridges dispatch agent events to the correct node's progress/console/screen state

**Agent node input (`waitForInput` → resume):**
- Agent `waitForInput` events show the input UI via the existing bridge pattern
- `inputRequired` suspends the stream, awaits user input, POSTs `:resume`, reconnects
- `raceAbort()` ensures input waits are cancellable on Stop/Restart
- `AbortController` stored on `run.main` so `stopRun()` can find it

**Input node support:**
- Backend `input_handler` builds a proper UI schema from node config (description → title, `p-modality` → format icon, `p-required` → `hint-required` behavior). Mirrors `createInputSchema()` in ask-user
- Frontend detects `inputNode` suspend events and shows the input UI directly (no agent bridge needed), with `addChatOutput` for the prompt text
- `resume_node` distinguishes input nodes from agent nodes via suspended context, extracts `LLMContent` values from form response

**Template substitution:**
- Python port of `Template.substitute()` from `template.ts`. Expands `{{"type":"in","path":"<node-id>"}}` placeholders in prompts with upstream node output text. Consumed ports excluded from separate context segments

**Wiring:**
- `services.ts`: `GraphRunService` registered on `AppServices`
- `actions.ts`: `BackendRun` module bound at bootstrap
- `board-actions.ts`: `runBoard()` branches on `graphRunService.enabled`

---

## Test Coverage

| Test File | Tests | Area |
|-----------|-------|------|
| `test_graph_condense.py` | 11 | Tarjan SCC, subgraph folding |
| `test_graph_plan.py` | 14 | Kahn topo sort, stages, edge mapping |
| `test_graph_session_store.py` | 22 | Store CRUD, atomic coordination |
| `test_graph_runner.py` | 10 | End-to-end graph execution, concurrency |
| `test_graph_session_router.py` | 15 | HTTP endpoints, SSE streaming |
| `test_agent_integration.py` | 5 | Agent event streaming, suspend/resume |
| `test_input_suspend_resume.py` | 5 | Input node lifecycle |
| `test_session_api.py` | (updated) | EventBus refactor compatibility |

---

## What's Next

| Phase | Description |
|-------|-------------|
| Phase 8 | Asset nodes + media generation |
| Phase 9 | Output node actions (Manual → HTML → Docs/Sheets/Slides) |
| Phase 10 | Drive graph loading + headless mode |
| Phase 11 | Reconnection + history |
