### PR TITLE
Integrate Cookie Consent Bar

### DIFF
--- a/packages/types/src/opal-shell-protocol.ts
+++ b/packages/types/src/opal-shell-protocol.ts
@@ -73,6 +73,12 @@ export declare interface OpalShellHostProtocol {
    * cannot paint above host-page elements.
    */
   setOneGoogleBarVisible(visible: boolean): void;
+
+  /**
+   * Re-show the cookie notification bar so the user can change their cookie
+   * preferences. Called from the guest iframe's "Manage cookies" link.
+   */
+  showCookieSettings(): Promise<void>;
 }
 
 export declare interface OpalShellGuestProtocol {

--- a/packages/types/src/opal-shell-protocol.ts
+++ b/packages/types/src/opal-shell-protocol.ts
@@ -79,6 +79,14 @@ export declare interface OpalShellHostProtocol {
    * preferences. Called from the guest iframe's "Manage cookies" link.
    */
   showCookieSettings(): Promise<void>;
+
+  /**
+   * Whether cookie consent management is available for the user's region.
+   * The cookie bar library only manages elements in the shell host document,
+   * so the guest must query the host to decide whether to show its own
+   * "Manage cookies" controls.
+   */
+  isCookieSettingsAvailable(): Promise<boolean>;
 }
 
 export declare interface OpalShellGuestProtocol {

--- a/packages/unified-server/src/csp.ts
+++ b/packages/unified-server/src/csp.ts
@@ -113,7 +113,9 @@ export const MAIN_APP_CSP = {
     "'self'",
     "data:",
     "https://*.google.com",
+    "https://*.googleapis.com", // Needed for cookiebar consent logging
     "https://*.google-analytics.com",
+    "https://www.gstatic.com", // Cookie notification bar config
   ],
   ["frame-src"]: [
     "'self'",

--- a/packages/unified-server/src/csp.ts
+++ b/packages/unified-server/src/csp.ts
@@ -41,6 +41,7 @@ export const SHELL_CSP = {
     "https://*.google.com",
     "https://*.googleapis.com",
     "https://*.google-analytics.com",
+    "https://www.gstatic.com", // Cookie notification bar config
     flags.BACKEND_API_ENDPOINT,
     // TODO(aomarks) Remove this after we have eliminated all credentialed RPCs
     // to the frontend server.
@@ -62,11 +63,12 @@ export const SHELL_CSP = {
     "'self'",
     "https://apis.google.com",
     "https://www.googletagmanager.com",
-    "https://www.gstatic.com", // Feedback JS
+    "https://www.gstatic.com", // Feedback JS + Cookie notification bar
   ],
   ["style-src"]: [
     "'self'",
     "'unsafe-inline'", // Needed for Drive picker and Drive share dialog
+    "https://www.gstatic.com", // Cookie notification bar CSS
   ],
   ["require-trusted-types-for"]: ["'script'"],
   ["trusted-types"]: [

--- a/packages/unified-server/src/csp.ts
+++ b/packages/unified-server/src/csp.ts
@@ -115,9 +115,7 @@ export const MAIN_APP_CSP = {
     "'self'",
     "data:",
     "https://*.google.com",
-    "https://*.googleapis.com", // Needed for cookiebar consent logging
     "https://*.google-analytics.com",
-    "https://www.gstatic.com", // Cookie notification bar config
   ],
   ["frame-src"]: [
     "'self'",

--- a/packages/visual-editor/eval/eval.ts
+++ b/packages/visual-editor/eval/eval.ts
@@ -371,6 +371,9 @@ class EvalRun implements EvalHarnessRuntimeArgs {
       setOneGoogleBarVisible: function (_visible: boolean): void {
         // No-op in eval harness.
       },
+      showCookieSettings: async function (): Promise<void> {
+        // No-op in eval harness.
+      },
     } satisfies OpalShellHostProtocol,
   };
 }

--- a/packages/visual-editor/eval/eval.ts
+++ b/packages/visual-editor/eval/eval.ts
@@ -374,6 +374,9 @@ class EvalRun implements EvalHarnessRuntimeArgs {
       showCookieSettings: async function (): Promise<void> {
         // No-op in eval harness.
       },
+      isCookieSettingsAvailable: async function (): Promise<boolean> {
+        return false;
+      },
     } satisfies OpalShellHostProtocol,
   };
 }

--- a/packages/visual-editor/eval/graph-editing-eval.ts
+++ b/packages/visual-editor/eval/graph-editing-eval.ts
@@ -992,6 +992,9 @@ class GraphEditingEvalRun implements EvalLogger {
         setOneGoogleBarVisible: function (_visible: boolean): void {
           // No-op in eval harness.
         },
+        showCookieSettings: async function (): Promise<void> {
+          // No-op in eval harness.
+        },
       } satisfies OpalShellHostProtocol,
     };
 

--- a/packages/visual-editor/eval/graph-editing-eval.ts
+++ b/packages/visual-editor/eval/graph-editing-eval.ts
@@ -995,6 +995,9 @@ class GraphEditingEvalRun implements EvalLogger {
         showCookieSettings: async function (): Promise<void> {
           // No-op in eval harness.
         },
+        isCookieSettingsAvailable: async function (): Promise<boolean> {
+          return false;
+        },
       } satisfies OpalShellHostProtocol,
     };
 

