### PR TITLE
[eval] Human Rater Judgement Surfacing in Eval Viewer

### DIFF
--- a/packages/visual-editor/eval/viewer/src/filesystem.ts
+++ b/packages/visual-editor/eval/viewer/src/filesystem.ts
@@ -243,6 +243,7 @@ export class FileSystemEvalBackend {
       const raterMap = new Map<string, string>();
       const ratingScoreMap = new Map<string, number>();
       const notesCountMap = new Map<string, number>();
+      const humanJudgementMap = new Map<string, "good" | "bad">();
       const bglTitleMap = new Map<string, string>();
       const transcriptMap = new Set<string>();
 
@@ -288,6 +289,13 @@ export class FileSystemEvalBackend {
               const count = Array.isArray(parsed?.notes) ? parsed.notes.length : 0;
               const baseName = name.replace(/\.notes\.json$/, "");
               notesCountMap.set(baseName, count);
+
+              const reactionNote = Array.isArray(parsed?.notes)
+                ? parsed.notes.find((n) => n.location.type === "rater" && n.location.fieldName === "overall_judgement" && n.reaction)
+                : null;
+              if (reactionNote && reactionNote.reaction) {
+                humanJudgementMap.set(baseName, reactionNote.reaction);
+              }
             } catch {
               // Ignore failure.
             }
@@ -310,6 +318,7 @@ export class FileSystemEvalBackend {
           parsed.rating = ratingScoreMap.get(baseName) || parsed.judgement;
           parsed.noteCount = notesCountMap.get(baseName) || 0;
           parsed.title = bglTitleMap.get(baseName);
+          parsed.humanJudgement = humanJudgementMap.get(baseName);
           parsed.hasSidecars = bglTitleMap.has(baseName) || raterMap.has(baseName) || notesCountMap.has(baseName) || transcriptMap.has(baseName);
           queryEntries.push(parsed);
         }

--- a/packages/visual-editor/eval/viewer/src/parse-file-name.ts
+++ b/packages/visual-editor/eval/viewer/src/parse-file-name.ts
@@ -16,6 +16,7 @@ export type ParsedFileMedata = {
   title?: string;
   rating?: string | number;
   hasSidecars?: boolean;
+  humanJudgement?: "good" | "bad";
 };
 
 export type GroupedByName = {

--- a/packages/visual-editor/eval/viewer/src/ui/bgl-viewer.ts
+++ b/packages/visual-editor/eval/viewer/src/ui/bgl-viewer.ts
@@ -1082,6 +1082,23 @@ class BGLViewer extends LitElement {
             <div class="status-dot ${statusClass}"></div>
             <span>Eval: ${judgement}</span>
           </div>
+          ${(() => {
+            const humanReactionNote = Array.isArray(this.notes)
+              ? this.notes.find((n) => n.location.type === "rater" && n.location.fieldName === "overall_judgement" && n.reaction)
+              : null;
+            const humanReaction = humanReactionNote?.reaction;
+            if (!humanReaction) return nothing;
+
+            const isGood = humanReaction === "good";
+            const color = isGood ? "#34a853" : "#ea4335";
+            const text = isGood ? "Human Agrees" : "Marked AI Wrong";
+            const icon = isGood ? "thumb_up" : "thumb_down";
+
+            return html`<div style="display: flex; align-items: center; gap: var(--bb-grid-size-2); font-size: 11px; font-weight: 600; color: ${color}; margin-top: calc(-1 * var(--bb-grid-size)); margin-bottom: var(--bb-grid-size-2);">
+              <span class="g-icon filled round" style="font-size: 14px; color: ${color};">${icon}</span>
+              <span>${text}</span>
+            </div>`;
+          })()}
           <button @click=${() => this.#showRaterModal()}>Show Details</button>
           <button 
             style="margin-top: var(--bb-grid-size); ${(this.notes || []).length > 0 ? '' : 'opacity: 0.5;'}" 

--- a/packages/visual-editor/eval/viewer/src/ui/simplified-file-list.ts
+++ b/packages/visual-editor/eval/viewer/src/ui/simplified-file-list.ts
@@ -181,6 +181,14 @@ class EvalSimplifiedFileList extends LitElement {
                 ${count}
               </span>`
             : nothing}
+          ${f.humanJudgement
+            ? html`<span 
+                style="display: flex; align-items: center; justify-content: center; width: 20px; height: 20px; border-radius: 50%; background: ${f.humanJudgement === "good" ? "#34a853" : "#ea4335"}; color: white; border: 1px solid white; box-shadow: 0 1px 3px rgba(0,0,0,0.1); flex-shrink: 0;"
+                title=${f.humanJudgement === "good" ? "Human Rater Agrees" : "Human Marked AI as Wrong"}
+              >
+                <span class="g-icon filled round" style="font-size: 11px;">${f.humanJudgement === "good" ? "thumb_up" : "thumb_down"}</span>
+              </span>`
+            : nothing}
           ${ratingIcon
             ? html`<span class=${classMap(ratingClass)} title="Rating: ${rating}">
                 <span class="g-icon filled round">${ratingIcon}</span>


### PR DESCRIPTION
## What
Enhance the Breadboard Evaluation Viewer to parse and surface human rater judgements (agreements and disagreements) by extracting and visualizing thumbs-up and thumbs-down reaction notes placed on AI evaluation fields.

## Why
Enables users to quickly inspect evaluation runs, audit AI Rater accuracy, and readily distinguish where human reviewers agree with AI judgements or flagged the AI as incorrect.

## Changes
- **Packages/Visual-Editor/Eval/Viewer**:
  - **[parse-file-name.ts](file:///Users/dglazkov/Documents/code/breadboard-2/packages/visual-editor/eval/viewer/src/parse-file-name.ts)**: Augmented the `ParsedFileMedata` interface with an optional `humanJudgement` field.
  - **[filesystem.ts](file:///Users/dglazkov/Documents/code/breadboard-2/packages/visual-editor/eval/viewer/src/filesystem.ts)**: Upgraded `FileSystemEvalBackend.query()` to parse `.notes.json` sidecar files and map reactions from the `overall_judgement` rater location.
  - **[simplified-file-list.ts](file:///Users/dglazkov/Documents/code/breadboard-2/packages/visual-editor/eval/viewer/src/ui/simplified-file-list.ts)**: Implemented floating reaction badges popping next to rating metadata in the file list.
  - **[bgl-viewer.ts](file:///Users/dglazkov/Documents/code/breadboard-2/packages/visual-editor/eval/viewer/src/ui/bgl-viewer.ts)**: Extended the floating evaluation indicator to reflect "Human Agrees" or "Marked AI Wrong" states based on recorded human rater feedback.

## Testing
1. Launch `eval:viewer` on evaluation datasets with populated `.notes.json` files.
2. Provide a thumbs-up or thumbs-down note on the Rater Details' `overall_judgement` field.
3. Observe the newly populated reactive indicators update both in the left sidebar and top-right viewer panel.
