### PR TITLE
[ve] Update prompt NL to open Opie

### DIFF
--- a/packages/visual-editor/src/sca/controller/subcontrollers/editor/graph-editing-agent-controller.ts
+++ b/packages/visual-editor/src/sca/controller/subcontrollers/editor/graph-editing-agent-controller.ts
@@ -66,6 +66,9 @@ class GraphEditingAgentController extends RootController {
   @field()
   accessor currentFlow: string | null = null;
 
+  @field()
+  accessor autoFocus = false;
+
   // ═══════════════════════════════════════════════════════════════════════════
   // ACCESSORS
   // ═══════════════════════════════════════════════════════════════════════════
@@ -122,5 +125,6 @@ class GraphEditingAgentController extends RootController {
     this.loopRunning = false;
     this.currentFlow = null;
     this.feedbackReaction = "none";
+    this.autoFocus = false;
   }
 }

--- a/packages/visual-editor/src/ui/elements/entity-editor/entity-editor.ts
+++ b/packages/visual-editor/src/ui/elements/entity-editor/entity-editor.ts
@@ -81,6 +81,8 @@ import { icons } from "../../styles/icons.js";
 import { getBoardUrlFromCurrentWindow } from "../../navigation/board-id.js";
 import { iconSubstitute } from "../../utils/icon-substitute.js";
 
+import "../graph-editing-chat/opie-avatar.js";
+
 const Strings = StringsHelper.forSection("Editor");
 
 // A type that is like a port (and fits InspectablePort), but could also be
@@ -796,11 +798,42 @@ export class EntityEditor extends SignalWatcher(LitElement) {
             }
           }
 
-          bb-flowgen-in-step-button {
+          bb-flowgen-in-step-button,
+          #describe-with-opie {
             z-index: 1;
             position: absolute;
             bottom: calc(var(--bb-grid-size-11) * -1);
             right: var(--bb-grid-size-6);
+          }
+
+          #describe-with-opie {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: var(--bb-grid-size-9);
+            height: var(--bb-grid-size-9);
+            border: none;
+            background: light-dark(
+              var(--ui-custom-o-10),
+              var(--ui-custom-o-30)
+            );
+            border-radius: 50%;
+            transition: background-color 0.2s cubic-bezier(0, 0, 0.3, 1);
+            cursor: pointer;
+            padding: 0;
+
+            & > bb-opie-avatar {
+              pointer-events: none;
+            }
+
+            & .g-icon {
+              color: var(--light-dark-n-20);
+            }
+
+            &:hover,
+            &:focus {
+              background: var(--ui-custom-o-20);
+            }
           }
         }
       }