--- a/packages/visual-editor/fake/fake-mode-opal-shell.ts
+++ b/packages/visual-editor/fake/fake-mode-opal-shell.ts
@@ -171,4 +171,8 @@ class FakeModeOpalShell implements OpalShellHostProtocol {
   showCookieSettings = async (): Promise<void> => {
     // No-op in fake mode — there is no cookie bar.
   };
+
+  isCookieSettingsAvailable = async (): Promise<boolean> => {
+    return false;
+  };
 }

--- a/packages/visual-editor/fake/fake-mode-opal-shell.ts
+++ b/packages/visual-editor/fake/fake-mode-opal-shell.ts
@@ -167,4 +167,8 @@ class FakeModeOpalShell implements OpalShellHostProtocol {
   setOneGoogleBarVisible = (_visible: boolean): void => {
     // No-op in fake mode — there is no OGB.
   };
+
+  showCookieSettings = async (): Promise<void> => {
+    // No-op in fake mode — there is no cookie bar.
+  };
 }

--- a/packages/visual-editor/landing/index.html
+++ b/packages/visual-editor/landing/index.html
@@ -25,6 +25,16 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Google+Symbols:opsz,wght,FILL,GRAD,ROND@20..48,100..700,0..1,-50..200,0..100&display=swap&icon_names=chevron_left,chevron_right,close,code_off,polyline,rocket_launch"
     />
+    <!-- Cookie Notification Bar -->
+    <link
+      href="https://www.gstatic.com/glue/cookienotificationbar/cookienotificationbar.min.css"
+      rel="stylesheet"
+    />
+    <script
+      src="https://www.gstatic.com/glue/cookienotificationbar/cookienotificationbar.min.js"
+      data-glue-cookie-notification-bar-category="2A"
+      data-glue-cookie-notification-bar-site-id="Opal"
+    ></script>
   </head>
   <body>
     <nav>
@@ -186,6 +196,14 @@
           <li><a href="https://policies.google.com/privacy" target="_blank">Privacy</a></li>
           <li><a href="https://policies.google.com/terms" target="_blank">Terms</a></li>
           <li><a href="https://developers.google.com/opal/faq" target="_blank">FAQ</a></li>
+          <li aria-hidden="true" class="glue-footer__global-links-list-item">
+            <button
+              aria-hidden="true"
+              class="glue-cookie-notification-bar-control"
+            >
+              Manage cookies
+            </button>
+          </li>
           <li><a href="https://support.google.com/" target="_blank">Help</a></li>
         </ul>
       </section>

--- a/packages/visual-editor/landing/index.html
+++ b/packages/visual-editor/landing/index.html
@@ -25,10 +25,7 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Google+Symbols:opsz,wght,FILL,GRAD,ROND@20..48,100..700,0..1,-50..200,0..100&display=swap&icon_names=chevron_left,chevron_right,close,code_off,polyline,rocket_launch"
     />
-    <link
-      rel="stylesheet"
-      href="https://www.gstatic.com/glue/cookienotificationbar/cookienotificationbar.min.css"
-    />
+
   </head>
   <body>
     <nav>
@@ -261,11 +258,7 @@
         {{config}}
       </script></template
     >
-    <script
-      src="https://www.gstatic.com/glue/cookienotificationbar/cookienotificationbar.min.js"
-      data-glue-cookie-notification-bar-category="2A"
-      data-glue-cookie-notification-bar-site-id="Opal"
-    ></script>
+
     <script src="/src/landing/main.ts" type="module"></script>
   </body>
 </html>

--- a/packages/visual-editor/landing/index.html
+++ b/packages/visual-editor/landing/index.html
@@ -187,8 +187,9 @@
           <li><a href="https://policies.google.com/privacy" target="_blank">Privacy</a></li>
           <li><a href="https://policies.google.com/terms" target="_blank">Terms</a></li>
           <li><a href="https://developers.google.com/opal/faq" target="_blank">FAQ</a></li>
-          <li aria-hidden="true" class="glue-footer__global-links-list-item">
+          <li hidden aria-hidden="true" class="glue-footer__global-links-list-item">
             <button
+              hidden
               aria-hidden="true"
               class="glue-cookie-notification-bar-control"
             >

--- a/packages/visual-editor/landing/index.html
+++ b/packages/visual-editor/landing/index.html
@@ -25,16 +25,10 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Google+Symbols:opsz,wght,FILL,GRAD,ROND@20..48,100..700,0..1,-50..200,0..100&display=swap&icon_names=chevron_left,chevron_right,close,code_off,polyline,rocket_launch"
     />
-    <!-- Cookie Notification Bar -->
     <link
-      href="https://www.gstatic.com/glue/cookienotificationbar/cookienotificationbar.min.css"
       rel="stylesheet"
+      href="https://www.gstatic.com/glue/cookienotificationbar/cookienotificationbar.min.css"
     />
-    <script
-      src="https://www.gstatic.com/glue/cookienotificationbar/cookienotificationbar.min.js"
-      data-glue-cookie-notification-bar-category="2A"
-      data-glue-cookie-notification-bar-site-id="Opal"
-    ></script>
   </head>
   <body>
     <nav>
@@ -267,6 +261,11 @@
         {{config}}
       </script></template
     >
+    <script
+      src="https://www.gstatic.com/glue/cookienotificationbar/cookienotificationbar.min.js"
+      data-glue-cookie-notification-bar-category="2A"
+      data-glue-cookie-notification-bar-site-id="Opal"
+    ></script>
     <script src="/src/landing/main.ts" type="module"></script>
   </body>
 </html>

