### PR TITLE
[eval] Yellow Post-it Note Aesthetic for User Notes in Eval Viewer

### DIFF
--- a/packages/visual-editor/eval/viewer/src/inspector.ts
+++ b/packages/visual-editor/eval/viewer/src/inspector.ts
@@ -1198,7 +1198,7 @@ export class A2UIEvalInspector extends SignalWatcher(LitElement) {
                                   if (!icon) return nothing;
                                   return html`<div style="display: flex; align-items: center; gap: 4px; flex-shrink: 0;">
                                     ${f.noteCount && f.noteCount > 0 ? html`<span 
-                                      style="background: var(--light-dark-n-0); color: var(--light-dark-n-100); font-size: 10px; font-weight: 600; padding: 2px 6px; border-radius: 8px; border: 1px solid var(--border-color);"
+                                      style="background: #fef08a; color: #854d0e; font-size: 10px; font-weight: 700; padding: 2px 6px; border-radius: 4px; border: 1px solid #facc15; box-shadow: 0 1px 2px rgba(0,0,0,0.05);"
                                       title="${f.noteCount} notes"
                                     >${f.noteCount}</span>` : nothing}
                                     <span 
@@ -1208,7 +1208,7 @@ export class A2UIEvalInspector extends SignalWatcher(LitElement) {
                                     >${icon}</span>
                                   </div>`;
                                 })() : (f.noteCount && f.noteCount > 0 ? html`<span 
-                                  style="background: var(--light-dark-n-0); color: var(--light-dark-n-100); font-size: 10px; font-weight: 600; padding: 2px 6px; border-radius: 8px; border: 1px solid var(--border-color); margin-left: 8px; flex-shrink: 0;"
+                                  style="background: #fef08a; color: #854d0e; font-size: 10px; font-weight: 700; padding: 2px 6px; border-radius: 4px; border: 1px solid #facc15; margin-left: 8px; flex-shrink: 0; box-shadow: 0 1px 2px rgba(0,0,0,0.05);"
                                   title="${f.noteCount} notes"
                                 >${f.noteCount}</span>` : nothing)}
                               </button>

