### PR TITLE
[heartstone] Phase 10: Drive graph loading & headless mode

### DIFF
--- a/packages/opal-backend/opal_backend/dev/main.py
+++ b/packages/opal-backend/opal_backend/dev/main.py
@@ -123,6 +123,10 @@ _graph_session_router = create_graph_session_router(
     event_bus=_event_bus,
     runner=_graph_runner,
     scheduler=_graph_scheduler,
+    drive_client_factory=lambda token: HttpDriveOperationsClient(
+        httpx_client=httpx.AsyncClient(timeout=120.0),
+        access_token=token,
+    ),
 )
 
 

--- a/packages/opal-backend/opal_backend/drive_operations_client.py
+++ b/packages/opal-backend/opal_backend/drive_operations_client.py
@@ -29,6 +29,10 @@ class DriveOperationsClient(Protocol):
         """Get file metadata."""
         ...
 
+    async def get_file_media(self, file_id: str) -> bytes:
+        """Download raw file content as bytes (alt=media)."""
+        ...
+
     async def delete_file(self, file_id: str) -> None:
         """Trash a file."""
         ...

--- a/packages/opal-backend/opal_backend/graph_runner.py
+++ b/packages/opal-backend/opal_backend/graph_runner.py
@@ -38,6 +38,20 @@ from .task_scheduler import TaskScheduler
 
 __all__ = ["GraphRunner"]
 
+_HEADLESS_AGENT_NOTE = (
+    "Note to agent: You are currently running in headless mode and the "
+    "user is not present to answer questions. Do your best to make "
+    "decisions without their input, and fail the objective if you "
+    "determine you cannot."
+)
+
+_HEADLESS_AGENT_NOTE_WITH_CONTEXT = (
+    "Note to agent: You are currently running in headless mode and the "
+    "user is not present to answer questions, however they provided the "
+    "following context for you to consider. Do your best to make "
+    "decisions based on this context, and fail the objective if you "
+    "determine you cannot."
+)
 
 class GraphRunner:
     """Runs individual node tasks and coordinates the graph lifecycle.
@@ -292,7 +306,114 @@ class GraphRunner:
         self, session_id: str, node_id: str,
         suspended: NodeSuspended,
     ) -> None:
-        """Handle a NodeSuspended exception from a handler."""
+        """Handle a NodeSuspended exception from a handler.
+
+        In headless mode, nodes auto-resolve instead of emitting
+        ``inputRequired``:
+
+        **Input nodes** (``"inputs"`` in context):
+        - Headless input exists → auto-resume with ``{"context": [value]}``
+        - No input and ``p-required`` is true → error the node
+        - No input and not required → skip with ``{"context": []}``
+
+        **Agent nodes** (``"segments"`` in context):
+        - Save suspend state, then immediately call ``resume_node``
+          with the headless mode note (+ any pre-supplied context).
+        - Subsequent suspends also auto-resume with just the note.
+        """
+        is_input_node = "inputs" in suspended.context
+
+        # Headless auto-resolve for input nodes.
+        if is_input_node:
+            headless_value = await self._store.get_headless_input(
+                session_id, node_id,
+            )
+            if headless_value is not None:
+                # Pre-supplied input → auto-resume.
+                outputs = {"context": [headless_value]}
+                try:
+                    await self._complete_node(session_id, node_id, outputs)
+                except Exception as exc:
+                    await self._handle_node_error(session_id, node_id, exc)
+                return
+
+            # No pre-supplied value — check if headless mode.
+            config = await self._store.get_node_config(session_id, node_id)
+            is_headless = await self._is_headless_session(session_id)
+            if is_headless:
+                is_required = config.get("p-required", False)
+                if is_required:
+                    # Required input missing in headless mode → error.
+                    await self._handle_node_error(
+                        session_id, node_id,
+                        ValueError(
+                            f"Required input for node '{node_id}' "
+                            f"not provided in headless inputs",
+                        ),
+                    )
+                    return
+                else:
+                    # Optional input missing → skip with empty context.
+                    outputs: dict[str, Any] = {"context": []}
+                    try:
+                        await self._complete_node(
+                            session_id, node_id, outputs,
+                        )
+                    except Exception as exc:
+                        await self._handle_node_error(
+                            session_id, node_id, exc,
+                        )
+                    return
+
+        # Headless auto-resolve for agent nodes.
+        if not is_input_node and await self._is_headless_session(session_id):
+            # Save suspend state so resume_node can load it.
+            state = SuspendedNodeState(
+                node_id=node_id,
+                interaction_id=suspended.interaction_id,
+                context=suspended.context,
+            )
+            await self._store.suspend_node(
+                session_id, node_id,
+                suspended.interaction_id, state,
+            )
+
+            # Build the auto-response with headless mode note.
+            # Prepend the note as a text part, then append the user's
+            # original parts (preserving multimodal content).
+            headless_value = await self._store.get_headless_input(
+                session_id, node_id,
+            )
+            if headless_value is not None:
+                note = _HEADLESS_AGENT_NOTE_WITH_CONTEXT
+                # Extract parts from the pre-supplied context.
+                if isinstance(headless_value, dict):
+                    user_parts = list(headless_value.get("parts", []))
+                elif isinstance(headless_value, str):
+                    user_parts = [{"text": headless_value}]
+                else:
+                    user_parts = [{"text": str(headless_value)}]
+                parts = [{"text": note}] + user_parts
+            else:
+                parts = [{"text": _HEADLESS_AGENT_NOTE}]
+
+            response = {
+                "input": {
+                    "role": "user",
+                    "parts": parts,
+                },
+            }
+
+            # Immediately resume the agent — no inputRequired event.
+            try:
+                await self.resume_node(
+                    session_id, suspended.interaction_id, response,
+                )
+            except Exception as exc:
+                await self._handle_node_error(session_id, node_id, exc)
+            return
+
+        # Interactive mode — suspend normally.
         state = SuspendedNodeState(
             node_id=node_id,
             interaction_id=suspended.interaction_id,
@@ -313,6 +434,12 @@ class GraphRunner:
         }
         await self._store.append_event(session_id, event)
         await self._event_bus.publish(session_id, event)
+
+    async def _is_headless_session(
+        self, session_id: str,
+    ) -> bool:
+        """Check if the session is running in headless mode."""
+        return await self._store.is_headless_session(session_id)
 
     async def _get_node_type(
         self, session_id: str, node_id: str,

--- a/packages/opal-backend/opal_backend/graph_session_store.py
+++ b/packages/opal-backend/opal_backend/graph_session_store.py
@@ -53,8 +53,16 @@ class GraphSessionStore(Protocol):
 
     async def create(
         self, session_id: str, plan: GraphPlan,
+        *,
+        headless_inputs: dict[str, Any] | None = None,
     ) -> None:
-        """Store plan with initial dependency counts."""
+        """Store plan with initial dependency counts.
+
+        Args:
+            headless_inputs: Optional mapping of node_id → LLMContent
+                for headless mode. When set, input nodes auto-resolve
+                using pre-supplied values instead of suspending.
+        """
         ...
 
     async def get_plan(
@@ -91,6 +99,28 @@ class GraphSessionStore(Protocol):
         self, session_id: str, node_id: str,
     ) -> dict[str, Any]:
         """Load node configuration from the stored plan."""
+        ...
+
+    # ── Headless Inputs ──
+
+    async def get_headless_input(
+        self, session_id: str, node_id: str,
+    ) -> Any | None:
+        """Look up a pre-supplied input for headless mode.
+
+        Returns the LLMContent value for the given node ID, or None
+        if no headless input was provided (or session is interactive).
+        """
+        ...
+
+    async def is_headless_session(
+        self, session_id: str,
+    ) -> bool:
+        """Return True if the session was created in headless mode.
+
+        A session is headless when ``headless_inputs`` was provided
+        to ``create()`` (even if the dict is empty).
+        """
         ...
 
     # ── Suspend / Resume ──

--- a/packages/opal-backend/opal_backend/local/drive_operations_client_impl.py
+++ b/packages/opal-backend/opal_backend/local/drive_operations_client_impl.py
@@ -71,6 +71,28 @@ class HttpDriveOperationsClient:
         url = f"{GOOGLE_DRIVE_FILES_API}/{quote(file_id, safe='')}"
         return await self._api(url, "GET")
 
+    async def get_file_media(self, file_id: str) -> bytes:
+        """Download raw file content as bytes.
+
+        Port of ``GET /drive/v3/files/{id}?alt=media``.
+        Unlike JSON API calls, this returns raw bytes so we bypass
+        ``_api()`` and read the response content directly.
+        """
+        url = (
+            f"{GOOGLE_DRIVE_FILES_API}/{quote(file_id, safe='')}"
+            f"?alt=media"
+        )
+        response = await self._httpx.request(
+            "GET", url, headers={
+                "Authorization": f"Bearer {self._access_token}",
+            },
+        )
+        if response.status_code != 200:
+            raise ValueError(
+                f"Drive API error: {response.status_code} {response.reason_phrase}"
+            )
+        return response.content
+
     async def delete_file(self, file_id: str) -> None:
         """Trash a file.
 

