### PR TITLE
[Heartstone] Phase 8a/b: Asset resolution & data part transforms

### DIFF
--- a/packages/opal-backend/opal_backend/graph_condense.py
+++ b/packages/opal-backend/opal_backend/graph_condense.py
@@ -125,6 +125,7 @@ def _create_condensed_graph(
         graphs=dict(graph.graphs) if graph.graphs else {},
         title=graph.title,
         description=graph.description,
+        assets=graph.assets,
     )
 
     for i, scc in enumerate(sccs):

--- a/packages/opal-backend/opal_backend/graph_plan.py
+++ b/packages/opal-backend/opal_backend/graph_plan.py
@@ -115,4 +115,4 @@ def create_plan(graph: GraphDescriptor) -> GraphPlan:
 
         queue = next_queue
 
-    return GraphPlan(stages=stages)
+    return GraphPlan(stages=stages, assets=graph.assets or {})

--- a/packages/opal-backend/opal_backend/graph_runner.py
+++ b/packages/opal-backend/opal_backend/graph_runner.py
@@ -205,14 +205,18 @@ class GraphRunner:
         # 3. Load node config.
         config = await self._store.get_node_config(session_id, node_id)
 
-        # 4. Build handler deps.
-        deps = self._build_handler_deps(session_id, node_id)
+        # 4. Load graph-level assets for template substitution.
+        plan = await self._store.get_plan(session_id)
+        assets = plan.assets if plan else {}
 
-        # 5. Determine node type and dispatch.
+        # 5. Build handler deps.
+        deps = self._build_handler_deps(session_id, node_id, assets)
+
+        # 6. Determine node type and dispatch.
         node_type = await self._get_node_type(session_id, node_id)
         outputs = await dispatch_handler(node_type, inputs, config, deps)
 
