### PR TITLE
[opie] Add fallback comment and test for unpositioned graph steps

### DIFF
--- a/packages/visual-editor/src/a2/agent/graph-editing/graph-overview.ts
+++ b/packages/visual-editor/src/a2/agent/graph-editing/graph-overview.ts
@@ -57,8 +57,7 @@ function graphOverviewYaml(
   const presentation = graph.metadata?.visual?.presentation;
   const themeId = presentation?.theme;
   const themes = presentation?.themes;
-  const currentTheme =
-    themeId && themes ? themes[themeId] : undefined;
+  const currentTheme = themeId && themes ? themes[themeId] : undefined;
 
   const isCustom =
     !!currentTheme?.splashScreen && !currentTheme?.isDefaultTheme;
@@ -109,6 +108,8 @@ function graphOverviewYaml(
     if (typeof visual.x === "number" && typeof visual.y === "number") {
       lines.push(`    x: ${Math.round(visual.x)}`);
       lines.push(`    y: ${Math.round(visual.y)}`);
+    } else {
+      lines.push(`    # Newly Added. TODO: Position this step`);
     }
 
     if (canvas && typeof canvas.getStepDimensions === "function") {
@@ -122,9 +123,7 @@ function graphOverviewYaml(
 
     // Convert prompt back to pidgin for readability
     const prompt =
-      config?.["config$prompt"] ||
-      config?.["description"] ||
-      config?.["text"];
+      config?.["config$prompt"] || config?.["description"] || config?.["text"];
 
     if (prompt && typeof prompt === "object") {
       const pidgin = translator.toPidgin(prompt as LLMContent);
@@ -146,9 +145,7 @@ function graphOverviewYaml(
       inferredStepType = "output";
     } else if (node.type === GENERATE_COMPONENT_URL) {
       const genMode =
-        config &&
-        typeof config === "object" &&
-        "generation-mode" in config
+        config && typeof config === "object" && "generation-mode" in config
           ? (config["generation-mode"] as string)
           : undefined;
       inferredStepType = genMode || "text-3-flash";
@@ -236,8 +233,7 @@ function inferAssetFriendlyType(asset: Asset): string {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const data = asset.data as any[];
   const part = data?.[0]?.parts?.[0];
-  const mimeType =
-    part?.storedData?.mimeType || part?.inlineData?.mimeType;
+  const mimeType = part?.storedData?.mimeType || part?.inlineData?.mimeType;
   const handle = part?.storedData?.handle;
 
   if (mimeType) {

--- a/packages/visual-editor/tests/agent/graph-editing/graph-overview.test.ts
+++ b/packages/visual-editor/tests/agent/graph-editing/graph-overview.test.ts
@@ -339,5 +339,29 @@ describe("graphOverviewYaml", () => {
 
     ok(yaml.includes("# Newly Added. TODO: Position this asset"));
   });
+
+  it("includes YAML comment for unpositioned steps", () => {
+    const translator = new EditingAgentPidginTranslator();
+    const nodes: NodeDescriptor[] = [
+      {
+        id: "step-1",
+        type: GENERATE_COMPONENT_URL,
+        metadata: {
+          title: "My Unpositioned Step",
+        },
+      },
+    ];
+
+    const yaml = graphOverviewYaml(
+      {
+        title: "Test Graph",
+      },
+      nodes,
+      [],
+      translator
+    );
+
+    ok(yaml.includes("# Newly Added. TODO: Position this step"));
+  });
 });
 


### PR DESCRIPTION
## What
Adds a fallback comment `# Newly Added. TODO: Position this step` when generating the graph overview YAML for nodes/steps that lack positioning coordinates (`x` and `y`).

## Why
This warning ensures that newly added steps without coordinates are flagged for the layout/positioning engine or the developer, preventing unpositioned steps from silently rendering at default/overlapping coordinates without notice.

## Changes
### packages/visual-editor
* **graph-overview.ts**: Added a fallback condition to output `# Newly Added. TODO: Position this step` when step coordinates are missing.
* **graph-overview.test.ts**: Added a new test `includes YAML comment for unpositioned steps` to verify this comment is correctly injected for unpositioned nodes.

## Testing
Run the test command to verify:
```bash
npm run test:file -- './dist/tsc/tests/agent/graph-editing/graph-overview.test.js'
```
