### PR TITLE
[ve/opie] Shift Lite mode welcome mat to Opie

### DIFF
--- a/packages/visual-editor/src/index-lite.ts
+++ b/packages/visual-editor/src/index-lite.ts
@@ -16,8 +16,10 @@ import { MainBase } from "./main-base.js";
 import { classMap } from "lit/directives/class-map.js";
 import { StateEvent, StateEventDetailMap } from "./ui/events/events.js";
 import { LiteEditInputController } from "./ui/lite/input/editor-input-lite.js";
+import "./ui/lite/input/editor-input-lite-opie.js";
 
 import { reactive } from "./sca/reactive.js";
+import { isHydrating } from "./sca/utils/helpers/helpers.js";
 
 import { blankBoard } from "./ui/utils/blank-board.js";
 import { repeat } from "lit/directives/repeat.js";
@@ -108,8 +110,12 @@ export class LiteMain extends MainBase implements LiteEditInputController {
           }
         }
 
-        & bb-editor-input-lite {
+        & bb-editor-input-lite,
+        & bb-editor-input-lite-opie {
           flex: 0 0 auto;
+        }
+
+        & bb-editor-input-lite {
           box-shadow: 0 2px 8px -2px rgba(0, 0, 0, 0.16);
         }
 
@@ -302,7 +308,8 @@ export class LiteMain extends MainBase implements LiteEditInputController {
             }
           }
 
