### PR TITLE
[agent] Connect HTML Generation progress to Agent Progress Reporter

### DIFF
--- a/packages/visual-editor/src/a2/a2/generate-webpage-stream.ts
+++ b/packages/visual-editor/src/a2/a2/generate-webpage-stream.ts
@@ -15,6 +15,7 @@ import { iteratorFromStream } from "@breadboard-ai/utils";
 import {
   getCurrentStepState,
   createReporter,
+  type ProgressReporter,
 } from "../agent/progress-work-item.js";
 import {
   encodeBase64,
@@ -185,17 +186,24 @@ function parseStoredDataUrl(handle: string): string {
 async function executeWebpageStream(
   moduleArgs: A2ModuleArgs,
   instruction: string,
-  content: LLMContent[]
+  content: LLMContent[],
+  reporter?: ProgressReporter | null
 ): Promise<Outcome<LLMContent>> {
-  const reporter = createReporter(moduleArgs, {
-    title: `Generating webpage`,
-    icon: "web",
-  });
+  const hasReporter = !!reporter;
+  const effectiveReporter =
+    reporter ??
+    createReporter(moduleArgs, {
+      title: `Generating webpage`,
+      icon: "web",
+    });
 
   const { appScreen } = getCurrentStepState(moduleArgs);
 
   try {
-    reporter.addJson("Preparing request", {}, "upload");
+    const lastInput = content.at(-1);
+    if (lastInput) {
+      effectiveReporter.addContent("Context", lastInput, "upload");
+    }
 
     if (appScreen) appScreen.progress = "Generating HTML";
 
@@ -217,13 +225,13 @@ async function executeWebpageStream(
 
     if (!response.ok) {
       const errorText = await response.text();
-      return reporter.addError(
+      return effectiveReporter.addError(
         err(`Streaming request failed: ${response.status} ${errorText}`)
       );
     }
 
     if (!response.body) {
-      return reporter.addError(err("No response body from streaming API"));
+      return effectiveReporter.addError(err("No response body from streaming API"));
     }
 
     // Process the SSE stream
@@ -245,29 +253,31 @@ async function executeWebpageStream(
             setScreenDuration(appScreen, -1);
           }
 
-          reporter.addText(`Thinking (${thoughtCount})`, text, "spark");
+          effectiveReporter.addJson(`Thinking (${thoughtCount})`, { thought: text }, "spark");
         } else if (chunkType === "html") {
           htmlResult = text;
-          reporter.addText("Generated HTML", "HTML output ready", "download");
+          effectiveReporter.addJson("Generated HTML", { status: "HTML output ready" }, "download");
         } else if (chunkType === "error") {
-          return reporter.addError(err(parseStreamError(text)));
+          return effectiveReporter.addError(err(parseStreamError(text)));
         }
       }
     }
 
     if (!htmlResult) {
-      return reporter.addError(err("No HTML content received from stream"));
+      return effectiveReporter.addError(err("No HTML content received from stream"));
     }
 
     // Return HTML as inlineData with text/html mimeType to match legacy behavior
     return toLLMContentInline("text/html", encodeBase64(htmlResult), "model");
   } catch (e) {
-    return reporter.addError(err(formatAgentError(e), classifyCaughtError(e)));
+    return effectiveReporter.addError(err(formatAgentError(e), classifyCaughtError(e)));
   } finally {
     if (appScreen) {
       appScreen.progress = undefined;
       setScreenDuration(appScreen, -1);
     }
-    reporter.finish();
+    if (!hasReporter) {
+      effectiveReporter.finish();
+    }
   }
 }

--- a/packages/visual-editor/src/a2/a2/html-generator.ts
+++ b/packages/visual-editor/src/a2/a2/html-generator.ts
@@ -11,6 +11,7 @@
 import { GraphDescriptor, LLMContent, Outcome } from "@breadboard-ai/types";
 import { executeWebpageStream } from "./generate-webpage-stream.js";
 import { A2ModuleArgs } from "../runnable-module-factory.js";
+import { type ProgressReporter } from "../agent/progress-work-item.js";
 export { callGenWebpage, generateWebpage };
 
 type ThemeColors = {
@@ -106,7 +107,8 @@ function getPalettePrompt(colors: PaletteColors): string {
 async function generateWebpage(
   moduleArgs: A2ModuleArgs,
   systemText: string,
-  content: LLMContent[]
+  content: LLMContent[],
+  reporter?: ProgressReporter | null
 ): Promise<Outcome<LLMContent>> {
   const graph = moduleArgs.context.currentGraph;
   const palette = getPaletteColors(graph);
@@ -116,7 +118,7 @@ async function generateWebpage(
     const themeColors = getThemeColors(graph);
     systemText += themeColorsPrompt(themeColors);
   }
-  return callGenWebpage(moduleArgs, systemText, content, "HTML");
+  return callGenWebpage(moduleArgs, systemText, content, "HTML", reporter);
 }
 
 /**
@@ -126,7 +128,8 @@ async function callGenWebpage(
   moduleArgs: A2ModuleArgs,
   instruction: string,
   content: LLMContent[],
-  _renderMode: string
+  _renderMode: string,
+  reporter?: ProgressReporter | null
 ): Promise<Outcome<LLMContent>> {
-  return executeWebpageStream(moduleArgs, instruction, content);
+  return executeWebpageStream(moduleArgs, instruction, content, reporter);
 }

--- a/packages/visual-editor/src/a2/agent/agent-event.ts
+++ b/packages/visual-editor/src/a2/agent/agent-event.ts
@@ -229,6 +229,13 @@ type SubagentAddJsonPayload = {
   icon?: string;
 };
 
+type SubagentAddContentPayload = {
+  callId: string;
+  title: string;
+  content: LLMContent;
+  icon?: string;
+};
+
 type SubagentErrorPayload = {
   callId: string;
   error: { $error: string; metadata?: ErrorMetadata };
@@ -277,6 +284,7 @@ type AgentEventMap = {
   error: ErrorPayload;
   finish: FinishPayload;
   subagentAddJson: SubagentAddJsonPayload;
+  subagentAddContent: SubagentAddContentPayload;
   subagentError: SubagentErrorPayload;
   subagentFinish: SubagentFinishPayload;
   usageMetadata: UsageMetadataPayload;

--- a/packages/visual-editor/src/a2/agent/console-work-item.ts
+++ b/packages/visual-editor/src/a2/agent/console-work-item.ts
@@ -7,6 +7,7 @@
 import {
   ConsoleUpdate,
   JsonSerializable,
+  LLMContent,
   WorkItem,
 } from "@breadboard-ai/types";
 import { signal } from "signal-utils";
@@ -73,6 +74,19 @@ class ConsoleWorkItem implements WorkItem, ProgressReporter {
       title,
       icon: icon ?? "data_object",
       body: { parts: [{ json: data as JsonSerializable }] },
+    });
+  }
+
+  /**
+   * Add LLMContent to this work item.
+   * Part of ProgressReporter interface.
+   */
+  addContent(title: string, content: LLMContent, icon?: string) {
+    this.addProduct({
+      type: "text",
+      title,
+      icon: icon ?? "info",
+      body: content,
     });
   }
 

--- a/packages/visual-editor/src/a2/agent/functions/generate.ts
+++ b/packages/visual-editor/src/a2/agent/functions/generate.ts
@@ -478,7 +478,8 @@ DO NOT start with "Okay", or "Alright" or any preambles. Just the output, please
         task_id,
         status_update,
       }: GenerateHtmlParams,
-      statusUpdater
+      statusUpdater,
+      reporter
     ) => {
       taskTreeManager.setInProgress(task_id, status_update);
       statusUpdater(status_update || "Generating HTML", {
@@ -491,7 +492,8 @@ DO NOT start with "Okay", or "Alright" or any preambles. Just the output, please
       const webPage = await generateWebpage(
         moduleArgs,
         toText(defaultSystemInstruction()),
-        [translated]
+        [translated],
+        reporter
       );
 
       statusUpdater(null);

--- a/packages/visual-editor/src/a2/agent/loop-setup.ts
+++ b/packages/visual-editor/src/a2/agent/loop-setup.ts
@@ -273,6 +273,16 @@ function buildHooksFromSink(sink: AgentEventSink): LoopHooks {
             },
           });
         },
+        addContent(contentTitle, content, contentIcon?) {
+          sink.emit({
+            subagentAddContent: {
+              callId,
+              title: contentTitle,
+              content,
+              icon: contentIcon,
+            },
+          });
+        },
         addError(error) {
           sink.emit({ subagentError: { callId, error } });
           return error;

--- a/packages/visual-editor/src/a2/agent/main.ts
+++ b/packages/visual-editor/src/a2/agent/main.ts
@@ -233,6 +233,11 @@ async function invokeAgent(
         .get(event.callId)
         ?.addJson(event.title, event.data, event.icon);
     })
+    .on("subagentAddContent", (event) => {
+      reporterMap
+        .get(event.callId)
+        ?.addContent(event.title, event.content, event.icon);
+    })
     .on("subagentError", (event) => {
       reporterMap.get(event.callId)?.addError(event.error);
     })

--- a/packages/visual-editor/src/a2/agent/register-progress-handlers.ts
+++ b/packages/visual-editor/src/a2/agent/register-progress-handlers.ts
@@ -111,6 +111,11 @@ function registerProgressHandlers(
         .get(event.callId)
         ?.addJson(event.title, event.data, event.icon);
     })
