### PR TITLE
[opie] Enriched Structured Asset Metadata Pipeline

### DIFF
--- a/packages/visual-editor/src/sca/actions/input-asset/input-asset-actions.ts
+++ b/packages/visual-editor/src/sca/actions/input-asset/input-asset-actions.ts
@@ -16,7 +16,7 @@
  * that requires Services or cross-controller coordination.
  */
 
-import type { LLMContent } from "@breadboard-ai/types";
+import type { AssetMetadata, LLMContent } from "@breadboard-ai/types";
 import { NOTEBOOKLM_MIMETYPE, toNotebookLmUrl } from "@breadboard-ai/utils";
 
 import { makeAction } from "../binder.js";
@@ -38,37 +38,46 @@ const bind = makeAction();
 const addFromModal = asAction(
   "InputAsset.addFromModal",
   { mode: ActionMode.Immediate },
-  async (assetOrContent: GraphAssetDescriptor | LLMContent): Promise<void> => {
+  async (
+    assetOrContent: GraphAssetDescriptor | LLMContent,
+    metadata?: AssetMetadata
+  ): Promise<void> => {
     const { controller } = bind;
 
     let descriptor: GraphAssetDescriptor;
     if ("data" in assetOrContent && "path" in assetOrContent) {
       descriptor = assetOrContent as GraphAssetDescriptor;
     } else {
+      if (!metadata) {
+        throw new Error("Metadata is required when adding raw LLMContent assets");
+      }
       const content = assetOrContent as LLMContent;
-      let title = "Attachment";
-      
-      // Attempt to infer a friendly title from the parts
-      for (const part of content.parts) {
-        if ("inlineData" in part && part.inlineData.mimeType) {
-          if (part.inlineData.mimeType.startsWith("image/")) title = "Image Attachment";
-          else if (part.inlineData.mimeType.startsWith("audio/")) title = "Audio Attachment";
-          else if (part.inlineData.mimeType.startsWith("video/")) title = "Video Attachment";
-          else if (part.inlineData.mimeType.includes("pdf")) title = "PDF Document";
-          else if (part.inlineData.mimeType.startsWith("text/")) title = "Text File";
-          break;
-        } else if ("storedData" in part) {
-          title = "Stored Attachment";
-          break;
+
+      // Infer extension from subType or title
+      let ext = "webp";
+      const mime = (metadata.subType || "").toLowerCase();
+      if (mime.includes("png")) ext = "png";
+      else if (mime.includes("jpeg") || mime.includes("jpg")) ext = "jpg";
+      else if (mime.includes("pdf")) ext = "pdf";
+      else if (mime.includes("mp4")) ext = "mp4";
+      else if (mime.includes("webm")) ext = "webm";
+      else if (mime.includes("csv")) ext = "csv";
+      else if (mime.includes("html")) ext = "html";
+      else if (mime.includes("json")) ext = "json";
+      else if (mime.includes("text/plain") || mime.includes("text/"))
+        ext = "txt";
+
+      if (metadata.title && metadata.title.includes(".")) {
+        const parts = metadata.title.split(".");
+        const last = parts[parts.length - 1].toLowerCase();
+        if (last.length >= 1 && last.length <= 4) {
+          ext = last;
         }
       }
 
       descriptor = {
-        metadata: {
-          title,
-          type: "file",
-        },
-        path: `asset-${globalThis.crypto.randomUUID().slice(0, 8)}.webp`,
+        metadata,
+        path: `asset-${globalThis.crypto.randomUUID().slice(0, 8)}.${ext}`,
         data: [content],
       };
     }

--- a/packages/visual-editor/src/ui/elements/graph-editing-chat/chat-panel.ts
+++ b/packages/visual-editor/src/ui/elements/graph-editing-chat/chat-panel.ts
@@ -730,7 +730,7 @@ class ChatPanel extends SignalWatcher(LitElement) {
         this.#showAddAssetModal = false;
         this.#addAssetType = null;
         this.#allowedMimeTypes = null;
-        this.sca.actions.inputAsset.addFromModal(evt.asset);
+        this.sca.actions.inputAsset.addFromModal(evt.asset, evt.metadata);
         this.requestUpdate();
       }}
     ></bb-add-asset-modal>`;

--- a/packages/visual-editor/src/ui/elements/input/add-asset/add-asset-modal.ts
+++ b/packages/visual-editor/src/ui/elements/input/add-asset/add-asset-modal.ts
@@ -17,7 +17,7 @@ import {
   OverlayDismissedEvent,
 } from "../../../events/events.js";
 import { createRef, ref, Ref } from "lit/directives/ref.js";
-import { InlineDataCapabilityPart, LLMContent } from "@breadboard-ai/types";
+import { AssetMetadata, LLMContent } from "@breadboard-ai/types";
 import { DrawableInput } from "../drawable/drawable.js";
 import { GoogleDriveFileId } from "../../google-drive/google-drive-file-id.js";
 import { WebcamVideoInput } from "../webcam/webcam-video.js";
@@ -207,8 +207,6 @@ export class AddAssetModal extends LitElement {
       "input,select,textarea,bb-drawable-input,bb-webcam-video-input,bb-google-drive-file-id"
     );
 
-    let canSubmit = true;
-    let item: LLMContent | null = null;
     for (const input of inputs) {
       const isPlatformInputField = !(
         input instanceof DrawableInput ||
@@ -217,10 +215,10 @@ export class AddAssetModal extends LitElement {
       );
       if (isPlatformInputField && !input.checkValidity()) {
         input.reportValidity();
-        canSubmit = false;
         continue;
       }
 
+      let item: LLMContent;
       switch (this.assetType) {
         case "youtube": {
           if (!isPlatformInputField) {
@@ -233,6 +231,13 @@ export class AddAssetModal extends LitElement {
               { fileData: { fileUri: input.value, mimeType: "video/mp4" } },
             ],
           };
+          const metadata: AssetMetadata = {
+            title: "YouTube Video",
+            type: "file",
+            subType: "video/mp4",
+          };
+
+          this.dispatchEvent(new AddAssetEvent(item, metadata));
           break;
         }
 
@@ -252,6 +257,13 @@ export class AddAssetModal extends LitElement {
               },
             ],
           };
+          const metadata: AssetMetadata = {
+            title: "Drawing",
+            type: "file",
+            subType: input.type,
+          };
+
+          this.dispatchEvent(new AddAssetEvent(item, metadata));
           break;
         }
 
@@ -272,6 +284,13 @@ export class AddAssetModal extends LitElement {
                 },
               ],
             };
+            const metadata: AssetMetadata = {
+              title: "Webcam Video",
+              type: "file",
+              subType: input.type,
+            };
+
+            this.dispatchEvent(new AddAssetEvent(item, metadata));
           } catch (err) {
             // The user hasn't recorded anything.
             console.warn(err);
@@ -296,6 +315,13 @@ export class AddAssetModal extends LitElement {
               },
             ],
           };
+          const metadata: AssetMetadata = {
+            title: input.metadata?.docName || input.docName || "Google Drive File",
+            type: "file",
+            subType: input.value.mimeType,
+          };
+
+          this.dispatchEvent(new AddAssetEvent(item, metadata));
           break;
         }
 
@@ -304,14 +330,14 @@ export class AddAssetModal extends LitElement {
             break;
           }
 
-          if (!input.files) {
+          if (!input.files || input.files.length === 0) {
             break;
           }
 
-          const fileData: Promise<InlineDataCapabilityPart>[] = [
-            ...input.files,
-          ].map((file) => {
-            return new Promise((resolve, reject) => {
+          for (const file of [...input.files]) {
+            const dataUrlPromise = new Promise<{
+              inlineData: { data: string; mimeType: string };
+            }>((resolve, reject) => {
               const fileReader = new FileReader();
               fileReader.onloadend = () => {
                 const premable = `data:${file.type};base64,`.length;
@@ -327,24 +353,26 @@ export class AddAssetModal extends LitElement {
               fileReader.onerror = () => reject();
               fileReader.readAsDataURL(file);
             });
-          });
 
-          const parts = await Promise.all(fileData);
-          item = {
-            role: "user",
-            parts,
-          };
+            const part = await dataUrlPromise;
+            const singleItem: LLMContent = {
+              role: "user",
+              parts: [part],
+            };
+
+            const metadata: AssetMetadata = {
+              title: file.name,
+              type: "file",
+              subType: file.type,
+            };
+
+            this.dispatchEvent(new AddAssetEvent(singleItem, metadata));
+          }
 
           break;
         }
       }
     }
-
-    if (!canSubmit || !item) {
-      return;
-    }
-
-    this.dispatchEvent(new AddAssetEvent(item));
   }
 
   protected updated(): void {

--- a/packages/visual-editor/src/ui/events/events.ts
+++ b/packages/visual-editor/src/ui/events/events.ts
@@ -5,6 +5,7 @@
  */
 
 import type {
+  AssetMetadata,
   GraphIdentifier,
   GraphMetadata,
   InspectablePort,
@@ -1039,7 +1040,10 @@ export class AddAssetRequestEvent extends Event {
 export class AddAssetEvent extends Event {
   static eventName = "bbaddasset";
 
-  constructor(public readonly asset: LLMContent) {
+  constructor(
+    public readonly asset: LLMContent,
+    public readonly metadata?: AssetMetadata
+  ) {
     super(AddAssetEvent.eventName, { ...eventInit });
   }
 }

--- a/packages/visual-editor/tests/sca/actions/input-asset/input-asset-actions.test.ts
+++ b/packages/visual-editor/tests/sca/actions/input-asset/input-asset-actions.test.ts
@@ -6,7 +6,7 @@
 
 import assert from "node:assert";
 import { suite, test } from "node:test";
-import type { LLMContent } from "@breadboard-ai/types";
+import type { AssetMetadata, LLMContent } from "@breadboard-ai/types";
 import * as InputAsset from "../../../../src/sca/actions/input-asset/input-asset-actions.js";
 import { AppController } from "../../../../src/sca/controller/controller.js";
 import { AppServices } from "../../../../src/sca/services/services.js";
@@ -42,11 +42,77 @@ suite("InputAsset Actions", () => {
         parts: [{ inlineData: { data: "base64data", mimeType: "image/png" } }],
       };
 
-      await InputAsset.addFromModal(asset);
+      const metadata: AssetMetadata = {
+        title: "Image Attachment",
+        type: "file",
+        subType: "image/png",
+      };
+
+      await InputAsset.addFromModal(asset, metadata);
 
       assert.strictEqual(inputAssets.assets.length, 1);
       assert.strictEqual(inputAssets.assets[0].metadata?.title, "Image Attachment");
       assert.strictEqual(inputAssets.assets[0].data[0], asset);
+    });
+
+    test("throws an error when adding raw LLMContent without metadata", async () => {
+      const inputAssets = makeInputAssetController();
+      bindWithController(inputAssets);
+
+      const asset: LLMContent = {
+        role: "user",
+        parts: [{ text: "missing metadata" }],
+      };
+
+      await assert.rejects(
+        InputAsset.addFromModal(asset),
+        /Metadata is required when adding raw LLMContent assets/
+      );
+    });
+
+    test("adds an asset with explicit AssetMetadata", async () => {
+      const inputAssets = makeInputAssetController();
+      bindWithController(inputAssets);
+
+      const asset: LLMContent = {
+        role: "user",
+        parts: [{ inlineData: { data: "base64", mimeType: "application/pdf" } }],
+      };
+
+      const metadata: AssetMetadata = {
+        title: "Report.pdf",
+        type: "file",
+        subType: "application/pdf",
+      };
+
+      await InputAsset.addFromModal(asset, metadata);
+
+      assert.strictEqual(inputAssets.assets.length, 1);
+      assert.strictEqual(inputAssets.assets[0].metadata?.title, "Report.pdf");
+      assert.strictEqual(inputAssets.assets[0].metadata?.subType, "application/pdf");
+      assert.strictEqual(inputAssets.assets[0].metadata?.type, "file");
+      assert.ok(inputAssets.assets[0].path.endsWith(".pdf"));
+    });
+
+    test("derives correct file extension from subType fallback", async () => {
+      const inputAssets = makeInputAssetController();
+      bindWithController(inputAssets);
+
+      const asset: LLMContent = {
+        role: "user",
+        parts: [{ inlineData: { data: "csvdata", mimeType: "text/csv" } }],
+      };
+
+      const metadata: AssetMetadata = {
+        title: "data",
+        type: "file",
+        subType: "text/csv",
+      };
+
+      await InputAsset.addFromModal(asset, metadata);
+
+      assert.strictEqual(inputAssets.assets.length, 1);
+      assert.ok(inputAssets.assets[0].path.endsWith(".csv"));
     });
 
     test("adds multiple assets sequentially", async () => {
@@ -62,8 +128,11 @@ suite("InputAsset Actions", () => {
         parts: [{ inlineData: { data: "img", mimeType: "image/jpeg" } }],
       };
 
-      await InputAsset.addFromModal(a1);
-      await InputAsset.addFromModal(a2);
+      const m1: AssetMetadata = { title: "first", type: "file" };
+      const m2: AssetMetadata = { title: "img", type: "file", subType: "image/jpeg" };
+
+      await InputAsset.addFromModal(a1, m1);
+      await InputAsset.addFromModal(a2, m2);
 
       assert.strictEqual(inputAssets.assets.length, 2);
       assert.strictEqual(inputAssets.assets[0].data[0], a1);


### PR DESCRIPTION
## What
Enriches the media ingestion pipeline by creating and propagating structured `AssetMetadata` across the `AddAssetEvent` and Visual Editor SCA action layers.

## Why
This transition provides Breadboard's Graph Engine with the native format information, pristine titles, and precise MIME types required to assemble valid `GraphDescriptor` topologies dynamically without relying on generic backend inference fallbacks.

## Changes
### UI Elements (`packages/visual-editor/src/ui/`)
- **`events.ts`**: Upgraded `AddAssetEvent` to support carrying a structured `AssetMetadata` payload.
- **`add-asset-modal.ts`**: Extracted granular title and MIME subTypes for YouTube, Google Drive, Webcam, Drawings, and uploaded files. Updated the multi-file Uploader to map each selected file to its own structured event.
- **`chat-panel.ts`**: Wired the chat panel to pass the enriched metadata directly to the SCA Action.

### SCA Layers (`packages/visual-editor/src/sca/`)
- **`input-asset-actions.ts`**: Redesigned `addFromModal` to enforce structured metadata parameter presence, deriving dynamic file extensions for stored asset paths based on precise MIME-type and title inputs.

## Testing
Verify with existing and expanded action tests by running:
```bash
npm run test:file -- './dist/tsc/tests/sca/actions/input-asset/input-asset-actions.test.js'
```
