### PR TITLE
[heartstone] Phase 8c: Media generation modes + nodeEnd outputs + nodeError handling

### DIFF
--- a/packages/opal-backend/opal_backend/graph_runner.py
+++ b/packages/opal-backend/opal_backend/graph_runner.py
@@ -229,10 +229,10 @@ class GraphRunner:
         )
 
         await self._store.append_event(session_id, {
-            "type": "nodeEnd", "nodeId": node_id,
+            "type": "nodeEnd", "nodeId": node_id, "outputs": outputs,
         })
         await self._event_bus.publish(session_id, {
-            "type": "nodeEnd", "nodeId": node_id,
+            "type": "nodeEnd", "nodeId": node_id, "outputs": outputs,
         })
 
         for nid in newly_ready:

--- a/packages/opal-backend/opal_backend/node_handlers.py
+++ b/packages/opal-backend/opal_backend/node_handlers.py
@@ -11,7 +11,9 @@ Only stdlib + typing — no external deps (synced to production).
 
 Handler types by phase:
 - ``passthrough_handler`` — returns inputs as outputs (output nodes)
-- ``text_gen_handler`` — stub for direct Gemini text generation
+- ``text_gen_handler`` — direct Gemini text generation
+- ``media_gen_handler`` — executeStep-based media generation
+  (image, audio, video, music)
 - ``agent_handler`` — full agent loop via ``run_agent()``
 """
 
@@ -27,6 +29,7 @@ from typing import Any, AsyncIterator, Callable, Coroutine
 from .backend_client import BackendClient
 from .conform_body import conform_body
 from .events import SUSPEND_TYPES, AgentEvent
+from .step_executor import execute_step, resolve_part_to_chunk, encode_base64
 
 __all__ = [
     "NodeSuspended",
@@ -34,6 +37,7 @@ __all__ = [
     "dispatch_handler",
     "passthrough_handler",
     "text_gen_handler",
+    "media_gen_handler",
     "input_handler",
     "agent_handler",
 ]
@@ -42,6 +46,15 @@ logger = logging.getLogger(__name__)
 
 # Default model — same as AGENT_MODEL in loop.py.
 DEFAULT_MODEL = "gemini-3-flash-preview"
+
+# Default system instruction for text generation — port of
+# defaultSystemInstruction() from system-instruction.ts.
+_DEFAULT_SYSTEM_INSTRUCTION = (
+    "You are working as part of an AI system, so no chit-chat "
+    "and no explaining what you're doing and why.\n"
+    'DO NOT start with "Okay", or "Alright" or any preambles. '
+    "Just the output, please."
+)
 
 @dataclass
 class NodeSuspended(Exception):
@@ -158,20 +171,38 @@ def _get_system_instruction(config: dict[str, Any]) -> str:
     """Extract system instruction text from config.
 
     Handles both:
-    - Simple string: ``{"systemInstruction": "Be helpful"}``
+    - Simple string: ``{"systemInstruction": "Do X"}``
     - LLMContent: ``{"b-system-instruction": {"parts": [{"text": "..."}]}}``
