### PR TITLE
[opie] Standardizing Asset ID Resolution for Graph Editing Agent

### DIFF
--- a/packages/visual-editor/src/a2/agent/graph-editing/editing-agent-pidgin-translator.ts
+++ b/packages/visual-editor/src/a2/agent/graph-editing/editing-agent-pidgin-translator.ts
@@ -94,7 +94,9 @@ class EditingAgentPidginTranslator {
   fromPidgin(
     content: string,
     resolveNodeTitle?: (nodeId: string) => string | undefined,
-    resolveAssetTitle?: (assetPath: string) => string | undefined
+    resolveAsset?: (
+      assetRef: string
+    ) => { path: string; title: string } | undefined
   ): LLMContent {
     const segments = content.split(SPLIT_REGEX);
     const textParts: string[] = [];
@@ -117,8 +119,24 @@ class EditingAgentPidginTranslator {
       const fileMatch = segment.match(FILE_PARSE_REGEX);
       if (fileMatch) {
         const path = fileMatch[1];
-        const title = resolveAssetTitle?.(path) ?? path;
-        textParts.push(Template.part({ type: "asset", path, title }));
+        if (resolveAsset) {
+          const resolved = resolveAsset(path);
+          if (resolved) {
+            textParts.push(
+              Template.part({
+                type: "asset",
+                path: resolved.path,
+                title: resolved.title,
+              })
+            );
+          } else {
+            throw new Error(
+              `Asset reference "${path}" is invalid. No asset with this ID or title exists in the graph.`
+            );
+          }
+        } else {
+          textParts.push(Template.part({ type: "asset", path, title: path }));
+        }
         continue;
       }
 

--- a/packages/visual-editor/src/a2/agent/graph-editing/functions.ts
+++ b/packages/visual-editor/src/a2/agent/graph-editing/functions.ts
@@ -5,6 +5,7 @@
  */
 
 import type {
+  Asset,
   AssetMetadata,
   AssetType,
   EditSpec,
@@ -79,7 +80,7 @@ optional markup tags to express connections and tool usage:
 STEP_ID must be a valid ID from the most recent snapshot of the graph.
 - <tool name="TOOL_NAME" /> — attach a tool to the step. Available tools:
 ${TOOL_NAMES}
-- <file src="PATH" /> — reference a file asset.
+- <file src="ASSET_ID" /> — reference a file asset.
 - <a href="URL">TITLE</a> — add a route (navigation link).
 
 Any text outside of these tags is the prompt content.`;
@@ -213,7 +214,9 @@ function defineGraphEditingFunctions(
    */
   async function titleResolvers(): Promise<{
     nodeResolver: (nodeId: string) => string | undefined;
-    assetResolver: (assetPath: string) => string | undefined;
+    assetResolver: (
+      assetRef: string
+    ) => { path: string; title: string } | undefined;
   }> {
     const graph = await readGraph();
     return {
@@ -221,9 +224,30 @@ function defineGraphEditingFunctions(
         const node = graph.nodes?.find((n) => n.id === nodeId);
         return node?.metadata?.title;
       },
-      assetResolver: (assetPath: string) => {
-        const asset = graph.assets?.[assetPath];
-        return asset?.metadata?.title;
+      assetResolver: (assetRef: string) => {
+        if (!graph.assets) return undefined;
+        const cleanRef = assetRef.replace(/^\/?assets\//, "");
+        if (graph.assets[cleanRef]) {
+          return {
+            path: cleanRef,
+            title: graph.assets[cleanRef].metadata?.title ?? cleanRef,
+          };
+        }
+        for (const [key, asset] of Object.entries(graph.assets)) {
+          if (asset.metadata?.title === cleanRef) {
+            return { path: key, title: cleanRef };
+          }
+          const title = asset.metadata?.title;
+          if (title && !cleanRef.includes(".")) {
+            const dotIndex = title.lastIndexOf(".");
+            const baseName =
+              dotIndex !== -1 ? title.substring(0, dotIndex) : title;
+            if (baseName === cleanRef) {
+              return { path: key, title };
+            }
+          }
+        }
+        return undefined;
       },
     };
   }
@@ -243,6 +267,41 @@ function defineGraphEditingFunctions(
     );
     const ports = extractResultPorts(prompt, translator);
     return { promptContent, ports };
+  }
+
+  /**
+   * Resolves a path or title of an asset to its canonical ID/key in graph.assets,
+   * and checks that the asset exists.
+   */
+  async function resolveAndValidateAsset(
+    assetRef: string
+  ): Promise<{ error: string } | { resolvedId: string; asset: Asset }> {
+    const graph = await readGraph();
+    if (!graph.assets) {
+      return { error: `No assets in graph to resolve "${assetRef}"` };
+    }
+
+    const cleanRef = assetRef.replace(/^\/?assets\//, "");
+
+    if (graph.assets[cleanRef]) {
+      return { resolvedId: cleanRef, asset: graph.assets[cleanRef] };
+    }
+
+    for (const [key, asset] of Object.entries(graph.assets)) {
+      if (asset.metadata?.title === cleanRef) {
+        return { resolvedId: key, asset };
+      }
+      const title = asset.metadata?.title;
+      if (title && !cleanRef.includes(".")) {
+        const dotIndex = title.lastIndexOf(".");
+        const baseName = dotIndex !== -1 ? title.substring(0, dotIndex) : title;
+        if (baseName === cleanRef) {
+          return { resolvedId: key, asset };
+        }
+      }
+    }
+
+    return { error: `Asset "${assetRef}" not found in graph assets` };
   }
 
   /**
@@ -432,12 +491,12 @@ function defineGraphEditingFunctions(
         name: GRAPH_REMOVE_ASSET,
         title: "Removing asset",
         icon: "delete",
-        description: "Remove an asset from the graph by its path.",
+        description: "Remove an asset from the graph by its ID.",
         parameters: {
-          path: z
+          asset_id: z
             .string()
             .describe(
-              "The path of the asset to remove (e.g. /assets/my_image.png)"
+              "The ID of the asset to remove (e.g. 'asset-XYZ.png' or 'my_image.png')"
             ),
         },
         response: {
@@ -450,16 +509,23 @@ function defineGraphEditingFunctions(
             ),
         },
       },
-      async ({ path }) => {
+      async ({ asset_id }) => {
+        const resolved = await resolveAndValidateAsset(asset_id);
+        if ("error" in resolved) {
+          return {
+            success: false,
+            error: resolved.error,
+          };
+        }
         const result = await applyEdits(
-          [{ type: "removeasset", path }],
-          `Remove asset: ${path}`
+          [{ type: "removeasset", path: resolved.resolvedId }],
+          `Remove asset: ${resolved.resolvedId}`
         );
 
         if (!result.success) {
           return {
             success: false,
-            error: `Failed to remove asset "${path}"`,
+            error: `Failed to remove asset "${asset_id}"`,
           };
         }
 
@@ -579,7 +645,7 @@ function defineGraphEditingFunctions(
           items: z
             .array(
               z.object({
-                id: z.string().describe("The step id or asset path"),
+                id: z.string().describe("The step id or asset id"),
                 x: z.number().describe("The x coordinate on canvas"),
                 y: z.number().describe("The y coordinate on canvas"),
               })
@@ -622,32 +688,35 @@ function defineGraphEditingFunctions(
               graphId: "",
               metadata,
             });
-          } else if (graph.assets && graph.assets[item.id]) {
-            const asset = graph.assets[item.id];
-            const existingMetadata = (asset.metadata ?? {}) as Record<
-              string,
-              unknown
-            >;
-            const existingVisual = (existingMetadata.visual ?? {}) as Record<
-              string,
-              unknown
-            >;
-            const metadata: AssetMetadata = {
-              title: (existingMetadata.title as string) ?? "",
-              type: (existingMetadata.type as AssetType) ?? "file",
-              ...existingMetadata,
-              visual: { ...existingVisual, x: item.x, y: item.y },
-            };
-            edits.push({
-              type: "changeassetmetadata",
-              path: item.id,
-              metadata,
-            });
           } else {
-            return {
-              success: false,
-              error: `Item "${item.id}" not found in graph steps or assets`,
-            };
+            const assetRes = await resolveAndValidateAsset(item.id);
+            if (!("error" in assetRes)) {
+              const asset = assetRes.asset;
+              const existingMetadata = (asset.metadata ?? {}) as Record<
+                string,
+                unknown
+              >;
+              const existingVisual = (existingMetadata.visual ?? {}) as Record<
+                string,
+                unknown
+              >;
+              const metadata: AssetMetadata = {
+                title: (existingMetadata.title as string) ?? "",
+                type: (existingMetadata.type as AssetType) ?? "file",
+                ...existingMetadata,
+                visual: { ...existingVisual, x: item.x, y: item.y },
+              };
+              edits.push({
+                type: "changeassetmetadata",
+                path: assetRes.resolvedId,
+                metadata,
+              });
+            } else {
+              return {
+                success: false,
+                error: `Item "${item.id}" not found in graph steps or assets`,
+              };
+            }
           }
         }
 
@@ -702,10 +771,18 @@ function defineGraphEditingFunctions(
         },
       },
       async ({ step_id, title, prompt }) => {
-        const { promptContent, ports } = await resolvePromptAndPorts(
-          prompt,
-          translator
-        );
+        let promptContent;
+        let ports;
+        try {
+          const resolved = await resolvePromptAndPorts(prompt, translator);
+          promptContent = resolved.promptContent;
+          ports = resolved.ports;
+        } catch (e) {
+          const error = e instanceof Error ? e.message : String(e);
+          return {
+            error: error || "Failed to resolve prompt",
+          };
+        }
 
         let stepId: string;
         let isCreate = false;
@@ -836,10 +913,18 @@ function defineGraphEditingFunctions(
         },
       },
       async ({ step_id, step_type, title, prompt, options }) => {
-        const { promptContent, ports } = await resolvePromptAndPorts(
-          prompt,
-          translator
-        );
+        let promptContent;
+        let ports;
+        try {
+          const resolved = await resolvePromptAndPorts(prompt, translator);
+          promptContent = resolved.promptContent;
+          ports = resolved.ports;
+        } catch (e) {
+          const error = e instanceof Error ? e.message : String(e);
+          return {
+            error: error || "Failed to resolve prompt",
+          };
+        }
 
         let stepId: string;
         let isCreate = false;

--- a/packages/visual-editor/tests/agent/graph-editing/editing-agent-pidgin-translator.test.ts
+++ b/packages/visual-editor/tests/agent/graph-editing/editing-agent-pidgin-translator.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it } from "node:test";
 import { EditingAgentPidginTranslator } from "../../../src/a2/agent/graph-editing/editing-agent-pidgin-translator.js";
-import { deepStrictEqual, strictEqual } from "node:assert";
+import assert, { deepStrictEqual, strictEqual } from "node:assert";
 import { Template } from "../../../src/a2/a2/template.js";
 import {
   ROUTE_TOOL_PATH,
@@ -168,20 +168,22 @@ describe("EditingAgentPidginTranslator", () => {
       });
     });
 
-    it("resolves asset title using resolveAssetTitle resolver", () => {
+    it("resolves asset using resolveAsset resolver", () => {
       const translator = new EditingAgentPidginTranslator();
       const result = translator.fromPidgin(
         'Check <file src="/assets/logo.png" />',
         undefined,
         (assetPath) => {
-          if (assetPath === "/assets/logo.png") return "Brand Logo";
+          if (assetPath === "/assets/logo.png") {
+            return { path: "asset-123.png", title: "Brand Logo" };
+          }
           return undefined;
         }
       );
 
       const expectedText = `Check ${Template.part({
         type: "asset",
-        path: "/assets/logo.png",
+        path: "asset-123.png",
         title: "Brand Logo",
       })}`;
 
@@ -189,6 +191,17 @@ describe("EditingAgentPidginTranslator", () => {
         parts: [{ text: expectedText }],
         role: "user",
       });
+    });
+
+    it("throws an error when asset resolution fails", () => {
+      const translator = new EditingAgentPidginTranslator();
+      assert.throws(() => {
+        translator.fromPidgin(
+          'Check <file src="/assets/nonexistent.png" />',
+          undefined,
+          () => undefined
+        );
+      }, /Asset reference "\/assets\/nonexistent\.png" is invalid/);
     });
 
     it("reconstructs file asset placeholders", () => {

--- a/packages/visual-editor/tests/agent/graph-editing/graph-editing-functions-suspend.test.ts
+++ b/packages/visual-editor/tests/agent/graph-editing/graph-editing-functions-suspend.test.ts
@@ -129,6 +129,20 @@ suite("Graph editing functions suspend/resume", () => {
     const bridge = new LocalAgentEventBridge(consumer);
     const translator = new EditingAgentPidginTranslator();
 
+    consumer.on("readGraph", () => {
+      return Promise.resolve({
+        graph: {
+          ...makeMockGraph(),
+          assets: {
+            "image.png": {
+              metadata: { title: "image.png", type: "file" },
+              data: [],
+            },
+          },
+        },
+      });
+    });
+
     const captured: ApplyEditsPayload[] = [];
     consumer.on("applyEdits", (payload) => {
       captured.push(payload);
@@ -137,7 +151,7 @@ suite("Graph editing functions suspend/resume", () => {
 
     const group = getGraphEditingFunctionGroup(bridge, translator);
     const handler = findHandler(group, "graph_remove_asset");
-    const result = await handler({ path: "/assets/image.png" }, noop, null);
+    const result = await handler({ asset_id: "/assets/image.png" }, noop, null);
 
     assert.strictEqual(captured.length, 1);
     assert.ok(captured[0].requestId, "Should have a requestId");
@@ -145,10 +159,32 @@ suite("Graph editing functions suspend/resume", () => {
     assert.strictEqual(captured[0].edits!.length, 1);
     assert.deepStrictEqual(captured[0].edits![0], {
       type: "removeasset",
-      path: "/assets/image.png",
+      path: "image.png",
     });
 
     assert.strictEqual(result.success, true);
+  });
+
+  test("graph_remove_asset returns error when asset does not exist", async () => {
+    const consumer = new AgentEventConsumer();
+    const bridge = new LocalAgentEventBridge(consumer);
+    const translator = new EditingAgentPidginTranslator();
+
+    consumer.on("readGraph", () => {
+      return Promise.resolve({
+        graph: {
+          ...makeMockGraph(),
+          assets: {},
+        },
+      });
+    });
+
+    const group = getGraphEditingFunctionGroup(bridge, translator);
+    const handler = findHandler(group, "graph_remove_asset");
+    const result = await handler({ asset_id: "nonexistent.png" }, noop, null);
+
+    assert.strictEqual(result.success, false);
+    assert.match(result.error ?? "", /Asset "nonexistent\.png" not found/);
   });
 
   test("graph_remove_step returns error on failure", async () => {
@@ -478,6 +514,131 @@ suite("Graph editing functions suspend/resume", () => {
     assert.strictEqual(captured.length, 1);
     assert.strictEqual(captured[0].edits![0].type, "addnode");
     assert.strictEqual(captured[0].edits![0].node.id, "my-custom-legacy-step");
+  });
+
+  // ── graph_position_items ──────────────────────────────────────────────────
+
+  test("graph_position_items positions node step via applyEdits changemetadata", async () => {
+    const consumer = new AgentEventConsumer();
+    const bridge = new LocalAgentEventBridge(consumer);
+    const translator = new EditingAgentPidginTranslator();
+
+    // Pre-register a handle for step-a so translator can resolve it
+    translator.getOrCreateHandle("step-a");
+
+    consumer.on("readGraph", () => {
+      return Promise.resolve({ graph: makeMockGraph() });
+    });
+
+    const captured: ApplyEditsPayload[] = [];
+    consumer.on("applyEdits", (payload) => {
+      captured.push(payload);
+      return Promise.resolve({ success: true });
+    });
+
+    const group = getGraphEditingFunctionGroup(bridge, translator);
+    const handler = findHandler(group, "graph_position_items");
+
+    const handle = translator.getOrCreateHandle("step-a");
+    const result = await handler(
+      {
+        items: [{ id: handle, x: 100, y: 200 }],
+      },
+      noop,
+      null
+    );
+
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(captured.length, 1);
+    assert.strictEqual(captured[0].edits!.length, 1);
+    assert.deepStrictEqual(captured[0].edits![0], {
+      type: "changemetadata",
+      id: "step-a",
+      graphId: "",
+      metadata: {
+        title: "Step Alpha",
+        visual: { x: 100, y: 200 },
+      },
+    });
+  });
+
+  test("graph_position_items positions asset via applyEdits changeassetmetadata", async () => {
+    const consumer = new AgentEventConsumer();
+    const bridge = new LocalAgentEventBridge(consumer);
+    const translator = new EditingAgentPidginTranslator();
+
+    consumer.on("readGraph", () => {
+      return Promise.resolve({
+        graph: {
+          ...makeMockGraph(),
+          assets: {
+            "image.png": {
+              metadata: { title: "image.png", type: "file" },
+              data: [],
+            },
+          },
+        },
+      });
+    });
+
+    const captured: ApplyEditsPayload[] = [];
+    consumer.on("applyEdits", (payload) => {
+      captured.push(payload);
+      return Promise.resolve({ success: true });
+    });
+
+    const group = getGraphEditingFunctionGroup(bridge, translator);
+    const handler = findHandler(group, "graph_position_items");
+
+    const result = await handler(
+      {
+        items: [{ id: "/assets/image.png", x: 300, y: 400 }],
+      },
+      noop,
+      null
+    );
+
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(captured.length, 1);
+    assert.strictEqual(captured[0].edits!.length, 1);
+    assert.deepStrictEqual(captured[0].edits![0], {
+      type: "changeassetmetadata",
+      path: "image.png",
+      metadata: {
+        title: "image.png",
+        type: "file",
+        visual: { x: 300, y: 400 },
+      },
+    });
+  });
+
+  test("graph_position_items returns error for nonexistent items", async () => {
+    const consumer = new AgentEventConsumer();
+    const bridge = new LocalAgentEventBridge(consumer);
+    const translator = new EditingAgentPidginTranslator();
+
+    consumer.on("readGraph", () => {
+      return Promise.resolve({
+        graph: {
+          ...makeMockGraph(),
+          assets: {},
+        },
+      });
+    });
+
+    const group = getGraphEditingFunctionGroup(bridge, translator);
+    const handler = findHandler(group, "graph_position_items");
+
+    const result = await handler(
+      {
+        items: [{ id: "nonexistent", x: 10, y: 20 }],
+      },
+      noop,
+      null
+    );
+
+    assert.strictEqual(result.success, false);
+    assert.match(result.error ?? "", /Item "nonexistent" not found/);
   });
 
   // ── instruction generation and product name replacements ──────────────────


### PR DESCRIPTION
## What
Resolves an incongruity in how file asset identifiers are processed by the graph editing agent. Asset paths/titles are now systematically resolved to their canonical asset IDs from `graph.assets` instead of causing failures during edits or producing invalid graph structures.

## Why
The visual editor backend indexes assets by unique IDs, but the agent referred to assets using user-facing paths (e.g., `/assets/my_image.png`) or titles, causing tool failures or corrupt graph schemas.

## Changes
### Visual Editor Core
- **`editing-agent-pidgin-translator.ts`**: Updated `fromPidgin` to use a `resolveAsset` hook that maps raw references to canonical IDs and titles, throwing errors on invalid references.
- **`functions.ts`**: Added `resolveAndValidateAsset` helper to clean paths and map keys/titles to canonical asset IDs. Updated `graph_remove_asset` (using parameter `asset_id`), `graph_position_items`, and prompt parsing in `upsert_agent_step` and `upsert_legacy_step` to leverage this helper.

### Testing
- **`editing-agent-pidgin-translator.test.ts`**: Added tests for asset validation throwing and canonical key resolution.
- **`graph-editing-functions-suspend.test.ts`**: Updated existing tests and added new test cases for asset deletion and canvas positioning.

## Testing
Verify that all unit tests pass:
```bash
npm run test
```