--- a/packages/visual-editor/public/styles/landing/landing.css
+++ b/packages/visual-editor/public/styles/landing/landing.css
@@ -1104,3 +1104,19 @@ footer {
     opacity: 1;
   }
 }
+
+#links ul li button.glue-cookie-notification-bar-control {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: var(--n-0);
+  cursor: pointer;
+  text-decoration: none;
+}
+
+#links ul li button.glue-cookie-notification-bar-control:hover {
+  text-decoration: underline;
+}
+

--- a/packages/visual-editor/public/styles/landing/landing.css
+++ b/packages/visual-editor/public/styles/landing/landing.css
@@ -869,6 +869,17 @@ footer {
       color: var(--n-0);
     }
 
+    & .glue-cookie-notification-bar-control {
+      background: none;
+      border: none;
+      padding: 0;
+      margin: 0;
+      font: inherit;
+      color: var(--n-0);
+      cursor: pointer;
+      text-decoration: none;
+    }
+
     &:last-of-type {
       border-bottom: none;
     }
@@ -1103,20 +1114,5 @@ footer {
   to {
     opacity: 1;
   }
-}
-
-#links ul li button.glue-cookie-notification-bar-control {
-  background: none;
-  border: none;
-  padding: 0;
-  margin: 0;
-  font: inherit;
-  color: var(--n-0);
-  cursor: pointer;
-  text-decoration: none;
-}
-
-#links ul li button.glue-cookie-notification-bar-control:hover {
-  text-decoration: underline;
 }
 

--- a/packages/visual-editor/shell/index.html
+++ b/packages/visual-editor/shell/index.html
@@ -26,10 +26,11 @@
     sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-modals allow-storage-access-by-user-activation allow-downloads allow-top-navigation"
     allow="clipboard-read; clipboard-write; microphone; camera"
   ></iframe>
-  <!-- Hidden control for the cookie notification bar. The bar script binds
-       click handlers to this class. Triggered programmatically via
-       showCookieSettings() when the guest iframe's "Manage cookies" link
-       is clicked. -->
+  <!-- Control for the cookie notification bar. The bar script binds click
+       handlers to elements with this class and manages aria-hidden based on
+       the user's region. Kept off-screen so the library can process it while
+       remaining invisible. Triggered programmatically via showCookieSettings()
+       when the guest iframe's "Manage cookies" link is clicked. -->
   <button
     hidden
     aria-hidden="true"

--- a/packages/visual-editor/shell/index.html
+++ b/packages/visual-editor/shell/index.html
@@ -15,6 +15,10 @@
     content="{{origin}}/images/share-card-{{bucket}}.png"
   />
   <link rel="stylesheet" href="/styles/shell.css" />
+  <link
+    rel="stylesheet"
+    href="https://www.gstatic.com/glue/cookienotificationbar/cookienotificationbar.min.css"
+  />
 </head>
 <body>
   <iframe
@@ -27,5 +31,10 @@
       {{config}}
     </script>
   </template>
+  <script
+    src="https://www.gstatic.com/glue/cookienotificationbar/cookienotificationbar.min.js"
+    data-glue-cookie-notification-bar-category="2A"
+    data-glue-cookie-notification-bar-site-id="Opal"
+  ></script>
   <script src="/src/shell/opal-shell-host.ts" type="module"></script>
 </body>

--- a/packages/visual-editor/shell/index.html
+++ b/packages/visual-editor/shell/index.html
@@ -26,6 +26,15 @@
     sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-modals allow-storage-access-by-user-activation allow-downloads allow-top-navigation"
     allow="clipboard-read; clipboard-write; microphone; camera"
   ></iframe>
+  <!-- Hidden control for the cookie notification bar. The bar script binds
+       click handlers to this class. Triggered programmatically via
+       showCookieSettings() when the guest iframe's "Manage cookies" link
+       is clicked. -->
+  <button
+    hidden
+    aria-hidden="true"
+    class="glue-cookie-notification-bar-control"
+  ></button>
   <template>
     <script type="application/json">
       {{config}}

