### PR TITLE
[feedback] Switch feedback history to use AgentEventConsumer.history

### DIFF
--- a/packages/visual-editor/src/sca/actions/agent/graph-editing-agent-actions.ts
+++ b/packages/visual-editor/src/sca/actions/agent/graph-editing-agent-actions.ts
@@ -35,7 +35,12 @@ import {
   GraphEditingManager,
   GraphThemeGenerator,
 } from "../../../a2/agent/graph-editing/graph-editing-manager.js";
-import type { ChatEntry } from "../../types.js";
+import {
+  eventType,
+  eventPayload,
+  type AgentEvent,
+  type Payload,
+} from "../../../a2/agent/agent-event.js";
 
 export { bind, startGraphEditingAgent, resolveGraphEditingInput };
 
@@ -101,6 +106,7 @@ function startGraphEditingAgent(
     objective,
   }) as LocalAgentRun;
   currentRun = handle;
+  agent.setHistory(handle.events.history);
 
   const devtools = controller.editor.devtools?.opie;
   const translator = new EditingAgentPidginTranslator();
@@ -334,20 +340,76 @@ export const resetGraphEditingAgent = asAction(
 
 let feedbackTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
-function formatConversation(entries: readonly ChatEntry[], n = 10): string {
-  const lastN = entries.slice(-n);
-  return lastN
-    .map((entry) => {
-      if (entry.kind === "message") {
-        return `${entry.role.toUpperCase()}: ${entry.text}`;
-      }
-      if (entry.kind === "thought-group") {
-        const thoughts = entry.thoughts
-          .map((t) => `${t.title ?? "Thought"}: ${t.body}`)
-          .join("\n");
-        return `THOUGHTS:\n${thoughts}`;
+function formatLLMContent(content: LLMContent): string {
+  if (!content || !content.parts) return "";
+  return content.parts
+    .map((part) => {
+      if ("text" in part) {
+        return part.text;
       }
       return "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function formatAgentEventHistory(
+  events: ReadonlyArray<AgentEvent>,
+  n = 20
+): string {
+  const lastN = events.slice(-n);
+  return lastN
+    .map((event) => {
+      const type = eventType(event);
+      const payload = eventPayload(event);
+
+      switch (type) {
+        case "start": {
+          const p = payload as Payload<"start">;
+          return `START OBJECTIVE:\n${formatLLMContent(p.objective)}`;
+        }
+        case "thought": {
+          const p = payload as Payload<"thought">;
+          return `THOUGHT:\n${p.text}`;
+        }
+        case "functionCall": {
+          const p = payload as Payload<"functionCall">;
+          return `CALL TOOL: ${p.name}\nArgs: ${JSON.stringify(p.args)}`;
+        }
+        case "functionResult": {
+          const p = payload as Payload<"functionResult">;
+          return `TOOL RESULT: ${formatLLMContent(p.content)}`;
+        }
+        case "content": {
+          const p = payload as Payload<"content">;
+          return `MODEL:\n${formatLLMContent(p.content)}`;
+        }
+        case "waitForInput": {
+          const p = payload as Payload<"waitForInput">;
+          return `WAIT FOR INPUT:\n${formatLLMContent(p.prompt)}`;
+        }
+        case "waitForChoice": {
+          const p = payload as Payload<"waitForChoice">;
+          const choicesStr = p.choices
+            .map((c) => formatLLMContent(c.content))
+            .join(" | ");
+          return `WAIT FOR CHOICE:\n${formatLLMContent(p.prompt)}\nChoices: ${choicesStr}`;
+        }
+        case "applyEdits": {
+          const p = payload as Payload<"applyEdits">;
+          return `APPLY EDITS: ${p.label}`;
+        }
+        case "error": {
+          const p = payload as Payload<"error">;
+          return `ERROR: ${p.message}`;
+        }
+        case "complete": {
+          const p = payload as Payload<"complete">;
+          return `COMPLETE:\n${JSON.stringify(p.result)}`;
+        }
+        default:
+          return `${type.toUpperCase()} EVENT`;
+      }
     })
     .join("\n---\n");
 }
@@ -372,7 +434,8 @@ export const setOpieReaction = asAction(
 
     if (newReaction !== "none") {
       feedbackTimeoutId = setTimeout(() => {
-        const conversation = formatConversation(agent.entries, 10);
+        const events = agent.history;
+        const conversation = formatAgentEventHistory(events, 20);
         const productData = {
           reaction: newReaction,
           conversation,

--- a/packages/visual-editor/src/sca/controller/subcontrollers/editor/graph-editing-agent-controller.ts
+++ b/packages/visual-editor/src/sca/controller/subcontrollers/editor/graph-editing-agent-controller.ts
@@ -8,6 +8,7 @@ import { field } from "../../decorators/field.js";
 import { RootController } from "../root-controller.js";
 import { parseThought } from "../../../../a2/agent/thought-parser.js";
 import type { ChatEntry } from "../../../types.js";
+import type { AgentEvent } from "../../../../a2/agent/agent-event.js";
 import type { AppEnvironment } from "../../../environment/environment.js";
 
 export { GraphEditingAgentController };
@@ -31,6 +32,8 @@ const GREETINGS = [
  */
 class GraphEditingAgentController extends RootController {
   #env: AppEnvironment | undefined;
+
+  #history: ReadonlyArray<AgentEvent> = [];
 
   constructor(
     controllerId: string,
@@ -70,9 +73,17 @@ class GraphEditingAgentController extends RootController {
     return this._entries;
   }
 
+  get history(): ReadonlyArray<AgentEvent> {
+    return this.#history;
+  }
+
   // ═══════════════════════════════════════════════════════════════════════════
   // MUTATIONS
   // ═══════════════════════════════════════════════════════════════════════════
+
+  setHistory(history: ReadonlyArray<AgentEvent>) {
+    this.#history = history;
+  }
 
   addMessage(role: "user" | "model" | "system", text: string) {
     if (role === "user") {
@@ -118,5 +129,6 @@ class GraphEditingAgentController extends RootController {
     this.loopRunning = false;
     this.feedbackReaction = "none";
     this.autoFocus = false;
+    this.#history = [];
   }
 }

--- a/packages/visual-editor/tests/sca/actions/agent/graph-editing-agent-actions.test.ts
+++ b/packages/visual-editor/tests/sca/actions/agent/graph-editing-agent-actions.test.ts
@@ -11,8 +11,10 @@ import {
   startGraphEditingAgent,
   resolveGraphEditingInput,
   resetGraphEditingAgent,
+  setOpieReaction,
 } from "../../../../src/sca/actions/agent/graph-editing-agent-actions.js";
 import { GraphEditingAgentController } from "../../../../src/sca/controller/subcontrollers/editor/graph-editing-agent-controller.js";
+import { FeedbackController } from "../../../../src/sca/controller/subcontrollers/global/feedback-controller.js";
 import type {
   ChatEntry,
   GraphAssetDescriptor,
@@ -748,5 +750,78 @@ suite("graph-editing-agent-actions", () => {
     );
 
     services.agentService.endRun(activeHandle!.runId);
+  });
+
+  // ── setOpieReaction ────────────────────────────────────────────────────────
+
+  test("setOpieReaction sets feedback reaction and triggers feedback submission", async () => {
+    const controller = await makeControllerStub("GEA_act_set_opie");
+    controller.global.feedback = {
+      open: mock.fn(),
+    } as unknown as FeedbackController;
+    const services = makeServicesStub();
+    bind({
+      controller,
+      services,
+      env: createMockEnvironment(defaultRuntimeFlags),
+    });
+
+    const agent = controller.editor.graphEditingAgent;
+
+    // Start a dummy run to populate agent history
+    const runConfig = {
+      kind: "graph-editing",
+      objective: { parts: [{ text: "test prompt" }] },
+    };
+    const handle = services.agentService.startRun(runConfig);
+    agent.setHistory(handle.events.history);
+
+    // Add some events to eventConsumer
+    handle.events.handle({ start: { objective: { parts: [{ text: "test prompt" }] } } });
+    handle.events.handle({ thought: { text: "Thinking about test prompt..." } });
+
+    // Spy on setTimeout to capture the callback
+    const setTimeoutCalls: { callback: () => void; delay: number }[] = [];
+    mock.method(globalThis, "setTimeout", (callback: () => void, delay: number) => {
+      setTimeoutCalls.push({ callback, delay });
+      return 123 as unknown as ReturnType<typeof setTimeout>;
+    });
+    mock.method(globalThis, "clearTimeout", () => {});
+
+    await setOpieReaction("up");
+
+    assert.strictEqual(agent.feedbackReaction, "up");
+    assert.strictEqual(setTimeoutCalls.length, 1);
+    assert.strictEqual(setTimeoutCalls[0].delay, 3000);
+
+    // Call the callback to trigger feedback.open
+    setTimeoutCalls[0].callback();
+
+    const openMock = controller.global.feedback.open as unknown as {
+      mock: {
+        callCount(): number;
+        calls: Array<{
+          arguments: [
+            {
+              bucketSuffix: string;
+              flow: string;
+              description: string;
+              productData: {
+                reaction: string;
+                conversation: string;
+              };
+            },
+          ];
+        }>;
+      };
+    };
+    assert.strictEqual(openMock.mock.callCount(), 1);
+    const args = openMock.mock.calls[0].arguments[0];
+    assert.strictEqual(args.bucketSuffix, "opie");
+    assert.strictEqual(args.flow, "submit");
+    assert.strictEqual(args.description, "User sentiment: up");
+    assert.ok(args.productData.conversation.includes("START OBJECTIVE:\ntest prompt"));
+    assert.ok(args.productData.conversation.includes("THOUGHT:\nThinking about test prompt..."));
+    assert.strictEqual(args.productData.reaction, "up");
   });
 });

--- a/packages/visual-editor/tests/sca/helpers/mock-controller.ts
+++ b/packages/visual-editor/tests/sca/helpers/mock-controller.ts
@@ -200,6 +200,13 @@ export function makeTestController(options: TestControllerOptions = {}) {
         addMessage(role: string, text: string) {
           this.entries.push({ role, text });
         },
+        _history: [] as unknown[],
+        get history() {
+          return this._history;
+        },
+        setHistory(history: unknown[]) {
+          this._history = history;
+        },
       },
       devtools: {
         isOpen: false,


### PR DESCRIPTION
## What
Switched how the Opie graph editing agent collects and formats event history for product feedback submissions. Instead of using the simplified ChatEntry entries, it now uses the `AgentEventConsumer.history` from the active or most recent run.

## Why
Using `AgentEventConsumer.history` provides a much more granular and technically complete telemetry of what occurred during the agent run (including thought sequences, tool calls, tool responses, error messages, and completed objectives) which helps when analyzing user feedback submissions.

## Changes

- **GraphEditingAgentController**:
  - Replaced storing the full `AgentEventConsumer` object with a private `#history` property that tracks `ReadonlyArray<AgentEvent>`.
  - Added a `history` getter and `setHistory` mutation method.
  - Reset `#history` to `[]` in `reset()`.

- **Graph Editing Agent Actions**:
  - Wired up `agent.setHistory(handle.events.history)` during `startGraphEditingAgent`.
  - Updated `setOpieReaction` to format events using the new `formatAgentEventHistory` and `formatLLMContent` helper functions.
  - Removed the unused `ChatEntry` import.

- **Tests & Mocks**:
  - Added a comprehensive unit test covering `setOpieReaction` behavior, including timer triggering and feedback opening.
  - Cleaned up `as any` type-casting in test files by using structural typing.
  - Updated controller stubs in `mock-controller.ts` to implement the new `history` property and `setHistory` method.

## Testing
- Verified typescript compilation successfully: `npm run build:tsc -w packages/visual-editor`.
- Verified all visual-editor tests pass successfully: `npm run test -w packages/visual-editor`.