-          & bb-editor-input-lite {
+          & bb-editor-input-lite,
+          & bb-editor-input-lite-opie {
             max-width: 90%;
             width: 100%;
             margin: 0 auto;
@@ -593,6 +600,20 @@ export class LiteMain extends MainBase implements LiteEditInputController {
   #renderUserInput() {
     const editable =
       !this.sca.controller.editor.graph.readOnly || this.#viewType !== "editor";
+
+    const isHydratingAgent = isHydrating(() =>
+      this.sca.env.flags.get("enableGraphEditorAgent")
+    );
+    const enableGraphEditorAgent =
+      !isHydratingAgent && this.sca.env.flags.get("enableGraphEditorAgent");
+
+    if (enableGraphEditorAgent && this.#viewType === "home") {
+      return html`<bb-editor-input-lite-opie
+        ?inert=${this.#isInert()}
+        .editable=${editable}
+      ></bb-editor-input-lite-opie>`;
+    }
+
     return html`<bb-editor-input-lite
       ?inert=${this.#isInert()}
       .controller=${this}

--- a/packages/visual-editor/src/ui/elements/graph-editing-chat/opie-avatar.ts
+++ b/packages/visual-editor/src/ui/elements/graph-editing-chat/opie-avatar.ts
@@ -20,6 +20,9 @@ export class OpieAvatar extends SignalWatcher(LitElement) {
   @property({ type: Boolean, reflect: true })
   accessor inverted = false;
 
+  @property({ type: Boolean, reflect: true })
+  accessor supportsHover = true;
+
   @property({ type: Boolean, reflect: true, attribute: "static" })
   accessor isStatic = false;
 
@@ -75,7 +78,7 @@ export class OpieAvatar extends SignalWatcher(LitElement) {
         border-color 0.2s ease;
     }
 
-    :host(:hover)::after {
+    :host([supportsHover]:hover)::after {
       opacity: 1;
       border-color: var(--light-dark-n-50);
     }
@@ -195,8 +198,8 @@ export class OpieAvatar extends SignalWatcher(LitElement) {
     }
 
     :host([mode="hero"]) .eyes {
-      gap: 7px;
-      margin-top: 16px;
+      gap: 5px;
+      margin-top: 12px;
     }
 
     :host([mode="hero"]) .eyes.left {
@@ -208,8 +211,8 @@ export class OpieAvatar extends SignalWatcher(LitElement) {
     }
 
     :host([mode="hero"]) .eye {
-      width: 7px;
-      height: 14px;
+      width: 6px;
+      height: 12px;
       border-radius: 3px;
     }
   `;

--- a/packages/visual-editor/src/ui/elements/input/expanding-textarea.ts
+++ b/packages/visual-editor/src/ui/elements/input/expanding-textarea.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { LitElement, css, html, type PropertyValues } from "lit";
+import { LitElement, css, html, nothing, type PropertyValues } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { createRef, ref } from "lit/directives/ref.js";
 import * as Styles from "../../styles/styles.js";
@@ -54,6 +54,9 @@ export class ExpandingTextarea extends LitElement {
 
   @property({ reflect: true, type: Boolean })
   accessor isPopulated = false;
+
+  @property({ type: Boolean })
+  accessor showSubmitButton = true;
 
   #measure = createRef<HTMLElement>();
   #textarea = createRef<HTMLTextAreaElement>();
@@ -245,16 +248,18 @@ export class ExpandingTextarea extends LitElement {
           ></div>
         </div>
         <slot name="mic"></slot>
-        <button
-          ?disabled=${this.disabled}
-          id="submit"
-          aria-label="Submit"
-          @click=${this.#submit}
-        >
-          <slot name="submit">
-            <span class="g-icon">spark</span>
-          </slot>
-        </button>
+        ${this.showSubmitButton
+          ? html`<button
+              ?disabled=${this.disabled}
+              id="submit"
+              aria-label="Submit"
+              @click=${this.#submit}
+            >
+              <slot name="submit">
+                <span class="g-icon">spark</span>
+              </slot>
+            </button>`
+          : nothing}
       </div>
     `;
   }

--- a/packages/visual-editor/src/ui/lite/input/editor-input-lite-opie.ts
+++ b/packages/visual-editor/src/ui/lite/input/editor-input-lite-opie.ts
@@ -1,0 +1,245 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SignalWatcher } from "@lit-labs/signals";
+import { consume } from "@lit/context";
+import { LitElement, css, html } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { classMap } from "lit/directives/class-map.js";
+import { createRef, ref } from "lit/directives/ref.js";
+
+import "../../elements/input/expanding-textarea.js";
+import "../../elements/graph-editing-chat/opie-avatar.js";
+import * as StringsHelper from "../../strings/helper.js";
+import * as Styles from "../../styles/styles.js";
+import type { SCA } from "../../../sca/sca.js";
+import { scaContext } from "../../../sca/context/context.js";
+import { ExpandingTextarea } from "../../elements/input/expanding-textarea.js";
+
+const Strings = StringsHelper.forSection("Editor");
+
+@customElement("bb-editor-input-lite-opie")
+export class EditorInputLiteOpie extends SignalWatcher(LitElement) {
+  @consume({ context: scaContext })
+  accessor sca!: SCA;
+
+  static styles = [
+    Styles.HostIcons.icons,
+    Styles.HostBehavior.behavior,
+    Styles.HostColorsMaterial.baseColors,
+    Styles.HostType.type,
+    css`
+      * {
+        box-sizing: border-box;
+      }
+
+      :host {
+        display: block;
+        width: 100%;
+      }
+
+      #container {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        width: 100%;
+        gap: var(--bb-grid-size-3);
+      }
+
+      #input-pill {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        flex: 1;
+        border: 1px solid var(--sys-color--outline-variant);
+        border-radius: 100px;
+        background-color: var(--sys-color--body-background);
+        padding: 6px 16px 6px 6px;
+        gap: var(--bb-grid-size);
+        transition:
+          border-color 0.15s ease,
+          box-shadow 0.15s ease;
+
+        &:focus-within {
+          border-color: var(--light-dark-n-70);
+          box-shadow: 0 0 0 1px var(--light-dark-n-70);
+        }
+      }
+
+      bb-opie-avatar {
+        flex-shrink: 0;
+      }
+
+      bb-expanding-textarea {
+        flex: 1;
+        --min-lines: 1;
+        --max-lines: 4;
+        --padding: 0;
+        --border-color: transparent;
+        --background-color: transparent;
+        color: var(--sys-color--on-surface);
+
+        &[disabled] {
+          opacity: 0.3;
+        }
+      }
+
+      #submit-button {
+        width: 48px;
+        height: 48px;
+        border: none;
+        border-radius: 50%;
+        background-color: var(--light-dark-n-90);
+        color: var(--light-dark-n-40);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        transition:
+          color 0.15s ease,
+          transform 0.1s ease;
+        flex-shrink: 0;
+
+        &:hover {
+          color: var(--light-dark-n-10);
+        }
+
+        &[disabled] {
+          opacity: 0.5;
+          cursor: default;
+          pointer-events: none;
+        }
+
+        & .g-icon {
+          font-size: 24px;
+        }
+      }
+
+      .rotate {
+        animation: rotate 1s linear infinite;
+      }
+
+      @keyframes rotate {
+        from {
+          rotate: 0deg;
+        }
+
+        to {
+          rotate: 360deg;
+        }
+      }
+    `,
+  ];
+
+  @property({ type: Boolean, reflect: true })
+  accessor focused = false;
+
+  @property({ reflect: true, type: Boolean })
+  accessor highlighted = false;
+
+  @property({ reflect: true, type: Boolean })
+  accessor editable = false;
+
+  private descriptionInput = createRef<ExpandingTextarea>();
+
+  private get isCreating() {
+    return this.sca.controller.global.main.blockingAction;
+  }
+
+  private get isFresh() {
+    const state = this.sca.controller.editor.graph.graphContentState;
+    return state === "loading" || state === "empty";
+  }
+
+  private get currentExampleIntent() {
+    return this.sca.controller.global.flowgenInput.currentExampleIntent;
+  }
+
+  override render() {
+    const iconClasses = {
+      "g-icon": true,
+      filled: true,
+      heavy: true,
+      round: true,
+      rotate: this.isCreating,
+    };
+    return html`
+      <div id="container">
+        <div id="input-pill">
+          <bb-opie-avatar
+            mode="hero"
+            .supportsHover=${false}
+            ?static=${this.isCreating}
+          ></bb-opie-avatar>
+          <bb-expanding-textarea
+            ${ref(this.descriptionInput)}
+            .disabled=${this.isCreating || !this.editable}
+            .classes=${"sans-flex w-400 md-body-large"}
+            .orientation=${"vertical"}
+            .value=${this.currentExampleIntent}
+            .placeholder=${this.isFresh
+              ? Strings.from("COMMAND_DESCRIBE_FRESH_FLOW_ALT")
+              : Strings.from("COMMAND_DESCRIBE_EDIT_FLOW")}
+            .showSubmitButton=${false}
+            @change=${this.submit}
+            @focus=${this.onInputFocus}
+            @blur=${this.onInputBlur}
+          ></bb-expanding-textarea>
+        </div>
+        <button
+          id="submit-button"
+          ?disabled=${this.isCreating || !this.editable}
+          @click=${this.submit}
+        >
+          <span class=${classMap(iconClasses)}
+            >${this.isCreating ? "progress_activity" : "send"}</span
+          >
+        </button>
+      </div>
+    `;
+  }
+
+  async submit() {
+    await this.onInputChange();
+  }
+
+  private async onInputChange() {
+    const input = this.descriptionInput.value;
+    if (!input) {
+      return;
+    }
+
+    const description = input.value;
+    if (!description) return;
+
+    const result = await this.sca.actions.opie.createNew(description);
+    if (result.success) {
+      this.clearInput();
+    } else {
+      console.error("Failed to create board with Opie", result.reason);
+    }
+  }
+
+  private clearInput() {
+    if (this.descriptionInput.value) {
+      this.descriptionInput.value.value = "";
+    }
+  }
+
+  private onInputFocus() {
+    this.focused = true;
+  }
+
+  private onInputBlur() {
+    this.focused = false;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "bb-editor-input-lite-opie": EditorInputLiteOpie;
+  }
+}

--- a/packages/visual-editor/src/ui/lite/input/editor-input-lite.ts
+++ b/packages/visual-editor/src/ui/lite/input/editor-input-lite.ts
@@ -112,9 +112,10 @@ export class EditorInputLite extends SignalWatcher(LitElement) {
     return this.sca.controller.global.flowgenInput.currentExampleIntent;
   }
 
-  /** Get empty state from SCA */
-  get #empty() {
-    return this.sca.controller.editor.graph.empty;
+  /** Get fresh flow state from SCA */
+  get #isFresh() {
+    const state = this.sca.controller.editor.graph.graphContentState;
+    return state === "loading" || state === "empty";
   }
 
   /** Get graph URL from SCA */
@@ -138,7 +139,7 @@ export class EditorInputLite extends SignalWatcher(LitElement) {
           .classes=${"sans-flex w-400 md-body-large"}
           .orientation=${"vertical"}
           .value=${this.#currentExampleIntent}
-          .placeholder=${this.#empty
+          .placeholder=${this.#isFresh
             ? Strings.from("COMMAND_DESCRIBE_FRESH_FLOW_ALT")
             : Strings.from("COMMAND_DESCRIBE_EDIT_FLOW")}
           @change=${this.#onInputChange}

--- a/packages/visual-editor/tests/ui/lite/input/editor-input-lite-opie.test.ts
+++ b/packages/visual-editor/tests/ui/lite/input/editor-input-lite-opie.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import assert from "node:assert";
+import { suite, test, after, before, mock } from "node:test";
+import { setDOM, unsetDOM } from "../../../fake-dom.js";
+import { createMockEnvironment } from "../../../sca/helpers/mock-environment.js";
+import { defaultRuntimeFlags } from "../../../sca/controller/data/default-flags.js";
+import {
+  makeTestController,
+  makeTestServices,
+} from "../../../sca/helpers/index.js";
+import { EditorInputLiteOpie } from "../../../../src/ui/lite/input/editor-input-lite-opie.js";
+import type { SCA } from "../../../../src/sca/sca.js";
+
+suite("editor-input-lite-opie", () => {
+  before(() => {
+    setDOM();
+  });
+
+  after(() => {
+    mock.restoreAll();
+    unsetDOM();
+  });
+
+  test("can instantiate component and trigger createNew on submit", async () => {
+    const controller = makeTestController().controller;
+    const services = makeTestServices().services;
+    const env = createMockEnvironment(defaultRuntimeFlags);
+
+    const mockCreateNew = mock.fn(async (_intent?: string) => {
+      return {
+        success: true,
+        url: new URL("https://drive.google.com/file/d/test-id"),
+      };
+    });
+
+    const mockSca = {
+      controller,
+      services,
+      env,
+      actions: {
+        opie: {
+          createNew: mockCreateNew,
+        },
+      },
+    } as unknown as SCA;
+
+    // Instantiate element class directly
+    const element = new EditorInputLiteOpie();
+    element.sca = mockSca;
+    element.editable = true;
+
+    // Mock the expanding textarea ref using any/unknown cast since it is private
+    const mockTextarea = {
+      value: "Create a snake game",
+    };
+
+    // Set private field using bracket notation
+    (element as unknown as Record<string, unknown>)["descriptionInput"] = {
+      value: mockTextarea,
+    };
+
+    // Invoke submit directly
+    await element.submit();
+
+    // Verify createNew action is called with the correct description
+    assert.strictEqual(mockCreateNew.mock.callCount(), 1);
+    assert.strictEqual(
+      mockCreateNew.mock.calls[0].arguments[0],
+      "Create a snake game"
+    );
+  });
+});


### PR DESCRIPTION
## What
Implemented the new Opie Welcome Mat UX in Lite Mode. Designed a standalone white-pill input UI (featuring a circular Opie avatar and external detached spark-submit button) and bound it to exclusive Graph Editing Agent orchestration.

## Why
Improves onboarding visual precision and interaction hygiene for new Lite users, and sets up robust foundations for future node-level Graph Editing Agent integrations.

## Changes
- **packages/visual-editor**:
  - **Opie UX Input**: Deployed `<bb-editor-input-lite-opie>` integrating direct execution to the `Opie.createNew` action.
  - **Element State Hygiene**: Refactored private class attributes and updated `#render` functions to consume the `GraphController.graphContentState` tri-state signal directly, ensuring zero-plinth flashing of placeholders during URL routing transitions (`lite=true&new=true`).
  - **SCA Integration**: Hooked UI triggers into `withUIBlocking` to automatically activate component-level `progress_activity` spinners while awaiting board server responses.

## Testing
- Verified full visual-editor compilation suite via `npm run build`.
- Ran and passed localized component suite via `npm run test:file -- './dist/tsc/tests/ui/lite/input/editor-input-lite-opie.test.js'`.
