### PR TITLE
[ve] Consolidate workbench preview header

### DIFF
--- a/packages/visual-editor/src/sca/actions/workbench/workbench-actions.ts
+++ b/packages/visual-editor/src/sca/actions/workbench/workbench-actions.ts
@@ -133,6 +133,16 @@ export const toggleRunsPanel = asAction(
   }
 );
 
+export const togglePreview = asAction(
+  "Workbench.togglePreview",
+  { mode: ActionMode.Immediate },
+  async (show?: boolean): Promise<void> => {
+    const { controller } = bind;
+    controller.editor.workbench.showPreview =
+      show ?? !controller.editor.workbench.showPreview;
+  }
+);
+
 /**
  * Applies updated objective text to the agent node.
  *

--- a/packages/visual-editor/src/sca/controller/subcontrollers/editor/workbench/workbench-controller.ts
+++ b/packages/visual-editor/src/sca/controller/subcontrollers/editor/workbench/workbench-controller.ts
@@ -20,6 +20,9 @@ export class WorkbenchController extends RootController {
   @field({ persist: "session" })
   accessor runsOpen = false;
 
+  @field({ persist: "session" })
+  accessor showPreview = false;
+
   readonly splitter: WorkbenchSplitterController;
 
   constructor(id: string, name: string) {

--- a/packages/visual-editor/src/ui/app-templates/basic/index.ts
+++ b/packages/visual-editor/src/ui/app-templates/basic/index.ts
@@ -222,6 +222,11 @@ export class Template extends SignalWatcher(LitElement) implements AppTemplate {
   }
 
   #renderControls() {
+    const { replay, menu, fullscreen } = this.headerConfig;
+    if (!replay && !menu && !fullscreen) {
+      return nothing;
+    }
+
     return html`<bb-app-header
       .isEmpty=${this.isEmpty}
       .progress=${this.sca.controller.run.main.progress}

--- a/packages/visual-editor/src/ui/elements/agent-workbench/agent-config-column.ts
+++ b/packages/visual-editor/src/ui/elements/agent-workbench/agent-config-column.ts
@@ -44,6 +44,7 @@ import "../shared/agent-avatar.js";
 import "../input/text-editor/text-editor-remix.js";
 import "./asset-shelf/asset-shelf.js";
 import "./tool-shelf/tool-shelf.js";
+import "../app-controller/app-controller.js";
 
 @customElement("bb-agent-config-column")
 export class AgentConfigColumn extends SignalWatcher(LitElement) {
@@ -73,6 +74,14 @@ export class AgentConfigColumn extends SignalWatcher(LitElement) {
         position: relative;
       }
 
+      #container {
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+        width: 100%;
+        position: relative;
+      }
+
       /* ── Column Header ── */
       #column-header {
         position: relative;
@@ -84,6 +93,10 @@ export class AgentConfigColumn extends SignalWatcher(LitElement) {
         flex: 0 0 auto;
         padding: 0 var(--bb-grid-size-5);
         background: var(--light-dark-n-100);
+      }
+
+      #column-header.preview-active {
+        background: light-dark(var(--s-90), var(--p-30));
       }
 
       #header-scrim {
@@ -99,10 +112,14 @@ export class AgentConfigColumn extends SignalWatcher(LitElement) {
         z-index: 3;
       }
 
+      #header-scrim.preview-active {
+        display: none;
+      }
+
       #header-left {
         display: flex;
         align-items: center;
-        gap: var(--bb-grid-size-6);
+        gap: var(--bb-grid-size-2);
       }
 
       #save-status-container {
@@ -178,6 +195,92 @@ export class AgentConfigColumn extends SignalWatcher(LitElement) {
           --selected-item-hover-color: light-dark(var(--n-95), var(--n-30));
           --selected-item-border-radius: 50%;
         }
