### PR TITLE
[agent] Handle Transient Model Errors Gracefully and Retry

### DIFF
--- a/packages/visual-editor/src/a2/a2/gemini.ts
+++ b/packages/visual-editor/src/a2/a2/gemini.ts
@@ -330,6 +330,96 @@ const MODEL_FALLBACKS: Record<string, readonly string[]> = {
 };
 
 const NO_RETRY_CODES: readonly number[] = [400, 429, 404, 403];
+const RETRY_DELAY_MS = 200;
+
+function isRetryableError(errorMessage?: string): boolean {
+  if (!errorMessage) return false;
+  try {
+    const parsed = JSON.parse(errorMessage);
+    if (parsed && typeof parsed === "object") {
+      const code = parsed.code;
+      if (typeof code === "string") {
+        const retryableCodes = ["INTERNAL", "UNAVAILABLE", "DEADLINE_EXCEEDED"];
+        if (retryableCodes.includes(code.toUpperCase())) {
+          return true;
+        }
+        const nonRetryableCodes = [
+          "INVALID_ARGUMENT",
+          "PERMISSION_DENIED",
+          "NOT_FOUND",
+          "RESOURCE_EXHAUSTED",
+        ];
+        if (nonRetryableCodes.includes(code.toUpperCase())) {
+          return false;
+        }
+      }
+    }
+  } catch {
+    // Ignore and check strings
+  }
+  const lowerMsg = errorMessage.toLowerCase();
+  if (
+    lowerMsg.includes("try again") ||
+    lowerMsg.includes("unexpected error") ||
+    lowerMsg.includes("timeout") ||
+    lowerMsg.includes("overloaded")
+  ) {
+    return true;
+  }
+  return false;
+}
+
+class RetrySession {
+  readonly maxAttempts: number;
+  readonly delayMs: number;
+  #attempt = 0;
+  #lastError: unknown = null;
+
+  constructor(opts: { maxAttempts: number; delayMs: number }) {
+    this.maxAttempts = opts.maxAttempts;
+    this.delayMs = opts.delayMs;
+  }
+
+  get attempt(): number {
+    return this.#attempt;
+  }
+
+  get lastError(): unknown {
+    return this.#lastError;
+  }
+
+  get isLastAttempt(): boolean {
+    return this.#attempt >= this.maxAttempts;
+  }
+
+  nextAttempt(): void {
+    this.#attempt++;
+  }
+
+  classifyStatus(status: number): { retryable: boolean } {
+    return {
+      retryable: !NO_RETRY_CODES.includes(status),
+    };
+  }
+
+  classifyError(errorMessage: string): { retryable: boolean; formatted: string } {
+    return {
+      retryable: isRetryableError(errorMessage),
+      formatted: maybeExtractError(errorMessage),
+    };
+  }
+
+  async handleRetryableFailure(error: unknown): Promise<boolean> {
+    this.#lastError = error;
+    if (this.#attempt < this.maxAttempts) {
+      await new Promise((resolve) => setTimeout(resolve, this.delayMs));
+      return true;
+    }
+    return false;
+  }
+}
+
+
 
 const REASONS: Record<string, { $error: string; metadata?: ErrorMetadata }> = {
   MAX_TOKENS: {
@@ -403,25 +493,6 @@ function errFromFinishReason(
   return e;
 }
 
-/**
- * Using
- * `{"error":{"code":400,"message":"Invalid JSON paylo…'contents[0].parts[0]': Cannot find field."}]}]}
- * as template for this type.
- */
-type GeminiError = {
-  error: {
-    code: number;
-    details: {
-      type: string;
-      fieldViolations: {
-        description: string;
-        field: string;
-      }[];
-    }[];
-    message: string;
-    status: string;
-  };
-};
 
 function textToJson(content: LLMContent): LLMContent {
   if (!content.parts) return content;
@@ -510,9 +581,14 @@ async function callAPI(
     }
 
     const prefix = await resolvePrefix();
-    let $error: string = "Unknown error";
-    const maxRetries = retries;
-    while (retries) {
+    const retry = new RetrySession({
+      maxAttempts: retries,
+      delayMs: RETRY_DELAY_MS,
+    });
+    let $error = "Unknown error";
+
+    while (!moduleArgs.context.signal?.aborted) {
+      retry.nextAttempt();
       const result = await moduleArgs.fetchWithCreds(
         endpointURL(prefix, model),
         {
@@ -522,32 +598,19 @@ async function callAPI(
         }
       );
       const json = await result.json();
+      const status = result.status;
+      const errObject = json;
+
       if (!result.ok) {
-        // Fetch is a bit weird, because it returns various props
-        // along with the `$error`. Let's handle that here.
-        const errObject = json;
-        const status = result.status;
-        if (!status) {
-          if (errObject)
+        const formattedErr = maybeExtractError(errObject);
+        if (!status || !retry.classifyStatus(status).retryable) {
+          if (!status) {
             return reporter.addError(
-              err(errObject, {
-                origin: "server",
-                model,
-              })
+              err(formattedErr, { origin: "server", model })
             );
-          // This is not an error response, presume fatal error.
+          }
           return reporter.addError({
-            $error,
-            metadata: {
-              origin: "server",
-              model,
-            },
-          });
-        }
-        $error = maybeExtractError(errObject);
-        if (NO_RETRY_CODES.includes(status)) {
-          return reporter.addError({
-            $error,
+            $error: formattedErr,
             metadata: {
               origin: "server",
               kind: kindFromStatus(status),
@@ -555,71 +618,102 @@ async function callAPI(
             },
           });
         }
+
+        $error = formattedErr;
         reporter.addError(
           err(
-            `Got an error ${status} response, retrying (${maxRetries - retries + 1}/${maxRetries})`
+            `Got an error ${status} response, retrying (${retry.attempt}/${retry.maxAttempts})`
           )
         );
-      } else {
-        const outputs = json as GeminiAPIOutputs;
-        if (outputs.errorMessage) {
-          return reporter.addError(
-            err(outputs.errorMessage, { origin: "server", model })
+        if (await retry.handleRetryableFailure($error)) {
+          continue;
+        }
+        return reporter.addError({
+          $error,
+          metadata: {
+            origin: "server",
+            kind: kindFromStatus(status),
+            model,
+          },
+        });
+      }
+
+      const outputs = json as GeminiAPIOutputs;
+      if (outputs.errorMessage) {
+        const { retryable, formatted } = retry.classifyError(outputs.errorMessage);
+        if (retryable) {
+          reporter.addError(
+            err(
+              `Got a retryable error message response, retrying (${retry.attempt}/${retry.maxAttempts}): ${outputs.errorMessage}`
+            )
           );
-        }
-        const candidate = outputs?.candidates?.at(0);
-        if (!candidate) {
-          reporter.addJson("Model Response", outputs || result, "warning");
-          return reporter.addError(
-            err("Unable to get a good response from Gemini", {
-              origin: "server",
-              model,
-            })
-          );
-        }
-        if (
-          "content" in candidate &&
-          candidate.content &&
-          candidate.content.parts
-        ) {
-          if (body.generationConfig?.responseMimeType === "application/json") {
-            candidate.content = textToJson(candidate.content);
+          if (await retry.handleRetryableFailure(formatted)) {
+            continue;
           }
-          const links = candidate.groundingMetadata?.groundingChunks
-            ?.map((chunk) => {
-              if (chunk.web) return { ...chunk.web, iconUri: chunk.web.title };
-              if (chunk.maps) {
-                return { ...chunk.maps, iconUri: "maps.google.com" };
-              }
-              return null;
-            })
-            .filter((item) => item !== null);
-          if (links && links.length > 0) {
-            reporter.addLinks("Grounding metadata", links, "link");
-          }
-          reporter.addContent("Model Response", candidate.content, "download");
-          if (outputs.usageMetadata) {
-            accumulateUsageMetadata(moduleArgs, outputs.usageMetadata);
-          }
-          return outputs;
         }
-        reporter.addJson("Model response", outputs, "warning");
-        if (
-          candidate.finishReason &&
-          candidate.finishReason !== "STOP" &&
-          candidate.finishReason !== "MALFORMED_FUNCTION_CALL"
-        ) {
-          return reporter.addError(
-            errFromFinishReason(candidate.finishReason, model)
-          );
-        }
-        reporter.addError(
-          err(
-            `Did not get a useful response, retrying (${maxRetries - retries + 1}/${maxRetries})`
-          )
+        return reporter.addError(
+          err(formatted, { origin: "server", model })
         );
       }
-      retries--;
+
+      const candidate = outputs?.candidates?.at(0);
+      if (!candidate) {
+        reporter.addJson("Model Response", outputs || result, "warning");
+        return reporter.addError(
+          err("Unable to get a good response from Gemini", {
+            origin: "server",
+            model,
+          })
+        );
+      }
+
+      if (
+        "content" in candidate &&
+        candidate.content &&
+        candidate.content.parts
+      ) {
+        if (body.generationConfig?.responseMimeType === "application/json") {
+          candidate.content = textToJson(candidate.content);
+        }
+        const links = candidate.groundingMetadata?.groundingChunks
+          ?.map((chunk) => {
+            if (chunk.web) return { ...chunk.web, iconUri: chunk.web.title };
+            if (chunk.maps) {
+              return { ...chunk.maps, iconUri: "maps.google.com" };
+            }
+            return null;
+          })
+          .filter((item) => item !== null);
+        if (links && links.length > 0) {
+          reporter.addLinks("Grounding metadata", links, "link");
+        }
+        reporter.addContent("Model Response", candidate.content, "download");
+        if (outputs.usageMetadata) {
+          accumulateUsageMetadata(moduleArgs, outputs.usageMetadata);
+        }
+        return outputs;
+      }
+
+      reporter.addJson("Model response", outputs, "warning");
+      if (
+        candidate.finishReason &&
+        candidate.finishReason !== "STOP" &&
+        candidate.finishReason !== "MALFORMED_FUNCTION_CALL"
+      ) {
+        return reporter.addError(
+          errFromFinishReason(candidate.finishReason, model)
+        );
+      }
+
+      $error = "Did not get a useful response";
+      reporter.addError(
+        err(
+          `Did not get a useful response, retrying (${retry.attempt}/${retry.maxAttempts})`
+        )
+      );
+      if (await retry.handleRetryableFailure($error)) {
+        continue;
+      }
     }
     return reporter.addError({
       $error,
@@ -634,8 +728,17 @@ async function callAPI(
 
 function maybeExtractError(e: string): string {
   try {
-    const parsed = JSON.parse(e) as GeminiError;
-    return parsed.error.message;
+    const parsed = JSON.parse(e) as Record<string, unknown>;
+    if (parsed.error && typeof parsed.error === "object") {
+      const errorObj = parsed.error as Record<string, unknown>;
+      if (typeof errorObj.message === "string") {
+        return errorObj.message;
+      }
+    }
+    if (typeof parsed.message === "string") {
+      return parsed.message;
+    }
+    return e;
   } catch {
     return e;
   }
@@ -801,7 +904,14 @@ async function streamGenerateContent(
 ): Promise<Outcome<AsyncIterable<GeminiAPIOutputs>>> {
   const { fetchWithCreds, context } = moduleArgs;
   const prefix = await resolvePrefix();
-  for (let attempt = 0; attempt < STREAM_MAX_RETRIES; attempt++) {
+
+  const retry = new RetrySession({
+    maxAttempts: STREAM_MAX_RETRIES,
+    delayMs: STREAM_RETRY_DELAY_MS,
+  });
+
+  while (!context.signal?.aborted) {
+    retry.nextAttempt();
     try {
       const result = await fetchWithCreds(streamEndpointURL(prefix, model), {
         method: "POST",
@@ -811,11 +921,24 @@ async function streamGenerateContent(
 
       if (!result.ok) {
         const errObject = await result.text();
-        return err(maybeExtractError(errObject), { origin: "server", model });
+        const status = result.status;
+        const { retryable } = retry.classifyStatus(status);
+        const formattedErr = maybeExtractError(errObject);
+        if (!retryable) {
+          return err(formattedErr, { origin: "server", model });
+        }
+        if (await retry.handleRetryableFailure(formattedErr)) {
+          continue;
+        }
+        return err(formattedErr, { origin: "server", model });
       }
 
       if (!result.body) {
-        return err(`No stream returned`, { origin: "server", model });
+        const errorMsg = "No stream returned";
+        if (await retry.handleRetryableFailure(errorMsg)) {
+          continue;
+        }
+        return err(errorMsg, { origin: "server", model });
       }
 
       // Create an async iterator from the stream
@@ -827,11 +950,8 @@ async function streamGenerateContent(
       const firstResult = await streamIterator.next();
 
       if (firstResult.done) {
-        // Empty stream - retry
-        if (attempt < STREAM_MAX_RETRIES - 1) {
-          await new Promise((resolve) =>
-            setTimeout(resolve, STREAM_RETRY_DELAY_MS)
-          );
+        const errorMsg = "Empty stream response";
+        if (await retry.handleRetryableFailure(errorMsg)) {
           continue;
         }
         // Exhausted retries, return empty iterator
@@ -842,7 +962,13 @@ async function streamGenerateContent(
 
       // Check for errorMessage in the first chunk (Opal backend proxy error).
       if (firstChunk.errorMessage) {
-        return err(firstChunk.errorMessage, { origin: "server", model });
+        const { retryable, formatted } = retry.classifyError(firstChunk.errorMessage);
+        if (retryable) {
+          if (await retry.handleRetryableFailure(formatted)) {
+            continue;
+          }
+        }
+        return err(formatted, { origin: "server", model });
       }
 
       // If first chunk has meaningful content, stream in real-time
@@ -863,10 +989,24 @@ async function streamGenerateContent(
       // which closes it and silently discards remaining chunks.
       const bufferedChunks: GeminiAPIOutputs[] = [firstChunk];
       let nextResult = await streamIterator.next();
+      let streamFailedWithFatalError: Outcome<AsyncIterable<GeminiAPIOutputs>> | null = null;
       while (!nextResult.done) {
-        bufferedChunks.push(nextResult.value);
+        const chunk = nextResult.value;
+        if (chunk.errorMessage) {
+          const { retryable, formatted } = retry.classifyError(chunk.errorMessage);
+          if (!retryable || retry.isLastAttempt) {
+            streamFailedWithFatalError = err(formatted, {
+              origin: "server",
+              model,
+            });
+            break;
+          }
+          // Break so we fall through to the retry logic below
+          break;
+        }
+        bufferedChunks.push(chunk);
         // Check each chunk as it arrives - if we find content, switch to streaming
-        if (hasChunkContent(nextResult.value)) {
+        if (hasChunkContent(chunk)) {
           // Found content! Return an iterator that yields buffered + remaining
           return (async function* () {
             for (const buffered of bufferedChunks) {
@@ -882,12 +1022,14 @@ async function streamGenerateContent(
         nextResult = await streamIterator.next();
       }
 
+      if (streamFailedWithFatalError) {
+        return streamFailedWithFatalError;
+      }
+
       // All chunks were empty - check if we should retry
       if (!hasStreamContent(bufferedChunks)) {
-        if (attempt < STREAM_MAX_RETRIES - 1) {
-          await new Promise((resolve) =>
-            setTimeout(resolve, STREAM_RETRY_DELAY_MS)
-          );
+        const errorMsg = "Stream ended with no content";
+        if (await retry.handleRetryableFailure(errorMsg)) {
           continue;
         }
       }
@@ -899,7 +1041,11 @@ async function streamGenerateContent(
         }
       })();
     } catch (e) {
-      return err(formatAgentError(e), { ...classifyCaughtError(e), model });
+      const formattedErr = formatAgentError(e);
+      if (await retry.handleRetryableFailure(formattedErr)) {
+        continue;
+      }
+      return err(formattedErr, { ...classifyCaughtError(e), model });
     }
   }
 

--- a/packages/visual-editor/tests/a2/gemini.test.ts
+++ b/packages/visual-editor/tests/a2/gemini.test.ts
@@ -1,0 +1,270 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { ok } from "@breadboard-ai/utils/outcome.js";
+import type { NodeHandlerContext } from "@breadboard-ai/types";
+import { streamGenerateContent } from "../../src/a2/a2/gemini.js";
+import type { A2ModuleArgs } from "../../src/a2/runnable-module-factory.js";
+import type { GeminiAPIOutputs } from "../../src/a2/a2/gemini.js";
+
+// Helper to create chunk encoder for SSE streams
+function sseChunk(data: unknown): Uint8Array {
+  const payload = `data: ${JSON.stringify(data)}\n\n`;
+  return new TextEncoder().encode(payload);
+}
+
+// Simple mock for A2ModuleArgs
+function makeMockModuleArgs(
+  fetchResponses: Array<{ status: number; ok: boolean; body?: unknown; chunks?: unknown[] }>
+): A2ModuleArgs {
+  let callCount = 0;
+  const mockFetch = async (_url: string, _init?: unknown) => {
+    const nextResponse = fetchResponses[callCount] || fetchResponses[fetchResponses.length - 1];
+    callCount++;
+
+    if (!nextResponse.ok) {
+      return new Response(JSON.stringify(nextResponse.body || {}), {
+        status: nextResponse.status,
+      });
+    }
+
+    if (nextResponse.chunks) {
+      const stream = new ReadableStream({
+        start(controller) {
+          for (const chunk of nextResponse.chunks!) {
+            controller.enqueue(sseChunk(chunk));
+          }
+          controller.close();
+        },
+      });
+      return new Response(stream, { status: 200 });
+    }
+
+    return new Response(JSON.stringify(nextResponse.body || {}), { status: 200 });
+  };
+
+  return {
+    fetchWithCreds: mockFetch as unknown as typeof globalThis.fetch,
+    context: {
+      signal: new AbortController().signal,
+    } as unknown as NodeHandlerContext,
+  } as unknown as A2ModuleArgs;
+}
+
+describe("Gemini streamGenerateContent retry logic", () => {
+  it("should succeed immediately when first chunk has content", async () => {
+    const mockArgs = makeMockModuleArgs([
+      {
+        ok: true,
+        status: 200,
+        chunks: [
+          {
+            candidates: [
+              {
+                content: {
+                  parts: [{ text: "Hello world" }],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    const result = await streamGenerateContent("model-name", { contents: [] }, mockArgs);
+    if (!ok(result)) {
+      assert.fail(`Expected success, got: ${result.$error}`);
+    }
+
+    const chunks: GeminiAPIOutputs[] = [];
+    for await (const chunk of result) {
+      chunks.push(chunk);
+    }
+
+    assert.equal(chunks.length, 1);
+    const part = chunks[0]?.candidates?.[0]?.content?.parts?.[0];
+    assert.ok(part && "text" in part);
+    assert.equal(part.text, "Hello world");
+  });
+
+  it("should retry and succeed when first attempt returns a transient INTERNAL error", async () => {
+    const mockArgs = makeMockModuleArgs([
+      {
+        ok: true,
+        status: 200,
+        chunks: [
+          {
+            errorMessage: JSON.stringify({
+              code: "INTERNAL",
+              message: "An unexpected error occurred. Please try again.",
+            }),
+          },
+        ],
+      },
+      {
+        ok: true,
+        status: 200,
+        chunks: [
+          {
+            candidates: [
+              {
+                content: {
+                  parts: [{ text: "Recovered output" }],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    const result = await streamGenerateContent("model-name", { contents: [] }, mockArgs);
+    if (!ok(result)) {
+      assert.fail(`Expected success, got: ${result.$error}`);
+    }
+
+    const chunks: GeminiAPIOutputs[] = [];
+    for await (const chunk of result) {
+      chunks.push(chunk);
+    }
+
+    assert.equal(chunks.length, 1);
+    const part = chunks[0]?.candidates?.[0]?.content?.parts?.[0];
+    assert.ok(part && "text" in part);
+    assert.equal(part.text, "Recovered output");
+  });
+
+  it("should fail immediately without retry on non-retryable error (e.g. INVALID_ARGUMENT)", async () => {
+    const mockArgs = makeMockModuleArgs([
+      {
+        ok: true,
+        status: 200,
+        chunks: [
+          {
+            errorMessage: JSON.stringify({
+              code: "INVALID_ARGUMENT",
+              message: "Invalid prompt structure",
+            }),
+          },
+        ],
+      },
+    ]);
+
+    const result = await streamGenerateContent("model-name", { contents: [] }, mockArgs);
+    if (ok(result)) {
+      assert.fail("Expected failure");
+    }
+    assert.equal(result.$error.includes("Invalid prompt structure"), true);
+  });
+
+  it("should retry and succeed when HTTP status 503 is returned", async () => {
+    const mockArgs = makeMockModuleArgs([
+      {
+        ok: false,
+        status: 503,
+        body: { message: "Service Unavailable" },
+      },
+      {
+        ok: true,
+        status: 200,
+        chunks: [
+          {
+            candidates: [
+              {
+                content: {
+                  parts: [{ text: "Success after HTTP retry" }],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    const result = await streamGenerateContent("model-name", { contents: [] }, mockArgs);
+    if (!ok(result)) {
+      assert.fail(`Expected success, got: ${result.$error}`);
+    }
+
+    const chunks: GeminiAPIOutputs[] = [];
+    for await (const chunk of result) {
+      chunks.push(chunk);
+    }
+
+    assert.equal(chunks.length, 1);
+    const part = chunks[0]?.candidates?.[0]?.content?.parts?.[0];
+    assert.ok(part && "text" in part);
+    assert.equal(part.text, "Success after HTTP retry");
+  });
+
+  it("should fail immediately on HTTP status 400 without retrying", async () => {
+    const mockArgs = makeMockModuleArgs([
+      {
+        ok: false,
+        status: 400,
+        body: { error: { message: "Bad Request" } },
+      },
+    ]);
+
+    const result = await streamGenerateContent("model-name", { contents: [] }, mockArgs);
+    if (ok(result)) {
+      assert.fail("Expected failure");
+    }
+    assert.equal(result.$error.includes("Bad Request"), true);
+  });
+
+  it("should retry and succeed when a retryable error occurs inside the buffering loop", async () => {
+    const mockArgs = makeMockModuleArgs([
+      {
+        ok: true,
+        status: 200,
+        chunks: [
+          // First chunk is empty (e.g. metadata/usage only), triggering buffering
+          { candidates: [] },
+          // Second chunk has retryable error
+          {
+            errorMessage: JSON.stringify({
+              code: "INTERNAL",
+              message: "Intermittent stream failure",
+            }),
+          },
+        ],
+      },
+      {
+        ok: true,
+        status: 200,
+        chunks: [
+          {
+            candidates: [
+              {
+                content: {
+                  parts: [{ text: "Recovered during buffering" }],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    const result = await streamGenerateContent("model-name", { contents: [] }, mockArgs);
+    if (!ok(result)) {
+      assert.fail(`Expected success, got: ${result.$error}`);
+    }
+
+    const chunks: GeminiAPIOutputs[] = [];
+    for await (const chunk of result) {
+      chunks.push(chunk);
+    }
+
+    assert.equal(chunks.length, 1);
+    const part = chunks[0]?.candidates?.[0]?.content?.parts?.[0];
+    assert.ok(part && "text" in part);
+    assert.equal(part.text, "Recovered during buffering");
+  });
+});


### PR DESCRIPTION
## What
Refactors `packages/visual-editor/src/a2/a2/gemini.ts` to introduce a `RetrySession` helper class that encapsulates retry attempts, delays, state tracking, and classification rules. Replaces duplicated retry and parsing logic in both streaming (`streamGenerateContent`) and non-streaming (`callAPI`) interfaces with this unified class.

## Why
Duplicated retry counters, delay timeouts, and error message checking were spread across various places, leading to inconsistent error handling and fragility when encountering transient internal errors from Gemini/Opal proxy.

## Changes
- **`packages/visual-editor/src/a2/a2/gemini.ts`**:
  - Implemented `RetrySession` class that manages max attempts, delay sleeping, HTTP status classification (`classifyStatus`), and error classification (`classifyError`).
  - Refactored `callAPI` to use `RetrySession` for handling HTTP errors, transient error messages, and retry delays.
  - Refactored `streamGenerateContent` to use `RetrySession` for retrying HTTP errors, transient errors in first/buffered chunks, and empty stream responses.
  - Removed unused `GeminiError` type definition and fixed TS lint errors.
- **`packages/visual-editor/tests/a2/gemini.test.ts`**:
  - Added new comprehensive unit tests validating correct retry behavior for all streaming error scenarios.

## Testing
Tested with new suite:
```bash
npm run test:file -w packages/visual-editor -- './dist/tsc/tests/a2/gemini.test.js'
```
And verified entire visual-editor tests pass successfully.
