### PR TITLE
[eval] Eval Viewer Quick Reactions and Comments Dashboard

### DIFF
--- a/packages/visual-editor/eval/viewer/src/filesystem.ts
+++ b/packages/visual-editor/eval/viewer/src/filesystem.ts
@@ -262,7 +262,7 @@ export class FileSystemEvalBackend {
               const fileBlob = await (descriptor as FileSystemFileHandle).getFile();
               const text = await fileBlob.text();
               const parsed = JSON.parse(text) as RunNotes;
-              const count = parsed?.notes?.length || 0;
+              const count = (parsed?.notes || []).filter((n) => !n.reaction).length;
               const baseName = name.replace(/\.notes\.json$/, "");
               notesCountMap.set(baseName, count);
             } catch {

--- a/packages/visual-editor/eval/viewer/src/inspector.ts
+++ b/packages/visual-editor/eval/viewer/src/inspector.ts
@@ -947,34 +947,71 @@ export class A2UIEvalInspector extends SignalWatcher(LitElement) {
     </section>`;
   }
 
-  async #handleAddNote(e: CustomEvent<{ location: NoteLocation; text: string }>) {
-    if (!this.selectedFilePath) return;
+  async #handleAddNote(e: CustomEvent<{ location: NoteLocation; text: string; reaction?: "good" | "bad" }>) {
+    if (!this.selectedFilePath) {
+      console.warn("Inspector: No selectedFilePath available!");
+      return;
+    }
 
     const newNote: UserNote = {
       id: crypto.randomUUID(),
       location: e.detail.location,
       text: e.detail.text,
       timestamp: new Date().toISOString(),
+      reaction: e.detail.reaction,
     };
 
-    const updatedNotes = [...this.notes, newNote];
+    let updatedNotes = [...this.notes];
+
+    if (e.detail.reaction) {
+      // Enforce Singleton & Mutually Exclusive: Filter out any existing reaction note for this location.
+      updatedNotes = updatedNotes.filter((n) => {
+        const isSameLoc = (locA: NoteLocation, locB: NoteLocation) => {
+          if (locA.type !== locB.type) return false;
+          if (locA.type === "node-config" && locB.type === "node-config") {
+            return locA.nodeId === locB.nodeId && locA.fieldName === locB.fieldName;
+          }
+          if (locA.type === "rater" && locB.type === "rater") {
+            return locA.dimension === locB.dimension && locA.fieldName === locB.fieldName;
+          }
+          if (locA.type === "transcript" && locB.type === "transcript") {
+            return locA.turn === locB.turn && locA.eventIndex === locB.eventIndex && locA.fieldName === locB.fieldName;
+          }
+          return false;
+        };
+
+        const hasReaction = n.reaction !== undefined;
+        const isSame = isSameLoc(n.location, e.detail.location);
+
+        // Keep the note if it's NOT a reaction note at the same location.
+        return !(hasReaction && isSame);
+      });
+    }
+
+    updatedNotes.push(newNote);
+
     const result = await this.#fileSystem.writeNotes(this.selectedFilePath, { notes: updatedNotes });
     if (ok(result)) {
       this.notes = updatedNotes;
-      this.#updateSidebarNoteCount(this.selectedFilePath, updatedNotes.length);
+      const nonReactionCount = updatedNotes.filter((n) => !n.reaction).length;
+      this.#updateSidebarNoteCount(this.selectedFilePath, nonReactionCount);
     } else {
       console.warn("Failed to save note:", result.$error);
     }
   }
 
   async #handleDeleteNote(e: CustomEvent<{ noteId: string }>) {
-    if (!this.selectedFilePath) return;
+    if (!this.selectedFilePath) {
+      console.warn("Inspector: No selectedFilePath available!");
+      return;
+    }
 
     const updatedNotes = this.notes.filter((n) => n.id !== e.detail.noteId);
     const result = await this.#fileSystem.writeNotes(this.selectedFilePath, { notes: updatedNotes });
     if (ok(result)) {
       this.notes = updatedNotes;
-      this.#updateSidebarNoteCount(this.selectedFilePath, updatedNotes.length);
+      const nonReactionCount = updatedNotes.filter((n) => !n.reaction).length;
+      this.#updateSidebarNoteCount(this.selectedFilePath, nonReactionCount);
     } else {
       console.warn("Failed to delete note:", result.$error);
     }

--- a/packages/visual-editor/eval/viewer/src/types.ts
+++ b/packages/visual-editor/eval/viewer/src/types.ts
@@ -14,6 +14,7 @@ export type UserNote = {
   location: NoteLocation;
   text: string;
   timestamp: string;
+  reaction?: "good" | "bad";
 };
 
 export type RunNotes = {

--- a/packages/visual-editor/eval/viewer/src/ui/bgl-viewer.ts
+++ b/packages/visual-editor/eval/viewer/src/ui/bgl-viewer.ts
@@ -989,7 +989,8 @@ class BGLViewer extends LitElement {
   }
 
   #renderAllNotesModal() {
-    if (!this.notes || this.notes.length === 0) {
+    const nonReactionNotes = (this.notes || []).filter((n) => !n.reaction);
+    if (nonReactionNotes.length === 0) {
       return html`<dialog ${ref(this.#allNotesDialogRef)}>
         <form method="dialog">
           <div id="dialog-header">
@@ -1006,7 +1007,7 @@ class BGLViewer extends LitElement {
     }
 
     const groups = new Map<string, UserNote[]>();
-    for (const note of this.notes) {
+    for (const note of nonReactionNotes) {
       const section = this.#getSectionTitle(note.location);
       if (!groups.has(section)) {
         groups.set(section, []);
@@ -1017,7 +1018,7 @@ class BGLViewer extends LitElement {
     return html`<dialog ${ref(this.#allNotesDialogRef)}>
       <form method="dialog">
         <div id="dialog-header">
-          <h2>All Comments (${this.notes.length})</h2>
+          <h2>All Comments (${nonReactionNotes.length})</h2>
           <button type="submit" aria-label="Close">
             <span class="g-icon filled round">close</span>
           </button>
@@ -1036,7 +1037,14 @@ class BGLViewer extends LitElement {
                       <span style="font-weight: 600; color: var(--light-dark-n-20);">${fieldRef}</span>
                       <span>${new Date(note.timestamp).toLocaleString()}</span>
                     </div>
-                    <div style="white-space: pre-wrap;">${note.text}</div>
+                    <div style="display: flex; align-items: center; gap: var(--bb-grid-size-2);">
+                      ${note.reaction ? html`<span 
+                        class="g-icon round" 
+                        style="color: ${note.reaction === 'good' ? '#34a853' : '#ea4335'}; font-size: 16px; flex-shrink: 0;"
+                        title=${note.reaction === 'good' ? 'Marked as Good' : 'Marked as Bad'}
+                      >${note.reaction === 'good' ? 'thumb_up' : 'thumb_down'}</span>` : nothing}
+                      <div style="white-space: pre-wrap;">${note.text}</div>
+                    </div>
                   </div>`;
                 })}
               </div>
@@ -1076,9 +1084,9 @@ class BGLViewer extends LitElement {
           </div>
           <button @click=${() => this.#showRaterModal()}>Show Details</button>
           <button 
-            style="margin-top: var(--bb-grid-size); ${this.notes && this.notes.length > 0 ? '' : 'opacity: 0.5;'}" 
+            style="margin-top: var(--bb-grid-size); ${(this.notes || []).filter((n) => !n.reaction).length > 0 ? '' : 'opacity: 0.5;'}" 
             @click=${() => this.#showAllNotesModal()}
-          >All Comments (${this.notes?.length || 0})</button>
+          >All Comments (${(this.notes || []).filter((n) => !n.reaction).length})</button>
         </div>` : nothing}
       </div>
       <div

--- a/packages/visual-editor/eval/viewer/src/ui/notes-container.ts
+++ b/packages/visual-editor/eval/viewer/src/ui/notes-container.ts
@@ -6,8 +6,10 @@
 
 import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
+import { classMap } from "lit/directives/class-map.js";
 import { UserNote, NoteLocation } from "../types.js";
 import { icons } from "../../../../src/ui/styles/icons.js";
+
 
 export { NotesContainer };
 
@@ -77,74 +79,152 @@ class NotesContainer extends LitElement {
         }
       }
 
-      .add-note-section {
-        display: flex;
-        flex-direction: column;
-        gap: var(--bb-grid-size-2);
-      }
-
-      textarea {
-        width: 100%;
-        border-radius: var(--bb-grid-size-2);
-        border: 1px solid var(--border-color);
-        background: var(--light-dark-n-100);
-        color: var(--light-dark-n-0);
-        padding: var(--bb-grid-size-2);
-        resize: vertical;
-        font-family: var(--font-family);
-        font-size: 13px;
-
-        &:focus {
-          outline: none;
-          border-color: var(--primary);
+        .add-note-section {
+          display: flex;
+          flex-direction: column;
+          gap: var(--bb-grid-size-2);
         }
-      }
 
-      .actions {
-        display: flex;
-        justify-content: flex-end;
-        gap: var(--bb-grid-size-2);
+        textarea {
+          width: 100%;
+          border-radius: var(--bb-grid-size-2);
+          border: 1px solid var(--border-color);
+          background: var(--light-dark-n-100);
+          color: var(--light-dark-n-0);
+          padding: var(--bb-grid-size-2);
+          resize: vertical;
+          font-family: var(--font-family);
+          font-size: 13px;
 
-        button {
-          padding: var(--bb-grid-size) var(--bb-grid-size-3);
-          border-radius: var(--bb-grid-size);
-          font-size: 12px;
+          &:focus {
+            outline: none;
+            border-color: var(--primary);
+          }
+        }
+
+        .actions {
+          display: flex;
+          justify-content: flex-end;
+          gap: var(--bb-grid-size-2);
+
+          button {
+            padding: var(--bb-grid-size) var(--bb-grid-size-3);
+            border-radius: var(--bb-grid-size);
+            font-size: 12px;
+            cursor: pointer;
+            border: none;
+            font-weight: 500;
+          }
+
+          .save-btn {
+            background: var(--primary);
+            color: var(--text-color);
+          }
+
+          .cancel-btn {
+            background: var(--light-dark-n-90);
+            color: var(--light-dark-n-10);
+          }
+        }
+
+        .reaction-actions {
+          display: flex;
+          align-items: center;
+          gap: var(--bb-grid-size-3);
+          width: 100%;
+          margin-top: var(--bb-grid-size-2);
+        }
+
+        .reaction-btn {
+          background: var(--light-dark-n-95, transparent);
+          border: 1px solid var(--border-color, #e0e0e0);
+          border-radius: var(--bb-grid-size-3);
+          color: var(--light-dark-n-30, #555);
           cursor: pointer;
-          border: none;
-          font-weight: 500;
-        }
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          height: 38px;
+          width: 38px;
+          flex-shrink: 0;
+          transition: 
+            background 0.2s cubic-bezier(0, 0, 0.3, 1),
+            color 0.2s cubic-bezier(0, 0, 0.3, 1),
+            border-color 0.2s cubic-bezier(0, 0, 0.3, 1),
+            transform 0.1s cubic-bezier(0, 0, 0.3, 1);
 
-        .save-btn {
-          background: var(--primary);
-          color: var(--text-color);
-        }
+          &:hover {
+            color: var(--primary);
+            border-color: var(--primary);
+            background: oklch(from var(--primary) l c h / 0.1);
+          }
 
-        .cancel-btn {
-          background: var(--light-dark-n-90);
-          color: var(--light-dark-n-10);
+          &.good:hover {
+            color: #34a853;
+            border-color: #34a853;
+            background: oklch(from #34a853 l c h / 0.15);
+          }
+
+          &.good.active {
+            color: #ffffff !important;
+            background: #34a853 !important;
+            border-color: #34a853 !important;
+          }
+
+          &.bad:hover {
+            color: #ea4335;
+            border-color: #ea4335;
+            background: oklch(from #ea4335 l c h / 0.15);
+          }
+
+          &.bad.active {
+            color: #ffffff !important;
+            background: #ea4335 !important;
+            border-color: #ea4335 !important;
+          }
+
+          &:active {
+            transform: scale(0.95);
+          }
+
+          & .g-icon {
+            font-size: 18px;
+          }
         }
 
         .add-btn {
-          background: none;
-          border: 1px dashed var(--border-color);
+          background: var(--light-dark-n-95, transparent);
+          border: 1px dashed var(--border-color, #e0e0e0);
+          border-radius: var(--bb-grid-size-3);
           color: var(--primary);
           display: flex;
           align-items: center;
-          gap: var(--bb-grid-size);
-          width: 100%;
+          gap: var(--bb-grid-size-2);
+          flex-grow: 1;
           justify-content: center;
-          padding: var(--bb-grid-size-2);
+          padding: var(--bb-grid-size-2) var(--bb-grid-size-4);
+          height: 38px;
+          font-weight: 500;
+          cursor: pointer;
+          transition: 
+            background 0.2s cubic-bezier(0, 0, 0.3, 1),
+            color 0.2s cubic-bezier(0, 0, 0.3, 1),
+            border-color 0.2s cubic-bezier(0, 0, 0.3, 1),
+            transform 0.1s cubic-bezier(0, 0, 0.3, 1);
 
           &:hover {
             background: oklch(from var(--primary) l c h / 0.1);
             border-color: var(--primary);
           }
 
+          &:active {
+            transform: scale(0.98);
+          }
+
           & .g-icon {
             font-size: 16px;
           }
         }
-      }
     `,
   ];
 
@@ -178,19 +258,24 @@ class NotesContainer extends LitElement {
   }
 
   render() {
+    const notes = Array.isArray(this.notes) ? this.notes : [];
+    const nonReactionNotes = notes.filter((n) => !n.reaction);
+    const hasGood = notes.some((n) => n?.reaction === "good");
+    const hasBad = notes.some((n) => n?.reaction === "bad");
+
     return html`
       <div class="note-list">
-        ${this.notes.map(
+        ${nonReactionNotes.map(
           (note) => html`
             <div class="note-item">
               <div class="note-header">
-                <span>${new Date(note.timestamp).toLocaleString()}</span>
+                <span>${note.timestamp ? new Date(note.timestamp).toLocaleString() : ""}</span>
                 <button
                   class="delete-btn"
                   @click=${() => this.#handleDelete(note.id)}
                   title="Delete Note"
                 >
-                  <span class="g-icon filled round">delete</span>
+                  <span class="g-icon round">delete</span>
                 </button>
               </div>
               <div class="note-text">${note.text}</div>
@@ -218,13 +303,59 @@ class NotesContainer extends LitElement {
             </div>
           `
         : html`
-            <div class="actions">
+            <div class="reaction-actions">
               <button class="add-btn" @click=${() => (this.#isEditing = true)}>
-                <span class="g-icon filled round">add</span>
+                <span class="g-icon round">add</span>
                 Add Note
+              </button>
+              <button
+                class=${classMap({ "reaction-btn": true, "good": true, "active": hasGood })}
+                @click=${() => this.#handleReaction("good")}
+                title="Mark as Good"
+              >
+                <span class=${classMap({ "g-icon": true, "round": true, "filled": hasGood })}>thumb_up</span>
+              </button>
+              <button
+                class=${classMap({ "reaction-btn": true, "bad": true, "active": hasBad })}
+                @click=${() => this.#handleReaction("bad")}
+                title="Mark as Bad"
+              >
+                <span class=${classMap({ "g-icon": true, "round": true, "filled": hasBad })}>thumb_down</span>
               </button>
             </div>
           `}
     `;
   }
+
+  #handleReaction(reaction: "good" | "bad") {
+    const existingNote = Array.isArray(this.notes) 
+      ? this.notes.find((n) => n.reaction === reaction)
+      : null;
+
+    if (existingNote) {
+      this.dispatchEvent(
+        new CustomEvent("delete-note", {
+          detail: {
+            noteId: existingNote.id,
+          },
+          bubbles: true,
+          composed: true,
+        })
+      );
+      return;
+    }
+
+    this.dispatchEvent(
+      new CustomEvent("add-note", {
+        detail: {
+          location: this.location,
+          text: reaction === "good" ? "Good" : "Bad",
+          reaction,
+        },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  }
 }
+


### PR DESCRIPTION
## What
Added Thumbs Up and Thumbs Down reaction toggles for immediate evaluation rating in the Breadboard Eval Viewer's Topology inspector, and established a grouped "All Comments" modal to aggregate visual notes by section.

## Why
Improves evaluation velocity by allowing raters to visually endorse ("Good") or flag ("Bad") individual Node Configurations, Dimensions, and Transcript events via mutually-exclusive singleton reaction toggles stored cleanly as `.notes.json` sidecar files.

## Changes
- **Backend & Types (`types.ts`, `filesystem.ts`)**: Expanded `UserNote` to accommodate optional `.reaction` fields. Added dedicated `.notes.json` read/write capabilities to `FileSystemEvalBackend`.
- **UI Components (`notes-container.ts`, `bgl-viewer.ts`)**: Built `<ui-notes-container>` delivering distinct hover-light-up reactivity, composed bubbling for event delegation, and real-time active state styles. Incorporated a dashboard for grouping non-reaction notes by context.
- **State Orchestration (`inspector.ts`)**: Engineered `add-note` and `delete-note` custom event handlers in `A2UIEvalInspector` enforcing singleton and mutually-exclusive reaction conditions dynamically on state updates.

## Testing
- Navigate to the Eval Viewer's Topology mode.
- Click Thumbs Up or Thumbs Down on any configuration item; verify the corresponding button lights up and replaces opposite reactions.
- Click the lit reaction button again to toggle it OFF.
- Open `.notes.json` to confirm identical state persistence on disk.