+    .on("subagentAddContent", (event) => {
+      reporterMap
+        .get(event.callId)
+        ?.addContent(event.title, event.content, event.icon);
+    })
     .on("subagentError", (event) => {
       reporterMap.get(event.callId)?.addError(event.error);
     })

--- a/packages/visual-editor/src/a2/agent/types.ts
+++ b/packages/visual-editor/src/a2/agent/types.ts
@@ -41,6 +41,7 @@ import type { Params } from "../a2/common.js";
  */
 export type ProgressReporter = {
   addJson(title: string, data: unknown, icon?: string): void;
+  addContent(title: string, content: LLMContent, icon?: string): void;
   addError(error: { $error: string; metadata?: ErrorMetadata }): {
     $error: string;
     metadata?: ErrorMetadata;

--- a/packages/visual-editor/tests/agent/functions/generate-html.test.ts
+++ b/packages/visual-editor/tests/agent/functions/generate-html.test.ts
@@ -8,13 +8,14 @@ import { describe, it, mock } from "node:test";
 import { deepStrictEqual, ok as assertOk } from "node:assert";
 import { getGenerateFunctionGroup } from "../../../src/a2/agent/functions/generate.js";
 import type { A2ModuleArgs } from "../../../src/a2/runnable-module-factory.js";
+import type { ProgressReporter } from "../../../src/a2/agent/progress-work-item.js";
 import {
   createTestArgs,
   createMockStatusUpdater,
   getHandler,
   createMockFileSystem,
 } from "./generate-test-utils.js";
-import { RuntimeFlags, RuntimeFlagManager } from "@breadboard-ai/types";
+import { RuntimeFlags, RuntimeFlagManager, LLMContent } from "@breadboard-ai/types";
 import { PidginTranslator } from "../../../src/a2/agent/pidgin-translator.js";
 
 // Helper to create chunk encoder for SSE streams
@@ -267,5 +268,89 @@ describe("generate_html", () => {
     // Verify fetch WAS called (generation not bypassed)
     assertOk(fetchWithCreds.mock.calls.length > 0);
     deepStrictEqual(result, { html: "/mnt/updated.html" });
+  });
+
+  it("reports progress to the passed reporter", async () => {
+    const fetchWithCreds = makeMockFetch([
+      {
+        parts: [
+          {
+            text: "doing first thing",
+            partMetadata: { chunk_type: "thought" },
+          },
+          {
+            text: "<html><body>Done</body></html>",
+            partMetadata: { chunk_type: "html" },
+          },
+        ],
+      },
+    ]);
+
+    const runtimeFlags = {
+      enableGenerateHtml: true,
+    } as unknown as RuntimeFlags;
+
+    const args = createTestArgs({
+      runtimeFlags,
+      moduleArgs: {
+        fetchWithCreds: fetchWithCreds as unknown as typeof globalThis.fetch,
+        context: {
+          currentGraph: { url: "drive:/test-stub", title: "Test Stub" },
+          flags: {
+            flags: async () => runtimeFlags,
+          } as unknown as RuntimeFlagManager,
+        },
+      } as unknown as A2ModuleArgs,
+    });
+
+    const group = getGenerateFunctionGroup(args);
+    const handler = getHandler(group, "generate_html");
+
+    const reporterAddJsonCalls: Array<{ title: string; data: unknown; icon?: string }> = [];
+    const reporterAddContentCalls: Array<{ title: string; content: LLMContent; icon?: string }> = [];
+    const finishMock = mock.fn();
+    const mockReporter: ProgressReporter = {
+      addJson: mock.fn((title: string, data: unknown, icon?: string) => {
+        reporterAddJsonCalls.push({ title, data, icon });
+      }),
+      addContent: mock.fn((title: string, content: LLMContent, icon?: string) => {
+        reporterAddContentCalls.push({ title, content, icon });
+      }),
+      addError: mock.fn((error) => error),
+      finish: finishMock,
+    };
+
+    const result = await handler(
+      {
+        prompt: "Generate a simple page",
+        status_update: "Designing webpage",
+        file_name: "index.html",
+      },
+      createMockStatusUpdater(),
+      mockReporter
+    );
+
+    deepStrictEqual(result, { html: "/mnt/index.html" });
+
+    // Verify reporter was called with input content
+    deepStrictEqual(reporterAddContentCalls, [
+      {
+        title: "Request Input Context",
+        content: {
+          parts: [{ text: "Generate a simple page" }],
+          role: "user",
+        },
+        icon: "upload",
+      },
+    ]);
+
+    // Verify reporter was called for thoughts and generated html
+    deepStrictEqual(reporterAddJsonCalls, [
+      { title: "Thinking (1)", data: { thought: "doing first thing" }, icon: "spark" },
+      { title: "Generated HTML", data: { status: "HTML output ready" }, icon: "download" },
+    ]);
+
+    // Verify finish was NOT called since the reporter was passed from the caller
+    deepStrictEqual(finishMock.mock.calls.length, 0);
   });
 });

