### PR TITLE
[opie] Separate Graph Properties and Theme Editing Transforms

### DIFF
--- a/packages/visual-editor/src/a2/agent/agent-event.ts
+++ b/packages/visual-editor/src/a2/agent/agent-event.ts
@@ -158,13 +158,20 @@ type ApplyEditsPayload = {
  */
 type TransformDescriptor =
   | UpdateNodeDescriptor
-  | UpdateGraphPropertiesDescriptor;
+  | UpdateGraphPropertiesDescriptor
+  | UpdateThemeDescriptor;
 
 type UpdateGraphPropertiesDescriptor = {
   kind: "updateGraphProperties";
   title?: string;
   description?: string;
-  themeIntent?: string;
+};
+
+type UpdateThemeDescriptor = {
+  kind: "updateTheme";
+  themeIntent: string;
+  title?: string;
+  description?: string;
 };
 
 

--- a/packages/visual-editor/src/a2/agent/graph-editing/functions.ts
+++ b/packages/visual-editor/src/a2/agent/graph-editing/functions.ts
@@ -198,7 +198,7 @@ function defineGraphEditingFunctions(
         requestId: crypto.randomUUID(),
         label: "Update theme",
         transform: {
-          kind: "updateGraphProperties",
+          kind: "updateTheme",
           title,
           description,
           themeIntent,

--- a/packages/visual-editor/src/a2/agent/graph-editing/graph-editing-manager.ts
+++ b/packages/visual-editor/src/a2/agent/graph-editing/graph-editing-manager.ts
@@ -98,60 +98,78 @@ class GraphEditingManager {
 
 
         case "updateGraphProperties": {
-          const { title, description, themeIntent } = transform;
-          let metadata: GraphMetadata | undefined;
-
-          if (themeIntent && themeGenerator) {
-            const rawGraph = editor.raw();
-            const promptTitle = title ?? rawGraph.title ?? "Application";
-            const promptDesc = description ?? rawGraph.description ?? "";
-
-            const appThemeResult = await themeGenerator({
-              title: promptTitle,
-              description: promptDesc,
-              userInstruction: themeIntent,
-              signal: options?.signal,
-            });
-
-            const errPayload = appThemeResult as Record<string, unknown>;
-            if (
-              errPayload &&
-              typeof errPayload === "object" &&
-              "$error" in errPayload &&
-              typeof errPayload.$error === "string"
-            ) {
-              return {
-                success: false,
-                error: `Theme generation failed: ${errPayload.$error}`,
-              };
-            }
-
-            metadata = editor.raw().metadata ?? {};
-            metadata.visual ??= {};
-            metadata.visual.presentation ??= {};
-            metadata.visual.presentation.themes ??= {};
-
-            const id = globalThis.crypto.randomUUID();
-            const themes = metadata.visual.presentation.themes as Record<string, unknown>;
-            themes[id] = appThemeResult;
-            metadata.visual.presentation.theme = id;
-
-            if (options?.onThemeUpdated) {
-              options.onThemeUpdated(metadata);
-            }
-          }
-
+          const { title, description } = transform;
           const result = await editor.edit(
             [
               {
                 type: "changegraphmetadata",
                 title: title ?? undefined,
                 description: description ?? undefined,
-                metadata,
                 graphId: "",
               },
             ],
             "Updating graph properties"
+          );
+
+          if (!result.success) {
+            return { success: false, error: result.error };
+          }
+          return { success: true };
+        }
+
+        case "updateTheme": {
+          const { title, description, themeIntent } = transform;
+          if (!themeGenerator) {
+            return { success: false, error: "Theme generator not available" };
+          }
+
+          const rawGraph = editor.raw();
+          const promptTitle = title ?? rawGraph.title ?? "Application";
+          const promptDesc = description ?? rawGraph.description ?? "";
+
+          const appThemeResult = await themeGenerator({
+            title: promptTitle,
+            description: promptDesc,
+            userInstruction: themeIntent,
+            signal: options?.signal,
+          });
+
+          const errPayload = appThemeResult as Record<string, unknown>;
+          if (
+            errPayload &&
+            typeof errPayload === "object" &&
+            "$error" in errPayload &&
+            typeof errPayload.$error === "string"
+          ) {
+            return {
+              success: false,
+              error: `Theme generation failed: ${errPayload.$error}`,
+            };
+          }
+
+          const metadata = editor.raw().metadata ?? {};
+          metadata.visual ??= {};
+          metadata.visual.presentation ??= {};
+          metadata.visual.presentation.themes ??= {};
+
+          const id = globalThis.crypto.randomUUID();
+          const themes = metadata.visual.presentation.themes as Record<string, unknown>;
+          themes[id] = appThemeResult;
+          metadata.visual.presentation.theme = id;
+
+          if (options?.onThemeUpdated) {
+            options.onThemeUpdated(metadata);
+          }
+
+          const result = await editor.edit(
+            [
+              {
+                type: "changegraphmetadata",
+                metadata,
+                graphId: "",
+              },
+            ],
+            "Updating theme"
           );
 
           if (!result.success) {

--- a/packages/visual-editor/tests/a2/agent/graph-editing/graph-editing-manager.test.ts
+++ b/packages/visual-editor/tests/a2/agent/graph-editing/graph-editing-manager.test.ts
@@ -69,4 +69,73 @@ describe("GraphEditingManager", () => {
     assert.strictEqual(editor.raw().edges?.length, 1);
     assert.strictEqual(editor.raw().edges?.[0].from, "node-1");
   });
+
+  it("executes updateGraphProperties transform successfully", async () => {
+    const graph: GraphDescriptor = {
+      title: "Old Title",
+      description: "Old Description",
+      nodes: [],
+      edges: [],
+    };
+
+    const editor = HeadlessGraphEditor.create(graph);
+    const manager = new GraphEditingManager(editor);
+
+    const result = await manager.applyEdits({
+      transform: {
+        kind: "updateGraphProperties",
+        title: "New Title",
+        description: "New Description",
+      },
+      label: "Update title and description",
+    });
+
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(editor.raw().title, "New Title");
+    assert.strictEqual(editor.raw().description, "New Description");
+  });
+
+  it("executes updateTheme transform successfully", async () => {
+    const graph: GraphDescriptor = {
+      title: "Opal",
+      description: "A cool app",
+      nodes: [],
+      edges: [],
+    };
+
+    const editor = HeadlessGraphEditor.create(graph);
+    const mockThemeResult = { success: true, value: { colors: ["red", "blue"] } };
+    const themeGenerator = async () => mockThemeResult;
+
+    let themeUpdatedCalled = false;
+    const manager = new GraphEditingManager(editor, themeGenerator);
+
+    const result = await manager.applyEdits(
+      {
+        transform: {
+          kind: "updateTheme",
+          themeIntent: "sunset vibe",
+          title: "Opal",
+          description: "A cool app",
+        },
+        label: "Update theme",
+      },
+      {
+        onThemeUpdated: (metadata) => {
+          themeUpdatedCalled = true;
+          assert.ok(metadata.visual?.presentation?.themes);
+        },
+      }
+    );
+
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(themeUpdatedCalled, true);
+
+    const metadata = editor.raw().metadata;
+    assert.ok(metadata?.visual?.presentation?.theme);
+    const activeThemeId = metadata.visual.presentation.theme;
+    const themes = metadata.visual.presentation.themes as Record<string, unknown>;
+    assert.deepStrictEqual(themes[activeThemeId], mockThemeResult);
+  });
 });
+

--- a/packages/visual-editor/tests/agent/graph-editing/graph-editing-functions-suspend.test.ts
+++ b/packages/visual-editor/tests/agent/graph-editing/graph-editing-functions-suspend.test.ts
@@ -329,7 +329,6 @@ suite("Graph editing functions suspend/resume", () => {
         captured[0].transform!.description,
         "Updated Description"
       );
-      assert.strictEqual(captured[0].transform!.themeIntent, undefined);
     }
 
     assert.strictEqual(result.success, true);
@@ -386,8 +385,8 @@ suite("Graph editing functions suspend/resume", () => {
     assert.strictEqual(captured.length, 1);
     assert.ok(captured[0].requestId, "Should have a requestId");
     assert.ok(captured[0].transform, "Should have a transform");
-    assert.strictEqual(captured[0].transform!.kind, "updateGraphProperties");
-    if (captured[0].transform!.kind === "updateGraphProperties") {
+    assert.strictEqual(captured[0].transform!.kind, "updateTheme");
+    if (captured[0].transform!.kind === "updateTheme") {
       assert.strictEqual(
         captured[0].transform!.title,
         "My Great Opal",


### PR DESCRIPTION
## What
Splits the unified `updateGraphProperties` transform kind into two separate, dedicated transform kinds: `updateGraphProperties` (for basic title and description metadata updates) and `updateTheme` (for generating and updating themes).

## Why
Provides proper separation of concerns that aligns with the separate tools and UI renderers in the devtools panel (`graph_edit_properties` and `graph_update_theme`), ensuring theme updates do not accidentally override or modify basic graph metadata.

## Changes

### `packages/visual-editor`
- **`src/a2/agent/agent-event.ts`**:
  - Split `UpdateGraphPropertiesDescriptor` and added a new `UpdateThemeDescriptor` to `TransformDescriptor`.
- **`src/a2/agent/graph-editing/functions.ts`**:
  - Updated `applyUpdateTheme` to suspend with the `"updateTheme"` transform kind.
- **`src/a2/agent/graph-editing/graph-editing-manager.ts`**:
  - Split `case "updateGraphProperties"` into separate `case "updateGraphProperties"` and `case "updateTheme"` handlers.
- **`tests/agent/graph-editing/graph-editing-functions-suspend.test.ts`**:
  - Updated tests to assert that the theme update tool dispatches the `"updateTheme"` transform kind.
- **`tests/a2/agent/graph-editing/graph-editing-manager.test.ts`**:
  - Added comprehensive unit tests explicitly verifying both property updates and theme updates run successfully within `GraphEditingManager`.

## Testing
Verified by running the local unit tests:
- `npm run test:file -- "./dist/tsc/tests/agent/graph-editing/graph-editing-functions-suspend.test.js"`
- `npm run test:file -- "./dist/tsc/tests/a2/agent/graph-editing/graph-editing-manager.test.js"`
