### PR TITLE
[heartstone] Phase 9a — Render output handler

### DIFF
--- a/packages/opal-backend/opal_backend/backend_client.py
+++ b/packages/opal-backend/opal_backend/backend_client.py
@@ -30,6 +30,7 @@ __all__ = ["BackendClient"]
 EXECUTE_STEP_ENDPOINT = "/v1beta1/executeStep"
 UPLOAD_GEMINI_FILE_ENDPOINT = "/v1beta1/uploadGeminiFile"
 UPLOAD_BLOB_FILE_ENDPOINT = "/v1beta1/uploadBlobFile"
+GENERATE_WEBPAGE_ENDPOINT = "/v1beta1/generateWebpageStream"
 
 
 @runtime_checkable
@@ -120,6 +121,18 @@ class BackendClient(Protocol):
         """
         ...
 
+    def stream_generate_webpage(
+        self,
+        body: dict[str, Any],
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Stream webpage generation from the AppCatalyst backend.
+
+        Calls the ``generateWebpageStream`` endpoint via SSE. Each
+        yielded dict contains ``parts`` with ``partMetadata.chunk_type``
+        of ``"thought"``, ``"html"``, or ``"error"``.
+        """
+        ...
+
     async def create_cached_content(
         self,
         body: dict[str, Any],
@@ -163,3 +176,4 @@ class BackendClient(Protocol):
             GeminiAPIError: If the API returns a non-200 status.
         """
         ...
+

--- a/packages/opal-backend/opal_backend/graph_runner.py
+++ b/packages/opal-backend/opal_backend/graph_runner.py
@@ -270,9 +270,18 @@ class GraphRunner:
             await self._store.append_event(session_id, wrapped)
             await self._event_bus.publish(session_id, wrapped)
 
+        async def on_thought_event(text: str) -> None:
+            """Forward thought events from generateWebpageStream."""
+            await self._event_bus.publish(session_id, {
+                "type": "thoughtEvent",
+                "nodeId": node_id,
+                "text": text,
+            })
+
         token, origin = self._session_auth.get(session_id, ("", ""))
         return NodeHandlerDeps(
             on_agent_event=on_agent_event,
+            on_thought_event=on_thought_event,
             run_agent_fn=self._run_agent_fn,
             backend=self._backend_factory(token, origin) if self._backend_factory else None,
             interaction_store=self._interaction_store,

--- a/packages/opal-backend/opal_backend/local/backend_client_impl.py
+++ b/packages/opal-backend/opal_backend/local/backend_client_impl.py
@@ -20,6 +20,7 @@ import httpx
 from ..backend_client import (
     BackendClient,
     EXECUTE_STEP_ENDPOINT,
+    GENERATE_WEBPAGE_ENDPOINT,
     UPLOAD_GEMINI_FILE_ENDPOINT,
     UPLOAD_BLOB_FILE_ENDPOINT,
 )
@@ -189,6 +190,42 @@ class HttpBackendClient:
                         logger.warning(
                             "Failed to parse SSE chunk: %s", json_str[:100]
                         )
+
+    async def stream_generate_webpage(
+        self, body: dict[str, Any],
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Stream from AppCatalyst generateWebpageStream via SSE."""
+        url = (
+            f"{self._upstream_base.rstrip('/')}"
+            f"{GENERATE_WEBPAGE_ENDPOINT}?alt=sse"
+        )
+        headers = self._headers()
+
+        # AppCatalyst requires the access token in the JSON body.
+        augmented_body = {**body, "accessToken": self._access_token}
+
+        async with self._httpx.stream(
+            "POST", url, json=augmented_body, headers=headers
+        ) as response:
+            if response.status_code != 200:
+                error_text = await response.aread()
+                raise ValueError(
+                    f"generateWebpageStream failed: {response.status_code} "
+                    f"{error_text.decode()[:500]}"
+                )
+
+            async for line in response.aiter_lines():
+                line = line.strip()
+                if line.startswith("data: "):
+                    json_str = line[len("data: "):]
+                    try:
+                        yield json.loads(json_str)
+                    except json.JSONDecodeError:
+                        logger.warning(
+                            "Failed to parse webpage SSE chunk: %s",
+                            json_str[:100],
+                        )
+
 
     async def create_cached_content(
         self,

--- a/packages/opal-backend/opal_backend/node_handlers.py
+++ b/packages/opal-backend/opal_backend/node_handlers.py
@@ -10,7 +10,7 @@ signal that the node needs user input.
 Only stdlib + typing — no external deps (synced to production).
 
 Handler types by phase:
-- ``passthrough_handler`` — returns inputs as outputs (output nodes)
+- ``output_handler`` — mode-aware output (output/render-outputs nodes)
 - ``text_gen_handler`` — direct Gemini text generation
 - ``media_gen_handler`` — executeStep-based media generation
   (image, audio, video, music)
@@ -19,12 +19,13 @@ Handler types by phase:
 
 from __future__ import annotations
 
+import base64
 import json
 import logging
 import re
 import uuid
 from dataclasses import dataclass, field
-from typing import Any, AsyncIterator, Callable, Coroutine
+from typing import Any, AsyncIterator, Awaitable, Callable, Coroutine
 
 from .backend_client import BackendClient
 from .conform_body import conform_body
@@ -35,7 +36,7 @@ __all__ = [
     "NodeSuspended",
     "consume_agent_events",
     "dispatch_handler",
-    "passthrough_handler",
+    "output_handler",
     "text_gen_handler",
     "media_gen_handler",
     "input_handler",
@@ -81,6 +82,12 @@ class NodeHandlerDeps:
     # Signature: (event_dict) -> None
     on_agent_event: Callable[
         [dict[str, Any]], Coroutine[Any, Any, None],
+    ] | None = None
+
+    # Called for each thought event during webpage generation.
+    # Signature: (text) -> None
+    on_thought_event: Callable[
+        [str], Awaitable[None]
     ] | None = None
 
     # Agent runner — async iterator factory.
@@ -235,7 +242,7 @@ async def dispatch_handler(
 
     match effective_type:
         case "output" | "render-outputs":
-            return await passthrough_handler(inputs, config)
+            return await output_handler(inputs, config, deps)
         case "input":
             return await input_handler(inputs, config)
         case "generate":
@@ -249,17 +256,14 @@ async def dispatch_handler(
             return await text_gen_handler(inputs, config, deps)
         case _:
             # Default passthrough for unknown types.
-            return await passthrough_handler(inputs, config)
+            return _passthrough(inputs)
 
 
-async def passthrough_handler(
-    inputs: dict[str, list[Any]],
-    config: dict[str, Any],
-) -> dict[str, Any]:
-    """Return inputs as outputs.
+def _passthrough(inputs: dict[str, list[Any]]) -> dict[str, Any]:
+    """Simple passthrough — returns inputs as outputs (legacy behavior).
 
     Flattens multi-value input ports: if a port has a single value,
-    unwrap it. This is the behavior for output/render-outputs nodes.
+    unwrap it.
     """
     outputs: dict[str, Any] = {}
     for port, values in inputs.items():
@@ -268,6 +272,252 @@ async def passthrough_handler(
         else:
             outputs[port] = values
     return outputs
+
+
+async def output_handler(
+    inputs: dict[str, list[Any]],
+    config: dict[str, Any],
+    deps: NodeHandlerDeps | None = None,
+) -> dict[str, Any]:
+    """Handle output / render-outputs nodes with mode dispatch.
+
+    Reads ``p-render-mode`` from config and dispatches to the
+    appropriate handler. Modes:
+
+    * ``"Manual layout"`` (default) — passthrough with template substitution.
+    * ``"Auto"`` / ``"consistent-ui"`` — HTML auto-layout via AppCatalyst
+      ``generateWebpageStream``.
+    * ``"google-doc"`` — save to Google Docs (TODO).
+    * ``"google-sheets"`` — save to Google Sheets (TODO).
+    * ``"google-slides"`` — save to Google Slides (TODO).
+    """
+    mode = config.get("p-render-mode", "Manual layout")
+
+    if mode in ("Auto", "consistent-ui"):
+        return await _html_auto_layout_handler(inputs, config, deps)
+    elif mode == "google-doc":
+        # TODO(Phase 9): Implement Google Docs handler.
+        return _manual_output_handler(inputs, config, deps)
+    elif mode == "google-sheets":
+        # TODO(Phase 9): Implement Google Sheets handler.
+        return _manual_output_handler(inputs, config, deps)
+    elif mode == "google-slides":
+        # TODO(Phase 9): Implement Google Slides handler.
+        return _manual_output_handler(inputs, config, deps)
+    else:
+        # "Manual layout" or unknown — passthrough.
+        return _manual_output_handler(inputs, config, deps)
+
+
+def _manual_output_handler(
+    inputs: dict[str, list[Any]],
+    config: dict[str, Any],
+    deps: NodeHandlerDeps | None = None,
+) -> dict[str, Any]:
+    """Manual output mode — passthrough with template substitution.
+
+    The ``text`` template (with ``{{type: "in", ...}}`` placeholders)
+    lives in ``config`` — it's part of the node configuration, not an
+    edge-connected input.  ``inputs`` only contains the upstream port
+    values (``p-z-*``).
+    """
+    # The text template is a config value, not an edge input.
+    text_config = config.get("text")
+    if text_config is None:
+        # Fall back to old passthrough behavior for backward compat.
+        return _passthrough(inputs)
+
+    # Extract the raw text from the config value (may be LLMContent dict).
+    if isinstance(text_config, str):
+        raw_text = text_config
+    elif isinstance(text_config, dict):
+        raw_text = _extract_text_from_content(text_config)
+    else:
+        return _passthrough(inputs)
+
+    # Apply template substitution using edge inputs as params.
+    assets = deps.assets if deps else None
+    substituted = _substitute_template(raw_text, inputs, assets)
+    return {"context": substituted}
+
+
+async def _html_auto_layout_handler(
+    inputs: dict[str, list[Any]],
+    config: dict[str, Any],
+    deps: NodeHandlerDeps | None = None,
+) -> dict[str, Any]:
+    """HTML auto-layout via AppCatalyst ``generateWebpageStream``.
+
+    Builds a request body matching the TS ``buildStreamingRequestBody()``
+    and streams the response. Thought chunks are forwarded via
+    ``deps.on_thought_event`` for frontend progress display.
+
+    The ``text`` template lives in ``config`` (node configuration), not
+    in ``inputs`` (edge-connected ports).  We first substitute the
+    template to get concrete text, then build the webpage request body.
+    """
+    # The text template is a config value, not an edge input.
+    text_config = config.get("text")
+    if text_config is None:
+        return _manual_output_handler(inputs, config, deps)
+
+    # Extract raw text and run template substitution.
+    if isinstance(text_config, str):
+        raw_text = text_config
+    elif isinstance(text_config, dict):
+        raw_text = _extract_text_from_content(text_config)
+    else:
+        return _manual_output_handler(inputs, config, deps)
+
+    assets = deps.assets if deps else None
+
+    # Use multimodal-aware substitution that preserves storedData /
+    # inlineData parts from inputs (e.g. images), matching the TS
+    # Template.substitute() behavior.
+    parts = _substitute_template_parts(raw_text, inputs, assets)
+
+    # Wrap as LLMContent for the request body.
+    content: list[dict[str, Any]] = [
+        {"role": "user", "parts": parts}
+    ]
+
+    # Extract system instruction for the request.
+    si = config.get("b-system-instruction", "")
+    if isinstance(si, list) and si:
+        # System instruction may be LLMContent — extract text.
+        si_parts = si[0].get("parts", []) if isinstance(si[0], dict) else []
+        si = " ".join(p.get("text", "") for p in si_parts if "text" in p)
+    elif isinstance(si, dict):
+        si = _extract_text_from_content(si)
+    elif not isinstance(si, str):
+        si = ""
+
+    body = _build_webpage_request_body(content, si)
+
+    if not deps or not deps.backend:
+        # No backend — fall back to manual mode.
+        return _manual_output_handler(inputs, config, deps)
+
+    # Stream from AppCatalyst generateWebpageStream.
+    html_result = ""
+    async for chunk in deps.backend.stream_generate_webpage(body):
+        for part in chunk.get("parts", []):
+            chunk_type = part.get("partMetadata", {}).get("chunk_type")
+            if chunk_type == "thought" and deps.on_thought_event:
+                await deps.on_thought_event(part.get("text", ""))
+            elif chunk_type == "html":
+                html_result = part.get("text", "")
+            elif chunk_type == "error":
+                raise ValueError(
+                    part.get("text", "Webpage generation failed")
+                )
+
+    if not html_result:
+        # Fallback: return raw content via manual mode.
+        return _manual_output_handler(inputs, config, deps)
+
+    # Return as inlineData text/html (matching TS toLLMContentInline).
+    encoded = base64.b64encode(html_result.encode()).decode()
+    return {
+        "context": [
+            {
+                "role": "model",
+                "parts": [
+                    {
+                        "inlineData": {
+                            "mimeType": "text/html",
+                            "data": encoded,
+                        }
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def _build_webpage_request_body(
+    content: list[dict[str, Any]], user_instruction: str,
+) -> dict[str, Any]:
+    """Build generateWebpageStream request body.
+
+    Ports ``buildStreamingRequestBody`` from
+    ``visual-editor/src/a2/a2/generate-webpage-stream.ts``.
+    """
+    contents: list[dict[str, Any]] = []
+    text_count = 0
+    media_count = 0
+
+    for item in content:
+        if not isinstance(item, dict):
+            continue
+        for part in item.get("parts", []):
+            if "text" in part:
+                text_count += 1
+                contents.append({
+                    "parts": [{
+                        "text": part["text"],
+                        "partMetadata": {"input_name": f"text_{text_count}"},
+                    }],
+                    "role": "user",
+                })
+            elif "inlineData" in part:
+                media_count += 1
+                contents.append({
+                    "parts": [{
+                        "inlineData": {
+                            "mimeType": part["inlineData"]["mimeType"],
+                            "data": part["inlineData"]["data"],
+                        },
+                        "partMetadata": {"input_name": f"media_{media_count}"},
+                    }],
+                    "role": "user",
+                })
+            elif "storedData" in part:
+                media_count += 1
+                handle = part["storedData"].get("handle", "")
+                mime_type = part["storedData"].get("mimeType", "")
+                file_uri = _parse_stored_data_url(handle)
+                contents.append({
+                    "parts": [{
+                        "fileData": {
+                            "mimeType": mime_type,
+                            "fileUri": file_uri,
+                        },
+                        "partMetadata": {"input_name": f"media_{media_count}"},
+                    }],
+                    "role": "user",
+                })
+
+    return {
+        "intent": "",
+        "userInstruction": user_instruction,
+        "contents": contents,
+    }
+
+
+def _parse_stored_data_url(handle: str) -> str:
+    """Parse a stored data URL into the appropriate fileUri format.
+
+    Ports ``parseStoredDataUrl`` from ``generate-webpage-stream.ts``.
+    """
+    # Handle drive:/ prefix.
+    if handle.startswith("drive:/"):
+        drive_id = re.sub(r"^drive:/+", "", handle)
+        return f"drive://{drive_id}"
+
+    # Handle Google Drive preview URLs.
+    drive_match = re.search(
+        r"https?://drive\.google\.com/file/d/([^/]+)", handle,
+    )
+    if drive_match:
+        return f"drive://{drive_match.group(1)}"
+
+    # Handle blob URLs.
+    blob_match = re.search(r"/board/blobs/([^/?#]+)", handle)
+    if blob_match:
+        return f"gs://{blob_match.group(1)}"
+
+    return handle
 
 
 # Maps input node modality config → format icon for the frontend.
@@ -959,6 +1209,9 @@ def _substitute_template(
 ) -> str:
     """Replace template placeholders in prompt text with input values.
 
+    Text-only variant: returns a flat string.  Used by text_gen_handler
+    and _manual_output_handler where multimodal parts aren't needed.
+
     Mirrors ``Template.substitute()`` + ``#replaceParam()`` from
     ``template.ts``.
 
@@ -991,6 +1244,118 @@ def _substitute_template(
         return m.group(0)  # Unknown param type — leave as-is.
 
     return _TEMPLATE_RE.sub(replace_match, text)
+
+
+def _substitute_template_parts(
+    text: str,
+    inputs: dict[str, list[Any]],
+    assets: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Replace template placeholders, preserving multimodal parts.
+
+    Multimodal variant of ``_substitute_template``.  Returns a flat list
+    of LLMContent parts (``{"text": ...}``, ``{"storedData": ...}``,
+    ``{"inlineData": ...}``, etc.) instead of a plain string.
+
+    Mirrors the TS ``Template.substitute()`` which spreads
+    ``LLMContent.parts`` into the result, preserving images and other
+    binary data alongside text.
+    """
+    parts: list[dict[str, Any]] = []
+    last_end = 0
+
+    for m in _TEMPLATE_RE.finditer(text):
+        # Text before this placeholder.
+        before = text[last_end:m.start()]
+        if before:
+            parts.append({"text": before})
+        last_end = m.end()
+
+        inner_json = m.group(1)
+        try:
+            param = json.loads(inner_json)
+        except (json.JSONDecodeError, TypeError):
+            parts.append({"text": m.group(0)})
+            continue
+
+        if not isinstance(param, dict):
+            parts.append({"text": m.group(0)})
+            continue
+
+        param_type = param.get("type")
+
+        if param_type == "in":
+            path = param.get("path", "")
+            title = param.get("title", "")
+            port_name = f"p-z-{path}"
+            if port_name not in inputs:
+                parts.append({"text": title})
+            else:
+                parts.extend(_get_input_parts(inputs[port_name]))
+        elif param_type == "asset":
+            # Assets are text-only for now.
+            parts.append({"text": _resolve_asset_text(param, assets)})
+        else:
+            parts.append({"text": m.group(0)})
+
+    # Trailing text after last placeholder.
+    trailing = text[last_end:]
+    if trailing:
+        parts.append({"text": trailing})
+
+    return _merge_adjacent_text_parts(parts)
+
+
+def _get_input_parts(values: list[Any]) -> list[dict[str, Any]]:
+    """Extract parts from an input port's values, preserving all part types.
+
+    Mirrors the TS ``Template.substitute()`` logic:
+    - ``LLMContent`` → spread its ``.parts``
+    - ``LLMContent[]`` → spread last non-$metadata item's ``.parts``
+    - ``string`` → ``[{"text": value}]``
+    """
+    if not values:
+        return []
+
+    value = values[0]
+
+    if isinstance(value, str):
+        return [{"text": value}]
+
+    if isinstance(value, dict) and "parts" in value:
+        # Single LLMContent.
+        return list(value.get("parts", []))
+
+    if isinstance(value, list):
+        # LLMContent[] — get last non-metadata item.
+        last = _get_last_non_metadata(value)
+        if last:
+            return list(last.get("parts", []))
+
+    return [{"text": json.dumps(value) if value is not None else ""}]
+
+
+def _merge_adjacent_text_parts(
+    parts: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Merge consecutive text parts into single parts.
+
+    Mirrors ``Template.#mergeTextParts()`` from template.ts.
+    """
+    if not parts:
+        return parts
+
+    merged: list[dict[str, Any]] = []
+    for part in parts:
+        if (
+            "text" in part
+            and merged
+            and "text" in merged[-1]
+        ):
+            merged[-1] = {"text": merged[-1]["text"] + part["text"]}
+        else:
+            merged.append(part)
+    return merged
 
 
 def _template_consumed_ports(

--- a/packages/opal-backend/tests/test_output_handler.py
+++ b/packages/opal-backend/tests/test_output_handler.py
@@ -1,0 +1,577 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the output handler logic."""
+
+from __future__ import annotations
+
+import base64
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from opal_backend.node_handlers import (
+    NodeHandlerDeps,
+    output_handler,
+)
+# Private helpers under test.
+from opal_backend.node_handlers import (
+    _build_webpage_request_body,
+    _get_input_parts,
+    _html_auto_layout_handler,
+    _manual_output_handler,
+    _parse_stored_data_url,
+    _passthrough,
+    _substitute_template_parts,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_deps(
+    stream_chunks: list[dict] | None = None,
+    assets: dict | None = None,
+) -> NodeHandlerDeps:
+    """Build NodeHandlerDeps with a mocked backend for webpage generation."""
+    backend = MagicMock()
+
+    if stream_chunks is not None:
+        async def _mock_stream(*args, **kwargs):
+            for chunk in stream_chunks:
+                yield chunk
+        backend.stream_generate_webpage = _mock_stream
+    else:
+        backend.stream_generate_webpage = AsyncMock()
+
+    return NodeHandlerDeps(
+        on_agent_event=AsyncMock(),
+        on_thought_event=AsyncMock(),
+        run_agent_fn=None,
+        backend=backend,
+        interaction_store=None,
+        assets=assets,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _parse_stored_data_url
+# ---------------------------------------------------------------------------
+
+class TestParseStoredDataUrl:
+    """Test URL parsing for stored data handles."""
+
+    def test_drive_prefix(self):
+        """drive:/ prefix → drive:// format."""
+        result = _parse_stored_data_url("drive:/abc123")
+        assert result == "drive://abc123"
+
+    def test_drive_prefix_multiple_slashes(self):
+        """drive:/// prefix → drive:// format (extra slashes stripped)."""
+        result = _parse_stored_data_url("drive:///abc123")
+        assert result == "drive://abc123"
+
+    def test_google_drive_file_url(self):
+        """Google Drive file URL → drive:// format."""
+        url = "https://drive.google.com/file/d/FILE_ID_123/view"
+        result = _parse_stored_data_url(url)
+        assert result == "drive://FILE_ID_123"
+
+    def test_blob_url(self):
+        """Blob URL → gs:// format."""
+        url = "https://example.com/board/blobs/blob-id-456"
+        result = _parse_stored_data_url(url)
+        assert result == "gs://blob-id-456"
+
+    def test_unknown_url_passthrough(self):
+        """Unknown URL → returned unchanged."""
+        url = "https://example.com/other/path"
+        result = _parse_stored_data_url(url)
+        assert result == url
+
+
+# ---------------------------------------------------------------------------
+# _build_webpage_request_body
+# ---------------------------------------------------------------------------
+
+class TestBuildWebpageRequestBody:
+    """Test request body construction for generateWebpageStream."""
+
+    def test_text_parts_get_metadata(self):
+        """Text parts get partMetadata with input_name: 'text_N'."""
+        content = [
+            {"role": "user", "parts": [{"text": "Hello"}]},
+            {"role": "user", "parts": [{"text": "World"}]},
+        ]
+        body = _build_webpage_request_body(content, "instruction")
+        contents = body["contents"]
+        assert len(contents) == 2
+        assert contents[0]["parts"][0]["text"] == "Hello"
+        assert contents[0]["parts"][0]["partMetadata"] == {"input_name": "text_1"}
+        assert contents[1]["parts"][0]["text"] == "World"
+        assert contents[1]["parts"][0]["partMetadata"] == {"input_name": "text_2"}
+
+    def test_inline_data_parts_get_metadata(self):
+        """InlineData parts get partMetadata with input_name: 'media_N'."""
+        content = [{
+            "role": "user",
+            "parts": [{"inlineData": {"mimeType": "image/png", "data": "abc"}}],
+        }]
+        body = _build_webpage_request_body(content, "")
+        contents = body["contents"]
+        assert len(contents) == 1
+        part = contents[0]["parts"][0]
+        assert "inlineData" in part
+        assert part["inlineData"]["mimeType"] == "image/png"
+        assert part["partMetadata"] == {"input_name": "media_1"}
+
+    def test_stored_data_converted_to_file_data(self):
+        """StoredData parts are converted to fileData with media_N metadata."""
+        content = [{
+            "role": "user",
+            "parts": [{
+                "storedData": {
+                    "handle": "drive:/file123",
+                    "mimeType": "image/jpeg",
+                },
+            }],
+        }]
+        body = _build_webpage_request_body(content, "")
+        contents = body["contents"]
+        assert len(contents) == 1
+        part = contents[0]["parts"][0]
+        assert "fileData" in part
+        assert part["fileData"]["mimeType"] == "image/jpeg"
+        assert part["fileData"]["fileUri"] == "drive://file123"
+        assert part["partMetadata"] == {"input_name": "media_1"}
+
+    def test_empty_content(self):
+        """Empty content → empty contents list."""
+        body = _build_webpage_request_body([], "instruction")
+        assert body["contents"] == []
+        assert body["intent"] == ""
+        assert body["userInstruction"] == "instruction"
+
+    def test_mixed_content(self):
+        """Mixed text and media content — counts are independent."""
+        content = [
+            {"role": "user", "parts": [{"text": "Describe this"}]},
+            {"role": "user", "parts": [
+                {"inlineData": {"mimeType": "image/png", "data": "img"}},
+            ]},
+            {"role": "user", "parts": [{"text": "And this"}]},
+        ]
+        body = _build_webpage_request_body(content, "sys")
+        contents = body["contents"]
+        assert len(contents) == 3
+        assert contents[0]["parts"][0]["partMetadata"] == {"input_name": "text_1"}
+        assert contents[1]["parts"][0]["partMetadata"] == {"input_name": "media_1"}
+        assert contents[2]["parts"][0]["partMetadata"] == {"input_name": "text_2"}
+        assert body["userInstruction"] == "sys"
+
+
+# ---------------------------------------------------------------------------
+# _passthrough
+# ---------------------------------------------------------------------------
+
+class TestPassthrough:
+    """Test simple passthrough behavior."""
+
+    def test_single_input_unwrapped(self):
+        """Single input value is unwrapped from its list."""
+        result = _passthrough({"context": ["hello"]})
+        assert result == {"context": "hello"}
+
+    def test_multiple_inputs_stay_as_list(self):
+        """Multiple input values stay as a list."""
+        result = _passthrough({"context": ["a", "b"]})
+        assert result == {"context": ["a", "b"]}
+
+    def test_multiple_ports(self):
+        """Multiple ports each get unwrapped independently."""
+        result = _passthrough({
+            "text": ["hello"],
+            "image": ["img1", "img2"],
+        })
+        assert result == {"text": "hello", "image": ["img1", "img2"]}
+
+
+# ---------------------------------------------------------------------------
+# _manual_output_handler
+# ---------------------------------------------------------------------------
+
+class TestManualOutputHandler:
+    """Test manual output mode — template substitution + passthrough."""
+
+    def test_with_text_config_calls_substitute(self):
+        """Text in config triggers template substitution and returns context."""
+        inputs: dict = {}
+        config = {"text": "Hello world"}
+        result = _manual_output_handler(inputs, config)
+        assert "context" in result
+        # Simple text should pass through substitution unchanged.
+        assert result["context"] == "Hello world"
+
+    def test_without_text_config_falls_through(self):
+        """No 'text' in config → falls through to _passthrough."""
+        inputs = {"image": ["img_data"]}
+        config: dict = {}
+        result = _manual_output_handler(inputs, config)
+        # _passthrough unwraps single values.
+        assert result == {"image": "img_data"}
+
+    def test_with_llm_content_text_config(self):
+        """LLMContent dict in config with text parts is extracted."""
+        inputs: dict = {}
+        config = {
+            "text": {"role": "user", "parts": [{"text": "extracted text"}]},
+        }
+        result = _manual_output_handler(inputs, config)
+        assert result["context"] == "extracted text"
+
+
+# ---------------------------------------------------------------------------
+# output_handler — mode dispatch
+# ---------------------------------------------------------------------------
+
+class TestOutputHandlerDispatch:
+    """Test that output_handler dispatches to the correct sub-handler."""
+
+    @pytest.mark.asyncio
+    async def test_default_mode_uses_manual(self):
+        """Missing mode defaults to manual handler."""
+        inputs: dict = {}
+        config = {"text": "default output"}
+        result = await output_handler(inputs, config)
+        assert result["context"] == "default output"
+
+    @pytest.mark.asyncio
+    async def test_manual_layout_mode(self):
+        """'Manual layout' mode → manual handler."""
+        inputs: dict = {}
+        config = {"p-render-mode": "Manual layout", "text": "manual"}
+        result = await output_handler(inputs, config)
+        assert result["context"] == "manual"
+
+    @pytest.mark.asyncio
+    async def test_auto_mode_dispatches_to_html(self):
+        """'Auto' mode → HTML handler (falls back to manual without backend)."""
+        inputs: dict = {}
+        config = {"p-render-mode": "Auto", "text": "auto output"}
+        # No deps/backend → html handler falls back to manual.
+        result = await output_handler(inputs, config, deps=None)
+        assert result["context"] == "auto output"
+
+    @pytest.mark.asyncio
+    async def test_consistent_ui_mode_dispatches_to_html(self):
+        """'consistent-ui' mode → HTML handler."""
+        inputs: dict = {}
+        config = {"p-render-mode": "consistent-ui", "text": "consistent"}
+        result = await output_handler(inputs, config, deps=None)
+        assert result["context"] == "consistent"
+
+    @pytest.mark.asyncio
+    async def test_google_doc_mode_uses_manual(self):
+        """'google-doc' mode → manual handler (TODO stub)."""
+        inputs: dict = {}
+        config = {"p-render-mode": "google-doc", "text": "doc output"}
+        result = await output_handler(inputs, config)
+        assert result["context"] == "doc output"
+
+
+# ---------------------------------------------------------------------------
+# _html_auto_layout_handler
+# ---------------------------------------------------------------------------
+
+class TestHtmlAutoLayoutHandler:
+    """Test HTML auto-layout via generateWebpageStream."""
+
+    @pytest.mark.asyncio
+    async def test_happy_path(self):
+        """Stream with thought + html → base64-encoded HTML output."""
+        thought_text = "Planning layout..."
+        html_text = "<html><body>Hello</body></html>"
+        chunks = [
+            {"parts": [
+                {"text": thought_text,
+                 "partMetadata": {"chunk_type": "thought"}},
+            ]},
+            {"parts": [
+                {"text": html_text,
+                 "partMetadata": {"chunk_type": "html"}},
+            ]},
+        ]
+        deps = _make_deps(stream_chunks=chunks)
+        inputs: dict = {}
+        config = {"text": "Some content"}
+
+        result = await _html_auto_layout_handler(inputs, config, deps)
+
+        # on_thought_event called with thought text.
+        deps.on_thought_event.assert_called_once_with(thought_text)
+
+        # Result is base64-encoded HTML as inlineData.
+        context = result["context"]
+        assert len(context) == 1
+        part = context[0]["parts"][0]
+        assert part["inlineData"]["mimeType"] == "text/html"
+        decoded = base64.b64decode(part["inlineData"]["data"]).decode()
+        assert decoded == html_text
+
+    @pytest.mark.asyncio
+    async def test_error_chunk_raises(self):
+        """Error chunk raises ValueError."""
+        chunks = [
+            {"parts": [
+                {"text": "Something went wrong",
+                 "partMetadata": {"chunk_type": "error"}},
+            ]},
+        ]
+        deps = _make_deps(stream_chunks=chunks)
+        inputs: dict = {}
+        config = {"text": "content"}
+
+        with pytest.raises(ValueError, match="Something went wrong"):
+            await _html_auto_layout_handler(inputs, config, deps)
+
+    @pytest.mark.asyncio
+    async def test_no_html_result_falls_back_to_manual(self):
+        """No html result → falls back to manual handler."""
+        # Stream with only a thought, no html chunk.
+        chunks = [
+            {"parts": [
+                {"text": "thinking...",
+                 "partMetadata": {"chunk_type": "thought"}},
+            ]},
+        ]
+        deps = _make_deps(stream_chunks=chunks)
+        inputs: dict = {}
+        config = {"text": "fallback text"}
+
+        result = await _html_auto_layout_handler(inputs, config, deps)
+
+        # Should fall back to manual → returns substituted text.
+        assert result["context"] == "fallback text"
+
+    @pytest.mark.asyncio
+    async def test_no_backend_falls_back_to_manual(self):
+        """No backend → falls back to manual handler."""
+        deps = NodeHandlerDeps(
+            on_agent_event=AsyncMock(),
+            run_agent_fn=None,
+            backend=None,
+            interaction_store=None,
+        )
+        inputs: dict = {}
+        config = {"text": "no backend text"}
+
+        result = await _html_auto_layout_handler(inputs, config, deps)
+        assert result["context"] == "no backend text"
+
+    @pytest.mark.asyncio
+    async def test_no_text_config_falls_back_to_manual(self):
+        """No text in config → falls back to manual handler (passthrough)."""
+        deps = _make_deps(stream_chunks=[])
+        inputs = {"image": ["img_data"]}
+        config: dict = {}
+
+        result = await _html_auto_layout_handler(inputs, config, deps)
+        # _manual_output_handler → _passthrough since no "text" in config.
+        assert result == {"image": "img_data"}
+
+    @pytest.mark.asyncio
+    async def test_string_text_config(self):
+        """String text in config is used directly for the request."""
+        html_text = "<p>Result</p>"
+        chunks = [
+            {"parts": [
+                {"text": html_text,
+                 "partMetadata": {"chunk_type": "html"}},
+            ]},
+        ]
+        deps = _make_deps(stream_chunks=chunks)
+        inputs: dict = {}
+        config = {"text": "Hello plain text"}
+
+        result = await _html_auto_layout_handler(inputs, config, deps)
+
+        # Should succeed and return HTML.
+        context = result["context"]
+        decoded = base64.b64decode(context[0]["parts"][0]["inlineData"]["data"]).decode()
+        assert decoded == html_text
+
+    @pytest.mark.asyncio
+    async def test_image_input_preserved_in_request_body(self):
+        """Image storedData from an input is included in the webpage request."""
+        html_text = "<html><body><img src='...'></body></html>"
+        chunks = [
+            {"parts": [
+                {"text": html_text,
+                 "partMetadata": {"chunk_type": "html"}},
+            ]},
+        ]
+        captured_bodies: list[dict] = []
+
+        async def _capture_stream(body):
+            captured_bodies.append(body)
+            for chunk in chunks:
+                yield chunk
+
+        deps = _make_deps(stream_chunks=chunks)
+        deps.backend.stream_generate_webpage = _capture_stream
+
+        # Template references both an image and text input.
+        template = (
+            '{{"type":"in","path":"img-node","title":"Image"}}'
+            ' {{"type":"in","path":"txt-node","title":"Text"}}'
+        )
+        inputs = {
+            "p-z-img-node": [[
+                {"role": "user", "parts": [{
+                    "storedData": {
+                        "handle": "/board/blobs/abc123",
+                        "mimeType": "image/png",
+                    }
+                }]}
+            ]],
+            "p-z-txt-node": [[
+                {"role": "model", "parts": [{"text": "A haiku"}]}
+            ]],
+        }
+        config = {
+            "text": {"role": "user", "parts": [{"text": template}]},
+        }
+
+        result = await _html_auto_layout_handler(inputs, config, deps)
+
+        # Verify the request body was captured.
+        assert len(captured_bodies) == 1
+        body = captured_bodies[0]
+        contents = body["contents"]
+
+        # Should have 2 content items: storedData (as fileData) + text.
+        assert len(contents) == 2
+
+        # First content: the image (storedData → fileData).
+        media_part = contents[0]["parts"][0]
+        assert "fileData" in media_part
+        assert media_part["fileData"]["mimeType"] == "image/png"
+
+        # Second content: the text.
+        text_part = contents[1]["parts"][0]
+        assert "text" in text_part
+        assert "A haiku" in text_part["text"]
+
+
+# ---------------------------------------------------------------------------
+# _substitute_template_parts (multimodal template substitution)
+# ---------------------------------------------------------------------------
+
+class TestSubstituteTemplateParts:
+    """Test multimodal-aware template substitution."""
+
+    def test_text_only(self):
+        """Pure text input is preserved."""
+        parts = _substitute_template_parts("Hello world", {})
+        assert parts == [{"text": "Hello world"}]
+
+    def test_text_input_substituted(self):
+        """Text input is inlined as a text part."""
+        inputs = {
+            "p-z-node1": [[
+                {"role": "model", "parts": [{"text": "replaced"}]}
+            ]],
+        }
+        parts = _substitute_template_parts(
+            'before {{"type":"in","path":"node1","title":"Node"}} after',
+            inputs,
+        )
+        # Adjacent text parts should be merged.
+        assert len(parts) == 1
+        assert parts[0]["text"] == "before replaced after"
+
+    def test_image_input_preserved(self):
+        """storedData parts from inputs are preserved, not converted to text."""
+        inputs = {
+            "p-z-img": [[
+                {"role": "user", "parts": [{
+                    "storedData": {
+                        "handle": "/board/blobs/abc",
+                        "mimeType": "image/png",
+                    }
+                }]}
+            ]],
+        }
+        parts = _substitute_template_parts(
+            '{{"type":"in","path":"img","title":"Image"}}',
+            inputs,
+        )
+        assert len(parts) == 1
+        assert "storedData" in parts[0]
+        assert parts[0]["storedData"]["mimeType"] == "image/png"
+
+    def test_mixed_text_and_image(self):
+        """Template with both text and image produces mixed parts list."""
+        inputs = {
+            "p-z-img": [[
+                {"role": "user", "parts": [{
+                    "storedData": {
+                        "handle": "/board/blobs/xyz",
+                        "mimeType": "image/png",
+                    }
+                }]}
+            ]],
+            "p-z-txt": [[
+                {"role": "model", "parts": [{"text": "poem"}]}
+            ]],
+        }
+        parts = _substitute_template_parts(
+            '{{"type":"in","path":"img","title":"Img"}}'
+            ' {{"type":"in","path":"txt","title":"Txt"}}',
+            inputs,
+        )
+        # Should be: storedData, then " poem" (merged text).
+        assert len(parts) == 2
+        assert "storedData" in parts[0]
+        assert parts[1] == {"text": " poem"}
+
+    def test_missing_input_uses_title(self):
+        """Missing input falls back to the placeholder title."""
+        parts = _substitute_template_parts(
+            '{{"type":"in","path":"missing","title":"Fallback"}}',
+            {},
+        )
+        assert parts == [{"text": "Fallback"}]
+
+
+# ---------------------------------------------------------------------------
+# _get_input_parts
+# ---------------------------------------------------------------------------
+
+class TestGetInputParts:
+    """Test extracting parts from input port values."""
+
+    def test_string_value(self):
+        assert _get_input_parts(["hello"]) == [{"text": "hello"}]
+
+    def test_single_llm_content(self):
+        value = {"role": "model", "parts": [{"text": "hi"}]}
+        assert _get_input_parts([value]) == [{"text": "hi"}]
+
+    def test_llm_content_array(self):
+        value = [
+            {"role": "$metadata", "parts": [{"text": "meta"}]},
+            {"role": "model", "parts": [{"text": "content"}]},
+        ]
+        assert _get_input_parts([value]) == [{"text": "content"}]
+
+    def test_stored_data_preserved(self):
+        value = {"role": "user", "parts": [
+            {"storedData": {"handle": "h", "mimeType": "image/png"}}
+        ]}
+        result = _get_input_parts([value])
+        assert len(result) == 1
+        assert "storedData" in result[0]
+
+    def test_empty_values(self):
+        assert _get_input_parts([]) == []

--- a/packages/visual-editor/src/sca/actions/run/backend-run-action.ts
+++ b/packages/visual-editor/src/sca/actions/run/backend-run-action.ts
@@ -52,7 +52,7 @@ import {
 const LABEL = "Backend Run";
 
 export { startBackendRun, processEvent };
-export type { ProcessResult, NodeAgentBridge };
+export type { ProcessResult, NodeEventBridge };
 
 export const bind = makeAction();
 
@@ -81,12 +81,13 @@ function raceAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
 }
 
 // ---------------------------------------------------------------------------
-// Per-node agent bridge
+// Per-node event bridge
 // ---------------------------------------------------------------------------
 
 /**
  * Tracks the AgentEventConsumer and progress state for a single node
- * so we can dispatch agent events to the correct consumer.
+ * so we can dispatch agent events and thought events to the correct
+ * consumer.
  *
  * Also captures the agent's `outcomes` from the `complete` event so
  * that `nodeEnd` can populate the console entry's output map.
@@ -96,7 +97,7 @@ function raceAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
  * between the `waitForInput` agent event (which shows the UI) and
  * the `inputRequired` graph event (which triggers the resume flow).
  */
-interface NodeAgentBridge {
+interface NodeEventBridge {
   consumer: AgentEventConsumer;
   progress: ConsoleProgressManager;
   /** Captured from the `complete` agent event — the agent's final output. */
@@ -159,8 +160,8 @@ async function startBackendRun(): Promise<void> {
   const abortController = new AbortController();
   controller.run.main.abortController = abortController;
 
-  // Per-node agent bridges for dispatching agent events.
-  const bridges = new Map<string, NodeAgentBridge>();
+  // Per-node event bridges for dispatching agent and thought events.
+  const bridges = new Map<string, NodeEventBridge>();
 
   try {
     const session = await graphRunService.createSession(
@@ -369,7 +370,7 @@ type ProcessResult = "continue" | "done" | "suspend";
 function processEvent(
   event: GraphRunEvent,
   controller: AppController,
-  bridges: Map<string, NodeAgentBridge>
+  bridges: Map<string, NodeEventBridge>
 ): ProcessResult {
   switch (event.type) {
     case "nodeStart": {
@@ -506,6 +507,14 @@ function processEvent(
       return "continue";
     }
 
+    case "thoughtEvent": {
+      const bridge = bridges.get(event.nodeId);
+      if (bridge) {
+        bridge.progress.thought(event.text);
+      }
+      return "continue";
+    }
+
     case "inputRequired": {
       // Signal the main loop to suspend and handle input.
       return "suspend";
@@ -542,7 +551,7 @@ function processEvent(
 // ---------------------------------------------------------------------------
 
 /**
- * Creates a per-node agent bridge and registers progress handlers.
+ * Creates a per-node event bridge and registers progress handlers.
  *
  * Also registers a `waitForInput` handler that bridges the frontend
  * input UI to the backend suspend/resume flow. When the agent emits
@@ -557,12 +566,12 @@ function createBridge(
   consoleEntry: ConsoleEntry | undefined,
   appScreen: AppScreen | undefined,
   controller: AppController,
-  bridges: Map<string, NodeAgentBridge>
+  bridges: Map<string, NodeEventBridge>
 ): void {
   const consumer = new AgentEventConsumer();
   const progress = new ConsoleProgressManager(consoleEntry, appScreen);
 
-  const bridge: NodeAgentBridge = { consumer, progress };
+  const bridge: NodeEventBridge = { consumer, progress };
 
   registerProgressHandlers(consumer, progress, {
     onComplete: (result) => {

--- a/packages/visual-editor/src/sca/services/graph-run-service.ts
+++ b/packages/visual-editor/src/sca/services/graph-run-service.ts
@@ -53,6 +53,11 @@ type GraphRunEvent = GraphRunEventBase &
         event: Record<string, unknown>;
       }
     | {
+        type: "thoughtEvent";
+        nodeId: string;
+        text: string;
+      }
+    | {
         type: "inputRequired";
         nodeId: string;
         interactionId: string;

--- a/packages/visual-editor/tests/sca/actions/run/backend-run-action.test.ts
+++ b/packages/visual-editor/tests/sca/actions/run/backend-run-action.test.ts
@@ -10,7 +10,7 @@ import { setDOM } from "../../../fake-dom.js";
 import { makeTestController } from "../../helpers/mock-controller.js";
 import {
   processEvent,
-  type NodeAgentBridge,
+  type NodeEventBridge,
 } from "../../../../src/sca/actions/run/backend-run-action.js";
 import type { GraphRunEvent } from "../../../../src/sca/services/graph-run-service.js";
 import type { AppController } from "../../../../src/sca/controller/controller.js";
@@ -80,7 +80,7 @@ function makeControllerWithGraph() {
 function dispatch(
   event: GraphRunEvent,
   controller: AppController,
-  bridges: Map<string, NodeAgentBridge>
+  bridges: Map<string, NodeEventBridge>
 ) {
   return processEvent(event, controller, bridges);
 }
@@ -92,7 +92,7 @@ function dispatch(
 suite("processEvent", () => {
   let controller: AppController;
   let addNode: (id: string, title?: string, outputSchema?: object) => void;
-  let bridges: Map<string, NodeAgentBridge>;
+  let bridges: Map<string, NodeEventBridge>;
 
   beforeEach(() => {
     setDOM();
@@ -199,6 +199,53 @@ suite("processEvent", () => {
       assert.ok(entry);
       // Output should have been populated via toLLMContentArray.
       assert.ok(entry.output.size > 0, "outputs should be populated");
+    });
+  });
+
+  // --- thoughtEvent --------------------------------------------------------
+
+  suite("thoughtEvent", () => {
+    test("forwards thought text to bridge progress", () => {
+      addNode("n1", "Step One");
+
+      // nodeStart to create the bridge.
+      dispatch(
+        { type: "nodeStart", nodeId: "n1", index: 0 },
+        controller,
+        bridges
+      );
+
+      const bridge = bridges.get("n1");
+      assert.ok(bridge, "bridge should exist after nodeStart");
+
+      // Spy on progress.thought.
+      const thoughtCalls: string[] = [];
+      const originalThought = bridge.progress.thought.bind(bridge.progress);
+      bridge.progress.thought = (text: string) => {
+        thoughtCalls.push(text);
+        return originalThought(text);
+      };
+
+      const result = dispatch(
+        { type: "thoughtEvent", nodeId: "n1", text: "Thinking about layout...", index: 1 },
+        controller,
+        bridges
+      );
+
+      assert.strictEqual(result, "continue");
+      assert.strictEqual(thoughtCalls.length, 1);
+      assert.strictEqual(thoughtCalls[0], "Thinking about layout...");
+    });
+
+    test("ignores thoughtEvent for unknown node", () => {
+      // No nodeStart — no bridge exists.
+      const result = dispatch(
+        { type: "thoughtEvent", nodeId: "unknown", text: "Some thought", index: 0 },
+        controller,
+        bridges
+      );
+
+      assert.strictEqual(result, "continue");
     });
   });
 


### PR DESCRIPTION
## What
Adds render-output node handling to the Python graph runner with mode dispatch (Manual layout, HTML auto-layout), and multimodal-aware template substitution that preserves images.

## Why
The output/render-outputs node was previously a passthrough — it didn't actually render anything server-side. This PR makes it functional: Manual layout does template substitution, and HTML auto-layout streams through AppCatalyst's `generateWebpageStream` to produce styled HTML output with embedded images.

## Changes

**Output handler (`node_handlers.py`)**
- Refactor `passthrough_handler` → `output_handler` with `p-render-mode` dispatch
- Manual layout: template substitution with `_substitute_template()`
- HTML auto-layout: calls `generateWebpageStream`, streams thoughts via `on_thought_event`, returns base64-encoded HTML as `inlineData`
- Port `buildStreamingRequestBody` + `parseStoredDataUrl` from TS

**Multimodal template substitution (`node_handlers.py`)**
- Add `_substitute_template_parts()` — preserves `storedData`/`inlineData` parts from inputs (e.g. images) instead of collapsing everything to text
- HTML auto-layout now sends images to `generateWebpageStream` so generated HTML can include them

**BackendClient protocol (`backend_client.py`, `backend_client_impl.py`)**
- Add `stream_generate_webpage()` to `BackendClient` protocol + `HttpBackendClient`

**Frontend bridge (`backend-run-action.ts`, `graph-run-service.ts`)**
- Rename `NodeAgentBridge` → `NodeEventBridge` (more general)
- Add `thoughtEvent` to `GraphRunEvent` union + `processEvent` handler
- Wire `on_thought_event` callback through `GraphRunner` → `EventBus`

## Testing
- 38 new Python tests in `test_output_handler.py` covering mode dispatch, manual layout, HTML auto-layout (happy path, error, fallback), multimodal template parts, storedData URL parsing, and request body construction
- 2 new TS tests for `thoughtEvent` dispatching in `backend-run-action.test.ts`
- Full suite: 752 Python tests pass, TS tests pass

