### PR TITLE
[ve] Various editor fixes

### DIFF
--- a/packages/visual-editor/src/sca/controller/subcontrollers/editor/fast-access/fast-access-controller.ts
+++ b/packages/visual-editor/src/sca/controller/subcontrollers/editor/fast-access/fast-access-controller.ts
@@ -64,11 +64,11 @@ class FastAccessController extends RootController {
     const mode = this.fastAccessMode;
     if (!mode) return [];
 
-    const showAssets = mode === "browse";
-    const showTools = mode !== "route";
-    const showComponents = mode !== "route";
+    const showAssets = mode === "browse" || mode === "browse-assets";
+    const showTools = mode !== "route" && mode !== "browse-assets";
+    const showComponents = mode !== "route" && mode !== "browse-assets";
     const showRoutes = mode === "route";
-    const showAgentModeTools = mode !== "route";
+    const showAgentModeTools = mode !== "route" && mode !== "browse-assets";
 
     const filterRe = this.filter ? new RegExp(this.filter, "gim") : null;
     const items: DisplayItem[] = [];
@@ -140,7 +140,7 @@ class FastAccessController extends RootController {
     }
 
     // Append integration tools from IntegrationsController
-    if (opts.integrationsController) {
+    if (opts.integrationsController && mode !== "browse-assets") {
       for (const [url, state] of opts.integrationsController.registered) {
         if (state.status !== "complete") continue;
         for (const [, tool] of state.tools) {

--- a/packages/visual-editor/src/sca/types.ts
+++ b/packages/visual-editor/src/sca/types.ts
@@ -592,7 +592,7 @@ export type FastAccessItem =
  * - `"browse"` — Full `@` menu (text-editor). Shows assets, tools, components, agent-mode.
  * - `"route"` — Chiclet re-targeting. Shows routes only.
  */
-export type FastAccessMode = "tools" | "browse" | "route";
+export type FastAccessMode = "tools" | "browse" | "route" | "browse-assets";
 
 /**
  * Extended item type that includes integration tools (managed by legacy

--- a/packages/visual-editor/src/ui/elements/agent-workbench/agent-config-column.ts
+++ b/packages/visual-editor/src/ui/elements/agent-workbench/agent-config-column.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { LitElement, html, css, nothing } from "lit";
+import { LitElement, html, css, nothing, noChange } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { SignalWatcher } from "@lit-labs/signals";
@@ -414,8 +414,8 @@ export class AgentConfigColumn extends SignalWatcher(LitElement) {
       });
       // Mirror the blur handler: release ownership before the graph
       // update so the re-render passes the real objectiveText (not
-      // `nothing`, which Lit resolves to `undefined` and wipes the
-      // editor model).
+      // `noChange`, which would leave the editor stale if the saved
+      // value diverged from the editor model).
       this.#focused = false;
       this.sca.actions.workbench.applyObjective(blocks);
     }
@@ -754,7 +754,7 @@ export class AgentConfigColumn extends SignalWatcher(LitElement) {
     // While focused, don't pass .value — the text editor owns its
     // internal state and re-setting it would clobber the cursor and
     // any in-progress edits.
-    const editorValue = this.#focused ? nothing : objectiveText;
+    const editorValue = this.#focused ? noChange : objectiveText;
     const title = graphController.title ?? "Untitled agent";
 
     // Dynamically resolve theme colors from the graph's visual metadata
@@ -820,6 +820,7 @@ export class AgentConfigColumn extends SignalWatcher(LitElement) {
             <bb-text-editor-remix
               .value=${editorValue}
               .supportsFastAccess=${true}
+              .fastAccessMode=${"browse-assets"}
               @focus=${this.#onFocus}
               @blur=${this.#onBlur}
               @keydown=${this.#onKeyDown}

--- a/packages/visual-editor/src/ui/elements/agent-workbench/asset-shelf/asset-shelf.ts
+++ b/packages/visual-editor/src/ui/elements/agent-workbench/asset-shelf/asset-shelf.ts
@@ -6,23 +6,25 @@
 
 import { LitElement, html, css, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
+import { keyed } from "lit/directives/keyed.js";
 import { SignalWatcher } from "@lit-labs/signals";
 import { consume } from "@lit/context";
 import { scaContext } from "../../../../sca/context/context.js";
 import { type SCA } from "../../../../sca/sca.js";
-import { Template } from "@breadboard-ai/utils";
+import {
+  Template,
+  NOTEBOOKLM_MIMETYPE,
+  toNotebookLmUrl,
+} from "@breadboard-ai/utils";
 import type {
   GraphAsset,
   GraphAssetDescriptor,
 } from "../../../../sca/types.js";
 import * as Styles from "../../../styles/styles.js";
 import { extractPromptText } from "../../../../utils/prompt-utils.js";
-import { until } from "lit/directives/until.js";
-import { resolveImage } from "../../../media/image.js";
-import { NOTEBOOKLM_MIMETYPE } from "@breadboard-ai/utils";
-import { notebookLmIcon } from "../../../styles/svg-icons.js";
 import "../../input/add-asset/add-asset-button.js";
 import "../../input/add-asset/add-asset-modal.js";
+import "./asset-thumbnail.js";
 import {
   AddAssetEvent,
   AddAssetRequestEvent,
@@ -30,11 +32,6 @@ import {
   HideTooltipEvent,
 } from "../../../events/events.js";
 import type { AssetMetadata } from "@breadboard-ai/types";
-import {
-  videoIdFromWatchOrShortsOrEmbedUri,
-  isShareUri,
-  convertShareUriToEmbedUri,
-} from "../../../../utils/media/youtube.js";
 
 @customElement("bb-agent-asset-shelf")
 export class AgentAssetShelf extends SignalWatcher(LitElement) {
@@ -153,31 +150,6 @@ export class AgentAssetShelf extends SignalWatcher(LitElement) {
         opacity: 1;
       }
 
-      .audio-toggle-button {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        width: 100%;
-        height: 100%;
-        border: none;
-        background: var(--light-dark-n-90);
-        color: var(--light-dark-n-10);
-        border-radius: var(--bb-grid-size-2);
-        cursor: pointer;
-        transition:
-          background-color 0.15s ease,
-          color 0.15s ease;
-
-        &:hover {
-          background: var(--sys-color--primary);
-          color: var(--sys-color--on-primary);
-        }
-
-        & .g-icon {
-          font-size: 20px;
-        }
-      }
-
       .asset-info-wrapper {
         display: flex;
         align-items: center;
@@ -205,6 +177,7 @@ export class AgentAssetShelf extends SignalWatcher(LitElement) {
         margin-right: var(--bb-grid-size-5);
         flex-shrink: 0;
         outline: 1px solid var(--light-dark-n-90);
+        overflow: hidden;
 
         & .g-icon {
           font-size: 20px;
@@ -351,9 +324,7 @@ export class AgentAssetShelf extends SignalWatcher(LitElement) {
     return "upload";
   }
 
-  #onToggleAudio(evt: Event, asset: GraphAsset) {
-    evt.stopPropagation();
-
+  #onToggleAudio(asset: GraphAsset) {
     if (this._playingAudioPath === asset.path) {
       if (this._activeAudio) {
         this._activeAudio.pause();
@@ -424,141 +395,6 @@ export class AgentAssetShelf extends SignalWatcher(LitElement) {
     return undefined;
   }
 
-  #renderAssetIcon(asset: GraphAsset) {
-    const mimeType = this.#inferMimeType(asset) || "";
-    const firstPart = asset.data[0]?.parts[0];
-
-    if (mimeType === NOTEBOOKLM_MIMETYPE) {
-      return html`<div
-        style="width: 100%; height: 100%; display: flex; align-items: center; justify-content: center; padding: 4px;"
-      >
-        ${notebookLmIcon}
-      </div>`;
-    }
-
-    if (mimeType.startsWith("image/") && firstPart) {
-      if ("inlineData" in firstPart && firstPart.inlineData) {
-        const dataUrl = `data:${firstPart.inlineData.mimeType};base64,${firstPart.inlineData.data}`;
-        return html`<img
-          src=${dataUrl}
-          style="width: 100%; height: 100%; object-fit: cover; border-radius: 4px;"
-        />`;
-      }
-      if ("fileData" in firstPart && firstPart.fileData) {
-        return html`<img
-          src=${firstPart.fileData.fileUri}
-          style="width: 100%; height: 100%; object-fit: cover; border-radius: 4px;"
-        />`;
-      }
-      if ("storedData" in firstPart && firstPart.storedData) {
-        const handle = firstPart.storedData.handle;
-        if (
-          handle.startsWith("drive:/") &&
-          this.sca.services.googleDriveClient
-        ) {
-          const resolvedSrc = resolveImage(
-            this.sca.services.googleDriveClient,
-            handle
-          );
-          return html`${until(
-            resolvedSrc.then(
-              (src) =>
-                html`<img
-                  src=${src || ""}
-                  style="width: 100%; height: 100%; object-fit: cover; border-radius: 4px;"
-                />`
-            ),
-            html`<div
-              style="width: 100%; height: 100%; display: flex; align-items: center; justify-content: center;"
-            >
-              <span
-                class="g-icon filled"
-                style="font-size: 16px; color: var(--light-dark-n-40);"
-                >progress_activity</span
-              >
-            </div>`
-          )}`;
-        }
-
-        return html`<img
-          src=${handle}
-          style="width: 100%; height: 100%; object-fit: cover; border-radius: 4px;"
-        />`;
-      }
-    }
-
-    if (mimeType.startsWith("audio/")) {
-      const isPlaying = this._playingAudioPath === asset.path;
-      const audioIcon = isPlaying ? "pause" : "play_arrow";
-      return html`<button
-        class="audio-toggle-button"
-        @click=${(evt: Event) => this.#onToggleAudio(evt, asset)}
-        @pointerover=${(evt: PointerEvent) => {
-          this.dispatchEvent(
-            new ShowTooltipEvent(
-              isPlaying ? "Pause audio" : "Play audio",
-              evt.clientX,
-              evt.clientY
-            )
-          );
-        }}
-        @pointerout=${() => {
-          this.dispatchEvent(new HideTooltipEvent());
-        }}
-      >
-        <span class="g-icon filled">${audioIcon}</span>
-      </button>`;
-    }
-
-    if (
-      mimeType.startsWith("video/") ||
-      mimeType === "video/mp4" ||
-      mimeType === "youtube"
-    ) {
-      let videoId: string | null = null;
-      if (firstPart && "fileData" in firstPart && firstPart.fileData) {
-        const uri = firstPart.fileData.fileUri;
-        if (isShareUri(uri)) {
-          const embedUri = convertShareUriToEmbedUri(uri);
-          if (embedUri) {
-            videoId = videoIdFromWatchOrShortsOrEmbedUri(embedUri);
-          }
-        } else {
-          videoId = videoIdFromWatchOrShortsOrEmbedUri(uri);
-        }
-      }
-
-      if (videoId) {
-        return html`<img
-          src="https://img.youtube.com/vi/${videoId}/default.jpg"
-          style="width: 100%; height: 100%; object-fit: cover; border-radius: 4px;"
-        />`;
-      }
-
-      if (
-        firstPart &&
-        "inlineData" in firstPart &&
-        firstPart.inlineData &&
-        firstPart.inlineData.mimeType.startsWith("video/")
-      ) {
-        return html`<span class="g-icon round filled">video_file</span>`;
-      }
-    }
-
-    const icon = this.#getAssetIcon(mimeType);
-    return html`<span class="g-icon round filled">${icon}</span>`;
-  }
-
-  #getAssetIcon(mimeType?: string): string {
-    if (!mimeType) return "draft";
-    if (mimeType.startsWith("image/")) return "image";
-    if (mimeType.startsWith("audio/")) return "audio_file";
-    if (mimeType.startsWith("video/")) return "video_file";
-    if (mimeType === "application/pdf") return "picture_as_pdf";
-    if (mimeType.startsWith("text/")) return "description";
-    return "attachment";
-  }
-
   #getAssetBadgeLabel(mimeType?: string): string {
     if (!mimeType) return "FILE";
     if (mimeType.startsWith("image/")) return "IMAGE";
@@ -566,6 +402,7 @@ export class AgentAssetShelf extends SignalWatcher(LitElement) {
     if (mimeType.startsWith("video/")) return "VIDEO";
     if (mimeType === "application/pdf") return "PDF";
     if (mimeType.startsWith("text/")) return "TEXT";
+    if (mimeType === "application/x-notebooklm") return "NOTEBOOK";
     const parts = mimeType.split("/");
     return parts[parts.length - 1].toUpperCase();
   }
@@ -612,13 +449,8 @@ export class AgentAssetShelf extends SignalWatcher(LitElement) {
 
     const allAssets = Array.from(allAssetsMap.values());
 
-    // Sort: In-use assets first, then alphabetically by title
+    // Sort: Alphabetically by title
     allAssets.sort((a, b) => {
-      const aInUse = referencedAssetPaths.has(a.path);
-      const bInUse = referencedAssetPaths.has(b.path);
-      if (aInUse && !bInUse) return -1;
-      if (!aInUse && bInUse) return 1;
-
       const aTitle = a.metadata?.title || a.path;
       const bTitle = b.metadata?.title || b.path;
       return aTitle.localeCompare(bTitle);
@@ -630,9 +462,39 @@ export class AgentAssetShelf extends SignalWatcher(LitElement) {
           <h2>Assets</h2>
           <bb-add-asset-button
             .showGDrive=${true}
-            .showNotebookLm=${false}
+            .showNotebookLm=${!!this.sca.env.flags.get("enableNotebookLm")}
             .label=${"Add asset"}
             @bbaddassetrequest=${(evt: AddAssetRequestEvent) => {
+              if (evt.assetType === "notebooklm") {
+                this.sca.actions.notebookLmPicker.open(async (notebooks) => {
+                  for (const notebook of notebooks) {
+                    const descriptor: GraphAssetDescriptor = {
+                      metadata: {
+                        title: notebook.preview || notebook.name || "Notebook",
+                        type: "content",
+                        subType: "notebooklm",
+                      },
+                      path: `asset-${globalThis.crypto.randomUUID().slice(0, 8)}.webp`,
+                      data: [
+                        {
+                          role: "user",
+                          parts: [
+                            {
+                              storedData: {
+                                handle: toNotebookLmUrl(notebook.id),
+                                mimeType: NOTEBOOKLM_MIMETYPE,
+                              },
+                            },
+                          ],
+                        },
+                      ],
+                    };
+                    await this.sca.actions.asset.addGraphAsset(descriptor);
+                  }
+                  this.requestUpdate();
+                });
+                return;
+              }
               this._showAddAssetModal = true;
               this._addAssetType = evt.assetType;
               this._allowedMimeTypes = evt.allowedMimeTypes;
@@ -645,67 +507,76 @@ export class AgentAssetShelf extends SignalWatcher(LitElement) {
             const mimeType = this.#inferMimeType(asset);
             const badgeLabel = this.#getAssetBadgeLabel(mimeType);
             const isInUse = referencedAssetPaths.has(asset.path);
+            const isPlaying = this._playingAudioPath === asset.path;
 
-            return html`
-              <div class="asset-row">
-                <span
-                  class="drag-handle g-icon"
-                  draggable="true"
-                  @dragstart=${(evt: DragEvent) =>
-                    this.#onDragStart(evt, asset)}
-                  @pointerover=${(evt: PointerEvent) => {
-                    this.dispatchEvent(
-                      new ShowTooltipEvent(
-                        "Drag to add to agent instructions",
-                        evt.clientX,
-                        evt.clientY
-                      )
-                    );
-                  }}
-                  @pointerout=${() => {
-                    this.dispatchEvent(new HideTooltipEvent());
-                  }}
-                  >drag_indicator</span
-                >
-                <div
-                  class="asset-info-wrapper"
-                  @click=${() => this.#onEditAsset(asset)}
-                >
-                  <div class="asset-icon-container">
-                    ${this.#renderAssetIcon(asset)}
-                  </div>
-                  <div class="asset-details">
-                    <div class="asset-title">
-                      ${asset.metadata?.title || asset.path}
+            return keyed(
+              asset.path,
+              html`
+                <div class="asset-row">
+                  <span
+                    class="drag-handle g-icon"
+                    draggable="true"
+                    @dragstart=${(evt: DragEvent) =>
+                      this.#onDragStart(evt, asset)}
+                    @pointerover=${(evt: PointerEvent) => {
+                      this.dispatchEvent(
+                        new ShowTooltipEvent(
+                          "Drag to add to agent instructions",
+                          evt.clientX,
+                          evt.clientY
+                        )
+                      );
+                    }}
+                    @pointerout=${() => {
+                      this.dispatchEvent(new HideTooltipEvent());
+                    }}
+                    >drag_indicator</span
+                  >
+                  <div
+                    class="asset-info-wrapper"
+                    @click=${() => this.#onEditAsset(asset)}
+                  >
+                    <div class="asset-icon-container">
+                      <bb-asset-thumbnail
+                        .asset=${asset}
+                        .mimeType=${mimeType || ""}
+                        .playing=${isPlaying}
+                        @bb-audio-toggle=${() => this.#onToggleAudio(asset)}
+                      ></bb-asset-thumbnail>
                     </div>
-                    <div class="asset-meta">
-                      <span class="asset-badge">${badgeLabel}</span>
-                      ${isInUse
-                        ? html`<span class="in-use-pill">In use</span>`
-                        : nothing}
+                    <div class="asset-details">
+                      <div class="asset-title">
+                        ${asset.metadata?.title || asset.path}
+                      </div>
+                      <div class="asset-meta">
+                        <span class="asset-badge">${badgeLabel}</span>
+                        ${isInUse
+                          ? html`<span class="in-use-pill">In use</span>`
+                          : nothing}
+                      </div>
                     </div>
                   </div>
+                  <button
+                    class="remove-button"
+                    @click=${() => this.#onRemoveAsset(asset.path)}
+                    @pointerover=${(evt: PointerEvent) => {
+                      this.dispatchEvent(
+                        new ShowTooltipEvent(
+                          "Remove asset",
+                          evt.clientX,
+                          evt.clientY
+                        )
+                      );
+                    }}
+                    @pointerout=${() => {
+                      this.dispatchEvent(new HideTooltipEvent());
+                    }}
+                  >
+                    <span class="g-icon">close</span>
+                  </button>
                 </div>
-                <button
-                  class="remove-button"
-                  @click=${() => this.#onRemoveAsset(asset.path)}
-                  @pointerover=${(evt: PointerEvent) => {
-                    this.dispatchEvent(
-                      new ShowTooltipEvent(
-                        "Remove asset",
-                        evt.clientX,
-                        evt.clientY
-                      )
-                    );
-                  }}
-                  @pointerout=${() => {
-                    this.dispatchEvent(new HideTooltipEvent());
-                  }}
-                >
-                  <span class="g-icon">close</span>
-                </button>
-              </div>
-            `;
+              `
+            );
           })}
         </div>
       </div>

--- a/packages/visual-editor/src/ui/elements/agent-workbench/asset-shelf/asset-thumbnail.ts
+++ b/packages/visual-editor/src/ui/elements/agent-workbench/asset-shelf/asset-thumbnail.ts
@@ -1,0 +1,260 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { LitElement, html, css, nothing } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { SignalWatcher } from "@lit-labs/signals";
+import { consume } from "@lit/context";
+import { scaContext } from "../../../../sca/context/context.js";
+import { type SCA } from "../../../../sca/sca.js";
+import { until } from "lit/directives/until.js";
+import { guard } from "lit/directives/guard.js";
+import { resolveImage } from "../../../media/image.js";
+import { NOTEBOOKLM_MIMETYPE } from "@breadboard-ai/utils";
+import { notebookLmIcon } from "../../../styles/svg-icons.js";
+import { getAssetIcon } from "../../../../utils/media/mime-type.js";
+import {
+  videoIdFromWatchOrShortsOrEmbedUri,
+  isShareUri,
+  convertShareUriToEmbedUri,
+} from "../../../../utils/media/youtube.js";
+import type { GraphAsset } from "../../../../sca/types.js";
+import * as Styles from "../../../styles/styles.js";
+import { ShowTooltipEvent, HideTooltipEvent } from "../../../events/events.js";
+
+export { AssetThumbnail };
+
+/**
+ * A self-contained thumbnail renderer for graph assets.
+ *
+ * Handles images (inline, file, stored/Drive), audio (with play toggle),
+ * video (YouTube thumbnails), NotebookLM, and generic file icons.
+ *
+ * Uses the `guard` directive to prevent re-resolving Drive images when the
+ * asset handle hasn't changed, eliminating the flicker that occurred when
+ * the parent re-rendered the entire asset list.
+ */
+@customElement("bb-asset-thumbnail")
+class AssetThumbnail extends SignalWatcher(LitElement) {
+  @consume({ context: scaContext })
+  accessor sca!: SCA;
+
+  @property({ attribute: false })
+  accessor asset!: GraphAsset;
+
+  @property()
+  accessor mimeType = "";
+
+  @property({ type: Boolean, reflect: true })
+  accessor playing = false;
+
+  static styles = [
+    Styles.HostIcons.icons,
+    Styles.HostColorsBase.baseColors,
+    Styles.HostColorScheme.match,
+    css`
+      :host {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        height: 100%;
+      }
+
+      img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        border-radius: var(--bb-grid-size);
+      }
+
+      .icon-wrapper {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .notebooklm-wrapper {
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: var(--bb-grid-size);
+      }
+
+      .loading-spinner {
+        font-size: 16px;
+        color: var(--light-dark-n-40);
+      }
+
+      .audio-toggle {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        height: 100%;
+        border: none;
+        background: var(--light-dark-n-90);
+        color: var(--light-dark-n-10);
+        border-radius: var(--bb-grid-size-2);
+        cursor: pointer;
+        transition:
+          background-color 0.15s ease,
+          color 0.15s ease;
+
+        &:hover {
+          background: var(--sys-color--primary);
+          color: var(--sys-color--on-primary);
+        }
+
+        & .g-icon {
+          font-size: 20px;
+        }
+      }
+    `,
+  ];
+
+  render() {
+    if (!this.asset) return nothing;
+
+    const mimeType = this.mimeType;
+    const firstPart = this.asset.data[0]?.parts[0];
+
+    // NotebookLM
+    if (mimeType === NOTEBOOKLM_MIMETYPE) {
+      return html`<div class="notebooklm-wrapper">${notebookLmIcon}</div>`;
+    }
+
+    // Images
+    if (mimeType.startsWith("image/") && firstPart) {
+      return this.#renderImage(firstPart);
+    }
+
+    // Audio
+    if (mimeType.startsWith("audio/")) {
+      return this.#renderAudioToggle();
+    }
+
+    // Video
+    if (mimeType.startsWith("video/") || mimeType === "youtube") {
+      return this.#renderVideo(firstPart);
+    }
+
+    // Generic icon fallback
+    return html`<span class="g-icon round filled"
+      >${getAssetIcon(mimeType)}</span
+    >`;
+  }
+
+  #renderImage(firstPart: NonNullable<GraphAsset["data"][0]>["parts"][0]) {
+    if ("inlineData" in firstPart && firstPart.inlineData) {
+      const dataUrl = `data:${firstPart.inlineData.mimeType};base64,${firstPart.inlineData.data}`;
+      return html`<img src=${dataUrl} />`;
+    }
+
+    if ("fileData" in firstPart && firstPart.fileData) {
+      return html`<img src=${firstPart.fileData.fileUri} />`;
+    }
+
+    if ("storedData" in firstPart && firstPart.storedData) {
+      const handle = firstPart.storedData.handle;
+
+      if (handle.startsWith("drive:/") && this.sca.services.googleDriveClient) {
+        const client = this.sca.services.googleDriveClient;
+        // Guard on the handle string — only re-resolve when it changes.
+        return guard([handle], () => {
+          const resolvedSrc = resolveImage(client, handle);
+          return until(
+            resolvedSrc.then((src) => html`<img src=${src || ""} />`),
+            html`<div class="icon-wrapper">
+              <span class="g-icon filled loading-spinner"
+                >progress_activity</span
+              >
+            </div>`
+          );
+        });
+      }
+
+      return html`<img src=${handle} />`;
+    }
+
+    return html`<span class="g-icon round filled">image</span>`;
+  }
+
+  #renderAudioToggle() {
+    const icon = this.playing ? "pause" : "play_arrow";
+    return html`<button
+      class="audio-toggle"
+      @click=${(evt: Event) => {
+        evt.stopPropagation();
+        this.dispatchEvent(
+          new CustomEvent("bb-audio-toggle", {
+            bubbles: true,
+            composed: true,
+          })
+        );
+      }}
+      @pointerover=${(evt: PointerEvent) => {
+        this.dispatchEvent(
+          new ShowTooltipEvent(
+            this.playing ? "Pause audio" : "Play audio",
+            evt.clientX,
+            evt.clientY
+          )
+        );
+      }}
+      @pointerout=${() => {
+        this.dispatchEvent(new HideTooltipEvent());
+      }}
+    >
+      <span class="g-icon filled">${icon}</span>
+    </button>`;
+  }
+
+  #renderVideo(
+    firstPart: NonNullable<GraphAsset["data"][0]>["parts"][0] | undefined
+  ) {
+    if (firstPart && "fileData" in firstPart && firstPart.fileData) {
+      const uri = firstPart.fileData.fileUri;
+      let videoId: string | null = null;
+
+      if (isShareUri(uri)) {
+        const embedUri = convertShareUriToEmbedUri(uri);
+        if (embedUri) {
+          videoId = videoIdFromWatchOrShortsOrEmbedUri(embedUri);
+        }
+      } else {
+        videoId = videoIdFromWatchOrShortsOrEmbedUri(uri);
+      }
+
+      if (videoId) {
+        return html`<img
+          src="https://img.youtube.com/vi/${videoId}/default.jpg"
+        />`;
+      }
+    }
+
+    if (
+      firstPart &&
+      "inlineData" in firstPart &&
+      firstPart.inlineData &&
+      firstPart.inlineData.mimeType.startsWith("video/")
+    ) {
+      return html`<span class="g-icon round filled">video_file</span>`;
+    }
+
+    return html`<span class="g-icon round filled">video_file</span>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "bb-asset-thumbnail": AssetThumbnail;
+  }
+}

--- a/packages/visual-editor/src/ui/elements/fast-access-menu/fast-access-menu.ts
+++ b/packages/visual-editor/src/ui/elements/fast-access-menu/fast-access-menu.ts
@@ -14,7 +14,7 @@ import {
 } from "../../events/events.js";
 import { classMap } from "lit/directives/class-map.js";
 import { createRef, ref, Ref } from "lit/directives/ref.js";
-import { getAssetType, getMimeType } from "../../../utils/media/mime-type.js";
+import { getAssetIcon, getMimeType } from "../../../utils/media/mime-type.js";
 import { consume } from "@lit/context";
 import { scaContext } from "../../../sca/context/context.js";
 import type { SCA } from "../../../sca/sca.js";
@@ -253,6 +253,15 @@ export class FastAccessMenu extends SignalWatcher(LitElement) {
 
       .integration menu button {
         --background: var(--n-90);
+      }
+
+      .g-icon[data-icon="notebooklm"]::after {
+        content: "";
+        display: block;
+        width: 16px;
+        height: 16px;
+        background: url(/third_party/icons/notebooklm.svg) center / contain
+          no-repeat;
       }
     `,
   ];
@@ -534,26 +543,14 @@ export class FastAccessMenu extends SignalWatcher(LitElement) {
     asset: GraphAsset,
     globalIndex: number
   ): HTMLTemplateResult {
-    let icon = getAssetType(getMimeType(asset.data));
-    if (!icon) {
-      icon = "text_fields";
-      if (asset.metadata?.type === "file") {
-        icon = "upload";
-      }
-    }
+    const mimeType = getMimeType(asset.data);
+    let icon = getAssetIcon(mimeType);
 
-    // Override icon based on subType (e.g., youtube, drawable, gdrive)
+    // Override icon based on subType (e.g., youtube, drawable, gdrive, notebooklm, webcam-video)
     if (asset.metadata?.subType) {
-      switch (asset.metadata?.subType) {
-        case "youtube":
-          icon = "video_youtube";
-          break;
-        case "drawable":
-          icon = "draw";
-          break;
-        case "gdrive":
-          icon = "drive";
-          break;
+      const subTypeIcon = iconSubstitute(asset.metadata.subType);
+      if (subTypeIcon && !subTypeIcon.includes("/")) {
+        icon = subTypeIcon;
       }
     }
 
@@ -567,7 +564,9 @@ export class FastAccessMenu extends SignalWatcher(LitElement) {
           this.#emitCurrentItem();
         }}
       >
-        <span class="g-icon filled round">${icon}</span>
+        <span class="g-icon filled round" data-icon=${icon}
+          >${icon === "notebooklm" ? "" : icon}</span
+        >
         <span class="title">${asset.metadata?.title ?? "Untitled asset"}</span>
       </button>
     </li>`;
@@ -655,9 +654,9 @@ export class FastAccessMenu extends SignalWatcher(LitElement) {
 
   render() {
     const mode = this.sca?.controller.editor.fastAccess.fastAccessMode;
-    const showAssets = mode === "browse";
-    const showTools = mode !== "route";
-    const showComponents = mode !== "route";
+    const showAssets = mode === "browse" || mode === "browse-assets";
+    const showTools = mode !== "route" && mode !== "browse-assets";
+    const showComponents = mode !== "route" && mode !== "browse-assets";
     const showRoutes = mode === "route";
 
     const assets = this.#itemsOfKind("asset");

--- a/packages/visual-editor/src/ui/elements/input/add-asset/add-asset-modal.ts
+++ b/packages/visual-editor/src/ui/elements/input/add-asset/add-asset-modal.ts
@@ -368,8 +368,8 @@ export class AddAssetModal extends SignalWatcher(LitElement) {
           };
           const metadata: AssetMetadata = {
             title: updatedTitle,
-            type: "file",
-            subType: "video/mp4",
+            type: "content",
+            subType: "youtube",
           };
 
           this.dispatchEvent(new AddAssetEvent(item, metadata));
@@ -422,7 +422,7 @@ export class AddAssetModal extends SignalWatcher(LitElement) {
             const metadata: AssetMetadata = {
               title: updatedTitle,
               type: "file",
-              subType: input.type,
+              subType: "webcam-video",
             };
 
             this.dispatchEvent(new AddAssetEvent(item, metadata));
@@ -915,6 +915,10 @@ export class AddAssetModal extends SignalWatcher(LitElement) {
         }
         break;
       }
+
+      case "notebooklm":
+        assetCollector = html`<div id="field-container">${preview}</div>`;
+        break;
 
       default:
         assetCollector = html`Unknown asset type`;

--- a/packages/visual-editor/src/ui/elements/input/text-editor/editor-model.ts
+++ b/packages/visual-editor/src/ui/elements/input/text-editor/editor-model.ts
@@ -423,7 +423,15 @@ class EditorModel {
     }
 
     // If we get here, offset is past the end — append.
+    // Maintain the text-boundary invariant: the last segment must always be
+    // text. If the current last segment isn't text, add an empty one before
+    // the chiclet (this can happen if the array is empty after construction).
+    const last = this.#segments[this.#segments.length - 1];
+    if (!last || last.kind !== "text") {
+      this.#segments.push({ kind: "text", text: "" });
+    }
     this.#segments.push({ kind: "chiclet", part });
+    this.#segments.push({ kind: "text", text: "" });
   }
 
   /** Remove a segment by index, then merge any resulting adjacent text. */

--- a/packages/visual-editor/src/ui/elements/input/text-editor/text-editor-remix.ts
+++ b/packages/visual-editor/src/ui/elements/input/text-editor/text-editor-remix.ts
@@ -85,6 +85,7 @@ import { NOTEBOOKLM_TOOL_PATH } from "@breadboard-ai/utils";
 import type { SCA } from "../../../../sca/sca.js";
 import { consume } from "@lit/context";
 import { scaContext } from "../../../../sca/context/context.js";
+import type { FastAccessMode } from "../../../../sca/types.js";
 
 import { EditorModel } from "./editor-model.js";
 import type { ChicletSegment, Segment } from "./editor-model.js";
@@ -131,6 +132,10 @@ export class TextEditorRemix extends SignalWatcher(LitElement) {
   /** Whether the '@' key triggers the fast access menu. */
   @property({ reflect: true, type: Boolean })
   accessor supportsFastAccess = true;
+
+  /** The Fast Access mode to use when triggering the @ menu. */
+  @property()
+  accessor fastAccessMode: FastAccessMode = "browse";
 
   /** Sub-graph context for chiclet metadata resolution. */
   @property()
@@ -1575,7 +1580,7 @@ export class TextEditorRemix extends SignalWatcher(LitElement) {
     if (this.sca) {
       this.sca.controller.editor.fastAccess.fastAccessMode = hasTarget
         ? "route"
-        : "browse";
+        : this.fastAccessMode;
     }
     this.#isUsingFastAccess = true;
   }

--- a/packages/visual-editor/src/ui/elements/input/text-editor/text-editor.ts
+++ b/packages/visual-editor/src/ui/elements/input/text-editor/text-editor.ts
@@ -29,6 +29,7 @@ import { NOTEBOOKLM_TOOL_PATH } from "@breadboard-ai/utils";
 import { SCA } from "../../../../sca/sca.js";
 import { consume } from "@lit/context";
 import { scaContext } from "../../../../sca/context/context.js";
+import type { FastAccessMode } from "../../../../sca/types.js";
 
 export function chicletHtml(
   part: TemplatePart,
@@ -175,6 +176,10 @@ export class TextEditor extends SignalWatcher(LitElement) {
 
   @property({ reflect: true, type: Boolean })
   accessor supportsFastAccess = true;
+
+  /** The Fast Access mode to use when triggering the @ menu. */
+  @property()
+  accessor fastAccessMode: FastAccessMode = "browse";
 
   @property()
   accessor nodeId: string | null = null;
@@ -1092,7 +1097,7 @@ export class TextEditor extends SignalWatcher(LitElement) {
     if (this.sca) {
       this.sca.controller.editor.fastAccess.fastAccessMode = hasTarget
         ? "route"
-        : "browse";
+        : this.fastAccessMode;
     }
     this.#isUsingFastAccess = true;
   }

--- a/packages/visual-editor/src/ui/elements/notebooklm-picker/notebooklm-picker.ts
+++ b/packages/visual-editor/src/ui/elements/notebooklm-picker/notebooklm-picker.ts
@@ -155,6 +155,7 @@ export class NotebookLmPicker extends SignalWatcher(LitElement) {
         .showSaveCancel=${true}
         .saveButtonLabel=${"Add"}
         .saveButtonDisabled=${nlm.selectedNotebooks.size === 0}
+        .blurBackground=${true}
         @bbmodaldismissed=${(evt: ModalDismissedEvent) => {
           if (evt.withSave) {
             this.#handleConfirm();

--- a/packages/visual-editor/src/ui/styles/chiclet.ts
+++ b/packages/visual-editor/src/ui/styles/chiclet.ts
@@ -119,7 +119,7 @@ export const styles = [
       }
 
       &.asset {
-        background: var(--ui-asset-secondary) 5px center / 16px 16px no-repeat;
+        background: var(--ui-asset) 5px center / 16px 16px no-repeat;
         color: var(--n-10);
       }
 

--- a/packages/visual-editor/src/ui/utils/expand-chiclet.ts
+++ b/packages/visual-editor/src/ui/utils/expand-chiclet.ts
@@ -7,6 +7,7 @@
 import { ok, TemplatePart } from "@breadboard-ai/utils";
 import { getStepIcon } from "./get-step-icon.js";
 import { iconSubstitute } from "./icon-substitute.js";
+import { getAssetIcon, getMimeType } from "../../utils/media/mime-type.js";
 import type { SCA } from "../../sca/sca.js";
 
 export function expandChiclet(
@@ -68,13 +69,26 @@ export function expandChiclet(
       icon = "alternate_email";
 
       const assetInfo = graphController.graphAssets.get(path);
-      if (assetInfo?.metadata?.type) {
+      let mimeType = part.mimeType;
+      if (!mimeType && assetInfo) {
+        mimeType = getMimeType(assetInfo.data);
+      }
+
+      if (mimeType) {
+        icon = getAssetIcon(mimeType);
+      }
+
+      if (assetInfo?.metadata?.type && !mimeType) {
         icon = iconSubstitute(assetInfo.metadata.type);
       }
 
       if (assetInfo?.metadata?.subType) {
-        icon = iconSubstitute(assetInfo.metadata.subType);
+        const subTypeIcon = iconSubstitute(assetInfo.metadata.subType);
+        if (subTypeIcon && !subTypeIcon.includes("/")) {
+          icon = subTypeIcon;
+        }
       }
+      break;
     }
   }
 

--- a/packages/visual-editor/src/ui/utils/icon-substitute.ts
+++ b/packages/visual-editor/src/ui/utils/icon-substitute.ts
@@ -12,7 +12,11 @@
 export function iconSubstitute(
   src: string | undefined | null
 ): string | undefined | null {
-  if (src && typeof src === "string" && src.startsWith("application/vnd.google-apps.")) {
+  if (
+    src &&
+    typeof src === "string" &&
+    src.startsWith("application/vnd.google-apps.")
+  ) {
     switch (src) {
       case "application/vnd.google-apps.spreadsheet":
         return "sheets";
@@ -47,6 +51,10 @@ export function iconSubstitute(
       return "drive";
     case "drawable":
       return "draw";
+    case "notebooklm":
+      return "notebooklm";
+    case "webcam-video":
+      return "videocam";
     case "youtube":
       return "video_youtube";
     case "display":

--- a/packages/visual-editor/src/utils/media/mime-type.ts
+++ b/packages/visual-editor/src/utils/media/mime-type.ts
@@ -33,3 +33,14 @@ export function getMimeType(data: LLMContent[]): string | undefined {
     }
   }
 }
+
+export function getAssetIcon(mimeType?: string): string {
+  if (!mimeType) return "draft";
+  if (mimeType.startsWith("image/")) return "image";
+  if (mimeType.startsWith("audio/")) return "audio_file";
+  if (mimeType.startsWith("video/")) return "video_file";
+  if (mimeType === "application/pdf") return "picture_as_pdf";
+  if (mimeType.startsWith("text/")) return "description";
+  if (mimeType === "application/x-notebooklm") return "notebooklm";
+  return "attachment";
+}

--- a/packages/visual-editor/tests/sca/controller/subcontrollers/editor/fast-access/fast-access-controller.test.ts
+++ b/packages/visual-editor/tests/sca/controller/subcontrollers/editor/fast-access/fast-access-controller.test.ts
@@ -135,16 +135,29 @@ suite("FastAccessController", () => {
   });
 
   test("route mode shows routes only", () => {
-    controller.fastAccessMode = "route";
     const rawItems: FastAccessItem[] = [
       makeTool("MyTool"),
       makeAsset("photo.png", "Photo"),
       makeComponent("MyComponent"),
       makeRoute("MyRoute"),
     ];
+    controller.fastAccessMode = "route";
     const items = controller.getDisplayItems(rawItems, noAgentTools, noOpts);
     assert.strictEqual(items.length, 1);
     assert.strictEqual(items[0]!.kind, "route");
+  });
+
+  test("browse-assets mode shows assets only", () => {
+    const rawItems: FastAccessItem[] = [
+      makeTool("MyTool"),
+      makeAsset("photo.png", "Photo"),
+      makeComponent("MyComponent"),
+      makeRoute("MyRoute"),
+    ];
+    controller.fastAccessMode = "browse-assets";
+    const items = controller.getDisplayItems(rawItems, noAgentTools, noOpts);
+    assert.strictEqual(items.length, 1);
+    assert.strictEqual(items[0]!.kind, "asset");
   });
 
   // =========================================================================

--- a/packages/visual-editor/tests/ui/elements/text-editor/editor-model.test.ts
+++ b/packages/visual-editor/tests/ui/elements/text-editor/editor-model.test.ts
@@ -276,8 +276,41 @@ describe("EditorModel", () => {
       it("appends when offset is past the end", () => {
         const model = EditorModel.fromRawValue("Hi");
         model.insertChicletAtOffset(999, makePart());
-        assert.equal(model.length, 2);
+        // Text-boundary invariant: [text, chiclet, text("")]
+        assert.equal(model.length, 3);
+        assert.ok(isText(model.segmentAt(0)!));
         assert.ok(isChiclet(model.segmentAt(1)!));
+        assert.ok(isText(model.segmentAt(2)!));
+        assert.equal((model.segmentAt(2) as TextSegment).text, "");
+      });
+
+      it("maintains text boundary after drag-to-end (regression)", () => {
+        // Simulate: "Hello [chiclet] world" → drag chiclet to end
+        const part = makePart();
+        const raw = `Hello{${JSON.stringify(part)}} world`;
+        const model = EditorModel.fromRawValue(raw);
+        // ["Hello", chiclet, " world"]
+        assert.equal(model.length, 3);
+
+        // Remove chiclet (drag start)
+        model.removeSegment(1);
+        // After merge: ["Hello world"]
+        assert.equal(model.length, 1);
+
+        // Re-insert at end offset (drag drop at end of visible text)
+        const endOffset = model.visibleTextLength; // 11
+        model.insertChicletAtOffset(endOffset, part);
+        // Should be: ["Hello world", chiclet, ""]
+        assert.equal(model.length, 3);
+        assert.ok(isText(model.segmentAt(0)!));
+        assert.ok(isChiclet(model.segmentAt(1)!));
+        assert.ok(isText(model.segmentAt(2)!));
+
+        // Now inserting text (Enter key) into the trailing segment must work.
+        // segmentHint=2 tells the model the cursor is in the trailing text.
+        const newOffset = model.insertTextAtOffset(endOffset, "\n", 2);
+        assert.equal(newOffset, endOffset + 1);
+        assert.ok(model.toRawValue().endsWith("\n"));
       });
     });
 


### PR DESCRIPTION
## What
Refactored the agent workbench asset shelf to integrate NotebookLM and Webcam Video, restricted the `@` fast access menu to assets-only inside the prompt editor, unified icon resolution with a shared MIME-to-Symbol utility, and polished chiclet and modal backdrop aesthetics.

## Why
Implements seamless addition and referencing of specialized assets (NotebookLM, Youtube, Webcam Video) with accurate metadata encoding at the source, preventing broken icon ligatures and visual overlaps in menus and prompt chiclets.

## Changes

### Agent Workbench & Prompt Editor
* **Assets-Only @ Menu**: Added a `"browse-assets"` mode to [FastAccessController](file:///Users/paullewis/Projects/breadboard/packages/visual-editor/src/sca/controller/subcontrollers/editor/fast-access/fast-access-controller.ts) to restrict the prompt editor's `@` fast-access menu solely to assets.
* **NotebookLM Integration**: Wired the "NotebookLM" add button directly to the NotebookLM picker action, allowing users to browse and pick notebooks, automatically adding them with `type: "content"` and `subType: "notebooklm"`.
* **Backdrop Blur**: Enabled backdrop blur on the [NotebookLmPicker](file:///Users/paullewis/Projects/breadboard/packages/visual-editor/src/ui/elements/notebooklm-picker/notebooklm-picker.ts) modal.
* **Alphabetical Shelf Sorting**: Cleaned up asset shelf rendering to sort all assets alphabetically.

### Icon and Metadata Hardening
* **Shared Icon Utility**: Created a centralized `getAssetIcon` helper in [mime-type.ts](file:///Users/paullewis/Projects/breadboard/packages/visual-editor/src/utils/media/mime-type.ts) mapping MIME types to valid Material Symbols, including custom icon overrides.
* **Clean Metadata Encoding**: Corrected YouTube and Webcam video assets to be created with clean, semantic metadata (`subType: "youtube"` and `"webcam-video"`) at the source inside [AddAssetModal](file:///Users/paullewis/Projects/breadboard/packages/visual-editor/src/ui/elements/input/add-asset/add-asset-modal.ts), rather than relying on brittle regex overrides.
* **Icon Substitute Mappings**: Added `"notebooklm"` and `"webcam-video"` overrides to [icon-substitute.ts](file:///Users/paullewis/Projects/breadboard/packages/visual-editor/src/ui/utils/icon-substitute.ts).
* **Render overlap prevention**: Blocked text ligature rendering in [fast-access-menu.ts](file:///Users/paullewis/Projects/breadboard/packages/visual-editor/src/ui/elements/fast-access-menu/fast-access-menu.ts) for `"notebooklm"` to let only the custom SVG logo render.

### Styling & Aesthetics
* **Terracotta Theme**: Updated [chiclet.ts](file:///Users/paullewis/Projects/breadboard/packages/visual-editor/src/ui/styles/chiclet.ts) to render asset chiclets in the prompt editor with the premium, strong terracotta background (`var(--ui-asset)`).

## Testing
* All `FastAccessController` unit tests have been updated and pass successfully.
* Verified compilation with `npm run build:tsc`.