### PR TITLE
[agent] Enable Agentic HTML Generation with runtime flag gating

### DIFF
--- a/packages/opal-backend/opal_backend/declarations/generate.functions.json
+++ b/packages/opal-backend/opal_backend/declarations/generate.functions.json
@@ -350,5 +350,50 @@
       },
       "additionalProperties": false
     }
+  },
+  {
+    "name": "generate_html",
+    "description": "Generates a complete, beautiful HTML document based on a prompt and optional references to existing files (e.g. text files, images). Returns the generated document as a file path.",
+    "parametersJsonSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "prompt": {
+          "type": "string",
+          "description": "Detailed prompt describing the HTML document to generate. You can refer to other files (e.g. text content, images, etc.) using <file src=\"/mnt/filename.ext\" /> tag in the prompt."
+        },
+        "file_name": {
+          "type": "string",
+          "description": "Optional name for the generated HTML file (without extension). Use snake_case for naming. The system will automatically add the '.html' extension."
+        },
+        "task_id": {
+          "type": "string"
+        },
+        "status_update": {
+          "type": "string",
+          "description": "A status update to show in the UI that provides more detail on the reason why this function was called."
+        }
+      },
+      "required": [
+        "prompt",
+        "status_update"
+      ],
+      "additionalProperties": false
+    },
+    "responseJsonSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "string",
+          "description": "If an error has occurred, will contain a description of the error"
+        },
+        "html": {
+          "type": "string",
+          "description": "Generated HTML document, specified as a file path (e.g., /mnt/file.html)"
+        }
+      },
+      "additionalProperties": false
+    }
   }
 ]

--- a/packages/opal-backend/opal_backend/declarations/generate.instruction.md
+++ b/packages/opal-backend/opal_backend/declarations/generate.instruction.md
@@ -31,3 +31,9 @@ Because of this translation layer, DO NOT mention file system paths or file refe
 For example, if you need to include  an existing file at "/mnt/text3.md" into the prompt, you can reference it as <file src="/mnt/text3.md" />. If you do not use <file> tags, the code generator will not be able to access the file.
 
 For output, do not ask the code generator to name the files. It will assign its own file names names to save in the sandbox, and these will be picked up at the sandbox boundary and translated into <file> tags for you.
+<!-- if enableGenerateHtml -->
+## When to call "generate_html" function
+
+Use the "generate_html" function when you need to generate a complete, rich, formatted HTML document or webpage (such as a dashboard, a newsletter, a styled report, or an interactive page). Avoid using "generate_text" to write raw HTML code; instead, use "generate_html" to let the specialized HTML generator create a high-quality visual document.
+<!-- endif -->
+

--- a/packages/opal-backend/opal_backend/declarations/generate.metadata.json
+++ b/packages/opal-backend/opal_backend/declarations/generate.metadata.json
@@ -28,5 +28,10 @@
     "name": "generate_and_execute_code",
     "icon": "code",
     "title": "Generating and Executing Code"
+  },
+  {
+    "name": "generate_html",
+    "icon": "web",
+    "title": "Generating HTML"
   }
 ]

--- a/packages/types/src/flags.ts
+++ b/packages/types/src/flags.ts
@@ -109,6 +109,10 @@ export type RuntimeFlags = {
    * conversation / configuration / run-log view.
    */
   enableAgentWorkbench: boolean;
+  /**
+   * Enable Agentic HTML Generation function
+   */
+  enableGenerateHtml: boolean;
 };
 
 /**
@@ -263,4 +267,10 @@ export const RUNTIME_FLAG_META: Record<keyof RuntimeFlags, RuntimeFlagMeta> = {
     description: "Enables the Agent Workbench layout for single-agent Opals",
     visibility: "experimental",
   },
+  enableGenerateHtml: {
+    title: "Agentic HTML Generation",
+    description: "Enable the generate_html function for the agent",
+    visibility: "experimental",
+  },
 };
+

--- a/packages/unified-server/src/config.ts
+++ b/packages/unified-server/src/config.ts
@@ -83,6 +83,7 @@ export async function createClientConfig(opts: {
       enableAssetAccessConsent: flags.ENABLE_ASSET_ACCESS_CONSENT,
       enableBackendGraphRunner: flags.ENABLE_BACKEND_GRAPH_RUNNER,
       enableAgentWorkbench: flags.ENABLE_AGENT_WORKBENCH,
+      enableGenerateHtml: flags.ENABLE_GENERATE_HTML,
     },
   };
 }

--- a/packages/unified-server/src/flags.ts
+++ b/packages/unified-server/src/flags.ts
@@ -48,6 +48,8 @@ export const ENABLE_DEV_TOOLS = getBoolean("ENABLE_DEV_TOOLS");
 
 export const ENABLE_FORCE_2D_GRAPH = getBoolean("ENABLE_FORCE_2D_GRAPH");
 
+export const ENABLE_GENERATE_HTML = getBoolean("ENABLE_GENERATE_HTML");
+
 export const ENABLE_GOOGLE_DRIVE_TOOLS = getBoolean(
   "ENABLE_GOOGLE_DRIVE_TOOLS"
 );

--- a/packages/visual-editor/src/a2/a2/html-generator.ts
+++ b/packages/visual-editor/src/a2/a2/html-generator.ts
@@ -1,13 +1,125 @@
 /**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
  * @fileoverview Utility for calling generate_webpage tool.
  */
 
