### PR TITLE
[opie] Visual Editor Ingestion and Presentation Enhancements

### DIFF
--- a/packages/visual-editor/src/a2/agent/graph-editing/graph-overview.ts
+++ b/packages/visual-editor/src/a2/agent/graph-editing/graph-overview.ts
@@ -84,6 +84,8 @@ function graphOverviewYaml(
       if (typeof visual.x === "number" && typeof visual.y === "number") {
         lines.push(`    x: ${Math.round(visual.x)}`);
         lines.push(`    y: ${Math.round(visual.y)}`);
+      } else {
+        lines.push(`    # Newly Added. TODO: Position this asset`);
       }
 
       if (canvas && typeof canvas.getAssetDimensions === "function") {

--- a/packages/visual-editor/src/ui/elements/graph-editing-chat/chat-panel.ts
+++ b/packages/visual-editor/src/ui/elements/graph-editing-chat/chat-panel.ts
@@ -679,17 +679,15 @@ class ChatPanel extends SignalWatcher(LitElement) {
     agent.addMessage("user", displayText + assetSuffix);
     this.#scrollToBottom();
 
-    if (
-      !this.sca.actions.graphEditingAgent.resolveGraphEditingInput(
-        text || "(see attachments)",
-        assets
-      )
-    ) {
-      agent.processing = true;
-      this.sca.actions.graphEditingAgent.startGraphEditingAgent(
-        text || "(see attachments)",
-        assets
-      );
+    for (const asset of assets) {
+      await this.sca.actions.asset.addGraphAsset(asset);
+    }
+
+    if (text) {
+      if (!this.sca.actions.graphEditingAgent.resolveGraphEditingInput(text)) {
+        agent.processing = true;
+        this.sca.actions.graphEditingAgent.startGraphEditingAgent(text);
+      }
     }
   }
 

--- a/packages/visual-editor/src/ui/utils/icon-substitute.ts
+++ b/packages/visual-editor/src/ui/utils/icon-substitute.ts
@@ -12,6 +12,23 @@
 export function iconSubstitute(
   src: string | undefined | null
 ): string | undefined | null {
+  if (src && typeof src === "string" && src.startsWith("application/vnd.google-apps.")) {
+    switch (src) {
+      case "application/vnd.google-apps.spreadsheet":
+        return "sheets";
+      case "application/vnd.google-apps.document":
+        return "docs";
+      case "application/vnd.google-apps.presentation":
+        return "drive_presentation";
+      case "application/vnd.google-apps.drawing":
+        return "draw";
+      case "application/vnd.google-apps.folder":
+        return "folder";
+      default:
+        return "drive";
+    }
+  }
+
   switch (src) {
     case "content":
       return "text_fields";

--- a/packages/visual-editor/tests/agent/graph-editing/graph-overview.test.ts
+++ b/packages/visual-editor/tests/agent/graph-editing/graph-overview.test.ts
@@ -316,5 +316,28 @@ describe("graphOverviewYaml", () => {
     ok(yaml.includes("x: 50"));
     ok(yaml.includes("y: 76"));
   });
+
+  it("includes YAML comment for unpositioned assets", () => {
+    const translator = new EditingAgentPidginTranslator();
+    const yaml = graphOverviewYaml(
+      {
+        title: "Test Graph",
+        assets: {
+          "/assets/doc.txt": {
+            metadata: {
+              title: "My Unpositioned Doc",
+              type: "file",
+            },
+            data: [],
+          },
+        },
+      },
+      [],
+      [],
+      translator
+    );
+
+    ok(yaml.includes("# Newly Added. TODO: Position this asset"));
+  });
 });
 

--- a/packages/visual-editor/tests/ui/icon-substitute.test.ts
+++ b/packages/visual-editor/tests/ui/icon-substitute.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from "node:assert";
+import { suite, test } from "node:test";
+import { iconSubstitute } from "../../src/ui/utils/icon-substitute.js";
+
+suite("iconSubstitute", () => {
+  test("returns valid Google Symbols for standard types", () => {
+    assert.equal(iconSubstitute("content"), "text_fields");
+    assert.equal(iconSubstitute("generative-text"), "spark");
+    assert.equal(iconSubstitute("generative"), "spark");
+    assert.equal(iconSubstitute("ask-user"), "chat_mirror");
+    assert.equal(iconSubstitute("map-search"), "map_search");
+    assert.equal(iconSubstitute("web-search"), "search");
+    assert.equal(iconSubstitute("file"), "upload");
+    assert.equal(iconSubstitute("gdrive"), "drive");
+    assert.equal(iconSubstitute("drawable"), "draw");
+    assert.equal(iconSubstitute("youtube"), "video_youtube");
+    assert.equal(iconSubstitute("display"), "responsive_layout");
+    assert.equal(iconSubstitute("output"), "responsive_layout");
+  });
+
+  test("returns valid Google Symbols for Google Drive MIME types", () => {
+    assert.equal(
+      iconSubstitute("application/vnd.google-apps.spreadsheet"),
+      "sheets"
+    );
+    assert.equal(
+      iconSubstitute("application/vnd.google-apps.document"),
+      "docs"
+    );
+    assert.equal(
+      iconSubstitute("application/vnd.google-apps.presentation"),
+      "drive_presentation"
+    );
+    assert.equal(iconSubstitute("application/vnd.google-apps.drawing"), "draw");
+    assert.equal(iconSubstitute("application/vnd.google-apps.folder"), "folder");
+  });
+
+  test("returns 'drive' as safe fallback for unrecognized Google Apps MIME types", () => {
+    assert.equal(
+      iconSubstitute("application/vnd.google-apps.site"),
+      "drive"
+    );
+    assert.equal(
+      iconSubstitute("application/vnd.google-apps.form"),
+      "drive"
+    );
+    assert.equal(
+      iconSubstitute("application/vnd.google-apps.unknown"),
+      "drive"
+    );
+  });
+
+  test("returns source string for unknown or null/undefined types", () => {
+    assert.equal(iconSubstitute("custom-icon"), "custom-icon");
+    assert.equal(iconSubstitute(null), null);
+    assert.equal(iconSubstitute(undefined), undefined);
+  });
+});


### PR DESCRIPTION
Delivered holistic improvements to Visual Editor asset ingestion and presentation: decoupled graph editing input from immediate asset persistence in the Chat Panel, enriched Graph YAML overview generation with unpositioned asset detection, and mapped Google Workspace Apps MIME types to proper Google Symbols ligatures in the Entity and Text Editors.

Users encountered missing visual iconography (fallback letter "A") for Google Drive documents due to unmapped MIME type ligatures. Concurrently, unpositioned assets were missing corresponding notation in YAML graph summaries, and Chat Panel asset insertions were bound to immediate reasoning triggers instead of decoupled persistence queues.

- **Agent Subsystem**:
  - Updated [graph-overview.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/src/a2/agent/graph-editing/graph-overview.ts) to detect missing visual coordinates and inject a TODO YAML comment for unpositioned assets.
  - Added unit test coverage for this YAML case in [graph-overview.test.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/tests/agent/graph-editing/graph-overview.test.ts).
- **UI & Chat**:
  - Updated [chat-panel.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/src/ui/elements/graph-editing-chat/chat-panel.ts) to fire decoupled `addGraphAsset` calls for chat attachments.
  - Updated [icon-substitute.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/src/ui/utils/icon-substitute.ts) mapping Google Drive `.spreadsheet`, `.document`, `.presentation`, `.drawing`, and `.folder` MIME types to high-fidelity ligatures with a default `"drive"` icon fallback.
- **Tests**:
  - Created [icon-substitute.test.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/tests/ui/icon-substitute.test.ts) covering standard, MIME-type, and generic Drive fallback tests for `iconSubstitute`.

Verify all changed and newly created suites using wireit:
```bash
npm run test:file -- './dist/tsc/tests/ui/icon-substitute.test.js'
npm run test:file -- './dist/tsc/tests/agent/graph-editing/graph-overview.test.js'
```
