### PR TITLE
[agent] Fix webpage generation bypass for agent HTML editing

### DIFF
--- a/packages/visual-editor/src/a2/a2/html-generator.ts
+++ b/packages/visual-editor/src/a2/a2/html-generator.ts
@@ -11,8 +11,6 @@
 import { GraphDescriptor, LLMContent, Outcome } from "@breadboard-ai/types";
 import { executeWebpageStream } from "./generate-webpage-stream.js";
 import { A2ModuleArgs } from "../runnable-module-factory.js";
-import { isInlineData } from "../../data/common.js";
-
 export { callGenWebpage, generateWebpage };
 
 type ThemeColors = {
@@ -130,15 +128,5 @@ async function callGenWebpage(
   content: LLMContent[],
   _renderMode: string
 ): Promise<Outcome<LLMContent>> {
-  // If the content already contains HTML inlineData, pass it through
-  // without invoking webpage generation.
-  for (const item of content) {
-    for (const part of item.parts) {
-      if (isInlineData(part) && part.inlineData.mimeType === "text/html") {
-        return { role: "model", parts: [part] };
-      }
-    }
-  }
-
   return executeWebpageStream(moduleArgs, instruction, content);
 }

--- a/packages/visual-editor/src/a2/a2/render-outputs.ts
+++ b/packages/visual-editor/src/a2/a2/render-outputs.ts
@@ -16,7 +16,7 @@ import { readFlags } from "./settings.js";
 import { renderConsistentUI } from "./render-consistent-ui.js";
 import { A2ModuleArgs } from "../runnable-module-factory.js";
 import { Params } from "./common.js";
-import { isLLMContent, isLLMContentArray } from "../../data/common.js";
+import { isInlineData, isLLMContent, isLLMContentArray } from "../../data/common.js";
 
 import {
   DocEditMode,
@@ -238,6 +238,19 @@ async function invoke(
       return { context: [out] };
     }
     case "HTML": {
+      // If the content already contains HTML inlineData, pass it through
+      // without invoking webpage generation.
+      let hasHtml = false;
+      for (const part of context.parts) {
+        if (isInlineData(part) && part.inlineData.mimeType === "text/html") {
+          hasHtml = true;
+          break;
+        }
+      }
+      if (hasHtml) {
+        return { context: [context] };
+      }
+
       const webPage = await generateWebpage(
         moduleArgs,
         systemText,

--- a/packages/visual-editor/tests/agent/functions/generate-html.test.ts
+++ b/packages/visual-editor/tests/agent/functions/generate-html.test.ts
@@ -12,8 +12,10 @@ import {
   createTestArgs,
   createMockStatusUpdater,
   getHandler,
+  createMockFileSystem,
 } from "./generate-test-utils.js";
 import { RuntimeFlags, RuntimeFlagManager } from "@breadboard-ai/types";
+import { PidginTranslator } from "../../../src/a2/agent/pidgin-translator.js";
 
 // Helper to create chunk encoder for SSE streams
 function sseChunk(data: unknown): Uint8Array {
@@ -197,5 +199,73 @@ describe("generate_html", () => {
     );
 
     deepStrictEqual(result, { error: "Backend failed to compile HTML" });
+  });
+
+  it("does not bypass generateWebpage when referencing an existing HTML file in the prompt", async () => {
+    const fetchWithCreds = makeMockFetch([
+      {
+        parts: [
+          {
+            text: "<html><body>Updated Button Page</body></html>",
+            partMetadata: { chunk_type: "html" },
+          },
+        ],
+      },
+    ]);
+
+    const runtimeFlags = {
+      enableGenerateHtml: true,
+    } as unknown as RuntimeFlags;
+
+    const fileSystem = createMockFileSystem({
+      get: mock.fn(async (path: string) => {
+        if (path === "/mnt/button.html") {
+          return [
+            {
+              inlineData: {
+                mimeType: "text/html",
+                data: btoa("<html><body>Original Button</body></html>"),
+              },
+            },
+          ];
+        }
+        return [];
+      }),
+    });
+
+    const moduleArgs = {
+      fetchWithCreds: fetchWithCreds as unknown as typeof globalThis.fetch,
+      context: {
+        currentGraph: { url: "drive:/test-stub", title: "Test Stub" },
+        flags: {
+          flags: async () => runtimeFlags,
+        } as unknown as RuntimeFlagManager,
+      },
+    } as unknown as A2ModuleArgs;
+
+    const translator = new PidginTranslator(moduleArgs, fileSystem);
+
+    const args = createTestArgs({
+      runtimeFlags,
+      fileSystem,
+      moduleArgs,
+      translator,
+    });
+
+    const group = getGenerateFunctionGroup(args);
+    const handler = getHandler(group, "generate_html");
+
+    const result = await handler(
+      {
+        prompt: "Make background red in <file src=\"/mnt/button.html\" />",
+        status_update: "Updating webpage",
+        file_name: "updated.html",
+      },
+      createMockStatusUpdater()
+    );
+
+    // Verify fetch WAS called (generation not bypassed)
+    assertOk(fetchWithCreds.mock.calls.length > 0);
+    deepStrictEqual(result, { html: "/mnt/updated.html" });
   });
 });

--- a/packages/visual-editor/tests/agent/functions/generate-test-utils.ts
+++ b/packages/visual-editor/tests/agent/functions/generate-test-utils.ts
@@ -191,6 +191,7 @@ function createMockGenerators(overrides: Partial<Generators> = {}): Generators {
 function createMockFileSystem(
   overrides: Partial<{
     add: AgentFileSystem["add"];
+    get: AgentFileSystem["get"];
     getMany: AgentFileSystem["getMany"];
   }> = {}
 ): AgentFileSystem {
@@ -202,6 +203,9 @@ function createMockFileSystem(
         fileCounter++;
         return `/mnt/${name ?? `file${fileCounter}`}`;
       }),
+    get:
+      overrides.get ??
+      mock.fn(async () => []),
     getMany:
       overrides.getMany ??
       mock.fn(async (paths: string[]) => {
@@ -209,7 +213,6 @@ function createMockFileSystem(
           inlineData: { mimeType: "image/png", data: "mock" },
         }));
       }),
-    get: mock.fn(),
     files: {},
   } as unknown as AgentFileSystem;
 }


### PR DESCRIPTION
## What
Refactors the webpage generation bypass check to prevent the agent's `generate_html` tool from skipping code generation when referencing an existing HTML file in its prompt.

## Why
Previously, the bypass check was inside the shared webpage generation pipeline (`callGenWebpage`), which caused any content containing a `text/html` part to immediately skip Gemini and return the HTML as-is. This prevented the agent from being able to edit previously generated HTML files. Moving the check to the UI output rendering stage (`render-outputs.ts`) keeps the bypass functionality for the UI while restoring editing capability for the agent.

## Changes
- **visual-editor (webpage generation)**: Moved the HTML content bypass check out of `html-generator.ts` and into the case `"HTML"` handler in `render-outputs.ts`.
- **visual-editor (testing)**: Updated `createMockFileSystem` in `generate-test-utils.ts` to allow mocking the `get` file retrieval method, and added a unit test in `generate-html.test.ts` to assert that referencing an HTML file in `generate_html` prompt correctly triggers webpage generation.

## Testing
- Run `npm run test` in `packages/visual-editor` to verify all tests pass.
- Run the specific test: `npm run test:file -- './dist/tsc/tests/agent/functions/generate-html.test.js'`.
