### PR TITLE
[ve] Embedded Opie Conversation Column & Automatic Scope Selection

### DIFF
--- a/packages/visual-editor/src/sca/actions/agent/graph-editing-agent-actions.ts
+++ b/packages/visual-editor/src/sca/actions/agent/graph-editing-agent-actions.ts
@@ -304,6 +304,10 @@ function resolveGraphEditingInput(
 
 /**
  * Abort the current loop and reset all state.
+ *
+ * When the workbench is active the conversation column is always
+ * visible, so we immediately show a greeting after reset to avoid
+ * an empty column.
  */
 export const resetGraphEditingAgent = asAction(
   "GraphEditingAgent.reset",
@@ -318,6 +322,13 @@ export const resetGraphEditingAgent = asAction(
     const { controller } = bind;
     controller.editor.graphEditingAgent.reset();
     controller.editor.devtools?.opie?.clearLog();
+
+    // In workbench mode the conversation is always visible — greet
+    // immediately so the column is never empty after a graph change.
+    const wb = controller.editor.workbench;
+    if (wb.eligible && wb.view === "workbench") {
+      controller.editor.graphEditingAgent.showGreeting();
+    }
   }
 );
 

--- a/packages/visual-editor/src/sca/actions/workbench/triggers.ts
+++ b/packages/visual-editor/src/sca/actions/workbench/triggers.ts
@@ -31,3 +31,21 @@ export function onWorkbenchEligibilityChange(bind: ActionBind): SignalTrigger {
       : WorkbenchEligibility.INELIGIBLE;
   });
 }
+
+export function onWorkbenchActivation(bind: ActionBind): SignalTrigger {
+  let previousActive = false;
+
+  return signalTrigger("Workbench Activation", () => {
+    const { controller } = bind;
+    const active =
+      controller.editor.workbench.eligible &&
+      controller.editor.workbench.view === "workbench";
+
+    if (active === previousActive) {
+      return false;
+    }
+
+    previousActive = active;
+    return active;
+  });
+}

--- a/packages/visual-editor/src/sca/actions/workbench/workbench-actions.ts
+++ b/packages/visual-editor/src/sca/actions/workbench/workbench-actions.ts
@@ -9,6 +9,7 @@ import { asAction, ActionMode } from "../../coordination.js";
 import {
   onWorkbenchEligibilityChange,
   isSingleAgentGraph,
+  onWorkbenchActivation,
 } from "./triggers.js";
 import {
   parsePrompt,
@@ -89,6 +90,22 @@ export const updateWorkbenchEligibility = asAction(
     const flag = env.flags.get("enableAgentWorkbench");
     const graph = controller.editor.graph.graph;
     controller.editor.workbench.eligible = flag && isSingleAgentGraph(graph);
+  }
+);
+
+export const selectAgentNodeOnActivation = asAction(
+  "Workbench.selectAgentNodeOnActivation",
+  {
+    mode: ActionMode.Immediate,
+    triggeredBy: () => onWorkbenchActivation(bind),
+    runOnActivate: true,
+  },
+  async (): Promise<void> => {
+    const { controller } = bind;
+    const agentNode = getAgentNode();
+    if (agentNode) {
+      controller.editor.selection.selectNodes([agentNode.id]);
+    }
   }
 );
 

