### PR TITLE
[opie] Ensure Canvas Controller is Passed to graphOverviewYaml

### DIFF
--- a/packages/visual-editor/src/a2/agent/graph-editing/chat-functions.ts
+++ b/packages/visual-editor/src/a2/agent/graph-editing/chat-functions.ts
@@ -105,13 +105,16 @@ function getChatFunctionGroup(
         const afterData = await readGraph(sink);
         let graph_changes: string | undefined;
 
+        const { controller } = bind;
+
         // Always include the current graph overview.
         const overview = afterData
           ? graphOverviewYaml(
               afterData,
               afterData.nodes ?? [],
               afterData.edges ?? [],
-              translator
+              translator,
+              controller.editor.canvas
             )
           : "(no graph available)";
 
@@ -129,7 +132,6 @@ function getChatFunctionGroup(
         }
 
         // Include selection state.
-        const { controller } = bind;
         const selectedNodes = controller.editor.selection.selection.nodes;
         const selectionText = afterData
           ? describeSelection(selectedNodes, afterData.nodes, translator)

--- a/packages/visual-editor/src/a2/agent/graph-editing/functions.ts
+++ b/packages/visual-editor/src/a2/agent/graph-editing/functions.ts
@@ -30,6 +30,7 @@ import {
   LEGACY_OPTION_MAP,
 } from "./constants.js";
 import type { ApplyEditsResponse } from "./types.js";
+import { bind } from "../../../sca/actions/graph/graph-actions.js";
 import { readGraph } from "./read-graph.js";
 
 export { getGraphEditingFunctionGroup };
@@ -417,11 +418,13 @@ function defineGraphEditingFunctions(
       },
       async () => {
         const graph = await readGraph(sink);
+        const { controller } = bind;
         const overview = graphOverviewYaml(
           graph,
           graph.nodes ?? [],
           graph.edges ?? [],
-          translator
+          translator,
+          controller.editor.canvas
         );
         return { overview };
       }

--- a/packages/visual-editor/src/a2/agent/graph-editing/graph-overview.ts
+++ b/packages/visual-editor/src/a2/agent/graph-editing/graph-overview.ts
@@ -40,7 +40,7 @@ function graphOverviewYaml(
   nodes: NodeDescriptor[],
   edges: Edge[],
   translator: EditingAgentPidginTranslator,
-  canvas?: CanvasController
+  canvas: CanvasController | null
 ): string {
   // Register all nodes with the translator to get stable pidgin handles.
   const handleMap = new Map<string, string>();

--- a/packages/visual-editor/src/a2/agent/graph-editing/main.ts
+++ b/packages/visual-editor/src/a2/agent/graph-editing/main.ts
@@ -52,7 +52,7 @@ async function invokeGraphEditingAgent(
       graph.nodes ?? [],
       graph.edges ?? [],
       translator,
-      canvas
+      canvas ?? null
     );
 
     const selectedNodes = controller?.editor?.selection?.selection?.nodes;
@@ -65,7 +65,8 @@ async function invokeGraphEditingAgent(
       graph,
       graph.nodes ?? [],
       graph.edges ?? [],
-      translator
+      translator,
+      null
     );
   }
 

--- a/packages/visual-editor/tests/agent/graph-editing/chat-functions-suspend.test.ts
+++ b/packages/visual-editor/tests/agent/graph-editing/chat-functions-suspend.test.ts
@@ -63,6 +63,11 @@ function createMockBindDeps() {
     controller: {
       editor: {
         selection: { selection: { nodes: [] } },
+        canvas: {
+          viewport: { left: 0, top: 0, width: 0, height: 0 },
+          getStepDimensions: () => null,
+          getAssetDimensions: () => null,
+        },
       },
     },
     services: {},

--- a/packages/visual-editor/tests/agent/graph-editing/graph-editing-functions-suspend.test.ts
+++ b/packages/visual-editor/tests/agent/graph-editing/graph-editing-functions-suspend.test.ts
@@ -5,7 +5,7 @@
  */
 
 import assert from "node:assert";
-import { suite, test } from "node:test";
+import { suite, test, beforeEach, afterEach } from "node:test";
 import {
   AgentEventConsumer,
   LocalAgentEventBridge,
@@ -18,6 +18,8 @@ import type {
 import type { GraphDescriptor } from "@breadboard-ai/types";
 import { EditingAgentPidginTranslator } from "../../../src/a2/agent/graph-editing/editing-agent-pidgin-translator.js";
 import type { FunctionDefinition } from "../../../src/a2/agent/function-definition.js";
+import { setDOM, unsetDOM } from "../../fake-dom.js";
+import { bind } from "../../../src/sca/actions/graph/graph-actions.js";
 
 /**
  * A minimal mock graph for testing.
@@ -62,7 +64,32 @@ function findHandler(
 
 const noop = () => {};
 
+function createMockBindDeps() {
+  return {
+    controller: {
+      editor: {
+        selection: { selection: { nodes: [] } },
+        canvas: {
+          viewport: { left: 0, top: 0, width: 0, height: 0 },
+          getStepDimensions: () => null,
+          getAssetDimensions: () => null,
+        },
+      },
+    },
+    services: {},
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
 suite("Graph editing functions suspend/resume", () => {
+  beforeEach(() => {
+    setDOM();
+    bind(createMockBindDeps());
+  });
+  afterEach(() => {
+    unsetDOM();
+  });
+
   // ── graph_get_overview ────────────────────────────────────────────────────
 
   test("graph_get_overview emits readGraph and returns overview", async () => {

--- a/packages/visual-editor/tests/agent/graph-editing/graph-overview.test.ts
+++ b/packages/visual-editor/tests/agent/graph-editing/graph-overview.test.ts
@@ -9,6 +9,7 @@ import { ok } from "node:assert";
 import { graphOverviewYaml } from "../../../src/a2/agent/graph-editing/graph-overview.js";
 import { EditingAgentPidginTranslator } from "../../../src/a2/agent/graph-editing/editing-agent-pidgin-translator.js";
 import type { NodeDescriptor, Edge } from "@breadboard-ai/types";
+import type { CanvasController } from "../../../src/sca/controller/subcontrollers/editor/canvas/canvas-controller.js";
 
 const GENERATE_COMPONENT_URL = "embed://a2/generate.bgl.json#module:main";
 const USER_INPUT_COMPONENT_URL =
@@ -67,7 +68,8 @@ describe("graphOverviewYaml", () => {
       { title: "Test Graph", description: "This is a test description" },
       nodes,
       edges,
-      translator
+      translator,
+      null
     );
 
     ok(yaml.includes("options:"));
@@ -107,7 +109,8 @@ describe("graphOverviewYaml", () => {
       },
       [],
       [],
-      translator
+      translator,
+      null
     );
     ok(yaml.includes("splashImage: present"));
   });
@@ -132,7 +135,8 @@ describe("graphOverviewYaml", () => {
       },
       [],
       [],
-      translator
+      translator,
+      null
     );
     ok(yaml.includes("splashImage: default"));
   });
@@ -179,7 +183,8 @@ describe("graphOverviewYaml", () => {
       },
       [],
       [],
-      translator
+      translator,
+      null
     );
 
     ok(yaml.includes("assets:"));
@@ -220,7 +225,8 @@ describe("graphOverviewYaml", () => {
       },
       [],
       [],
-      translator
+      translator,
+      null
     );
     ok(yaml.includes("type: application/pdf"));
   });
@@ -267,7 +273,8 @@ describe("graphOverviewYaml", () => {
       },
       [],
       [],
-      translator
+      translator,
+      null
     );
 
     ok(yaml.includes("type: YouTube video"));
@@ -308,7 +315,8 @@ describe("graphOverviewYaml", () => {
       },
       nodes,
       [],
-      translator
+      translator,
+      null
     );
 
     ok(yaml.includes("x: 100"));
@@ -334,7 +342,8 @@ describe("graphOverviewYaml", () => {
       },
       [],
       [],
-      translator
+      translator,
+      null
     );
 
     ok(yaml.includes("# Newly Added. TODO: Position this asset"));
@@ -358,10 +367,72 @@ describe("graphOverviewYaml", () => {
       },
       nodes,
       [],
-      translator
+      translator,
+      null
     );
 
     ok(yaml.includes("# Newly Added. TODO: Position this step"));
+  });
+
+  it("includes viewport, step dimensions, and asset dimensions when canvas is provided", () => {
+    const translator = new EditingAgentPidginTranslator();
+    const nodes: NodeDescriptor[] = [
+      {
+        id: "step-1",
+        type: GENERATE_COMPONENT_URL,
+        metadata: {
+          title: "Positioned Step",
+          visual: { x: 100, y: 150 },
+        },
+      },
+    ];
+
+    const mockCanvas = {
+      viewport: { left: 10, top: 20, width: 800, height: 600 },
+      getStepDimensions: (id: string) => {
+        if (id === "step-1") return { width: 120.4, height: 80.6 };
+        return null;
+      },
+      getAssetDimensions: (path: string) => {
+        if (path === "/assets/img.png") return { width: 200, height: 150 };
+        return null;
+      },
+    } as unknown as CanvasController;
+
+    const yaml = graphOverviewYaml(
+      {
+        title: "Test Graph",
+        assets: {
+          "/assets/img.png": {
+            metadata: {
+              title: "My Image",
+              type: "file",
+              visual: { x: 50, y: 50 },
+            },
+            data: [],
+          },
+        },
+      },
+      nodes,
+      [],
+      translator,
+      mockCanvas
+    );
+
+    // Viewport assertions
+    ok(yaml.includes("viewport:"));
+    ok(yaml.includes("left: 10"));
+    ok(yaml.includes("top: 20"));
+    ok(yaml.includes("width: 800"));
+    ok(yaml.includes("height: 600"));
+
+    // Step dimensions assertions
+    ok(yaml.includes("width: 120"));
+    ok(yaml.includes("height: 81"));
+
+    // Asset dimensions assertions
+    ok(yaml.includes("width: 200"));
+    ok(yaml.includes("height: 150"));
   });
 });
 


### PR DESCRIPTION
## What
Required `canvas: CanvasController | null` in `graphOverviewYaml` to ensure layout metadata (viewport, step, and asset dimensions) is always propagated to the graph overview, and updated all callsites and tests to match.

## Why
Previously, the `canvas` parameter was optional and omitted at all active callsites of `graphOverviewYaml` except the initial bootstrap. This resulted in the agent receiving an overview without coordinate or scale limits, preventing proper node positioning.

## Changes
- **visual-editor**:
  - Required `canvas: CanvasController | null` in `graphOverviewYaml` signature ([graph-overview.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/src/a2/agent/graph-editing/graph-overview.ts)).
  - Passed `controller.editor.canvas` from `bind` in `chat-functions.ts` and `functions.ts`.
  - Updated `main.ts` bootstrap try/catch fallback to pass `null` when the binder is not yet set.
  - Added unit test to verify viewport and step/asset dimensions rendering when `canvas` is present ([graph-overview.test.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/tests/agent/graph-editing/graph-overview.test.ts)).
  - Wired mock canvas setups in `chat-functions-suspend.test.ts` and `graph-editing-functions-suspend.test.ts`.

## Testing
Verify that all unit tests pass:
```bash
npm run test:file -w packages/visual-editor -- './dist/tsc/tests/agent/graph-editing/**/*.test.js'
```
