### PR TITLE
[agent] Prevent Busy Loop in Agent Loop on Abort

### DIFF
--- a/packages/visual-editor/src/a2/agent/loop.ts
+++ b/packages/visual-editor/src/a2/agent/loop.ts
@@ -212,7 +212,7 @@ class Loop {
         }
       }
 
-      while (!this.controller.terminated) {
+      while (!this.controller.terminated && !moduleArgs.context.signal?.aborted) {
         // Build the request body. When a cache exists, reference it
         // and only send content accumulated after what's cached.
         const body: GeminiBody = cachedContentName
@@ -359,8 +359,14 @@ class Loop {
           }
         }
       }
+      if (moduleArgs.context.signal?.aborted) {
+        return err("Run was stopped");
+      }
       return this.controller.result;
     } catch (e) {
+      if (moduleArgs.context.signal?.aborted) {
+        return err("Run was stopped");
+      }
       return err(formatAgentError(e), { origin: "client", kind: "bug" });
     } finally {
       hooks.onFinish?.();

--- a/packages/visual-editor/tests/a2/agent/loop.test.ts
+++ b/packages/visual-editor/tests/a2/agent/loop.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { ok } from "@breadboard-ai/utils/outcome.js";
+import type { NodeHandlerContext } from "@breadboard-ai/types";
+import { Loop } from "../../../src/a2/agent/loop.js";
+import type { A2ModuleArgs } from "../../../src/a2/runnable-module-factory.js";
+
+describe("Agent Loop abort-signal handling", () => {
+  it("should cleanly terminate and return 'Run was stopped' when abort signal is triggered", async () => {
+    const abortController = new AbortController();
+    
+    // Create a mock fetch that hangs until aborted
+    const mockFetch = async (_url: string, init?: RequestInit) => {
+      return new Promise<Response>((_, reject) => {
+        const onAbort = () => {
+          reject(new DOMException("The user aborted a request.", "AbortError"));
+        };
+        if (init?.signal?.aborted) {
+          onAbort();
+          return;
+        }
+        init?.signal?.addEventListener("abort", onAbort);
+      });
+    };
+
+    const mockArgs = {
+      fetchWithCreds: mockFetch as unknown as typeof globalThis.fetch,
+      context: {
+        signal: abortController.signal,
+      } as unknown as NodeHandlerContext,
+      agentService: {
+        endRun: () => {},
+      },
+    } as unknown as A2ModuleArgs;
+
+    const loop = new Loop(mockArgs);
+
+    // Start the loop in the background
+    const runPromise = loop.run({
+      objective: { role: "user", parts: [{ text: "Solve world peace" }] },
+      functionGroups: [],
+    });
+
+    // Let the event loop cycle so the agent loop starts and hangs on the fetch call
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Abort the run
+    abortController.abort();
+
+    const result = await runPromise;
+
+    assert.equal(ok(result), false);
+    if (!ok(result)) {
+      assert.equal(result.$error, "Run was stopped");
+    }
+  });
+});


### PR DESCRIPTION
## What

Added abort-signal awareness to the main agent execution loop, ensuring it cleanly and immediately terminates when a run is stopped or reloaded.

## Why

When a run was stopped (e.g., via the "Reload" button), the underlying streaming/fetching was aborted. Because the agent loop was unaware of the abort signal and the aborted stream returned an empty response, the loop continuously and instantly retried, resulting in a tight synchronous busy loop consuming 100% CPU.

## Changes

### `visual-editor`

- **`packages/visual-editor/src/a2/agent/loop.ts`**:
  - Updated the main agent `while` loop condition to check `!moduleArgs.context.signal?.aborted`.
  - Added clean termination checks in both the end of the `run` method and the `catch` block to return `err("Run was stopped")` upon abort.
- **`packages/visual-editor/tests/a2/agent/loop.test.ts`**:
  - Added a new suite of integration tests verifying that the agent `Loop` cleanly aborts and returns the expected stop outcome when the runner's `AbortSignal` is triggered.

## Testing

- Verified with the new unit test suite:
  ```bash
  npm run test:file -w packages/visual-editor -- './dist/tsc/tests/a2/agent/loop.test.js'
  ```
- Ran all existing `visual-editor` tests to ensure no regressions:
  ```bash
  npm run test -w packages/visual-editor
  ```
- Ran package-level and root-level linters to ensure clean formatting and style:
  ```bash
  npm run lint
  ```
