### PR TITLE
[opie] Unify Suspend Graph Reading and Fix Theme/Asset Data Loss

### DIFF
--- a/packages/visual-editor/src/a2/agent/graph-editing/chat-functions.ts
+++ b/packages/visual-editor/src/a2/agent/graph-editing/chat-functions.ts
@@ -18,27 +18,9 @@ import {
   diffSnapshots,
   type GraphSnapshot,
 } from "./graph-diff.js";
-import type { ReadGraphResponse } from "./types.js";
+import { readGraph } from "./read-graph.js";
 
 export { getChatFunctionGroup };
-
-/**
- * Read the current graph data via the suspend mechanism.
- * Returns null if the graph descriptor has no nodes.
- */
-async function readGraphData(sink: AgentEventSink) {
-  const { graph } = await sink.suspend<ReadGraphResponse>({
-    readGraph: {
-      requestId: crypto.randomUUID(),
-    },
-  });
-  return {
-    title: graph.title,
-    description: graph.description,
-    nodes: graph.nodes ?? [],
-    edges: graph.edges ?? [],
-  };
-}
 
 /**
  * A chat function group for the persistent graph editing agent.
@@ -93,11 +75,11 @@ function getChatFunctionGroup(
       },
       async ({ message }) => {
         // Snapshot the graph before blocking on user input.
-        const beforeData = await readGraphData(sink);
+        const beforeData = await readGraph(sink);
         if (beforeData) {
           lastSnapshot = takeSnapshot(
-            beforeData.nodes,
-            beforeData.edges,
+            beforeData.nodes ?? [],
+            beforeData.edges ?? [],
             translator
           );
         }
@@ -120,23 +102,23 @@ function getChatFunctionGroup(
         const extraParts = response.input.parts.filter((p) => !("text" in p));
 
         // After user responds, check whether they edited the graph.
-        const afterData = await readGraphData(sink);
+        const afterData = await readGraph(sink);
         let graph_changes: string | undefined;
 
         // Always include the current graph overview.
         const overview = afterData
           ? graphOverviewYaml(
               afterData,
-              afterData.nodes,
-              afterData.edges,
+              afterData.nodes ?? [],
+              afterData.edges ?? [],
               translator
             )
           : "(no graph available)";
 
         if (lastSnapshot && afterData) {
           const currentSnapshot = takeSnapshot(
-            afterData.nodes,
-            afterData.edges,
+            afterData.nodes ?? [],
+            afterData.edges ?? [],
             translator
           );
           const diff = diffSnapshots(lastSnapshot, currentSnapshot);

--- a/packages/visual-editor/src/a2/agent/graph-editing/functions.ts
+++ b/packages/visual-editor/src/a2/agent/graph-editing/functions.ts
@@ -9,7 +9,6 @@ import type {
   AssetMetadata,
   AssetType,
   EditSpec,
-  GraphDescriptor,
   NodeConfiguration,
   NodeDescriptor,
   NodeMetadata,
@@ -30,7 +29,8 @@ import {
   OUTPUT_COMPONENT_URL,
   LEGACY_OPTION_MAP,
 } from "./constants.js";
-import type { ApplyEditsResponse, ReadGraphResponse } from "./types.js";
+import type { ApplyEditsResponse } from "./types.js";
+import { readGraph } from "./read-graph.js";
 
 export { getGraphEditingFunctionGroup };
 
@@ -107,19 +107,6 @@ function defineGraphEditingFunctions(
   sink: AgentEventSink,
   translator: EditingAgentPidginTranslator
 ) {
-  /**
-   * Reads the current graph via the suspend mechanism.
-   */
-  async function readGraph(): Promise<GraphDescriptor> {
-    return sink
-      .suspend<ReadGraphResponse>({
-        readGraph: {
-          requestId: crypto.randomUUID(),
-        },
-      })
-      .then((r) => r.graph);
-  }
-
   /**
    * Applies edits via the suspend mechanism, waiting for confirmation.
    */
