### PR TITLE
[opie] Conditional preview switch on theme update

### DIFF
--- a/packages/visual-editor/src/sca/actions/agent/graph-editing-agent-actions.ts
+++ b/packages/visual-editor/src/sca/actions/agent/graph-editing-agent-actions.ts
@@ -217,6 +217,9 @@ function startGraphEditingAgent(
       },
       onThemeUpdated: () => {
         controller.editor.theme.updateHash(controller.editor.graph.graph);
+        if (!controller.editor.step.focused) {
+          controller.editor.sidebar.section = "preview";
+        }
       },
     });
 

--- a/packages/visual-editor/src/sca/controller/subcontrollers/editor/step/step-controller.ts
+++ b/packages/visual-editor/src/sca/controller/subcontrollers/editor/step/step-controller.ts
@@ -19,6 +19,13 @@ export { StepController };
  */
 class StepController extends RootController {
   /**
+   * Tracks whether the entity editor (step editor) currently has focus.
+   * Updated by the EntityEditor component on focusin/focusout.
+   */
+  @field()
+  accessor focused: boolean = false;
+
+  /**
    * The current pending edit (transformed values, ready to apply).
    * Set by entity-editor when form values change.
    * Note: No deep: true - we replace the whole object, and deep proxies

--- a/packages/visual-editor/src/ui/elements/entity-editor/entity-editor.ts
+++ b/packages/visual-editor/src/ui/elements/entity-editor/entity-editor.ts
@@ -842,12 +842,29 @@ export class EntityEditor extends SignalWatcher(LitElement) {
   connectedCallback(): void {
     super.connectedCallback();
     window.addEventListener("pointerdown", this.#onPointerDownBound);
+    this.addEventListener("focusin", this.#updateFocusState);
+    this.addEventListener("focusout", this.#updateFocusState);
   }
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
     window.removeEventListener("pointerdown", this.#onPointerDownBound);
+    this.removeEventListener("focusin", this.#updateFocusState);
+    this.removeEventListener("focusout", this.#updateFocusState);
+    if (this.sca) {
+      this.sca.controller.editor.step.focused = false;
+    }
   }
+
+  #updateFocusState = () => {
+    requestAnimationFrame(() => {
+      if (!this.sca) return;
+      const isFocused =
+        this.shadowRoot?.activeElement !== null ||
+        document.activeElement === this;
+      this.sca.controller.editor.step.focused = isFocused;
+    });
+  };
 
   #onPointerDown() {
     this.#hideFastAccess();

--- a/packages/visual-editor/tests/sca/actions/agent/graph-editing-agent-actions.test.ts
+++ b/packages/visual-editor/tests/sca/actions/agent/graph-editing-agent-actions.test.ts
@@ -31,6 +31,7 @@ import type { AppServices } from "../../../../src/sca/services/services.js";
 import { setDOM, unsetDOM } from "../../../fake-dom.js";
 import { createMockEnvironment } from "../../helpers/mock-environment.js";
 import { defaultRuntimeFlags } from "../../controller/data/default-flags.js";
+import { GraphEditingManager } from "../../../../src/a2/agent/graph-editing/graph-editing-manager.js";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -595,5 +596,155 @@ suite("graph-editing-agent-actions", () => {
     assert.strictEqual(agent.loopRunning, false, "loopRunning should be false");
     assert.strictEqual(agent.processing, false, "processing should be false");
     assert.strictEqual(agent.waiting, false, "waiting should be false");
+  });
+
+  test("applyEdits updateTheme switches sidebar to preview when step is not focused", async () => {
+    const controller = await makeControllerStub("GEA_act_13");
+    const editorStub = controller.editor as unknown as {
+      sidebar: { section: string };
+      step: { focused: boolean };
+      theme: { updateHash: (graph: unknown) => void };
+      graph: {
+        editor: { raw: () => { edges: unknown[]; nodes: unknown[] } };
+        graph: { edges: unknown[]; nodes: unknown[] };
+      };
+    };
+    editorStub.sidebar = { section: "editor" };
+    editorStub.step = { focused: false };
+    editorStub.theme = { updateHash() {} };
+    editorStub.graph = {
+      editor: {
+        raw: () => ({ edges: [], nodes: [] }),
+      },
+      graph: { edges: [], nodes: [] },
+    };
+
+    const services = makeServicesStub();
+    bind({
+      controller,
+      services,
+      env: createMockEnvironment(defaultRuntimeFlags),
+    });
+
+    // Mock GraphEditingManager.applyEdits to simulate a successful theme update
+    mock.method(
+      GraphEditingManager.prototype,
+      "applyEdits",
+      async (_payload: unknown, options: unknown) => {
+        const opts = options as
+          | { onThemeUpdated?: (metadata: unknown) => void }
+          | undefined;
+        if (opts?.onThemeUpdated) {
+          opts.onThemeUpdated({});
+        }
+        return { success: true };
+      }
+    );
+
+    const originalStartRun = services.agentService.startRun.bind(
+      services.agentService
+    );
+    let activeHandle: AgentRunHandle | null = null;
+    mock.method(services.agentService, "startRun", (args: AgentRunConfig) => {
+      const handle = originalStartRun(args);
+      activeHandle = handle;
+      return handle;
+    });
+
+    startGraphEditingAgent("Build something");
+
+    await activeHandle!.events.handle({
+      applyEdits: {
+        requestId: "req-theme-1",
+        label: "Update theme",
+        transform: {
+          kind: "updateTheme",
+          themeIntent: "sunset vibe",
+        },
+      },
+    });
+
+    assert.strictEqual(
+      controller.editor.sidebar.section,
+      "preview",
+      "Sidebar should switch to preview when theme is updated and step is not focused"
+    );
+
+    services.agentService.endRun(activeHandle!.runId);
+  });
+
+  test("applyEdits updateTheme does not switch sidebar to preview when step is focused", async () => {
+    const controller = await makeControllerStub("GEA_act_14");
+    const editorStub = controller.editor as unknown as {
+      sidebar: { section: string };
+      step: { focused: boolean };
+      theme: { updateHash: (graph: unknown) => void };
+      graph: {
+        editor: { raw: () => { edges: unknown[]; nodes: unknown[] } };
+        graph: { edges: unknown[]; nodes: unknown[] };
+      };
+    };
+    editorStub.sidebar = { section: "editor" };
+    editorStub.step = { focused: true };
+    editorStub.theme = { updateHash() {} };
+    editorStub.graph = {
+      editor: {
+        raw: () => ({ edges: [], nodes: [] }),
+      },
+      graph: { edges: [], nodes: [] },
+    };
+
+    const services = makeServicesStub();
+    bind({
+      controller,
+      services,
+      env: createMockEnvironment(defaultRuntimeFlags),
+    });
+
+    // Mock GraphEditingManager.applyEdits to simulate a successful theme update
+    mock.method(
+      GraphEditingManager.prototype,
+      "applyEdits",
+      async (_payload: unknown, options: unknown) => {
+        const opts = options as
+          | { onThemeUpdated?: (metadata: unknown) => void }
+          | undefined;
+        if (opts?.onThemeUpdated) {
+          opts.onThemeUpdated({});
+        }
+        return { success: true };
+      }
+    );
+
+    const originalStartRun = services.agentService.startRun.bind(
+      services.agentService
+    );
+    let activeHandle: AgentRunHandle | null = null;
+    mock.method(services.agentService, "startRun", (args: AgentRunConfig) => {
+      const handle = originalStartRun(args);
+      activeHandle = handle;
+      return handle;
+    });
+
+    startGraphEditingAgent("Build something");
+
+    await activeHandle!.events.handle({
+      applyEdits: {
+        requestId: "req-theme-2",
+        label: "Update theme",
+        transform: {
+          kind: "updateTheme",
+          themeIntent: "sunset vibe",
+        },
+      },
+    });
+
+    assert.strictEqual(
+      controller.editor.sidebar.section,
+      "editor",
+      "Sidebar should NOT switch to preview when theme is updated and step is focused"
+    );
+
+    services.agentService.endRun(activeHandle!.runId);
   });
 });


### PR DESCRIPTION
## What
Ensures that after an agent updates the graph's theme, the sidebar switches to the "Preview" tab only if the user is not actively focused on editing step properties in the entity editor.

## Why
Prevents disrupting the user's workflow by closing the entity editor panel while they are typing or modifying node configurations.

## Changes
* **SCA / StepController**: Added `focused` signal property to track entity editor focus state.
* **UI / EntityEditor**: Bound `focusin`/`focusout` listeners to track focus and update the `focused` property.
* **SCA / GraphEditingAgentActions**: Conditionally update `sidebar.section` to `"preview"` only if `step.focused` is false.
* **Testing**: Added unit tests in `graph-editing-agent-actions.test.ts` validating both focused and unfocused theme update cases.

## Testing
Run the unit test suite:
`npm run test:file -w packages/visual-editor -- ./dist/tsc/tests/sca/actions/agent/graph-editing-agent-actions.test.js`
