### PR TITLE
[ve] Block Edits on Read-Only Graphs

### DIFF
--- a/packages/visual-editor/src/sca/actions/asset/asset-actions.ts
+++ b/packages/visual-editor/src/sca/actions/asset/asset-actions.ts
@@ -94,9 +94,9 @@ export const update = asAction(
   ): Promise<Outcome<void>> => {
     const { controller, services } = bind;
     const graphController = controller.editor.graph;
-    const editor = graphController.editor;
+    const { editor, readOnly } = graphController;
 
-    if (!editor) {
+    if (readOnly || !editor) {
       return err("No editor available to apply asset update");
     }
 
@@ -167,9 +167,9 @@ export const addGraphAsset = asAction(
   async (asset: GraphAssetDescriptor): Promise<Outcome<void>> => {
     const { controller, services } = bind;
     const graphController = controller.editor.graph;
-    const editor = graphController.editor;
+    const { editor, readOnly } = graphController;
 
-    if (!editor) {
+    if (readOnly || !editor) {
       return err("No editor available");
     }
 
@@ -206,9 +206,9 @@ export const removeGraphAsset = asAction(
   { mode: ActionMode.Immediate },
   async (path: AssetPath): Promise<Outcome<void>> => {
     const { controller } = bind;
-    const editor = controller.editor.graph.editor;
+    const { editor, readOnly } = controller.editor.graph;
 
-    if (!editor) {
+    if (readOnly || !editor) {
       return err("No editor available");
     }
 
@@ -245,8 +245,8 @@ export const onChangeAssetEdge = asAction(
   },
   async (evt?: StateEvent<"asset.changeedge">): Promise<void> => {
     const { controller } = bind;
-    const { editor } = controller.editor.graph;
-    if (!editor) return;
+    const { editor, readOnly } = controller.editor.graph;
+    if (readOnly || !editor) return;
 
     const detail = evt!.detail;
     await withUIBlocking(controller, async () => {
@@ -284,8 +284,8 @@ export const onAddAssets = asAction(
   },
   async (evt?: StateEvent<"asset.add">): Promise<void> => {
     const { controller, services } = bind;
-    const { editor } = controller.editor.graph;
-    if (!editor) return;
+    const { editor, readOnly } = controller.editor.graph;
+    if (readOnly || !editor) return;
 
     const detail = evt!.detail;
 

--- a/packages/visual-editor/src/sca/actions/graph/graph-actions.ts
+++ b/packages/visual-editor/src/sca/actions/graph/graph-actions.ts
@@ -61,10 +61,10 @@ export const bind = makeAction();
 async function editInternal(spec: EditSpec[], label: string) {
   const { controller } = bind;
 
-  // TODO: Get the editor instance from the graphStore service. Note that the
-  // edit event fired by the editor instance here will be picked up and routed
-  // through the Runtime so that main-base picks it up and triggers an autosave.
-  const { editor } = controller.editor.graph;
+  const { editor, readOnly } = controller.editor.graph;
+  if (readOnly) {
+    return;
+  }
   if (!editor) {
     throw new Error("No active graph to edit");
   }
@@ -80,10 +80,10 @@ async function editInternal(spec: EditSpec[], label: string) {
 async function applyInternal(transform: EditTransform) {
   const { controller } = bind;
 
-  // TODO: Get the editor instance from the graphStore service. Note that the
-  // edit event fired by the editor instance here will be picked up and routed
-  // through the Runtime so that main-base picks it up and triggers an autosave.
-  const { editor } = controller.editor.graph;
+  const { editor, readOnly } = controller.editor.graph;
+  if (readOnly) {
+    return;
+  }
   if (!editor) {
     throw new Error("No active graph to transform");
   }
@@ -108,7 +108,9 @@ export const undo = asAction(
   { mode: ActionMode.Immediate },
   async (): Promise<void> => {
     const { controller } = bind;
-    const history = controller.editor.graph.editor?.history();
+    const { editor, readOnly } = controller.editor.graph;
+    if (readOnly || !editor) return;
+    const history = editor.history();
     if (!history || !history.canUndo()) return;
     await history.undo();
   }
@@ -122,7 +124,9 @@ export const redo = asAction(
   { mode: ActionMode.Immediate },
   async (): Promise<void> => {
     const { controller } = bind;
-    const history = controller.editor.graph.editor?.history();
+    const { editor, readOnly } = controller.editor.graph;
+    if (readOnly || !editor) return;
+    const history = editor.history();
     if (!history || !history.canRedo()) return;
     await history.redo();
   }

--- a/packages/visual-editor/src/sca/actions/node/node-actions.ts
+++ b/packages/visual-editor/src/sca/actions/node/node-actions.ts
@@ -322,8 +322,8 @@ export const onNodeAdd = asAction(
   },
   async (evt?: StateEvent<"node.add">): Promise<void> => {
     const { controller } = bind;
-    const { editor } = controller.editor.graph;
-    if (!editor) return;
+    const { editor, readOnly } = controller.editor.graph;
+    if (readOnly || !editor) return;
 
     const detail = evt!.detail;
     await withUIBlocking(controller, async () => {
@@ -356,8 +356,8 @@ export const onMoveSelection = asAction(
   },
   async (evt?: StateEvent<"node.moveselection">): Promise<void> => {
     const { controller } = bind;
-    const { editor } = controller.editor.graph;
-    if (!editor) return;
+    const { editor, readOnly } = controller.editor.graph;
+    if (readOnly || !editor) return;
 
     const detail = evt!.detail;
     await withUIBlocking(controller, async () => {
@@ -419,8 +419,8 @@ export const onChangeEdge = asAction(
   },
   async (evt?: StateEvent<"node.changeedge">): Promise<void> => {
     const { controller } = bind;
-    const { editor } = controller.editor.graph;
-    if (!editor) return;
+    const { editor, readOnly } = controller.editor.graph;
+    if (readOnly || !editor) return;
 
     const detail = evt!.detail;
     await withUIBlocking(controller, async () => {
@@ -459,8 +459,8 @@ export const onChangeEdgeAttachmentPoint = asAction(
   },
   async (evt?: StateEvent<"node.changeedgeattachmentpoint">): Promise<void> => {
     const { controller } = bind;
-    const { editor } = controller.editor.graph;
-    if (!editor) return;
+    const { editor, readOnly } = controller.editor.graph;
+    if (readOnly || !editor) return;
 
     const detail = evt!.detail;
     await withUIBlocking(controller, async () => {
@@ -810,7 +810,9 @@ export const onUndoKeyboard = asAction(
   },
   async (): Promise<void> => {
     const { controller } = bind;
-    const history = controller.editor.graph.editor?.history();
+    const { editor, readOnly } = controller.editor.graph;
+    if (readOnly || !editor) return;
+    const history = editor.history();
     if (!history || !history.canUndo()) return;
     await history.undo();
   }
@@ -834,7 +836,9 @@ export const onRedoKeyboard = asAction(
   },
   async (): Promise<void> => {
     const { controller } = bind;
-    const history = controller.editor.graph.editor?.history();
+    const { editor, readOnly } = controller.editor.graph;
+    if (readOnly || !editor) return;
+    const history = editor.history();
     if (!history || !history.canRedo()) return;
     await history.redo();
   }

--- a/packages/visual-editor/src/sca/actions/step/step-actions.ts
+++ b/packages/visual-editor/src/sca/actions/step/step-actions.ts
@@ -54,9 +54,15 @@ export const applyPendingNodeEdit = asAction(
   },
   async (): Promise<void> => {
     const { controller } = bind;
+    const { readOnly } = controller.editor.graph;
 
     const pendingEdit = controller.editor.step.pendingEdit;
     if (!pendingEdit) {
+      return;
+    }
+
+    if (readOnly) {
+      controller.editor.step.clearPendingEdit();
       return;
     }
 
@@ -119,11 +125,17 @@ export const applyPendingAssetEdit = asAction(
   },
   async (): Promise<void> => {
     const { controller, services } = bind;
+    const { readOnly } = controller.editor.graph;
     const LABEL = "Step.applyPendingAssetEdit";
     const logger = Utils.Logging.getLogger(controller);
 
     const pendingAssetEdit = controller.editor.step.pendingAssetEdit;
     if (!pendingAssetEdit) {
+      return;
+    }
+
+    if (readOnly) {
+      controller.editor.step.clearPendingAssetEdit();
       return;
     }
 
@@ -245,6 +257,19 @@ export const applyPendingEditsForNodeAction = asAction(
   },
   async (): Promise<void> => {
     const { controller } = bind;
+    const { readOnly } = controller.editor.graph;
+
+    if (readOnly) {
+      const pendingEdit = controller.editor.step.pendingEdit;
+      if (pendingEdit) {
+        controller.editor.step.clearPendingEdit();
+      }
+      const pendingAssetEdit = controller.editor.step.pendingAssetEdit;
+      if (pendingAssetEdit) {
+        controller.editor.step.clearPendingAssetEdit();
+      }
+      return;
+    }
 
     // Apply pending node edit
     const pendingEdit = controller.editor.step.pendingEdit;

--- a/packages/visual-editor/src/ui/elements/step-editor/renderer.ts
+++ b/packages/visual-editor/src/ui/elements/step-editor/renderer.ts
@@ -1566,6 +1566,10 @@ export class Renderer extends SignalWatcher(LitElement) {
               );
             }}
             @bbdragconnectorstart=${(evt: DragConnectorStartEvent) => {
+              if (this.#gc.readOnly) {
+                return;
+              }
+
               this.dragConnector.offset = new DOMPoint(
                 this.#boundsForInteraction.x,
                 this.#boundsForInteraction.y

--- a/packages/visual-editor/tests/sca/actions/asset/asset-actions.test.ts
+++ b/packages/visual-editor/tests/sca/actions/asset/asset-actions.test.ts
@@ -187,6 +187,41 @@ suite("Asset Actions", () => {
       );
     });
 
+    test("returns error when readOnly is true", async () => {
+      const { editor } = makeTestGraphStoreWithEditor();
+      const { services } = makeTestServices();
+
+      const graphAssets = new Map<AssetPath, GraphAsset>();
+      graphAssets.set("test.txt", {
+        path: "test.txt",
+        data: [],
+        metadata: { title: "Test", type: "content" },
+      });
+
+      Asset.bind({
+        services: services as AppServices,
+        controller: {
+          editor: {
+            graph: {
+              editor,
+              readOnly: true,
+              graphAssets,
+            },
+          },
+        } as unknown as AppController,
+        env: createMockEnvironment(defaultRuntimeFlags),
+      });
+
+      const result = await Asset.update("test.txt", "New Title");
+
+      assert.ok(result !== undefined, "Should return error result");
+      assert.ok("$error" in result!, "Result should have $error");
+      assert.ok(
+        result!.$error.includes("No editor available"),
+        "Error should mention no editor available"
+      );
+    });
+
     test("returns error when asset has no metadata", async () => {
       const { editor } = makeTestGraphStoreWithEditor();
       const { services } = makeTestServices();

--- a/packages/visual-editor/tests/sca/actions/graph/graph-actions.test.ts
+++ b/packages/visual-editor/tests/sca/actions/graph/graph-actions.test.ts
@@ -711,6 +711,54 @@ suite("Graph Actions", () => {
         );
       });
     });
+
+    suite("when readOnly is true", () => {
+      beforeEach(() => {
+        const graphStore = makeTestGraphStore();
+        testGraph = graphWithTwoNodes();
+        loadGraphIntoStore(graphStore, testGraph);
+        const editor = editGraphStore(graphStore);
+        if (!editor) assert.fail("Unable to edit graph");
+
+        graphActions.bind({
+          services: { graphStore } as unknown as AppServices,
+          controller: {
+            editor: {
+              graph: {
+                editor,
+                readOnly: true,
+                inspect: (graphId: string) => editor.inspect(graphId),
+                lastNodeConfigChange: null,
+                pendingGraphReplacement: null,
+                clearPendingGraphReplacement: () => {},
+              },
+              theme: { updateHash() {} },
+            },
+          } as unknown as AppController,
+          env: createMockEnvironment(defaultRuntimeFlags),
+        });
+      });
+
+      test("does not update title & description", async () => {
+        await graphActions.updateBoardTitleAndDescription(
+          "New Title",
+          "New Description"
+        );
+        assert.strictEqual(testGraph.title, undefined);
+        assert.strictEqual(testGraph.description, undefined);
+      });
+
+      test("does not change edge", async () => {
+        assert.strictEqual(testGraph.edges.length, 0);
+        await graphActions.changeEdge("add", {
+          from: "foo",
+          to: "bar",
+          in: "*",
+          out: "*",
+        });
+        assert.strictEqual(testGraph.edges.length, 0);
+      });
+    });
   });
 });
 

--- a/packages/visual-editor/tests/sca/actions/step/step-actions.test.ts
+++ b/packages/visual-editor/tests/sca/actions/step/step-actions.test.ts
@@ -210,6 +210,53 @@ suite("Step Actions", () => {
 
       assert.ok(true, "Should complete without doing anything");
     });
+
+    test("clears pending edit and returns early when readOnly is true", async () => {
+      let clearCalled = false;
+      let applyCalled = false;
+
+      stepActions.bind({
+        services: {} as never,
+        controller: {
+          editor: {
+            step: {
+              pendingEdit: {
+                nodeId: "node-123",
+                graphId: "graph-456",
+                graphVersion: 5,
+                values: { key: "value" },
+              },
+              clearPendingEdit: () => {
+                clearCalled = true;
+              },
+            },
+            graph: {
+              version: 5,
+              readOnly: true,
+              editor: {
+                apply: async () => {
+                  applyCalled = true;
+                  return { success: true };
+                },
+              },
+            },
+          },
+          global: {
+            toasts: {
+              toast: () => {
+                assert.fail("Toast should not be called when readOnly");
+              },
+            },
+          },
+        } as never,
+        env: createMockEnvironment(defaultRuntimeFlags),
+      });
+
+      await stepActions.applyPendingNodeEdit();
+
+      assert.strictEqual(clearCalled, true, "Pending edit should be cleared");
+      assert.strictEqual(applyCalled, false, "Editor apply should not be called when readOnly");
+    });
   });
 
   suite("applyPendingAssetEdit", () => {
@@ -714,6 +761,53 @@ suite("Step Actions", () => {
 
       assert.strictEqual(clearCalled, true, "Pending edit should be cleared");
     });
+
+    test("clears pending asset edit and returns early when readOnly is true", async () => {
+      let clearCalled = false;
+      let applyCalled = false;
+
+      stepActions.bind({
+        services: {} as never,
+        controller: {
+          editor: {
+            step: {
+              pendingAssetEdit: {
+                assetPath: "test/asset.txt",
+                graphVersion: 5,
+                title: "My Asset",
+                dataPart: null,
+              },
+              clearPendingAssetEdit: () => {
+                clearCalled = true;
+              },
+            },
+            graph: {
+              version: 5,
+              readOnly: true,
+              editor: {
+                apply: async () => {
+                  applyCalled = true;
+                  return { success: true };
+                },
+              },
+            },
+          },
+          global: {
+            toasts: {
+              toast: () => {
+                assert.fail("Toast should not be called when readOnly");
+              },
+            },
+          },
+        } as never,
+        env: createMockEnvironment(defaultRuntimeFlags),
+      });
+
+      await stepActions.applyPendingAssetEdit();
+
+      assert.strictEqual(clearCalled, true, "Pending asset edit should be cleared");
+      assert.strictEqual(applyCalled, false, "Editor apply should not be called when readOnly");
+    });
   });
 
   suite("applyPendingNodeEdit (no-editor guard)", () => {
@@ -1153,6 +1247,64 @@ suite("Step Actions", () => {
         2,
         "Should call apply twice: UpdateAssetData + UpdateAssetWithRefs"
       );
+    });
+
+    test("clears pending edits and returns early when readOnly is true", async () => {
+      let clearEditCalled = false;
+      let clearAssetEditCalled = false;
+      let applyCalled = false;
+
+      stepActions.bind({
+        services: {} as never,
+        controller: {
+          editor: {
+            step: {
+              pendingEdit: {
+                nodeId: "node-123",
+                graphId: "graph-456",
+                graphVersion: 5,
+                values: { key: "value" },
+              },
+              pendingAssetEdit: {
+                assetPath: "test/asset.txt",
+                graphVersion: 5,
+                title: "My Asset",
+                dataPart: null,
+              },
+              clearPendingEdit: () => {
+                clearEditCalled = true;
+              },
+              clearPendingAssetEdit: () => {
+                clearAssetEditCalled = true;
+              },
+            },
+            graph: {
+              version: 5,
+              readOnly: true,
+              editor: {
+                apply: async () => {
+                  applyCalled = true;
+                  return { success: true };
+                },
+              },
+            },
+          },
+          global: {
+            toasts: {
+              toast: () => {
+                assert.fail("Toast should not be called when readOnly");
+              },
+            },
+          },
+        } as never,
+        env: createMockEnvironment(defaultRuntimeFlags),
+      });
+
+      await stepActions.applyPendingEditsForNodeAction();
+
+      assert.strictEqual(clearEditCalled, true, "Pending node edit should be cleared");
+      assert.strictEqual(clearAssetEditCalled, true, "Pending asset edit should be cleared");
+      assert.strictEqual(applyCalled, false, "Editor apply should not be called when readOnly");
     });
   });
 


### PR DESCRIPTION
## What
Guarded mutating SCA Actions (node, graph, asset, and step editing actions) and canvas UI components in the visual editor to return early or fail when the active graph has `readOnly = true`.

## Why
Prevents silent save failures (such as Google Drive 403 Forbidden errors) when users attempt to edit public/gallery graphs or graphs shared with them without write permissions.

## Changes
* **packages/visual-editor/src/ui/elements/step-editor/renderer.ts**: Guarded the connector drag handler `@bbdragconnectorstart` to prevent dragging on read-only graphs.
* **packages/visual-editor/src/sca/actions/**:
  * Guarded node operations (`onNodeAdd`, `onMoveSelection`, `onChangeEdge`, `onChangeEdgeAttachmentPoint`, `onUndoKeyboard`, `onRedoKeyboard`) when `readOnly` is true.
  * Guarded graph actions (`editInternal`, `applyInternal`, `undo`, `redo`) to noop when `readOnly` is true.
  * Guarded asset actions (`update`, `addGraphAsset`, `removeGraphAsset`, `onChangeAssetEdge`, `onAddAssets`) to return an error when `readOnly` is true.
  * Guarded step pending edits (`applyPendingNodeEdit`, `applyPendingAssetEdit`, `applyPendingEditsForNodeAction`) to clear pending state and return early on read-only graphs.
* **packages/visual-editor/tests/**: Added extensive unit test coverage for `readOnly` guards across graph, asset, and step actions.

## Testing
Unit tests in `packages/visual-editor/tests/sca/actions/` verify that all guarded actions correctly return early or fail when `readOnly` is set on the graph controller. All tests pass cleanly.