+
+    When no system instruction is present, falls back to the default
+    from ``system-instruction.ts#defaultSystemInstruction()``.
+
+    Always prepends the current date, matching
+    ``system-instruction.ts#createSystemInstruction()``.
     """
+    instruction = ""
+
     # Simple string format.
     simple = config.get("systemInstruction")
     if isinstance(simple, str):
-        return simple
+        instruction = simple
 
     # Real Breadboard LLMContent format.
-    llm_content = config.get("b-system-instruction")
-    if isinstance(llm_content, dict):
-        return _extract_text_from_content(llm_content)
+    if not instruction:
+        llm_content = config.get("b-system-instruction")
+        if isinstance(llm_content, dict):
+            instruction = _extract_text_from_content(llm_content)
 
-    return ""
+    # Default — port of defaultSystemInstruction() from system-instruction.ts.
+    if not instruction:
+        instruction = _DEFAULT_SYSTEM_INSTRUCTION
+
+    # Prepend date — port of createSystemInstruction() from
+    # system-instruction.ts.
+    from datetime import datetime
+    now = datetime.now()
+    date_str = now.strftime("%B %-d, %Y, %-I:%M %p")
+    return f"\nToday is {date_str}\n    \n{instruction}"
 
 
 def _get_prompt(config: dict[str, Any]) -> str:
@@ -211,6 +242,10 @@ async def dispatch_handler(
             mode = _get_mode(config)
             if mode == "agent" and deps and deps.run_agent_fn:
                 return await agent_handler(inputs, config, deps)
+            if mode in MEDIA_MODES:
+                return await media_gen_handler(
+                    inputs, config, deps, MEDIA_MODES[mode],
+                )
             return await text_gen_handler(inputs, config, deps)
         case _:
             # Default passthrough for unknown types.
@@ -404,6 +439,256 @@ async def text_gen_handler(
             }
         ],
     }
+
+
+# ---------------------------------------------------------------------------
+# Media generation modes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MediaModeConfig:
+    """Per-mode config for executeStep-based media generation.
+
+    Each media mode (image, audio, video, music) calls the same
+    backend executeStep API with different parameters.
+    """
+
+    model_api: str
+    step_name: str
+    output_key: str
+    prompt_input_key: str
+
+
+# Mode registry — maps mode ID to executeStep config.
+# Mirrors the ALL_MODES entries in generate/main.ts.
+MEDIA_MODES: dict[str, MediaModeConfig] = {
+    "image": MediaModeConfig(
+        model_api="ai_image_tool",
+        step_name="EditImage",
+        output_key="edited_image",
+        prompt_input_key="input_instruction",
+    ),
+    "image-pro": MediaModeConfig(
+        model_api="ai_image_tool",
+        step_name="EditImage",
+        output_key="edited_image",
+        prompt_input_key="input_instruction",
+    ),
+    "audio": MediaModeConfig(
+        model_api="tts",
+        step_name="GenerateAudio",
+        output_key="generated_speech",
+        prompt_input_key="text_to_speak",
+    ),
+    "video": MediaModeConfig(
+        model_api="generate_video",
+        step_name="GenerateVideo",
+        output_key="generated_video",
+        prompt_input_key="text_instruction",
+    ),
+    "music": MediaModeConfig(
+        model_api="generate_music",
+        step_name="GenerateMusic",
+        output_key="generated_music",
+        prompt_input_key="prompt",
+    ),
+}
+
+
+async def media_gen_handler(
+    inputs: dict[str, list[Any]],
+    config: dict[str, Any],
+    deps: NodeHandlerDeps | None,
+    mode_config: MediaModeConfig,
+) -> dict[str, Any]:
+    """Media generation handler (image, audio, video, music).
+
+    All media modes go through the One Platform ``/v1beta1/executeStep``
+    API with mode-specific ``planStep`` parameters.
+
+    Port of ``image-editor.ts``, ``audio-generator/main.ts``,
+    ``video-generator/main.ts``, and ``music-generator/main.ts`` —
+    all of which funnel into ``step-executor.ts``.
+    """
+    # Build the text prompt from template substitution + upstream context.
+    # Note: we use _build_segments_from_inputs for template substitution
+    # and context extraction, but SKIP system instruction segments.
+    # The TS media generators don't include system instruction — it's only
+    # for Gemini text/agent modes. Including it causes TTS failures
+    # ("Model tried to generate text, but it should only be used for TTS").
+    assets = deps.assets if deps else None
+    segments = _build_segments_from_inputs(inputs, config, assets)
+
+    # Filter: skip the first segment if it's the system instruction.
+    # _build_segments_from_inputs prepends system instruction as the first
+    # text segment when present in config.
+    system_instruction = _get_system_instruction(config)
+    prompt_parts = []
+    for seg in segments:
+        if seg.get("type") == "text" and seg.get("text"):
+            # Skip system instruction (exact match with first segment).
+            if seg["text"] == system_instruction:
+                system_instruction = None  # Only skip once.
+                continue
+            prompt_parts.append(seg["text"])
+    prompt = "\n\n".join(prompt_parts).strip()
+
+    if not prompt:
+        return {
+            "context": [
+                {"role": "model", "parts": [{"text": ""}]},
+            ],
+        }
+
+    # Build execution_inputs.
+    execution_inputs: dict[str, Any] = {
+        mode_config.prompt_input_key: {
+            "chunks": [{
+                "mimetype": "text/plain",
+                "data": encode_base64(prompt),
+            }],
+        },
+    }
+
+    input_parameters = [mode_config.prompt_input_key]
+
+    # Image/video modes: collect reference images from upstream context
+    # and asset segments for i2i/i2v support.
+    if mode_config.model_api in ("ai_image_tool", "generate_video"):
+        image_chunks = await _collect_reference_image_chunks(
+            inputs, segments, deps,
+        )
+        if image_chunks:
+            ref_key = (
+                "input_image"
+                if mode_config.model_api == "ai_image_tool"
+                else "reference_image"
+            )
+            execution_inputs[ref_key] = {"chunks": image_chunks}
+            input_parameters.append(ref_key)
+
+        # Aspect ratio (image and video).
+        aspect_ratio = config.get("p-aspect-ratio", "1:1")
+        execution_inputs["aspect_ratio_key"] = {
+            "chunks": [{
+                "mimetype": "text/plain",
+                "data": encode_base64(aspect_ratio),
+            }],
+        }
+
+    # Audio mode: voice selection.
+    if mode_config.model_api == "tts":
+        voice = config.get("voice", "en-US-female")
+        execution_inputs["voice_key"] = {
+            "chunks": [{
+                "mimetype": "text/plain",
+                "data": encode_base64(voice),
+            }],
+        }
+
+    # Build executeStep request body.
+    model_name = config.get("p-model-name", config.get("model", ""))
+    body: dict[str, Any] = {
+        "planStep": {
+            "stepName": mode_config.step_name,
+            "modelApi": mode_config.model_api,
+            "inputParameters": input_parameters,
+            "systemPrompt": "",
+            "output": mode_config.output_key,
+        },
+        "execution_inputs": execution_inputs,
+    }
+    if model_name:
+        body["planStep"]["options"] = {"modelName": model_name}
+
+    backend = deps.backend if deps else None
+    if not backend:
+        # No backend — stub response (unit tests).
+        return {
+            "context": [
+                {"role": "model", "parts": [{"text": "[generated media]"}]},
+            ],
+        }
+
+    result = await execute_step(body, backend=backend)
+    # result is {chunks: [LLMContent, ...], requestedModel?, executedModel?}
+    chunks = result.get("chunks", [])
+    if not chunks:
+        return {
+            "context": [
+                {"role": "model", "parts": [{"text": ""}]},
+            ],
+        }
+
+    return {"context": chunks}
+
+
+async def _collect_reference_image_chunks(
+    inputs: dict[str, list[Any]],
+    segments: list[dict[str, Any]],
+    deps: NodeHandlerDeps | None,
+) -> list[dict[str, Any]]:
+    """Collect reference image chunks for i2i/i2v modes.
+
+    Extracts inline image data and storedData references from upstream
+    context and asset segments. Mirrors ``extractMediaData`` +
+    ``driveFileToBlob`` + ``toGcsAwareChunk`` from image-utils.ts.
+    """
+    backend = deps.backend if deps else None
+    chunks: list[dict[str, Any]] = []
+
+    # Collect from upstream input context.
+    for values in inputs.values():
+        for value in values:
+            items = value if isinstance(value, list) else [value]
+            for item in items:
+                if not isinstance(item, dict):
+                    continue
+                for part in item.get("parts", []):
+                    chunk = await _part_to_image_chunk(part, backend)
+                    if chunk:
+                        chunks.append(chunk)
+
+    # Collect from asset segments.
+    for seg in segments:
+        if seg.get("type") != "asset" or not seg.get("content"):
+            continue
+        content = seg["content"]
+        for part in content.get("parts", []):
+            chunk = await _part_to_image_chunk(part, backend)
+            if chunk:
+                chunks.append(chunk)
+
+    return chunks
+
+
+async def _part_to_image_chunk(
+    part: dict[str, Any],
+    backend: BackendClient | None,
+) -> dict[str, Any] | None:
+    """Convert a single LLMContent part to an executeStep image chunk.
+
+    Returns None for non-image parts (text, etc.).
+    """
+    if "inlineData" in part:
+        inline = part["inlineData"]
+        mime = inline.get("mimeType", "")
+        if mime.startswith("image/"):
+            return {
+                "mimetype": mime,
+                "data": inline.get("data", ""),
+            }
+        return None
+
+    if "storedData" in part and backend:
+        try:
+            return await resolve_part_to_chunk(part, backend=backend)
+        except Exception as exc:
+            logger.warning("Failed to resolve storedData for media: %s", exc)
+            return None
+
+    return None
 
 
 async def agent_handler(

--- a/packages/opal-backend/tests/test_asset_resolution.py
+++ b/packages/opal-backend/tests/test_asset_resolution.py
@@ -246,10 +246,12 @@ class TestBuildSegmentsWithAssets:
             },
         }
         segments = _build_segments_from_inputs({}, config, TEXT_ASSET)
-        # Should have one text segment with the substituted prompt.
+        # Should have a text segment with the substituted prompt
+        # (plus the default system instruction segment).
         text_segments = [s for s in segments if s["type"] == "text"]
-        assert len(text_segments) == 1
-        assert "These are my notes." in text_segments[0]["text"]
+        prompt_segments = [s for s in text_segments if "my notes" in s["text"]]
+        assert len(prompt_segments) == 1
+        assert "These are my notes." in prompt_segments[0]["text"]
 
     def test_image_asset_produces_extra_segment(self):
         """Image assets produce both a text segment (empty sub) and an asset segment."""
@@ -261,9 +263,11 @@ class TestBuildSegmentsWithAssets:
             },
         }
         segments = _build_segments_from_inputs({}, config, IMAGE_ASSET)
+        # Prompt text segment + default SI segment.
         text_segments = [s for s in segments if s["type"] == "text"]
+        prompt_segments = [s for s in text_segments if "Describe" in s["text"]]
+        assert len(prompt_segments) == 1
         asset_segments = [s for s in segments if s["type"] == "asset"]
-        assert len(text_segments) == 1
         assert len(asset_segments) == 1
         assert asset_segments[0]["title"] == "Photo"
 

--- a/packages/opal-backend/tests/test_media_gen.py
+++ b/packages/opal-backend/tests/test_media_gen.py
@@ -1,0 +1,484 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for media_gen_handler (image, audio, video, music)."""
+
+from __future__ import annotations
+
+import base64
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from opal_backend.node_handlers import (
+    MediaModeConfig,
+    MEDIA_MODES,
+    NodeHandlerDeps,
+    dispatch_handler,
+    media_gen_handler,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_deps(
+    execute_step_response: dict | None = None,
+    assets: dict | None = None,
+) -> NodeHandlerDeps:
+    """Build NodeHandlerDeps with a mocked backend."""
+    backend = MagicMock()
+    if execute_step_response is not None:
+        backend.execute_step = AsyncMock(return_value=execute_step_response)
+    else:
+        backend.execute_step = AsyncMock(return_value={})
+    return NodeHandlerDeps(
+        on_agent_event=AsyncMock(),
+        run_agent_fn=None,
+        backend=backend,
+        interaction_store=None,
+        assets=assets,
+    )
+
+
+def _execute_step_response(
+    output_key: str,
+    chunks: list[dict],
+) -> dict:
+    """Build an executeStep API response."""
+    return {
+        "executionOutputs": {
+            output_key: {
+                "chunks": chunks,
+            },
+        },
+    }
+
+
+def _text_chunk(text: str) -> dict:
+    """Build an inline text chunk."""
+    encoded = base64.b64encode(text.encode()).decode()
+    return {"mimetype": "text/plain", "data": encoded}
+
+
+def _image_chunk() -> dict:
+    """Build an inline image chunk."""
+    return {"mimetype": "image/png", "data": "iVBORw0KGgo="}
+
+
+def _stored_data_chunk(blob_id: str) -> dict:
+    """Build a storedData chunk (GCS path)."""
+    return {"mimetype": "image/png/storedData", "data": f"bucket/{blob_id}"}
+
+
+# ---------------------------------------------------------------------------
+# Mode config registry
+# ---------------------------------------------------------------------------
+
+class TestMediaModeRegistry:
+    """Test the MEDIA_MODES registry."""
+
+    def test_all_active_modes_registered(self):
+        """All non-hidden active media modes are in the registry."""
+        expected = {"image", "image-pro", "audio", "video", "music"}
+        assert set(MEDIA_MODES.keys()) == expected
+
+    def test_image_config(self):
+        config = MEDIA_MODES["image"]
+        assert config.model_api == "ai_image_tool"
+        assert config.step_name == "EditImage"
+        assert config.output_key == "edited_image"
+        assert config.prompt_input_key == "input_instruction"
+
+    def test_audio_config(self):
+        config = MEDIA_MODES["audio"]
+        assert config.model_api == "tts"
+        assert config.step_name == "GenerateAudio"
+        assert config.output_key == "generated_speech"
+        assert config.prompt_input_key == "text_to_speak"
+
+    def test_video_config(self):
+        config = MEDIA_MODES["video"]
+        assert config.model_api == "generate_video"
+        assert config.step_name == "GenerateVideo"
+        assert config.output_key == "generated_video"
+        assert config.prompt_input_key == "text_instruction"
+
+    def test_music_config(self):
+        config = MEDIA_MODES["music"]
+        assert config.model_api == "generate_music"
+        assert config.step_name == "GenerateMusic"
+        assert config.output_key == "generated_music"
+        assert config.prompt_input_key == "prompt"
+
+
+# ---------------------------------------------------------------------------
+# Dispatch routing
+# ---------------------------------------------------------------------------
+
+class TestDispatchRouting:
+    """Test that dispatch_handler routes to media_gen_handler."""
+
+    @pytest.mark.asyncio
+    async def test_image_mode_routes_to_media_handler(self):
+        """Mode 'image' routes to media_gen_handler, not text_gen_handler."""
+        deps = _make_deps(_execute_step_response(
+            "edited_image",
+            [_image_chunk()],
+        ))
+        config = {"generation-mode": "image", "config$prompt": "a cat"}
+        result = await dispatch_handler(
+            "generate", {}, config, deps,
+        )
+        # Should have called execute_step on the backend.
+        deps.backend.execute_step.assert_called_once()
+        body = deps.backend.execute_step.call_args[0][0]
+        assert body["planStep"]["modelApi"] == "ai_image_tool"
+
+    @pytest.mark.asyncio
+    async def test_audio_mode_routes_to_media_handler(self):
+        deps = _make_deps(_execute_step_response(
+            "generated_speech",
+            [{"mimetype": "audio/wav", "data": "audio_data"}],
+        ))
+        config = {"generation-mode": "audio", "config$prompt": "Hello world"}
+        result = await dispatch_handler(
+            "generate", {}, config, deps,
+        )
+        deps.backend.execute_step.assert_called_once()
+        body = deps.backend.execute_step.call_args[0][0]
+        assert body["planStep"]["modelApi"] == "tts"
+
+    @pytest.mark.asyncio
+    async def test_text_mode_does_not_route_to_media_handler(self):
+        """Text modes should still use text_gen_handler."""
+        deps = _make_deps()
+        # Provide a streaming response for the text handler.
+        async def _stream(*a, **kw):
+            yield {"candidates": [{"content": {"parts": [{"text": "hi"}]}}]}
+        deps.backend.stream_generate_content = _stream
+        config = {"generation-mode": "text-3-flash", "config$prompt": "hi"}
+        result = await dispatch_handler(
+            "generate", {}, config, deps,
+        )
+        # Should NOT have called execute_step.
+        deps.backend.execute_step.assert_not_called()
+        assert result["context"][0]["parts"][0]["text"] == "hi"
+
+
+# ---------------------------------------------------------------------------
+# media_gen_handler — prompt extraction
+# ---------------------------------------------------------------------------
+
+class TestMediaGenPrompt:
+    """Test prompt extraction and template substitution."""
+
+    @pytest.mark.asyncio
+    async def test_prompt_from_config(self):
+        """Prompt is extracted from config$prompt."""
+        deps = _make_deps(_execute_step_response(
+            "generated_music", [_text_chunk("music data")],
+        ))
+        config = {"config$prompt": "a peaceful melody"}
+        result = await media_gen_handler(
+            {}, config, deps, MEDIA_MODES["music"],
+        )
+        body = deps.backend.execute_step.call_args[0][0]
+        prompt_data = body["execution_inputs"]["prompt"]["chunks"][0]["data"]
+        assert base64.b64decode(prompt_data).decode() == "a peaceful melody"
+
+    @pytest.mark.asyncio
+    async def test_empty_prompt_returns_empty(self):
+        """Empty prompt returns empty context."""
+        deps = _make_deps()
+        config = {}
+        result = await media_gen_handler(
+            {}, config, deps, MEDIA_MODES["music"],
+        )
+        assert result["context"][0]["parts"][0]["text"] == ""
+        deps.backend.execute_step.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_system_instruction_excluded_from_prompt(self):
+        """System instruction should NOT be in the media prompt.
+
+        The TS media generators don't include system instruction — it's
+        only for Gemini text/agent modes. Including it causes TTS failures.
+        """
+        deps = _make_deps(_execute_step_response(
+            "generated_speech", [_text_chunk("speech data")],
+        ))
+        config = {
+            "config$prompt": "Hello world",
+            "b-system-instruction": {
+                "parts": [{"text": "Be helpful and creative"}],
+            },
+        }
+        result = await media_gen_handler(
+            {}, config, deps, MEDIA_MODES["audio"],
+        )
+        body = deps.backend.execute_step.call_args[0][0]
+        prompt_data = body["execution_inputs"]["text_to_speak"]["chunks"][0]["data"]
+        decoded = base64.b64decode(prompt_data).decode()
+        assert "Hello world" in decoded
+        assert "Be helpful" not in decoded
+
+    @pytest.mark.asyncio
+    async def test_prompt_with_upstream_context(self):
+        """Upstream text context is included in the prompt."""
+        deps = _make_deps(_execute_step_response(
+            "generated_speech", [_text_chunk("speech data")],
+        ))
+        config = {"config$prompt": "Say this:"}
+        inputs = {
+            "context": [[
+                {"role": "user", "parts": [{"text": "Hello world"}]},
+            ]],
+        }
+        result = await media_gen_handler(
+            inputs, config, deps, MEDIA_MODES["audio"],
+        )
+        body = deps.backend.execute_step.call_args[0][0]
+        prompt_data = body["execution_inputs"]["text_to_speak"]["chunks"][0]["data"]
+        decoded = base64.b64decode(prompt_data).decode()
+        assert "Say this:" in decoded
+        assert "Hello world" in decoded
+
+    @pytest.mark.asyncio
+    async def test_template_substitution(self):
+        """Template placeholders are substituted with upstream values."""
+        deps = _make_deps(_execute_step_response(
+            "edited_image", [_image_chunk()],
+        ))
+        # Double braces: outer {} is template delimiter, inner {} is JSON.
+        prompt = '{{"type":"in","path":"style","title":"style"}} landscape'
+        config = {"config$prompt": prompt}
+        inputs = {
+            "p-z-style": [["watercolor"]],
+        }
+        result = await media_gen_handler(
+            inputs, config, deps, MEDIA_MODES["image"],
+        )
+        body = deps.backend.execute_step.call_args[0][0]
+        prompt_data = body["execution_inputs"]["input_instruction"]["chunks"][0]["data"]
+        decoded = base64.b64decode(prompt_data).decode()
+        assert "watercolor" in decoded
+        assert "landscape" in decoded
+
+
+# ---------------------------------------------------------------------------
+# media_gen_handler — executeStep body
+# ---------------------------------------------------------------------------
+
+class TestMediaGenBody:
+    """Test the executeStep request body construction."""
+
+    @pytest.mark.asyncio
+    async def test_image_body_structure(self):
+        deps = _make_deps(_execute_step_response(
+            "edited_image", [_image_chunk()],
+        ))
+        config = {
+            "config$prompt": "a sunset",
+            "p-aspect-ratio": "16:9",
+            "p-model-name": "custom-model",
+        }
+        await media_gen_handler({}, config, deps, MEDIA_MODES["image"])
+        body = deps.backend.execute_step.call_args[0][0]
+
+        assert body["planStep"]["stepName"] == "EditImage"
+        assert body["planStep"]["modelApi"] == "ai_image_tool"
+        assert body["planStep"]["output"] == "edited_image"
+        assert body["planStep"]["options"]["modelName"] == "custom-model"
+        assert "input_instruction" in body["execution_inputs"]
+        assert "aspect_ratio_key" in body["execution_inputs"]
+
+    @pytest.mark.asyncio
+    async def test_audio_body_includes_voice(self):
+        deps = _make_deps(_execute_step_response(
+            "generated_speech", [_text_chunk("audio")],
+        ))
+        config = {
+            "config$prompt": "hello",
+            "voice": "en-US-male",
+        }
+        await media_gen_handler({}, config, deps, MEDIA_MODES["audio"])
+        body = deps.backend.execute_step.call_args[0][0]
+
+        voice_data = body["execution_inputs"]["voice_key"]["chunks"][0]["data"]
+        assert base64.b64decode(voice_data).decode() == "en-US-male"
+
+    @pytest.mark.asyncio
+    async def test_audio_default_voice(self):
+        deps = _make_deps(_execute_step_response(
+            "generated_speech", [_text_chunk("audio")],
+        ))
+        config = {"config$prompt": "hello"}
+        await media_gen_handler({}, config, deps, MEDIA_MODES["audio"])
+        body = deps.backend.execute_step.call_args[0][0]
+
+        voice_data = body["execution_inputs"]["voice_key"]["chunks"][0]["data"]
+        assert base64.b64decode(voice_data).decode() == "en-US-female"
+
+    @pytest.mark.asyncio
+    async def test_video_body_structure(self):
+        deps = _make_deps(_execute_step_response(
+            "generated_video",
+            [{"mimetype": "video/mp4", "data": "video_data"}],
+        ))
+        config = {"config$prompt": "a cat walking"}
+        await media_gen_handler({}, config, deps, MEDIA_MODES["video"])
+        body = deps.backend.execute_step.call_args[0][0]
+
+        assert body["planStep"]["stepName"] == "GenerateVideo"
+        assert body["planStep"]["modelApi"] == "generate_video"
+        assert body["planStep"]["output"] == "generated_video"
+        assert "text_instruction" in body["execution_inputs"]
+        assert "aspect_ratio_key" in body["execution_inputs"]
+
+    @pytest.mark.asyncio
+    async def test_music_body_no_extras(self):
+        """Music mode should NOT have aspect_ratio or voice."""
+        deps = _make_deps(_execute_step_response(
+            "generated_music", [_text_chunk("music")],
+        ))
+        config = {"config$prompt": "jazz"}
+        await media_gen_handler({}, config, deps, MEDIA_MODES["music"])
+        body = deps.backend.execute_step.call_args[0][0]
+
+        assert "aspect_ratio_key" not in body["execution_inputs"]
+        assert "voice_key" not in body["execution_inputs"]
+        assert body["planStep"]["modelApi"] == "generate_music"
+
+
+# ---------------------------------------------------------------------------
+# media_gen_handler — output parsing
+# ---------------------------------------------------------------------------
+
+class TestMediaGenOutput:
+    """Test output parsing from executeStep response."""
+
+    @pytest.mark.asyncio
+    async def test_inline_image_output(self):
+        """Inline image chunks are returned as LLMContent."""
+        deps = _make_deps(_execute_step_response(
+            "edited_image",
+            [{"mimetype": "image/png", "data": "base64png"}],
+        ))
+        config = {"config$prompt": "a cat"}
+        result = await media_gen_handler(
+            {}, config, deps, MEDIA_MODES["image"],
+        )
+        context = result["context"]
+        assert len(context) == 1
+        part = context[0]["parts"][0]
+        assert part["inlineData"]["mimeType"] == "image/png"
+        assert part["inlineData"]["data"] == "base64png"
+
+    @pytest.mark.asyncio
+    async def test_stored_data_output(self):
+        """StoredData chunks are returned with blob handles."""
+        blob_id = "abc123-def456"
+        deps = _make_deps(_execute_step_response(
+            "edited_image",
+            [{"mimetype": "image/png/storedData", "data": f"bucket/{blob_id}"}],
+        ))
+        config = {"config$prompt": "a cat"}
+        result = await media_gen_handler(
+            {}, config, deps, MEDIA_MODES["image"],
+        )
+        context = result["context"]
+        assert len(context) == 1
+        part = context[0]["parts"][0]
+        assert part["storedData"]["handle"] == f"/board/blobs/{blob_id}"
+        assert part["storedData"]["mimeType"] == "image/png"
+
+    @pytest.mark.asyncio
+    async def test_no_backend_stub_response(self):
+        """Without a backend, returns a stub response."""
+        deps = NodeHandlerDeps(
+            on_agent_event=AsyncMock(),
+            run_agent_fn=None,
+            backend=None,
+            interaction_store=None,
+        )
+        config = {"config$prompt": "a cat"}
+        result = await media_gen_handler(
+            {}, config, deps, MEDIA_MODES["image"],
+        )
+        assert result["context"][0]["parts"][0]["text"] == "[generated media]"
+
+
+# ---------------------------------------------------------------------------
+# Reference image collection
+# ---------------------------------------------------------------------------
+
+class TestReferenceImages:
+    """Test reference image collection for i2i/i2v modes."""
+
+    @pytest.mark.asyncio
+    async def test_inline_image_from_upstream(self):
+        """Inline images from upstream context are collected."""
+        deps = _make_deps(_execute_step_response(
+            "edited_image", [_image_chunk()],
+        ))
+        inputs = {
+            "context": [[{
+                "role": "user",
+                "parts": [{"inlineData": {
+                    "mimeType": "image/png",
+                    "data": "upstream_img",
+                }}],
+            }]],
+        }
+        config = {"config$prompt": "edit this image"}
+        await media_gen_handler(inputs, config, deps, MEDIA_MODES["image"])
+        body = deps.backend.execute_step.call_args[0][0]
+
+        assert "input_image" in body["execution_inputs"]
+        chunks = body["execution_inputs"]["input_image"]["chunks"]
+        assert len(chunks) == 1
+        assert chunks[0]["data"] == "upstream_img"
+
+    @pytest.mark.asyncio
+    async def test_text_parts_not_collected_as_images(self):
+        """Text parts from upstream should not be collected as images."""
+        deps = _make_deps(_execute_step_response(
+            "edited_image", [_image_chunk()],
+        ))
+        inputs = {
+            "context": [[{
+                "role": "user",
+                "parts": [{"text": "just text"}],
+            }]],
+        }
+        config = {"config$prompt": "create image"}
+        await media_gen_handler(inputs, config, deps, MEDIA_MODES["image"])
+        body = deps.backend.execute_step.call_args[0][0]
+
+        # No reference images should be collected.
+        assert "input_image" not in body["execution_inputs"]
+
+    @pytest.mark.asyncio
+    async def test_video_reference_image_key(self):
+        """Video mode uses 'reference_image' not 'input_image'."""
+        deps = _make_deps(_execute_step_response(
+            "generated_video",
+            [{"mimetype": "video/mp4", "data": "video_data"}],
+        ))
+        inputs = {
+            "context": [[{
+                "role": "user",
+                "parts": [{"inlineData": {
+                    "mimeType": "image/jpeg",
+                    "data": "ref_img",
+                }}],
+            }]],
+        }
+        config = {"config$prompt": "animate this"}
+        await media_gen_handler(inputs, config, deps, MEDIA_MODES["video"])
+        body = deps.backend.execute_step.call_args[0][0]
+
+        assert "reference_image" in body["execution_inputs"]
+        assert "input_image" not in body["execution_inputs"]

--- a/packages/visual-editor/src/sca/actions/run/backend-run-action.ts
+++ b/packages/visual-editor/src/sca/actions/run/backend-run-action.ts
@@ -43,6 +43,7 @@ import {
 } from "../../utils/app-screen.js";
 import { toLLMContentArray } from "../../utils/common.js";
 import { makeAction } from "../binder.js";
+import type { AppController } from "../../controller/controller.js";
 import { Utils } from "../../utils.js";
 import {
   handleInputRequested,
@@ -50,7 +51,8 @@ import {
 
 const LABEL = "Backend Run";
 
-export { startBackendRun };
+export { startBackendRun, processEvent };
+export type { ProcessResult, NodeAgentBridge };
 
 export const bind = makeAction();
 
@@ -366,7 +368,7 @@ type ProcessResult = "continue" | "done" | "suspend";
  */
 function processEvent(
   event: GraphRunEvent,
-  controller: typeof bind.controller,
+  controller: AppController,
   bridges: Map<string, NodeAgentBridge>
 ): ProcessResult {
   switch (event.type) {
@@ -554,7 +556,7 @@ function createBridge(
   nodeId: string,
   consoleEntry: ConsoleEntry | undefined,
   appScreen: AppScreen | undefined,
-  controller: typeof bind.controller,
+  controller: AppController,
   bridges: Map<string, NodeAgentBridge>
 ): void {
   const consumer = new AgentEventConsumer();

--- a/packages/visual-editor/src/sca/actions/run/backend-run-action.ts
+++ b/packages/visual-editor/src/sca/actions/run/backend-run-action.ts
@@ -41,6 +41,7 @@ import {
   createAppScreen,
   tickScreenProgress,
 } from "../../utils/app-screen.js";
+import { toLLMContentArray } from "../../utils/common.js";
 import { makeAction } from "../binder.js";
 import { Utils } from "../../utils.js";
 import {
@@ -404,9 +405,24 @@ function processEvent(
       const bridge = bridges.get(nodeId);
       const existing = controller.run.main.console.get(nodeId);
 
-      // Populate outputs from the captured agent outcomes.
-      if (existing && bridge?.outcomes) {
-        existing.output.set("context", bridge.outcomes);
+      // Populate outputs: agent-mode nodes have bridge.outcomes from
+      // agentEvent→complete; non-agent nodes (text gen, media gen) carry
+      // outputs directly on the nodeEnd event.
+      if (existing) {
+        if (bridge?.outcomes) {
+          existing.output.set("context", bridge.outcomes);
+        } else if (event.outputs) {
+          const inspectable = controller.editor.graph.get()?.graphs.get("");
+          const node = inspectable?.nodeById(nodeId);
+          const outputSchema = node?.currentDescribe()?.outputSchema ?? {};
+          const { products } = toLLMContentArray(
+            outputSchema as Schema,
+            event.outputs as OutputValues
+          );
+          for (const [name, product] of Object.entries(products)) {
+            existing.output.set(name, product as LLMContent);
+          }
+        }
       }
 
       if (existing) {
@@ -432,7 +448,44 @@ function processEvent(
           };
           screen.outputs.set(nodeId, output);
           screen.last = output;
+        } else if (event.outputs) {
+          const inspectable = controller.editor.graph.get()?.graphs.get("");
+          const node = inspectable?.nodeById(nodeId);
+          const outputSchema = node?.currentDescribe()?.outputSchema;
+          const output: AppScreenOutput = {
+            output: event.outputs as OutputValues,
+            schema: outputSchema,
+          };
+          screen.outputs.set(nodeId, output);
+          screen.last = output;
         }
+        screen.status = "complete";
+      }
+
+      // Clean up bridge.
+      bridges.delete(nodeId);
+      return "continue";
+    }
+
+    case "nodeError": {
+      const { nodeId, error } = event;
+      const existing = controller.run.main.console.get(nodeId);
+
+      if (existing) {
+        controller.run.main.setConsoleEntry(nodeId, {
+          ...existing,
+          status: { status: "failed", errorMessage: error },
+          error: { message: error },
+          completed: true,
+        });
+      }
+      controller.run.renderer.setNodeState(nodeId, {
+        status: "failed",
+        errorMessage: error,
+      });
+
+      const screen = controller.run.screen.screens.get(nodeId);
+      if (screen) {
         screen.status = "complete";
       }
 

--- a/packages/visual-editor/src/sca/services/graph-run-service.ts
+++ b/packages/visual-editor/src/sca/services/graph-run-service.ts
@@ -45,7 +45,8 @@ type GraphRunEvent = GraphRunEventBase &
   (
     | { type: "graphStart"; sessionId: string }
     | { type: "nodeStart"; nodeId: string }
-    | { type: "nodeEnd"; nodeId: string }
+    | { type: "nodeEnd"; nodeId: string; outputs?: Record<string, unknown> }
+    | { type: "nodeError"; nodeId: string; error: string }
     | {
         type: "agentEvent";
         nodeId: string;

--- a/packages/visual-editor/tests/sca/actions/run/backend-run-action.test.ts
+++ b/packages/visual-editor/tests/sca/actions/run/backend-run-action.test.ts
@@ -1,0 +1,391 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from "node:assert";
+import { beforeEach, suite, test } from "node:test";
+import { setDOM } from "../../../fake-dom.js";
+import { makeTestController } from "../../helpers/mock-controller.js";
+import {
+  processEvent,
+  type NodeAgentBridge,
+} from "../../../../src/sca/actions/run/backend-run-action.js";
+import type { GraphRunEvent } from "../../../../src/sca/services/graph-run-service.js";
+import type { AppController } from "../../../../src/sca/controller/controller.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+
+
+/**
+ * Creates a controller with a mock inspectable graph that returns basic
+ * node metadata. This satisfies processEvent's `controller.editor.graph
+ * .get()?.graphs.get("")` lookups.
+ */
+function makeControllerWithGraph() {
+  const { controller, mocks } = makeTestController();
+
+  // Wire up the mock graph so that `controller.editor.graph.get()`
+  // returns an inspectable with a `.graphs` map containing the root
+  // graph (""). Each node stub returns a title and empty
+  // describe/ports.
+  const mockNodes = new Map<
+    string,
+    {
+      title: () => string;
+      currentDescribe: () => { metadata: object; outputSchema?: object };
+      currentPorts: () => {
+        inputs: { ports: never[] };
+        outputs: { ports: never[] };
+      };
+    }
+  >();
+
+  const mockRootGraph = {
+    nodeById: (id: string) => mockNodes.get(id),
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (controller.editor.graph as any).get = () => ({
+    graphs: new Map([["", mockRootGraph]]),
+  });
+
+  /** Register a node that processEvent can look up. */
+  function addNode(
+    id: string,
+    title = id,
+    outputSchema: object = {}
+  ) {
+    mockNodes.set(id, {
+      title: () => title,
+      currentDescribe: () => ({
+        metadata: {},
+        outputSchema,
+      }),
+      currentPorts: () => ({
+        inputs: { ports: [] },
+        outputs: { ports: [] },
+      }),
+    });
+  }
+
+  return { controller, mocks, addNode };
+}
+
+/** Shorthand — calls processEvent with the test controller. */
+function dispatch(
+  event: GraphRunEvent,
+  controller: AppController,
+  bridges: Map<string, NodeAgentBridge>
+) {
+  return processEvent(event, controller, bridges);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+suite("processEvent", () => {
+  let controller: AppController;
+  let addNode: (id: string, title?: string, outputSchema?: object) => void;
+  let bridges: Map<string, NodeAgentBridge>;
+
+  beforeEach(() => {
+    setDOM();
+    const ctx = makeControllerWithGraph();
+    controller = ctx.controller;
+    addNode = ctx.addNode;
+    bridges = new Map();
+  });
+
+  // --- nodeStart -----------------------------------------------------------
+
+  suite("nodeStart", () => {
+    test("creates console entry and sets working state", () => {
+      addNode("n1", "Step One");
+
+      const result = dispatch(
+        { type: "nodeStart", nodeId: "n1", index: 0 },
+        controller,
+        bridges
+      );
+
+      assert.strictEqual(result, "continue");
+      const entry = controller.run.main.console.get("n1");
+      assert.ok(entry, "console entry should exist");
+      assert.strictEqual(entry.title, "Step One");
+
+      const nodeState = controller.run.renderer.nodes.get("n1");
+      assert.ok(nodeState);
+      assert.strictEqual(nodeState.status, "working");
+
+      // Bridge should have been created.
+      assert.ok(bridges.has("n1"), "bridge should exist for node");
+    });
+  });
+
+  // --- nodeEnd -------------------------------------------------------------
+
+  suite("nodeEnd", () => {
+    test("marks node as succeeded and cleans up bridge", () => {
+      addNode("n1", "Step One");
+
+      // Simulate nodeStart first to populate console entry.
+      dispatch(
+        { type: "nodeStart", nodeId: "n1", index: 0 },
+        controller,
+        bridges
+      );
+
+      const result = dispatch(
+        { type: "nodeEnd", nodeId: "n1", index: 1 },
+        controller,
+        bridges
+      );
+
+      assert.strictEqual(result, "continue");
+
+      const entry = controller.run.main.console.get("n1");
+      assert.ok(entry);
+      assert.deepStrictEqual(entry.status, { status: "succeeded" });
+      assert.strictEqual(entry.completed, true);
+
+      const nodeState = controller.run.renderer.nodes.get("n1");
+      assert.ok(nodeState);
+      assert.strictEqual(nodeState.status, "succeeded");
+
+      // Bridge should be cleaned up.
+      assert.ok(!bridges.has("n1"), "bridge should be removed");
+    });
+
+    test("populates outputs from event when no bridge outcomes", () => {
+      // The outputSchema must have an `items` with a `behavior` array
+      // for toLLMContentArray to recognize the port as llm-content.
+      addNode("n1", "Step One", {
+        properties: {
+          context: {
+            type: "array",
+            items: {
+              behavior: ["llm-content"],
+            },
+          },
+        },
+      });
+
+      // nodeStart to set up console entry.
+      dispatch(
+        { type: "nodeStart", nodeId: "n1", index: 0 },
+        controller,
+        bridges
+      );
+
+      // nodeEnd with outputs (non-agent path).
+      const outputs = {
+        context: [
+          { role: "model", parts: [{ text: "Hello from text gen" }] },
+        ],
+      };
+      dispatch(
+        { type: "nodeEnd", nodeId: "n1", outputs, index: 1 },
+        controller,
+        bridges
+      );
+
+      const entry = controller.run.main.console.get("n1");
+      assert.ok(entry);
+      // Output should have been populated via toLLMContentArray.
+      assert.ok(entry.output.size > 0, "outputs should be populated");
+    });
+  });
+
+  // --- nodeError -----------------------------------------------------------
+
+  suite("nodeError", () => {
+    test("marks console entry as failed with error message", () => {
+      addNode("n1", "Step One");
+
+      // nodeStart to create the entry.
+      dispatch(
+        { type: "nodeStart", nodeId: "n1", index: 0 },
+        controller,
+        bridges
+      );
+
+      const result = dispatch(
+        {
+          type: "nodeError",
+          nodeId: "n1",
+          error: "TTS model rejected input",
+          index: 2,
+        },
+        controller,
+        bridges
+      );
+
+      assert.strictEqual(result, "continue");
+
+      const entry = controller.run.main.console.get("n1");
+      assert.ok(entry, "console entry should still exist");
+      assert.deepStrictEqual(entry.status, {
+        status: "failed",
+        errorMessage: "TTS model rejected input",
+      });
+      assert.deepStrictEqual(entry.error, {
+        message: "TTS model rejected input",
+      });
+      assert.strictEqual(entry.completed, true);
+    });
+
+    test("sets renderer node state to failed", () => {
+      addNode("n1", "Step One");
+
+      dispatch(
+        { type: "nodeStart", nodeId: "n1", index: 0 },
+        controller,
+        bridges
+      );
+      dispatch(
+        {
+          type: "nodeError",
+          nodeId: "n1",
+          error: "Bad request",
+          index: 2,
+        },
+        controller,
+        bridges
+      );
+
+      const nodeState = controller.run.renderer.nodes.get("n1");
+      assert.ok(nodeState);
+      assert.strictEqual(nodeState.status, "failed");
+      if (nodeState.status === "failed") {
+        assert.strictEqual(nodeState.errorMessage, "Bad request");
+      }
+    });
+
+    test("cleans up bridge on error", () => {
+      addNode("n1", "Step One");
+
+      dispatch(
+        { type: "nodeStart", nodeId: "n1", index: 0 },
+        controller,
+        bridges
+      );
+      assert.ok(bridges.has("n1"), "bridge should exist after nodeStart");
+
+      dispatch(
+        {
+          type: "nodeError",
+          nodeId: "n1",
+          error: "Error",
+          index: 2,
+        },
+        controller,
+        bridges
+      );
+      assert.ok(!bridges.has("n1"), "bridge should be cleaned up after error");
+    });
+
+    test("handles nodeError when no prior nodeStart (no console entry)", () => {
+      // nodeError without nodeStart — should not throw.
+      const result = dispatch(
+        {
+          type: "nodeError",
+          nodeId: "n1",
+          error: "Unexpected error",
+          index: 0,
+        },
+        controller,
+        bridges
+      );
+
+      assert.strictEqual(result, "continue");
+
+      // Renderer should still be updated.
+      const nodeState = controller.run.renderer.nodes.get("n1");
+      assert.ok(nodeState);
+      assert.strictEqual(nodeState.status, "failed");
+    });
+  });
+
+  // --- graphComplete -------------------------------------------------------
+
+  suite("graphComplete", () => {
+    test("returns done", () => {
+      const result = dispatch(
+        {
+          type: "graphComplete",
+          sessionId: "sess-1",
+          outputs: {},
+          index: 0,
+        },
+        controller,
+        bridges
+      );
+
+      assert.strictEqual(result, "done");
+    });
+  });
+
+  // --- graphError ----------------------------------------------------------
+
+  suite("graphError", () => {
+    test("sets error on run controller and returns done", () => {
+      const result = dispatch(
+        {
+          type: "graphError",
+          sessionId: "sess-1",
+          error: "Graph execution failed",
+          index: 0,
+        },
+        controller,
+        bridges
+      );
+
+      assert.strictEqual(result, "done");
+
+      // The run controller should have the error set.
+      const error = controller.run.main.error;
+      assert.ok(error, "error should be set");
+      assert.strictEqual(error.message, "Graph execution failed");
+    });
+  });
+
+  // --- inputRequired -------------------------------------------------------
+
+  suite("inputRequired", () => {
+    test("returns suspend", () => {
+      const result = dispatch(
+        {
+          type: "inputRequired",
+          nodeId: "n1",
+          interactionId: "int-1",
+          index: 0,
+        },
+        controller,
+        bridges
+      );
+
+      assert.strictEqual(result, "suspend");
+    });
+  });
+
+  // --- unknown event -------------------------------------------------------
+
+  suite("unknown event type", () => {
+    test("returns continue for unrecognized events", () => {
+      const result = dispatch(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        { type: "someFutureEvent", index: 0 } as any,
+        controller,
+        bridges
+      );
+
+      assert.strictEqual(result, "continue");
+    });
+  });
+});

--- a/projects/heartstone/PROJECT.md
+++ b/projects/heartstone/PROJECT.md
@@ -18,6 +18,34 @@ completion without races.
 
 ---
 
+## Porting Discipline
+
+Every handler or module ported from TypeScript to Python requires a **detailed
+trace of the TS source** before writing any Python code. The port must be
+faithful — not "inspired by". Specifically:
+
+1. **Read the full TS function**, not just the entry point. Trace through every
+   helper it calls, every default it applies, every fallback it uses.
+2. **Identify constants and defaults.** Model names, default system instructions,
+   fallback values, timeout durations — these are easy to miss and hard to catch
+   in testing.
+3. **Map the data flow end-to-end.** Inputs → template substitution → API call →
+   response parsing → output shape. Each stage can have mode-specific logic.
+4. **Check the describe function** too, not just invoke. The describe function
+   often defines schemas, defaults, and port mappings that affect runtime
+   behavior.
+5. **Write tests that verify TS-parity**, not just "does it work". If the TS
+   code applies a default system instruction when none is configured, the test
+   should assert that the Python code does too.
+
+> **Lesson learned:** The default system instruction
+> (`defaultSystemInstruction()` in `system-instruction.ts`) was missed during
+> the `text_gen_handler` port because only the config extraction was ported, not
+> the fallback logic in `createSystemInstruction()`. This required reading a
+> file two imports away from the handler entry point.
+
+---
+
 ## All Resolved Decisions
 
 | # | Decision | Resolution |


### PR DESCRIPTION
## Summary

Adds backend support for all non-agent generation modes (image, audio, video, music) and fixes two rendering gaps in the frontend: nodeEnd output display for non-agent nodes, and nodeError handling so the UI stops spinning when a node fails.

## What changed

### Backend: Media generation handler

All media modes route through the existing One Platform `/v1beta1/executeStep` API with mode-specific parameters. A `MediaModeConfig` dataclass + `MEDIA_MODES` registry maps mode IDs to their executeStep config:

| Mode | modelApi | stepName | Output key |
|------|----------|----------|------------|
| `image` / `image-pro` | `ai_image_tool` | `EditImage` | `edited_image` |
| `audio` | `tts` | `GenerateAudio` | `generated_speech` |
| `video` | `generate_video` | `GenerateVideo` | `generated_video` |
| `music` | `generate_music` | `GenerateMusic` | `generated_music` |

`dispatch_handler()` now routes `generate` nodes to one of three handlers based on mode:
- `mode == "agent"` → `agent_handler` (existing)
- `mode in MEDIA_MODES` → `media_gen_handler` (new)
- everything else → `text_gen_handler` (existing)

The media handler:
- Extracts the prompt from config template substitution + upstream context, **skipping system instruction** (only relevant for Gemini text/agent modes)
- Builds mode-specific `execution_inputs` (aspect ratio for image/video, voice for audio)
- Collects reference images from upstream context for i2i/i2v support
- Parses executeStep output chunks into LLMContent via the existing `step_executor.py`

### Backend: nodeEnd outputs

`_complete_node()` in `graph_runner.py` now includes `outputs` in `nodeEnd` events, enabling the frontend to render results for non-agent nodes that don't emit `agentEvent` streams.

### Frontend: nodeEnd output rendering

The `nodeEnd` handler in `backend-run-action.ts` now falls back to `event.outputs` (via `toLLMContentArray()`) when `bridge.outcomes` is absent — matching the existing in-process PlanRunner path.

### Frontend: nodeError handling

Added `nodeError` to `GraphRunEvent` type and a corresponding handler that:
- Marks the console entry as `failed` with the error message
- Sets the node renderer state to `failed`
- Sets screen status to `complete`
- Cleans up the bridge

Previously, `nodeError` events from the backend were silently ignored, leaving the UI spinning indefinitely.

## Bug fix: TTS prompt rejection

The TTS model was rejecting prompts with `400 INVALID_ARGUMENT: "Model tried to generate text, but it should only be used for TTS"`. Root cause: `media_gen_handler` was including the system instruction (e.g. "Be helpful") in the TTS prompt text. The TS audio generator doesn't include system instruction — it's only for Gemini text/agent modes. Fixed by filtering system instruction segments from the media prompt.

## Testing

- **24 new tests** in `test_media_gen.py` covering:
  - Mode config registry completeness
  - Dispatch routing (media modes → `media_gen_handler`, text modes → `text_gen_handler`)
  - Prompt extraction from config, upstream context, and template substitution
  - System instruction exclusion from media prompts
  - executeStep body construction (aspect ratio, voice, model name, input parameters)
  - Output parsing (inline, storedData, empty, stub)
  - Reference image collection for i2i/i2v (inline, text filtering, video key naming)
- **All 724+ existing tests pass**
- **TypeScript compiles clean**

## Files changed

| File | What |
|------|------|
| `opal_backend/node_handlers.py` | `MediaModeConfig`, `MEDIA_MODES`, `media_gen_handler`, `_collect_reference_image_chunks`, `_part_to_image_chunk`, dispatch routing |
| `opal_backend/graph_runner.py` | Include `outputs` in `nodeEnd` events |
| `tests/test_media_gen.py` | 24 new tests |
| `sca/actions/run/backend-run-action.ts` | `nodeEnd` output fallback + `nodeError` handler |
| `sca/services/graph-run-service.ts` | `nodeError` type in `GraphRunEvent` |
