### PR TITLE
[eval] User Notes in Eval Viewer Topology View

### DIFF
--- a/packages/visual-editor/eval/viewer/src/filesystem.ts
+++ b/packages/visual-editor/eval/viewer/src/filesystem.ts
@@ -7,12 +7,14 @@
 import { Outcome } from "@breadboard-ai/types";
 import { err, ok } from "@breadboard-ai/utils";
 import { openDB, DBSchema } from "idb";
+import { RunNotes } from "./types.js";
 import {
   buildFileHierarchy,
   GroupedByType,
   ParsedFileMedata,
   parseFileName,
 } from "./parse-file-name.js";
+
 
 export type FileSystemWalkerEntry =
   | FileSystemDirectoryHandle
@@ -78,7 +80,7 @@ declare global {
 
 const HANDLES_DB = "evalfilesystemhandles";
 
-type Mode = "read";
+type Mode = "read" | "readwrite";
 
 type HandleKey = [path: string];
 
@@ -156,8 +158,8 @@ export class FileSystemEvalBackend {
     let handle = await handlesDb.get("handles", key);
     handlesDb.close();
 
-    if (!createIfNeeded) {
-      return handle?.handle ?? null;
+    if (!createIfNeeded && !handle) {
+      return null;
     }
 
     // 2. If the handle doesn't exist, create it.
@@ -169,11 +171,15 @@ export class FileSystemEvalBackend {
     }
 
     // 3. Check the permission on the handle.
-    const permission = await handle.handle.queryPermission({ mode });
+    let permission = await handle.handle.queryPermission({ mode });
     if (permission !== "granted") {
-      return permission;
-      // 4. Renew the permission if needed.
-      // permission = await handle.handle.requestPermission({ mode });
+      if (mode === "readwrite") {
+        // Try to request permission for readwrite.
+        permission = await handle.handle.requestPermission({ mode });
+      }
+      if (permission !== "granted") {
+        return permission;
+      }
     }
 
     // 5. Return the handle.
@@ -235,6 +241,7 @@ export class FileSystemEvalBackend {
     try {
       const queryEntries: ParsedFileMedata[] = [];
       const raterMap = new Map<string, string>();
+      const notesCountMap = new Map<string, number>();
 
       try {
         for await (const [name, descriptor] of handle.entries()) {
@@ -246,6 +253,18 @@ export class FileSystemEvalBackend {
               const judgement = parsed?.overall_judgement || (parsed?.error ? 'FAIL' : 'UNKNOWN');
               const baseName = name.replace(/\.rater\.json$/, "");
               raterMap.set(baseName, judgement);
+            } catch {
+              // Ignore failure.
+            }
+          }
+          if (name.endsWith(".notes.json") && descriptor.kind === "file") {
+            try {
+              const fileBlob = await (descriptor as FileSystemFileHandle).getFile();
+              const text = await fileBlob.text();
+              const parsed = JSON.parse(text) as RunNotes;
+              const count = parsed?.notes?.length || 0;
+              const baseName = name.replace(/\.notes\.json$/, "");
+              notesCountMap.set(baseName, count);
             } catch {
               // Ignore failure.
             }
@@ -265,6 +284,7 @@ export class FileSystemEvalBackend {
         if (parsed) {
           const baseName = name.replace(/\.log\.json$/, "");
           parsed.judgement = raterMap.get(baseName);
+          parsed.noteCount = notesCountMap.get(baseName) || 0;
           queryEntries.push(parsed);
         }
       }
@@ -303,4 +323,51 @@ export class FileSystemEvalBackend {
 
     return { $error: `Unable to read file in directory: ${path}` };
   }
+
+  async write(path: string, content: string): Promise<Outcome<boolean>> {
+    const handle = await this.#obtainFileDirHandle(path, "readwrite", true);
+    if (!handle) {
+      return { $error: "Permission to write to directory was refused" };
+    }
+    if (handle === "prompt") {
+      return { $error: "prompt" };
+    }
+
+    try {
+      const fileName = path.split("/").at(-1);
+      if (!fileName) {
+        return { $error: "Invalid file path" };
+      }
+
+      const fileHandle = await handle.getFileHandle(fileName, { create: true });
+      const writable = await fileHandle.createWritable();
+      await writable.write(content);
+      await writable.close();
+      return true;
+    } catch (err) {
+      console.warn(err);
+      return { $error: `Unable to write file in directory: ${path}` };
+    }
+  }
+
+  async readNotes(logPath: string): Promise<Outcome<RunNotes>> {
+    const notesPath = logPath.replace(/\.log\.json$/, ".notes.json");
+    const result = await this.read(notesPath);
+    if (!ok(result)) {
+      // If file not found, return empty notes instead of error, or handle error accordingly.
+      // For now, let's assume empty notes if error.
+      return { notes: [] };
+    }
+    try {
+      return JSON.parse(result) as RunNotes;
+    } catch {
+      return { notes: [] };
+    }
+  }
+
+  async writeNotes(logPath: string, notes: RunNotes): Promise<Outcome<boolean>> {
+    const notesPath = logPath.replace(/\.log\.json$/, ".notes.json");
+    return this.write(notesPath, JSON.stringify(notes, null, 2));
+  }
 }
+

--- a/packages/visual-editor/eval/viewer/src/inspector.ts
+++ b/packages/visual-editor/eval/viewer/src/inspector.ts
@@ -30,6 +30,7 @@ import { signal } from "signal-utils";
 import * as UI from "../../../src/a2ui/0.8/ui/ui.js";
 import { v0_8 } from "../../../src/a2ui/index.js";
 import { FinalChainReport } from "../../collate-context.js";
+import { UserNote, NoteLocation } from "./types.js";
 import {
   FileSystemEvalBackend,
   FileSystemEvalBackendHandle,
@@ -78,6 +79,10 @@ export class A2UIEvalInspector extends SignalWatcher(LitElement) {
 
   @state()
   accessor transcript: unknown[] | null = null;
+
+  @state()
+  accessor notes: UserNote[] = [];
+
 
   @property()
   accessor selectedPath: FileSystemEvalBackendHandle | null = null;
@@ -763,6 +768,13 @@ export class A2UIEvalInspector extends SignalWatcher(LitElement) {
       } else {
         this.transcript = null;
       }
+
+      const notesResult = await this.#fileSystem.readNotes(path);
+      if (ok(notesResult)) {
+        this.notes = notesResult.notes || [];
+      } else {
+        this.notes = [];
+      }
     } catch (err) {
       console.warn(err);
       this.renderMode = "messages";
@@ -795,9 +807,17 @@ export class A2UIEvalInspector extends SignalWatcher(LitElement) {
   #renderContents() {
     if (this.renderMode === "topology") {
       return html`<section id="topology" style="width: 100%; height: 100%;">
-        <bgl-viewer .graph=${this.bgl} .rater=${this.rater} .transcript=${this.transcript}></bgl-viewer>
+        <bgl-viewer
+          .graph=${this.bgl}
+          .rater=${this.rater}
+          .transcript=${this.transcript}
+          .notes=${this.notes}
+          @add-note=${this.#handleAddNote}
+          @delete-note=${this.#handleDeleteNote}
+        ></bgl-viewer>
       </section>`;
     }
+
 
     if (this.#requesting) {
       return html`<section id="surfaces">
@@ -927,6 +947,69 @@ export class A2UIEvalInspector extends SignalWatcher(LitElement) {
     </section>`;
   }
 
+  async #handleAddNote(e: CustomEvent<{ location: NoteLocation; text: string }>) {
+    if (!this.selectedFilePath) return;
+
+    const newNote: UserNote = {
+      id: crypto.randomUUID(),
+      location: e.detail.location,
+      text: e.detail.text,
+      timestamp: new Date().toISOString(),
+    };
+
+    const updatedNotes = [...this.notes, newNote];
+    const result = await this.#fileSystem.writeNotes(this.selectedFilePath, { notes: updatedNotes });
+    if (ok(result)) {
+      this.notes = updatedNotes;
+      this.#updateSidebarNoteCount(this.selectedFilePath, updatedNotes.length);
+    } else {
+      console.warn("Failed to save note:", result.$error);
+    }
+  }
+
+  async #handleDeleteNote(e: CustomEvent<{ noteId: string }>) {
+    if (!this.selectedFilePath) return;
+
+    const updatedNotes = this.notes.filter((n) => n.id !== e.detail.noteId);
+    const result = await this.#fileSystem.writeNotes(this.selectedFilePath, { notes: updatedNotes });
+    if (ok(result)) {
+      this.notes = updatedNotes;
+      this.#updateSidebarNoteCount(this.selectedFilePath, updatedNotes.length);
+    } else {
+      console.warn("Failed to delete note:", result.$error);
+    }
+  }
+
+  #updateSidebarNoteCount(filePath: string, count: number) {
+    if (!this.#filesInMountedDir) return;
+
+    let updated = false;
+    const newDirs = this.#filesInMountedDir.map((dir) => {
+      return {
+        ...dir,
+        items: dir.items.map((item) => {
+          return {
+            ...item,
+            files: item.files.map((f) => {
+              if (f.path === filePath) {
+                updated = true;
+                return {
+                  ...f,
+                  noteCount: count,
+                };
+              }
+              return f;
+            }),
+          };
+        }),
+      };
+    });
+
+    if (updated) {
+      this.#filesInMountedDir = newDirs;
+    }
+  }
+
   #renderInput() {
     return html`<div>
         ${this.#dirs.length > 0
@@ -1025,12 +1108,21 @@ export class A2UIEvalInspector extends SignalWatcher(LitElement) {
                               const color = isPass ? '#34a853' : (isPartial ? '#fbbc04' : (isFail ? '#ea4335' : 'transparent'));
                               const icon = isPass ? 'check_circle' : (isPartial ? 'warning' : (isFail ? 'cancel' : ''));
                               if (!icon) return nothing;
-                              return html`<span 
-                                class="g-icon filled round" 
-                                style="color: ${color}; font-size: 16px; margin-left: 8px; flex-shrink: 0;"
-                                title="Evaluation Judgement: ${judgement}"
-                              >${icon}</span>`;
-                            })() : nothing}
+                              return html`<div style="display: flex; align-items: center; gap: 4px; flex-shrink: 0;">
+                                ${f.noteCount && f.noteCount > 0 ? html`<span 
+                                  style="background: var(--light-dark-n-0); color: var(--light-dark-n-100); font-size: 10px; font-weight: 600; padding: 2px 6px; border-radius: 8px; border: 1px solid var(--border-color);"
+                                  title="${f.noteCount} notes"
+                                >${f.noteCount}</span>` : nothing}
+                                <span 
+                                  class="g-icon filled round" 
+                                  style="color: ${color}; font-size: 16px;"
+                                  title="Evaluation Judgement: ${judgement}"
+                                >${icon}</span>
+                              </div>`;
+                            })() : (f.noteCount && f.noteCount > 0 ? html`<span 
+                              style="background: var(--light-dark-n-0); color: var(--light-dark-n-100); font-size: 10px; font-weight: 600; padding: 2px 6px; border-radius: 8px; border: 1px solid var(--border-color); margin-left: 8px; flex-shrink: 0;"
+                              title="${f.noteCount} notes"
+                            >${f.noteCount}</span>` : nothing)}
                           </button>
                         </li>`;
                       })}

--- a/packages/visual-editor/eval/viewer/src/parse-file-name.ts
+++ b/packages/visual-editor/eval/viewer/src/parse-file-name.ts
@@ -12,6 +12,7 @@ export type ParsedFileMedata = {
   name: string;
   date: Date;
   judgement?: string;
+  noteCount?: number;
 };
 
 export type GroupedByName = {

--- a/packages/visual-editor/eval/viewer/src/types.ts
+++ b/packages/visual-editor/eval/viewer/src/types.ts
@@ -1,0 +1,21 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type NoteLocation =
+  | { type: "node-config"; nodeId: string; fieldName: string }
+  | { type: "rater"; dimension?: string; fieldName?: string }
+  | { type: "transcript"; turn: number; eventIndex: number; fieldName?: string };
+
+export type UserNote = {
+  id: string;
+  location: NoteLocation;
+  text: string;
+  timestamp: string;
+};
+
+export type RunNotes = {
+  notes: UserNote[];
+};

--- a/packages/visual-editor/eval/viewer/src/ui/bgl-viewer.ts
+++ b/packages/visual-editor/eval/viewer/src/ui/bgl-viewer.ts
@@ -22,6 +22,8 @@ import { MAIN_BOARD_ID } from "../../../../src/sca/constants.js";
 import { provide } from "@lit/context";
 import { scaContext } from "../../../../src/sca/context/context.js";
 import { ok } from "@breadboard-ai/utils";
+import { UserNote, NoteLocation } from "../types.js";
+import "./notes-container.js";
 import { A2_TOOLS } from "../../../../src/a2/a2-registry.js";
 import "../../../../src/ui/elements/graph-editing-chat/opie-avatar.js";
 import "../../../../src/ui/elements/json-tree/json-tree.js";
@@ -99,6 +101,10 @@ class BGLViewer extends LitElement {
   @property()
   accessor transcript: unknown[] | null = null;
 
+  @property()
+  accessor notes: UserNote[] = [];
+
+
   @provide({ context: scaContext })
   accessor sca: any = {
     controller: {
@@ -146,6 +152,7 @@ class BGLViewer extends LitElement {
   #dialogRef: Ref<HTMLDialogElement> = createRef();
   #raterDialogRef: Ref<HTMLDialogElement> = createRef();
   #transcriptDialogRef: Ref<HTMLDialogElement> = createRef();
+  #allNotesDialogRef: Ref<HTMLDialogElement> = createRef();
 
   static styles = [
     icons,
@@ -660,6 +667,25 @@ class BGLViewer extends LitElement {
     });
   }
 
+  #getNotesForLocation(location: NoteLocation): UserNote[] {
+    if (!this.notes) return [];
+    return this.notes.filter((note) => {
+      const loc = note.location;
+      if (loc.type !== location.type) return false;
+
+      if (loc.type === "node-config" && location.type === "node-config") {
+        return loc.nodeId === location.nodeId && loc.fieldName === location.fieldName;
+      }
+      if (loc.type === "rater" && location.type === "rater") {
+        return loc.dimension === location.dimension && loc.fieldName === location.fieldName;
+      }
+      if (loc.type === "transcript" && location.type === "transcript") {
+        return loc.turn === location.turn && loc.eventIndex === location.eventIndex && loc.fieldName === location.fieldName;
+      }
+      return false;
+    });
+  }
+
   #renderModal() {
     if (!this.#selectedNode) {
       return nothing;
@@ -744,9 +770,16 @@ class BGLViewer extends LitElement {
               });
             };
 
+            const location: NoteLocation = {
+              type: "node-config",
+              nodeId: this.#selectedNode.id,
+              fieldName: key,
+            };
+
             return html`<div class="config-item">
               <h3>${key.replace(/([A-Z])/g, " $1").replace(/^./, (str) => str.toUpperCase())}</h3>
               <pre>${isLLMContent && typeof formattedValue === "string" ? renderChiclets(formattedValue) : formattedValue}</pre>
+              <ui-notes-container .location=${location} .notes=${this.#getNotesForLocation(location)}></ui-notes-container>
             </div>`;
           })}
         </div>
@@ -794,21 +827,33 @@ class BGLViewer extends LitElement {
                       const category = dimKey.replace(/_/g, " ").replace(/^./, (str) => str.toUpperCase());
                       const score = dimVal?.score ?? "-";
                       const rationale = dimVal?.rationale ?? "";
+                      const location: NoteLocation = {
+                        type: "rater",
+                        dimension: dimKey,
+                      };
                       return html`<tr>
                         <td><strong>${category}</strong></td>
                         <td class="score-cell">${score}/5</td>
-                        <td>${rationale}</td>
+                        <td>
+                          <div>${rationale}</div>
+                          <ui-notes-container .location=${location} .notes=${this.#getNotesForLocation(location)}></ui-notes-container>
+                        </td>
                       </tr>`;
                     })}
                   </tbody>
                 </table>
               </div>`;
             }
-            
+
             const formattedValue = typeof value === "object" ? JSON.stringify(value, null, 2) : String(value);
+            const location: NoteLocation = {
+              type: "rater",
+              fieldName: key,
+            };
             return html`<div class="config-item">
               <h3>${key.replace(/_/g, " ").replace(/^./, (str) => str.toUpperCase())}</h3>
               <pre>${formattedValue}</pre>
