### PR TITLE
[lite] Gate Graph-Editing Agent UI on Read-Only Graphs in Lite Mode

### DIFF
--- a/packages/visual-editor/src/index-lite.ts
+++ b/packages/visual-editor/src/index-lite.ts
@@ -675,8 +675,9 @@ export class LiteMain extends MainBase implements LiteEditInputController {
     );
     const enableGraphEditorAgent =
       !isHydratingAgent && this.sca.env.flags.get("enableGraphEditorAgent");
+    const isReadOnly = this.sca.controller.editor.graph.readOnly;
 
-    if (enableGraphEditorAgent) {
+    if (enableGraphEditorAgent && !isReadOnly) {
       return html`<div id="controls" slot="slot-0" class="opie-mode">
         ${[
           this.#renderOriginalPrompt(true),


### PR DESCRIPTION
## What
Modified the layout rendering in Opal's lite mode to hide the graph-editing agent UI when the graph is read-only, falling back to the standard disabled input text box.

## Why
The graph-editing agent UI is meant for modifying graphs. Displaying it on a read-only graph causes confusion, whereas falling back to a disabled input box matches the expected behavior and clearly indicates that the graph is read-only.

## Changes
* **packages/visual-editor**
  * [index-lite.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/src/index-lite.ts): Updated `#renderControls()` to check `this.sca.controller.editor.graph.readOnly` and only render the agent-based chat UI when `enableGraphEditorAgent` is active and the graph is not read-only.

## Testing
* Ran `npm run test` in `packages/visual-editor` to verify successful compilation and that all existing test suites pass.
