### PR TITLE
[selection] Reconcile Selection on Graph Mutation

### DIFF
--- a/packages/visual-editor/src/sca/actions/node/node-actions.ts
+++ b/packages/visual-editor/src/sca/actions/node/node-actions.ts
@@ -38,6 +38,7 @@ import {
   onNodeConfigChange,
   onNodeAction as onNodeActionTrigger,
   onCopyShortcut,
+  onGraphVersionChange,
 } from "./triggers.js";
 import { GraphUtils } from "../../../utils/graph-utils.js";
 import { ClipboardReader } from "../../../utils/clipboard-reader.js";
@@ -875,3 +876,27 @@ export const onNodeAction = asAction(
     controller.run.main.setNodeActionRequest({ nodeId, actionContext: mapped });
   }
 );
+
+/**
+ * Reconciles the selection with the current graph state.
+ *
+ * Removes any selected nodes, edges, assets, or asset edges that no longer
+ * exist in the graph.
+ *
+ * **Triggers:**
+ * - `onGraphVersionChange`: Fires when the graph version changes.
+ */
+export const syncSelection = asAction(
+  "Node.syncSelection",
+  {
+    mode: ActionMode.Immediate,
+    triggeredBy: () => onGraphVersionChange(bind),
+  },
+  async (): Promise<void> => {
+    const { controller } = bind;
+    const graphController = controller.editor.graph;
+    const graph = graphController.inspect("");
+    controller.editor.selection.reconcile(graph);
+  }
+);
+

--- a/packages/visual-editor/src/sca/actions/node/triggers.ts
+++ b/packages/visual-editor/src/sca/actions/node/triggers.ts
@@ -68,3 +68,14 @@ export function onCopyShortcut(): KeyboardTrigger {
     return isFocusedOnGraphRenderer(evt);
   });
 }
+
+/**
+ * Creates a trigger that fires when the graph version changes.
+ * Used to reconcile/prune the selection.
+ */
+export function onGraphVersionChange(bind: ActionBind): SignalTrigger {
+  return signalTrigger("Graph Version Change (Selection)", () => {
+    const { controller } = bind;
+    return controller.editor.graph.version + 1;
+  });
+}

--- a/packages/visual-editor/src/sca/controller/subcontrollers/editor/selection/selection-controller.ts
+++ b/packages/visual-editor/src/sca/controller/subcontrollers/editor/selection/selection-controller.ts
@@ -165,4 +165,55 @@ export class SelectionController extends RootController {
       }
     }
   }
+
+  reconcile(graph: InspectableGraph) {
+    let changed = false;
+
+    // Prune nodes
+    const existingNodes = new Set(graph.nodes().map((n) => n.descriptor.id));
+    for (const nodeId of [...this._selection.nodes]) {
+      if (!existingNodes.has(nodeId)) {
+        this._selection.nodes.delete(nodeId);
+        changed = true;
+      }
+    }
+
+    // Prune edges
+    const existingEdges = new Set(
+      graph.edges().map((e) => toEdgeIdentifier(e.raw()))
+    );
+    for (const edgeId of [...this._selection.edges]) {
+      if (!existingEdges.has(edgeId)) {
+        this._selection.edges.delete(edgeId);
+        changed = true;
+      }
+    }
+
+    // Prune assets
+    const existingAssets = new Set(graph.assets().keys());
+    for (const assetId of [...this._selection.assets]) {
+      if (!existingAssets.has(assetId)) {
+        this._selection.assets.delete(assetId);
+        changed = true;
+      }
+    }
+
+    // Prune asset edges
+    const assetEdgesResult = graph.assetEdges();
+    const existingAssetEdges = new Set(
+      ok(assetEdgesResult)
+        ? assetEdgesResult.map((ae) => toAssetEdgeIdentifier(ae))
+        : []
+    );
+    for (const assetEdgeId of [...this._selection.assetEdges]) {
+      if (!existingAssetEdges.has(assetEdgeId)) {
+        this._selection.assetEdges.delete(assetEdgeId);
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      this._selectionId++;
+    }
+  }
 }

--- a/packages/visual-editor/tests/sca/actions/node/node-actions.test.ts
+++ b/packages/visual-editor/tests/sca/actions/node/node-actions.test.ts
@@ -2127,3 +2127,39 @@ suite("onNodeAction", () => {
     );
   });
 });
+
+suite("syncSelection", () => {
+  beforeEach(() => {
+    coordination.reset();
+  });
+
+  test("calls reconcile on selection controller with inspectable graph", async () => {
+    const reconcileCalled = { value: false, graph: null as unknown };
+    const mockGraph = { type: "inspectable-graph" };
+    const controller = {
+      editor: {
+        graph: {
+          inspect: (graphId: string) => {
+            assert.strictEqual(graphId, "");
+            return mockGraph;
+          },
+        },
+        selection: {
+          reconcile: (graph: unknown) => {
+            reconcileCalled.value = true;
+            reconcileCalled.graph = graph;
+          },
+        },
+      },
+    } as unknown as AppController;
+
+    const services = {} as unknown as AppServices;
+
+    NodeActionsModule.bind({ controller, services, env });
+
+    await NodeActionsModule.syncSelection();
+
+    assert.ok(reconcileCalled.value, "reconcile should have been called");
+    assert.strictEqual(reconcileCalled.graph, mockGraph, "reconcile should be called with inspectable graph");
+  });
+});

