### PR TITLE
[opie/ve] Add Opie to gallery

### DIFF
--- a/packages/visual-editor/src/index-lite.ts
+++ b/packages/visual-editor/src/index-lite.ts
@@ -16,7 +16,7 @@ import { MainBase } from "./main-base.js";
 import { classMap } from "lit/directives/class-map.js";
 import { StateEvent, StateEventDetailMap } from "./ui/events/events.js";
 import { LiteEditInputController } from "./ui/lite/input/editor-input-lite.js";
-import "./ui/lite/input/editor-input-lite-opie.js";
+import "./ui/elements/input/opie-input-lite.js";
 import "./ui/elements/graph-editing-chat/chat-panel.js";
 import "./ui/elements/graph-editing-chat/opie-avatar.js";
 
@@ -117,7 +117,7 @@ export class LiteMain extends MainBase implements LiteEditInputController {
         }
 
         & bb-editor-input-lite,
-        & bb-editor-input-lite-opie {
+        & bb-opie-input-lite {
           flex: 0 0 auto;
         }
 
@@ -315,7 +315,7 @@ export class LiteMain extends MainBase implements LiteEditInputController {
           }
 
           & bb-editor-input-lite,
-          & bb-editor-input-lite-opie {
+          & bb-opie-input-lite {
             max-width: 90%;
             width: 100%;
             margin: 0 auto;
@@ -648,10 +648,10 @@ export class LiteMain extends MainBase implements LiteEditInputController {
       !isHydratingAgent && this.sca.env.flags.get("enableGraphEditorAgent");
 
     if (enableGraphEditorAgent && this.#viewType === "home") {
-      return html`<bb-editor-input-lite-opie
+      return html`<bb-opie-input-lite
         ?inert=${this.#isInert()}
         .editable=${editable}
-      ></bb-editor-input-lite-opie>`;
+      ></bb-opie-input-lite>`;
     }
 
     return html`<bb-editor-input-lite

--- a/packages/visual-editor/src/sca/actions/agent/opie-actions.ts
+++ b/packages/visual-editor/src/sca/actions/agent/opie-actions.ts
@@ -49,11 +49,12 @@ const GlobalStrings = Strings.forSection("Global");
  * 4. Wait for the board to finish loading
  * 5. If an intent is provided, start the Graph Editing Agent loop
  *
- * Uses `Exclusive` mode to prevent concurrent create operations.
+ * Uses `Immediate` mode — this action triggers Board.load (Exclusive) via
+ * navigation, so it must not hold any coordination slot.
  */
 const createNew = asAction(
   "Opie.createNew",
-  { mode: ActionMode.Exclusive },
+  { mode: ActionMode.Immediate },
   async (intent?: string): Promise<CreateNewResult> => {
     const { controller, services } = bind;
 

--- a/packages/visual-editor/src/ui/elements/canvas-controller/canvas-controller.ts
+++ b/packages/visual-editor/src/ui/elements/canvas-controller/canvas-controller.ts
@@ -499,7 +499,10 @@ export class CanvasController extends SignalWatcher(LitElement) {
   }
 
   #maybeRenderEmptyState() {
-    if (this.#lastKnownNlEditValue !== "") {
+    if (
+      this.#lastKnownNlEditValue !== "" ||
+      this.sca.controller.editor.graphEditingAgent.loopRunning
+    ) {
       return nothing;
     }
 

--- a/packages/visual-editor/src/ui/elements/effects/radial-glow.ts
+++ b/packages/visual-editor/src/ui/elements/effects/radial-glow.ts
@@ -46,11 +46,20 @@ export class RadialGlow extends LitElement {
   @property({ type: String, attribute: "border-radius" })
   accessor borderRadius: string | null = null;
 
-  @state()
-  private accessor resolvedBorderRadius = 24;
-
   @property({ type: Boolean, attribute: "continuous" })
   accessor continuous = false;
+
+  @property({ type: String, reflect: true })
+  accessor mode: "once" | "continuous" | "periodic" = "once";
+
+  @property({ type: Number })
+  accessor period = 5000;
+
+  @property({ type: Boolean, reflect: true })
+  accessor glowing = false;
+
+  @state()
+  private accessor resolvedBorderRadius = 24;
 
   @state()
   accessor active = false;
@@ -60,14 +69,25 @@ export class RadialGlow extends LitElement {
       display: inline-flex;
       will-change: transform;
       pointer-events: none;
+    }
 
+    :host([mode="once"]),
+    :host(:not([mode]):not([continuous])) {
       animation:
         mask-spin var(--glow-duration, 3s) cubic-bezier(0.2, 0, 0.5, 1) 1,
         color-spin var(--glow-duration, 3s) cubic-bezier(0.2, 0, 0.5, 1) 1,
         opacity-spin var(--glow-duration, 3s) cubic-bezier(0.2, 0, 0.5, 1) 1;
     }
 
-    :host([continuous]) {
+    :host([glowing]) {
+      animation:
+        mask-spin var(--glow-duration, 3s) cubic-bezier(0.2, 0, 0.5, 1) 1,
+        color-spin var(--glow-duration, 3s) cubic-bezier(0.2, 0, 0.5, 1) 1,
+        opacity-spin var(--glow-duration, 3s) cubic-bezier(0.2, 0, 0.5, 1) 1;
+    }
+
+    :host([continuous]),
+    :host([mode="continuous"]) {
       animation:
         mask-spin var(--glow-duration, 3s) cubic-bezier(0.2, 0, 0.5, 1) infinite,
         color-spin var(--glow-duration, 3s) cubic-bezier(0.2, 0, 0.5, 1)
@@ -86,7 +106,9 @@ export class RadialGlow extends LitElement {
       border-radius: var(--border-radius);
 
       & #content {
-        display: inline-flex;
+        display: flex;
+        width: 100%;
+        height: 100%;
         pointer-events: auto;
       }
     }
@@ -123,20 +145,8 @@ export class RadialGlow extends LitElement {
           transparent 270deg
         );
 
-      -webkit-mask-image:
-        url(#complex-glow-mask),
-        conic-gradient(
-          from
-            calc(
-              var(--start-angle, 0deg) + var(--mask-angle) + var(--base-angle)
-            ),
-          transparent 0deg,
-          #000 90deg,
-          transparent 180deg
-        );
-
       mask-composite: intersect;
-      -webkit-mask-composite: source-in;
+
       pointer-events: none;
     }
 
@@ -184,17 +194,66 @@ export class RadialGlow extends LitElement {
   `;
 
   private resizeObserver: ResizeObserver | null = null;
+  private periodicTimeoutId: number | null = null;
+
+  private get resolvedMode(): "once" | "continuous" | "periodic" {
+    if (this.mode) return this.mode;
+    return this.continuous ? "continuous" : "once";
+  }
 
   override connectedCallback() {
     super.connectedCallback();
     this.resizeObserver = new ResizeObserver(() => {
       this.updateBorderRadius();
     });
+    this.addEventListener("animationend", this.handleAnimationEnd);
   }
 
   override disconnectedCallback() {
     super.disconnectedCallback();
     this.resizeObserver?.disconnect();
+    this.clearGlowTimeout();
+    this.removeEventListener("animationend", this.handleAnimationEnd);
+  }
+
+  override willUpdate(changedProperties: Map<PropertyKey, unknown>) {
+    super.willUpdate(changedProperties);
+    if (
+      changedProperties.has("mode") ||
+      changedProperties.has("continuous") ||
+      changedProperties.has("period")
+    ) {
+      this.setupGlowLoop();
+    }
+  }
+
+  private setupGlowLoop() {
+    this.clearGlowTimeout();
+    this.glowing = this.resolvedMode === "periodic";
+  }
+
+  private clearGlowTimeout() {
+    if (this.periodicTimeoutId !== null) {
+      window.clearTimeout(this.periodicTimeoutId);
+      this.periodicTimeoutId = null;
+    }
+  }
+
+  private handleAnimationEnd = (e: AnimationEvent) => {
+    if (
+      e.animationName === "opacity-spin" &&
+      this.resolvedMode === "periodic"
+    ) {
+      this.glowing = false;
+      this.scheduleNextGlow();
+    }
+  };
+
+  private scheduleNextGlow() {
+    this.clearGlowTimeout();
+    this.periodicTimeoutId = window.setTimeout(() => {
+      this.glowing = true;
+    }, this.period);
   }
 
   private handleSlotChange(e: Event) {
@@ -237,6 +296,16 @@ export class RadialGlow extends LitElement {
     } else {
       const val = Number.parseFloat(radiusStr);
       this.resolvedBorderRadius = Number.isNaN(val) ? 0 : val;
+    }
+
+    // The browser auto-clamps border-radius to half the element height,
+    // so the SVG mask must match the actual visual radius.
+    const rect = firstElement.getBoundingClientRect();
+    if (rect.height > 0) {
+      const maxRadius = rect.height / 2;
+      if (this.resolvedBorderRadius > maxRadius) {
+        this.resolvedBorderRadius = maxRadius;
+      }
     }
   }
 

--- a/packages/visual-editor/src/ui/elements/effects/radial-glow.ts
+++ b/packages/visual-editor/src/ui/elements/effects/radial-glow.ts
@@ -8,7 +8,7 @@ import { LitElement, html, css, svg } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { styleMap } from "lit/directives/style-map.js";
 
-if ("registerProperty" in CSS) {
+if (typeof CSS !== "undefined" && "registerProperty" in CSS) {
   CSS.registerProperty({
     name: "--base-angle",
     syntax: "<angle>",

--- a/packages/visual-editor/src/ui/elements/graph-editing-chat/opie-avatar.ts
+++ b/packages/visual-editor/src/ui/elements/graph-editing-chat/opie-avatar.ts
@@ -12,7 +12,7 @@ import { styleMap } from "lit/directives/style-map.js";
 @customElement("bb-opie-avatar")
 export class OpieAvatar extends SignalWatcher(LitElement) {
   @property({ type: String, reflect: true })
-  accessor mode: "hero" | "normal" | "small" = "normal";
+  accessor mode: "hero" | "large" | "normal" | "small" = "normal";
 
   @property({ type: Boolean, reflect: true })
   accessor selected = false;
@@ -55,6 +55,9 @@ export class OpieAvatar extends SignalWatcher(LitElement) {
       height: var(--bb-grid-size-10);
       box-sizing: border-box;
       position: relative;
+    }
+
+    :host([supportsHover]) {
       cursor: pointer;
     }
 
@@ -192,28 +195,52 @@ export class OpieAvatar extends SignalWatcher(LitElement) {
       border-radius: 1px;
     }
 
-    :host([mode="hero"]) {
+    :host([mode="large"]) {
       width: var(--bb-grid-size-12);
       height: var(--bb-grid-size-12);
     }
 
-    :host([mode="hero"]) .eyes {
+    :host([mode="large"]) .eyes {
       gap: 5px;
       margin-top: 12px;
     }
 
-    :host([mode="hero"]) .eyes.left {
+    :host([mode="large"]) .eyes.left {
       transform: translateX(-3px);
     }
 
-    :host([mode="hero"]) .eyes.right {
+    :host([mode="large"]) .eyes.right {
       transform: translateX(3px);
     }
 
-    :host([mode="hero"]) .eye {
+    :host([mode="large"]) .eye {
       width: 6px;
       height: 12px;
-      border-radius: 3px;
+      border-radius: 4px;
+    }
+
+    :host([mode="hero"]) {
+      width: var(--bb-grid-size-16);
+      height: var(--bb-grid-size-16);
+    }
+
+    :host([mode="hero"]) .eyes {
+      gap: 6px;
+      margin-top: 16px;
+    }
+
+    :host([mode="hero"]) .eyes.left {
+      transform: translateX(-4px);
+    }
+
+    :host([mode="hero"]) .eyes.right {
+      transform: translateX(4px);
+    }
+
+    :host([mode="hero"]) .eye {
+      width: 7px;
+      height: 14px;
+      border-radius: 6px;
     }
   `;
 

--- a/packages/visual-editor/src/ui/elements/input/opie-input-lite.ts
+++ b/packages/visual-editor/src/ui/elements/input/opie-input-lite.ts
@@ -1,0 +1,246 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SignalWatcher } from "@lit-labs/signals";
+import { consume } from "@lit/context";
+import { LitElement, css, html } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { classMap } from "lit/directives/class-map.js";
+import { createRef, ref } from "lit/directives/ref.js";
+
+import "./expanding-textarea.js";
+import "../graph-editing-chat/opie-avatar.js";
+import * as StringsHelper from "../../strings/helper.js";
+import * as Styles from "../../styles/styles.js";
+import type { SCA } from "../../../sca/sca.js";
+import { scaContext } from "../../../sca/context/context.js";
+import { ExpandingTextarea } from "./expanding-textarea.js";
+
+const Strings = StringsHelper.forSection("Editor");
+
+@customElement("bb-opie-input-lite")
+export class OpieInputLite extends SignalWatcher(LitElement) {
+  @consume({ context: scaContext })
+  accessor sca!: SCA;
+
+  static styles = [
+    Styles.HostIcons.icons,
+    Styles.HostBehavior.behavior,
+    Styles.HostColorsMaterial.baseColors,
+    Styles.HostType.type,
+    css`
+      * {
+        box-sizing: border-box;
+      }
+
+      :host {
+        display: block;
+        width: 100%;
+      }
+
+      #container {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        width: 100%;
+        gap: var(--bb-grid-size-3);
+      }
+
+      #input-pill {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        flex: 1;
+        border: 1px solid var(--sys-color--outline-variant);
+        border-radius: 100px;
+        background-color: var(--sys-color--body-background);
+        padding: 6px 16px 6px 6px;
+        gap: var(--bb-grid-size);
+        transition:
+          border-color 0.15s ease,
+          box-shadow 0.15s ease;
+
+        &:focus-within {
+          border-color: var(--light-dark-n-70);
+          box-shadow: 0 0 0 1px var(--light-dark-n-70);
+        }
+      }
+
+      bb-opie-avatar {
+        flex-shrink: 0;
+      }
+
+      bb-expanding-textarea {
+        flex: 1;
+        --min-lines: 1;
+        --max-lines: 4;
+        --padding: 0;
+        --border-color: transparent;
+        --background-color: transparent;
+        color: var(--sys-color--on-surface);
+
+        &[disabled] {
+          opacity: 0.3;
+        }
+      }
+
+      #submit-button {
+        width: 48px;
+        height: 48px;
+        border: none;
+        border-radius: 50%;
+        background-color: var(--light-dark-n-90);
+        color: var(--light-dark-n-40);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        transition:
+          color 0.15s ease,
+          transform 0.1s ease;
+        flex-shrink: 0;
+
+        &:hover {
+          color: var(--light-dark-n-10);
+        }
+
+        &[disabled] {
+          opacity: 0.5;
+          cursor: default;
+          pointer-events: none;
+        }
+
+        & .g-icon {
+          font-size: 24px;
+        }
+      }
+
+      .rotate {
+        animation: rotate 1s linear infinite;
+      }
+
+      @keyframes rotate {
+        from {
+          rotate: 0deg;
+        }
+
+        to {
+          rotate: 360deg;
+        }
+      }
+    `,
+  ];
+
+  @property({ type: Boolean, reflect: true })
+  accessor focused = false;
+
+  @property({ reflect: true, type: Boolean })
+  accessor highlighted = false;
+
+  @property({ reflect: true, type: Boolean })
+  accessor editable = false;
+
+  private descriptionInput = createRef<ExpandingTextarea>();
+
+  private get isCreating() {
+    return this.sca.controller.global.main.blockingAction;
+  }
+
+  private get isFresh() {
+    const state = this.sca.controller.editor.graph.graphContentState;
+    return state === "loading" || state === "empty";
+  }
+
+  private get currentExampleIntent() {
+    return this.sca.controller.global.flowgenInput.currentExampleIntent;
+  }
+
+  override render() {
+    const iconClasses = {
+      "g-icon": true,
+      filled: true,
+      heavy: true,
+      round: true,
+      rotate: this.isCreating,
+    };
+
+    return html`
+      <div id="container">
+        <div id="input-pill">
+          <bb-opie-avatar
+            mode="large"
+            .supportsHover=${false}
+            ?static=${this.isCreating}
+          ></bb-opie-avatar>
+          <bb-expanding-textarea
+            ${ref(this.descriptionInput)}
+            .disabled=${this.isCreating || !this.editable}
+            .classes=${"sans-flex w-400 md-body-large"}
+            .orientation=${"vertical"}
+            .value=${this.currentExampleIntent}
+            .placeholder=${this.isFresh
+              ? Strings.from("COMMAND_DESCRIBE_FRESH_FLOW_ALT")
+              : Strings.from("COMMAND_DESCRIBE_EDIT_FLOW")}
+            .showSubmitButton=${false}
+            @change=${this.submit}
+            @focus=${this.onInputFocus}
+            @blur=${this.onInputBlur}
+          ></bb-expanding-textarea>
+        </div>
+        <button
+          id="submit-button"
+          ?disabled=${this.isCreating || !this.editable}
+          @click=${this.submit}
+        >
+          <span class=${classMap(iconClasses)}
+            >${this.isCreating ? "progress_activity" : "send"}</span
+          >
+        </button>
+      </div>
+    `;
+  }
+
+  async submit() {
+    await this.onInputChange();
+  }
+
+  private async onInputChange() {
+    const input = this.descriptionInput.value;
+    if (!input) {
+      return;
+    }
+
+    const description = input.value;
+    if (!description) return;
+
+    const result = await this.sca.actions.opie.createNew(description);
+    if (result.success) {
+      this.clearInput();
+    } else {
+      console.error("Failed to create board with Opie", result.reason);
+    }
+  }
+
+  private clearInput() {
+    if (this.descriptionInput.value) {
+      this.descriptionInput.value.value = "";
+    }
+  }
+
+  private onInputFocus() {
+    this.focused = true;
+  }
+
+  private onInputBlur() {
+    this.focused = false;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "bb-opie-input-lite": OpieInputLite;
+  }
+}

--- a/packages/visual-editor/src/ui/elements/input/opie-input.ts
+++ b/packages/visual-editor/src/ui/elements/input/opie-input.ts
@@ -7,29 +7,33 @@
 import { SignalWatcher } from "@lit-labs/signals";
 import { consume } from "@lit/context";
 import { LitElement, css, html } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import { customElement, property, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
+import { styleMap } from "lit/directives/style-map.js";
 import { createRef, ref } from "lit/directives/ref.js";
 
-import "../../elements/input/expanding-textarea.js";
-import "../../elements/graph-editing-chat/opie-avatar.js";
+import "./expanding-textarea.js";
+import "../effects/radial-glow.js";
 import * as StringsHelper from "../../strings/helper.js";
 import * as Styles from "../../styles/styles.js";
+import { baseColors } from "../../styles/host/base-colors.js";
 import type { SCA } from "../../../sca/sca.js";
 import { scaContext } from "../../../sca/context/context.js";
-import { ExpandingTextarea } from "../../elements/input/expanding-textarea.js";
+import { ExpandingTextarea } from "./expanding-textarea.js";
 
 const Strings = StringsHelper.forSection("Editor");
+const DEFAULT_GLOW_PERIOD = 5_000;
+const MAX_GLOW_PERIOD = 100_000;
 
-@customElement("bb-editor-input-lite-opie")
-export class EditorInputLiteOpie extends SignalWatcher(LitElement) {
+@customElement("bb-opie-input")
+export class OpieInput extends SignalWatcher(LitElement) {
   @consume({ context: scaContext })
   accessor sca!: SCA;
 
   static styles = [
     Styles.HostIcons.icons,
     Styles.HostBehavior.behavior,
-    Styles.HostColorsMaterial.baseColors,
+    baseColors,
     Styles.HostType.type,
     css`
       * {
@@ -54,23 +58,19 @@ export class EditorInputLiteOpie extends SignalWatcher(LitElement) {
         flex-direction: row;
         align-items: center;
         flex: 1;
-        border: 1px solid var(--sys-color--outline-variant);
-        border-radius: 100px;
-        background-color: var(--sys-color--body-background);
-        padding: 6px 16px 6px 6px;
+        border: 1px solid light-dark(var(--n-90), var(--n-30));
+        border-radius: 28px;
+        background-color: light-dark(var(--n-100), var(--n-10));
+        padding: 6px 16px;
         gap: var(--bb-grid-size);
         transition:
           border-color 0.15s ease,
           box-shadow 0.15s ease;
 
         &:focus-within {
-          border-color: var(--light-dark-n-70);
-          box-shadow: 0 0 0 1px var(--light-dark-n-70);
+          border-color: light-dark(var(--n-70), var(--n-50));
+          box-shadow: 0 0 0 1px light-dark(var(--n-70), var(--n-50));
         }
-      }
-
-      bb-opie-avatar {
-        flex-shrink: 0;
       }
 
       bb-expanding-textarea {
@@ -80,7 +80,7 @@ export class EditorInputLiteOpie extends SignalWatcher(LitElement) {
         --padding: 0;
         --border-color: transparent;
         --background-color: transparent;
-        color: var(--sys-color--on-surface);
+        color: light-dark(var(--n-10), var(--n-90));
 
         &[disabled] {
           opacity: 0.3;
@@ -92,8 +92,8 @@ export class EditorInputLiteOpie extends SignalWatcher(LitElement) {
         height: 48px;
         border: none;
         border-radius: 50%;
-        background-color: var(--light-dark-n-90);
-        color: var(--light-dark-n-40);
+        background-color: light-dark(var(--n-90), var(--n-20));
+        color: light-dark(var(--n-40), var(--n-70));
         display: flex;
         align-items: center;
         justify-content: center;
@@ -104,7 +104,7 @@ export class EditorInputLiteOpie extends SignalWatcher(LitElement) {
         flex-shrink: 0;
 
         &:hover {
-          color: var(--light-dark-n-10);
+          color: light-dark(var(--n-10), var(--n-95));
         }
 
         &[disabled] {
@@ -131,6 +131,11 @@ export class EditorInputLiteOpie extends SignalWatcher(LitElement) {
           rotate: 360deg;
         }
       }
+
+      radial-glow {
+        flex: 1;
+        display: flex;
+      }
     `,
   ];
 
@@ -142,6 +147,9 @@ export class EditorInputLiteOpie extends SignalWatcher(LitElement) {
 
   @property({ reflect: true, type: Boolean })
   accessor editable = false;
+
+  @state()
+  accessor hasContent = false;
 
   private descriptionInput = createRef<ExpandingTextarea>();
 
@@ -166,29 +174,45 @@ export class EditorInputLiteOpie extends SignalWatcher(LitElement) {
       round: true,
       rotate: this.isCreating,
     };
+
+    const glowPeriod =
+      this.focused || this.hasContent ? MAX_GLOW_PERIOD : DEFAULT_GLOW_PERIOD;
+
     return html`
       <div id="container">
-        <div id="input-pill">
-          <bb-opie-avatar
-            mode="hero"
-            .supportsHover=${false}
-            ?static=${this.isCreating}
-          ></bb-opie-avatar>
-          <bb-expanding-textarea
-            ${ref(this.descriptionInput)}
-            .disabled=${this.isCreating || !this.editable}
-            .classes=${"sans-flex w-400 md-body-large"}
-            .orientation=${"vertical"}
-            .value=${this.currentExampleIntent}
-            .placeholder=${this.isFresh
-              ? Strings.from("COMMAND_DESCRIBE_FRESH_FLOW_ALT")
-              : Strings.from("COMMAND_DESCRIBE_EDIT_FLOW")}
-            .showSubmitButton=${false}
-            @change=${this.submit}
-            @focus=${this.onInputFocus}
-            @blur=${this.onInputBlur}
-          ></bb-expanding-textarea>
-        </div>
+        <radial-glow
+          mode="periodic"
+          .period=${glowPeriod}
+          glow-size="18"
+          style=${styleMap({
+            "--start-angle": "0deg",
+            "--glow-duration": "3s",
+            "--mask-sweep": "360deg",
+            "--color-sweep": "360deg",
+            "--glow-colors": `var(--t-100) 0%,
+              var(--p-70) 30%,
+              var(--t-70) 40%,
+              var(--t-90) 50%,
+              var(--t-100) 55%`,
+          })}
+        >
+          <div id="input-pill">
+            <bb-expanding-textarea
+              ${ref(this.descriptionInput)}
+              .disabled=${this.isCreating || !this.editable}
+              .classes=${"sans-flex w-400 md-body-large"}
+              .orientation=${"vertical"}
+              .placeholder=${this.isFresh
+                ? Strings.from("COMMAND_DESCRIBE_FRESH_FLOW_ALT")
+                : Strings.from("COMMAND_DESCRIBE_EDIT_FLOW")}
+              .showSubmitButton=${false}
+              @input=${this.onInput}
+              @change=${this.submit}
+              @focus=${this.onInputFocus}
+              @blur=${this.onInputBlur}
+            ></bb-expanding-textarea>
+          </div>
+        </radial-glow>
         <button
           id="submit-button"
           ?disabled=${this.isCreating || !this.editable}
@@ -206,6 +230,28 @@ export class EditorInputLiteOpie extends SignalWatcher(LitElement) {
     await this.onInputChange();
   }
 
+  override updated(changedProperties: Map<PropertyKey, unknown>) {
+    super.updated(changedProperties);
+    // Seed the textarea when a suggestion chip is clicked, then clear the
+    // signal so it doesn't overwrite user edits on subsequent renders.
+    const intent = this.currentExampleIntent;
+    if (intent && this.descriptionInput.value) {
+      this.descriptionInput.value.value = intent;
+      this.hasContent = true;
+      this.sca.controller.global.flowgenInput.currentExampleIntent = "";
+    }
+  }
+
+  private onInput() {
+    const input = this.descriptionInput.value;
+    if (!input) {
+      return;
+    }
+
+    const description = input.value;
+    this.hasContent = description !== "";
+  }
+
   private async onInputChange() {
     const input = this.descriptionInput.value;
     if (!input) {
@@ -213,6 +259,7 @@ export class EditorInputLiteOpie extends SignalWatcher(LitElement) {
     }
 
     const description = input.value;
+    this.hasContent = description !== "";
     if (!description) return;
 
     const result = await this.sca.actions.opie.createNew(description);
@@ -240,6 +287,6 @@ export class EditorInputLiteOpie extends SignalWatcher(LitElement) {
 
 declare global {
   interface HTMLElementTagNameMap {
-    "bb-editor-input-lite-opie": EditorInputLiteOpie;
+    "bb-opie-input": OpieInput;
   }
 }

--- a/packages/visual-editor/src/ui/elements/welcome-panel/project-listing.ts
+++ b/packages/visual-editor/src/ui/elements/welcome-panel/project-listing.ts
@@ -21,8 +21,35 @@ import "../shared/expanding-search-button.js";
 import { ExpandingSearchButton } from "../shared/expanding-search-button.js";
 import { scaContext } from "../../../sca/context/context.js";
 import { type SCA } from "../../../sca/sca.js";
+import { chipStyles } from "../../styles/chip.js";
+import { isHydrating } from "../../../sca/utils/helpers/helpers.js";
+import "../input/opie-input.js";
+import "../graph-editing-chat/opie-avatar.js";
 
 const Strings = StringsHelper.forSection("ProjectListing");
+
+const CHIP_SUGGESTIONS = [
+  {
+    label: "Create an interactive quiz",
+    intent:
+      "Help me prepare for a quiz on a given topic by creating sample questions with hints as an interactive quiz",
+  },
+  {
+    label: "Generate recipe ideas",
+    intent:
+      "Take a photo of the leftovers in the fridge and generate different recipes with photos of the final dish",
+  },
+  {
+    label: "Draft key takeaways",
+    intent:
+      "Analyze a meeting transcript and draft an email of the key takeaways and action items",
+  },
+  {
+    label: "Critique a resume",
+    intent:
+      "An app that takes a given resume and a job description the candidate is interested in, then provides a critique of the resume",
+  },
+];
 
 const NARROW_PAGE_SIZE = 4;
 const WIDE_PAGE_SIZE = 8;
@@ -50,6 +77,7 @@ export class ProjectListing extends SignalWatcher(LitElement) {
     icons,
     baseColors,
     type,
+    chipStyles,
     css`
       * {
         box-sizing: border-box;
@@ -90,15 +118,40 @@ export class ProjectListing extends SignalWatcher(LitElement) {
         min-height: 100%;
 
         & #hero {
-          padding: 0 var(--bb-grid-size-16);
+          padding: var(--bb-grid-size-9) var(--bb-grid-size-16) 0
+            var(--bb-grid-size-16);
           display: flex;
           flex-direction: column;
           align-items: center;
+          gap: var(--bb-grid-size-4);
+
+          &.opie {
+            padding: var(--bb-grid-size-12) var(--bb-grid-size-12)
+              var(--bb-grid-size-16) var(--bb-grid-size-12);
+          }
 
           & h1 {
-            margin: var(--bb-grid-size-9) 0 0 0;
+            margin: 0 0 var(--bb-grid-size-4) 0;
             text-align: center;
             max-width: 560px;
+          }
+
+          & bb-opie-input {
+            max-width: 560px;
+            width: 100%;
+          }
+
+          & #chips-container {
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: center;
+            gap: var(--bb-grid-size-2);
+            max-width: 700px;
+            margin-top: var(--bb-grid-size-2);
+
+            & .bb-chip {
+              margin: 0;
+            }
           }
         }
 
@@ -367,6 +420,43 @@ export class ProjectListing extends SignalWatcher(LitElement) {
   }
 
   #renderHero() {
+    const isHydratingAgent = isHydrating(() =>
+      this.sca.env.flags.get("enableGraphEditorAgent")
+    );
+    const enableGraphEditorAgent =
+      !isHydratingAgent && this.sca.env.flags.get("enableGraphEditorAgent");
+
+    if (enableGraphEditorAgent) {
+      return html`
+        <section id="hero" class="opie">
+          <bb-opie-avatar mode="hero" .supportsHover=${false}></bb-opie-avatar>
+
+          <h1 class="sans-flex w-500 round md-headline-large">
+            ${Strings.from("LABEL_WELCOME_OPIE")}
+          </h1>
+
+          <bb-opie-input .editable=${true}></bb-opie-input>
+
+          <div id="chips-container">
+            ${CHIP_SUGGESTIONS.map((example) => {
+              return html`
+                <button
+                  class="bb-chip"
+                  @click=${() => {
+                    this.sca.controller.global.flowgenInput.currentExampleIntent =
+                      example.intent;
+                  }}
+                >
+                  <span class="g-icon">search_spark</span>
+                  <span>${example.label}</span>
+                </button>
+              `;
+            })}
+          </div>
+        </section>
+      `;
+    }
+
     return html`
       <section id="hero">
         <h1 class="sans-flex w-500 round md-headline-large">

--- a/packages/visual-editor/src/ui/strings/en_US/project-listing.ts
+++ b/packages/visual-editor/src/ui/strings/en_US/project-listing.ts
@@ -72,6 +72,9 @@ export default {
   LABEL_WELCOME_MESSAGE_B: {
     str: "Build, edit and share mini-AI apps using natural language",
   },
+  LABEL_WELCOME_OPIE: {
+    str: "Tell Opie what you'd like to build",
+  },
   LABEL_WELCOME_CTA: {
     str: "Describe what you want to build",
   },

--- a/packages/visual-editor/tests/ui/elements/input/opie-input.test.ts
+++ b/packages/visual-editor/tests/ui/elements/input/opie-input.test.ts
@@ -13,10 +13,10 @@ import {
   makeTestController,
   makeTestServices,
 } from "../../../sca/helpers/index.js";
-import { EditorInputLiteOpie } from "../../../../src/ui/lite/input/editor-input-lite-opie.js";
+import { OpieInput } from "../../../../src/ui/elements/input/opie-input.js";
 import type { SCA } from "../../../../src/sca/sca.js";
 
-suite("editor-input-lite-opie", () => {
+suite("opie-input", () => {
   before(() => {
     setDOM();
   });
@@ -50,7 +50,7 @@ suite("editor-input-lite-opie", () => {
     } as unknown as SCA;
 
     // Instantiate element class directly
-    const element = new EditorInputLiteOpie();
+    const element = new OpieInput();
     element.sca = mockSca;
     element.editable = true;
 


### PR DESCRIPTION
## What
Introduces the Opie agent input into the non-lite project gallery (behind `enableGraphEditorAgent` flag) and splits `bb-opie-input` into two purpose-built elements for lite and standard contexts.

## Why
The gallery welcome page needs an Opie-powered creation flow with a periodic radial glow and suggestion chips. The lite and standard editor contexts use different color systems and different UI configurations (avatar vs glow), so a single element with flag-driven branching was accumulating complexity. Splitting into two clean elements eliminates the conditional rendering and color system mismatch.

## Changes

**Element split:**
- New `bb-opie-input-lite` — avatar, no glow, Material colors (used in `index-lite.ts`)
- Rewritten `bb-opie-input` — no avatar, periodic radial glow, standard `baseColors` (used in `project-listing.ts`)
- Removed `hideAvatar` / `showGlow` flags

**Gallery hero (project-listing.ts):**
- Opie avatar + input + suggestion chips behind `enableGraphEditorAgent` flag
- Chip click seeds textarea via one-shot `currentExampleIntent` pattern (imperative set → clear signal)
- New welcome string `LABEL_WELCOME_OPIE`

**Radial glow (radial-glow.ts):**
- Added `mode="periodic"` with configurable `period` and `glowing` properties
- Periodic loop: CSS animation → `animationend` → `setTimeout` → next glow
- Replaced `foreignObject` approach with `::after` pseudo-element + `mask-composite: intersect`
- Dropped competing `-webkit-mask-image` / `-webkit-mask-composite`
- Height-based border-radius clamping for pill-shaped elements
- Fixed Lit update warning: `updated()` → `willUpdate()` for reactive property changes

**Action fix (opie-actions.ts):**
- Changed `Opie.createNew` from `ActionMode.Exclusive` to `ActionMode.Immediate` to prevent deadlock with `Board.load`

**Canvas controller:**
- Hide empty state when Opie agent loop is running

**Tests:**
- Renamed and updated test to match new `OpieInput` class location

## Testing
- Enable `enableGraphEditorAgent` flag
- Verify gallery shows Opie hero with periodic glow, suggestion chips populate the input
- Verify lite mode uses `bb-opie-input-lite` with avatar, no glow
- Verify creating an Opal from the gallery navigates and starts the agent loop without deadlock
- Run `npm run test:file -- './dist/tsc/tests/ui/elements/input/opie-input.test.js'`