-import { LLMContent, Outcome } from "@breadboard-ai/types";
+import { GraphDescriptor, LLMContent, Outcome } from "@breadboard-ai/types";
 import { executeWebpageStream } from "./generate-webpage-stream.js";
 import { A2ModuleArgs } from "../runnable-module-factory.js";
 import { isInlineData } from "../../data/common.js";
 
-export { callGenWebpage };
+export { callGenWebpage, generateWebpage };
+
+type ThemeColors = {
+  primaryColor?: string;
+  secondaryColor?: string;
+  backgroundColor?: string;
+  textColor?: string;
+  primaryTextColor?: string;
+};
+
+type Color = {
+  25?: string;
+  50?: string;
+  80?: string;
+  90?: string;
+  95?: string;
+  98?: string;
+};
+
+type PaletteColors = {
+  error?: Color;
+  neutral?: Color;
+  neutralVariant?: Color;
+  primary?: Color;
+  secondary?: Color;
+  tertiary?: Color;
+};
+
+function defaultThemeColors(): ThemeColors {
+  return {
+    primaryColor: "#246db5",
+    secondaryColor: "#5cadff",
+    backgroundColor: "#ffffff",
+    textColor: "#1a1a1a",
+    primaryTextColor: "#ffffff",
+  };
+}
+
+function getThemeColors(graph: GraphDescriptor | undefined): ThemeColors {
+  if (!graph) return defaultThemeColors();
+  const currentThemeId = graph.metadata?.visual?.presentation?.theme;
+  if (!currentThemeId) return defaultThemeColors();
+  const themeColors =
+    graph.metadata?.visual?.presentation?.themes?.[currentThemeId]?.themeColors;
+  if (!themeColors) return defaultThemeColors();
+  return { ...defaultThemeColors(), ...themeColors };
+}
+
+function getPaletteColors(
+  graph: GraphDescriptor | undefined
+): PaletteColors | undefined {
+  if (!graph) return;
+  const currentThemeId = graph.metadata?.visual?.presentation?.theme;
+  if (!currentThemeId) return;
+  const palette =
+    graph.metadata?.visual?.presentation?.themes?.[currentThemeId]?.palette;
+  if (!palette) return {};
+  return { ...palette };
+}
+
+function themeColorsPrompt(colors: ThemeColors): string {
+  return `Unless otherwise specified, use the following theme colors:
+
+- primary color: ${colors.primaryColor}
+- secondary color: ${colors.secondaryColor}
+- background color: ${colors.backgroundColor}
+- text color: ${colors.textColor}
+- primary text color: ${colors.primaryTextColor}
+
+`;
+}
+
+function getPalettePrompt(colors: PaletteColors): string {
+  return `Unless otherwise specified, use the following theme colors:
+  
+  - primary color, dark: ${colors.primary?.[25]}
+  - primary color, light: ${colors.primary?.[98]}
+  - secondary color, dark: ${colors.secondary?.[25]}
+  - secondary color, light: ${colors.secondary?.[95]}
+  - tertiary color, dark: ${colors.tertiary?.[25]}
+  - tertiary color, light: ${colors.tertiary?.[80]}
+  - background color: ${colors.secondary?.[90]}
+  - error color: ${colors.error?.[50]}
+  - neutral, dark: ${colors.neutral?.[25]}
+  - neutral, light: ${colors.neutral?.[98]}
+  `;
+}
+
+/**
+ * High-level wrapper that extracts graph visual styles (theme/palette)
+ * and appends them to the system text before calling generate_webpage.
+ */
+async function generateWebpage(
+  moduleArgs: A2ModuleArgs,
+  systemText: string,
+  content: LLMContent[]
+): Promise<Outcome<LLMContent>> {
+  const graph = moduleArgs.context.currentGraph;
+  const palette = getPaletteColors(graph);
+  if (palette?.primary) {
+    systemText += getPalettePrompt(palette);
+  } else {
+    const themeColors = getThemeColors(graph);
+    systemText += themeColorsPrompt(themeColors);
+  }
+  return callGenWebpage(moduleArgs, systemText, content, "HTML");
+}
 
 /**
  * Main entry point for generating webpage HTML via streaming API.

--- a/packages/visual-editor/src/a2/a2/render-outputs.ts
+++ b/packages/visual-editor/src/a2/a2/render-outputs.ts
@@ -3,14 +3,13 @@
  */
 
 import {
-  GraphDescriptor,
   LLMContent,
   Outcome,
   Schema,
   TextCapabilityPart,
 } from "@breadboard-ai/types";
 import connectorSave from "../google-drive/connector-save.js";
-import { callGenWebpage } from "./html-generator.js";
+import { generateWebpage } from "./html-generator.js";
 import { Template } from "./template.js";
 import { err, llm, mergeContent, ok, toLLMContent, toText } from "./utils.js";
 import { readFlags } from "./settings.js";