+      }
+
+      #preview-button {
+        display: flex;
+        align-items: center;
+        background: var(--light-dark-n-100);
+        border: 1px solid var(--light-dark-n-95);
+        border-radius: 100px;
+        color: var(--light-dark-n-0);
+        height: var(--bb-grid-size-8);
+        padding: 0 var(--bb-grid-size-4) 0 var(--bb-grid-size-2);
+        font-size: 14px;
+        cursor: pointer;
+        transition:
+          background 0.2s cubic-bezier(0, 0, 0.2, 1),
+          border 0.2s cubic-bezier(0, 0, 0.2, 1);
+
+        & .g-icon {
+          margin-right: var(--bb-grid-size-2);
+        }
+
+        &:hover {
+          border: 1px solid var(--light-dark-n-80);
+        }
+      }
+
+      #close-preview-button {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: var(--bb-grid-size-8);
+        height: var(--bb-grid-size-8);
+        border-radius: 50%;
+        border: none;
+        padding: 0;
+        cursor: pointer;
+        background: var(--light-dark-n-0);
+        color: var(--light-dark-n-100);
+        transition: opacity 0.2s cubic-bezier(0, 0, 0.2, 1);
+
+        & .g-icon {
+          font-size: 20px;
+        }
+
+        &:hover {
+          opacity: 0.8;
+        }
+      }
+
+      #restart-button {
+        display: flex;
+        align-items: center;
+        height: var(--bb-grid-size-8);
+        border-radius: 100px;
+        border: none;
+        padding: 0 var(--bb-grid-size-3) 0 var(--bb-grid-size-2);
+        cursor: pointer;
+        background: transparent;
+        color: var(--light-dark-n-0);
+        gap: var(--bb-grid-size);
+        font: 500 var(--bb-body-small) / var(--bb-body-line-height-small)
+          var(--bb-font-family);
+        transition: background 0.2s cubic-bezier(0, 0, 0.2, 1);
+
+        & .g-icon {
+          font-size: 20px;
+        }
+
+        &:hover {
+          background: var(--s-95, light-dark(var(--n-95), var(--n-30)));
+        }
+      }
+
+      .preview-container {
+        flex: 1 1 0;
+        min-height: 0;
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .preview-container bb-app-controller {
+        width: 100%;
+        height: 100%;
       }
 
       #share-button {
@@ -566,7 +669,7 @@ export class AgentConfigColumn extends SignalWatcher(LitElement) {
     </button>`;
   }
 
-  #renderThreeDotMenu() {
+  #renderThreeDotMenu(hoverStyle?: string) {
     const options: EnumValue[] = [
       {
         id: "more",
@@ -605,6 +708,7 @@ export class AgentConfigColumn extends SignalWatcher(LitElement) {
       .freezeValue=${0}
       .transparent=${true}
       .values=${options}
+      style=${hoverStyle ?? nothing}
       @change=${(evt: Event) => {
         const select = evt.target as ItemSelect;
         this.dispatchEvent(new HeaderActionEvent(select.value));
@@ -612,7 +716,7 @@ export class AgentConfigColumn extends SignalWatcher(LitElement) {
     ></bb-item-select>`;
   }
 
-  #renderSettingsCog() {
+  #renderSettingsCog(hoverStyle?: string) {
     const settingsOptions: EnumValue[] = [
       {
         id: "settings",
@@ -653,6 +757,7 @@ export class AgentConfigColumn extends SignalWatcher(LitElement) {
       .freezeValue=${0}
       .transparent=${true}
       .values=${settingsOptions}
+      style=${hoverStyle ?? nothing}
       @change=${(evt: Event) => {
         const select = evt.target as ItemSelect;
         this.dispatchEvent(new HeaderActionEvent(select.value));
@@ -761,6 +866,7 @@ export class AgentConfigColumn extends SignalWatcher(LitElement) {
     // any in-progress edits.
     const editorValue = this.#focused ? noChange : objectiveText;
     const title = graphController.title ?? "Untitled agent";
+    const showPreview = this.sca.controller.editor.workbench.showPreview;
 
     // Dynamically resolve theme colors from the graph's visual metadata
     let themeStyles: Record<string, string> = {};
@@ -783,63 +889,143 @@ export class AgentConfigColumn extends SignalWatcher(LitElement) {
     }
 
     return html`
-      <div id="column-header">
-        <div id="header-left">
-          ${this.#renderExperimentalLabel()}
-          <div id="save-status-container">
-            ${this.#renderSaveStatusLabel()}
-            <span class="dot">•</span>
-            <span id="draft-status">${this.status}</span>
+      <div id="container" style=${styleMap(themeStyles)}>
+        <div
+          id="column-header"
+          class=${classMap({ "preview-active": showPreview })}
+        >
+          <div id="header-left">
+            ${showPreview
+              ? html`
+                  <button
+                    id="close-preview-button"
+                    @click=${() => {
+                      this.sca.actions.workbench.togglePreview(false);
+                    }}
+                  >
+                    <span class="g-icon">close</span>
+                  </button>
+                  <button
+                    id="restart-button"
+                    @click=${() => {
+                      this.dispatchEvent(
+                        new StateEvent({ eventType: "board.stop" })
+                      );
+                    }}
+                  >
+                    <span class="g-icon">replay</span>Restart app
+                  </button>
+                `
+              : html`
+                  ${this.#renderExperimentalLabel()}
+                  <div id="save-status-container">
+                    ${this.#renderSaveStatusLabel()}
+                    <span class="dot">•</span>
+                    <span id="draft-status">${this.status}</span>
+                  </div>
+                `}
+          </div>
+
+          <div id="header-right">
+            ${showPreview
+              ? nothing
+              : html`
+                  <button
+                    id="preview-button"
+                    class="sans-flex round w-500"
+                    @click=${() => {
+                      this.sca.actions.workbench.togglePreview(true);
+                    }}
+                  >
+                    <span class="g-icon">play_arrow</span>Preview
+                  </button>
+                `}
+            ${this.#renderPublishButton()} ${this.#renderShareButton()}
+            ${(() => {
+              const hoverColor = showPreview
+                ? themeStyles["--s-95"]
+                : undefined;
+              const hoverStyle = hoverColor
+                ? `--selected-item-hover-color: ${hoverColor}`
+                : undefined;
+              return html`
+                ${this.#renderThreeDotMenu(hoverStyle)}
+                ${this.#renderSettingsCog(hoverStyle)}
+              `;
+            })()}
+            ${this.#renderUser()}
           </div>
         </div>
 
-        <div id="header-right">
-          ${this.#renderPublishButton()} ${this.#renderShareButton()}
-          ${this.#renderThreeDotMenu()} ${this.#renderSettingsCog()}
-          ${this.#renderUser()}
-        </div>
-      </div>
+        <div
+          id="header-scrim"
+          class=${classMap({ "preview-active": showPreview })}
+        ></div>
 
-      <div id="header-scrim"></div>
+        ${showPreview
+          ? html`
+              <div class="preview-container">
+                <bb-app-controller
+                  .graph=${graph}
+                  .graphContentState=${graphController.graphContentState}
+                  .graphTopologyUpdateId=${graphController.topologyVersion}
+                  .isMine=${!graphController.readOnly}
+                  .readOnly=${graphController.readOnly}
+                  .runtimeFlags=${this.sca.env.flags}
+                  .showGDrive=${this.sca.services.signinAdapter.stateSignal
+                    ?.status === "signedin"}
+                  .status=${this.sca.controller.run.main.status}
+                  .themeHash=${this.sca.controller.editor.theme.themeHash}
+                  .headerConfig=${{
+                    replay: false,
+                    menu: false,
+                    fullscreen: null,
+                    small: false,
+                  }}
+                ></bb-app-controller>
+              </div>
+            `
+          : html`
+              <div class="config-scroll">
+                <div class="config-container">
+                  <div class="avatar-section">
+                    <bb-agent-avatar
+                      mode="large"
+                      .supportsHover=${false}
+                    ></bb-agent-avatar>
+                  </div>
 
-      <div class="config-scroll">
-        <div class="config-container" style=${styleMap(themeStyles)}>
-          <div class="avatar-section">
-            <bb-agent-avatar
-              mode="large"
-              .supportsHover=${false}
-            ></bb-agent-avatar>
-          </div>
+                  <div class="heading-section">
+                    <h1
+                      contenteditable="true"
+                      @blur=${this.#onHeadingBlur}
+                      @keydown=${this.#onHeadingKeyDown}
+                      .innerText=${title}
+                    ></h1>
+                  </div>
 
-          <div class="heading-section">
-            <h1
-              contenteditable="true"
-              @blur=${this.#onHeadingBlur}
-              @keydown=${this.#onHeadingKeyDown}
-              .innerText=${title}
-            ></h1>
-          </div>
+                  <div class="instructions-section">
+                    <h3>Instructions</h3>
+                    <bb-text-editor-remix
+                      .value=${editorValue}
+                      .supportsFastAccess=${true}
+                      .fastAccessMode=${"browse-assets"}
+                      @focus=${this.#onFocus}
+                      @blur=${this.#onBlur}
+                      @keydown=${this.#onKeyDown}
+                    ></bb-text-editor-remix>
+                  </div>
 
-          <div class="instructions-section">
-            <h3>Instructions</h3>
-            <bb-text-editor-remix
-              .value=${editorValue}
-              .supportsFastAccess=${true}
-              .fastAccessMode=${"browse-assets"}
-              @focus=${this.#onFocus}
-              @blur=${this.#onBlur}
-              @keydown=${this.#onKeyDown}
-            ></bb-text-editor-remix>
-          </div>
+                  <div class="divider"></div>
 
-          <div class="divider"></div>
+                  <bb-agent-asset-shelf></bb-agent-asset-shelf>
 
-          <bb-agent-asset-shelf></bb-agent-asset-shelf>
+                  <div class="divider"></div>
 
-          <div class="divider"></div>
-
-          <bb-tool-shelf></bb-tool-shelf>
-        </div>
+                  <bb-tool-shelf></bb-tool-shelf>
+                </div>
+              </div>
+            `}
       </div>
     `;
   }

--- a/packages/visual-editor/tests/sca/actions/workbench/workbench-actions.test.ts
+++ b/packages/visual-editor/tests/sca/actions/workbench/workbench-actions.test.ts
@@ -261,6 +261,64 @@ suite("Workbench Actions", () => {
     });
   });
 
+  suite("togglePreview", () => {
+    test("toggles showPreview from false to true", async () => {
+      let showPreviewVal = false;
+
+      const env = createMockEnvironment(defaultRuntimeFlags);
+      await env.isHydrated;
+
+      workbenchActions.bind({
+        services: {} as never,
+        controller: {
+          editor: {
+            workbench: {
+              get showPreview() {
+                return showPreviewVal;
+              },
+              set showPreview(val: boolean) {
+                showPreviewVal = val;
+              },
+            },
+          },
+        } as never,
+        env,
+      });
+
+      await workbenchActions.togglePreview();
+
+      assert.strictEqual(showPreviewVal, true);
+    });
+
+    test("sets showPreview to explicit value", async () => {
+      let showPreviewVal = true;
+
+      const env = createMockEnvironment(defaultRuntimeFlags);
+      await env.isHydrated;
+
+      workbenchActions.bind({
+        services: {} as never,
+        controller: {
+          editor: {
+            workbench: {
+              get showPreview() {
+                return showPreviewVal;
+              },
+              set showPreview(val: boolean) {
+                showPreviewVal = val;
+              },
+            },
+          },
+        } as never,
+        env,
+      });
+
+      await workbenchActions.togglePreview(false);
+
+      assert.strictEqual(showPreviewVal, false);
+    });
+  });
+
   suite("applyObjective", () => {
     test("updates agent node config$prompt with new objective text while preserving existing tools", async () => {
       const singleAgentGraph: GraphDescriptor = {


### PR DESCRIPTION
## What

When the agent workbench preview is open, the app-internal header (hamburger, progress bar, replay) is now suppressed entirely. The workbench header absorbs restart and close controls, eliminating redundant items.

## Why

The preview previously rendered its own `bb-app-header` with hamburger menu, progress bar, and replay button — controls that are useful in the standalone consumer app view but redundant in the authoring preview where the workbench header already provides administrative actions. This change reduces visual noise and consolidates controls into a single, consistent header bar.

## Changes

### SCA layer

- **`workbench-controller.ts`** — Add `showPreview` field (session-persisted)
  to track preview visibility.
- **`workbench-actions.ts`** — Add `togglePreview` action that sets or toggles
  `showPreview`.
- **`workbench-actions.test.ts`** — Tests for toggle and explicit-set
  behaviors.

### App template

- **`app-templates/basic/index.ts`** — `#renderControls()` now returns `nothing` when all `headerConfig` controls are off (`!replay && !menu && !fullscreen`), hiding the app header entirely instead of rendering an empty bar. Lite mode is unaffected (always has `fullscreen` set).

### Workbench UI (`agent-config-column.ts`)

- **Preview mode header** — When preview is open:
  - Left side: close button (dark circle, white ×) + "Restart app" pill (icon + label, no outline).
  - Right side: Publish, Share, overflow menu, settings cog, user avatar (unchanged).
  - Left-side experiment badge and save status are hidden.
  - Preview button is hidden (replaced by close).
- **App header suppressed** — `bb-app-controller` receives an all-off `headerConfig` so the app template renders no header chrome.
- **Theme-aware hover** — `bb-item-select` (overflow menu, settings cog) hover colors use a concrete resolved value from `themeStyles['--s-95']` to bypass `baseColors` shadowing the token inside `bb-item-select`'s shadow DOM. The restart button uses `var(--s-95)` directly (no shadow DOM boundary).
- **Preview container** — Wraps `bb-app-controller` in a flex container that fills the remaining column height.

## Testing

- `npm run test:file -- './dist/tsc/tests/sca/actions/workbench/*.js'` — new tests pass.
- Visual: open an agent in the workbench → click Preview → verify the app header (hamburger, progress bar, replay) is gone, close (×) and "Restart app" appear on the left, and hovering the overflow/cog menus shows the themed tint (not gray).
