### PR TITLE
[opie] Transition Input Asset Scratchpad to `GraphAssetDescriptor`

### DIFF
--- a/packages/visual-editor/src/sca/actions/agent/graph-editing-agent-actions.ts
+++ b/packages/visual-editor/src/sca/actions/agent/graph-editing-agent-actions.ts
@@ -66,7 +66,7 @@ let pendingResolve: ((response: ChatResponse) => void) | null = null;
  */
 function startGraphEditingAgent(
   firstMessage: string,
-  assets?: LLMContent[]
+  assets?: GraphAssetDescriptor[]
 ): void {
   const { controller, services } = bind;
   const agent = controller.editor.graphEditingAgent;
@@ -82,7 +82,9 @@ function startGraphEditingAgent(
   };
 
   if (assets && assets.length > 0) {
-    objective.parts.push(...assets.flatMap((a) => a.parts));
+    objective.parts.push(
+      ...assets.flatMap((a) => a.data.flatMap((d) => d.parts))
+    );
   }
 
   const factory = services.sandbox as A2ModuleFactory;
@@ -259,6 +261,8 @@ function startGraphEditingAgent(
     });
 }
 
+import type { GraphAssetDescriptor } from "../../types.js";
+
 /**
  * Resolve the pending `waitForInput` suspend event with user text.
  * Constructs a `ChatResponse` and resolves the consumer handler's Promise.
@@ -266,7 +270,7 @@ function startGraphEditingAgent(
  */
 function resolveGraphEditingInput(
   text: string,
-  assets?: LLMContent[]
+  assets?: GraphAssetDescriptor[]
 ): boolean {
   if (!pendingResolve) return false;
   const resolve = pendingResolve;
@@ -278,7 +282,7 @@ function resolveGraphEditingInput(
 
   const parts: DataPart[] = [{ text }];
   if (assets && assets.length > 0) {
-    parts.push(...assets.flatMap((a) => a.parts));
+    parts.push(...assets.flatMap((a) => a.data.flatMap((d) => d.parts)));
   }
 
   resolve({ input: { parts } });

--- a/packages/visual-editor/src/sca/actions/input-asset/input-asset-actions.ts
+++ b/packages/visual-editor/src/sca/actions/input-asset/input-asset-actions.ts
@@ -22,6 +22,7 @@ import { NOTEBOOKLM_MIMETYPE, toNotebookLmUrl } from "@breadboard-ai/utils";
 import { makeAction } from "../binder.js";
 import { asAction, ActionMode } from "../../coordination.js";
 import type { NotebookPickedValue } from "../../controller/subcontrollers/editor/notebooklm-picker-controller.js";
+import type { GraphAssetDescriptor } from "../../types.js";
 
 export { bind, addFromModal, addFromNotebookLm };
 
@@ -30,25 +31,57 @@ const bind = makeAction();
 /**
  * Add an asset from the add-asset modal (upload, YouTube, drawable, etc.).
  *
- * The modal produces an `LLMContent` — this action simply deposits it
- * into the input asset controller. Exists as an action (rather than a
- * direct controller call) for coordination visibility and future
- * extensibility (e.g. telemetry, validation).
+ * Coordinates depositing a `GraphAssetDescriptor` into the input asset
+ * controller. Accepts either a complete `GraphAssetDescriptor` or lifts
+ * a plain `LLMContent` into a descriptor with synthesized metadata and path.
  */
 const addFromModal = asAction(
   "InputAsset.addFromModal",
   { mode: ActionMode.Immediate },
-  async (asset: LLMContent): Promise<void> => {
+  async (assetOrContent: GraphAssetDescriptor | LLMContent): Promise<void> => {
     const { controller } = bind;
-    controller.editor.inputAssets.add(asset);
+
+    let descriptor: GraphAssetDescriptor;
+    if ("data" in assetOrContent && "path" in assetOrContent) {
+      descriptor = assetOrContent as GraphAssetDescriptor;
+    } else {
+      const content = assetOrContent as LLMContent;
+      let title = "Attachment";
+      
+      // Attempt to infer a friendly title from the parts
+      for (const part of content.parts) {
+        if ("inlineData" in part && part.inlineData.mimeType) {
+          if (part.inlineData.mimeType.startsWith("image/")) title = "Image Attachment";
+          else if (part.inlineData.mimeType.startsWith("audio/")) title = "Audio Attachment";
+          else if (part.inlineData.mimeType.startsWith("video/")) title = "Video Attachment";
+          else if (part.inlineData.mimeType.includes("pdf")) title = "PDF Document";
+          else if (part.inlineData.mimeType.startsWith("text/")) title = "Text File";
+          break;
+        } else if ("storedData" in part) {
+          title = "Stored Attachment";
+          break;
+        }
+      }
+
+      descriptor = {
+        metadata: {
+          title,
+          type: "file",
+        },
+        path: `asset-${globalThis.crypto.randomUUID().slice(0, 8)}.webp`,
+        data: [content],
+      };
+    }
+
+    controller.editor.inputAssets.add(descriptor);
   }
 );
 
 /**
  * Add notebooks from the NotebookLM picker result.
  *
- * Converts each `NotebookPickedValue` into an `LLMContent` with a
- * `storedData` part and deposits it into the input asset controller.
+ * Converts each `NotebookPickedValue` into a `GraphAssetDescriptor` and deposits
+ * it into the input asset controller.
  */
 const addFromNotebookLm = asAction(
   "InputAsset.addFromNotebookLm",
@@ -58,18 +91,27 @@ const addFromNotebookLm = asAction(
     const inputAssets = controller.editor.inputAssets;
 
     for (const notebook of notebooks) {
-      const asset: LLMContent = {
-        role: "user",
-        parts: [
+      const descriptor: GraphAssetDescriptor = {
+        metadata: {
+          title: notebook.preview || notebook.name || "Notebook",
+          type: "file",
+        },
+        path: `asset-${globalThis.crypto.randomUUID().slice(0, 8)}.webp`,
+        data: [
           {
-            storedData: {
-              handle: toNotebookLmUrl(notebook.id),
-              mimeType: NOTEBOOKLM_MIMETYPE,
-            },
+            role: "user",
+            parts: [
+              {
+                storedData: {
+                  handle: toNotebookLmUrl(notebook.id),
+                  mimeType: NOTEBOOKLM_MIMETYPE,
+                },
+              },
+            ],
           },
         ],
       };
-      inputAssets.add(asset);
+      inputAssets.add(descriptor);
     }
   }
 );

--- a/packages/visual-editor/src/sca/controller/subcontrollers/editor/input-assets/input-asset-controller.ts
+++ b/packages/visual-editor/src/sca/controller/subcontrollers/editor/input-assets/input-asset-controller.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { LLMContent } from "@breadboard-ai/types";
+import type { GraphAssetDescriptor } from "../../../../types.js";
 import { field } from "../../../decorators/field.js";
 import { RootController } from "../../root-controller.js";
 
@@ -26,12 +26,12 @@ export { InputAssetController };
  */
 class InputAssetController extends RootController {
   @field({ deep: false })
-  private accessor _assets: LLMContent[] = [];
+  private accessor _assets: GraphAssetDescriptor[] = [];
 
   /**
    * The current pending assets. Read-only view for UI rendering.
    */
-  get assets(): readonly LLMContent[] {
+  get assets(): readonly GraphAssetDescriptor[] {
     return this._assets;
   }
 
@@ -45,14 +45,14 @@ class InputAssetController extends RootController {
   /**
    * Add an asset to the pending collection.
    */
-  add(asset: LLMContent): void {
+  add(asset: GraphAssetDescriptor): void {
     this._assets = [...this._assets, asset];
   }
 
   /**
    * Remove a specific asset by reference identity.
    */
-  remove(asset: LLMContent): void {
+  remove(asset: GraphAssetDescriptor): void {
     this._assets = this._assets.filter((a) => a !== asset);
   }
 
@@ -60,7 +60,7 @@ class InputAssetController extends RootController {
    * Return all pending assets and clear the shelf.
    * Used at submit time to merge assets into the outgoing message.
    */
-  drain(): LLMContent[] {
+  drain(): GraphAssetDescriptor[] {
     const drained = [...this._assets];
     this._assets = [];
     return drained;
@@ -73,3 +73,4 @@ class InputAssetController extends RootController {
     this._assets = [];
   }
 }
+

--- a/packages/visual-editor/src/ui/elements/graph-editing-chat/input-asset-shelf.ts
+++ b/packages/visual-editor/src/ui/elements/graph-editing-chat/input-asset-shelf.ts
@@ -10,7 +10,8 @@ import { customElement } from "lit/decorators.js";
 import { SignalWatcher } from "@lit-labs/signals";
 import { scaContext } from "../../../sca/context/context.js";
 import type { SCA } from "../../../sca/sca.js";
-import type { LLMContent } from "@breadboard-ai/types";
+
+import type { GraphAssetDescriptor } from "../../../sca/types.js";
 import { icons } from "../../styles/icons.js";
 import {
   isInlineData,
@@ -139,67 +140,75 @@ class InputAssetShelf extends SignalWatcher(LitElement) {
     `;
   }
 
-  #renderThumb(asset: LLMContent) {
+  #renderThumb(asset: GraphAssetDescriptor) {
     const inputAssets = this.sca.controller.editor.inputAssets;
     let preview: ReturnType<typeof html> | typeof nothing = nothing;
     let icon = "attachment";
+    const title = asset.metadata?.title || "";
 
-    for (const part of asset.parts) {
-      if (isInlineData(part)) {
-        if (part.inlineData.mimeType.startsWith("image")) {
-          preview = html`<img
-            src="data:${part.inlineData.mimeType};base64,${part.inlineData
-              .data}"
-          />`;
-          break;
-        }
-        if (part.inlineData.mimeType.startsWith("audio")) {
-          icon = "mic";
-          break;
-        }
-        if (part.inlineData.mimeType.startsWith("video")) {
-          icon = "movie";
-          break;
-        }
-        if (part.inlineData.mimeType.includes("pdf")) {
-          icon = "drive_pdf";
-          break;
-        }
-        if (part.inlineData.mimeType.startsWith("text")) {
-          icon = "text_fields";
-          break;
-        }
-      } else if (isFileDataCapabilityPart(part)) {
-        if (part.fileData.mimeType === "video/mp4") {
-          let uri: string | null = part.fileData.fileUri;
-          if (isWatchUri(uri) || isShortsUri(uri)) {
-            uri = convertWatchOrShortsUriToEmbedUri(uri);
-          } else if (isShareUri(uri)) {
-            uri = convertShareUriToEmbedUri(uri);
+    for (const data of asset.data) {
+      for (const part of data.parts) {
+        if (isInlineData(part)) {
+          if (part.inlineData.mimeType.startsWith("image")) {
+            preview = html`<img
+              src="data:${part.inlineData.mimeType};base64,${part.inlineData
+                .data}"
+              title="${title}"
+            />`;
+            break;
           }
-          if (uri && isEmbedUri(uri)) {
-            const videoId = videoIdFromWatchOrShortsOrEmbedUri(uri);
-            if (videoId) {
-              preview = html`<img
-                src="https://img.youtube.com/vi/${videoId}/mqdefault.jpg"
-              />`;
+          if (part.inlineData.mimeType.startsWith("audio")) {
+            icon = "mic";
+            break;
+          }
+          if (part.inlineData.mimeType.startsWith("video")) {
+            icon = "movie";
+            break;
+          }
+          if (part.inlineData.mimeType.includes("pdf")) {
+            icon = "drive_pdf";
+            break;
+          }
+          if (part.inlineData.mimeType.startsWith("text")) {
+            icon = "text_fields";
+            break;
+          }
+        } else if (isFileDataCapabilityPart(part)) {
+          if (part.fileData.mimeType === "video/mp4") {
+            let uri: string | null = part.fileData.fileUri;
+            if (isWatchUri(uri) || isShortsUri(uri)) {
+              uri = convertWatchOrShortsUriToEmbedUri(uri);
+            } else if (isShareUri(uri)) {
+              uri = convertShareUriToEmbedUri(uri);
             }
+            if (uri && isEmbedUri(uri)) {
+              const videoId = videoIdFromWatchOrShortsOrEmbedUri(uri);
+              if (videoId) {
+                preview = html`<img
+                  src="https://img.youtube.com/vi/${videoId}/mqdefault.jpg"
+                  title="${title}"
+                />`;
+              }
+            }
+            icon = "smart_display";
+            break;
           }
-          icon = "smart_display";
+          icon = "insert_drive_file";
+        } else if (
+          isStoredData(part) &&
+          part.storedData.mimeType === NOTEBOOKLM_MIMETYPE
+        ) {
+          icon = "auto_stories";
           break;
         }
-        icon = "insert_drive_file";
-      } else if (
-        isStoredData(part) &&
-        part.storedData.mimeType === NOTEBOOKLM_MIMETYPE
-      ) {
-        icon = "auto_stories";
+      }
+      if (preview !== nothing) {
         break;
       }
     }
 
     return html`
-      <div class="thumb">
+      <div class="thumb" title="${title}">
         <div class="thumb-content">
           ${preview !== nothing
             ? preview
@@ -210,7 +219,7 @@ class InputAssetShelf extends SignalWatcher(LitElement) {
         <button
           class="remove"
           @click=${() => inputAssets.remove(asset)}
-          title="Remove"
+          title="Remove ${title}"
         >
           <span class="g-icon">close</span>
         </button>

--- a/packages/visual-editor/tests/sca/actions/agent/graph-editing-agent-actions.test.ts
+++ b/packages/visual-editor/tests/sca/actions/agent/graph-editing-agent-actions.test.ts
@@ -13,7 +13,7 @@ import {
   resetGraphEditingAgent,
 } from "../../../../src/sca/actions/agent/graph-editing-agent-actions.js";
 import { GraphEditingAgentController } from "../../../../src/sca/controller/subcontrollers/editor/graph-editing-agent-controller.js";
-import type { ChatEntry } from "../../../../src/sca/types.js";
+import type { ChatEntry, GraphAssetDescriptor } from "../../../../src/sca/types.js";
 import { DevToolsController } from "../../../../src/sca/controller/subcontrollers/editor/devtools/devtools-controller.js";
 import { AgentService } from "../../../../src/a2/agent/agent-service.js";
 import type { WaitForInputPayload } from "../../../../src/a2/agent/agent-event.js";
@@ -196,15 +196,21 @@ suite("graph-editing-agent-actions", () => {
 
     const startRunSpy = mock.method(services.agentService, "startRun");
 
-    const mockAssets = [
+    const mockAssets: GraphAssetDescriptor[] = [
       {
-        role: "user",
-        parts: [
+        metadata: { title: "Test Asset", type: "file" },
+        path: "asset-123.webp",
+        data: [
           {
-            inlineData: {
-              mimeType: "image/png",
-              data: "base64data",
-            },
+            role: "user",
+            parts: [
+              {
+                inlineData: {
+                  mimeType: "image/png",
+                  data: "base64data",
+                },
+              },
+            ],
           },
         ],
       },
@@ -215,7 +221,7 @@ suite("graph-editing-agent-actions", () => {
     assert.strictEqual(startRunSpy.mock.callCount(), 1);
     const callArgs = startRunSpy.mock.calls[0].arguments[0];
     assert.strictEqual(callArgs.objective.parts.length, 2);
-    assert.deepStrictEqual(callArgs.objective.parts[1], mockAssets[0].parts[0]);
+    assert.deepStrictEqual(callArgs.objective.parts[1], mockAssets[0].data[0].parts[0]);
   });
 
   test("resolveGraphEditingInput with assets resolves with multimodal parts", async () => {
@@ -249,15 +255,21 @@ suite("graph-editing-agent-actions", () => {
       },
     });
 
-    const mockAssets = [
+    const mockAssets: GraphAssetDescriptor[] = [
       {
-        role: "user",
-        parts: [
+        metadata: { title: "Test Asset", type: "file" },
+        path: "asset-123.webp",
+        data: [
           {
-            inlineData: {
-              mimeType: "image/png",
-              data: "base64data",
-            },
+            role: "user",
+            parts: [
+              {
+                inlineData: {
+                  mimeType: "image/png",
+                  data: "base64data",
+                },
+              },
+            ],
           },
         ],
       },
@@ -268,7 +280,7 @@ suite("graph-editing-agent-actions", () => {
     const response = await resultPromise;
     assert.deepStrictEqual(response, {
       input: {
-        parts: [{ text: "User response" }, mockAssets[0].parts[0]],
+        parts: [{ text: "User response" }, mockAssets[0].data[0].parts[0]],
       },
     });
 

--- a/packages/visual-editor/tests/sca/actions/input-asset/input-asset-actions.test.ts
+++ b/packages/visual-editor/tests/sca/actions/input-asset/input-asset-actions.test.ts
@@ -45,7 +45,8 @@ suite("InputAsset Actions", () => {
       await InputAsset.addFromModal(asset);
 
       assert.strictEqual(inputAssets.assets.length, 1);
-      assert.strictEqual(inputAssets.assets[0], asset);
+      assert.strictEqual(inputAssets.assets[0].metadata?.title, "Image Attachment");
+      assert.strictEqual(inputAssets.assets[0].data[0], asset);
     });
 
     test("adds multiple assets sequentially", async () => {
@@ -65,8 +66,8 @@ suite("InputAsset Actions", () => {
       await InputAsset.addFromModal(a2);
 
       assert.strictEqual(inputAssets.assets.length, 2);
-      assert.strictEqual(inputAssets.assets[0], a1);
-      assert.strictEqual(inputAssets.assets[1], a2);
+      assert.strictEqual(inputAssets.assets[0].data[0], a1);
+      assert.strictEqual(inputAssets.assets[1].data[0], a2);
     });
   });
 
@@ -91,9 +92,13 @@ suite("InputAsset Actions", () => {
 
       // First notebook
       const first = inputAssets.assets[0];
-      assert.strictEqual(first.role, "user");
-      assert.strictEqual(first.parts.length, 1);
-      const firstPart = first.parts[0];
+      assert.strictEqual(first.metadata?.title, "My Notebook");
+      assert.strictEqual(first.metadata?.type, "file");
+      assert.ok(first.path);
+      assert.strictEqual(first.data.length, 1);
+      assert.strictEqual(first.data[0].role, "user");
+      assert.strictEqual(first.data[0].parts.length, 1);
+      const firstPart = first.data[0].parts[0];
       assert.ok("storedData" in firstPart);
       assert.strictEqual(
         firstPart.storedData.handle,
@@ -103,7 +108,10 @@ suite("InputAsset Actions", () => {
 
       // Second notebook
       const second = inputAssets.assets[1];
-      const secondPart = second.parts[0];
+      assert.strictEqual(second.metadata?.title, "Other Notebook");
+      assert.strictEqual(second.metadata?.type, "file");
+      assert.ok(second.path);
+      const secondPart = second.data[0].parts[0];
       assert.ok("storedData" in secondPart);
       assert.strictEqual(
         secondPart.storedData.handle,

--- a/packages/visual-editor/tests/sca/controller/subcontrollers/editor/input-asset-controller.test.ts
+++ b/packages/visual-editor/tests/sca/controller/subcontrollers/editor/input-asset-controller.test.ts
@@ -6,17 +6,29 @@
 
 import assert from "node:assert";
 import { suite, test } from "node:test";
-import type { LLMContent } from "@breadboard-ai/types";
+
 import { InputAssetController } from "../../../../../src/sca/controller/subcontrollers/editor/input-assets/input-asset-controller.js";
 
-function makeAsset(text: string): LLMContent {
-  return { role: "user", parts: [{ text }] };
+import type { GraphAssetDescriptor } from "../../../../../src/sca/types.js";
+
+function makeAsset(text: string): GraphAssetDescriptor {
+  return {
+    metadata: { title: text, type: "file" },
+    path: `asset-${globalThis.crypto.randomUUID().slice(0, 8)}.webp`,
+    data: [{ role: "user", parts: [{ text }] }],
+  };
 }
 
-function makeImageAsset(): LLMContent {
+function makeImageAsset(): GraphAssetDescriptor {
   return {
-    role: "user",
-    parts: [{ inlineData: { data: "iVBOR...", mimeType: "image/png" } }],
+    metadata: { title: "Image", type: "file" },
+    path: `asset-${globalThis.crypto.randomUUID().slice(0, 8)}.webp`,
+    data: [
+      {
+        role: "user",
+        parts: [{ inlineData: { data: "iVBOR...", mimeType: "image/png" } }],
+      },
+    ],
   };
 }
 


### PR DESCRIPTION
## What
Refactored the ephemeral Input Asset scratchpad infrastructure from using raw `LLMContent` to `GraphAssetDescriptor`. This establishes full metadata compatibility with saved graph assets, enabling rich labeling, distinct path tracing, and robust rendering.

## Why
Operating in terms of `GraphAssetDescriptor` across input controllers and actions preserves essential descriptive metadata (titles, asset types, visual annotations) created during asset ingestion (upload modals, NotebookLM, YouTube links), avoiding property loss when transferring data parts to active agents or appending them into outgoing prompts.

## Changes
- **SCA Controller**:
  - Migrated [InputAssetController](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/src/sca/controller/subcontrollers/editor/input-assets/input-asset-controller.ts) to hold and manage `GraphAssetDescriptor[]`.
- **Actions Orchestration**:
  - Upgraded `InputAsset.addFromModal` and `InputAsset.addFromNotebookLm` in [input-asset-actions.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/src/sca/actions/input-asset/input-asset-actions.ts) to yield rich Graph Asset Descriptors.
  - Refactored `startGraphEditingAgent` and `resolveGraphEditingInput` in [graph-editing-agent-actions.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/src/sca/actions/agent/graph-editing-agent-actions.ts) to process incoming descriptors securely.
- **UI & Rendering Layers**:
  - Enabled [InputAssetShelf](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/src/ui/elements/graph-editing-chat/input-asset-shelf.ts) to map descriptive metadata titles to thumbnail views and tooltip controls.

## Testing
1. **Automated Verification**: Run `npm run test:file -- './dist/tsc/tests/sca/actions/input-asset/input-asset-actions.test.js'` to confirm action lifters assemble `GraphAssetDescriptor` instances accurately.
2. **Visual Inspection**: Open the Graph Editing chat view and attach various file types; thumbnails should correctly respond to and highlight metadata.