@@ -141,92 +140,6 @@ type DescribeInputs = {
   };
 };
 
-type ThemeColors = {
-  primaryColor?: string;
-  secondaryColor?: string;
-  backgroundColor?: string;
-  textColor?: string;
-  primaryTextColor?: string;
-};
-
-type Color = {
-  25?: string;
-  50?: string;
-  80?: string;
-  90?: string;
-  95?: string;
-  98?: string;
-};
-
-type PaletteColors = {
-  error?: Color;
-  neutral?: Color;
-  neutralVariant?: Color;
-  primary?: Color;
-  secondary?: Color;
-  tertiary?: Color;
-};
-
-function defaultThemeColors(): ThemeColors {
-  return {
-    primaryColor: "#246db5",
-    secondaryColor: "#5cadff",
-    backgroundColor: "#ffffff",
-    textColor: "#1a1a1a",
-    primaryTextColor: "#ffffff",
-  };
-}
-
-function getThemeColors(graph: GraphDescriptor | undefined): ThemeColors {
-  if (!graph) return defaultThemeColors();
-  const currentThemeId = graph.metadata?.visual?.presentation?.theme;
-  if (!currentThemeId) return defaultThemeColors();
-  const themeColors =
-    graph.metadata?.visual?.presentation?.themes?.[currentThemeId]?.themeColors;
-  if (!themeColors) return defaultThemeColors();
-  return { ...defaultThemeColors(), ...themeColors };
-}
-
-function getPaletteColors(
-  graph: GraphDescriptor | undefined
-): PaletteColors | undefined {
-  if (!graph) return;
-  const currentThemeId = graph.metadata?.visual?.presentation?.theme;
-  if (!currentThemeId) return;
-  const palette =
-    graph.metadata?.visual?.presentation?.themes?.[currentThemeId]?.palette;
-  if (!palette) return {};
-  return { ...palette };
-}
-
-function themeColorsPrompt(colors: ThemeColors): string {
-  return `Unless otherwise specified, use the following theme colors:
-
-- primary color: ${colors.primaryColor}
-- secondary color: ${colors.secondaryColor}
-- background color: ${colors.backgroundColor}
-- text color: ${colors.textColor}
-- primary text color: ${colors.primaryTextColor}
-
-`;
-}
-
-function getPalettePrompt(colors: PaletteColors): string {
-  return `Unless otherwise specified, use the following theme colors:
-  
-  - primary color, dark: ${colors.primary?.[25]}
-  - primary color, light: ${colors.primary?.[98]}
-  - secondary color, dark: ${colors.secondary?.[25]}
-  - secondary color, light: ${colors.secondary?.[95]}
-  - tertiary color, dark: ${colors.tertiary?.[25]}
-  - tertiary color, light: ${colors.tertiary?.[80]}
-  - background color: ${colors.secondary?.[90]}
-  - error color: ${colors.error?.[50]}
-  - neutral, dark: ${colors.neutral?.[25]}
-  - neutral, light: ${colors.neutral?.[98]}
-  `;
-}
-
 async function saveToGoogleDrive(
   moduleArgs: A2ModuleArgs,
   content: LLMContent,
@@ -306,7 +219,7 @@ async function invoke(
   if (!text) {
     text = toLLMContent("");
   }
-  let systemText = toText(systemInstruction ?? defaultSystemInstruction());
+  const systemText = toText(systemInstruction ?? defaultSystemInstruction());
   const template = new Template(text, moduleArgs.context.currentGraph);
   const substituting = await template.substitute(params, async () => "");
   if (!ok(substituting)) {
@@ -325,20 +238,10 @@ async function invoke(
       return { context: [out] };
     }
     case "HTML": {
-      const graph = moduleArgs.context.currentGraph;
-      const palette = getPaletteColors(graph);
-      if (palette?.primary) {
-        systemText += getPalettePrompt(palette);
-      } else {
-        const themeColors = getThemeColors(graph);
-        systemText += themeColorsPrompt(themeColors);
-      }
-      console.log("SI :", systemText);
-      const webPage = await callGenWebpage(
+      const webPage = await generateWebpage(
         moduleArgs,
         systemText,
-        [context],
-        renderType
+        [context]
       );
       if (!ok(webPage)) {
         console.warn(

--- a/packages/visual-editor/src/a2/agent/agent-function-configurator.ts
+++ b/packages/visual-editor/src/a2/agent/agent-function-configurator.ts
@@ -28,6 +28,7 @@ function createAgentConfigurator(
   sink: AgentEventSink
 ): FunctionGroupConfigurator {
   return async (deps, flags) => {
+    const runtimeFlags = await moduleArgs.context.flags?.flags();
     const groups = [];
     const taskTreeManager = new TaskTreeManager(deps.fileSystem);
 
@@ -49,6 +50,7 @@ function createAgentConfigurator(
         taskTreeManager,
         generators,
         sink,
+        runtimeFlags,
       })
     );
 
@@ -64,7 +66,6 @@ function createAgentConfigurator(
       );
     }
 
-    const runtimeFlags = await moduleArgs.context.flags?.flags();
     if (flags.useNotebookLM && runtimeFlags?.enableNotebookLm) {
       groups.push(
         getNotebookLMFunctionGroup({

--- a/packages/visual-editor/src/a2/agent/functions/generate.ts
+++ b/packages/visual-editor/src/a2/agent/functions/generate.ts
@@ -3,10 +3,10 @@
  * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
-
 import {
   ConsentType,
   ErrorMetadata,
+  RuntimeFlags,
   TextCapabilityPart,
 } from "@breadboard-ai/types";
 import { ok } from "@breadboard-ai/utils";
@@ -37,7 +37,9 @@ import { FunctionGroup, Generators } from "../types.js";
 import { TaskTreeManager } from "../task-tree-manager.js";
 import { createReporter } from "../progress-work-item.js";
 import type { AgentEventSink } from "../agent-event-sink.js";
+import { generateWebpage } from "../../a2/html-generator.js";
 import { decodeErrorData } from "../../../sca/utils/decode-error.js";
+import { resolveInstruction } from "./shared.js";
 
 import {
   declarations,
@@ -49,6 +51,7 @@ import {
   type GenerateSpeechFromTextParams,
   type GenerateMusicFromTextParams,
   type GenerateAndExecuteCodeParams,
+  type GenerateHtmlParams,
 } from "./generated/generate.js";
 
 export { getGenerateFunctionGroup, GENERATE_TEXT_FUNCTION };
@@ -75,6 +78,7 @@ export type GenerateFunctionArgs = {
   taskTreeManager: TaskTreeManager;
   generators: Generators;
   sink: AgentEventSink;
+  runtimeFlags?: Readonly<RuntimeFlags>;
 };
 
 function getGenerateFunctionGroup(args: GenerateFunctionArgs): FunctionGroup {
@@ -85,9 +89,16 @@ function getGenerateFunctionGroup(args: GenerateFunctionArgs): FunctionGroup {
     taskTreeManager,
     generators,
     sink,
+    runtimeFlags,
   } = args;
 
-  return assembleFunctionGroup(declarations, metadata, instruction, {
+  const effectiveDeclarations = runtimeFlags?.enableGenerateHtml
+    ? declarations
+    : declarations.filter((d) => d.name !== "generate_html");
+
+  const effectiveInstruction = resolveInstruction(instruction, runtimeFlags);
+
+  return assembleFunctionGroup(effectiveDeclarations, metadata, effectiveInstruction, {
     generate_images: async (
       {
         prompt,
@@ -458,6 +469,49 @@ DO NOT start with "Okay", or "Alright" or any preambles. Just the output, please
         console.warn(`More than one part generated`, results);
       }
       return { result: toText({ parts: textParts }) };
+    },
+
+    generate_html: async (
+      {
+        prompt,
+        file_name,
+        task_id,
+        status_update,
+      }: GenerateHtmlParams,
+      statusUpdater
+    ) => {
+      taskTreeManager.setInProgress(task_id, status_update);
+      statusUpdater(status_update || "Generating HTML", {
+        expectedDurationInSec: 40,
+      });
+
+      const translated = await translator.fromPidginString(prompt);
+      if (!ok(translated)) return { error: translated.$error };
+
+      const webPage = await generateWebpage(
+        moduleArgs,
+        toText(defaultSystemInstruction()),
+        [translated]
+      );
+
+      statusUpdater(null);
+
+      if (!ok(webPage)) {
+        return { error: webPage.$error };
+      }
+
+      // Add HTML content to agent file system
+      const part = webPage.parts.at(0);
+      if (!part || !("inlineData" in part)) {
+        return { error: "No HTML content was generated" };
+      }
+
+      const htmlFile = fileSystem.add(part, file_name);
+      if (!ok(htmlFile)) {
+        return { error: htmlFile.$error };
+      }
+
+      return { html: htmlFile };
     },
   });
 }

--- a/packages/visual-editor/src/a2/agent/functions/generated/generate.ts
+++ b/packages/visual-editor/src/a2/agent/functions/generated/generate.ts
@@ -92,6 +92,18 @@ export type GenerateAndExecuteCodeResponse = {
   result?: string;
 };
 
+export type GenerateHtmlParams = {
+  prompt: string;
+  file_name?: string;
+  task_id?: string;
+  status_update: string;
+};
+
+export type GenerateHtmlResponse = {
+  error?: string;
+  html?: string;
+};
+
 export const declarations: FunctionDeclaration[] = [
   {
     "name": "generate_images",
@@ -444,6 +456,51 @@ export const declarations: FunctionDeclaration[] = [
       },
       "additionalProperties": false
     }
+  },
+  {
+    "name": "generate_html",
+    "description": "Generates a complete, beautiful HTML document based on a prompt and optional references to existing files (e.g. text files, images). Returns the generated document as a file path.",
+    "parametersJsonSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "prompt": {
+          "type": "string",
+          "description": "Detailed prompt describing the HTML document to generate. You can refer to other files (e.g. text content, images, etc.) using <file src=\"/mnt/filename.ext\" /> tag in the prompt."
+        },
+        "file_name": {
+          "type": "string",
+          "description": "Optional name for the generated HTML file (without extension). Use snake_case for naming. The system will automatically add the '.html' extension."
+        },
+        "task_id": {
+          "type": "string"
+        },
+        "status_update": {
+          "type": "string",
+          "description": "A status update to show in the UI that provides more detail on the reason why this function was called."
+        }
+      },
+      "required": [
+        "prompt",
+        "status_update"
+      ],
+      "additionalProperties": false
+    },
+    "responseJsonSchema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "error": {
+          "type": "string",
+          "description": "If an error has occurred, will contain a description of the error"
+        },
+        "html": {
+          "type": "string",
+          "description": "Generated HTML document, specified as a file path (e.g., /mnt/file.html)"
+        }
+      },
+      "additionalProperties": false
+    }
   }
 ];
 
@@ -471,7 +528,11 @@ export const metadata: Record<string, { icon?: string; title?: string }> = {
   "generate_and_execute_code": {
     "icon": "code",
     "title": "Generating and Executing Code"
+  },
+  "generate_html": {
+    "icon": "web",
+    "title": "Generating HTML"
   }
 };
 
-export const instruction: string = "## When to call \"generate_text\" function\n\nWhen evaluating the objective, make sure to determine whether calling \"generate_text\" function is warranted. The key tradeoff here is latency: because it's an additional model call, the \"generate_text\" will take longer to finish.\n\nYour job is to fulfill the objective as efficiently as possible, so weigh the need to invoke \"generate_text\" carefully.\n\nHere is the rules of thumb:\n\n- For shorter responses like a chat conversation, just do the text generation yourself. You are an LLM and you can do it without calling \"generate_text\" function.\n- For longer responses like generating a chapter of a book or analyzing a large and complex set of files, use \"generate_text\" function.\n\n\n### How to write a good prompt for the code generator\n\nThe \"generate_and_execute_code\" function is a self-contained code generator with a sandboxed code execution environment. Think of it as a sub-agent that both generates the code and executes it, then provides the result. This sub-agent takes a natural language prompt to do its job.\n\nA good code generator prompt will include the following components:\n\n1. Preference for the Python library to use. For example \"Use the reportlab library to generate PDF\"\n\n2. What to consume as input. Focus on the \"what\", rather than the \"how\". When binary files are passed as input, use the key words \"use provided file\". Do NOT refer to file paths, see below.\n\n3. The high-level approach to solving the problem with code. If applicable, specify algorithms or techniques to use.\n\n4. What to deliver as output. Again, do not worry about the \"how\", instead specify the \"what\". For text files, use the key word \"return\" in the prompt. For binary files, use the key word word \"save\". For example, \"Return the resulting number\" or \"Save the PDF file\" or \"Save all four resulting images\". Do NOT ask to name the files, see below.\n\nThe code generator prompt may include references to files and it may output references to files. However, theses references are translated at the boundary of the sandboxed code execution environment into actual files and file handles that will be different from what you specify. The Python code execution environment has no access to your file system.\n\nBecause of this translation layer, DO NOT mention file system paths or file references in the prompt outside of the <file> tag.\n\nFor example, if you need to include  an existing file at \"/mnt/text3.md\" into the prompt, you can reference it as <file src=\"/mnt/text3.md\" />. If you do not use <file> tags, the code generator will not be able to access the file.\n\nFor output, do not ask the code generator to name the files. It will assign its own file names names to save in the sandbox, and these will be picked up at the sandbox boundary and translated into <file> tags for you.";
+export const instruction: string = "## When to call \"generate_text\" function\n\nWhen evaluating the objective, make sure to determine whether calling \"generate_text\" function is warranted. The key tradeoff here is latency: because it's an additional model call, the \"generate_text\" will take longer to finish.\n\nYour job is to fulfill the objective as efficiently as possible, so weigh the need to invoke \"generate_text\" carefully.\n\nHere is the rules of thumb:\n\n- For shorter responses like a chat conversation, just do the text generation yourself. You are an LLM and you can do it without calling \"generate_text\" function.\n- For longer responses like generating a chapter of a book or analyzing a large and complex set of files, use \"generate_text\" function.\n\n\n### How to write a good prompt for the code generator\n\nThe \"generate_and_execute_code\" function is a self-contained code generator with a sandboxed code execution environment. Think of it as a sub-agent that both generates the code and executes it, then provides the result. This sub-agent takes a natural language prompt to do its job.\n\nA good code generator prompt will include the following components:\n\n1. Preference for the Python library to use. For example \"Use the reportlab library to generate PDF\"\n\n2. What to consume as input. Focus on the \"what\", rather than the \"how\". When binary files are passed as input, use the key words \"use provided file\". Do NOT refer to file paths, see below.\n\n3. The high-level approach to solving the problem with code. If applicable, specify algorithms or techniques to use.\n\n4. What to deliver as output. Again, do not worry about the \"how\", instead specify the \"what\". For text files, use the key word \"return\" in the prompt. For binary files, use the key word word \"save\". For example, \"Return the resulting number\" or \"Save the PDF file\" or \"Save all four resulting images\". Do NOT ask to name the files, see below.\n\nThe code generator prompt may include references to files and it may output references to files. However, theses references are translated at the boundary of the sandboxed code execution environment into actual files and file handles that will be different from what you specify. The Python code execution environment has no access to your file system.\n\nBecause of this translation layer, DO NOT mention file system paths or file references in the prompt outside of the <file> tag.\n\nFor example, if you need to include  an existing file at \"/mnt/text3.md\" into the prompt, you can reference it as <file src=\"/mnt/text3.md\" />. If you do not use <file> tags, the code generator will not be able to access the file.\n\nFor output, do not ask the code generator to name the files. It will assign its own file names names to save in the sandbox, and these will be picked up at the sandbox boundary and translated into <file> tags for you.\n<!-- if enableGenerateHtml -->\n## When to call \"generate_html\" function\n\nUse the \"generate_html\" function when you need to generate a complete, rich, formatted HTML document or webpage (such as a dashboard, a newsletter, a styled report, or an interactive page). Avoid using \"generate_text\" to write raw HTML code; instead, use \"generate_html\" to let the specialized HTML generator create a high-quality visual document.\n<!-- endif -->";

--- a/packages/visual-editor/src/a2/agent/functions/shared.ts
+++ b/packages/visual-editor/src/a2/agent/functions/shared.ts
@@ -4,10 +4,29 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { GENERATE_TEXT_FUNCTION };
+import type { RuntimeFlags } from "@breadboard-ai/types";
+
+export { GENERATE_TEXT_FUNCTION, resolveInstruction };
 
 /**
  * The canonical function name for the text generation tool.
  * Shared across system and generate function groups.
  */
 const GENERATE_TEXT_FUNCTION = "generate_text";
+
+/**
+ * Parses and resolves conditional blocks in markdown instructions based on runtime flags.
+ * Format: <!-- if flagName -->content<!-- endif -->
+ */
+function resolveInstruction(
+  instruction: string | undefined,
+  flags?: Readonly<RuntimeFlags>
+): string | undefined {
+  if (!instruction) return undefined;
+  return instruction.replace(
+    /<!-- if (\w+) -->([\s\S]*?)<!-- endif -->/g,
+    (_, flag, content) => {
+      return flags?.[flag as keyof RuntimeFlags] ? content : "";
+    }
+  );
+}

--- a/packages/visual-editor/src/ui/config/client-deployment-configuration.ts
+++ b/packages/visual-editor/src/ui/config/client-deployment-configuration.ts
@@ -34,6 +34,7 @@ const DEFAULT_FLAG_VALUES: RuntimeFlags = {
   enableAssetAccessConsent: false,
   enableBackendGraphRunner: false,
   enableAgentWorkbench: false,
+  enableGenerateHtml: false,
 };
 
 function populateFlags<T extends Partial<ClientDeploymentConfiguration>>(

--- a/packages/visual-editor/tests/agent/functions/generate-group.test.ts
+++ b/packages/visual-editor/tests/agent/functions/generate-group.test.ts
@@ -8,10 +8,12 @@ import { describe, it } from "node:test";
 import { deepStrictEqual, ok as assert } from "node:assert";
 import { getGenerateFunctionGroup } from "../../../src/a2/agent/functions/generate.js";
 import { createTestArgs } from "./generate-test-utils.js";
+import type { RuntimeFlags, RuntimeFlagManager } from "@breadboard-ai/types";
+import type { A2ModuleArgs } from "../../../src/a2/runnable-module-factory.js";
 
 describe("getGenerateFunctionGroup", () => {
   describe("function definitions", () => {
-    it("returns all six functions", () => {
+    it("returns all six functions by default (generate_html excluded)", () => {
       const args = createTestArgs();
       const group = getGenerateFunctionGroup(args);
 
@@ -40,6 +42,37 @@ describe("getGenerateFunctionGroup", () => {
         functionNames.includes("generate_and_execute_code"),
         "Should include generate_and_execute_code"
       );
+      assert(
+        !functionNames.includes("generate_html"),
+        "Should NOT include generate_html"
+      );
+      deepStrictEqual(functionNames.length, 6);
+    });
+
+    it("returns seven functions (including generate_html) when enableGenerateHtml is enabled", () => {
+      const runtimeFlags = {
+        enableGenerateHtml: true,
+      } as unknown as RuntimeFlags;
+
+      const args = createTestArgs({
+        runtimeFlags,
+        moduleArgs: {
+          context: {
+            flags: {
+              flags: async () => runtimeFlags,
+            } as unknown as RuntimeFlagManager,
+          },
+        } as unknown as A2ModuleArgs,
+      });
+
+      const group = getGenerateFunctionGroup(args);
+      const functionNames = group.definitions.map(([name]) => name);
+
+      assert(
+        functionNames.includes("generate_html"),
+        "Should include generate_html"
+      );
+      deepStrictEqual(functionNames.length, 7);
     });
   });
 
@@ -56,6 +89,32 @@ describe("getGenerateFunctionGroup", () => {
       assert(
         group.instruction!.includes("generate_and_execute_code"),
         "Instruction should mention generate_and_execute_code"
+      );
+    });
+
+    it("excludes generate_html instruction by default or when enableGenerateHtml is disabled", () => {
+      const args = createTestArgs();
+      const group = getGenerateFunctionGroup(args);
+
+      assert(group.instruction !== undefined, "Should have instruction");
+      assert(
+        !group.instruction!.includes("generate_html"),
+        "Instruction should not mention generate_html"
+      );
+    });
+
+    it("includes generate_html instruction when enableGenerateHtml is enabled", () => {
+      const runtimeFlags = {
+        enableGenerateHtml: true,
+      } as unknown as RuntimeFlags;
+
+      const args = createTestArgs({ runtimeFlags });
+      const group = getGenerateFunctionGroup(args);
+
+      assert(group.instruction !== undefined, "Should have instruction");
+      assert(
+        group.instruction!.includes("generate_html"),
+        "Instruction should mention generate_html"
       );
     });
   });

--- a/packages/visual-editor/tests/agent/functions/generate-html.test.ts
+++ b/packages/visual-editor/tests/agent/functions/generate-html.test.ts
@@ -1,0 +1,201 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, mock } from "node:test";
+import { deepStrictEqual, ok as assertOk } from "node:assert";
+import { getGenerateFunctionGroup } from "../../../src/a2/agent/functions/generate.js";
+import type { A2ModuleArgs } from "../../../src/a2/runnable-module-factory.js";
+import {
+  createTestArgs,
+  createMockStatusUpdater,
+  getHandler,
+} from "./generate-test-utils.js";
+import { RuntimeFlags, RuntimeFlagManager } from "@breadboard-ai/types";
+
+// Helper to create chunk encoder for SSE streams
+function sseChunk(data: unknown): Uint8Array {
+  const payload = `data: ${JSON.stringify(data)}\n\n`;
+  return new TextEncoder().encode(payload);
+}
+
+function makeMockFetch(chunks: unknown[]) {
+  return mock.fn(async (_url: string, _init?: RequestInit) => {
+    const stream = new ReadableStream({
+      start(controller) {
+        for (const chunk of chunks) {
+          controller.enqueue(sseChunk(chunk));
+        }
+        controller.close();
+      },
+    });
+    return new Response(stream, { status: 200 });
+  });
+}
+
+describe("generate_html", () => {
+  it("generates html successfully and stores it in the file system", async () => {
+    const fetchWithCreds = makeMockFetch([
+      {
+        parts: [
+          {
+            text: "<html><body>Generated HTML Page</body></html>",
+            partMetadata: { chunk_type: "html" },
+          },
+        ],
+      },
+    ]);
+
+    const runtimeFlags = {
+      enableGenerateHtml: true,
+    } as unknown as RuntimeFlags;
+
+    const args = createTestArgs({
+      runtimeFlags,
+      moduleArgs: {
+        fetchWithCreds: fetchWithCreds as unknown as typeof globalThis.fetch,
+        context: {
+          currentGraph: { url: "drive:/test-stub", title: "Test Stub" },
+          flags: {
+            flags: async () => runtimeFlags,
+          } as unknown as RuntimeFlagManager,
+        },
+      } as unknown as A2ModuleArgs,
+    });
+
+    const group = getGenerateFunctionGroup(args);
+    const handler = getHandler(group, "generate_html");
+
+    const result = await handler(
+      {
+        prompt: "Generate a simple page",
+        status_update: "Designing webpage",
+        file_name: "index.html",
+      },
+      createMockStatusUpdater()
+    );
+
+    deepStrictEqual(result, { html: "/mnt/index.html" });
+
+    // Verify fetch was called with the correct backend URL
+    assertOk(fetchWithCreds.mock.calls.length > 0);
+    const fetchUrl = fetchWithCreds.mock.calls[0].arguments[0] as string;
+    assertOk(fetchUrl.includes("v1beta1/generateWebpageStream"));
+
+    // Verify userInstruction matches input prompt and incorporates default theme fallback
+    const body = JSON.parse(fetchWithCreds.mock.calls[0].arguments[1]!.body as string);
+    assertOk(body.userInstruction.includes("Unless otherwise specified, use the following theme colors:"));
+  });
+
+  it("appends graph palette settings to the prompt system instruction when available", async () => {
+    const fetchWithCreds = makeMockFetch([
+      {
+        parts: [
+          {
+            text: "<html><body>Palette Page</body></html>",
+            partMetadata: { chunk_type: "html" },
+          },
+        ],
+      },
+    ]);
+
+    const runtimeFlags = {
+      enableGenerateHtml: true,
+    } as unknown as RuntimeFlags;
+
+    const args = createTestArgs({
+      runtimeFlags,
+      moduleArgs: {
+        fetchWithCreds: fetchWithCreds as unknown as typeof globalThis.fetch,
+        context: {
+          currentGraph: {
+            url: "drive:/test-stub",
+            title: "Test Stub",
+            metadata: {
+              visual: {
+                presentation: {
+                  theme: "custom-theme",
+                  themes: {
+                    "custom-theme": {
+                      palette: {
+                        primary: {
+                          25: "#000000",
+                          98: "#ffffff",
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          flags: {
+            flags: async () => runtimeFlags,
+          } as unknown as RuntimeFlagManager,
+        },
+      } as unknown as A2ModuleArgs,
+    });
+
+    const group = getGenerateFunctionGroup(args);
+    const handler = getHandler(group, "generate_html");
+
+    await handler(
+      {
+        prompt: "Generate a custom page",
+        status_update: "Designing webpage",
+        file_name: "custom",
+      },
+      createMockStatusUpdater()
+    );
+
+    assertOk(fetchWithCreds.mock.calls.length > 0);
+    const body = JSON.parse(fetchWithCreds.mock.calls[0].arguments[1]!.body as string);
+    assertOk(body.userInstruction.includes("primary color, dark: #000000"));
+    assertOk(body.userInstruction.includes("primary color, light: #ffffff"));
+  });
+
+  it("returns error message when streaming generation fails", async () => {
+    const fetchWithCreds = makeMockFetch([
+      {
+        parts: [
+          {
+            text: "Backend failed to compile HTML",
+            partMetadata: { chunk_type: "error" },
+          },
+        ],
+      },
+    ]);
+
+    const runtimeFlags = {
+      enableGenerateHtml: true,
+    } as unknown as RuntimeFlags;
+
+    const args = createTestArgs({
+      runtimeFlags,
+      moduleArgs: {
+        fetchWithCreds: fetchWithCreds as unknown as typeof globalThis.fetch,
+        context: {
+          currentGraph: { url: "drive:/test-stub", title: "Test Stub" },
+          flags: {
+            flags: async () => runtimeFlags,
+          } as unknown as RuntimeFlagManager,
+        },
+      } as unknown as A2ModuleArgs,
+    });
+
+    const group = getGenerateFunctionGroup(args);
+    const handler = getHandler(group, "generate_html");
+
+    const result = await handler(
+      {
+        prompt: "Generate faulty page",
+        status_update: "Designing webpage",
+      },
+      createMockStatusUpdater()
+    );
+
+    deepStrictEqual(result, { error: "Backend failed to compile HTML" });
+  });
+});

--- a/packages/visual-editor/tests/agent/functions/generate-test-utils.ts
+++ b/packages/visual-editor/tests/agent/functions/generate-test-utils.ts
@@ -330,6 +330,7 @@ function createTestArgs(
     taskTreeManager: overrides.taskTreeManager ?? createMockTaskTreeManager(),
     generators: overrides.generators ?? createMockGenerators(),
     sink: overrides.sink ?? createMockSink(),
+    runtimeFlags: overrides.runtimeFlags,
   };
 }
 

--- a/packages/visual-editor/tests/sca/controller/data/default-flags.ts
+++ b/packages/visual-editor/tests/sca/controller/data/default-flags.ts
@@ -26,4 +26,5 @@ export const defaultRuntimeFlags: RuntimeFlags = {
   enableAssetAccessConsent: false,
   enableBackendGraphRunner: false,
   enableAgentWorkbench: false,
+  enableGenerateHtml: false,
 };

--- a/packages/visual-editor/tests/sca/environment/environment.test.ts
+++ b/packages/visual-editor/tests/sca/environment/environment.test.ts
@@ -91,6 +91,7 @@ const testFlags: RuntimeFlags = {
   enableAssetAccessConsent: false,
   enableBackendGraphRunner: false,
   enableAgentWorkbench: false,
+  enableGenerateHtml: false,
 };
 
 suite("createEnvironment", () => {


### PR DESCRIPTION
## What
Adds a new runtime feature flag `enableGenerateHtml` ("Agentic HTML Generation") which, when enabled, exposes a new `generate_html` tool to the agent. It also implements conditional gating for the instruction markdown so the model does not receive instructions on how to use `generate_html` if the flag is disabled.

## Why
Exposes the capability for the agent to generate complete and styled HTML documents dynamically, while maintaining strict gating so that the new instruction set does not drift into models running with the flag disabled.

## Changes
- **Feature Flags**: Added `enableGenerateHtml` across types, frontend client configs, and backend server configs.
- **Shared HTML Generation**: Extracted styling color/palette extraction into `html-generator.ts` to share between outputs rendering and agent tool generation.
- **Inversion Declarations**: Declared `generate_html` in JSON schemas and conditionally gated instructions in `generate.instruction.md`.
- **Runtime Instruction Gating**: Added helper to parse comment-based condition flags in instruction markdown at runtime.
- **Dynamic Tool Dispatch**: Updated `getGenerateFunctionGroup` to only include the schema and filter instruction string dynamically based on active flags.
- **Testing**: Added unit tests verifying dynamic tool inclusion/exclusion and instruction gating when the flag is enabled/disabled.

## Testing
- Run `npm run test` in `packages/visual-editor` to verify all tests pass.
- Specific tests for instruction gating and tool registration can be found in `packages/visual-editor/tests/agent/functions/generate-group.test.ts`.