--- a/packages/visual-editor/tests/agent/functions/generate-html.test.ts
+++ b/packages/visual-editor/tests/agent/functions/generate-html.test.ts
@@ -335,7 +335,7 @@ describe("generate_html", () => {
     // Verify reporter was called with input content
     deepStrictEqual(reporterAddContentCalls, [
       {
-        title: "Request Input Context",
+        title: "Context",
         content: {
           parts: [{ text: "Generate a simple page" }],
           role: "user",

--- a/packages/visual-editor/tests/agent/functions/generate-test-utils.ts
+++ b/packages/visual-editor/tests/agent/functions/generate-test-utils.ts
@@ -9,6 +9,7 @@ import type { Outcome, LLMContent, DataPart } from "@breadboard-ai/types";
 import type {
   Generators,
   MappedDefinitions,
+  ProgressReporter,
 } from "../../../src/a2/agent/types.js";
 import type { GenerateFunctionArgs } from "../../../src/a2/agent/functions/generate.js";
 import type { AgentFileSystem } from "../../../src/a2/agent/file-system.js";
@@ -345,7 +346,8 @@ function getHandler(
   name: string
 ): (
   params: Record<string, unknown>,
-  statusUpdater: StatusUpdateCallback
+  statusUpdater: StatusUpdateCallback,
+  reporter?: ProgressReporter | null
 ) => Promise<Outcome<Record<string, unknown>>> {
   const def = group.definitions.find(([n]) => n === name);
   if (!def) {
@@ -353,6 +355,7 @@ function getHandler(
   }
   return def[1].handler as (
     params: Record<string, unknown>,
-    statusUpdater: StatusUpdateCallback
+    statusUpdater: StatusUpdateCallback,
+    reporter?: ProgressReporter | null
   ) => Promise<Outcome<Record<string, unknown>>>;
 }


### PR DESCRIPTION
## What
Exposed and propagated the `reporter` parameter to webpage generation, attaching the streaming updates and input context to the agent's function-calling progress reporter instead of launching a standalone reporter.

## Why
Ensures nested progress (such as thinking steps and generated HTML alerts) and nicely rendered input contexts for webpage generation are correctly grouped under the agent's active function-calling console entry, consistent with `generate_images` and `generate_music`.

## Changes

### `visual-editor`
- **`src/a2/agent/types.ts`**: Added `addContent` signature to `ProgressReporter`.
- **`src/a2/agent/console-work-item.ts`**: Implemented `addContent` on `ConsoleWorkItem`.
- **`src/a2/agent/agent-event.ts`**: Defined `subagentAddContent` event type and payload.
- **`src/a2/agent/loop-setup.ts`**: Emitted `subagentAddContent` from the subagent proxy reporter.
- **`src/a2/agent/register-progress-handlers.ts` & `src/a2/agent/main.ts`**: Handled `subagentAddContent` events to append them to the active work item.
- **`src/a2/agent/functions/generate.ts`**: Passed the `reporter` argument from `generate_html` to `generateWebpage`.
- **`src/a2/a2/html-generator.ts` & `src/a2/a2/generate-webpage-stream.ts`**:
  - Reused the passed-in `reporter` (if available) during webpage generation.
  - Logged the last input item nicely via `addContent`.
  - Conditioned `reporter.finish()` execution to only run if the reporter was created locally.

## Testing
- Added unit tests in `tests/agent/functions/generate-html.test.ts` verifying that `generate_html` correctly logs input context and stream status updates to a passed reporter, and that `finish` is not prematurely closed.
- Ran and passed all agent function tests: `npm run test:file -- './dist/tsc/tests/agent/functions/*.js'`.
