### PR TITLE
[ve]  Align Asset Shelf and Chiclet Consistency for NotebookLM and Google Drive

### DIFF
--- a/packages/visual-editor/src/ui/elements/agent-workbench/asset-shelf/asset-shelf.ts
+++ b/packages/visual-editor/src/ui/elements/agent-workbench/asset-shelf/asset-shelf.ts
@@ -323,6 +323,10 @@ export class AgentAssetShelf extends SignalWatcher(LitElement) {
   }
 
   #getAssetType(asset: GraphAsset): string | null {
+    if (asset.metadata?.subType === "notebooklm") {
+      return "notebooklm";
+    }
+
     const firstPart = asset.data[0]?.parts[0];
     if (!firstPart) return "upload";
 
@@ -335,6 +339,9 @@ export class AgentAssetShelf extends SignalWatcher(LitElement) {
     }
 
     if ("storedData" in firstPart && firstPart.storedData) {
+      if (firstPart.storedData.mimeType === NOTEBOOKLM_MIMETYPE) {
+        return "notebooklm";
+      }
       if (firstPart.storedData.handle.startsWith("drive:/")) {
         return "gdrive";
       }

--- a/packages/visual-editor/src/ui/elements/agent-workbench/asset-shelf/asset-thumbnail.ts
+++ b/packages/visual-editor/src/ui/elements/agent-workbench/asset-shelf/asset-thumbnail.ts
@@ -127,7 +127,7 @@ class AssetThumbnail extends SignalWatcher(LitElement) {
     const firstPart = this.asset.data[0]?.parts[0];
 
     // NotebookLM
-    if (mimeType === NOTEBOOKLM_MIMETYPE) {
+    if (mimeType === NOTEBOOKLM_MIMETYPE || mimeType === "notebooklm") {
       return html`<div class="notebooklm-wrapper">${notebookLmIcon}</div>`;
     }
 

--- a/packages/visual-editor/src/ui/elements/graph-editing-chat/input-asset-shelf.ts
+++ b/packages/visual-editor/src/ui/elements/graph-editing-chat/input-asset-shelf.ts
@@ -28,6 +28,7 @@ import {
   videoIdFromWatchOrShortsOrEmbedUri,
 } from "../../../utils/media/youtube.js";
 import { NOTEBOOKLM_MIMETYPE } from "@breadboard-ai/utils";
+import { notebookLmIcon } from "../../styles/svg-icons.js";
 
 export { InputAssetShelf };
 
@@ -198,7 +199,7 @@ class InputAssetShelf extends SignalWatcher(LitElement) {
           isStoredData(part) &&
           part.storedData.mimeType === NOTEBOOKLM_MIMETYPE
         ) {
-          icon = "auto_stories";
+          icon = "notebooklm";
           break;
         }
       }
@@ -213,7 +214,13 @@ class InputAssetShelf extends SignalWatcher(LitElement) {
           ${preview !== nothing
             ? preview
             : html`<div class="icon">
-                <span class="g-icon">${icon}</span>
+                ${icon === "notebooklm"
+                  ? html`<div
+                      style="color: #8f39fd; display: flex; align-items: center; justify-content: center; width: 24px; height: 24px;"
+                    >
+                      ${notebookLmIcon}
+                    </div>`
+                  : html`<span class="g-icon">${icon}</span>`}
               </div>`}
         </div>
         <button

--- a/packages/visual-editor/src/ui/elements/input/add-asset/add-asset-modal.ts
+++ b/packages/visual-editor/src/ui/elements/input/add-asset/add-asset-modal.ts
@@ -29,6 +29,7 @@ import { consume } from "@lit/context";
 import { scaContext } from "../../../../sca/context/context.js";
 import { type SCA } from "../../../../sca/sca.js";
 import { NOTEBOOKLM_MIMETYPE } from "@breadboard-ai/utils";
+import { notebookLmIcon } from "../../../styles/svg-icons.js";
 import {
   videoIdFromWatchOrShortsOrEmbedUri,
   isShareUri,
@@ -238,6 +239,21 @@ export class AddAssetModal extends SignalWatcher(LitElement) {
             font-size: 36px;
           }
 
+          & .notebooklm-icon-wrapper {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            width: 36px;
+            height: 36px;
+            color: #8f39fd;
+            flex-shrink: 0;
+
+            & svg {
+              width: 36px;
+              height: 36px;
+            }
+          }
+
           & .card-title {
             font-weight: 500;
             color: var(--light-dark-n-10);
@@ -337,6 +353,21 @@ export class AddAssetModal extends SignalWatcher(LitElement) {
     }
     const updatedTitle =
       titleInput?.value || this.editingAsset?.metadata?.title || defaultTitle;
+
+    if (
+      this.editingAsset &&
+      (this.assetType === "gdrive" || this.assetType === "notebooklm")
+    ) {
+      const metadata: AssetMetadata = {
+        title: updatedTitle,
+        type: this.editingAsset.metadata?.type || "file",
+        subType: this.editingAsset.metadata?.subType,
+      };
+      this.dispatchEvent(
+        new AddAssetEvent(this.editingAsset.data[0], metadata)
+      );
+      return;
+    }
 
     for (const input of inputs) {
       if (input === titleInput) {
@@ -619,13 +650,9 @@ export class AddAssetModal extends SignalWatcher(LitElement) {
       else if (source.endsWith(".json")) mimeType = "application/json";
     }
 
-    if (mimeType === NOTEBOOKLM_MIMETYPE) {
+    if (mimeType === NOTEBOOKLM_MIMETYPE || mimeType === "notebooklm") {
       return html`<div class="preview-card">
-        <span
-          class="g-icon filled"
-          style="font-family: 'Google Symbols'; color: #8f39fd;"
-          >book</span
-        >
+        <div class="notebooklm-icon-wrapper">${notebookLmIcon}</div>
         <div>
           <div class="card-title">
             ${this.editingAsset.metadata?.title ||
@@ -880,24 +907,7 @@ export class AddAssetModal extends SignalWatcher(LitElement) {
 
       case "gdrive": {
         if (this.editingAsset) {
-          assetCollector = html`<div id="field-container">
-            ${preview}
-            <div
-              style="margin-top: var(--bb-grid-size-4); display: flex; flex-direction: column; gap: var(--bb-grid-size-2);"
-            >
-              <label
-                class="md-label-medium"
-                style="display: block; color: var(--light-dark-n-40);"
-                >Replace Google Drive File</label
-              >
-              <bb-google-drive-file-id
-                id="add-drive-proxy"
-                ${ref(this.#addDriveInputRef)}
-                .autoTrigger=${false}
-                .allowCreate=${false}
-              ></bb-google-drive-file-id>
-            </div>
-          </div>`;
+          assetCollector = html`<div id="field-container">${preview}</div>`;
         } else {
           assetCollector = html`
             <bb-google-drive-file-id


### PR DESCRIPTION
## What

Refactored the asset shelf, the details modal, and the chat panel's input shelf to present NotebookLM and Google Drive assets consistently, utilizing premium SVG iconography and preventing invalid file replacements.

## Why

Improves visual and functional polish of the agent workbench by ensuring NotebookLM displays its logo everywhere rather than falling back to standard icons, and locks Google Drive assets to prevent users from attempting invalid file replacement workflows.

## Changes

### packages/visual-editor

* **Asset Shelf Thumbnail**
  * Updated the asset thumbnail renderer to match the `"notebooklm"` subType alongside `NOTEBOOKLM_MIMETYPE` so that the custom NotebookLM logo displays in the workbench asset list.
* **Asset Shelf Core**
  * Fixed `#getAssetType` to correctly identify NotebookLM assets as `"notebooklm"` instead of defaulting them to `"upload"`.
* **Add Asset Modal**
  * Updated the add-asset modal to import and render the `notebookLmIcon` SVG inside the preview card.
  * Removed the file picker/replacement fields for Google Drive assets when editing them.
  * Added a custom CSS selector to scale the NotebookLM SVG logo to 36px in the details preview card.
  * Handled title-only saves in `#processAndEmit` for Google Drive and NotebookLM assets to bypass file input checks.
* **Chat Panel Input Asset Shelf**
  * Aligned the chat panel's input asset shelf to map NotebookLM assets to `"notebooklm"` and render the premium NotebookLM logo instead of the generic book icon.

## Testing

* Verified that TypeScript type-checks and Vite compilation passed without warnings.
* Ran the visual-editor test suite and verified that all tests passed successfully.