--- a/packages/visual-editor/eval/viewer/src/ui/bgl-viewer.ts
+++ b/packages/visual-editor/eval/viewer/src/ui/bgl-viewer.ts
@@ -1029,12 +1029,12 @@ class BGLViewer extends LitElement {
               <h3 style="font-size: 14px; font-weight: 600; color: var(--primary); margin: 0 0 var(--bb-grid-size-3) 0; border-bottom: 1px solid var(--border-color); padding-bottom: var(--bb-grid-size-2);">
                 ${section}
               </h3>
-              <div style="display: flex; flex-direction: column; gap: var(--bb-grid-size-2);">
+              <div style="display: flex; flex-direction: column; gap: var(--bb-grid-size-2); padding: var(--bb-grid-size) var(--bb-grid-size-2); margin-bottom: var(--bb-grid-size-2);">
                 ${notes.map((note) => {
                   const fieldRef = this.#getFieldReference(note.location);
-                  return html`<div style="background: var(--light-dark-n-98); border: 1px solid var(--border-color); border-radius: var(--bb-grid-size-2); padding: var(--bb-grid-size-3); font-size: 13px; color: var(--light-dark-n-10);">
-                    <div style="display: flex; justify-content: space-between; font-size: 11px; color: var(--light-dark-n-40); margin-bottom: var(--bb-grid-size-2); font-weight: 500;">
-                      <span style="font-weight: 600; color: var(--light-dark-n-20);">${fieldRef}</span>
+                  return html`<div style="background: #fef08a; border: 1px solid #facc15; border-bottom-right-radius: 12px 4px; border-radius: 4px; padding: var(--bb-grid-size-3); font-size: 13px; color: #1e293b; box-shadow: 1px 3px 6px oklch(0 0 0 / 0.08), 0 1px 2px oklch(0 0 0 / 0.04); margin: 2px 4px 8px 4px;">
+                    <div style="display: flex; justify-content: space-between; font-size: 11px; color: #64748b; margin-bottom: var(--bb-grid-size-2); font-weight: 500; border-bottom: 1px dashed oklch(from #facc15 l c h / 0.5); padding-bottom: var(--bb-grid-size);">
+                      <span style="font-weight: 600; color: #475569;">${fieldRef}</span>
                       <span>${new Date(note.timestamp).toLocaleString()}</span>
                     </div>
                     <div style="display: flex; align-items: center; gap: var(--bb-grid-size-2);">
@@ -1043,7 +1043,7 @@ class BGLViewer extends LitElement {
                         style="color: ${note.reaction === 'good' ? '#34a853' : '#ea4335'}; font-size: 16px; flex-shrink: 0;"
                         title=${note.reaction === 'good' ? 'Marked as Good' : 'Marked as Bad'}
                       >${note.reaction === 'good' ? 'thumb_up' : 'thumb_down'}</span>` : nothing}
-                      <div style="white-space: pre-wrap;">${note.text}</div>
+                      <div style="white-space: pre-wrap; line-height: 1.5;">${note.text}</div>
                     </div>
                   </div>`;
                 })}

--- a/packages/visual-editor/eval/viewer/src/ui/notes-container.ts
+++ b/packages/visual-editor/eval/viewer/src/ui/notes-container.ts
@@ -39,38 +39,71 @@ class NotesContainer extends LitElement {
       .note-list {
         display: flex;
         flex-direction: column;
-        gap: var(--bb-grid-size-2);
-        margin-bottom: var(--bb-grid-size-2);
+        gap: var(--bb-grid-size-3);
+        margin: var(--bb-grid-size-2) var(--bb-grid-size-2) var(--bb-grid-size-3) var(--bb-grid-size);
+        padding: var(--bb-grid-size) var(--bb-grid-size-2);
       }
 
       .note-item {
-        background: var(--light-dark-n-98);
-        border: 1px solid var(--border-color);
-        border-radius: var(--bb-grid-size-2);
+        background: #fef08a; /* Bright yellow postit */
+        border: 1px solid #facc15;
+        border-bottom-right-radius: 12px 4px;
+        border-radius: 4px;
         padding: var(--bb-grid-size-2) var(--bb-grid-size-3);
         font-size: 13px;
         position: relative;
-        color: var(--light-dark-n-10);
+        color: #1e293b; /* Readable dark slate */
+        box-shadow: 
+          1px 3px 6px oklch(0 0 0 / 0.08),
+          0 1px 2px oklch(0 0 0 / 0.04);
+        transform: rotate(-0.6deg);
+        transition: transform 0.2s cubic-bezier(0.3, 0, 0.2, 1), box-shadow 0.2s cubic-bezier(0.3, 0, 0.2, 1);
+
+        &:nth-child(even) {
+          transform: rotate(0.6deg);
+          border-bottom-left-radius: 12px 4px;
+          border-bottom-right-radius: 4px;
+        }
+
+        &:hover {
+          transform: translateY(-2px) scale(1.005) rotate(0deg);
+          box-shadow: 
+            3px 6px 12px oklch(0 0 0 / 0.1),
+            0 2px 4px oklch(0 0 0 / 0.05);
+        }
 
         .note-header {
           display: flex;
           justify-content: space-between;
           font-size: 11px;
-          color: var(--light-dark-n-50);
+          color: #64748b;
           margin-bottom: var(--bb-grid-size);
+          border-bottom: 1px dashed oklch(from #facc15 l c h / 0.5);
+          padding-bottom: var(--bb-grid-size);
+          font-weight: 500;
+        }
+
+        .note-text {
+          line-height: 1.5;
+          white-space: pre-wrap;
+          font-weight: 400;
         }
 
         .delete-btn {
           background: none;
           border: none;
-          color: var(--light-dark-e-40);
+          color: #ef4444;
           cursor: pointer;
           padding: 0;
           display: flex;
           align-items: center;
+          opacity: 0.6;
+          transition: opacity 0.2s ease-in-out, transform 0.1s ease-in-out;
 
           &:hover {
-            color: var(--light-dark-e-20);
+            opacity: 1;
+            color: #dc2626;
+            transform: scale(1.05);
           }
 
           & .g-icon {
@@ -79,152 +112,176 @@ class NotesContainer extends LitElement {
         }
       }
 
-        .add-note-section {
-          display: flex;
-          flex-direction: column;
-          gap: var(--bb-grid-size-2);
+      .add-note-section {
+        display: flex;
+        flex-direction: column;
+        gap: var(--bb-grid-size-2);
+        background: #fef9c3; /* Lighter composed note */
+        border: 1px dashed #facc15;
+        padding: var(--bb-grid-size-2);
+        border-radius: 6px;
+        box-shadow: inset 0 1px 2px oklch(0 0 0 / 0.05);
+      }
+
+      textarea {
+        width: 100%;
+        border-radius: 4px;
+        border: 1px solid #e2e8f0;
+        background: #ffffff;
+        color: #1e293b;
+        padding: var(--bb-grid-size-2);
+        resize: vertical;
+        font-family: var(--font-family);
+        font-size: 13px;
+        box-shadow: inset 0 1px 2px oklch(0 0 0 / 0.04);
+        transition: border-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+
+        &:focus {
+          outline: none;
+          border-color: #f59e0b;
+          box-shadow: inset 0 1px 2px oklch(0 0 0 / 0.04), 0 0 0 3px oklch(from #f59e0b l c h / 0.2);
         }
+      }
 
-        textarea {
-          width: 100%;
-          border-radius: var(--bb-grid-size-2);
-          border: 1px solid var(--border-color);
-          background: var(--light-dark-n-100);
-          color: var(--light-dark-n-0);
-          padding: var(--bb-grid-size-2);
-          resize: vertical;
-          font-family: var(--font-family);
-          font-size: 13px;
+      .actions {
+        display: flex;
+        justify-content: flex-end;
+        gap: var(--bb-grid-size-2);
 
-          &:focus {
-            outline: none;
-            border-color: var(--primary);
-          }
-        }
-
-        .actions {
-          display: flex;
-          justify-content: flex-end;
-          gap: var(--bb-grid-size-2);
-
-          button {
-            padding: var(--bb-grid-size) var(--bb-grid-size-3);
-            border-radius: var(--bb-grid-size);
-            font-size: 12px;
-            cursor: pointer;
-            border: none;
-            font-weight: 500;
-          }
-
-          .save-btn {
-            background: var(--primary);
-            color: var(--text-color);
-          }
-
-          .cancel-btn {
-            background: var(--light-dark-n-90);
-            color: var(--light-dark-n-10);
-          }
-        }
-
-        .reaction-actions {
-          display: flex;
-          align-items: center;
-          gap: var(--bb-grid-size-3);
-          width: 100%;
-          margin-top: var(--bb-grid-size-2);
-        }
-
-        .reaction-btn {
-          background: var(--light-dark-n-95, transparent);
-          border: 1px solid var(--border-color, #e0e0e0);
-          border-radius: var(--bb-grid-size-3);
-          color: var(--light-dark-n-30, #555);
+        button {
+          padding: var(--bb-grid-size) var(--bb-grid-size-3);
+          border-radius: 6px;
+          font-size: 12px;
           cursor: pointer;
-          display: flex;
-          align-items: center;
-          justify-content: center;
-          height: 38px;
-          width: 38px;
-          flex-shrink: 0;
-          transition: 
-            background 0.2s cubic-bezier(0, 0, 0.3, 1),
-            color 0.2s cubic-bezier(0, 0, 0.3, 1),
-            border-color 0.2s cubic-bezier(0, 0, 0.3, 1),
-            transform 0.1s cubic-bezier(0, 0, 0.3, 1);
+          border: none;
+          font-weight: 600;
+          transition: transform 0.1s ease, background 0.2s ease;
+        }
+
+        .save-btn {
+          background: #f59e0b;
+          color: #ffffff;
+          box-shadow: 0 1px 2px oklch(0 0 0 / 0.05);
 
           &:hover {
-            color: var(--primary);
-            border-color: var(--primary);
-            background: oklch(from var(--primary) l c h / 0.1);
+            background: #d97706;
           }
-
-          &.good:hover {
-            color: #34a853;
-            border-color: #34a853;
-            background: oklch(from #34a853 l c h / 0.15);
-          }
-
-          &.good.active {
-            color: #ffffff !important;
-            background: #34a853 !important;
-            border-color: #34a853 !important;
-          }
-
-          &.bad:hover {
-            color: #ea4335;
-            border-color: #ea4335;
-            background: oklch(from #ea4335 l c h / 0.15);
-          }
-
-          &.bad.active {
-            color: #ffffff !important;
-            background: #ea4335 !important;
-            border-color: #ea4335 !important;
-          }
-
-          &:active {
-            transform: scale(0.95);
-          }
-
-          & .g-icon {
-            font-size: 18px;
-          }
-        }
-
-        .add-btn {
-          background: var(--light-dark-n-95, transparent);
-          border: 1px dashed var(--border-color, #e0e0e0);
-          border-radius: var(--bb-grid-size-3);
-          color: var(--primary);
-          display: flex;
-          align-items: center;
-          gap: var(--bb-grid-size-2);
-          flex-grow: 1;
-          justify-content: center;
-          padding: var(--bb-grid-size-2) var(--bb-grid-size-4);
-          height: 38px;
-          font-weight: 500;
-          cursor: pointer;
-          transition: 
-            background 0.2s cubic-bezier(0, 0, 0.3, 1),
-            color 0.2s cubic-bezier(0, 0, 0.3, 1),
-            border-color 0.2s cubic-bezier(0, 0, 0.3, 1),
-            transform 0.1s cubic-bezier(0, 0, 0.3, 1);
-
-          &:hover {
-            background: oklch(from var(--primary) l c h / 0.1);
-            border-color: var(--primary);
-          }
-
           &:active {
             transform: scale(0.98);
           }
+        }
 
-          & .g-icon {
-            font-size: 16px;
+        .cancel-btn {
+          background: #e2e8f0;
+          color: #475569;
+
+          &:hover {
+            background: #cbd5e1;
+          }
+          &:active {
+            transform: scale(0.98);
           }
         }
+      }
+
+      .reaction-actions {
+        display: flex;
+        align-items: center;
+        gap: var(--bb-grid-size-3);
+        width: 100%;
+        margin-top: var(--bb-grid-size-2);
+      }
+
+      .reaction-btn {
+        background: var(--light-dark-n-95, transparent);
+        border: 1px solid var(--border-color, #e0e0e0);
+        border-radius: var(--bb-grid-size-3);
+        color: var(--light-dark-n-30, #555);
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        height: 38px;
+        width: 38px;
+        flex-shrink: 0;
+        transition: 
+          background 0.2s cubic-bezier(0, 0, 0.3, 1),
+          color 0.2s cubic-bezier(0, 0, 0.3, 1),
+          border-color 0.2s cubic-bezier(0, 0, 0.3, 1),
+          transform 0.1s cubic-bezier(0, 0, 0.3, 1);
+
+        &:hover {
+          color: var(--primary);
+          border-color: var(--primary);
+          background: oklch(from var(--primary) l c h / 0.1);
+        }
+
+        &.good:hover {
+          color: #34a853;
+          border-color: #34a853;
+          background: oklch(from #34a853 l c h / 0.15);
+        }
+
+        &.good.active {
+          color: #ffffff !important;
+          background: #34a853 !important;
+          border-color: #34a853 !important;
+        }
+
+        &.bad:hover {
+          color: #ea4335;
+          border-color: #ea4335;
+          background: oklch(from #ea4335 l c h / 0.15);
+        }
+
+        &.bad.active {
+          color: #ffffff !important;
+          background: #ea4335 !important;
+          border-color: #ea4335 !important;
+        }
+
+        &:active {
+          transform: scale(0.95);
+        }
+
+        & .g-icon {
+          font-size: 18px;
+        }
+      }
+
+      .add-btn {
+        background: var(--light-dark-n-95, transparent);
+        border: 1px dashed var(--border-color, #e0e0e0);
+        border-radius: var(--bb-grid-size-3);
+        color: var(--primary);
+        display: flex;
+        align-items: center;
+        gap: var(--bb-grid-size-2);
+        flex-grow: 1;
+        justify-content: center;
+        padding: var(--bb-grid-size-2) var(--bb-grid-size-4);
+        height: 38px;
+        font-weight: 500;
+        cursor: pointer;
+        transition: 
+          background 0.2s cubic-bezier(0, 0, 0.3, 1),
+          color 0.2s cubic-bezier(0, 0, 0.3, 1),
+          border-color 0.2s cubic-bezier(0, 0, 0.3, 1),
+          transform 0.1s cubic-bezier(0, 0, 0.3, 1);
+
+        &:hover {
+          background: oklch(from var(--primary) l c h / 0.1);
+          border-color: var(--primary);
+        }
+
+        &:active {
+          transform: scale(0.98);
+        }
+
+        & .g-icon {
+          font-size: 16px;
+        }
+      }
     `,
   ];
 

--- a/packages/visual-editor/eval/viewer/src/ui/simplified-file-list.ts
+++ b/packages/visual-editor/eval/viewer/src/ui/simplified-file-list.ts
@@ -81,17 +81,18 @@ class EvalSimplifiedFileList extends LitElement {
           display: flex;
           align-items: center;
           gap: 4px;
-          font-size: 11px;
-          font-weight: 600;
+          font-size: 10px;
+          font-weight: 700;
           padding: 2px 8px;
-          border-radius: 8px;
-          border: 1px solid var(--border-color);
-          background: var(--light-dark-n-0);
-          color: var(--light-dark-n-100);
+          border-radius: 4px;
+          background: #fef08a; /* Yellow Post-it */
+          color: #854d0e; /* Brownish yellow text */
+          border: 1px solid #facc15;
+          box-shadow: 0 1px 2px rgba(0,0,0,0.05);
 
           & .g-icon {
             font-size: 12px;
-            color: var(--light-dark-n-100);
+            color: #854d0e;
           }
         }
 


### PR DESCRIPTION
## What
Refactored the styling and display of User Notes, note counts, and comment badges throughout the Eval Viewer to adopt a visual "Yellow Post-it Note" design language, complete with curled paper corners, dropped paper shadows, and natural rotation angles.

## Why
Improves the visibility, distinction, and overall design aesthetics of user notes, annotations, and ratings across the Evaluation Viewer interface against standard structural and evaluation items.

## Changes
### Visual Editor Eval Viewer
- **[notes-container.ts](file:///packages/visual-editor/eval/viewer/src/ui/notes-container.ts)**: Enhanced `.note-item` and `.add-note-section` to deliver the Post-it paper visual layout alongside comprehensive padding/margin clearance fixes to prevent layout clipping.
- **[simplified-file-list.ts](file:///packages/visual-editor/eval/viewer/src/ui/simplified-file-list.ts)**: Re-styled note badges in the simplified left-sidebar list to integrate cohesive golden-yellow design tones.
- **[inspector.ts](file:///packages/visual-editor/eval/viewer/src/inspector.ts)**: Unified item-level comment indicator badges to propagate post-it visual themes.
- **[bgl-viewer.ts](file:///packages/visual-editor/eval/viewer/src/ui/bgl-viewer.ts)**: Standardized notes inside the `All Comments` dialog body to employ Post-it UI values elegantly with padded container clearance.

## Testing
- Run `npm run test` in `packages/visual-editor` to verify coverage.
- Open the visual evaluation harness viewer and inspect topology notes, sidebars, and dialogue modals for the yellow Post-it styling.