--- a/packages/visual-editor/src/landing/main.ts
+++ b/packages/visual-editor/src/landing/main.ts
@@ -95,6 +95,17 @@ async function init() {
 
   const actionTracker = createActionTracker(shellHost);
 
+  // The cookie notification bar lives in the shell host (parent frame).
+  // Wire the landing page's "Manage cookies" button to call through comlink.
+  const manageCookiesButton = document.querySelector<HTMLElement>(
+    ".glue-cookie-notification-bar-control"
+  );
+  if (manageCookiesButton) {
+    manageCookiesButton.addEventListener("click", () => {
+      shellHost.showCookieSettings();
+    });
+  }
+
 
   embedHandler?.sendToEmbedder({
     type: "home_loaded",

--- a/packages/visual-editor/src/landing/main.ts
+++ b/packages/visual-editor/src/landing/main.ts
@@ -96,11 +96,23 @@ async function init() {
   const actionTracker = createActionTracker(shellHost);
 
   // The cookie notification bar lives in the shell host (parent frame).
-  // Wire the landing page's "Manage cookies" button to call through comlink.
+  // Wire the landing page's "Manage cookies" button to call through comlink,
+  // and only show it when the user's region requires cookie consent.
   const manageCookiesButton = document.querySelector<HTMLElement>(
     ".glue-cookie-notification-bar-control"
   );
   if (manageCookiesButton) {
+    shellHost.isCookieSettingsAvailable().then((available) => {
+      if (available) {
+        manageCookiesButton.removeAttribute("aria-hidden");
+        manageCookiesButton.hidden = false;
+        const parentLi = manageCookiesButton.closest("li");
+        if (parentLi) {
+          parentLi.removeAttribute("aria-hidden");
+          parentLi.hidden = false;
+        }
+      }
+    });
     manageCookiesButton.addEventListener("click", () => {
       shellHost.showCookieSettings();
     });

--- a/packages/visual-editor/src/landing/main.ts
+++ b/packages/visual-editor/src/landing/main.ts
@@ -11,35 +11,11 @@ import type {
 } from "../sca/types.js";
 import type { LanguagePack } from "../ui/types/types.js";
 import { createActionTracker } from "../ui/utils/action-tracker.js";
-import { CLIENT_DEPLOYMENT_CONFIG } from "../ui/config/client-deployment-configuration.js";
-import { GTagEventSender } from "../ui/utils/gtag-event-sender.js";
 import { connectToOpalShellHost } from "../ui/utils/opal-shell-guest.js";
 import { SigninAdapter } from "../ui/utils/signin-adapter.js";
 import { makeUrl, parseUrl } from "../ui/navigation/urls.js";
 import "./carousel.js";
 import * as Shell from "./shell.js";
-
-declare global {
-  interface Window {
-    glueCookieNotificationBarLoaded?: (event: CustomEvent) => void;
-    glue?: {
-      CookieNotificationBar?: {
-        instance?: {
-          status: string;
-          listen: (
-            event: string,
-            callback: (event: CustomEvent) => void
-          ) => void;
-        };
-        status: {
-          ACCEPTED: string;
-          REJECTED: string;
-          UNKNOWN: string;
-        };
-      };
-    };
-  }
-}
 
 const parsedUrl = parseUrl(window.location.href) as LandingUrlInit;
 if (parsedUrl.page !== "landing") {
@@ -119,46 +95,6 @@ async function init() {
 
   const actionTracker = createActionTracker(shellHost);
 
-  // Initialize analytics only after cookie consent is granted.
-  // Uses the cookie notification bar instance API.
-  const initAnalytics = () => {
-    new GTagEventSender(CLIENT_DEPLOYMENT_CONFIG.MEASUREMENT_ID);
-    actionTracker.load("landing");
-  };
-
-  const cookieBar = window.glue?.CookieNotificationBar;
-  
-  const handleCookieBarEvent = (currentCookieBar: NonNullable<typeof window.glue>["CookieNotificationBar"]) => {
-    if (!currentCookieBar?.instance) return;
-    const ACCEPTED = currentCookieBar.status.ACCEPTED;
-    if (currentCookieBar.instance.status === ACCEPTED) {
-      // Returning visitor who already consented, or non-eligible region.
-      initAnalytics();
-    } else {
-      // First-time visitor: wait for consent via the cookie bar UI.
-      currentCookieBar.instance.listen("statuschange", (event: CustomEvent) => {
-        if (event.detail.status === ACCEPTED) {
-          initAnalytics();
-        }
-      });
-    }
-  };
-
-  if (cookieBar?.instance) {
-    handleCookieBarEvent(cookieBar);
-  } else if (document.querySelector('script[src*="cookienotificationbar"]')) {
-    // Script is on the page but not initialized yet.
-    // Register the global loaded callback.
-    window.glueCookieNotificationBarLoaded = () => {
-      const currentCnb = window.glue?.CookieNotificationBar;
-      if (currentCnb) {
-        handleCookieBarEvent(currentCnb);
-      }
-    };
-  } else {
-    // Cookie bar not loaded or not present (e.g. local dev) — initialize analytics directly.
-    initAnalytics();
-  }
 
   embedHandler?.sendToEmbedder({
     type: "home_loaded",

--- a/packages/visual-editor/src/landing/main.ts
+++ b/packages/visual-editor/src/landing/main.ts
@@ -11,11 +11,35 @@ import type {
 } from "../sca/types.js";
 import type { LanguagePack } from "../ui/types/types.js";
 import { createActionTracker } from "../ui/utils/action-tracker.js";
+import { CLIENT_DEPLOYMENT_CONFIG } from "../ui/config/client-deployment-configuration.js";
+import { GTagEventSender } from "../ui/utils/gtag-event-sender.js";
 import { connectToOpalShellHost } from "../ui/utils/opal-shell-guest.js";
 import { SigninAdapter } from "../ui/utils/signin-adapter.js";
 import { makeUrl, parseUrl } from "../ui/navigation/urls.js";
 import "./carousel.js";
 import * as Shell from "./shell.js";
+
+declare global {
+  interface Window {
+    glueCookieNotificationBarLoaded?: (event: CustomEvent) => void;
+    glue?: {
+      CookieNotificationBar?: {
+        instance?: {
+          status: string;
+          listen: (
+            event: string,
+            callback: (event: CustomEvent) => void
+          ) => void;
+        };
+        status: {
+          ACCEPTED: string;
+          REJECTED: string;
+          UNKNOWN: string;
+        };
+      };
+    };
+  }
+}
 
 const parsedUrl = parseUrl(window.location.href) as LandingUrlInit;
 if (parsedUrl.page !== "landing") {
@@ -94,6 +118,47 @@ async function init() {
   }
 
   const actionTracker = createActionTracker(shellHost);
+
+  // Initialize analytics only after cookie consent is granted.
+  // Uses the cookie notification bar instance API.
+  const initAnalytics = () => {
+    new GTagEventSender(CLIENT_DEPLOYMENT_CONFIG.MEASUREMENT_ID);
+    actionTracker.load("landing");
+  };
+
+  const cookieBar = window.glue?.CookieNotificationBar;
+  
+  const handleCookieBarEvent = (currentCookieBar: NonNullable<typeof window.glue>["CookieNotificationBar"]) => {
+    if (!currentCookieBar?.instance) return;
+    const ACCEPTED = currentCookieBar.status.ACCEPTED;
+    if (currentCookieBar.instance.status === ACCEPTED) {
+      // Returning visitor who already consented, or non-eligible region.
+      initAnalytics();
+    } else {
+      // First-time visitor: wait for consent via the cookie bar UI.
+      currentCookieBar.instance.listen("statuschange", (event: CustomEvent) => {
+        if (event.detail.status === ACCEPTED) {
+          initAnalytics();
+        }
+      });
+    }
+  };
+
+  if (cookieBar?.instance) {
+    handleCookieBarEvent(cookieBar);
+  } else if (document.querySelector('script[src*="cookienotificationbar"]')) {
+    // Script is on the page but not initialized yet.
+    // Register the global loaded callback.
+    window.glueCookieNotificationBarLoaded = () => {
+      const currentCnb = window.glue?.CookieNotificationBar;
+      if (currentCnb) {
+        handleCookieBarEvent(currentCnb);
+      }
+    };
+  } else {
+    // Cookie bar not loaded or not present (e.g. local dev) — initialize analytics directly.
+    initAnalytics();
+  }
 
   embedHandler?.sendToEmbedder({
     type: "home_loaded",

--- a/packages/visual-editor/src/shell/opal-shell-host.ts
+++ b/packages/visual-editor/src/shell/opal-shell-host.ts
@@ -21,7 +21,7 @@ import { Utils } from "../sca/utils.js";
 
 declare global {
   interface Window {
-    glueCookieNotificationBarLoaded?: (event: CustomEvent) => void;
+    glueCookieNotificationBarLoaded?: () => void;
     glue?: {
       CookieNotificationBar?: {
         instance?: {
@@ -48,8 +48,8 @@ declare global {
 //
 // Returns two promises:
 //   consentGranted — resolves when the user accepts cookies (or no bar).
-//   required       — resolves with whether cookie management is needed for
-//                    this user's region (from the loaded event's `required`).
+//   required       — resolves with whether the "Manage cookies" control
+//                    should be shown for the user's region.
 // ---------------------------------------------------------------------------
 
 type CookieBar = NonNullable<typeof window.glue>["CookieNotificationBar"];

--- a/packages/visual-editor/src/shell/opal-shell-host.ts
+++ b/packages/visual-editor/src/shell/opal-shell-host.ts
@@ -42,31 +42,45 @@ declare global {
 }
 
 // ---------------------------------------------------------------------------
-// Cookie consent detection — must happen at module scope (synchronously) so
-// we don't miss the glueCookieNotificationBarLoaded callback fired by the
-// cookie bar script that loads before this module.
+// Cookie bar setup — must happen at module scope (synchronously) so we don't
+// miss the glueCookieNotificationBarLoaded callback fired by the cookie bar
+// script that loads before this module.
+//
+// Returns two promises:
+//   consentGranted — resolves when the user accepts cookies (or no bar).
+//   required       — resolves with whether cookie management is needed for
+//                    this user's region (from the loaded event's `required`).
 // ---------------------------------------------------------------------------
 
-/** Resolves when cookie consent is granted (or when no cookie bar is present). */
-const cookieConsentGranted = createCookieConsentPromise();
+type CookieBar = NonNullable<typeof window.glue>["CookieNotificationBar"];
 
-function createCookieConsentPromise(): Promise<void> {
+const { consentGranted: cookieConsentGranted, required: cookieBarRequired } =
+  setupCookieBar();
+
+function setupCookieBar(): {
+  consentGranted: Promise<void>;
+  required: Promise<boolean>;
+} {
   const cookieBar = window.glue?.CookieNotificationBar;
 
-  // Helper: watch a cookie bar for ACCEPTED status.
-  const watchForConsent = (
-    cnb: NonNullable<typeof window.glue>["CookieNotificationBar"]
-  ): Promise<void> => {
+  // Helper: watch a cookie bar instance for ACCEPTED status.
+  const watchForConsent = (cnb: CookieBar): Promise<void> => {
     if (!cnb?.instance) return Promise.resolve();
     const ACCEPTED = cnb.status.ACCEPTED;
 
-    // Already accepted — resolve immediately.
+    // Already accepted (loaded event already fired for a returning user).
     if (cnb.instance.status === ACCEPTED) {
       return Promise.resolve();
     }
 
-    // Wait for a status change to ACCEPTED.
     return new Promise<void>((resolve) => {
+      // Returning user: the loaded event carries the stored consent status.
+      cnb.instance!.listen("loaded", (event: CustomEvent) => {
+        if (event.detail.status === ACCEPTED) {
+          resolve();
+        }
+      });
+      // New consent: the statuschange event fires when the user interacts.
       cnb.instance!.listen("statuschange", (event: CustomEvent) => {
         if (event.detail.status === ACCEPTED) {
           resolve();
@@ -75,28 +89,86 @@ function createCookieConsentPromise(): Promise<void> {
     });
   };
 
-  // Case 1: Cookie bar already has an instance.
+  // Helper: determine whether the "Manage cookies" control should be shown.
+  // Two mechanisms run in parallel to handle a timing race: the cookie bar
+  // script (regular <script>) executes before our module (deferred), so the
+  // loaded event may have already fired by the time we listen.
+  const shouldShowControl = (cnb: CookieBar): Promise<boolean> => {
+    if (!cnb?.instance) return Promise.resolve(false);
+
+    return new Promise<boolean>((resolve) => {
+      let settled = false;
+      const settle = (v: boolean) => {
+        if (!settled) {
+          settled = true;
+          resolve(v);
+        }
+      };
+
+      // Primary: catch the loaded event if it hasn't fired yet.
+      cnb.instance!.listen("loaded", (event: CustomEvent) => {
+        settle(event.detail.required === true && event.detail.eea !== true);
+      });
+
+      // Fallback: if loaded already fired, the library will have already
+      // processed the control button. Check after a frame to see if
+      // aria-hidden was removed (the library's signal that the control
+      // should be visible).
+      requestAnimationFrame(() => {
+        if (settled) return;
+        const control = document.querySelector(
+          ".glue-cookie-notification-bar-control"
+        );
+        if (control && !control.hasAttribute("aria-hidden")) {
+          settle(true);
+        }
+        // If aria-hidden is still present, don't settle — the loaded event
+        // will fire and settle via the listener, or the bar isn't required
+        // and not showing the button is the correct default.
+      });
+    });
+  };
+
+  // Case 1: Cookie bar already has an instance (script loaded before us).
   if (cookieBar?.instance) {
-    return watchForConsent(cookieBar);
+    return {
+      consentGranted: watchForConsent(cookieBar),
+      required: shouldShowControl(cookieBar),
+    };
   }
 
   // Case 2: Cookie bar script is on the page but hasn't initialized yet.
-  // Register the global loaded callback synchronously so we catch it.
+  // Register the global callback synchronously so we catch it.
   if (document.querySelector('script[src*="cookienotificationbar"]')) {
-    return new Promise<void>((resolve) => {
-      window.glueCookieNotificationBarLoaded = () => {
-        const cnb = window.glue?.CookieNotificationBar;
-        if (cnb) {
-          watchForConsent(cnb).then(resolve);
-        } else {
-          resolve();
-        }
-      };
+    let resolveConsent!: () => void;
+    let resolveRequired!: (value: boolean) => void;
+
+    const consentGranted = new Promise<void>((r) => {
+      resolveConsent = r;
     });
+    const required = new Promise<boolean>((r) => {
+      resolveRequired = r;
+    });
+
+    window.glueCookieNotificationBarLoaded = () => {
+      const cnb = window.glue?.CookieNotificationBar;
+      if (cnb) {
+        watchForConsent(cnb).then(resolveConsent);
+        shouldShowControl(cnb).then(resolveRequired);
+      } else {
+        resolveConsent();
+        resolveRequired(false);
+      }
+    };
+
+    return { consentGranted, required };
   }
 
   // Case 3: No cookie bar present (e.g. local dev) — consent not required.
-  return Promise.resolve();
+  return {
+    consentGranted: Promise.resolve(),
+    required: Promise.resolve(false),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -145,6 +217,9 @@ async function initializeOpalShellGuest() {
     // Enable analytics once cookie consent is granted. The consent promise
     // was set up at module scope so it's already listening.
     cookieConsentGranted.then(() => oauthShell.enableAnalytics());
+
+    // Tell the shell whether cookie management is needed for this region.
+    oauthShell.cookieBarRequired = cookieBarRequired;
   }
 
   const boxedState: {

--- a/packages/visual-editor/src/shell/opal-shell-host.ts
+++ b/packages/visual-editor/src/shell/opal-shell-host.ts
@@ -19,6 +19,90 @@ import {
 import * as comlink from "comlink";
 import { Utils } from "../sca/utils.js";
 
+declare global {
+  interface Window {
+    glueCookieNotificationBarLoaded?: (event: CustomEvent) => void;
+    glue?: {
+      CookieNotificationBar?: {
+        instance?: {
+          status: string;
+          listen: (
+            event: string,
+            callback: (event: CustomEvent) => void
+          ) => void;
+        };
+        status: {
+          ACCEPTED: string;
+          REJECTED: string;
+          UNKNOWN: string;
+        };
+      };
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cookie consent detection — must happen at module scope (synchronously) so
+// we don't miss the glueCookieNotificationBarLoaded callback fired by the
+// cookie bar script that loads before this module.
+// ---------------------------------------------------------------------------
+
+/** Resolves when cookie consent is granted (or when no cookie bar is present). */
+const cookieConsentGranted = createCookieConsentPromise();
+
+function createCookieConsentPromise(): Promise<void> {
+  const cookieBar = window.glue?.CookieNotificationBar;
+
+  // Helper: watch a cookie bar for ACCEPTED status.
+  const watchForConsent = (
+    cnb: NonNullable<typeof window.glue>["CookieNotificationBar"]
+  ): Promise<void> => {
+    if (!cnb?.instance) return Promise.resolve();
+    const ACCEPTED = cnb.status.ACCEPTED;
+
+    // Already accepted — resolve immediately.
+    if (cnb.instance.status === ACCEPTED) {
+      return Promise.resolve();
+    }
+
+    // Wait for a status change to ACCEPTED.
+    return new Promise<void>((resolve) => {
+      cnb.instance!.listen("statuschange", (event: CustomEvent) => {
+        if (event.detail.status === ACCEPTED) {
+          resolve();
+        }
+      });
+    });
+  };
+
+  // Case 1: Cookie bar already has an instance.
+  if (cookieBar?.instance) {
+    return watchForConsent(cookieBar);
+  }
+
+  // Case 2: Cookie bar script is on the page but hasn't initialized yet.
+  // Register the global loaded callback synchronously so we catch it.
+  if (document.querySelector('script[src*="cookienotificationbar"]')) {
+    return new Promise<void>((resolve) => {
+      window.glueCookieNotificationBarLoaded = () => {
+        const cnb = window.glue?.CookieNotificationBar;
+        if (cnb) {
+          watchForConsent(cnb).then(resolve);
+        } else {
+          resolve();
+        }
+      };
+    });
+  }
+
+  // Case 3: No cookie bar present (e.g. local dev) — consent not required.
+  return Promise.resolve();
+}
+
+// ---------------------------------------------------------------------------
+// Shell initialization
+// ---------------------------------------------------------------------------
+
 initializeOpalShellGuest();
 
 async function initializeOpalShellGuest() {
@@ -55,7 +139,12 @@ async function initializeOpalShellGuest() {
       await import("../../fake/fake-mode-opal-shell.js");
     shellHost = new FakeModeOpalShell();
   } else {
-    shellHost = new OAuthBasedOpalShell();
+    const oauthShell = new OAuthBasedOpalShell();
+    shellHost = oauthShell;
+
+    // Enable analytics once cookie consent is granted. The consent promise
+    // was set up at module scope so it's already listening.
+    cookieConsentGranted.then(() => oauthShell.enableAnalytics());
   }
 
   const boxedState: {

--- a/packages/visual-editor/src/ui/elements/shell/global-settings.ts
+++ b/packages/visual-editor/src/ui/elements/shell/global-settings.ts
@@ -82,7 +82,8 @@ export class VEGlobalSettingsModal extends SignalWatcher(LitElement) {
     this.emailPrefsManager?.refreshPrefs();
     this.sca.env.shellHost
       .isCookieSettingsAvailable()
-      .then((available) => (this.cookieSettingsAvailable = available));
+      .then((available) => (this.cookieSettingsAvailable = available))
+      .catch(() => {}); // Default to hidden on failure.
   }
 
   static styles = [
@@ -182,10 +183,10 @@ export class VEGlobalSettingsModal extends SignalWatcher(LitElement) {
         text-decoration: underline;
         font: inherit;
         text-align: left;
-      }
 
-      .manage-cookies-link:hover {
-        color: light-dark(var(--p-40), var(--p-80));
+        &:hover {
+          color: light-dark(var(--p-40), var(--p-80));
+        }
       }
     `,
   ];
@@ -231,7 +232,7 @@ export class VEGlobalSettingsModal extends SignalWatcher(LitElement) {
                 </label>
                 ${this.cookieSettingsAvailable
                   ? html`<button
-                      class="glue-cookie-notification-bar-control manage-cookies-link"
+                      class="manage-cookies-link"
                       @click=${() => {
                         this.sca.env.shellHost.showCookieSettings();
                         this.dispatchEvent(

--- a/packages/visual-editor/src/ui/elements/shell/global-settings.ts
+++ b/packages/visual-editor/src/ui/elements/shell/global-settings.ts
@@ -68,6 +68,9 @@ export class VEGlobalSettingsModal extends SignalWatcher(LitElement) {
   @state()
   accessor activeTabId: TabId = TabId.GENERAL;
 
+  @state()
+  accessor cookieSettingsAvailable = false;
+
   connectedCallback() {
     super.connectedCallback();
     if (
@@ -77,6 +80,9 @@ export class VEGlobalSettingsModal extends SignalWatcher(LitElement) {
       this.activeTabId = this.initialTab as TabId;
     }
     this.emailPrefsManager?.refreshPrefs();
+    this.sca.env.shellHost
+      .isCookieSettingsAvailable()
+      .then((available) => (this.cookieSettingsAvailable = available));
   }
 
   static styles = [
@@ -166,6 +172,21 @@ export class VEGlobalSettingsModal extends SignalWatcher(LitElement) {
         margin-right: var(--bb-grid-size);
         flex-shrink: 0;
       }
+
+      .manage-cookies-link {
+        background: none;
+        border: none;
+        padding: var(--bb-grid-size-2) 0;
+        color: light-dark(var(--p-50), var(--p-70));
+        cursor: pointer;
+        text-decoration: underline;
+        font: inherit;
+        text-align: left;
+      }
+
+      .manage-cookies-link:hover {
+        color: light-dark(var(--p-40), var(--p-80));
+      }
     `,
   ];
 
@@ -207,7 +228,20 @@ export class VEGlobalSettingsModal extends SignalWatcher(LitElement) {
                       ])}
                   ></md-checkbox>
                   ${Strings.from("LABEL_EMAIL_RESEARCH")}
-                </label>`,
+                </label>
+                ${this.cookieSettingsAvailable
+                  ? html`<button
+                      class="glue-cookie-notification-bar-control manage-cookies-link"
+                      @click=${() => {
+                        this.sca.env.shellHost.showCookieSettings();
+                        this.dispatchEvent(
+                          new BreadboardUI.Events.ModalDismissedEvent()
+                        );
+                      }}
+                    >
+                      Manage cookies
+                    </button>`
+                  : nothing}`,
       },
       [TabId.INTEGRATIONS]: {
         name: Strings.from("LABEL_SETTINGS_INTEGRATIONS"),

--- a/packages/visual-editor/src/ui/utils/oauth-based-opal-shell.ts
+++ b/packages/visual-editor/src/ui/utils/oauth-based-opal-shell.ts
@@ -969,4 +969,11 @@ export class OAuthBasedOpalShell implements OpalShellHostProtocol {
       (document.activeElement as HTMLElement | null)?.blur();
     });
   };
+
+  isCookieSettingsAvailable = async (): Promise<boolean> => {
+    const control = document.querySelector(
+      ".glue-cookie-notification-bar-control"
+    );
+    return control !== null && control.getAttribute("aria-hidden") !== "true";
+  };
 }

--- a/packages/visual-editor/src/ui/utils/oauth-based-opal-shell.ts
+++ b/packages/visual-editor/src/ui/utils/oauth-based-opal-shell.ts
@@ -970,10 +970,13 @@ export class OAuthBasedOpalShell implements OpalShellHostProtocol {
     });
   };
 
+  /**
+   * Set by the shell host after the cookie bar's `loaded` event resolves.
+   * Indicates whether cookie management is needed for this user's region.
+   */
+  cookieBarRequired: Promise<boolean> = Promise.resolve(false);
+
   isCookieSettingsAvailable = async (): Promise<boolean> => {
-    const control = document.querySelector(
-      ".glue-cookie-notification-bar-control"
-    );
-    return control !== null && control.getAttribute("aria-hidden") !== "true";
+    return this.cookieBarRequired;
   };
 }

--- a/packages/visual-editor/src/ui/utils/oauth-based-opal-shell.ts
+++ b/packages/visual-editor/src/ui/utils/oauth-based-opal-shell.ts
@@ -963,5 +963,10 @@ export class OAuthBasedOpalShell implements OpalShellHostProtocol {
       ".glue-cookie-notification-bar-control"
     );
     control?.click();
+    // The cookie bar applies focus asynchronously after rendering. Defer the
+    // blur so it runs after the bar has finished setting up its UI.
+    requestAnimationFrame(() => {
+      (document.activeElement as HTMLElement | null)?.blur();
+    });
   };
 }

--- a/packages/visual-editor/src/ui/utils/oauth-based-opal-shell.ts
+++ b/packages/visual-editor/src/ui/utils/oauth-based-opal-shell.ts
@@ -955,4 +955,13 @@ export class OAuthBasedOpalShell implements OpalShellHostProtocol {
   trackProperties = async (payload: Record<string, string | undefined>) => {
     this.actionEventSender?.setProperties(payload);
   };
+
+  showCookieSettings = async (): Promise<void> => {
+    // Trigger the cookie notification bar's built-in control. The bar script
+    // binds click handlers to elements with this class in the host document.
+    const control = document.querySelector<HTMLElement>(
+      ".glue-cookie-notification-bar-control"
+    );
+    control?.click();
+  };
 }

--- a/packages/visual-editor/src/ui/utils/oauth-based-opal-shell.ts
+++ b/packages/visual-editor/src/ui/utils/oauth-based-opal-shell.ts
@@ -935,14 +935,24 @@ export class OAuthBasedOpalShell implements OpalShellHostProtocol {
     });
   };
 
-  private readonly actionEventSender = new GTagEventSender(
-    CLIENT_DEPLOYMENT_CONFIG.MEASUREMENT_ID
-  );
+  private actionEventSender: GTagEventSender | undefined;
+
+  /**
+   * Enable analytics tracking. Called by the shell host after cookie consent
+   * has been granted.
+   */
+  enableAnalytics(): void {
+    if (this.actionEventSender) return;
+    this.actionEventSender = new GTagEventSender(
+      CLIENT_DEPLOYMENT_CONFIG.MEASUREMENT_ID
+    );
+  }
+
   trackAction = async (action: string, payload: Record<string, string>) => {
-    this.actionEventSender.sendEvent(action, payload);
+    this.actionEventSender?.sendEvent(action, payload);
   };
 
   trackProperties = async (payload: Record<string, string | undefined>) => {
-    this.actionEventSender.setProperties(payload);
+    this.actionEventSender?.setProperties(payload);
   };
 }


### PR DESCRIPTION
## Functional Changes

1. Show a cookie consent bar that allow users to opt-in to using non-essential cookies (like Google Analytics) in regions that require manual opt-ins.
    1. For these regions show a `Manage cookies` button to change the preference later.
1. Show informational consent bar in regions that require an informational bar to be shown without an ability to opt-out of non-essential cookies.
1. Don't show the cookie bar in regions that don't require any consent bar to be shown.
1. Appropriate translations for legal disclaimers.

## Changes

1. Using Glue notification bar library which handles all functional requirements.
    1. Translations <img width="3456" height="502" alt="image" src="https://github.com/user-attachments/assets/0184d99e-8596-445b-add8-a642a7477297" />
1. Cookie bar is placed in the host shell and `Manage cookies` button is placed in the landing page (for the unsigned in state) and the visual editor global settings dialog (for the signed in state).
1. Using comlink to progagate show/hide and onclick events for the `Manage cookies` buttons.
1. Handling race conditions stemming from how the notification bar library is loaded and the iframe interactions 