### PR TITLE
[eval] Sidecar-Enabled Evaluation Viewer

### DIFF
--- a/packages/visual-editor/eval/viewer/src/filesystem.ts
+++ b/packages/visual-editor/eval/viewer/src/filesystem.ts
@@ -241,7 +241,10 @@ export class FileSystemEvalBackend {
     try {
       const queryEntries: ParsedFileMedata[] = [];
       const raterMap = new Map<string, string>();
+      const ratingScoreMap = new Map<string, number>();
       const notesCountMap = new Map<string, number>();
+      const bglTitleMap = new Map<string, string>();
+      const transcriptMap = new Set<string>();
 
       try {
         for await (const [name, descriptor] of handle.entries()) {
@@ -251,11 +254,31 @@ export class FileSystemEvalBackend {
               const text = await fileBlob.text();
               const parsed = JSON.parse(text);
               const judgement = parsed?.overall_judgement || (parsed?.error ? 'FAIL' : 'UNKNOWN');
+              const score = parsed?.dimensions?.intent_fulfillment?.score;
               const baseName = name.replace(/\.rater\.json$/, "");
               raterMap.set(baseName, judgement);
+              if (typeof score === 'number') {
+                ratingScoreMap.set(baseName, score);
+              }
             } catch {
               // Ignore failure.
             }
+          }
+          if (name.endsWith(".bgl.json") && descriptor.kind === "file") {
+            try {
+              const fileBlob = await (descriptor as FileSystemFileHandle).getFile();
+              const text = await fileBlob.text();
+              const parsed = JSON.parse(text);
+              const title = parsed?.title || "";
+              const baseName = name.replace(/\.bgl\.json$/, "");
+              bglTitleMap.set(baseName, title);
+            } catch {
+              // Ignore failure.
+            }
+          }
+          if (name.endsWith(".transcript.jsonl") && descriptor.kind === "file") {
+            const baseName = name.replace(/\.transcript\.jsonl$/, "");
+            transcriptMap.add(baseName);
           }
           if (name.endsWith(".notes.json") && descriptor.kind === "file") {
             try {
@@ -284,7 +307,10 @@ export class FileSystemEvalBackend {
         if (parsed) {
           const baseName = name.replace(/\.log\.json$/, "");
           parsed.judgement = raterMap.get(baseName);
+          parsed.rating = ratingScoreMap.get(baseName) || parsed.judgement;
           parsed.noteCount = notesCountMap.get(baseName) || 0;
+          parsed.title = bglTitleMap.get(baseName);
+          parsed.hasSidecars = bglTitleMap.has(baseName) || raterMap.has(baseName) || notesCountMap.has(baseName) || transcriptMap.has(baseName);
           queryEntries.push(parsed);
         }
       }

--- a/packages/visual-editor/eval/viewer/src/inspector.ts
+++ b/packages/visual-editor/eval/viewer/src/inspector.ts
@@ -43,6 +43,7 @@ import {
 import { OutcomePayload, EvalFileData } from "../../../src/types/types.js";
 import "./ui/contexts-viewer.js";
 import "./ui/outcome-viewer.js";
+import "./ui/simplified-file-list.js";
 
 type RenderMode = "surfaces" | "messages" | "contexts" | "outcome" | "topology";
 
@@ -107,6 +108,12 @@ export class A2UIEvalInspector extends SignalWatcher(LitElement) {
 
   @signal
   accessor #surfaces: v0_8.Types.ServerToClientMessage[][] | null = null;
+  @signal
+  accessor #flatFiles: ParsedFileMedata[] = [];
+
+  @signal
+  accessor #hasSidecars: boolean = false;
+
   #processor = v0_8.Data.createSignalA2UIModelProcessor();
 
   @state()
@@ -250,6 +257,11 @@ export class A2UIEvalInspector extends SignalWatcher(LitElement) {
         grid-template-rows: 42px 1fr;
 
         --light-dark-n-10: var(--primary);
+      }
+
+      :host(.sidecar),
+      :host([sidecar]) {
+        grid-template-rows: 1fr;
       }
 
       header {
@@ -396,6 +408,12 @@ export class A2UIEvalInspector extends SignalWatcher(LitElement) {
             width: 100%;
             overflow: auto;
 
+            &.sidecar {
+              border: none;
+              padding: 0;
+              background: none;
+            }
+
             & #file-list {
               padding: 0;
               margin: 0;
@@ -473,6 +491,14 @@ export class A2UIEvalInspector extends SignalWatcher(LitElement) {
           display: grid;
           grid-template-rows: 32px 1fr;
           gap: var(--bb-grid-size-4);
+          height: 100%;
+
+          &.sidecar {
+            padding: 0;
+            display: block;
+            gap: 0;
+            height: 100%;
+          }
 
           & #current-file {
             flex: 1;
@@ -785,6 +811,8 @@ export class A2UIEvalInspector extends SignalWatcher(LitElement) {
   #updateFiles(f: Outcome<GroupedByType[]>, path: string) {
     if (!ok(f)) {
       this.#filesInMountedDir = [];
+      this.#flatFiles = [];
+      this.#hasSidecars = false;
       if (f.$error === "prompt") {
         this.#showPromptOption = path;
       }
@@ -793,6 +821,20 @@ export class A2UIEvalInspector extends SignalWatcher(LitElement) {
 
     this.#showPromptOption = null;
     this.#filesInMountedDir = f;
+
+    const flatFiles: ParsedFileMedata[] = [];
+    for (const group of f) {
+      for (const item of group.items) {
+        flatFiles.push(...item.files);
+      }
+    }
+    this.#flatFiles = flatFiles;
+    this.#hasSidecars = flatFiles.some((f) => !!f.hasSidecars);
+    this.classList.toggle("sidecar", this.#hasSidecars);
+    this.toggleAttribute("sidecar", this.#hasSidecars);
+    if (this.#hasSidecars) {
+      this.renderMode = "topology";
+    }
   }
 
   async #refresh() {
@@ -1078,6 +1120,7 @@ export class A2UIEvalInspector extends SignalWatcher(LitElement) {
           "typography-w-400": true,
           "typography-f-s": true,
           "typography-sz-bl": true,
+          sidecar: this.#hasSidecars,
         })}
       >
         ${this.#showPromptOption
@@ -1107,67 +1150,77 @@ export class A2UIEvalInspector extends SignalWatcher(LitElement) {
               </button>
             </div>`
           : nothing}
-        <ul id="file-list">
-          ${this.#filesInMountedDir.map((file) => {
-            return html`<li>
-              <h2>${file.type}</h2>
-              <ul>
-                ${file.items.map((item) => {
-                  return html`<li>
-                    <h2>${item.name}</h2>
-                    <ul>
-                      ${item.files.map((f) => {
-                        return html`<li>
-                          <button
-                            ?selected=${f.path === this.selectedFilePath}
-                            @click=${async () => {
-                              this.selectedFile = f;
-                              this.selectedFilePath = f.path;
-                            }}
-                            style="display: flex; align-items: center; justify-content: space-between; width: 100%;"
-                          >
-                            <span style="flex-grow: 1; text-align: left;">
-                              ${f.date.toLocaleString(
-                                Intl.DateTimeFormat().resolvedOptions().locale,
-                                {
-                                  dateStyle: "short",
-                                  timeStyle: "medium",
-                                }
-                              )}
-                            </span>
-                            ${f.judgement ? (() => {
-                              const judgement = f.judgement;
-                              const isPass = judgement === 'PASS';
-                              const isPartial = judgement === 'PARTIAL';
-                              const isFail = judgement === 'FAIL';
-                              const color = isPass ? '#34a853' : (isPartial ? '#fbbc04' : (isFail ? '#ea4335' : 'transparent'));
-                              const icon = isPass ? 'check_circle' : (isPartial ? 'warning' : (isFail ? 'cancel' : ''));
-                              if (!icon) return nothing;
-                              return html`<div style="display: flex; align-items: center; gap: 4px; flex-shrink: 0;">
-                                ${f.noteCount && f.noteCount > 0 ? html`<span 
-                                  style="background: var(--light-dark-n-0); color: var(--light-dark-n-100); font-size: 10px; font-weight: 600; padding: 2px 6px; border-radius: 8px; border: 1px solid var(--border-color);"
+        ${this.#hasSidecars
+          ? html`<eval-simplified-file-list
+              .files=${this.#flatFiles}
+              .selectedFilePath=${this.selectedFilePath}
+              @file-selected=${(evt: CustomEvent) => {
+                const { file, path } = evt.detail;
+                this.selectedFile = file;
+                this.selectedFilePath = path;
+              }}
+            ></eval-simplified-file-list>`
+          : html`<ul id="file-list">
+              ${this.#filesInMountedDir.map((file) => {
+                return html`<li>
+                  <h2>${file.type}</h2>
+                  <ul>
+                    ${file.items.map((item) => {
+                      return html`<li>
+                        <h2>${item.name}</h2>
+                        <ul>
+                          ${item.files.map((f) => {
+                            return html`<li>
+                              <button
+                                ?selected=${f.path === this.selectedFilePath}
+                                @click=${async () => {
+                                  this.selectedFile = f;
+                                  this.selectedFilePath = f.path;
+                                }}
+                                style="display: flex; align-items: center; justify-content: space-between; width: 100%;"
+                              >
+                                <span style="flex-grow: 1; text-align: left;">
+                                  ${f.date.toLocaleString(
+                                    Intl.DateTimeFormat().resolvedOptions().locale,
+                                    {
+                                      dateStyle: "short",
+                                      timeStyle: "medium",
+                                    }
+                                  )}
+                                </span>
+                                ${f.judgement ? (() => {
+                                  const judgement = f.judgement;
+                                  const isPass = judgement === 'PASS';
+                                  const isPartial = judgement === 'PARTIAL';
+                                  const isFail = judgement === 'FAIL';
+                                  const color = isPass ? '#34a853' : (isPartial ? '#fbbc04' : (isFail ? '#ea4335' : 'transparent'));
+                                  const icon = isPass ? 'check_circle' : (isPartial ? 'warning' : (isFail ? 'cancel' : ''));
+                                  if (!icon) return nothing;
+                                  return html`<div style="display: flex; align-items: center; gap: 4px; flex-shrink: 0;">
+                                    ${f.noteCount && f.noteCount > 0 ? html`<span 
+                                      style="background: var(--light-dark-n-0); color: var(--light-dark-n-100); font-size: 10px; font-weight: 600; padding: 2px 6px; border-radius: 8px; border: 1px solid var(--border-color);"
+                                      title="${f.noteCount} notes"
+                                    >${f.noteCount}</span>` : nothing}
+                                    <span 
+                                      class="g-icon filled round" 
+                                      style="color: ${color}; font-size: 16px;"
+                                      title="Evaluation Judgement: ${judgement}"
+                                    >${icon}</span>
+                                  </div>`;
+                                })() : (f.noteCount && f.noteCount > 0 ? html`<span 
+                                  style="background: var(--light-dark-n-0); color: var(--light-dark-n-100); font-size: 10px; font-weight: 600; padding: 2px 6px; border-radius: 8px; border: 1px solid var(--border-color); margin-left: 8px; flex-shrink: 0;"
                                   title="${f.noteCount} notes"
-                                >${f.noteCount}</span>` : nothing}
-                                <span 
-                                  class="g-icon filled round" 
-                                  style="color: ${color}; font-size: 16px;"
-                                  title="Evaluation Judgement: ${judgement}"
-                                >${icon}</span>
-                              </div>`;
-                            })() : (f.noteCount && f.noteCount > 0 ? html`<span 
-                              style="background: var(--light-dark-n-0); color: var(--light-dark-n-100); font-size: 10px; font-weight: 600; padding: 2px 6px; border-radius: 8px; border: 1px solid var(--border-color); margin-left: 8px; flex-shrink: 0;"
-                              title="${f.noteCount} notes"
-                            >${f.noteCount}</span>` : nothing)}
-                          </button>
-                        </li>`;
-                      })}
-                    </ul>
-                  </li>`;
-                })}
-              </ul>
-            </li>`;
-          })}
-        </ul>
+                                >${f.noteCount}</span>` : nothing)}
+                              </button>
+                            </li>`;
+                          })}
+                        </ul>
+                      </li>`;
+                    })}
+                  </ul>
+                </li>`;
+              })}
+            </ul>`}
       </div>`;
   }
 
@@ -1206,57 +1259,59 @@ export class A2UIEvalInspector extends SignalWatcher(LitElement) {
           </h2>
           ${this.#renderInput()}
         </div>
-        <div id="surface-container" slot="slot-1">
-          <h2
-            class="typography-w-400 typography-f-s typography-sz-tl layout-sp-bt"
-          >
-            <div id="current-file">${this.selectedFile?.name}</div>
-            <div id="render-mode">
-              <button
-                class=${classMap({ active: this.#renderMode === "contexts" })}
-                @click=${() => (this.renderMode = "contexts")}
-                title="View Conversation Contexts"
+        <div id="surface-container" class=${classMap({ sidecar: this.#hasSidecars })} slot="slot-1">
+          ${this.#hasSidecars
+            ? nothing
+            : html`<h2
+                class="typography-w-400 typography-f-s typography-sz-tl layout-sp-bt"
               >
-                <span class="g-icon filled round">forum</span>Contexts
-              </button>
-
-              ${this.bgl
-                ? html`<button
-                    class=${classMap({
-                      active: this.#renderMode === "topology",
-                    })}
-                    @click=${() => (this.renderMode = "topology")}
-                    title="View BGL Topology"
+                <div id="current-file">${this.selectedFile?.title || this.selectedFile?.name}</div>
+                <div id="render-mode">
+                  <button
+                    class=${classMap({ active: this.#renderMode === "contexts" })}
+                    @click=${() => (this.renderMode = "contexts")}
+                    title="View Conversation Contexts"
                   >
-                    <span class="g-icon filled round">hub</span>Topology
-                  </button>`
-                : nothing}
+                    <span class="g-icon filled round">forum</span>Contexts
+                  </button>
 
-              <button
-                class=${classMap({ active: this.#renderMode === "outcome" })}
-                @click=${() => (this.renderMode = "outcome")}
-                title="View Outcome"
-              >
-                <span class="g-icon filled round">data_check</span>Outcome
-              </button>
+                  ${this.bgl
+                    ? html`<button
+                        class=${classMap({
+                          active: this.#renderMode === "topology",
+                        })}
+                        @click=${() => (this.renderMode = "topology")}
+                        title="View BGL Topology"
+                      >
+                        <span class="g-icon filled round">hub</span>Topology
+                      </button>`
+                    : nothing}
 
-              <button
-                class=${classMap({ active: this.#renderMode === "surfaces" })}
-                @click=${() => (this.renderMode = "surfaces")}
-                title="View Generated Surfaces"
-              >
-                <span class="g-icon filled round">mobile_layout</span>Surfaces
-              </button>
+                  <button
+                    class=${classMap({ active: this.#renderMode === "outcome" })}
+                    @click=${() => (this.renderMode = "outcome")}
+                    title="View Outcome"
+                  >
+                    <span class="g-icon filled round">data_check</span>Outcome
+                  </button>
 
-              <button
-                class=${classMap({ active: this.#renderMode === "messages" })}
-                @click=${() => (this.renderMode = "messages")}
-                title="View A2UI Messages"
-              >
-                <span class="g-icon filled round">communication</span>A2UI
-              </button>
-            </div>
-          </h2>
+                  <button
+                    class=${classMap({ active: this.#renderMode === "surfaces" })}
+                    @click=${() => (this.renderMode = "surfaces")}
+                    title="View Generated Surfaces"
+                  >
+                    <span class="g-icon filled round">mobile_layout</span>Surfaces
+                  </button>
+
+                  <button
+                    class=${classMap({ active: this.#renderMode === "messages" })}
+                    @click=${() => (this.renderMode = "messages")}
+                    title="View A2UI Messages"
+                  >
+                    <span class="g-icon filled round">communication</span>A2UI
+                  </button>
+                </div>
+              </h2>`}
           ${this.#renderContents()}
         </div>
       </ui-splitter>
@@ -1264,6 +1319,9 @@ export class A2UIEvalInspector extends SignalWatcher(LitElement) {
   }
 
   #renderUI() {
+    if (this.#hasSidecars) {
+      return [this.#renderMain()];
+    }
     return [this.#renderHeader(), this.#renderMain()];
   }
 

--- a/packages/visual-editor/eval/viewer/src/parse-file-name.ts
+++ b/packages/visual-editor/eval/viewer/src/parse-file-name.ts
@@ -13,6 +13,9 @@ export type ParsedFileMedata = {
   date: Date;
   judgement?: string;
   noteCount?: number;
+  title?: string;
+  rating?: string | number;
+  hasSidecars?: boolean;
 };
 
 export type GroupedByName = {

--- a/packages/visual-editor/eval/viewer/src/ui/simplified-file-list.ts
+++ b/packages/visual-editor/eval/viewer/src/ui/simplified-file-list.ts
@@ -1,0 +1,193 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { css, html, LitElement, nothing } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { classMap } from "lit/directives/class-map.js";
+import { map } from "lit/directives/map.js";
+import { icons } from "../../../../src/ui/styles/icons.js";
+import { ParsedFileMedata } from "../parse-file-name.js";
+
+export { EvalSimplifiedFileList };
+
+@customElement("eval-simplified-file-list")
+class EvalSimplifiedFileList extends LitElement {
+  @property()
+  accessor files: ParsedFileMedata[] = [];
+
+  @property()
+  accessor selectedFilePath: string | null = null;
+
+  static styles = [
+    icons,
+    css`
+      :host {
+        display: flex;
+        flex-direction: column;
+        gap: var(--bb-grid-size-2);
+        padding: 0;
+        height: 100%;
+        overflow-y: auto;
+        scrollbar-width: none;
+      }
+
+      .item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: var(--bb-grid-size-3);
+        border-radius: var(--bb-grid-size-2);
+        background: var(--elevated-background-light);
+        border: 1px solid var(--border-color);
+        cursor: pointer;
+        transition: all 0.2s cubic-bezier(0, 0, 0.3, 1);
+
+        &:hover {
+          background: oklch(from var(--primary) l c h / 0.1);
+          transform: translateY(-1px);
+          box-shadow: 0 2px 8px oklch(from var(--light-dark-n-10) l c h / 0.1);
+        }
+
+        &.selected {
+          border-color: var(--primary);
+          background: oklch(from var(--primary) l c h / 0.15);
+          transform: none;
+          box-shadow: none;
+        }
+
+        .title {
+          font-family: var(--font-family);
+          font-size: 13px;
+          font-weight: 500;
+          color: var(--text-color);
+          flex-grow: 1;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          margin-right: var(--bb-grid-size-3);
+        }
+
+        .meta {
+          display: flex;
+          align-items: center;
+          gap: var(--bb-grid-size-2);
+          flex-shrink: 0;
+        }
+
+        .badge {
+          display: flex;
+          align-items: center;
+          gap: 4px;
+          font-size: 11px;
+          font-weight: 600;
+          padding: 2px 8px;
+          border-radius: 8px;
+          border: 1px solid var(--border-color);
+          background: var(--light-dark-n-0);
+          color: var(--light-dark-n-100);
+
+          & .g-icon {
+            font-size: 12px;
+            color: var(--light-dark-n-100);
+          }
+        }
+
+        .rating {
+          display: flex;
+          align-items: center;
+          gap: 4px;
+          font-size: 11px;
+          font-weight: 600;
+          padding: 3px 8px;
+          border-radius: 8px;
+          border: none;
+
+          &.pass {
+            background: #34a853;
+            color: white;
+          }
+          &.partial {
+            background: #fbbc04;
+            color: black;
+          }
+          &.fail {
+            background: #ea4335;
+            color: white;
+          }
+          &.unknown {
+            background: var(--border-color);
+            color: var(--text-color);
+          }
+
+          & .g-icon {
+            font-size: 14px;
+          }
+        }
+      }
+    `,
+  ];
+
+  render() {
+    if (!this.files || this.files.length === 0) {
+      return html`<div style="display: flex; align-items: center; justify-content: center; height: 100%; color: var(--light-dark-n-60); font-size: 13px;">
+        No eval sessions found.
+      </div>`;
+    }
+
+    return map(this.files, (f) => {
+      const isSelected = f.path === this.selectedFilePath;
+      const title = f.title || f.name || "Untitled Graph";
+      const count = f.noteCount || 0;
+      const rating = f.rating || f.judgement || "UNKNOWN";
+
+      const ratingClass = {
+        rating: true,
+        pass: rating === "PASS" || rating === 5 || rating === 4,
+        partial: rating === "PARTIAL" || rating === 3,
+        fail: rating === "FAIL" || rating === 1 || rating === 2,
+        unknown: rating === "UNKNOWN",
+      };
+
+      const ratingIcon =
+        rating === "PASS" || rating === 5 || rating === 4
+          ? "check_circle"
+          : rating === "PARTIAL" || rating === 3
+            ? "warning"
+            : rating === "FAIL" || rating === 1 || rating === 2
+              ? "cancel"
+              : "";
+
+      return html`<div
+        class=${classMap({ item: true, selected: isSelected })}
+        @click=${() => {
+          this.dispatchEvent(
+            new CustomEvent("file-selected", {
+              detail: { file: f, path: f.path },
+              bubbles: true,
+              composed: true,
+            })
+          );
+        }}
+      >
+        <span class="title" title="${title}">${title}</span>
+        <div class="meta">
+          ${count > 0
+            ? html`<span class="badge" title="${count} comments">
+                <span class="g-icon filled round">comment</span>
+                ${count}
+              </span>`
+            : nothing}
+          ${ratingIcon
+            ? html`<span class=${classMap(ratingClass)} title="Rating: ${rating}">
+                <span class="g-icon filled round">${ratingIcon}</span>
+                ${rating}
+              </span>`
+            : nothing}
+        </div>
+      </div>`;
+    });
+  }
+}

--- a/packages/visual-editor/eval/viewer/src/ui/ui.ts
+++ b/packages/visual-editor/eval/viewer/src/ui/ui.ts
@@ -17,4 +17,5 @@
 export { Splitter } from "./splitter.js";
 export { BGLViewer } from "./bgl-viewer.js";
 export { NotesContainer } from "./notes-container.js";
+export { EvalSimplifiedFileList } from "./simplified-file-list.js";
 


### PR DESCRIPTION
## What
Refactored the evaluation viewer to flexibly detect and adapt its UI for sidecar evaluation artifacts (`.bgl.json`, `.rater.json`, `.notes.json`, `.transcript.jsonl`), displaying a simplified sidebar with direct Topology rendering.

## Why
Improves the evaluation workflow analysis by presenting aggregated metadata directly alongside topology diagrams and eliminating redundant legacy headers in automated multi-file scenarios.

## Changes
- **Eval Backend (filesystem.ts)**: Enhanced directory `query()` API to parse sidecar graph titles, comment counts, and rating assessments, attaching them dynamically into unified file metadata.
- **Eval Inspector UI (inspector.ts)**: Implemented context-aware rendering, omitting `Context`, `Outcome`, `Surfaces`, and `A2UI` render modes in sidecar mode, decommissioning old-style headers and padding frames to maximize topological viewport size.
- **Simplified File List (simplified-file-list.ts)**: Introduced a premium, borderless flat List element for displaying direct sidebar insights into session rating pills and comment metrics.

## Testing
1. Mount a directory with sidecar evaluation outputs.
2. Verify that the viewer boots directly into the `Topology` view without displaying the `A2UI Inspector` header or mode selectors.
3. Verify that the left sidebar contains a flat list of evaluated graphs showing graph titles, color-graded assessment badges, and comment counts.