-        # 6. Complete node (save outputs, emit nodeEnd, schedule, check).
+        # 7. Complete node (save outputs, emit nodeEnd, schedule, check).
         await self._complete_node(session_id, node_id, outputs)
 
     async def _complete_node(
@@ -252,6 +256,7 @@ class GraphRunner:
 
     def _build_handler_deps(
         self, session_id: str, node_id: str,
+        assets: dict[str, Any] | None = None,
     ) -> NodeHandlerDeps:
         """Build handler dependencies for the current node."""
 
@@ -271,6 +276,7 @@ class GraphRunner:
             run_agent_fn=self._run_agent_fn,
             backend=self._backend_factory(token, origin) if self._backend_factory else None,
             interaction_store=self._interaction_store,
+            assets=assets,
         )
 
     async def _handle_suspend(

--- a/packages/opal-backend/opal_backend/graph_types.py
+++ b/packages/opal-backend/opal_backend/graph_types.py
@@ -122,6 +122,7 @@ class GraphDescriptor:
     graphs: dict[str, GraphDescriptor] | None = None
     title: str | None = None
     description: str | None = None
+    assets: dict[str, Any] | None = None
 
     @staticmethod
     def from_dict(d: dict[str, Any]) -> GraphDescriptor:
@@ -138,6 +139,7 @@ class GraphDescriptor:
             graphs=graphs,
             title=d.get("title"),
             description=d.get("description"),
+            assets=d.get("assets"),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -152,6 +154,8 @@ class GraphDescriptor:
             d["title"] = self.title
         if self.description is not None:
             d["description"] = self.description
+        if self.assets is not None:
+            d["assets"] = self.assets
         return d
 
 
@@ -185,6 +189,7 @@ class GraphPlan:
     """
 
     stages: list[list[PlanNodeInfo]] = field(default_factory=list)
+    assets: dict[str, Any] = field(default_factory=dict)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/opal-backend/opal_backend/node_handlers.py
+++ b/packages/opal-backend/opal_backend/node_handlers.py
@@ -72,6 +72,10 @@ class NodeHandlerDeps:
     interaction_store: Any = None
     graph_info: dict[str, Any] | None = None
 
+    # Graph-level assets — {path: {data: LLMContent[], metadata: ...}}.
+    # Used by template substitution to resolve asset references.
+    assets: dict[str, Any] | None = None
+
 
 def _extract_text_from_content(content: dict[str, Any]) -> str:
     """Extract plain text from an LLMContent dict."""
@@ -339,7 +343,7 @@ async def agent_handler(
         raise RuntimeError("agent_handler requires run_agent_fn in deps")
 
     # Build segments from inputs.
-    segments = _build_segments_from_inputs(inputs, config)
+    segments = _build_segments_from_inputs(inputs, config, deps.assets)
 
     agent_iter = deps.run_agent_fn(
         segments=segments,
@@ -402,6 +406,7 @@ async def consume_agent_events(
 def _build_segments_from_inputs(
     inputs: dict[str, list[Any]],
     config: dict[str, Any],
+    assets: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     """Build agent segments from node inputs and config.
 
@@ -421,9 +426,18 @@ def _build_segments_from_inputs(
     # Initial prompt from config (real Breadboard config$prompt).
     prompt = _get_prompt(config)
     if prompt:
-        # Substitute template placeholders with upstream input values.
-        prompt = _substitute_template(prompt, inputs)
+        # Substitute template placeholders with upstream input values
+        # and text-based assets.
+        prompt = _substitute_template(prompt, inputs, assets)
         segments.append({"type": "text", "text": prompt})
+
+        # Collect multimodal asset segments (images, PDFs, etc.).
+        # These are resolved from template placeholders with
+        # {"type": "asset"} — text substitution returns the text
+        # part, but binary parts need to be sent as separate
+        # asset segments for `to_pidgin()` to handle.
+        asset_segments = _collect_asset_segments(prompt, config, assets)
+        segments.extend(asset_segments)
 
     # Input context from upstream nodes — extract text from LLMContent.
     # Only include ports that were NOT consumed by template substitution.
@@ -450,6 +464,119 @@ def _build_segments_from_inputs(
 
 
 # ---------------------------------------------------------------------------
+# Asset resolution — port of Template.loadAsset() from template.ts
+# ---------------------------------------------------------------------------
+
+
+def _get_last_non_metadata(content_list: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Return the last LLMContent item whose role is not 'metadata'.
+
+    Mirrors ``#getLastNonMetadata()`` in template.ts.
+    """
+    for item in reversed(content_list):
+        if isinstance(item, dict) and item.get("role") != "$metadata":
+            return item
+    return None
+
+
+def _resolve_asset_text(
+    param: dict[str, Any],
+    assets: dict[str, Any] | None,
+) -> str:
+    """Resolve an asset placeholder to its text content.
+
+    For text assets, returns the extracted text. For binary assets
+    (images, PDFs), returns empty string — the binary parts are
+    handled separately by ``_collect_asset_segments()``.
+
+    Mirrors ``Template.loadAsset()`` + the text extraction in
+    ``Template.substitute()`` from template.ts.
+    """
+    if not assets:
+        return param.get("title", "")
+
+    path = param.get("path", "")
+    asset = assets.get(path)
+    if not asset or not asset.get("data"):
+        return param.get("title", "")
+
+    data = asset["data"]
+    if not isinstance(data, list):
+        return param.get("title", "")
+
+    last = _get_last_non_metadata(data)
+    if not last:
+        return param.get("title", "")
+
+    return _extract_text_from_content(last)
+
+
+def _collect_asset_segments(
+    raw_prompt: str,
+    config: dict[str, Any],
+    assets: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    """Collect asset segments for multimodal content in the prompt.
+
+    Scans the original (pre-substitution) prompt for ``"asset"``
+    placeholders and builds structured ``assetSegment`` objects for
+    any assets that contain non-text parts (inlineData, storedData).
+    These segments are consumed by ``to_pidgin()`` which already
+    knows how to handle ``"asset"`` type segments.
+
+    Text-only assets are already handled by ``_substitute_template``
+    and don't need separate segments.
+    """
+    if not assets:
+        return []
+
+    # Re-scan the raw prompt text from config for asset references.
+    # We use the original config$prompt (pre-substitution) because
+    # _substitute_template has already replaced the placeholders.
+    raw_text = _get_prompt(config)
+    if not raw_text:
+        return []
+
+    segments: list[dict[str, Any]] = []
+    for m in _TEMPLATE_RE.finditer(raw_text):
+        try:
+            param = json.loads(m.group(1))
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if not isinstance(param, dict) or param.get("type") != "asset":
+            continue
+
+        path = param.get("path", "")
+        asset = assets.get(path)
+        if not asset or not asset.get("data"):
+            continue
+
+        data = asset["data"]
+        if not isinstance(data, list):
+            continue
+
+        last = _get_last_non_metadata(data)
+        if not last:
+            continue
+
+        # Check if this asset has any non-text parts (binary data).
+        parts = last.get("parts", [])
+        has_binary = any(
+            isinstance(p, dict) and ("inlineData" in p or "storedData" in p)
+            for p in parts
+        )
+        if has_binary:
+            title = param.get("title", "asset")
+            segments.append({
+                "type": "asset",
+                "title": title,
+                "content": last,
+            })
+
+    return segments
+
+
+# ---------------------------------------------------------------------------
 # Template substitution — port of Template.substitute() from template.ts
 # ---------------------------------------------------------------------------
 
@@ -462,13 +589,15 @@ _TEMPLATE_RE = re.compile(r"\{(\{(?:.*?)\})\}", re.IGNORECASE | re.DOTALL)
 def _substitute_template(
     text: str,
     inputs: dict[str, list[Any]],
+    assets: dict[str, Any] | None = None,
 ) -> str:
     """Replace template placeholders in prompt text with input values.
 
     Mirrors ``Template.substitute()`` + ``#replaceParam()`` from
-    ``template.ts``. For ``{"type": "in", "path": "<node-id>"}``
-    placeholders, looks up the input port ``p-z-<node-id>`` and
-    substitutes the text content of the upstream node's output.
+    ``template.ts``.
+
+    - ``{"type": "in", ...}`` — upstream node outputs
+    - ``{"type": "asset", ...}`` — graph-level assets
     """
     def replace_match(m: re.Match[str]) -> str:
         inner_json = m.group(1)
@@ -477,18 +606,23 @@ def _substitute_template(
         except (json.JSONDecodeError, TypeError):
             return m.group(0)  # Not valid JSON — leave as-is.
 
-        if not isinstance(param, dict) or param.get("type") != "in":
-            return m.group(0)  # Not an "in" param — leave as-is.
+        if not isinstance(param, dict):
+            return m.group(0)
 
-        path = param.get("path", "")
-        title = param.get("title", "")
-        port_name = f"p-z-{path}"
+        param_type = param.get("type")
 
-        if port_name not in inputs:
-            # Fallback to title, same as TS #replaceParam.
-            return title
+        if param_type == "in":
+            path = param.get("path", "")
+            title = param.get("title", "")
+            port_name = f"p-z-{path}"
+            if port_name not in inputs:
+                return title
+            return _extract_input_text(inputs[port_name])
 
-        return _extract_input_text(inputs[port_name])
+        if param_type == "asset":
+            return _resolve_asset_text(param, assets)
+
+        return m.group(0)  # Unknown param type — leave as-is.
 
     return _TEMPLATE_RE.sub(replace_match, text)
 

--- a/packages/opal-backend/opal_backend/node_handlers.py
+++ b/packages/opal-backend/opal_backend/node_handlers.py
@@ -18,11 +18,14 @@ Handler types by phase:
 from __future__ import annotations
 
 import json
+import logging
 import re
 import uuid
 from dataclasses import dataclass, field
 from typing import Any, AsyncIterator, Callable, Coroutine
 
+from .backend_client import BackendClient
+from .conform_body import conform_body
 from .events import SUSPEND_TYPES, AgentEvent
 
 __all__ = [
@@ -35,6 +38,10 @@ __all__ = [
     "agent_handler",
 ]
 
+logger = logging.getLogger(__name__)
+
+# Default model — same as AGENT_MODEL in loop.py.
+DEFAULT_MODEL = "gemini-3-flash-preview"
 
 @dataclass
 class NodeSuspended(Exception):
@@ -138,6 +145,15 @@ def _get_mode(config: dict[str, Any]) -> str:
     return config.get("generation-mode", config.get("mode", "text"))
 
 
+def _get_model(config: dict[str, Any]) -> str:
+    """Read the Gemini model name from config.
+
+    Real Breadboard stores the model in ``model``; falls back to
+    ``DEFAULT_MODEL``.
+    """
+    return config.get("model", DEFAULT_MODEL)
+
+
 def _get_system_instruction(config: dict[str, Any]) -> str:
     """Extract system instruction text from config.
 
@@ -195,7 +211,7 @@ async def dispatch_handler(
             mode = _get_mode(config)
             if mode == "agent" and deps and deps.run_agent_fn:
                 return await agent_handler(inputs, config, deps)
-            return await text_gen_handler(inputs, config)
+            return await text_gen_handler(inputs, config, deps)
         case _:
             # Default passthrough for unknown types.
             return await passthrough_handler(inputs, config)
@@ -309,12 +325,77 @@ async def input_handler(
 async def text_gen_handler(
     inputs: dict[str, list[Any]],
     config: dict[str, Any],
+    deps: NodeHandlerDeps | None = None,
 ) -> dict[str, Any]:
-    """Stub text generation handler.
+    """Text generation handler.
 
-    Returns a mock response. Full implementation will call
-    ``BackendClient.stream_generate_content()``.
+    Builds a Gemini request body from inputs and config, resolves
+    data parts via ``conform_body()``, then streams the response
+    via ``BackendClient.stream_generate_content()``.
+
+    Falls back to a stub response if no backend is available
+    (e.g. in unit tests).
     """
+    # Build segments the same way as agent mode.
+    assets = deps.assets if deps else None
+    segments = _build_segments_from_inputs(inputs, config, assets)
+
+    # Assemble a minimal Gemini body.
+    contents: list[dict[str, Any]] = []
+    for seg in segments:
+        if seg.get("type") == "text" and seg.get("text"):
+            contents.append({
+                "role": "user",
+                "parts": [{"text": seg["text"]}],
+            })
+        elif seg.get("type") == "asset" and seg.get("content"):
+            contents.append(seg["content"])
+
+    if not contents:
+        return {
+            "context": [
+                {"role": "model", "parts": [{"text": ""}]},
+            ],
+        }
+
+    body: dict[str, Any] = {"contents": contents}
+
+    # System instruction from config.
+    system_instruction = _get_system_instruction(config)
+    if system_instruction:
+        body["systemInstruction"] = {
+            "parts": [{"text": system_instruction}],
+            "role": "user",
+        }
+
+    # Resolve storedData/fileData/json parts.
+    backend = deps.backend if deps else None
+    if backend:
+        try:
+            body = await conform_body(body, backend=backend)
+        except Exception as exc:
+            logger.error("text_gen_handler conform_body error: %s", exc)
+            # Continue with untransformed body — may fail at API level.
+
+        # Stream from Gemini.
+        model = _get_model(config)
+        result_text = ""
+        async for chunk in backend.stream_generate_content(model, body):
+            # Accumulate text from streaming chunks.
+            candidates = chunk.get("candidates", [])
+            for candidate in candidates:
+                content = candidate.get("content", {})
+                for part in content.get("parts", []):
+                    if "text" in part:
+                        result_text += part["text"]
+
+        return {
+            "context": [
+                {"role": "model", "parts": [{"text": result_text}]},
+            ],
+        }
+
+    # No backend — stub response (unit tests).
     return {
         "context": [
             {

--- a/packages/opal-backend/tests/test_asset_resolution.py
+++ b/packages/opal-backend/tests/test_asset_resolution.py
@@ -1,0 +1,324 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for asset resolution in template substitution.
+
+Verifies that ``{\"type\": \"asset\"}`` template placeholders in
+node prompts are resolved by looking up ``graph.assets[path].data``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from opal_backend.node_handlers import (
+    _build_segments_from_inputs,
+    _collect_asset_segments,
+    _get_last_non_metadata,
+    _resolve_asset_text,
+    _substitute_template,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+TEXT_ASSET = {
+    "@a/notes": {
+        "metadata": {"title": "Notes", "type": "content"},
+        "data": [
+            {"role": "user", "parts": [{"text": "These are my notes."}]},
+        ],
+    },
+}
+
+IMAGE_ASSET = {
+    "@a/photo": {
+        "metadata": {"title": "Photo", "type": "file"},
+        "data": [
+            {
+                "role": "user",
+                "parts": [
+                    {"inlineData": {"data": "iVBORw0KGgo=", "mimeType": "image/png"}},
+                ],
+            },
+        ],
+    },
+}
+
+MIXED_ASSET = {
+    "@a/doc": {
+        "metadata": {"title": "Document", "type": "content"},
+        "data": [
+            {
+                "role": "user",
+                "parts": [
+                    {"text": "Summary of the document."},
+                    {"inlineData": {"data": "JVBER==", "mimeType": "application/pdf"}},
+                ],
+            },
+        ],
+    },
+}
+
+METADATA_ASSET = {
+    "@a/with-meta": {
+        "metadata": {"title": "With Metadata", "type": "content"},
+        "data": [
+            {"role": "$metadata", "parts": [{"text": "meta info"}]},
+            {"role": "user", "parts": [{"text": "actual content"}]},
+        ],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# _get_last_non_metadata
+# ---------------------------------------------------------------------------
+
+
+class TestGetLastNonMetadata:
+    def test_returns_last_non_metadata_item(self):
+        data = [
+            {"role": "$metadata", "parts": [{"text": "meta"}]},
+            {"role": "user", "parts": [{"text": "first"}]},
+            {"role": "user", "parts": [{"text": "second"}]},
+        ]
+        result = _get_last_non_metadata(data)
+        assert result is not None
+        assert result["parts"][0]["text"] == "second"
+
+    def test_skips_metadata_at_end(self):
+        data = [
+            {"role": "user", "parts": [{"text": "content"}]},
+            {"role": "$metadata", "parts": [{"text": "meta"}]},
+        ]
+        result = _get_last_non_metadata(data)
+        assert result is not None
+        assert result["parts"][0]["text"] == "content"
+
+    def test_returns_none_for_all_metadata(self):
+        data = [
+            {"role": "$metadata", "parts": [{"text": "meta"}]},
+        ]
+        assert _get_last_non_metadata(data) is None
+
+    def test_returns_none_for_empty_list(self):
+        assert _get_last_non_metadata([]) is None
+
+
+# ---------------------------------------------------------------------------
+# _resolve_asset_text
+# ---------------------------------------------------------------------------
+
+
+class TestResolveAssetText:
+    def test_text_asset_returns_text(self):
+        param = {"type": "asset", "path": "@a/notes", "title": "Notes"}
+        result = _resolve_asset_text(param, TEXT_ASSET)
+        assert result == "These are my notes."
+
+    def test_image_asset_returns_empty(self):
+        """Binary assets have no text — text extraction returns empty."""
+        param = {"type": "asset", "path": "@a/photo", "title": "Photo"}
+        result = _resolve_asset_text(param, IMAGE_ASSET)
+        assert result == ""
+
+    def test_missing_asset_returns_title(self):
+        param = {"type": "asset", "path": "@a/missing", "title": "Fallback"}
+        result = _resolve_asset_text(param, TEXT_ASSET)
+        assert result == "Fallback"
+
+    def test_no_assets_returns_title(self):
+        param = {"type": "asset", "path": "@a/notes", "title": "Fallback"}
+        result = _resolve_asset_text(param, None)
+        assert result == "Fallback"
+
+    def test_metadata_item_skipped(self):
+        param = {"type": "asset", "path": "@a/with-meta", "title": "With Metadata"}
+        result = _resolve_asset_text(param, METADATA_ASSET)
+        assert result == "actual content"
+
+
+# ---------------------------------------------------------------------------
+# _substitute_template — asset handling
+# ---------------------------------------------------------------------------
+
+
+class TestSubstituteTemplateAssets:
+    def test_text_asset_substituted(self):
+        prompt = 'Summarize: {{"type":"asset","path":"@a/notes","title":"Notes"}}'
+        result = _substitute_template(prompt, {}, TEXT_ASSET)
+        assert result == "Summarize: These are my notes."
+
+    def test_missing_asset_falls_back_to_title(self):
+        prompt = 'About: {{"type":"asset","path":"@a/gone","title":"Missing Doc"}}'
+        result = _substitute_template(prompt, {}, TEXT_ASSET)
+        assert result == "About: Missing Doc"
+
+    def test_mixed_in_and_asset_placeholders(self):
+        prompt = (
+            'Topic: {{"type":"in","path":"node-1","title":"Topic"}} '
+            'Notes: {{"type":"asset","path":"@a/notes","title":"Notes"}}'
+        )
+        inputs = {"p-z-node-1": [{"role": "user", "parts": [{"text": "cats"}]}]}
+        result = _substitute_template(prompt, inputs, TEXT_ASSET)
+        assert result == "Topic: cats Notes: These are my notes."
+
+    def test_image_asset_substituted_as_empty(self):
+        """Binary assets contribute no inline text (handled as segments)."""
+        prompt = 'Describe: {{"type":"asset","path":"@a/photo","title":"Photo"}}'
+        result = _substitute_template(prompt, {}, IMAGE_ASSET)
+        assert result == "Describe: "
+
+
+# ---------------------------------------------------------------------------
+# _collect_asset_segments
+# ---------------------------------------------------------------------------
+
+
+class TestCollectAssetSegments:
+    def test_image_asset_produces_segment(self):
+        config = {
+            "config$prompt": {
+                "parts": [
+                    {"text": 'Describe: {{"type":"asset","path":"@a/photo","title":"Photo"}}'},
+                ],
+            },
+        }
+        segments = _collect_asset_segments("", config, IMAGE_ASSET)
+        assert len(segments) == 1
+        assert segments[0]["type"] == "asset"
+        assert segments[0]["title"] == "Photo"
+        assert segments[0]["content"]["parts"][0]["inlineData"]["mimeType"] == "image/png"
+
+    def test_text_asset_produces_no_segment(self):
+        """Text-only assets are handled by _substitute_template, not segments."""
+        config = {
+            "config$prompt": {
+                "parts": [
+                    {"text": 'Read: {{"type":"asset","path":"@a/notes","title":"Notes"}}'},
+                ],
+            },
+        }
+        segments = _collect_asset_segments("", config, TEXT_ASSET)
+        assert len(segments) == 0
+
+    def test_mixed_asset_produces_segment(self):
+        """Assets with both text and binary parts produce a segment."""
+        config = {
+            "config$prompt": {
+                "parts": [
+                    {"text": 'Analyze: {{"type":"asset","path":"@a/doc","title":"Document"}}'},
+                ],
+            },
+        }
+        segments = _collect_asset_segments("", config, MIXED_ASSET)
+        assert len(segments) == 1
+        assert segments[0]["title"] == "Document"
+
+    def test_no_assets_produces_empty(self):
+        config = {
+            "config$prompt": {
+                "parts": [
+                    {"text": 'Read: {{"type":"asset","path":"@a/notes","title":"Notes"}}'},
+                ],
+            },
+        }
+        segments = _collect_asset_segments("", config, None)
+        assert len(segments) == 0
+
+
+# ---------------------------------------------------------------------------
+# _build_segments_from_inputs — with assets
+# ---------------------------------------------------------------------------
+
+
+class TestBuildSegmentsWithAssets:
+    def test_text_asset_in_prompt_substituted(self):
+        """Text assets are substituted inline in the prompt segment."""
+        config = {
+            "config$prompt": {
+                "parts": [
+                    {"text": 'Summarize: {{"type":"asset","path":"@a/notes","title":"Notes"}}'},
+                ],
+            },
+        }
+        segments = _build_segments_from_inputs({}, config, TEXT_ASSET)
+        # Should have one text segment with the substituted prompt.
+        text_segments = [s for s in segments if s["type"] == "text"]
+        assert len(text_segments) == 1
+        assert "These are my notes." in text_segments[0]["text"]
+
+    def test_image_asset_produces_extra_segment(self):
+        """Image assets produce both a text segment (empty sub) and an asset segment."""
+        config = {
+            "config$prompt": {
+                "parts": [
+                    {"text": 'Describe: {{"type":"asset","path":"@a/photo","title":"Photo"}}'},
+                ],
+            },
+        }
+        segments = _build_segments_from_inputs({}, config, IMAGE_ASSET)
+        text_segments = [s for s in segments if s["type"] == "text"]
+        asset_segments = [s for s in segments if s["type"] == "asset"]
+        assert len(text_segments) == 1
+        assert len(asset_segments) == 1
+        assert asset_segments[0]["title"] == "Photo"
+
+
+# ---------------------------------------------------------------------------
+# Integration: GraphDescriptor → GraphPlan assets threading
+# ---------------------------------------------------------------------------
+
+
+class TestAssetsThreading:
+    def test_graph_descriptor_from_dict_preserves_assets(self):
+        """Assets from BGL JSON are preserved in GraphDescriptor."""
+        from opal_backend.graph_types import GraphDescriptor
+
+        d = {
+            "nodes": [{"id": "n1", "type": "generate"}],
+            "edges": [],
+            "assets": {
+                "@a/notes": {
+                    "metadata": {"title": "Notes", "type": "content"},
+                    "data": [{"role": "user", "parts": [{"text": "hello"}]}],
+                },
+            },
+        }
+        graph = GraphDescriptor.from_dict(d)
+        assert graph.assets is not None
+        assert "@a/notes" in graph.assets
+        assert graph.assets["@a/notes"]["data"][0]["parts"][0]["text"] == "hello"
+
+    def test_graph_descriptor_to_dict_includes_assets(self):
+        """Assets survive round-trip through to_dict."""
+        from opal_backend.graph_types import GraphDescriptor
+
+        assets = {"@a/x": {"data": [{"parts": [{"text": "y"}]}]}}
+        graph = GraphDescriptor(nodes=[], edges=[], assets=assets)
+        d = graph.to_dict()
+        assert d["assets"] == assets
+
+    def test_graph_plan_carries_assets(self):
+        """create_plan passes assets from GraphDescriptor into GraphPlan."""
+        from opal_backend.graph_condense import condense
+        from opal_backend.graph_plan import create_plan
+        from opal_backend.graph_types import GraphDescriptor
+
+        d = {
+            "nodes": [
+                {"id": "gen", "type": "generate"},
+                {"id": "out", "type": "output"},
+            ],
+            "edges": [
+                {"from": "gen", "to": "out", "out": "context", "in": "result"},
+            ],
+            "assets": TEXT_ASSET,
+        }
+        graph = GraphDescriptor.from_dict(d)
+        condensed = condense(graph)
+        plan = create_plan(condensed)
+        assert plan.assets == TEXT_ASSET

--- a/packages/visual-editor/src/ui/utils/fetch-allowlist.ts
+++ b/packages/visual-editor/src/ui/utils/fetch-allowlist.ts
@@ -48,7 +48,9 @@ const FETCH_ALLOWLIST: AllowListParams[] = [
       url.includes("/generateWebpageStream") ||
       url.includes("/streamRunAgent") ||
       url.includes("/sessions/new") ||
-      (url.includes("/sessions/") && url.includes(":resume")),
+      (url.includes("/sessions/") && url.includes(":resume")) ||
+      url.includes("/graphSessions/new") ||
+      (url.includes("/graphSessions/") && url.includes(":resume")),
   },
   {
     canonicalPrefix: new URL(CANONICAL.GOOGLE_DRIVE_FILES_API_PREFIX),


### PR DESCRIPTION
# [Heartstone] Phase 8: Asset resolution & data part transforms

Adds asset resolution and data part transforms to the backend graph runner, completing the data pipeline for generate nodes that reference graph-level assets (uploaded files, inline content).

## Phase 8a: Asset resolution (`6f296edd7`)

Adds support for `{"type": "asset"}` template placeholders in node prompts. Assets are graph-level embedded data (uploaded files, inline content) stored in `graph.assets` and referenced from generate node templates.

### Data model
- Add `assets` field to `GraphDescriptor` and `GraphPlan` (`from_dict`/`to_dict`)
- Preserve assets through `condense()` (SCC folding into subgraphs)
- Thread assets from `create_plan()` into `GraphPlan`

### Template substitution
- Extend `_substitute_template` to handle `"asset"` type alongside `"in"`
- `_resolve_asset_text`: look up `graph.assets[path].data`, extract text from last non-metadata `LLMContent` (mirrors TS `Template.loadAsset()`)
- `_collect_asset_segments`: build structured segments for binary assets (images, PDFs) consumed by `to_pidgin()`

### Plumbing
- Add `assets` to `NodeHandlerDeps`
- `GraphRunner._run_node_inner` loads `plan.assets`, passes to handler deps
- `agent_handler` threads assets into `_build_segments_from_inputs`

### Tests
- **22 new tests** in `test_asset_resolution.py` covering text/image/mixed/missing assets, metadata skipping, `GraphDescriptor` round-trip, and full condense→plan pipeline integration

## Phase 8b: `conform_body` + `accessToken` plumbing (`4572d4660`)

Wires `conform_body()` into `text_gen_handler` so `drive:/` and blob `storedData` parts are resolved to Gemini File API URLs before API calls. The agent path already had this via `loop.py`; the text path was missing it.

### Backend (`node_handlers.py`)
- Import `conform_body` and `BackendClient`; add logger
- Add `DEFAULT_MODEL` constant and `_get_model()` helper
- Rewrite `text_gen_handler` to accept `NodeHandlerDeps`, build a Gemini body from segments, call `conform_body()`, then stream via `backend.stream_generate_content(model, body)`
- Falls back to stub response when no backend (unit tests)

### Frontend (`fetch-allowlist.ts`)
- Add `/graphSessions/new` and `/graphSessions/:resume` to `shouldAddAccessTokenToJsonBody` so `fetchWithCreds` injects the OAuth token into the JSON body (required for production where the `Authorization` header is consumed by infrastructure)

## Changed files

| File | Change |
|------|--------|
| `opal_backend/graph_types.py` | `+5` — `assets` field on `GraphDescriptor` |
| `opal_backend/graph_plan.py` | `+1 −1` — Thread assets into `GraphPlan` |
| `opal_backend/graph_condense.py` | `+1` — Preserve assets in condensed graph |
| `opal_backend/graph_runner.py` | `+14 −1` — Load assets, pass to handler deps |
| `opal_backend/node_handlers.py` | `+253 −22` — Asset resolution + `conform_body` + `text_gen_handler` rewrite |
| `tests/test_asset_resolution.py` | `+324` — 22 new tests |
| `fetch-allowlist.ts` | `+4 −2` — Graph session token plumbing |

**Total: 7 files, +578 −25**
