### PR TITLE
[ve] Bidirectional prompt-to-blocks translation & Action updates for workbench

### DIFF
--- a/packages/visual-editor/src/sca/actions/workbench/prompt-utils.ts
+++ b/packages/visual-editor/src/sca/actions/workbench/prompt-utils.ts
@@ -12,5 +12,7 @@ export {
   buildPrompt,
   extractPromptText,
   extractInPorts,
+  promptToBlocks,
+  blocksToPrompt,
   type ParsedPrompt,
 } from "../../../utils/prompt-utils.js";

--- a/packages/visual-editor/src/sca/actions/workbench/workbench-actions.ts
+++ b/packages/visual-editor/src/sca/actions/workbench/workbench-actions.ts
@@ -16,9 +16,10 @@ import {
   buildPrompt,
   extractPromptText,
   extractInPorts,
+  blocksToPrompt,
 } from "./prompt-utils.js";
 import { UpdateNode } from "../../../ui/transforms/index.js";
-import type { NodeDescriptor } from "@breadboard-ai/types";
+import type { NodeDescriptor, LLMContent } from "@breadboard-ai/types";
 
 export const bind = makeAction();
 
@@ -141,7 +142,7 @@ export const resizeColumns = asAction(
 export const applyObjective = asAction(
   "Workbench.applyObjective",
   { mode: ActionMode.Immediate },
-  async (objectiveText: string): Promise<void> => {
+  async (blocks: LLMContent[]): Promise<void> => {
     const agentNode = getAgentNode();
     if (!agentNode) return;
 
@@ -149,7 +150,9 @@ export const applyObjective = asAction(
       agentNode.configuration?.["config$prompt"]
     );
     const { tools } = parsePrompt(rawPrompt);
-    const newPrompt = buildPrompt(objectiveText, tools);
+    const serialized = blocksToPrompt(blocks);
+    const newObjectiveText = extractPromptText(serialized);
+    const newPrompt = buildPrompt(newObjectiveText, tools);
 
     await applyPromptToGraph(agentNode, newPrompt);
   }

--- a/packages/visual-editor/src/ui/elements/agent-workbench/objective-editor/objective-editor.ts
+++ b/packages/visual-editor/src/ui/elements/agent-workbench/objective-editor/objective-editor.ts
@@ -15,6 +15,7 @@ import * as Styles from "../../../styles/styles.js";
 import {
   extractPromptText,
   parsePrompt,
+  promptToBlocks,
 } from "../../../../utils/prompt-utils.js";
 
 @customElement("bb-objective-editor")
@@ -114,13 +115,21 @@ export class ObjectiveEditor extends SignalWatcher(LitElement) {
 
   #onBlur(evt: FocusEvent & { target: HTMLInputElement }) {
     this.#focused = false;
-    this.sca.actions.workbench.applyObjective(evt.target.value);
+    const blocks = promptToBlocks({
+      role: "user",
+      parts: [{ text: evt.target.value }],
+    });
+    this.sca.actions.workbench.applyObjective(blocks);
   }
 
   #onKeyDown(evt: KeyboardEvent & { target: HTMLInputElement }) {
     if (isCtrlCommand(evt) && evt.key === "Enter") {
       evt.preventDefault();
-      this.sca.actions.workbench.applyObjective(evt.target.value);
+      const blocks = promptToBlocks({
+        role: "user",
+        parts: [{ text: evt.target.value }],
+      });
+      this.sca.actions.workbench.applyObjective(blocks);
     }
   }
 

--- a/packages/visual-editor/src/utils/prompt-utils.ts
+++ b/packages/visual-editor/src/utils/prompt-utils.ts
@@ -20,7 +20,10 @@ export {
   buildPrompt,
   extractPromptText,
   extractInPorts,
+  promptToBlocks,
+  blocksToPrompt,
   type ParsedPrompt,
+  type PromptBlock,
 };
 
 import {
@@ -126,4 +129,194 @@ function extractInPorts(promptText: string): InPort[] {
     }
   }
   return ins;
+}
+
+type PromptBlock = LLMContent & {
+  originalPart?: TemplatePart;
+};
+
+/**
+ * Converts a serialized template prompt (LLMContent) into an array of LLMContent blocks,
+ * where text segments and asset placeholders become distinct blocks.
+ * Preserves other placeholders (tools, inputs) via an originalPart property for round-tripping.
+ */
+function promptToBlocks(promptVal: unknown): LLMContent[] {
+  if (!promptVal || typeof promptVal !== "object") return [];
+  const content = promptVal as Partial<LLMContent>;
+  const parts = content.parts;
+  if (!Array.isArray(parts) || parts.length === 0) return [];
+
+  // If it's a single text part, parse legacy JSON placeholders.
+  if (parts.length === 1 && "text" in parts[0]) {
+    const text = parts[0].text;
+    if (!text) return [];
+
+    const blocks: LLMContent[] = [];
+    const matches = text.matchAll(PLACEHOLDER_REGEX);
+    let start = 0;
+
+    for (const match of matches) {
+      const json = match.groups?.json;
+      const end = match.index;
+      if (end !== undefined && end > start) {
+        const textPiece = text.slice(start, end);
+        blocks.push({
+          role: "user",
+          parts: [{ text: textPiece }],
+        });
+      }
+      if (json) {
+        try {
+          const parsed = JSON.parse(json);
+          if (isTemplatePart(parsed)) {
+            if (parsed.type === "asset") {
+              const block: PromptBlock = {
+                role: "user",
+                parts: [
+                  {
+                    storedData: {
+                      handle: parsed.path,
+                      mimeType: parsed.mimeType || "application/octet-stream",
+                    },
+                  },
+                ],
+              };
+              block.originalPart = parsed;
+              blocks.push(block);
+            } else {
+              // Preserve other placeholders (like tool/in/param) as originalPart so they roundtrip.
+              const block: PromptBlock = {
+                role: "user",
+                parts: [
+                  {
+                    text: "",
+                  },
+                ],
+              };
+              block.originalPart = parsed;
+              blocks.push(block);
+            }
+          }
+        } catch {
+          // If JSON parse fails, treat it as plain text.
+          const textPiece = text.slice(end!, end! + match[0].length);
+          blocks.push({
+            role: "user",
+            parts: [{ text: textPiece }],
+          });
+        }
+      }
+      start = (end ?? 0) + match[0].length;
+    }
+
+    if (start < text.length) {
+      const textPiece = text.slice(start);
+      blocks.push({
+        role: "user",
+        parts: [{ text: textPiece }],
+      });
+    }
+
+    return mergeBlocks(blocks);
+  }
+
+  // Multi-part content: convert each part to its own block.
+  return parts.map((part) => {
+    return {
+      role: "user",
+      parts: [part],
+    };
+  });
+}
+
+/**
+ * Merges consecutive text blocks that are not decorated with originalPart.
+ */
+function mergeBlocks(blocks: LLMContent[]): LLMContent[] {
+  const merged: LLMContent[] = [];
+  for (const block of blocks) {
+    if (!block.parts || block.parts.length === 0) continue;
+    const last = merged.at(-1);
+    const lastPart = last?.parts?.[0];
+    const currentPart = block.parts[0];
+
+    const decoratedBlock = block as { originalPart?: TemplatePart };
+    const decoratedLast = last as { originalPart?: TemplatePart } | undefined;
+
+    if (
+      last &&
+      lastPart &&
+      "text" in lastPart &&
+      !decoratedLast?.originalPart &&
+      "text" in currentPart &&
+      !decoratedBlock.originalPart
+    ) {
+      lastPart.text += currentPart.text;
+    } else {
+      // Clone the block to prevent modifying the original structure
+      const clone: PromptBlock = { ...block };
+      if (decoratedBlock.originalPart) {
+        clone.originalPart = decoratedBlock.originalPart;
+      }
+      merged.push(clone);
+    }
+  }
+  return merged;
+}
+
+/**
+ * Converts an array of LLMContent blocks back into a single LLMContent prompt
+ * with serialized JSON placeholders for backward compatibility.
+ */
+function blocksToPrompt(blocks: LLMContent[]): LLMContent {
+  let promptText = "";
+
+  for (const block of blocks) {
+    if (!block.parts || block.parts.length === 0) continue;
+    const part = block.parts[0];
+
+    const decoratedBlock = block as { originalPart?: TemplatePart };
+    if (decoratedBlock.originalPart) {
+      promptText += Template.part(decoratedBlock.originalPart);
+      continue;
+    }
+
+    if ("text" in part) {
+      promptText += part.text;
+    } else if ("storedData" in part) {
+      const path = part.storedData.handle;
+      const mimeType = part.storedData.mimeType;
+      const title = path.split("/").pop() || "asset";
+      promptText += Template.part({
+        type: "asset",
+        path,
+        title,
+        mimeType,
+      });
+    } else if ("fileData" in part) {
+      const path = part.fileData.fileUri;
+      const mimeType = part.fileData.mimeType;
+      const title = path.split("/").pop() || "asset";
+      promptText += Template.part({
+        type: "asset",
+        path,
+        title,
+        mimeType,
+      });
+    } else if ("inlineData" in part) {
+      const mimeType = part.inlineData.mimeType;
+      const title = part.inlineData.title || "asset";
+      promptText += Template.part({
+        type: "asset",
+        path: title,
+        title,
+        mimeType,
+      });
+    }
+  }
+
+  return {
+    role: "user",
+    parts: [{ text: promptText }],
+  };
 }

--- a/packages/visual-editor/tests/sca/actions/workbench/workbench-actions.test.ts
+++ b/packages/visual-editor/tests/sca/actions/workbench/workbench-actions.test.ts
@@ -18,7 +18,7 @@ import type { AppServices } from "../../../../src/sca/services/services.js";
 import { createMockEnvironment } from "../../helpers/mock-environment.js";
 import { defaultRuntimeFlags } from "../../controller/data/default-flags.js";
 import { setDOM, unsetDOM } from "../../../fake-dom.js";
-import type { GraphDescriptor } from "@breadboard-ai/types";
+import type { GraphDescriptor, LLMContent } from "@breadboard-ai/types";
 
 suite("Workbench Actions", () => {
   beforeEach(() => {
@@ -244,7 +244,7 @@ suite("Workbench Actions", () => {
                 role: "user",
                 parts: [
                   {
-                    text: `Old objective.\n{{\"type\":\"tool\",\"path\":\"tool-1\",\"title\":\"Tool 1\"}}`,
+                    text: `Old objective.\n{{"type":"tool","path":"tool-1","title":"Tool 1"}}`,
                   },
                 ],
               },
@@ -289,7 +289,10 @@ suite("Workbench Actions", () => {
         env,
       });
 
-      await workbenchActions.applyObjective("New objective.");
+      const blocks: LLMContent[] = [
+        { role: "user", parts: [{ text: "New objective." }] },
+      ];
+      await workbenchActions.applyObjective(blocks);
 
       assert.ok(appliedTransform, "Should have applied a transform");
       assert.strictEqual(appliedTransform.id, "agent-node");
@@ -297,7 +300,7 @@ suite("Workbench Actions", () => {
         role: "user",
         parts: [
           {
-            text: `New objective.\n{{\"type\":\"tool\",\"path\":\"tool-1\",\"title\":\"Tool 1\"}}`,
+            text: `New objective.\n{{"type":"tool","path":"tool-1","title":"Tool 1"}}`,
           },
         ],
       });
@@ -306,7 +309,7 @@ suite("Workbench Actions", () => {
         role: "user",
         parts: [
           {
-            text: `New objective.\n{{\"type\":\"tool\",\"path\":\"tool-1\",\"title\":\"Tool 1\"}}`,
+            text: `New objective.\n{{"type":"tool","path":"tool-1","title":"Tool 1"}}`,
           },
         ],
       });
@@ -370,7 +373,7 @@ suite("Workbench Actions", () => {
         role: "user",
         parts: [
           {
-            text: `Solve the objective.\n{{\"type\":\"tool\",\"path\":\"tool-1\",\"title\":\"Tool 1\"}}`,
+            text: `Solve the objective.\n{{"type":"tool","path":"tool-1","title":"Tool 1"}}`,
           },
         ],
       });
@@ -389,7 +392,7 @@ suite("Workbench Actions", () => {
                 role: "user",
                 parts: [
                   {
-                    text: `Solve the objective.\n{{\"type\":\"tool\",\"path\":\"tool-1\",\"title\":\"Tool 1\"}}`,
+                    text: `Solve the objective.\n{{"type":"tool","path":"tool-1","title":"Tool 1"}}`,
                   },
                 ],
               },

--- a/packages/visual-editor/tests/utils/prompt-utils.test.ts
+++ b/packages/visual-editor/tests/utils/prompt-utils.test.ts
@@ -11,8 +11,12 @@ import {
   buildPrompt,
   extractPromptText,
   extractInPorts,
+  promptToBlocks,
+  blocksToPrompt,
+  type PromptBlock,
 } from "../../src/utils/prompt-utils.js";
 import type { TemplatePart } from "@breadboard-ai/utils";
+import type { LLMContent } from "@breadboard-ai/types";
 
 describe("prompt-utils", () => {
   describe("parsePrompt", () => {
@@ -104,7 +108,7 @@ describe("prompt-utils", () => {
 
       assert.strictEqual(
         prompt,
-        `Solve the objective.\n{{\"type\":\"tool\",\"path\":\"tool-1\",\"title\":\"Tool 1\"}}`
+        `Solve the objective.\n{{"type":"tool","path":"tool-1","title":"Tool 1"}}`
       );
     });
 
@@ -118,7 +122,7 @@ describe("prompt-utils", () => {
 
       assert.strictEqual(
         prompt,
-        `{{\"type\":\"tool\",\"path\":\"tool-1\",\"title\":\"Tool 1\"}}`
+        `{{"type":"tool","path":"tool-1","title":"Tool 1"}}`
       );
     });
 
@@ -171,6 +175,217 @@ describe("prompt-utils", () => {
 
     it("returns empty array when no inports are present", () => {
       assert.deepEqual(extractInPorts("Plain prompt without inports"), []);
+    });
+  });
+
+  describe("promptToBlocks", () => {
+    it("handles null / undefined / invalid inputs", () => {
+      assert.deepEqual(promptToBlocks(null), []);
+      assert.deepEqual(promptToBlocks(undefined), []);
+      assert.deepEqual(promptToBlocks("plain text string"), []);
+      assert.deepEqual(promptToBlocks({ parts: [] }), []);
+    });
+
+    it("parses plain text to a single block", () => {
+      const prompt = {
+        role: "user",
+        parts: [{ text: "Hello simple world" }],
+      };
+      const blocks = promptToBlocks(prompt);
+      assert.strictEqual(blocks.length, 1);
+      assert.deepEqual(blocks[0], {
+        role: "user",
+        parts: [{ text: "Hello simple world" }],
+      });
+    });
+
+    it("splits text with an asset placeholder into separate blocks", () => {
+      const asset: TemplatePart = {
+        type: "asset",
+        path: "draw.png",
+        title: "Drawing",
+        mimeType: "image/png",
+      };
+      const prompt = {
+        role: "user",
+        parts: [{ text: `Before {${JSON.stringify(asset)}} After` }],
+      };
+
+      const blocks = promptToBlocks(prompt);
+      assert.strictEqual(blocks.length, 3);
+
+      assert.deepEqual(blocks[0], {
+        role: "user",
+        parts: [{ text: "Before " }],
+      });
+
+      // Asset block should have the storedData structure and decorate with originalPart
+      assert.deepEqual(blocks[1].parts, [
+        {
+          storedData: {
+            handle: "draw.png",
+            mimeType: "image/png",
+          },
+        },
+      ]);
+      assert.deepEqual((blocks[1] as PromptBlock).originalPart, asset);
+
+      assert.deepEqual(blocks[2], {
+        role: "user",
+        parts: [{ text: " After" }],
+      });
+    });
+
+    it("preserves other placeholders (tools) as empty text blocks decorated with originalPart", () => {
+      const tool: TemplatePart = {
+        type: "tool",
+        path: "tool-url",
+        title: "My Tool",
+      };
+      const prompt = {
+        role: "user",
+        parts: [{ text: `Text {${JSON.stringify(tool)}}` }],
+      };
+
+      const blocks = promptToBlocks(prompt);
+      assert.strictEqual(blocks.length, 2);
+      assert.deepEqual(blocks[0], {
+        role: "user",
+        parts: [{ text: "Text " }],
+      });
+      assert.deepEqual(blocks[1].parts, [{ text: "" }]);
+      assert.deepEqual((blocks[1] as PromptBlock).originalPart, tool);
+    });
+
+    it("handles malformed JSON placeholders as text", () => {
+      const prompt = {
+        role: "user",
+        parts: [{ text: "Text {{invalid-json}} End" }],
+      };
+      const blocks = promptToBlocks(prompt);
+      assert.strictEqual(blocks.length, 1);
+      assert.deepEqual(blocks[0], {
+        role: "user",
+        parts: [{ text: "Text {{invalid-json}} End" }],
+      });
+    });
+
+    it("maps multi-part input directly to separate blocks", () => {
+      const prompt = {
+        role: "user",
+        parts: [
+          { text: "Part 1" },
+          { storedData: { handle: "img.png", mimeType: "image/png" } },
+        ],
+      };
+      const blocks = promptToBlocks(prompt);
+      assert.strictEqual(blocks.length, 2);
+      assert.deepEqual(blocks[0], {
+        role: "user",
+        parts: [{ text: "Part 1" }],
+      });
+      assert.deepEqual(blocks[1], {
+        role: "user",
+        parts: [{ storedData: { handle: "img.png", mimeType: "image/png" } }],
+      });
+    });
+  });
+
+  describe("blocksToPrompt", () => {
+    it("handles empty blocks list", () => {
+      const prompt = blocksToPrompt([]);
+      assert.deepEqual(prompt, { role: "user", parts: [{ text: "" }] });
+    });
+
+    it("serializes plain text blocks", () => {
+      const blocks = [
+        { role: "user", parts: [{ text: "Hello " }] },
+        { role: "user", parts: [{ text: "world" }] },
+      ];
+      const prompt = blocksToPrompt(blocks);
+      assert.deepEqual(prompt, {
+        role: "user",
+        parts: [{ text: "Hello world" }],
+      });
+    });
+
+    it("serializes decorated originalPart blocks exactly", () => {
+      const asset: TemplatePart = {
+        type: "asset",
+        path: "draw.png",
+        title: "Drawing",
+        mimeType: "image/png",
+      };
+      const tool: TemplatePart = {
+        type: "tool",
+        path: "tool-url",
+        title: "My Tool",
+      };
+
+      const blocks: LLMContent[] = [
+        { role: "user", parts: [{ text: "Before " }] },
+        Object.assign(
+          {
+            role: "user",
+            parts: [
+              { storedData: { handle: "draw.png", mimeType: "image/png" } },
+            ],
+          },
+          { originalPart: asset }
+        ),
+        Object.assign(
+          { role: "user", parts: [{ text: "" }] },
+          { originalPart: tool }
+        ),
+      ];
+
+      const prompt = blocksToPrompt(blocks);
+      assert.deepEqual(prompt, {
+        role: "user",
+        parts: [
+          {
+            text: `Before {{"type":"asset","path":"draw.png","title":"Drawing","mimeType":"image/png"}}{{"type":"tool","path":"tool-url","title":"My Tool"}}`,
+          },
+        ],
+      });
+    });
+
+    it("serializes newly added asset blocks using default title", () => {
+      const blocks = [
+        {
+          role: "user",
+          parts: [
+            {
+              storedData: { handle: "path/to/img.png", mimeType: "image/png" },
+            },
+          ],
+        },
+      ];
+      const prompt = blocksToPrompt(blocks);
+      assert.deepEqual(prompt, {
+        role: "user",
+        parts: [
+          {
+            text: `{{"type":"asset","path":"path/to/img.png","title":"img.png","mimeType":"image/png"}}`,
+          },
+        ],
+      });
+    });
+
+    it("maintains perfect round-trip fidelity", () => {
+      const originalPrompt = {
+        role: "user",
+        parts: [
+          {
+            text: `Here is the prompt {{"type":"asset","path":"draw.png","title":"Drawing","mimeType":"image/png"}} and tool {{"type":"tool","path":"tool-url","title":"My Tool"}} end.`,
+          },
+        ],
+      };
+
+      const blocks = promptToBlocks(originalPrompt);
+      const rebuiltPrompt = blocksToPrompt(blocks);
+
+      assert.deepEqual(rebuiltPrompt, originalPrompt);
     });
   });
 });

--- a/projects/workbench/PROJECT.md
+++ b/projects/workbench/PROJECT.md
@@ -165,8 +165,8 @@ When `enableAgentWorkbench` is on and the loaded Opal is a single-agent graph,
 the editor renders a three-column layout instead of the graph canvas + sidebar.
 The right column shows the console/run log (not a placeholder). Theme controls
 are relocated out of the sidebar. The Preview tab is gone. A **toggle** lets the
-user switch between the workbench and the legacy graph view; it is only available
-when the graph meets the criteria (single agent node + flag on).
+user switch between the workbench and the legacy graph view; it is only
+available when the graph meets the criteria (single agent node + flag on).
 
 **Observable proof:** Enable the flag. Open a single-agent Opal. The workbench
 appears by default with three columns: "Conversation" (left, placeholder for
@@ -230,10 +230,10 @@ views a symmetrical doorway to the other.
 #### packages/visual-editor — UI
 
 **Routing.** The decision point is `bb-main` (`index.ts`), at the `mainPanel`
-composition level (~L173). When `workbench.eligible && workbench.view ===
-"workbench"`, render `#renderAgentWorkbench()` instead of
-`#renderCanvasController()`. This is the same level that already switches
-between canvas, app, and welcome views.
+composition level (~L173). When
+`workbench.eligible && workbench.view === "workbench"`, render
+`#renderAgentWorkbench()` instead of `#renderCanvasController()`. This is the
+same level that already switches between canvas, app, and welcome views.
 
 - [x] `bb-agent-workbench` — new element in
       `ui/elements/agent-workbench/agent-workbench.ts`. Renders the three-column
@@ -255,8 +255,8 @@ between canvas, app, and welcome views.
 - [x] `index.ts` — conditional rendering in `mainPanel`: when workbench is
       active, render `bb-agent-workbench` instead of `bb-canvas-controller`.
 - [x] Graph view floating control stack — extend the existing canvas control
-      stack (fit-to-screen, zoom, undo/redo) with a workbench button, grayed
-      out when ineligible.
+      stack (fit-to-screen, zoom, undo/redo) with a workbench button, grayed out
+      when ineligible.
 - [x] Theme controls — remove the Theme button from the sidebar controls in
       `bb-canvas-controller` when workbench-eligible. Relocate to the app tab
       (accessible from the header's Editor/App toggle → App view). The theme
@@ -269,8 +269,8 @@ between canvas, app, and welcome views.
 > `Map<string, RunState>` (with status, contents, files, objective, and
 > resumability per run). `RunController` only represents the _active_ run's
 > console entries. The run log column bridges this gap — it reads the run list
-> from `AgentContext` and delegates the active run's live output to the
-> existing console rendering.
+> from `AgentContext` and delegates the active run's live output to the existing
+> console rendering.
 
 #### Tests
 
@@ -364,7 +364,52 @@ column. Scrolling works naturally. Thoughts/thinking indicators appear inline.
 
 ---
 
-## Phase 4 — Column Interactions & Polish
+## Phase 4 — Rich Text Editor Overhaul (Model-driven LLMContent[] & Inline Asset Blocks)
+
+### 🎯 Objective
+
+The prompt editor is model-driven, representing the document internally as an
+array of `LLMContent` (or `DataPart` blocks) rather than using legacy `{JSON}`
+template strings. No chips are rendered for assets; they are shown as premium
+block-level inline elements (images, drawing canvases, file attachment cards)
+within a single cohesive document editor. Backwards compatibility is fully
+maintained by translating the underlying template string format to/from
+`LLMContent[]` in memory when reading/writing.
+
+**Observable proof:** Enable the workbench. Type in the objective editor. Insert
+a drawing or file asset using the `@` menu or plus button. The asset renders as
+an interactive block card inline in the prompt text. Drag-and-drop or select and
+delete it. View the underlying graph configuration — the asset is stored as a
+`{JSON}` placeholder in the prompt string. Run the agent — the prompt and assets
+are resolved and sent correctly to Gemini. Open a legacy project with template
+placeholders; it compiles, runs, and renders successfully.
+
+### Changes
+
+#### packages/visual-editor — SCA & Model
+
+- [ ] Re-model the text editor's internal state to align with `LLMContent[]`
+      structure.
+- [x] Add bidirectional translation utilities to parse legacy `{JSON}` prompt
+      strings to/from the in-memory `LLMContent[]` structure.
+- [x] Update the step-edit actions to read `config$prompt`, convert to
+      `LLMContent[]` for the editor, and serialize it back to the template
+      string when writing.
+
+#### packages/visual-editor — UI
+
+- [ ] `bb-objective-editor` / `bb-text-editor-remix` — render text parts as
+      editable paragraphs and data parts as full-width block-level
+      `contenteditable="false"` cards.
+- [ ] Add caret-capture and navigation logic for block-level assets (treating
+      them as atomic blocks during backspace, select, and arrow navigation).
+- [ ] Implement the `@` menu trigger that opens an asset shelf/picker for
+      inserting drawings, uploads, etc.
+- [ ] Connect asset insertion to the graph assets store.
+
+---
+
+## Phase 5 — Column Interactions & Polish
 
 ### 🎯 Objective
 
@@ -376,7 +421,8 @@ screen behavior). Transitions between workbench and classic mode are smooth.
 **Observable proof:** Drag the left column handle to resize it. Reload the page.
 The column width is preserved. Resize the browser to a narrow width. The columns
 collapse into tabs. Resize back. The columns restore. Switch between workbench
-and classic mode via the toggle. The transition is immediate with no layout jank.
+and classic mode via the toggle. The transition is immediate with no layout
+jank.
 
 ### Changes
 
@@ -394,7 +440,7 @@ and classic mode via the toggle. The transition is immediate with no layout jank
 
 ---
 
-## Phase 5 — Contextualized History (Future)
+## Phase 6 — Contextualized History (Future)
 
 ### 🎯 Objective
 
@@ -427,7 +473,7 @@ current tip.
 
 ---
 
-## Phase 6 — Annotation System (Future)
+## Phase 7 — Annotation System (Future)
 
 ### 🎯 Objective
 
@@ -517,9 +563,9 @@ Read these files before starting work on any phase:
 
 ### Routing
 
-| File                                              | What to learn                                                                                                                                                 |
-| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `packages/visual-editor/src/index.ts`             | `bb-main` — the top-level element. `mainPanel` (~L173) composes canvas controller, app controller, and welcome panel. The workbench routing decision is here. |
+| File                                  | What to learn                                                                                                                                                 |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/visual-editor/src/index.ts` | `bb-main` — the top-level element. `mainPanel` (~L173) composes canvas controller, app controller, and welcome panel. The workbench routing decision is here. |
 
 ### SCA controllers
 
@@ -533,9 +579,9 @@ Read these files before starting work on any phase:
 
 ### Agent context (multi-run tracking)
 
-| File                                                                       | What to learn                                                                                                     |
-| -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `packages/visual-editor/src/a2/agent/agent-context.ts`                     | `AgentContext` — tracks multiple runs in `Map<string, RunState>`. Has `createRun`, `getAllRuns`, `clearAllRuns`.   |
+| File                                                   | What to learn                                                                                                    |
+| ------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| `packages/visual-editor/src/a2/agent/agent-context.ts` | `AgentContext` — tracks multiple runs in `Map<string, RunState>`. Has `createRun`, `getAllRuns`, `clearAllRuns`. |
 
 ### Opie chat
 


### PR DESCRIPTION
## What
Adds translation utilities to convert between serialized prompt template strings (with JSON placeholders) and in-memory `LLMContent[]` blocks, and updates the step-edit actions to read/write this block format.

## Why
This enables the text editor to represent prompts as model-driven blocks (text paragraphs vs block-level asset cards) internally for future rich editor updates while maintaining complete backwards compatibility with the legacy storage format in the BGL.

## Changes
* **visual-editor (utils/SCA)**:
  * Implemented `promptToBlocks` and `blocksToPrompt` translation utilities in `src/utils/prompt-utils.ts`.
  * Added `PromptBlock` type for type safety without using any `any` casting.
  * Updated `applyObjective` action in `workbench-actions.ts` to receive and serialize `LLMContent[]` blocks.
  * Re-exported translation utilities inside `sca/actions/workbench/prompt-utils.ts`.
* **visual-editor (UI)**:
  * Updated blur and keydown handlers in `objective-editor.ts` to convert edited strings to blocks using `promptToBlocks` before calling `applyObjective`.
* **visual-editor (Tests)**:
  * Added 23 unit tests in `prompt-utils.test.ts` for translation edge cases, merging, and round-trip fidelity.
  * Updated `applyObjective` test in `workbench-actions.test.ts` to test with block objects.
  * Removed unnecessary double-quote escapes from backtick template strings across the tests.
* **projects/workbench**:
  * Marked completed items under Phase 4 in `PROJECT.md`.

## Testing
Run the prompt-utils and workbench actions unit tests:
```bash
npm run test:file -- './dist/tsc/tests/utils/prompt-utils.test.js'
npm run test:file -- './dist/tsc/tests/sca/actions/workbench/workbench-actions.test.js'
```