--- a/packages/opal-backend/opal_backend/local/graph_session_router.py
+++ b/packages/opal-backend/opal_backend/local/graph_session_router.py
@@ -39,6 +39,7 @@ def create_graph_session_router(
     event_bus: EventBus,
     runner: GraphRunner,
     scheduler: TaskScheduler,
+    drive_client_factory: Any | None = None,
 ) -> APIRouter:
     """Create a FastAPI router with graph session endpoints.
 
@@ -47,6 +48,8 @@ def create_graph_session_router(
         event_bus: EventBus for live SSE event delivery.
         runner: GraphRunner for node task execution.
         scheduler: TaskScheduler for cancellation support.
+        drive_client_factory: Optional callable ``(access_token: str) -> DriveOperationsClient``.
+            Required when clients use ``graphId`` to load graphs from Drive.
     """
     router = APIRouter(prefix="/v1beta1/graphSessions")
 
@@ -55,18 +58,47 @@ def create_graph_session_router(
         """Start a new graph run.
 
         Body: {graph: GraphDescriptor, accessToken?: str}
+              OR {graphId: str, accessToken: str}
+
+        Optional:
+            mode: "interactive" (default) or "headless"
+            inputs: {nodeId: LLMContent, ...}  (headless pre-supplied inputs)
         """
         body = await request.json()
         graph_data = body.get("graph")
-        if not graph_data:
+        graph_id = body.get("graphId")
+
+        if not graph_data and not graph_id:
             return JSONResponse(
-                {"error": "Missing 'graph' in request body"},
+                {"error": "Missing 'graph' or 'graphId' in request body"},
                 status_code=400,
             )
 
         # Extract user's OAuth token (same pattern as session_router).
         access_token = body.get("accessToken", "")
         origin = request.headers.get("origin", "")
+
+        # Load graph from Drive if graphId is provided.
+        if graph_id:
+            if not access_token:
+                return JSONResponse(
+                    {"error": "'accessToken' is required when using 'graphId'"},
+                    status_code=400,
+                )
+            if drive_client_factory is None:
+                return JSONResponse(
+                    {"error": "Drive graph loading is not configured"},
+                    status_code=500,
+                )
+            try:
+                drive_client = drive_client_factory(access_token)
+                file_bytes = await drive_client.get_file_media(graph_id)
+                graph_data = json.loads(file_bytes)
+            except (ValueError, json.JSONDecodeError) as exc:
+                return JSONResponse(
+                    {"error": f"Failed to load graph from Drive: {exc}"},
+                    status_code=400,
+                )
 
         # Parse, condense (break cycles), and plan.
         graph = GraphDescriptor.from_dict(graph_data)
@@ -81,8 +113,13 @@ def create_graph_session_router(
 
         session_id = str(uuid.uuid4())
 
+        # Headless mode: pass pre-supplied inputs to the store.
+        mode = body.get("mode", "interactive")
+        inputs = body.get("inputs", {})
+        headless_inputs = inputs if mode == "headless" else None
+
         # Store the plan and kick off initial tasks.
-        await store.create(session_id, plan)
+        await store.create(session_id, plan, headless_inputs=headless_inputs)
         await runner.start_graph(
             session_id, access_token=access_token, origin=origin,
         )

--- a/packages/opal-backend/opal_backend/local/graph_session_store_impl.py
+++ b/packages/opal-backend/opal_backend/local/graph_session_store_impl.py
@@ -39,6 +39,8 @@ class _SessionState:
     suspended: dict[str, SuspendedNodeState] = field(default_factory=dict)
     # interaction_id → node_id
     interaction_index: dict[str, str] = field(default_factory=dict)
+    # Headless mode: node_id → pre-supplied LLMContent value.
+    headless_inputs: dict[str, Any] | None = None
 
 
 class InMemoryGraphSessionStore:
@@ -55,9 +57,11 @@ class InMemoryGraphSessionStore:
 
     async def create(
         self, session_id: str, plan: GraphPlan,
+        *,
+        headless_inputs: dict[str, Any] | None = None,
     ) -> None:
         """Store plan with initial dependency counts."""
-        state = _SessionState(plan=plan)
+        state = _SessionState(plan=plan, headless_inputs=headless_inputs)
 
         # Compute per-node pending dep counts from plan stages.
         for stage in plan.stages:
@@ -143,6 +147,26 @@ class InMemoryGraphSessionStore:
                 if info.node.id == node_id:
                     return info.node.configuration or {}
         return {}
+
+    # ── Headless Inputs ──
+
+    async def get_headless_input(
+        self, session_id: str, node_id: str,
+    ) -> Any | None:
+        """Look up a pre-supplied input for headless mode."""
+        state = self._sessions.get(session_id)
+        if not state or state.headless_inputs is None:
+            return None
+        return state.headless_inputs.get(node_id)
+
+    async def is_headless_session(
+        self, session_id: str,
+    ) -> bool:
+        """Return True if the session was created in headless mode."""
+        state = self._sessions.get(session_id)
+        if not state:
+            return False
+        return state.headless_inputs is not None
 
     # ── Suspend / Resume ──
 

--- a/packages/opal-backend/opal_backend/node_handlers.py
+++ b/packages/opal-backend/opal_backend/node_handlers.py
@@ -1013,6 +1013,14 @@ async def consume_agent_events(
             if content:
                 result_content.append(content)
 
+        # Extract final outcomes from the complete event.
+        if event.type == "complete":
+            result = getattr(event, "result", None)
+            if result:
+                outcomes = getattr(result, "outcomes", None)
+                if outcomes:
+                    result_content.append(outcomes)
+
     if result_content:
         return {"context": result_content}
 

--- a/packages/opal-backend/tests/test_drive_graph_loading.py
+++ b/packages/opal-backend/tests/test_drive_graph_loading.py
@@ -1,0 +1,282 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Drive graph loading (graphId-based session creation).
+
+Covers:
+- ``get_file_media`` in ``HttpDriveOperationsClient`` (mock httpx)
+- ``create_graph_session`` with ``graphId`` (mock Drive client)
+- Error cases: graphId without accessToken, Drive errors
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from opal_backend.graph_runner import GraphRunner
+from opal_backend.local.drive_operations_client_impl import (
+    GOOGLE_DRIVE_FILES_API,
+    HttpDriveOperationsClient,
+)
+from opal_backend.local.event_bus_impl import InMemoryEventBus
+from opal_backend.local.graph_session_router import create_graph_session_router
+from opal_backend.local.graph_session_store_impl import InMemoryGraphSessionStore
+from opal_backend.local.task_scheduler_impl import LocalTaskScheduler
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+ACCESS_TOKEN = "test-token-456"
+
+
+def _make_drive_client(handler) -> HttpDriveOperationsClient:
+    """Build a Drive client backed by a mock httpx transport."""
+    transport = httpx.MockTransport(handler)
+    httpx_client = httpx.AsyncClient(transport=transport)
+    return HttpDriveOperationsClient(
+        httpx_client=httpx_client,
+        access_token=ACCESS_TOKEN,
+    )
+
+
+def _simple_graph() -> dict:
+    """A two-node inline graph (generate → output)."""
+    return {
+        "nodes": [
+            {"id": "gen", "type": "generate"},
+            {"id": "out", "type": "output"},
+        ],
+        "edges": [
+            {
+                "from": "gen", "to": "out",
+                "out": "context", "in": "result",
+            },
+        ],
+    }
+
+
+def _create_app(drive_client_factory=None):
+    """Create a FastAPI app with graph session router wired up."""
+    store = InMemoryGraphSessionStore()
+    bus = InMemoryEventBus()
+    runner = GraphRunner(store=store, event_bus=bus, scheduler=None)
+    scheduler = LocalTaskScheduler(run_fn=runner.run_node)
+    runner._scheduler = scheduler
+
+    router = create_graph_session_router(
+        store=store,
+        event_bus=bus,
+        runner=runner,
+        scheduler=scheduler,
+        drive_client_factory=drive_client_factory,
+    )
+
+    app = FastAPI()
+    app.include_router(router)
+    return app, store, bus
+
+
+# =============================================================================
+# HttpDriveOperationsClient.get_file_media
+# =============================================================================
+
+
+class TestGetFileMedia:
+    @pytest.mark.asyncio
+    async def test_downloads_file_content(self):
+        """get_file_media sends GET with ?alt=media and returns raw bytes."""
+        graph_json = json.dumps(_simple_graph()).encode()
+        captured: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(
+                status_code=200,
+                content=graph_json,
+            )
+
+        client = _make_drive_client(handler)
+        result = await client.get_file_media("file-abc")
+
+        assert result == graph_json
+        assert len(captured) == 1
+        assert captured[0].method == "GET"
+        url = str(captured[0].url)
+        assert f"{GOOGLE_DRIVE_FILES_API}/file-abc" in url
+        assert "alt=media" in url
+        assert captured[0].headers["authorization"] == f"Bearer {ACCESS_TOKEN}"
+
+    @pytest.mark.asyncio
+    async def test_raises_on_error_status(self):
+        """get_file_media raises ValueError on non-200 response."""
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(status_code=404)
+
+        client = _make_drive_client(handler)
+        with pytest.raises(ValueError, match="Drive API error"):
+            await client.get_file_media("nonexistent")
+
+    @pytest.mark.asyncio
+    async def test_url_encodes_file_id(self):
+        """get_file_media URL-encodes special characters in file_id."""
+        captured: list[httpx.Request] = []
+
+        async def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(status_code=200, content=b"{}")
+
+        client = _make_drive_client(handler)
+        await client.get_file_media("id/with/slashes")
+
+        url = str(captured[0].url)
+        # Slashes in the ID should be percent-encoded.
+        assert "id%2Fwith%2Fslashes" in url
+
+
+# =============================================================================
+# Router: graphId-based session creation
+# =============================================================================
+
+
+class TestGraphIdSessionCreation:
+    def test_creates_session_from_graph_id(self):
+        """graphId + accessToken loads graph from Drive and starts session."""
+        graph_bytes = json.dumps(_simple_graph()).encode()
+
+        mock_drive = AsyncMock()
+        mock_drive.get_file_media = AsyncMock(return_value=graph_bytes)
+
+        app, *_ = _create_app(
+            drive_client_factory=lambda token: mock_drive,
+        )
+        client = TestClient(app)
+
+        resp = client.post(
+            "/v1beta1/graphSessions/new",
+            json={"graphId": "drive-file-123", "accessToken": "my-token"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "sessionId" in data
+
+        # Verify the Drive client was called with the correct file ID.
+        mock_drive.get_file_media.assert_awaited_once_with("drive-file-123")
+
+    def test_graph_id_without_access_token_returns_400(self):
+        """graphId without accessToken is an error."""
+        app, *_ = _create_app(
+            drive_client_factory=lambda token: AsyncMock(),
+        )
+        client = TestClient(app)
+
+        resp = client.post(
+            "/v1beta1/graphSessions/new",
+            json={"graphId": "drive-file-123"},
+        )
+        assert resp.status_code == 400
+        assert "accessToken" in resp.json()["error"]
+
+    def test_graph_id_without_factory_returns_500(self):
+        """graphId without drive_client_factory configured is a server error."""
+        app, *_ = _create_app(drive_client_factory=None)
+        client = TestClient(app)
+
+        resp = client.post(
+            "/v1beta1/graphSessions/new",
+            json={"graphId": "drive-file-123", "accessToken": "token"},
+        )
+        assert resp.status_code == 500
+        assert "not configured" in resp.json()["error"]
+
+    def test_drive_error_returns_400(self):
+        """Drive API error while loading graphId returns 400."""
+        mock_drive = AsyncMock()
+        mock_drive.get_file_media = AsyncMock(
+            side_effect=ValueError("Drive API error: 404 Not Found"),
+        )
+
+        app, *_ = _create_app(
+            drive_client_factory=lambda token: mock_drive,
+        )
+        client = TestClient(app)
+
+        resp = client.post(
+            "/v1beta1/graphSessions/new",
+            json={"graphId": "bad-id", "accessToken": "token"},
+        )
+        assert resp.status_code == 400
+        assert "Failed to load graph from Drive" in resp.json()["error"]
+
+    def test_invalid_json_from_drive_returns_400(self):
+        """Non-JSON content from Drive returns 400."""
+        mock_drive = AsyncMock()
+        mock_drive.get_file_media = AsyncMock(
+            return_value=b"this is not json",
+        )
+
+        app, *_ = _create_app(
+            drive_client_factory=lambda token: mock_drive,
+        )
+        client = TestClient(app)
+
+        resp = client.post(
+            "/v1beta1/graphSessions/new",
+            json={"graphId": "bad-content", "accessToken": "token"},
+        )
+        assert resp.status_code == 400
+        assert "Failed to load graph from Drive" in resp.json()["error"]
+
+    def test_missing_both_graph_and_graph_id_returns_400(self):
+        """Neither graph nor graphId returns 400."""
+        app, *_ = _create_app()
+        client = TestClient(app)
+
+        resp = client.post(
+            "/v1beta1/graphSessions/new",
+            json={"accessToken": "token"},
+        )
+        assert resp.status_code == 400
+        assert "Missing" in resp.json()["error"]
+
+    def test_inline_graph_still_works(self):
+        """Existing inline graph path continues to work unchanged."""
+        app, *_ = _create_app()
+        client = TestClient(app)
+
+        resp = client.post(
+            "/v1beta1/graphSessions/new",
+            json={"graph": _simple_graph()},
+        )
+        assert resp.status_code == 200
+        assert "sessionId" in resp.json()
+
+    def test_factory_receives_correct_token(self):
+        """drive_client_factory is called with the request's accessToken."""
+        graph_bytes = json.dumps(_simple_graph()).encode()
+        captured_tokens: list[str] = []
+
+        mock_drive = AsyncMock()
+        mock_drive.get_file_media = AsyncMock(return_value=graph_bytes)
+
+        def factory(token: str):
+            captured_tokens.append(token)
+            return mock_drive
+
+        app, *_ = _create_app(drive_client_factory=factory)
+        client = TestClient(app)
+
+        client.post(
+            "/v1beta1/graphSessions/new",
+            json={"graphId": "file-id", "accessToken": "my-oauth-token"},
+        )
+
+        assert captured_tokens == ["my-oauth-token"]

--- a/packages/opal-backend/tests/test_headless_mode.py
+++ b/packages/opal-backend/tests/test_headless_mode.py
@@ -1,0 +1,592 @@
+# Copyright 2026 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for headless mode — pre-supplied inputs for non-interactive runs.
+
+🎯 Input nodes auto-resolve with pre-supplied inputs when
+running in headless mode. Required inputs without pre-supplied
+values error; optional inputs skip with empty context.
+Agent nodes still suspend normally in headless mode.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from opal_backend.graph_runner import GraphRunner
+from opal_backend.graph_types import Edge, GraphPlan, NodeDescriptor, PlanNodeInfo
+from opal_backend.local.event_bus_impl import InMemoryEventBus
+from opal_backend.local.graph_session_store_impl import InMemoryGraphSessionStore
+from opal_backend.local.task_scheduler_impl import LocalTaskScheduler
+
+
+# ---------------------------------------------------------------------------
+# Plan helpers
+# ---------------------------------------------------------------------------
+
+
+def _input_gen_output_plan(
+    *,
+    input_config: dict | None = None,
+) -> GraphPlan:
+    """input → generate → output.
+
+    Args:
+        input_config: Optional config for the input node
+            (e.g. {"p-required": True}).
+    """
+    inp = NodeDescriptor(
+        id="inp", type="input",
+        configuration=input_config or {},
+    )
+    gen = NodeDescriptor(id="gen", type="generate")
+    out = NodeDescriptor(id="out", type="output")
+
+    e1 = Edge(from_node="inp", to_node="gen", out_port="context", in_port="input")
+    e2 = Edge(from_node="gen", to_node="out", out_port="context", in_port="result")
+
+    return GraphPlan(stages=[
+        [PlanNodeInfo(node=inp, downstream=[e1], upstream=[])],
+        [PlanNodeInfo(node=gen, downstream=[e2], upstream=[e1])],
+        [PlanNodeInfo(node=out, downstream=[], upstream=[e2])],
+    ])
+
+
+def _two_input_plan(
+    *,
+    inp1_config: dict | None = None,
+    inp2_config: dict | None = None,
+) -> GraphPlan:
+    """Two independent inputs → output."""
+    inp1 = NodeDescriptor(
+        id="inp1", type="input",
+        configuration=inp1_config or {},
+    )
+    inp2 = NodeDescriptor(
+        id="inp2", type="input",
+        configuration=inp2_config or {},
+    )
+    out = NodeDescriptor(id="out", type="output")
+
+    e1 = Edge(from_node="inp1", to_node="out", out_port="context", in_port="r1")
+    e2 = Edge(from_node="inp2", to_node="out", out_port="context", in_port="r2")
+
+    return GraphPlan(stages=[
+        [
+            PlanNodeInfo(node=inp1, downstream=[e1], upstream=[]),
+            PlanNodeInfo(node=inp2, downstream=[e2], upstream=[]),
+        ],
+        [PlanNodeInfo(node=out, downstream=[], upstream=[e1, e2])],
+    ])
+
+
+def _agent_node_plan() -> GraphPlan:
+    """Single agent node (generate with mode=agent) — no input node."""
+    agent = NodeDescriptor(
+        id="agent", type="generate",
+        configuration={"generation-mode": "agent"},
+    )
+    return GraphPlan(stages=[
+        [PlanNodeInfo(node=agent, downstream=[], upstream=[])],
+    ])
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_runner(
+    store: InMemoryGraphSessionStore,
+    bus: InMemoryEventBus,
+) -> GraphRunner:
+    """Create a wired runner + scheduler."""
+    runner = GraphRunner(store=store, event_bus=bus, scheduler=None)
+    scheduler = LocalTaskScheduler(run_fn=runner.run_node)
+    runner._scheduler = scheduler
+    return runner
+
+
+async def _collect_until(subscriber, event_type: str) -> list[dict]:
+    """Collect events from a subscriber until a specific event type."""
+    events: list[dict] = []
+    async for event in subscriber:
+        events.append(event)
+        if event.get("type") == event_type:
+            break
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Store tests
+# ---------------------------------------------------------------------------
+
+
+class TestHeadlessInputStorage:
+    """Headless inputs are stored and retrieved correctly."""
+
+    @pytest.mark.asyncio
+    async def test_store_and_retrieve_headless_input(self):
+        store = InMemoryGraphSessionStore()
+        plan = _input_gen_output_plan()
+        headless_inputs = {
+            "inp": {"role": "user", "parts": [{"text": "Hello"}]},
+        }
+        await store.create("s1", plan, headless_inputs=headless_inputs)
+
+        result = await store.get_headless_input("s1", "inp")
+        assert result == {"role": "user", "parts": [{"text": "Hello"}]}
+
+    @pytest.mark.asyncio
+    async def test_get_headless_input_missing_node(self):
+        store = InMemoryGraphSessionStore()
+        plan = _input_gen_output_plan()
+        await store.create("s1", plan, headless_inputs={"other": "x"})
+
+        result = await store.get_headless_input("s1", "inp")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_headless_input_interactive_session(self):
+        """Interactive session (no headless_inputs) returns None."""
+        store = InMemoryGraphSessionStore()
+        plan = _input_gen_output_plan()
+        await store.create("s1", plan)
+
+        result = await store.get_headless_input("s1", "inp")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_headless_input_missing_session(self):
+        store = InMemoryGraphSessionStore()
+        result = await store.get_headless_input("missing", "inp")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_is_headless_session_true(self):
+        store = InMemoryGraphSessionStore()
+        plan = _input_gen_output_plan()
+        await store.create("s1", plan, headless_inputs={})
+
+        assert await store.is_headless_session("s1") is True
+
+    @pytest.mark.asyncio
+    async def test_is_headless_session_false(self):
+        store = InMemoryGraphSessionStore()
+        plan = _input_gen_output_plan()
+        await store.create("s1", plan)
+
+        assert await store.is_headless_session("s1") is False
+
+    @pytest.mark.asyncio
+    async def test_is_headless_session_missing(self):
+        store = InMemoryGraphSessionStore()
+        assert await store.is_headless_session("missing") is False
+
+
+# ---------------------------------------------------------------------------
+# GraphRunner headless tests
+# ---------------------------------------------------------------------------
+
+
+class TestHeadlessAutoResolve:
+    """Input nodes auto-resolve with pre-supplied headless inputs."""
+
+    @pytest.mark.asyncio
+    async def test_input_auto_resolves_with_headless_value(self):
+        """Input node completes immediately with pre-supplied value."""
+        store = InMemoryGraphSessionStore()
+        bus = InMemoryEventBus()
+        runner = _make_runner(store, bus)
+
+        plan = _input_gen_output_plan()
+        headless_inputs = {
+            "inp": {"role": "user", "parts": [{"text": "Hello headless"}]},
+        }
+        await store.create("s1", plan, headless_inputs=headless_inputs)
+
+        subscriber = bus.subscribe("s1")
+        await runner.start_graph("s1")
+
+        events = await _collect_until(subscriber, "graphComplete")
+
+        # No inputRequired should have been emitted.
+        input_reqs = [e for e in events if e["type"] == "inputRequired"]
+        assert len(input_reqs) == 0
+
+        # Graph should complete.
+        assert await store.is_graph_complete("s1")
+        assert await store.get_status("s1") == "completed"
+
+        # Input node output should contain the pre-supplied value.
+        outputs = await store.get_graph_outputs("s1")
+        assert "inp" in outputs
+        assert outputs["inp"]["context"] == [
+            {"role": "user", "parts": [{"text": "Hello headless"}]},
+        ]
+
+    @pytest.mark.asyncio
+    async def test_two_inputs_both_auto_resolve(self):
+        """Multiple input nodes each auto-resolve independently."""
+        store = InMemoryGraphSessionStore()
+        bus = InMemoryEventBus()
+        runner = _make_runner(store, bus)
+
+        plan = _two_input_plan()
+        headless_inputs = {
+            "inp1": {"role": "user", "parts": [{"text": "First"}]},
+            "inp2": {"role": "user", "parts": [{"text": "Second"}]},
+        }
+        await store.create("s1", plan, headless_inputs=headless_inputs)
+
+        subscriber = bus.subscribe("s1")
+        await runner.start_graph("s1")
+
+        events = await _collect_until(subscriber, "graphComplete")
+
+        # No inputRequired events.
+        assert not any(e["type"] == "inputRequired" for e in events)
+
+        # All nodes completed.
+        assert await store.is_graph_complete("s1")
+
+        outputs = await store.get_graph_outputs("s1")
+        assert outputs["inp1"]["context"] == [
+            {"role": "user", "parts": [{"text": "First"}]},
+        ]
+        assert outputs["inp2"]["context"] == [
+            {"role": "user", "parts": [{"text": "Second"}]},
+        ]
+
+
+class TestHeadlessRequiredInputError:
+    """Required inputs without pre-supplied values error."""
+
+    @pytest.mark.asyncio
+    async def test_required_input_missing_errors(self):
+        """A required input node with no headless value errors."""
+        store = InMemoryGraphSessionStore()
+        bus = InMemoryEventBus()
+        runner = _make_runner(store, bus)
+
+        plan = _input_gen_output_plan(
+            input_config={"p-required": True},
+        )
+        # Headless mode, but no input for "inp".
+        await store.create("s1", plan, headless_inputs={})
+
+        subscriber = bus.subscribe("s1")
+        await runner.start_graph("s1")
+
+        # Collect events — should get nodeError, not inputRequired.
+        events: list[dict] = []
+        async for event in subscriber:
+            events.append(event)
+            if event.get("type") in ("graphComplete", "nodeError"):
+                # The graph might complete after error (node failed +
+                # dependents skipped), or we see the error first.
+                if event.get("type") == "graphComplete":
+                    break
+                # Keep going to see if graphComplete follows.
+                continue
+            if event.get("type") == "graphComplete":
+                break
+
+        # Should have a nodeError for the input node.
+        node_errors = [e for e in events if e["type"] == "nodeError"]
+        assert len(node_errors) >= 1
+        error_event = node_errors[0]
+        assert error_event["nodeId"] == "inp"
+        assert "Required input" in error_event["error"]
+
+        # No inputRequired should have been emitted.
+        input_reqs = [e for e in events if e["type"] == "inputRequired"]
+        assert len(input_reqs) == 0
+
+
+class TestHeadlessOptionalInputSkip:
+    """Optional inputs without pre-supplied values skip."""
+
+    @pytest.mark.asyncio
+    async def test_optional_input_skips_with_empty_context(self):
+        """An optional input node auto-completes with empty context."""
+        store = InMemoryGraphSessionStore()
+        bus = InMemoryEventBus()
+        runner = _make_runner(store, bus)
+
+        plan = _input_gen_output_plan(
+            input_config={"p-required": False},
+        )
+        # Headless mode, no input for "inp".
+        await store.create("s1", plan, headless_inputs={})
+
+        subscriber = bus.subscribe("s1")
+        await runner.start_graph("s1")
+
+        events = await _collect_until(subscriber, "graphComplete")
+
+        # No inputRequired — auto-skipped.
+        assert not any(e["type"] == "inputRequired" for e in events)
+
+        # Graph completed.
+        assert await store.is_graph_complete("s1")
+        assert await store.get_status("s1") == "completed"
+
+        # Input node output has empty context.
+        outputs = await store.get_graph_outputs("s1")
+        assert outputs["inp"]["context"] == []
+
+    @pytest.mark.asyncio
+    async def test_default_required_is_false(self):
+        """Input with no p-required config defaults to optional (skip)."""
+        store = InMemoryGraphSessionStore()
+        bus = InMemoryEventBus()
+        runner = _make_runner(store, bus)
+
+        plan = _input_gen_output_plan()  # No config → p-required defaults False.
+        await store.create("s1", plan, headless_inputs={})
+
+        subscriber = bus.subscribe("s1")
+        await runner.start_graph("s1")
+
+        events = await _collect_until(subscriber, "graphComplete")
+
+        assert not any(e["type"] == "inputRequired" for e in events)
+        assert await store.is_graph_complete("s1")
+
+        outputs = await store.get_graph_outputs("s1")
+        assert outputs["inp"]["context"] == []
+
+
+class TestHeadlessMixedInputs:
+    """Mix of supplied and missing inputs."""
+
+    @pytest.mark.asyncio
+    async def test_one_supplied_one_optional_skipped(self):
+        """One input supplied, other optional → both auto-resolve."""
+        store = InMemoryGraphSessionStore()
+        bus = InMemoryEventBus()
+        runner = _make_runner(store, bus)
+
+        plan = _two_input_plan(
+            inp1_config={},  # optional
+            inp2_config={},  # optional
+        )
+        # Only supply inp1.
+        headless_inputs = {
+            "inp1": {"role": "user", "parts": [{"text": "Supplied"}]},
+        }
+        await store.create("s1", plan, headless_inputs=headless_inputs)
+
+        subscriber = bus.subscribe("s1")
+        await runner.start_graph("s1")
+
+        events = await _collect_until(subscriber, "graphComplete")
+
+        assert not any(e["type"] == "inputRequired" for e in events)
+        assert await store.is_graph_complete("s1")
+
+        outputs = await store.get_graph_outputs("s1")
+        assert outputs["inp1"]["context"] == [
+            {"role": "user", "parts": [{"text": "Supplied"}]},
+        ]
+        assert outputs["inp2"]["context"] == []  # Skipped.
+
+
+class TestInteractiveModeUnchanged:
+    """Interactive mode (no headless_inputs) still suspends normally."""
+
+    @pytest.mark.asyncio
+    async def test_input_still_suspends_in_interactive_mode(self):
+        """Without headless_inputs, input nodes suspend as before."""
+        store = InMemoryGraphSessionStore()
+        bus = InMemoryEventBus()
+        runner = _make_runner(store, bus)
+
+        plan = _input_gen_output_plan()
+        # Interactive mode: no headless_inputs.
+        await store.create("s1", plan)
+
+        subscriber = bus.subscribe("s1")
+        await runner.start_graph("s1")
+
+        events: list[dict] = []
+        async for event in subscriber:
+            events.append(event)
+            if event.get("type") == "inputRequired":
+                break
+
+        # inputRequired should fire.
+        input_reqs = [e for e in events if e["type"] == "inputRequired"]
+        assert len(input_reqs) == 1
+        assert input_reqs[0]["nodeId"] == "inp"
+
+        # Session is suspended.
+        assert await store.get_status("s1") == "suspended"
+
+
+class TestAgentNodeInHeadlessMode:
+    """Agent nodes auto-resolve in headless mode.
+
+    In headless mode, when an agent suspends (waitForInput), the
+    graph runner saves suspend state and immediately calls resume_node
+    with the headless mode note (+ any pre-supplied context).
+    """
+
+    @pytest.mark.asyncio
+    async def test_agent_auto_resolves_with_headless_note(self):
+        """Agent node in headless mode auto-resumes with note text.
+
+        Verifies: suspend → save state → resume_node called with
+        headless note, no inputRequired emitted.
+        """
+        store = InMemoryGraphSessionStore()
+        bus = InMemoryEventBus()
+
+        # Track resume_node calls.
+        resumed: list[dict] = []
+
+        async def _fake_run_agent(*, segments, backend, store, graph):
+            """Yield a suspend event to trigger headless auto-resolve."""
+            from opal_backend.events import WaitForInputEvent
+            yield WaitForInputEvent(
+                prompt="What topic?",
+                input_type="text",
+                interaction_id="int-1",
+            )
+
+        async def _fake_resume_agent(
+            *, interaction_id, response, backend, store, **kwargs,
+        ):
+            """Capture the resume call and complete."""
+            resumed.append({
+                "interaction_id": interaction_id,
+                "response": response,
+            })
+            # Yield nothing — agent completes.
+            return
+            yield  # Make it an async generator.
+
+        runner = GraphRunner(
+            store=store,
+            event_bus=bus,
+            scheduler=None,
+            run_agent_fn=_fake_run_agent,
+            resume_agent_fn=_fake_resume_agent,
+        )
+        scheduler = LocalTaskScheduler(run_fn=runner.run_node)
+        runner._scheduler = scheduler
+
+        plan = _agent_node_plan()
+        await store.create("s1", plan, headless_inputs={})
+
+        subscriber = bus.subscribe("s1")
+        await runner.start_graph("s1")
+
+        events = await _collect_until(subscriber, "graphComplete")
+
+        # No inputRequired should have been emitted.
+        input_reqs = [e for e in events if e["type"] == "inputRequired"]
+        assert len(input_reqs) == 0
+
+        # resume_node should have been called.
+        assert len(resumed) == 1
+        response_parts = resumed[0]["response"]["input"]["parts"]
+        # Single part — just the note, no user context.
+        assert len(response_parts) == 1
+        assert "headless mode" in response_parts[0]["text"]
+        assert "without their input" in response_parts[0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_agent_headless_with_pre_supplied_context(self):
+        """Agent in headless mode gets headless note + pre-supplied text."""
+        store = InMemoryGraphSessionStore()
+        bus = InMemoryEventBus()
+        resumed: list[dict] = []
+
+        async def _fake_run_agent(*, segments, backend, store, graph):
+            from opal_backend.events import WaitForInputEvent
+            yield WaitForInputEvent(
+                prompt="What topic?",
+                input_type="text",
+                interaction_id="int-1",
+            )
+
+        async def _fake_resume_agent(
+            *, interaction_id, response, backend, store, **kwargs,
+        ):
+            resumed.append({"response": response})
+            return
+            yield
+
+        runner = GraphRunner(
+            store=store,
+            event_bus=bus,
+            scheduler=None,
+            run_agent_fn=_fake_run_agent,
+            resume_agent_fn=_fake_resume_agent,
+        )
+        scheduler = LocalTaskScheduler(run_fn=runner.run_node)
+        runner._scheduler = scheduler
+
+        plan = _agent_node_plan()
+        # Pre-supply context for the agent node.
+        headless_inputs = {
+            "agent": {
+                "role": "user",
+                "parts": [{"text": "Write about bananas"}],
+            },
+        }
+        await store.create("s1", plan, headless_inputs=headless_inputs)
+
+        subscriber = bus.subscribe("s1")
+        await runner.start_graph("s1")
+        await _collect_until(subscriber, "graphComplete")
+
+        assert len(resumed) == 1
+        response_parts = resumed[0]["response"]["input"]["parts"]
+        # First part is the note, second is the user's context.
+        assert len(response_parts) == 2
+        assert "headless mode" in response_parts[0]["text"]
+        assert "context for you to consider" in response_parts[0]["text"]
+        assert response_parts[1] == {"text": "Write about bananas"}
+
+    @pytest.mark.asyncio
+    async def test_agent_interactive_mode_still_suspends(self):
+        """Agent node in interactive mode emits inputRequired normally."""
+        store = InMemoryGraphSessionStore()
+        bus = InMemoryEventBus()
+
+        async def _fake_run_agent(*, segments, backend, store, graph):
+            from opal_backend.events import WaitForInputEvent
+            yield WaitForInputEvent(
+                prompt="What topic?",
+                input_type="text",
+                interaction_id="int-1",
+            )
+
+        runner = GraphRunner(
+            store=store,
+            event_bus=bus,
+            scheduler=None,
+            run_agent_fn=_fake_run_agent,
+        )
+        scheduler = LocalTaskScheduler(run_fn=runner.run_node)
+        runner._scheduler = scheduler
+
+        plan = _agent_node_plan()
+        # Interactive mode — no headless_inputs.
+        await store.create("s1", plan)
+
+        subscriber = bus.subscribe("s1")
+        await runner.start_graph("s1")
+
+        events = await _collect_until(subscriber, "inputRequired")
+
+        # inputRequired should have been emitted.
+        input_reqs = [e for e in events if e["type"] == "inputRequired"]
+        assert len(input_reqs) == 1
+        assert input_reqs[0]["nodeId"] == "agent"
+
+        # Session should be suspended.
+        assert await store.get_status("s1") == "suspended"


### PR DESCRIPTION
## What
Adds the ability to load graphs from Google Drive by file ID and run them in headless mode with pre-supplied inputs, enabling non-interactive graph execution via API.

## Why
Headless mode is the foundation for programmatic graph execution — batch runs, scheduled jobs, and API-driven workflows that don't require a browser.

## Changes

### Drive Graph Loading
- Add `get_file_media(file_id)` to `DriveOperationsClient` protocol + HTTP impl
- `POST /graphSessions/new` now accepts `graphId` as alternative to inline `graph`
- Wire `drive_client_factory` in `dev/main.py`

### Headless Mode
- Add `headless_inputs` storage to `GraphSessionStore` protocol + in-memory impl
- `POST /graphSessions/new` accepts `mode: "headless"` and `inputs: {nodeId: LLMContent}`
- **Input nodes** auto-resolve: pre-supplied value → use it; required missing → error; optional missing → skip (empty context)
- **Agent nodes** auto-resolve with instructive note telling the agent to operate autonomously; pre-supplied context wrapped in `<user_provided_context>` tags

### Bug Fix
- `consume_agent_events` now captures `CompleteEvent.result.outcomes`, fixing empty context output for agent nodes (affected both interactive and headless modes)

## Testing
- 28 new tests: 11 in `test_drive_graph_loading.py`, 17 in `test_headless_mode.py`
- 791 total tests passing, 0 regressions
- Manual E2E test: `curl -X POST /graphSessions/new` with `graphId`, `mode: "headless"`, and `inputs` runs a haiku+image graph end-to-end
