### PR TITLE
[opie] Clear Selection and Style Selection Chips

### DIFF
--- a/packages/visual-editor/src/sca/actions/board/board-actions.ts
+++ b/packages/visual-editor/src/sca/actions/board/board-actions.ts
@@ -545,6 +545,7 @@ export const load = asAction(
     controller.run.screen.reset();
     controller.run.renderer.reset();
     controller.editor.share.reset();
+    controller.editor.selection.deselectAll();
 
     // 10. Update board controller state
     if (versionInfo?.isNewer) {
@@ -581,6 +582,9 @@ export const close = asAction(
 
     // Reset the graph controller state
     controller.editor.graph.resetAll();
+
+    // Clear selection state
+    controller.editor.selection.deselectAll();
 
     // Return to home state
     controller.global.main.loadState = "Home";
@@ -950,7 +954,11 @@ async function runBoard(): Promise<void> {
   // Check batch consent for all Drive assets in the graph before running.
   // This shows a single modal listing all Drive files instead of one per asset.
   // Gated behind the enableAssetAccessConsent flag.
-  if (gc.readOnly && gc.graph && bind.env.flags.get("enableAssetAccessConsent")) {
+  if (
+    gc.readOnly &&
+    gc.graph &&
+    bind.env.flags.get("enableAssetAccessConsent")
+  ) {
     const driveAssets = findGoogleDriveAssetsInGraph(gc.graph, {
       omitSplashImages: true,
     });
@@ -983,14 +991,13 @@ async function runBoard(): Promise<void> {
             let fileName = asset.fileId.id;
             let iconLink = "";
             try {
-              const meta =
-                await services.googleDriveClient.getFileMetadata(
-                  {
-                    id: asset.fileId.id,
-                    resourceKey: asset.fileId.resourceKey,
-                  },
-                  { fields: ["name", "iconLink"] }
-                );
+              const meta = await services.googleDriveClient.getFileMetadata(
+                {
+                  id: asset.fileId.id,
+                  resourceKey: asset.fileId.resourceKey,
+                },
+                { fields: ["name", "iconLink"] }
+              );
               if (meta?.name) fileName = meta.name;
               if (meta?.iconLink) iconLink = meta.iconLink;
             } catch {
@@ -1006,8 +1013,7 @@ async function runBoard(): Promise<void> {
           })
         );
 
-        const allowed =
-          await consentCtrl.requestBatchConsent(assetInfos);
+        const allowed = await consentCtrl.requestBatchConsent(assetInfos);
 
         if (!allowed) {
           logger.log(

--- a/packages/visual-editor/src/ui/elements/graph-editing-chat/chat-panel.ts
+++ b/packages/visual-editor/src/ui/elements/graph-editing-chat/chat-panel.ts
@@ -20,6 +20,9 @@ import type { ExpandingTextarea } from "../input/expanding-textarea.js";
 import "./opie-avatar.js";
 import "../effects/radial-glow.js";
 import { styleMap } from "lit/directives/style-map.js";
+import { classMap } from "lit/directives/class-map.js";
+import { getStepIcon } from "../../utils/get-step-icon.js";
+import type { InspectableNode } from "@breadboard-ai/types";
 import type {
   AddAssetRequestEvent,
   AddAssetEvent,
@@ -55,6 +58,7 @@ class ChatPanel extends SignalWatcher(LitElement) {
   static styles = [
     icons,
     Styles.HostType.type,
+    Styles.HostColorsBase.baseColors,
     css`
       :host {
         display: block;
@@ -371,11 +375,27 @@ class ChatPanel extends SignalWatcher(LitElement) {
         align-items: center;
         gap: var(--bb-grid-size);
         background: var(--light-dark-p-90);
-        color: var(--light-dark-n-10);
+        color: light-dark(var(--n-0), var(--n-10));
         border-radius: var(--bb-grid-size-3);
         padding: 2px var(--bb-grid-size) 2px var(--bb-grid-size-2);
         font-size: 12px;
         font-weight: 500;
+      }
+
+      .selection-chip.generate {
+        background: var(--ui-generate);
+      }
+
+      .selection-chip.get-input {
+        background: var(--ui-get-input);
+      }
+
+      .selection-chip.display {
+        background: var(--ui-display);
+      }
+
+      .selection-chip.default {
+        background: var(--light-dark-n-70);
       }
 
       .selection-chip button {
@@ -660,8 +680,14 @@ class ChatPanel extends SignalWatcher(LitElement) {
     const chips = [...selectedNodes].map((nodeId) => {
       const node = inspector.nodeById(nodeId);
       const title = node?.metadata()?.title ?? "(untitled)";
+      const colorClass = node ? getNodeColorClass(node) : "default";
       return html`
-        <span class="selection-chip">
+        <span
+          class=${classMap({
+            "selection-chip": true,
+            [colorClass]: true,
+          })}
+        >
           ${title}
           <button
             @click=${() => {
@@ -763,4 +789,76 @@ class ChatPanel extends SignalWatcher(LitElement) {
       }}
     ></bb-add-asset-modal>`;
   }
+}
+
+function getNodeColorClass(node: InspectableNode): string {
+  const ports = node.currentPorts();
+  const metadata = node.type().currentMetadata();
+  const icon = getStepIcon(metadata.icon, ports) || null;
+  const legacyNodeType = node.type().type();
+
+  const classes = new Set<string>();
+  if (metadata.tags) {
+    for (const tag of metadata.tags) {
+      classes.add(tag);
+    }
+  }
+
+  let nodeIcon = icon;
+  if (!URL.canParse(legacyNodeType)) {
+    if (!nodeIcon) {
+      nodeIcon = legacyNodeType;
+    }
+    if (legacyNodeType.startsWith("#module")) {
+      classes.add("module");
+    } else {
+      classes.add(legacyNodeType);
+    }
+  }
+
+  if (
+    classes.has("generative") ||
+    classes.has("module") ||
+    [
+      "spark",
+      "photo_spark",
+      "audio_magic_eraser",
+      "text_analysis",
+      "button_magic",
+      "generative-image-edit",
+      "generative-code",
+      "videocam_auto",
+      "generative-search",
+      "generative",
+      "select_all",
+      "laps",
+    ].includes(nodeIcon || "")
+  ) {
+    return "generate";
+  }
+
+  if (
+    [
+      "output",
+      "docs",
+      "drive_presentation",
+      "sheets",
+      "code",
+      "web",
+      "responsive_layout",
+    ].includes(nodeIcon || "")
+  ) {
+    return "display";
+  }
+
+  if (
+    classes.has("input") ||
+    classes.has("output") ||
+    classes.has("core") ||
+    ["input", "ask-user", "chat_mirror"].includes(nodeIcon || "")
+  ) {
+    return "get-input";
+  }
+
+  return "default";
 }

--- a/packages/visual-editor/tests/sca/actions/board/board-actions.test.ts
+++ b/packages/visual-editor/tests/sca/actions/board/board-actions.test.ts
@@ -41,6 +41,9 @@ function makeMockController(options: {
     controller: {
       editor: {
         graph: options,
+        selection: {
+          deselectAll: () => {},
+        },
       },
       global: {
         debug: {
@@ -586,6 +589,7 @@ suite("Board Actions", () => {
       let clearRunnerCalled = false;
       let screenResetCalled = false;
       let rendererResetCalled = false;
+      let deselectAllCalled = false;
 
       const mockController = {
         editor: {
@@ -596,6 +600,11 @@ suite("Board Actions", () => {
             url: null,
             readOnly: false,
             editor: null,
+          },
+          selection: {
+            deselectAll: () => {
+              deselectAllCalled = true;
+            },
           },
         },
         run: {
@@ -654,6 +663,11 @@ suite("Board Actions", () => {
         rendererResetCalled,
         true,
         "Should call run.renderer.reset"
+      );
+      assert.strictEqual(
+        deselectAllCalled,
+        true,
+        "Should call selection.deselectAll"
       );
     });
   });


### PR DESCRIPTION
## What
1. Added logic to automatically deselect all selected nodes, edges, asset edges, and assets on graph transitions (loading a new board or closing a board).
2. Adapted the selection chips in the Opie chat panel to match the background/foreground colors of the corresponding nodes.

## Why
1. Stale selected node IDs from the previous graph remained in `SelectionController` when loading/closing boards, causing incorrect selection states.
2. Having node selection chips in the chat panel match node visual colors makes the relationship between selection and nodes much clearer and consistent.

## Changes
- **board-actions.ts**: Cleared selection in `Board.load` and `Board.close`.
- **board-actions.test.ts**: Updated mocks to handle selection controller and asserted selection is cleared on close.
- **chat-panel.ts**:
  - Imported `Styles.HostColorsBase.baseColors` to access CSS step colors (`--ui-generate`, etc.).
  - Added `getNodeColorClass()` helper matching the classification logic used by `GraphNode` (`generate`, `get-input`, `display`, `default`).
  - Rendered chips using the `classMap` directive to apply color classes dynamically.
  - Added CSS style definitions for these color classes on `.selection-chip`.

## Testing
- Compiled project successfully.
- Ran Board action unit tests: all 72 passed.