### PR TITLE
[agent] Add history property to AgentEventConsumer

### DIFF
--- a/packages/visual-editor/src/a2/agent/agent-event-consumer.ts
+++ b/packages/visual-editor/src/a2/agent/agent-event-consumer.ts
@@ -33,6 +33,12 @@ class AgentEventConsumer {
     (payload: AgentEventMap[AgentEventType]) => void | Promise<unknown>
   >();
 
+  readonly #history: AgentEvent[] = [];
+
+  get history(): ReadonlyArray<AgentEvent> {
+    return this.#history;
+  }
+
   /**
    * Register a handler for a specific event type.
    * Suspend-event handlers (waitForInput, waitForChoice) must return
@@ -63,6 +69,7 @@ class AgentEventConsumer {
    * Returns a Promise for suspend events, undefined otherwise.
    */
   handle(event: AgentEvent): void | Promise<unknown> {
+    this.#history.push(event);
     const type = eventType(event);
     const payload = eventPayload(event);
     const handler = this.#handlers.get(type);

--- a/packages/visual-editor/tests/agent/agent-event-consumer.test.ts
+++ b/packages/visual-editor/tests/agent/agent-event-consumer.test.ts
@@ -40,6 +40,18 @@ suite("AgentEventConsumer", () => {
     assert.strictEqual(result, undefined);
   });
 
+  test("accumulates history of all events handled", () => {
+    const consumer = new AgentEventConsumer();
+
+    consumer.handle({ thought: { text: "hello" } });
+    consumer.handle({ thought: { text: "world" } });
+
+    assert.deepStrictEqual(consumer.history, [
+      { thought: { text: "hello" } },
+      { thought: { text: "world" } },
+    ]);
+  });
+
   test("on() is chainable", () => {
     const consumer = new AgentEventConsumer();
     const thoughts: string[] = [];


### PR DESCRIPTION
## What
Adds a read-only `history` property to the `AgentEventConsumer` that accumulates all `AgentEvent`s processed by the handler.

## Why
This allows clients of `AgentEventConsumer` to retroactively inspect event history without needing to subscribe to events in real time or maintain their own duplicate event stores.

## Changes
- **packages/visual-editor**:
  - In `AgentEventConsumer` ([agent-event-consumer.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/src/a2/agent/agent-event-consumer.ts)), added a private `#history` array and a public `history` getter that exposes it as `ReadonlyArray<AgentEvent>`.
  - Updated `handle` to push events to `#history`.
  - Added unit tests in [agent-event-consumer.test.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/tests/agent/agent-event-consumer.test.ts) to verify event accumulation in `history`.

## Testing
- Run `npm run test:file -- './dist/tsc/tests/agent/agent-event-consumer.test.js'` in `packages/visual-editor`.