@@ -218,7 +205,7 @@ function defineGraphEditingFunctions(
       assetRef: string
     ) => { path: string; title: string } | undefined;
   }> {
-    const graph = await readGraph();
+    const graph = await readGraph(sink);
     return {
       nodeResolver: (nodeId: string) => {
         const node = graph.nodes?.find((n) => n.id === nodeId);
@@ -276,7 +263,7 @@ function defineGraphEditingFunctions(
   async function resolveAndValidateAsset(
     assetRef: string
   ): Promise<{ error: string } | { resolvedId: string; asset: Asset }> {
-    const graph = await readGraph();
+    const graph = await readGraph(sink);
     if (!graph.assets) {
       return { error: `No assets in graph to resolve "${assetRef}"` };
     }
@@ -312,7 +299,7 @@ function defineGraphEditingFunctions(
     translator: EditingAgentPidginTranslator
   ): Promise<{ error: string } | { resolvedId: string; node: NodeDescriptor }> {
     const resolvedId = translator.getNodeId(step_id) ?? step_id;
-    const graph = await readGraph();
+    const graph = await readGraph(sink);
     const node = graph.nodes?.find((n) => n.id === resolvedId);
     if (!node) {
       return { error: `Step "${step_id}" not found` };
@@ -429,7 +416,7 @@ function defineGraphEditingFunctions(
         },
       },
       async () => {
-        const graph = await readGraph();
+        const graph = await readGraph(sink);
         const overview = graphOverviewYaml(
           graph,
           graph.nodes ?? [],
@@ -608,7 +595,7 @@ function defineGraphEditingFunctions(
       async ({ theme_intent }) => {
         // Read the current graph to snapshot title/description — they are
         // significant inputs for the splash-image generator.
-        const graph = await readGraph();
+        const graph = await readGraph(sink);
         const title = graph.title;
         const description = graph.description;
 
@@ -663,7 +650,7 @@ function defineGraphEditingFunctions(
         },
       },
       async ({ items }) => {
-        const graph = await readGraph();
+        const graph = await readGraph(sink);
         const edits: EditSpec[] = [];
 
         for (const item of items) {

--- a/packages/visual-editor/src/a2/agent/graph-editing/main.ts
+++ b/packages/visual-editor/src/a2/agent/graph-editing/main.ts
@@ -13,7 +13,7 @@ import { graphOverviewYaml, describeSelection } from "./graph-overview.js";
 import { bind } from "../../../sca/actions/graph/graph-actions.js";
 import type { LoopHooks } from "../types.js";
 import type { AgentEventSink } from "../agent-event-sink.js";
-import type { ReadGraphResponse } from "./types.js";
+import { readGraph } from "./read-graph.js";
 
 export { invokeGraphEditingAgent };
 
@@ -39,11 +39,7 @@ async function invokeGraphEditingAgent(
   });
 
   // Read the current graph via suspend so the agent knows the state.
-  const { graph } = await sink.suspend<ReadGraphResponse>({
-    readGraph: {
-      requestId: crypto.randomUUID(),
-    },
-  });
+  const graph = await readGraph(sink);
 
   let overview = "";
   let selectionInfo = "";

--- a/packages/visual-editor/src/a2/agent/graph-editing/read-graph.ts
+++ b/packages/visual-editor/src/a2/agent/graph-editing/read-graph.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { GraphDescriptor } from "@breadboard-ai/types";
+import type { AgentEventSink } from "../agent-event-sink.js";
+import type { ReadGraphResponse } from "./types.js";
+
+export { readGraph };
+
+/**
+ * Reads the current graph via the suspend mechanism.
+ */
+async function readGraph(sink: AgentEventSink): Promise<GraphDescriptor> {
+  const { graph } = await sink.suspend<ReadGraphResponse>({
+    readGraph: {
+      requestId: crypto.randomUUID(),
+    },
+  });
+  return graph;
+}


### PR DESCRIPTION
## What
Created a unified `readGraph` helper function to read the full `GraphDescriptor` via the suspend mechanism and refactored the visual-editor's graph-editing agent functions to use it.

## Why
Previously, the chat function `readGraphData` returned a partial representation of the graph, causing properties like themes and assets to be stripped out, which led to incorrect rendering/awareness of themes and assets in the agent's canvas overview.

## Changes
- **Graph Editing Utility**:
  - Created [read-graph.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/src/a2/agent/graph-editing/read-graph.ts) to define a shared `readGraph` function.
- **Visual Editor Agent**:
  - Refactored [chat-functions.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/src/a2/agent/graph-editing/chat-functions.ts) to import and call `readGraph`, replacing the incomplete `readGraphData` helper.
  - Refactored [functions.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/src/a2/agent/graph-editing/functions.ts) to remove the duplicate wrapper and alias, calling the shared `readGraph(sink)` directly.
  - Refactored [main.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/src/a2/agent/graph-editing/main.ts) to use `readGraph` instead of suspending manually.

## Testing
- Ran [chat-functions-suspend.test.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/tests/agent/graph-editing/chat-functions-suspend.test.ts): `npm run test:file -w packages/visual-editor -- './dist/tsc/tests/agent/graph-editing/chat-functions-suspend.test.js'`
- Ran full workspace test suite: `npm run test`
