### PR TITLE
[ve] Expressive Thinking Avatars & Decoupled Shell Sharing

### DIFF
--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -7,7 +7,8 @@
 import { html, nothing } from "lit";
 import { customElement } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
-import { ref } from "lit/directives/ref.js";
+import { ref, createRef } from "lit/directives/ref.js";
+import { SharePanel } from "./ui/elements/share-panel/share-panel.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { MainBase, RenderValues } from "./main-base.js";
 import { IterateOnPromptMessage } from "./ui/embed/embed.js";
@@ -33,6 +34,8 @@ export { Main };
 
 @customElement("bb-main")
 class Main extends MainBase {
+  readonly #sharePanelRef = createRef<SharePanel>();
+
   override async doPostInitWork() {
     await Promise.all([
       this.sca.controller.global.performMigrations(),
@@ -237,6 +240,9 @@ class Main extends MainBase {
       class=${classMap({
         "workbench-active": workbenchActive,
       })}
+      @bbsharerequested=${() => {
+        this.#sharePanelRef.value?.open();
+      }}
       @bbevent=${async (
         evt: BreadboardUI.Events.StateEvent<
           keyof BreadboardUI.Events.StateEventDetailMap
@@ -304,6 +310,7 @@ class Main extends MainBase {
         this.#renderFeedbackPanel(),
         this.renderConsentRequests(),
         this.#maybeRenderDebugPanel(),
+        html`<bb-share-panel ${ref(this.#sharePanelRef)}></bb-share-panel>`,
       ]}
     </div>`;
   }
@@ -707,13 +714,6 @@ class Main extends MainBase {
           console.warn(err);
         }
       }}
-      @bbsharerequested=${() => {
-        if (!this.canvasControllerRef.value) {
-          return;
-        }
-
-        this.canvasControllerRef.value.openSharePanel();
-      }}
       @change=${async (evt: Event) => {
         const [select] = evt.composedPath();
         if (!(select instanceof BreadboardUI.Elements.ItemSelect)) {
@@ -811,7 +811,7 @@ class Main extends MainBase {
           }
 
           case "share": {
-            this.canvasControllerRef.value?.openSharePanel();
+            this.#sharePanelRef.value?.open();
             break;
           }
 

--- a/packages/visual-editor/src/ui/elements/canvas-controller/canvas-controller.ts
+++ b/packages/visual-editor/src/ui/elements/canvas-controller/canvas-controller.ts
@@ -45,7 +45,6 @@ import {
 import { icons } from "../../styles/icons.js";
 import { EntityEditor } from "../elements.js";
 import { consume } from "@lit/context";
-import { SharePanel } from "../share-panel/share-panel.js";
 
 import { effects } from "../../styles/host/effects.js";
 import { GraphTheme } from "@breadboard-ai/types";
@@ -98,7 +97,6 @@ export class CanvasController extends SignalWatcher(LitElement) {
   accessor showAssetOrganizer = false;
 
   #entityEditorRef: Ref<EntityEditor> = createRef();
-  #sharePanelRef: Ref<SharePanel> = createRef();
   #lastKnownNlEditValue = "";
   #prevMainGraphId: MainGraphIdentifier | null = null;
   #prevGraph: GraphDescriptor | null = null;
@@ -332,9 +330,6 @@ export class CanvasController extends SignalWatcher(LitElement) {
               this.showThemeDesigner = true;
               this.#themeOptions = evt.themeOptions;
             }}
-            @bbsharerequested=${() => {
-              this.openSharePanel();
-            }}
           ></bb-app-controller>`;
         }
       )}`,
@@ -501,7 +496,6 @@ export class CanvasController extends SignalWatcher(LitElement) {
           : html`<section id="content" class="welcome">
               ${graphEditor}
             </section>`,
-      html`<bb-share-panel ${ref(this.#sharePanelRef)}></bb-share-panel>`,
     ];
   }
 
@@ -520,9 +514,5 @@ export class CanvasController extends SignalWatcher(LitElement) {
     }
 
     return html`<bb-empty-state></bb-empty-state>`;
-  }
-
-  openSharePanel() {
-    this.#sharePanelRef?.value?.open();
   }
 }

--- a/packages/visual-editor/src/ui/elements/graph-editing-chat/chat-panel.ts
+++ b/packages/visual-editor/src/ui/elements/graph-editing-chat/chat-panel.ts
@@ -13,6 +13,9 @@ import { scaContext } from "../../../sca/context/context.js";
 import type { SCA } from "../../../sca/sca.js";
 import type { ChatEntry } from "../../../sca/types.js";
 import { markdown } from "../../directives/markdown.js";
+import * as StringsHelper from "../../strings/helper.js";
+
+const GlobalStrings = StringsHelper.forSection("Global");
 import { icons } from "../../styles/icons.js";
 import * as Styles from "../../styles/styles.js";
 import "../input/expanding-textarea.js";
@@ -428,10 +431,20 @@ class ChatPanel extends SignalWatcher(LitElement) {
         border: 1px solid var(--light-dark-n-90);
         border-radius: 24px;
         padding: var(--bb-grid-size-3) var(--bb-grid-size-4);
-        margin: 0 var(--bb-grid-size-6) var(--bb-grid-size-5)
-          var(--bb-grid-size-6); /* Matches side padding (24px) and bottom padding (20px) */
+        margin: 0 var(--bb-grid-size-6) var(--bb-grid-size-2)
+          var(--bb-grid-size-6); /* Matches side padding (24px) and bottom padding (8px) */
         box-shadow: 0 8px 40px 0 rgba(0, 0, 0, 0.1);
         flex-shrink: 0;
+      }
+
+      #disclaimer {
+        font: 400 11px / 1.4 var(--bb-font-family);
+        color: var(--light-dark-n-50);
+        text-align: center;
+        margin-bottom: var(--bb-grid-size-4);
+        margin-top: 0;
+        user-select: none;
+        pointer-events: none;
       }
 
       bb-expanding-textarea {
@@ -723,6 +736,7 @@ class ChatPanel extends SignalWatcher(LitElement) {
 
         ${this.showSelectionStrip ? this.#renderSelectionStrip() : nothing}
         ${this.#renderInputArea()}
+        <div id="disclaimer">${GlobalStrings.from("LABEL_DISCLAIMER")}</div>
       </div>
       ${this.#renderAddAssetModal()}
     `;

--- a/packages/visual-editor/src/ui/elements/shared/agent-avatar.ts
+++ b/packages/visual-editor/src/ui/elements/shared/agent-avatar.ts
@@ -38,6 +38,9 @@ export class AgentAvatar extends SignalWatcher(LitElement) {
   @property({ type: Number })
   accessor count = 0;
 
+  @property({ type: Boolean, reflect: true })
+  accessor thinking = false;
+
   @state()
   accessor lookDirection: "left" | "center" | "right" = "center";
 
@@ -45,6 +48,20 @@ export class AgentAvatar extends SignalWatcher(LitElement) {
   accessor blinking = false;
 
   #blinkTimeout: ReturnType<typeof setTimeout> | undefined;
+  #thinkingTimeout: ReturnType<typeof setTimeout> | undefined;
+
+  constructor() {
+    super();
+    this.addEventListener("click", () => {
+      if (!this.supportsHover && !this.isStatic) {
+        this.thinking = true;
+        clearTimeout(this.#thinkingTimeout);
+        this.#thinkingTimeout = setTimeout(() => {
+          this.thinking = false;
+        }, 3000);
+      }
+    });
+  }
 
   static styles = css`
     :host {
@@ -55,6 +72,11 @@ export class AgentAvatar extends SignalWatcher(LitElement) {
       height: var(--bb-grid-size-10);
       box-sizing: border-box;
       position: relative;
+
+      --eyes-drift-x-neg: -2px;
+      --eyes-drift-x-pos: 2px;
+      --eyes-thinking-x: 2px;
+      --eyes-thinking-y: -3px;
     }
 
     :host([supportsHover]) {
@@ -117,16 +139,30 @@ export class AgentAvatar extends SignalWatcher(LitElement) {
       display: flex;
       gap: 5px;
       margin-top: 11px;
-      transition: transform 0.1s ease-in-out;
+      transition: transform 0.15s cubic-bezier(0.2, 0.8, 0.2, 1);
       z-index: 2; /* Above background! */
+      transform: translate(
+        var(--eyes-translate-x, 0px),
+        var(--eyes-translate-y, 0px)
+      );
     }
 
     .eyes.left {
-      transform: translateX(-2px);
+      --eyes-translate-x: var(--eyes-drift-x-neg);
     }
 
     .eyes.right {
-      transform: translateX(2px);
+      --eyes-translate-x: var(--eyes-drift-x-pos);
+    }
+
+    .eyes.thinking {
+      --eyes-translate-y: var(--eyes-thinking-y);
+      --eye-scale-y: 0.3;
+      transition: transform 0.5s cubic-bezier(0.2, 0.8, 0.2, 1);
+    }
+
+    .eyes.thinking .eye {
+      transition-duration: 0.5s;
     }
 
     .eye {
@@ -134,8 +170,9 @@ export class AgentAvatar extends SignalWatcher(LitElement) {
       height: 10px;
       background: var(--light-dark-n-100);
       border-radius: 2px;
-      transition: transform 0.1s ease-in-out;
+      transition: transform 0.15s cubic-bezier(0.2, 0.8, 0.2, 1);
       transform-origin: center;
+      transform: scaleY(var(--eye-scale-y, 1));
     }
 
     .bubble {
@@ -164,7 +201,8 @@ export class AgentAvatar extends SignalWatcher(LitElement) {
     }
 
     .eye.blink {
-      transform: scaleY(0);
+      --eye-scale-y: 0;
+      transition-duration: 0.08s;
     }
 
     .eye:nth-child(2) {
@@ -174,19 +212,15 @@ export class AgentAvatar extends SignalWatcher(LitElement) {
     :host([mode="small"]) {
       width: var(--bb-grid-size-5);
       height: var(--bb-grid-size-5);
+      --eyes-drift-x-neg: -1px;
+      --eyes-drift-x-pos: 1px;
+      --eyes-thinking-x: 1px;
+      --eyes-thinking-y: -1.5px;
     }
 
     :host([mode="small"]) .eyes {
       gap: 2px;
       margin-top: 5px;
-    }
-
-    :host([mode="small"]) .eyes.left {
-      transform: translateX(-1px);
-    }
-
-    :host([mode="small"]) .eyes.right {
-      transform: translateX(1px);
     }
 
     :host([mode="small"]) .eye {
@@ -198,19 +232,15 @@ export class AgentAvatar extends SignalWatcher(LitElement) {
     :host([mode="large"]) {
       width: var(--bb-grid-size-12);
       height: var(--bb-grid-size-12);
+      --eyes-drift-x-neg: -3px;
+      --eyes-drift-x-pos: 3px;
+      --eyes-thinking-x: 3px;
+      --eyes-thinking-y: -4px;
     }
 
     :host([mode="large"]) .eyes {
       gap: 5px;
       margin-top: 12px;
-    }
-
-    :host([mode="large"]) .eyes.left {
-      transform: translateX(-3px);
-    }
-
-    :host([mode="large"]) .eyes.right {
-      transform: translateX(3px);
     }
 
     :host([mode="large"]) .eye {
@@ -222,19 +252,15 @@ export class AgentAvatar extends SignalWatcher(LitElement) {
     :host([mode="hero"]) {
       width: var(--bb-grid-size-16);
       height: var(--bb-grid-size-16);
+      --eyes-drift-x-neg: -4px;
+      --eyes-drift-x-pos: 4px;
+      --eyes-thinking-x: 4px;
+      --eyes-thinking-y: -5px;
     }
 
     :host([mode="hero"]) .eyes {
       gap: 6px;
       margin-top: 16px;
-    }
-
-    :host([mode="hero"]) .eyes.left {
-      transform: translateX(-4px);
-    }
-
-    :host([mode="hero"]) .eyes.right {
-      transform: translateX(4px);
     }
 
     :host([mode="hero"]) .eye {
@@ -254,6 +280,7 @@ export class AgentAvatar extends SignalWatcher(LitElement) {
   disconnectedCallback() {
     super.disconnectedCallback();
     clearTimeout(this.#blinkTimeout);
+    clearTimeout(this.#thinkingTimeout);
   }
 
   #scheduleBlink() {
@@ -291,7 +318,13 @@ export class AgentAvatar extends SignalWatcher(LitElement) {
       <div class="clipper">
         <div class="bg" style=${bgStyle}></div>
       </div>
-      <div class="${classMap({ eyes: true, [this.lookDirection]: true })}">
+      <div
+        class="${classMap({
+          eyes: true,
+          [this.lookDirection]: true,
+          thinking: this.thinking,
+        })}"
+      >
         <div
           class="${classMap({ eye: true, blink: this.blinking })}"
           style=${eyeStyle}


### PR DESCRIPTION
## What
Adds an expressive "thinking" state (squint and look-away drift) to the agent avatar that cleanly composes with blinking and look-directions. Elevates the share panel to the top-level shell, resolving the inert Share and Publish buttons in the new Agent Workbench.

## Why
* **Avatar Expressiveness**: Gives Opie a cute, focused "thinking" pose while ensuring that blinking remains fast and non-conflicting.
* **Workbench Sharing**: Decouples sharing from the canvas controller so users can share and publish their Opals directly from the Agent Workbench view.

## Changes

### `packages/visual-editor`

* **`agent-avatar.ts`**:
  - Added a reflected `thinking` property.
  - Added a click event listener that triggers a 3-second thinking cycle when `supportsHover` is false.
  - Implemented CSS Custom Property state-inheritance on the eyes so that blinking (`scaleY(0)`) cleanly overrides the thinking squint (`scaleY(0.3)`) and drift, using custom transition-durations (fast blink, slow drift).
  - Configured the thinking vertical shift to combine dynamically with the current look direction (shifting up-left, up-right, or up-center).

* **`chat-panel.ts`**:
  - Shifted the input card up and injected the standard disclaimer ("*Breadboard can make mistakes, so double-check it*") at the bottom of the panel.

* **`canvas-controller.ts`**:
  - Removed `<bb-share-panel>` and its local `openSharePanel` method to decouple sharing from the canvas.

* **`index.ts`**:
  - Elevated and mounted `<bb-share-panel>` at the root of the shell container so it is always present.
  - Added a single global `@bbsharerequested` listener on the top-level `#container` div to catch and open the share panel from any sub-component (header, canvas, or workbench).
  - Reverted redundant intermediate event listeners.

## Testing
* **Avatar**: Click on a static avatar (`supportsHover=false`) and verify it squints and looks away to think. Verify that blinks still happen cleanly and quickly during the thinking state.
* **Workbench Sharing**: Open the Agent Workbench, click the **Share** button in the config column, and verify the share panel opens. Verify the **Publish** button activates and functions after sharing.
* **Disclaimer**: Verify the disclaimer is rendered centered underneath the input card.