+              <ui-notes-container .location=${location} .notes=${this.#getNotesForLocation(location)}></ui-notes-container>
             </div>`;
           })}
         </div>
@@ -838,11 +883,18 @@ class BGLViewer extends LitElement {
         </div>
         <div id="dialog-body" style="padding: var(--bb-grid-size-4); display: flex; flex-direction: column; gap: var(--bb-grid-size-4);">
           ${this.transcript.map((turn: any) => {
-            const eventsHtml = (turn.events || []).map((evt: any) => {
+            const eventsHtml = (turn.events || []).map((evt: any, eventIndex: number) => {
+              const location: NoteLocation = {
+                type: "transcript",
+                turn: turn.turn,
+                eventIndex,
+              };
+
               if (evt.type === "objective") {
                 return html`<div class="config-item" style="background: var(--light-dark-n-95); padding: var(--bb-grid-size-3); border-radius: var(--bb-grid-size-2); margin-bottom: var(--bb-grid-size-2);">
                   <h4 style="margin: 0 0 var(--bb-grid-size-2) 0; color: var(--primary);">Objective</h4>
                   <pre style="white-space: pre-wrap; font-family: monospace; margin: 0; font-size: 12px; color: var(--light-dark-n-20);">${evt.text}</pre>
+                  <ui-notes-container .location=${location} .notes=${this.#getNotesForLocation(location)}></ui-notes-container>
                 </div>`;
               }
               if (evt.type === "thought") {
@@ -850,6 +902,7 @@ class BGLViewer extends LitElement {
                 return html`<div style="border-left: 3px solid var(--primary); padding-left: var(--bb-grid-size-3); margin-bottom: var(--bb-grid-size-2);">
                   <h4 style="margin: 0 0 var(--bb-grid-size-1) 0; color: var(--light-dark-n-40);">${parsed.title || "Thoughts"}</h4>
                   <div style="font-style: italic; font-size: 13px; color: var(--light-dark-n-40); white-space: pre-wrap;">${parsed.body}</div>
+                  <ui-notes-container .location=${location} .notes=${this.#getNotesForLocation(location)}></ui-notes-container>
                 </div>`;
               }
               if (evt.type === "functionCall") {
@@ -859,6 +912,7 @@ class BGLViewer extends LitElement {
                     <span style="background: oklch(from var(--primary) l c h / 0.15); color: var(--primary); font-size: 10px; font-weight: 600; text-transform: uppercase; padding: 2px 6px; border-radius: 4px; border: 1px solid oklch(from var(--primary) l c h / 0.25);">call</span>
                   </div>
                   <bb-json-tree .json=${evt.args as any} autoExpand></bb-json-tree>
+                  <ui-notes-container .location=${location} .notes=${this.#getNotesForLocation(location)}></ui-notes-container>
                 </div>`;
               }
               if (evt.type === "functionResponse") {
@@ -870,6 +924,7 @@ class BGLViewer extends LitElement {
                     <span style="background: oklch(0.75 0.12 150 / 0.15); color: oklch(0.75 0.12 150); font-size: 10px; font-weight: 600; text-transform: uppercase; padding: 2px 6px; border-radius: 4px; border: 1px solid oklch(0.75 0.12 150 / 0.25);">response</span>
                   </div>
                   <bb-json-tree .json=${responseData as any}></bb-json-tree>
+                  <ui-notes-container .location=${location} .notes=${this.#getNotesForLocation(location)}></ui-notes-container>
                 </div>`;
               }
               if (evt.type === "usageMetadata") {
@@ -887,6 +942,104 @@ class BGLViewer extends LitElement {
                 <div style="flex-grow: 1; height: 1px; background: var(--light-dark-n-80);"></div>
               </div>
               ${eventsHtml}
+            </div>`;
+          })}
+        </div>
+      </form>
+    </dialog>`;
+  }
+
+  #showAllNotesModal() {
+    this.requestUpdate();
+    requestAnimationFrame(() => {
+      this.#allNotesDialogRef.value?.showModal();
+    });
+  }
+
+
+
+  #getSectionTitle(location: NoteLocation): string {
+    if (location.type === "node-config") {
+      const node = this.graph?.nodes.find((n: any) => n.id === location.nodeId);
+      const a2Component = node ? A2_COMPONENT_MAP.get(node.type) : undefined;
+      const title = node?.metadata?.title || a2Component?.title || location.nodeId;
+      return `Node: ${title}`;
+    }
+    if (location.type === "rater") {
+      const category = location.dimension ? location.dimension.replace(/_/g, " ").replace(/^./, (str) => str.toUpperCase()) : "General";
+      return `Eval: ${category}`;
+    }
+    if (location.type === "transcript") {
+      return `Transcript: Turn ${location.turn}`;
+    }
+    return "Other";
+  }
+
+  #getFieldReference(location: NoteLocation): string {
+    if (location.type === "node-config") {
+      return location.fieldName;
+    }
+    if (location.type === "rater") {
+      return location.fieldName ? location.fieldName.replace(/_/g, " ").replace(/^./, (str) => str.toUpperCase()) : "";
+    }
+    if (location.type === "transcript") {
+      return `Event ${location.eventIndex + 1}`;
+    }
+    return "";
+  }
+
+  #renderAllNotesModal() {
+    if (!this.notes || this.notes.length === 0) {
+      return html`<dialog ${ref(this.#allNotesDialogRef)}>
+        <form method="dialog">
+          <div id="dialog-header">
+            <h2>All Comments</h2>
+            <button type="submit" aria-label="Close">
+              <span class="g-icon filled round">close</span>
+            </button>
+          </div>
+          <div id="dialog-body" style="padding: var(--bb-grid-size-4); color: var(--light-dark-n-40);">
+            No comments added yet for this evaluation.
+          </div>
+        </form>
+      </dialog>`;
+    }
+
+    const groups = new Map<string, UserNote[]>();
+    for (const note of this.notes) {
+      const section = this.#getSectionTitle(note.location);
+      if (!groups.has(section)) {
+        groups.set(section, []);
+      }
+      groups.get(section)!.push(note);
+    }
+
+    return html`<dialog ${ref(this.#allNotesDialogRef)}>
+      <form method="dialog">
+        <div id="dialog-header">
+          <h2>All Comments (${this.notes.length})</h2>
+          <button type="submit" aria-label="Close">
+            <span class="g-icon filled round">close</span>
+          </button>
+        </div>
+        <div id="dialog-body" style="padding: var(--bb-grid-size-4); display: flex; flex-direction: column; gap: var(--bb-grid-size-4);">
+          ${Array.from(groups.entries()).map(([section, notes]) => {
+            return html`<div class="section-group">
+              <h3 style="font-size: 14px; font-weight: 600; color: var(--primary); margin: 0 0 var(--bb-grid-size-3) 0; border-bottom: 1px solid var(--border-color); padding-bottom: var(--bb-grid-size-2);">
+                ${section}
+              </h3>
+              <div style="display: flex; flex-direction: column; gap: var(--bb-grid-size-2);">
+                ${notes.map((note) => {
+                  const fieldRef = this.#getFieldReference(note.location);
+                  return html`<div style="background: var(--light-dark-n-98); border: 1px solid var(--border-color); border-radius: var(--bb-grid-size-2); padding: var(--bb-grid-size-3); font-size: 13px; color: var(--light-dark-n-10);">
+                    <div style="display: flex; justify-content: space-between; font-size: 11px; color: var(--light-dark-n-40); margin-bottom: var(--bb-grid-size-2); font-weight: 500;">
+                      <span style="font-weight: 600; color: var(--light-dark-n-20);">${fieldRef}</span>
+                      <span>${new Date(note.timestamp).toLocaleString()}</span>
+                    </div>
+                    <div style="white-space: pre-wrap;">${note.text}</div>
+                  </div>`;
+                })}
+              </div>
             </div>`;
           })}
         </div>
@@ -922,6 +1075,10 @@ class BGLViewer extends LitElement {
             <span>Eval: ${judgement}</span>
           </div>
           <button @click=${() => this.#showRaterModal()}>Show Details</button>
+          <button 
+            style="margin-top: var(--bb-grid-size); ${this.notes && this.notes.length > 0 ? '' : 'opacity: 0.5;'}" 
+            @click=${() => this.#showAllNotesModal()}
+          >All Comments (${this.notes?.length || 0})</button>
         </div>` : nothing}
       </div>
       <div
@@ -949,6 +1106,7 @@ class BGLViewer extends LitElement {
       </div>
       ${this.#renderModal()}
       ${this.#renderRaterModal()}
-      ${this.#renderTranscriptModal()}`;
+      ${this.#renderTranscriptModal()}
+      ${this.#renderAllNotesModal()}`;
   }
 }

--- a/packages/visual-editor/eval/viewer/src/ui/notes-container.ts
+++ b/packages/visual-editor/eval/viewer/src/ui/notes-container.ts
@@ -1,0 +1,230 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { css, html, LitElement } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import { UserNote, NoteLocation } from "../types.js";
+import { icons } from "../../../../src/ui/styles/icons.js";
+
+export { NotesContainer };
+
+@customElement("ui-notes-container")
+class NotesContainer extends LitElement {
+  @property()
+  accessor location!: NoteLocation;
+
+  @property()
+  accessor notes: UserNote[] = [];
+
+  @state()
+  accessor #isEditing = false;
+
+  @state()
+  accessor #newNoteText = "";
+
+  static styles = [
+    icons,
+    css`
+      :host {
+        display: block;
+        margin-top: var(--bb-grid-size-2);
+        font-family: var(--font-family);
+      }
+
+      .note-list {
+        display: flex;
+        flex-direction: column;
+        gap: var(--bb-grid-size-2);
+        margin-bottom: var(--bb-grid-size-2);
+      }
+
+      .note-item {
+        background: var(--light-dark-n-98);
+        border: 1px solid var(--border-color);
+        border-radius: var(--bb-grid-size-2);
+        padding: var(--bb-grid-size-2) var(--bb-grid-size-3);
+        font-size: 13px;
+        position: relative;
+        color: var(--light-dark-n-10);
+
+        .note-header {
+          display: flex;
+          justify-content: space-between;
+          font-size: 11px;
+          color: var(--light-dark-n-50);
+          margin-bottom: var(--bb-grid-size);
+        }
+
+        .delete-btn {
+          background: none;
+          border: none;
+          color: var(--light-dark-e-40);
+          cursor: pointer;
+          padding: 0;
+          display: flex;
+          align-items: center;
+
+          &:hover {
+            color: var(--light-dark-e-20);
+          }
+
+          & .g-icon {
+            font-size: 14px;
+          }
+        }
+      }
+
+      .add-note-section {
+        display: flex;
+        flex-direction: column;
+        gap: var(--bb-grid-size-2);
+      }
+
+      textarea {
+        width: 100%;
+        border-radius: var(--bb-grid-size-2);
+        border: 1px solid var(--border-color);
+        background: var(--light-dark-n-100);
+        color: var(--light-dark-n-0);
+        padding: var(--bb-grid-size-2);
+        resize: vertical;
+        font-family: var(--font-family);
+        font-size: 13px;
+
+        &:focus {
+          outline: none;
+          border-color: var(--primary);
+        }
+      }
+
+      .actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: var(--bb-grid-size-2);
+
+        button {
+          padding: var(--bb-grid-size) var(--bb-grid-size-3);
+          border-radius: var(--bb-grid-size);
+          font-size: 12px;
+          cursor: pointer;
+          border: none;
+          font-weight: 500;
+        }
+
+        .save-btn {
+          background: var(--primary);
+          color: var(--text-color);
+        }
+
+        .cancel-btn {
+          background: var(--light-dark-n-90);
+          color: var(--light-dark-n-10);
+        }
+
+        .add-btn {
+          background: none;
+          border: 1px dashed var(--border-color);
+          color: var(--primary);
+          display: flex;
+          align-items: center;
+          gap: var(--bb-grid-size);
+          width: 100%;
+          justify-content: center;
+          padding: var(--bb-grid-size-2);
+
+          &:hover {
+            background: oklch(from var(--primary) l c h / 0.1);
+            border-color: var(--primary);
+          }
+
+          & .g-icon {
+            font-size: 16px;
+          }
+        }
+      }
+    `,
+  ];
+
+  #handleSave() {
+    if (this.#newNoteText.trim()) {
+      this.dispatchEvent(
+        new CustomEvent("add-note", {
+          detail: {
+            location: this.location,
+            text: this.#newNoteText.trim(),
+          },
+          bubbles: true,
+          composed: true,
+        })
+      );
+      this.#newNoteText = "";
+      this.#isEditing = false;
+    }
+  }
+
+  #handleDelete(noteId: string) {
+    this.dispatchEvent(
+      new CustomEvent("delete-note", {
+        detail: {
+          noteId,
+        },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
+
+  render() {
+    return html`
+      <div class="note-list">
+        ${this.notes.map(
+          (note) => html`
+            <div class="note-item">
+              <div class="note-header">
+                <span>${new Date(note.timestamp).toLocaleString()}</span>
+                <button
+                  class="delete-btn"
+                  @click=${() => this.#handleDelete(note.id)}
+                  title="Delete Note"
+                >
+                  <span class="g-icon filled round">delete</span>
+                </button>
+              </div>
+              <div class="note-text">${note.text}</div>
+            </div>
+          `
+        )}
+      </div>
+
+      ${this.#isEditing
+        ? html`
+            <div class="add-note-section">
+              <textarea
+                placeholder="Add a note..."
+                .value=${this.#newNoteText}
+                @input=${(e: Event) =>
+                  (this.#newNoteText = (e.target as HTMLTextAreaElement).value)}
+                rows="3"
+              ></textarea>
+              <div class="actions">
+                <button class="cancel-btn" @click=${() => (this.#isEditing = false)}>
+                  Cancel
+                </button>
+                <button class="save-btn" @click=${this.#handleSave}>Save Note</button>
+              </div>
+            </div>
+          `
+        : html`
+            <div class="actions">
+              <button class="add-btn" @click=${() => (this.#isEditing = true)}>
+                <span class="g-icon filled round">add</span>
+                Add Note
+              </button>
+            </div>
+          `}
+    `;
+  }
+}

--- a/packages/visual-editor/eval/viewer/src/ui/ui.ts
+++ b/packages/visual-editor/eval/viewer/src/ui/ui.ts
@@ -16,3 +16,5 @@
 
 export { Splitter } from "./splitter.js";
 export { BGLViewer } from "./bgl-viewer.js";
+export { NotesContainer } from "./notes-container.js";
+


### PR DESCRIPTION
Added the ability for users to annotate and evaluate the quality of evaluations by leaving detailed, persisted-on-disk notes directly alongside individual fields in the Node Configuration, Evaluation Results, and Session Transcript modals in the Eval Viewer.

To enable users to evaluate the quality of AI evaluations effectively and annotate inconsistencies with detailed feedback, persisting these insights alongside the evaluation sidecars using the File System API.

- **Eval Viewer Backend**:
    - Enhanced `FileSystemEvalBackend` to support `"readwrite"` filesystem access.
    - Implemented methods to save and retrieve notes in a dedicated sidecar format (`.notes.json`).
- **Lit Components**:
    - Implemented the `<ui-notes-container>` Lit element to provide a standalone UI for managing annotations at specific locations.
- **Eval Viewer UI**:
    - Integrated note containers across modals in `<bgl-viewer>` (Node Details, dimensions, and transcripts).
    - Orchestrated note loading, saving, and deletion in `<a2ui-eval-inspector>`.

1. Navigate to the Topology view in the Eval Viewer.
2. Open any detailed field menu (Node Info, Rater details, or Opie avatar transcript).
3. Append or remove notes for specific items; confirm they persist on-disk via the File System API alongside other evaluation sidecars upon reloading the file.