@@ -1530,22 +1563,50 @@ export class EntityEditor extends SignalWatcher(LitElement) {
 
           ${extendedInfoOutput}
           ${this.#graph
-            ? html`<bb-flowgen-in-step-button
-                monochrome
-                popoverPosition="below"
-                .label=${Strings.from("COMMAND_DESCRIBE_EDIT_STEP")}
-                .currentGraph=${this.#graph.raw() satisfies GraphDescriptor}
-                .constraint=${{
-                  kind: "EDIT_STEP_CONFIG",
-                  stepId: nodeId,
-                } satisfies FlowGenConstraint}
-                @bbgraphreplace=${() => {
-                  this.sca?.services.actionTracker?.editStep("flowgen");
-                  // Ignore all edits to this point so that we don't issue
-                  // a submit and stomp the new values.
-                  this.#edited = false;
-                }}
-              ></bb-flowgen-in-step-button>`
+            ? this.sca.env.flags.get("enableGraphEditorAgent")
+              ? html`<button
+                  id="describe-with-opie"
+                  @click=${() => {
+                    const agent = this.sca.controller.editor.graphEditingAgent;
+                    agent.open = true;
+                    agent.showGreeting();
+                    agent.autoFocus = true;
+                  }}
+                  @pointerover=${(evt: PointerEvent) => {
+                    this.dispatchEvent(
+                      new ShowTooltipEvent(
+                        Strings.from("COMMAND_DESCRIBE_EDIT_STEP"),
+                        evt.clientX,
+                        evt.clientY
+                      )
+                    );
+                  }}
+                  @pointerout=${() => {
+                    this.dispatchEvent(new HideTooltipEvent());
+                  }}
+                >
+                  <bb-opie-avatar
+                    mode="small"
+                    .supportsHover=${false}
+                    static
+                  ></bb-opie-avatar>
+                </button>`
+              : html`<bb-flowgen-in-step-button
+                  monochrome
+                  popoverPosition="below"
+                  .label=${Strings.from("COMMAND_DESCRIBE_EDIT_STEP")}
+                  .currentGraph=${this.#graph.raw() satisfies GraphDescriptor}
+                  .constraint=${{
+                    kind: "EDIT_STEP_CONFIG",
+                    stepId: nodeId,
+                  } satisfies FlowGenConstraint}
+                  @bbgraphreplace=${() => {
+                    this.sca?.services.actionTracker?.editStep("flowgen");
+                    // Ignore all edits to this point so that we don't issue
+                    // a submit and stomp the new values.
+                    this.#edited = false;
+                  }}
+                ></bb-flowgen-in-step-button>`
             : nothing}`;
       }
 
@@ -2017,8 +2078,6 @@ function extractModelId(ports: InspectableNodePorts): string | null {
 function isGenerativeNode(node: InspectableNode): boolean {
   return node.descriptor.type === "embed://a2/generate.bgl.json#module:main";
 }
-
-
 
 // Returns true if LLM text part of node contains tools/assets or is absent.
 function containsToolsOrAssets(ports: InspectableNodePorts): boolean {

--- a/packages/visual-editor/src/ui/elements/graph-editing-chat/chat-panel.ts
+++ b/packages/visual-editor/src/ui/elements/graph-editing-chat/chat-panel.ts
@@ -466,6 +466,12 @@ class ChatPanel extends SignalWatcher(LitElement) {
 
   override updated() {
     this.#scrollToBottom();
+
+    const agent = this.sca.controller.editor.graphEditingAgent;
+    if (agent.autoFocus) {
+      agent.autoFocus = false;
+      this.focus();
+    }
   }
 
   get inputRef() {
@@ -475,6 +481,7 @@ class ChatPanel extends SignalWatcher(LitElement) {
   render() {
     const readOnly = this.sca.controller.editor.graph.readOnly;
     const agent = this.sca.controller.editor.graphEditingAgent;
+    void agent.autoFocus;
     const inputAssets = this.sca.controller.editor.inputAssets;
     const inputDisabled = agent.processing;
     const hasInput = !!this.#inputRef.value?.value;

--- a/packages/visual-editor/src/ui/elements/graph-editing-chat/graph-editing-chat.ts
+++ b/packages/visual-editor/src/ui/elements/graph-editing-chat/graph-editing-chat.ts
@@ -224,10 +224,7 @@ class GraphEditingChat extends SignalWatcher(LitElement) {
 
         agent.open = true;
         agent.showGreeting();
-        // Re-focus after Lit update completes
-        this.updateComplete.then(() => {
-          this.#panelRef.value?.focus();
-        });
+        agent.autoFocus = true;
       }}
     ></bb-opie-avatar>`;
 

--- a/packages/visual-editor/tests/sca/controller/subcontrollers/editor/graph-editing-agent/graph-editing-agent-controller.test.ts
+++ b/packages/visual-editor/tests/sca/controller/subcontrollers/editor/graph-editing-agent/graph-editing-agent-controller.test.ts
@@ -196,6 +196,7 @@ suite("GraphEditingAgentController", () => {
     assert.strictEqual(ctrl.waiting, false);
     assert.strictEqual(ctrl.processing, false);
     assert.strictEqual(ctrl.loopRunning, false);
+    assert.strictEqual(ctrl.autoFocus, false);
   });
 
   test("boolean flags are settable", async () => {
@@ -209,12 +210,14 @@ suite("GraphEditingAgentController", () => {
     ctrl.waiting = true;
     ctrl.processing = true;
     ctrl.loopRunning = true;
+    ctrl.autoFocus = true;
     await ctrl.isSettled;
 
     assert.strictEqual(ctrl.open, true);
     assert.strictEqual(ctrl.waiting, true);
     assert.strictEqual(ctrl.processing, true);
     assert.strictEqual(ctrl.loopRunning, true);
+    assert.strictEqual(ctrl.autoFocus, true);
   });
 
   // ── currentFlow ───────────────────────────────────────────────────────────
@@ -258,6 +261,7 @@ suite("GraphEditingAgentController", () => {
     ctrl.processing = true;
     ctrl.loopRunning = true;
     ctrl.currentFlow = "flow-xyz";
+    ctrl.autoFocus = true;
     await ctrl.isSettled;
 
     ctrl.reset();
@@ -269,5 +273,6 @@ suite("GraphEditingAgentController", () => {
     assert.strictEqual(ctrl.processing, false);
     assert.strictEqual(ctrl.loopRunning, false);
     assert.strictEqual(ctrl.currentFlow, null);
+    assert.strictEqual(ctrl.autoFocus, false);
   });
 });


### PR DESCRIPTION
## What
Adds a state-driven mechanism to open Opie and focus its chat prompt directly when the "Describe change" button is clicked in the step editor, or when the Opie avatar is clicked.

## Why
Improves the user experience by allowing conversational step edits via Opie with automatic prompt focusing, avoiding manual focus-forcing and consolidating all focus flow under the controller state.

## Changes
* **SCA Controller**: Added `autoFocus` signal/accessor to `GraphEditingAgentController` to track focus requests.
* **Opie Chat Panel**: Modified `<bb-chat-panel>` to subscribe to `agent.autoFocus`, resetting it and triggering focus in the `updated` lifecycle method.
* **Opie Chat Avatar**: Simplified `<bb-graph-editing-chat>` click handler to set `agent.autoFocus = true` rather than manually focusing.
* **Entity Editor**: Replaced the `<bb-flowgen-in-step-button>` in `<bb-entity-editor>` with a `#describe-with-opie` button featuring a small static Opie avatar when `enableGraphEditorAgent` is active.
* **Tests**: Added tests for the new `autoFocus` flag in `graph-editing-agent-controller.test.ts`.

## Testing
Verified that all 14 tests in `graph-editing-agent-controller.test.ts` compile and pass successfully.