--- a/packages/visual-editor/tests/sca/actions/node/node-triggers.test.ts
+++ b/packages/visual-editor/tests/sca/actions/node/node-triggers.test.ts
@@ -9,6 +9,7 @@ import assert from "node:assert";
 import {
   onNodeConfigChange,
   onCopyShortcut,
+  onGraphVersionChange,
 } from "../../../../src/sca/actions/node/triggers.js";
 import { setDOM, unsetDOM } from "../../../fake-dom.js";
 
@@ -196,6 +197,41 @@ suite("Node Triggers", () => {
       );
 
       getSelectionSpy.mock.restore();
+    });
+  });
+
+  suite("onGraphVersionChange", () => {
+    test("returns version + 1 when version is set", () => {
+      const mockBind = {
+        controller: {
+          editor: {
+            graph: {
+              version: 5,
+            },
+          },
+        },
+        services: {},
+      };
+
+      const trigger = onGraphVersionChange(mockBind as never);
+      const result = trigger.condition();
+
+      assert.strictEqual(
+        result,
+        6,
+        "Should return version + 1"
+      );
+    });
+
+    test("has correct trigger name", () => {
+      const mockBind = {
+        controller: { editor: { graph: { version: 0 } } },
+        services: {},
+      };
+
+      const trigger = onGraphVersionChange(mockBind as never);
+
+      assert.strictEqual(trigger.name, "Graph Version Change (Selection)");
     });
   });
 });

--- a/packages/visual-editor/tests/sca/controller/subcontrollers/editor/selection/selection-controller.test.ts
+++ b/packages/visual-editor/tests/sca/controller/subcontrollers/editor/selection/selection-controller.test.ts
@@ -278,4 +278,64 @@ suite("SelectionController", () => {
       assetEdges: new Set(),
     });
   });
+
+  test("reconcile prunes non-existent elements", async () => {
+    const store = new SelectionController(
+      "Selection_11",
+      "SelectionController"
+    );
+    await store.isHydrated;
+
+    const graphStore = makeTestGraphStore();
+
+    loadGraphIntoStore(graphStore, testGraph);
+    const inspectableGraph = graphStore.get()?.graphs.get("");
+    if (!inspectableGraph) assert.fail("Unable to inspect graph");
+
+    store.selectAll(inspectableGraph);
+    await store.isSettled;
+
+    assert.deepStrictEqual(unwrap(store.selection), full);
+
+    // Create a modified graph with some elements removed
+    const modifiedGraph: GraphDescriptor & Required<Pick<GraphDescriptor, "assets">> = {
+      nodes: [
+        {
+          id: "a",
+          type: "type",
+          configuration: {
+            config$prompt: {
+              parts: [
+                {
+                  text: '{{"type": "asset", "path": "asset-a", "title": "Asset"}} ',
+                },
+              ],
+              role: "user",
+            },
+          },
+        },
+      ],
+      edges: [
+        { from: "a", to: "a", out: "a", in: "a" },
+      ],
+      assets: {
+        "asset-a": { data: "" },
+      },
+    };
+
+    const graphStore2 = makeTestGraphStore();
+    loadGraphIntoStore(graphStore2, modifiedGraph);
+    const inspectableGraph2 = graphStore2.get()?.graphs.get("");
+    if (!inspectableGraph2) assert.fail("Unable to inspect graph");
+
+    store.reconcile(inspectableGraph2);
+    await store.isSettled;
+
+    assert.deepStrictEqual(unwrap(store.selection), {
+      nodes: new Set(["a"]),
+      edges: new Set([edge0]),
+      assets: new Set(["asset-a"]),
+      assetEdges: new Set([assetEdge0]),
+    });
+  });
 });


### PR DESCRIPTION
## What
Added a mechanism to reactively reconcile and prune the selection state in the visual editor whenever the graph is mutated (e.g., when a node is deleted).

## Why
Previously, the `SelectionController` was decoupled from the `GraphController`. When a selected node, edge, or asset was deleted, it remained in the selection state, causing stale and untitled chips to persist in the UI (such as in the chat panel).

## Changes
- **SelectionController**: Added a `reconcile(graph: InspectableGraph)` method to safely prune selected nodes, edges, assets, and asset-edges that are no longer present in the graph.
- **Node Triggers**: Created an `onGraphVersionChange` signal trigger using the Version + 1 pattern to detect graph edits reactively.
- **Node Actions**: Created a `syncSelection` action triggered by `onGraphVersionChange` that invokes the selection reconciliation.
- **Unit Tests**: Added comprehensive unit tests for `SelectionController.reconcile`, the `onGraphVersionChange` trigger, and the `syncSelection` action.

## Testing
Verify that all unit tests pass:
```bash
npm run test:file -- './dist/tsc/tests/sca/controller/subcontrollers/editor/selection/selection-controller.test.js' './dist/tsc/tests/sca/actions/node/node-triggers.test.js' './dist/tsc/tests/sca/actions/node/node-actions.test.js'
```