--- a/packages/visual-editor/src/sca/controller/subcontrollers/editor/graph-editing-agent-controller.ts
+++ b/packages/visual-editor/src/sca/controller/subcontrollers/editor/graph-editing-agent-controller.ts
@@ -59,13 +59,6 @@ class GraphEditingAgentController extends RootController {
   @field()
   accessor loopRunning = false;
 
-  /**
-   * The flow ID that the current loop was started for.
-   * Used to detect graph changes and restart the loop.
-   */
-  @field()
-  accessor currentFlow: string | null = null;
-
   @field()
   accessor autoFocus = false;
 
@@ -123,7 +116,6 @@ class GraphEditingAgentController extends RootController {
     this.waiting = false;
     this.processing = false;
     this.loopRunning = false;
-    this.currentFlow = null;
     this.feedbackReaction = "none";
     this.autoFocus = false;
   }

--- a/packages/visual-editor/src/ui/elements/agent-workbench/agent-workbench.ts
+++ b/packages/visual-editor/src/ui/elements/agent-workbench/agent-workbench.ts
@@ -16,6 +16,7 @@ import { styles } from "./agent-workbench.styles.js";
 import "./run-log-column.js";
 import "./objective-editor/objective-editor.js";
 import "./tool-shelf/tool-shelf.js";
+import "./conversation-column.js";
 
 @customElement("bb-agent-workbench")
 export class AgentWorkbench extends SignalWatcher(LitElement) {
@@ -34,11 +35,7 @@ export class AgentWorkbench extends SignalWatcher(LitElement) {
 
     return html`
       <ui-tri-splitter>
-        <div slot="s0" class="column-placeholder">
-          <span class="g-icon">chat</span>
-          <h2>Opie Conversation</h2>
-          <p>This column will contain the contextual conversation history.</p>
-        </div>
+        <bb-conversation-column slot="s0"></bb-conversation-column>
         <div slot="s1" class="agent-config-column">
           <bb-objective-editor></bb-objective-editor>
           <bb-tool-shelf></bb-tool-shelf>

--- a/packages/visual-editor/src/ui/elements/agent-workbench/conversation-column.ts
+++ b/packages/visual-editor/src/ui/elements/agent-workbench/conversation-column.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { LitElement, html, css } from "lit";
+import { customElement } from "lit/decorators.js";
+import { SignalWatcher } from "@lit-labs/signals";
+import { consume } from "@lit/context";
+import { scaContext } from "../../../sca/context/context.js";
+import { type SCA } from "../../../sca/sca.js";
+
+import "../graph-editing-chat/chat-panel.js";
+
+export { ConversationColumn };
+
+/**
+ * Full-height conversation column for the Agent Workbench.
+ *
+ * Mounts `<bb-chat-panel mode="embedded">` as a permanently visible
+ * conversation surface — no floating bubble, no toggle. The greeting
+ * is shown automatically via the `resetGraphEditingAgent` trigger
+ * (which fires on graph URL change and calls `showGreeting` when the
+ * workbench is active).
+ *
+ * On first mount, if no entries exist yet, we show the greeting
+ * immediately so the column is never empty.
+ */
+@customElement("bb-conversation-column")
+class ConversationColumn extends SignalWatcher(LitElement) {
+  @consume({ context: scaContext })
+  accessor sca!: SCA;
+
+  static styles = css`
+    :host {
+      display: flex;
+      flex-direction: column;
+      width: 100%;
+      height: 100%;
+      background: light-dark(var(--n-98), var(--n-15));
+    }
+
+    bb-chat-panel {
+      flex: 1;
+      min-height: 0;
+    }
+  `;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+
+    // Ensure the conversation opens with a greeting when the workbench
+    // first mounts. The trigger handles subsequent graph changes.
+    const agent = this.sca.controller.editor.graphEditingAgent;
+    agent.showGreeting();
+  }
+
+  render() {
+    return html`<bb-chat-panel
+      mode="embedded"
+      .showSelectionStrip=${false}
+    ></bb-chat-panel>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "bb-conversation-column": ConversationColumn;
+  }
+}

--- a/packages/visual-editor/src/ui/elements/elements.ts
+++ b/packages/visual-editor/src/ui/elements/elements.ts
@@ -69,6 +69,7 @@ export { Snackbar } from "./toast/snackbar.js";
 export { UISplitter } from "./splitter/ui-splitter.js";
 export { UITriSplitter } from "./splitter/ui-tri-splitter.js";
 export { AgentWorkbench } from "./agent-workbench/agent-workbench.js";
+export { ConversationColumn } from "./agent-workbench/conversation-column.js";
 export { RunLogColumn } from "./agent-workbench/run-log-column.js";
 export { RunView } from "./agent-workbench/run-view.js";
 export { ObjectiveEditor } from "./agent-workbench/objective-editor/objective-editor.js";

--- a/packages/visual-editor/src/ui/elements/graph-editing-chat/chat-panel.ts
+++ b/packages/visual-editor/src/ui/elements/graph-editing-chat/chat-panel.ts
@@ -49,6 +49,9 @@ class ChatPanel extends SignalWatcher(LitElement) {
   @property({ type: String, reflect: true })
   accessor mode: "floating" | "embedded" = "floating";
 
+  @property({ type: Boolean })
+  accessor showSelectionStrip = true;
+
   readonly #inputRef = createRef<ExpandingTextarea>();
 
   #showAddAssetModal = false;
@@ -95,11 +98,36 @@ class ChatPanel extends SignalWatcher(LitElement) {
         border-top: none;
         box-shadow: none;
         flex: 1;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
       }
 
       :host([mode="embedded"]) .messages {
         mask-image: none;
         -webkit-mask-image: none;
+        min-height: 0;
+        flex: 1;
+        padding-bottom: var(--bb-grid-size-4);
+      }
+
+      /* Spacer pushes content to the bottom when the conversation
+         is short. Compresses to zero when it overflows, allowing
+         normal scrolling. */
+      :host([mode="embedded"]) .messages::before {
+        content: "";
+        flex: 1;
+      }
+
+      :host([mode="embedded"]) .input-area {
+        background: light-dark(var(--n-98), var(--n-15));
+        border-top: 1px solid light-dark(var(--n-90), var(--n-70));
+        flex-shrink: 0;
+      }
+
+      :host([mode="embedded"]) bb-expanding-textarea {
+        background: var(--light-dark-n-100);
+        scrollbar-width: none;
       }
 
       /* ── Messages ── */
@@ -111,8 +139,6 @@ class ChatPanel extends SignalWatcher(LitElement) {
         display: flex;
         flex-direction: column;
         gap: var(--bb-grid-size-3);
-        margin-right: 4px;
-        margin-top: 8px;
         scrollbar-width: thin;
         scrollbar-color: var(--light-dark-n-60) transparent;
         mask-image: linear-gradient(transparent 0%, black 12px, black 100%);
@@ -290,7 +316,7 @@ class ChatPanel extends SignalWatcher(LitElement) {
         display: flex;
         flex-direction: column;
         gap: 0;
-        border-top: 1px solid var(--light-dark-n-95);
+        border-top: 1px solid light-dark(var(--n-90), var(--n-70));
       }
 
       .input-row {
@@ -561,7 +587,7 @@ class ChatPanel extends SignalWatcher(LitElement) {
             : nothing}
         </div>
 
-        ${this.#renderSelectionStrip()}
+        ${this.showSelectionStrip ? this.#renderSelectionStrip() : nothing}
 
         <div class="input-area">
           ${this.#renderAssetShelf()}

--- a/packages/visual-editor/src/ui/elements/graph-editing-chat/graph-editing-chat.ts
+++ b/packages/visual-editor/src/ui/elements/graph-editing-chat/graph-editing-chat.ts
@@ -208,12 +208,6 @@ class GraphEditingChat extends SignalWatcher(LitElement) {
       return nothing;
     }
 
-    // If the graph changed, reset the loop
-    if (agent.currentFlow !== parsedUrl.flow) {
-      this.sca.actions.graphEditingAgent.resetGraphEditingAgent();
-      agent.currentFlow = parsedUrl.flow ?? null;
-    }
-
     const opie = html`<bb-opie-avatar
       ?highlighted=${agent.open}
       @click=${() => {

--- a/packages/visual-editor/tests/sca/actions/agent/graph-editing-agent-actions.test.ts
+++ b/packages/visual-editor/tests/sca/actions/agent/graph-editing-agent-actions.test.ts
@@ -45,7 +45,11 @@ async function makeControllerStub(id: string): Promise<AppController> {
   await devtools.isHydrated;
   await devtools.opie.isHydrated;
   return {
-    editor: { graphEditingAgent: agent, devtools },
+    editor: {
+      graphEditingAgent: agent,
+      devtools,
+      workbench: { eligible: false, view: "classic" },
+    },
     global: { onboarding: { appMode: "canvas" } },
   } as unknown as AppController;
 }
@@ -98,7 +102,6 @@ suite("graph-editing-agent-actions", () => {
     agent.loopRunning = true;
     agent.waiting = true;
     agent.processing = true;
-    agent.currentFlow = "flow-1";
     agent.addMessage("user", "Hello");
     const devtools = controller.editor.devtools;
     const opie = devtools.opie;
@@ -119,7 +122,6 @@ suite("graph-editing-agent-actions", () => {
     assert.strictEqual(agent.loopRunning, false);
     assert.strictEqual(agent.waiting, false);
     assert.strictEqual(agent.processing, false);
-    assert.strictEqual(agent.currentFlow, null);
 
     assert.deepStrictEqual(opie.entries, []);
     assert.strictEqual(opie.systemInstruction, "");

--- a/packages/visual-editor/tests/sca/actions/workbench/workbench-actions.test.ts
+++ b/packages/visual-editor/tests/sca/actions/workbench/workbench-actions.test.ts
@@ -11,6 +11,7 @@ import * as workbenchActions from "../../../../src/sca/actions/workbench/workben
 import {
   onWorkbenchEligibilityChange,
   WorkbenchEligibility,
+  onWorkbenchActivation,
 } from "../../../../src/sca/actions/workbench/triggers.js";
 import type { AppController } from "../../../../src/sca/controller/controller.js";
 import type { AppServices } from "../../../../src/sca/services/services.js";
@@ -437,6 +438,53 @@ suite("Workbench Actions", () => {
       });
     });
   });
+
+  suite("selectAgentNodeOnActivation", () => {
+    test("selects agent node when workbench becomes active", async () => {
+      let selectedIds: string[] | undefined;
+
+      const singleAgentGraph: GraphDescriptor = {
+        title: "Single Agent",
+        nodes: [
+          {
+            id: "agent-node",
+            type: "embed://a2/generate.bgl.json#module:main",
+            configuration: { "generation-mode": "agent" },
+          },
+        ],
+        edges: [],
+      };
+
+      const env = createMockEnvironment({
+        ...defaultRuntimeFlags,
+        enableAgentWorkbench: true,
+      });
+      await env.isHydrated;
+
+      workbenchActions.bind({
+        services: {} as never,
+        controller: {
+          editor: {
+            graph: {
+              get graph() {
+                return singleAgentGraph;
+              },
+            },
+            selection: {
+              selectNodes: (ids: string[]) => {
+                selectedIds = ids;
+              },
+            },
+          },
+        } as never,
+        env,
+      });
+
+      await workbenchActions.selectAgentNodeOnActivation();
+
+      assert.deepEqual(selectedIds, ["agent-node"]);
+    });
+  });
 });
 
 suite("Workbench Triggers", () => {
@@ -526,6 +574,71 @@ suite("Workbench Triggers", () => {
       const trigger = onWorkbenchEligibilityChange(bind);
 
       assert.strictEqual(trigger.condition(), WorkbenchEligibility.INELIGIBLE);
+    });
+  });
+
+  suite("onWorkbenchActivation", () => {
+    test("returns true only when transition to active occurs", async () => {
+      const singleAgentGraph: GraphDescriptor = {
+        title: "Single Agent",
+        nodes: [
+          {
+            id: "agent-node",
+            type: "embed://a2/generate.bgl.json#module:main",
+            configuration: { "generation-mode": "agent" },
+          },
+        ],
+        edges: [],
+      };
+
+      const env = createMockEnvironment({
+        ...defaultRuntimeFlags,
+        enableAgentWorkbench: true,
+      });
+      await env.isHydrated;
+
+      const controller = {
+        editor: {
+          graph: {
+            get graph() {
+              return singleAgentGraph;
+            },
+          },
+          workbench: {
+            eligible: false,
+            view: "classic",
+          },
+        },
+      } as unknown as AppController;
+
+      const bind = {
+        controller,
+        services: {} as unknown as AppServices,
+        env,
+      };
+
+      const trigger = onWorkbenchActivation(bind);
+
+      // Initially inactive -> returns false
+      assert.strictEqual(trigger.condition(), false);
+
+      // Change workbench state to active
+      controller.editor.workbench.eligible = true;
+      controller.editor.workbench.view = "workbench";
+
+      // Should return true on active transition
+      assert.strictEqual(trigger.condition(), true);
+
+      // Next check remains active -> returns false (no change)
+      assert.strictEqual(trigger.condition(), false);
+
+      // Deactivate
+      controller.editor.workbench.view = "classic";
+      assert.strictEqual(trigger.condition(), false);
+
+      // Reactivate -> returns true
+      controller.editor.workbench.view = "workbench";
+      assert.strictEqual(trigger.condition(), true);
     });
   });
 });

--- a/packages/visual-editor/tests/sca/controller/subcontrollers/editor/graph-editing-agent/graph-editing-agent-controller.test.ts
+++ b/packages/visual-editor/tests/sca/controller/subcontrollers/editor/graph-editing-agent/graph-editing-agent-controller.test.ts
@@ -220,30 +220,6 @@ suite("GraphEditingAgentController", () => {
     assert.strictEqual(ctrl.autoFocus, true);
   });
 
-  // ── currentFlow ───────────────────────────────────────────────────────────
-
-  test("currentFlow defaults to null", async () => {
-    const ctrl = new GraphEditingAgentController(
-      "GEA_ctrl_12",
-      "GraphEditingAgentController"
-    );
-    await ctrl.isHydrated;
-
-    assert.strictEqual(ctrl.currentFlow, null);
-  });
-
-  test("currentFlow is settable", async () => {
-    const ctrl = new GraphEditingAgentController(
-      "GEA_ctrl_13",
-      "GraphEditingAgentController"
-    );
-    await ctrl.isHydrated;
-
-    ctrl.currentFlow = "flow-123";
-    await ctrl.isSettled;
-    assert.strictEqual(ctrl.currentFlow, "flow-123");
-  });
-
   // ── reset ─────────────────────────────────────────────────────────────────
 
   test("reset clears all state", async () => {
@@ -260,7 +236,6 @@ suite("GraphEditingAgentController", () => {
     ctrl.waiting = true;
     ctrl.processing = true;
     ctrl.loopRunning = true;
-    ctrl.currentFlow = "flow-xyz";
     ctrl.autoFocus = true;
     await ctrl.isSettled;
 
@@ -272,7 +247,6 @@ suite("GraphEditingAgentController", () => {
     assert.strictEqual(ctrl.waiting, false);
     assert.strictEqual(ctrl.processing, false);
     assert.strictEqual(ctrl.loopRunning, false);
-    assert.strictEqual(ctrl.currentFlow, null);
     assert.strictEqual(ctrl.autoFocus, false);
   });
 });

--- a/projects/workbench/PROJECT.md
+++ b/projects/workbench/PROJECT.md
@@ -339,20 +339,20 @@ column. Scrolling works naturally. Thoughts/thinking indicators appear inline.
 
 #### packages/visual-editor — UI
 
-- [ ] `bb-conversation-column` — new element wrapping the existing Opie chat
+- [x] `bb-conversation-column` — new element wrapping the existing Opie chat
       rendering. Extracts the chat log rendering from `bb-chat-panel` and mounts
       it as a full-height column with:
   - Conversation history (scrollable).
   - Input area at the bottom.
   - Opie avatar and greeting.
-- [ ] `bb-agent-workbench` — mount `bb-conversation-column` in the left column
+- [x] `bb-agent-workbench` — mount `bb-conversation-column` in the left column
       slot.
-- [ ] `bb-canvas-controller` / `bb-graph-editing-chat` — skip rendering the
+- [x] `bb-canvas-controller` / `bb-graph-editing-chat` — skip rendering the
       floating chat panel when workbench mode is active.
 
 #### packages/visual-editor — SCA
 
-- [ ] `GraphEditingAgentController` — the `open` field becomes irrelevant in
+- [x] `GraphEditingAgentController` — the `open` field becomes irrelevant in
       workbench mode (the conversation is always visible). The controller
       continues to own chat entries and processing state.
 


### PR DESCRIPTION
## What
Introduces `bb-conversation-column` as a permanently embedded chat interface for Opie in the Agent Workbench view, and automatically selects the single agent node upon workbench activation.

## Why
Supports Phase 3 of the Agent Workbench project, moving Opie from a floating bubble overlay to a structured, full-height left column container, and ensures Opie is automatically scoped to the single agent node upon entering the workbench.

## Changes

### packages/visual-editor (UI & Layout)
- **New Element**: Added `bb-conversation-column` hosting the embedded chat panel.
- **Agent Workbench**: Mounted the new conversation column in the left column slot, replacing the placeholder.
- **Selection Strip Bypassing**: Added `showSelectionStrip` property to `bb-chat-panel` to bypass rendering selection chips in embedded/workbench mode since there is only one selection possible.
- **Embedded Mode Styling**: Reconfigured `bb-chat-panel` in embedded mode to use static flexbox layout, anchoring the input area naturally at the bottom and preventing overlap quirks when the text area expands dynamically. Added a contrast background color for the expanding textarea.

### packages/visual-editor (SCA State, Actions & Triggers)
- **Automatic Selection**: Added `onWorkbenchActivation` trigger and `selectAgentNodeOnActivation` action to automatically select the single agent node when the workbench becomes active.
- **Controller Cleanup**: Removed the redundant `currentFlow` tracking field on `GraphEditingAgentController` since url-change tracking is already fully managed by triggers.
- **Auto-Greeting Trigger**: Hooked `showGreeting()` directly into the `resetGraphEditingAgent` action so a greeting is displayed automatically upon graph reset when in workbench mode.
- **Trigger Consolidation**: Cleaned up the redundant render-method reset checks in `graph-editing-chat.ts` to defer exclusively to the `onGraphUrlChange` signal trigger.

## Testing
- Added unit tests for `onWorkbenchActivation` and `selectAgentNodeOnActivation`.
- Verified unit test suite: `npm run test:file` passes for both action and controller tests.
- Checked TypeScript compiler validation: `npx tsc --noEmit` compiles cleanly.