### PR TITLE
[feedback] Refactor Agent Feedback History Collection & Formatting

### DIFF
--- a/packages/visual-editor/src/sca/actions/agent/graph-editing-agent-actions.ts
+++ b/packages/visual-editor/src/sca/actions/agent/graph-editing-agent-actions.ts
@@ -35,12 +35,7 @@ import {
   GraphEditingManager,
   GraphThemeGenerator,
 } from "../../../a2/agent/graph-editing/graph-editing-manager.js";
-import {
-  eventType,
-  eventPayload,
-  type AgentEvent,
-  type Payload,
-} from "../../../a2/agent/agent-event.js";
+
 
 export { bind, startGraphEditingAgent, resolveGraphEditingInput };
 
@@ -340,80 +335,6 @@ export const resetGraphEditingAgent = asAction(
 
 let feedbackTimeoutId: ReturnType<typeof setTimeout> | null = null;
 
-function formatLLMContent(content: LLMContent): string {
-  if (!content || !content.parts) return "";
-  return content.parts
-    .map((part) => {
-      if ("text" in part) {
-        return part.text;
-      }
-      return "";
-    })
-    .filter(Boolean)
-    .join("\n");
-}
-
-function formatAgentEventHistory(
-  events: ReadonlyArray<AgentEvent>,
-  n = 20
-): string {
-  const lastN = events.slice(-n);
-  return lastN
-    .map((event) => {
-      const type = eventType(event);
-      const payload = eventPayload(event);
-
-      switch (type) {
-        case "start": {
-          const p = payload as Payload<"start">;
-          return `START OBJECTIVE:\n${formatLLMContent(p.objective)}`;
-        }
-        case "thought": {
-          const p = payload as Payload<"thought">;
-          return `THOUGHT:\n${p.text}`;
-        }
-        case "functionCall": {
-          const p = payload as Payload<"functionCall">;
-          return `CALL TOOL: ${p.name}\nArgs: ${JSON.stringify(p.args)}`;
-        }
-        case "functionResult": {
-          const p = payload as Payload<"functionResult">;
-          return `TOOL RESULT: ${formatLLMContent(p.content)}`;
-        }
-        case "content": {
-          const p = payload as Payload<"content">;
-          return `MODEL:\n${formatLLMContent(p.content)}`;
-        }
-        case "waitForInput": {
-          const p = payload as Payload<"waitForInput">;
-          return `WAIT FOR INPUT:\n${formatLLMContent(p.prompt)}`;
-        }
-        case "waitForChoice": {
-          const p = payload as Payload<"waitForChoice">;
-          const choicesStr = p.choices
-            .map((c) => formatLLMContent(c.content))
-            .join(" | ");
-          return `WAIT FOR CHOICE:\n${formatLLMContent(p.prompt)}\nChoices: ${choicesStr}`;
-        }
-        case "applyEdits": {
-          const p = payload as Payload<"applyEdits">;
-          return `APPLY EDITS: ${p.label}`;
-        }
-        case "error": {
-          const p = payload as Payload<"error">;
-          return `ERROR: ${p.message}`;
-        }
-        case "complete": {
-          const p = payload as Payload<"complete">;
-          return `COMPLETE:\n${JSON.stringify(p.result)}`;
-        }
-        default:
-          return `${type.toUpperCase()} EVENT`;
-      }
-    })
-    .join("\n---\n");
-}
-
 export const setOpieReaction = asAction(
   "GraphEditingAgent.setOpieReaction",
   {
@@ -435,14 +356,13 @@ export const setOpieReaction = asAction(
     if (newReaction !== "none") {
       feedbackTimeoutId = setTimeout(() => {
         const events = agent.history;
-        const conversation = formatAgentEventHistory(events, 20);
         const productData = {
           reaction: newReaction,
-          conversation,
         };
         controller.global.feedback.open({
           bucketSuffix: "opie",
           productData,
+          agentEvents: [events],
           flow: "submit",
           description: `User sentiment: ${newReaction}`,
         });

--- a/packages/visual-editor/src/sca/controller/subcontrollers/global/feedback-controller.ts
+++ b/packages/visual-editor/src/sca/controller/subcontrollers/global/feedback-controller.ts
@@ -10,6 +10,13 @@ import { createTrustedFeedbackURL } from "../../../../ui/trusted-types/feedback-
 import { field } from "../../decorators/field.js";
 import type { TrustedScriptURL } from "trusted-types/lib/index.js";
 import { Utils } from "../../../utils.js";
+import type { LLMContent } from "@breadboard-ai/types";
+import {
+  eventType,
+  eventPayload,
+  type AgentEvent,
+  type Payload,
+} from "../../../../a2/agent/agent-event.js";
 
 type UserFeedbackApi = {
   startFeedback(
@@ -134,6 +141,7 @@ export class FeedbackController extends RootController {
     options: {
       bucketSuffix?: string;
       productData?: Record<string, string>;
+      agentEvents?: Array<ReadonlyArray<AgentEvent>>;
     } & (
       | { flow?: undefined; description?: never }
       | { flow: "submit"; description: string }
@@ -142,7 +150,20 @@ export class FeedbackController extends RootController {
     const LABEL = "Feedback.open";
     const logger = Utils.Logging.getLogger();
 
-    const { bucketSuffix, productData, flow } = options;
+    const { bucketSuffix, productData, flow, agentEvents } = options;
+
+    const finalProductData = { ...productData };
+    if (agentEvents && agentEvents.length > 0) {
+      const formattedConversations = agentEvents
+        .map((events, index) => {
+          const formatted = formatAgentEventHistory(events, 20);
+          return agentEvents.length > 1
+            ? `=== Agent Session #${index + 1} ===\n${formatted}`
+            : formatted;
+        })
+        .join("\n\n");
+      finalProductData.conversation = formattedConversations;
+    }
     const description = "description" in options ? options.description : undefined;
 
     if (this.status !== "closed") {
@@ -155,7 +176,7 @@ export class FeedbackController extends RootController {
       {
         timestamp: Date.now(),
         bucketSuffix,
-        productData,
+        productData: finalProductData,
         flow,
         description,
         status: "pending",
@@ -284,7 +305,7 @@ export class FeedbackController extends RootController {
     }
 
     try {
-      api.startFeedback(config, productData);
+      api.startFeedback(config, finalProductData);
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       updateEntryStatus("error", `Error starting feedback: ${msg}`);
@@ -305,4 +326,78 @@ export class FeedbackController extends RootController {
       this.entries = newEntries;
     }
   }
+}
+
+function formatLLMContent(content: LLMContent): string {
+  if (!content || !content.parts) return "";
+  return content.parts
+    .map((part) => {
+      if ("text" in part) {
+        return part.text;
+      }
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function formatAgentEventHistory(
+  events: ReadonlyArray<AgentEvent>,
+  n = 20
+): string {
+  const lastN = events.slice(-n);
+  return lastN
+    .map((event) => {
+      const type = eventType(event);
+      const payload = eventPayload(event);
+
+      switch (type) {
+        case "start": {
+          const p = payload as Payload<"start">;
+          return `START OBJECTIVE:\n${formatLLMContent(p.objective)}`;
+        }
+        case "thought": {
+          const p = payload as Payload<"thought">;
+          return `THOUGHT:\n${p.text}`;
+        }
+        case "functionCall": {
+          const p = payload as Payload<"functionCall">;
+          return `CALL TOOL: ${p.name}\nArgs: ${JSON.stringify(p.args)}`;
+        }
+        case "functionResult": {
+          const p = payload as Payload<"functionResult">;
+          return `TOOL RESULT: ${formatLLMContent(p.content)}`;
+        }
+        case "content": {
+          const p = payload as Payload<"content">;
+          return `MODEL:\n${formatLLMContent(p.content)}`;
+        }
+        case "waitForInput": {
+          const p = payload as Payload<"waitForInput">;
+          return `WAIT FOR INPUT:\n${formatLLMContent(p.prompt)}`;
+        }
+        case "waitForChoice": {
+          const p = payload as Payload<"waitForChoice">;
+          const choicesStr = p.choices
+            .map((c) => formatLLMContent(c.content))
+            .join(" | ");
+          return `WAIT FOR CHOICE:\n${formatLLMContent(p.prompt)}\nChoices: ${choicesStr}`;
+        }
+        case "applyEdits": {
+          const p = payload as Payload<"applyEdits">;
+          return `APPLY EDITS: ${p.label}`;
+        }
+        case "error": {
+          const p = payload as Payload<"error">;
+          return `ERROR: ${p.message}`;
+        }
+        case "complete": {
+          const p = payload as Payload<"complete">;
+          return `COMPLETE:\n${JSON.stringify(p.result)}`;
+        }
+        default:
+          return `${type.toUpperCase()} EVENT`;
+      }
+    })
+    .join("\n---\n");
 }

--- a/packages/visual-editor/tests/sca/actions/agent/graph-editing-agent-actions.test.ts
+++ b/packages/visual-editor/tests/sca/actions/agent/graph-editing-agent-actions.test.ts
@@ -27,7 +27,10 @@ import {
   type AgentRunConfig,
 } from "../../../../src/a2/agent/agent-service.js";
 import type { LocalAgentRun } from "../../../../src/a2/agent/local-agent-run.js";
-import type { WaitForInputPayload } from "../../../../src/a2/agent/agent-event.js";
+import {
+  type AgentEvent,
+  type WaitForInputPayload,
+} from "../../../../src/a2/agent/agent-event.js";
 import type { AppController } from "../../../../src/sca/controller/controller.js";
 import type { AppServices } from "../../../../src/sca/services/services.js";
 import { setDOM, unsetDOM } from "../../../fake-dom.js";
@@ -806,9 +809,9 @@ suite("graph-editing-agent-actions", () => {
               bucketSuffix: string;
               flow: string;
               description: string;
+              agentEvents: Array<ReadonlyArray<AgentEvent>>;
               productData: {
                 reaction: string;
-                conversation: string;
               };
             },
           ];
@@ -820,8 +823,8 @@ suite("graph-editing-agent-actions", () => {
     assert.strictEqual(args.bucketSuffix, "opie");
     assert.strictEqual(args.flow, "submit");
     assert.strictEqual(args.description, "User sentiment: up");
-    assert.ok(args.productData.conversation.includes("START OBJECTIVE:\ntest prompt"));
-    assert.ok(args.productData.conversation.includes("THOUGHT:\nThinking about test prompt..."));
     assert.strictEqual(args.productData.reaction, "up");
+    assert.strictEqual(args.agentEvents.length, 1);
+    assert.strictEqual(args.agentEvents[0].length, 2);
   });
 });

--- a/packages/visual-editor/tests/sca/controller/subcontrollers/global/feedback-controller.test.ts
+++ b/packages/visual-editor/tests/sca/controller/subcontrollers/global/feedback-controller.test.ts
@@ -17,6 +17,7 @@ import {
 import { FeedbackController } from "../../../../../src/sca/controller/subcontrollers/global/feedback-controller.js";
 import type { AppEnvironment } from "../../../../../src/sca/environment/environment.js";
 import { setDOM, unsetDOM } from "../../../../fake-dom.js";
+import { type AgentEvent } from "../../../../../src/a2/agent/agent-event.js";
 
 type UserFeedbackConfig = {
   productId: string;
@@ -48,6 +49,7 @@ suite("FeedbackController", () => {
   let mockEnv: AppEnvironment;
   let windowWithUserFeedback: WindowWithUserFeedbackApi;
   let providedConfig: UserFeedbackConfig;
+  let providedProductData: Record<string, string> | undefined;
 
   before(() => {
     setDOM();
@@ -83,10 +85,16 @@ suite("FeedbackController", () => {
     await controller.isHydrated;
 
     const mockApi = {
-      startFeedback: mock.fn((config: UserFeedbackConfig) => {
-        if (config.onLoadCallback) config.onLoadCallback();
-        providedConfig = config;
-      }),
+      startFeedback: mock.fn(
+        (
+          config: UserFeedbackConfig,
+          productData?: Record<string, string>
+        ) => {
+          if (config.onLoadCallback) config.onLoadCallback();
+          providedConfig = config;
+          providedProductData = productData;
+        }
+      ),
     };
     windowWithUserFeedback.userfeedback = { api: mockApi };
 
@@ -104,6 +112,7 @@ suite("FeedbackController", () => {
   afterEach(() => {
     mock.reset();
     windowWithUserFeedback.userfeedback = undefined;
+    providedProductData = undefined;
   });
 
   test("Initial status is closed", () => {
@@ -223,5 +232,37 @@ suite("FeedbackController", () => {
     const lastEntry = controller.entries[controller.entries.length - 1];
     assert.strictEqual(lastEntry.status, "error");
     assert.match(lastEntry.errorMessage || "", /Headless feedback submission requires a valid 'description'/);
+  });
+
+  test("open() with agentEvents formats and sends conversation in productData", async () => {
+    const events: AgentEvent[] = [
+      { start: { objective: { parts: [{ text: "Solve world hunger" }] } } },
+      { thought: { text: "Thinking of a recipe..." } },
+    ];
+    await controller.open({
+      agentEvents: [events],
+    });
+
+    assert.ok(providedProductData);
+    assert.strictEqual(providedProductData.conversation.includes("START OBJECTIVE:\nSolve world hunger"), true);
+    assert.strictEqual(providedProductData.conversation.includes("THOUGHT:\nThinking of a recipe..."), true);
+  });
+
+  test("open() with multiple agentEvents arrays formats and separates them in productData", async () => {
+    const session1: AgentEvent[] = [
+      { start: { objective: { parts: [{ text: "Session 1 objective" }] } } },
+    ];
+    const session2: AgentEvent[] = [
+      { start: { objective: { parts: [{ text: "Session 2 objective" }] } } },
+    ];
+    await controller.open({
+      agentEvents: [session1, session2],
+    });
+
+    assert.ok(providedProductData);
+    assert.strictEqual(providedProductData.conversation.includes("=== Agent Session #1 ==="), true);
+    assert.strictEqual(providedProductData.conversation.includes("START OBJECTIVE:\nSession 1 objective"), true);
+    assert.strictEqual(providedProductData.conversation.includes("=== Agent Session #2 ==="), true);
+    assert.strictEqual(providedProductData.conversation.includes("START OBJECTIVE:\nSession 2 objective"), true);
   });
 });


### PR DESCRIPTION
## What
Shifted the agent event history formatting logic from the graph editing agent action module to the global feedback controller, modifying the feedback API to accept raw event histories instead of pre-formatted strings, and added support for formatting multiple agent sessions.

## Why
Enables other types of feedback to easily include agent event histories. Centralizing this formatting inside `FeedbackController` keeps action coordinators clean and allows the feedback system to handle multiple agent sessions (e.g. graph editing and other agent sessions in the same graph) uniformly.

## Changes

### 1. Centralized Formatting in Feedback Controller
- **Location**: [feedback-controller.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/src/sca/controller/subcontrollers/global/feedback-controller.ts)
- Imported `AgentEvent` and associated event payload helpers.
- Added private module-level helpers `formatLLMContent` and `formatAgentEventHistory`.
- Updated `open()` to accept an optional `agentEvents` array of histories: `agentEvents?: Array<ReadonlyArray<AgentEvent>>`.
- Formats and joins multiple histories with headers (e.g., `=== Agent Session #1 ===`) if more than one session is present, storing the resulting string under the `conversation` field in `productData`.

### 2. Action Simplification
- **Location**: [graph-editing-agent-actions.ts](file:///Users/dglazkov/Documents/code/breadboard/packages/visual-editor/src/sca/actions/agent/graph-editing-agent-actions.ts)
- Removed local `formatLLMContent` and `formatAgentEventHistory` functions and cleaned up unused imports.
- Updated `setOpieReaction` to pass the raw history array `[events]` via the `agentEvents` option of `feedback.open`.

### 3. Unit Test Coverage
- **Location**: [graph-editing-agent-actions.test.ts](file:///Users/dglazkov/Documents/code/breadboard/tests/sca/actions/agent/graph-editing-agent-actions.test.ts)
  - Updated the `setOpieReaction` test to assert that `feedback.open` is called with the raw `agentEvents` array instead of the pre-formatted `conversation` string.
- **Location**: [feedback-controller.test.ts](file:///Users/dglazkov/Documents/code/breadboard/tests/sca/controller/subcontrollers/global/feedback-controller.test.ts)
  - Updated the `startFeedback` mock to capture `providedProductData`.
  - Added new test cases to verify correct formatting and separation of single and multiple agent session histories.

## Testing
Verified that all tests compile and pass successfully:
- `npm run test:file -- './dist/tsc/tests/sca/controller/subcontrollers/global/feedback-controller.test.js'` (14/14 passed)
- `npm run test:file -- './dist/tsc/tests/sca/actions/agent/graph-editing-agent-actions.test.js'` (17/17 passed)
