### PR TITLE
Use backend client for MCP proxy

### DIFF
--- a/docs/dev/backend_reference.md
+++ b/docs/dev/backend_reference.md
@@ -157,8 +157,7 @@
   call via the Opal Backend proxy layer.
 - **Call Location:**
   [proxy-backed-client.ts](https://github.com/breadboard-ai/breadboard/tree/main/packages/visual-editor/src/mcp/proxy-backed-client.ts)
-- **Backend Client:** ✅ uses `OpalBackendClient` when `ENABLE_BACKEND_CLIENT`
-  is on; falls back to `fetchWithCreds` otherwise.
+- **Backend Client:** ✅ uses `OpalBackendClient` (exclusive path; no fallback)
 
 #### `POST /v1beta1/listMcpTools`
 
@@ -166,8 +165,7 @@
   all remote MCP tools available.
 - **Call Location:**
   [proxy-backed-client.ts](https://github.com/breadboard-ai/breadboard/tree/main/packages/visual-editor/src/mcp/proxy-backed-client.ts)
-- **Backend Client:** ✅ uses `OpalBackendClient` when `ENABLE_BACKEND_CLIENT`
-  is on; falls back to `fetchWithCreds` otherwise.
+- **Backend Client:** ✅ uses `OpalBackendClient` (exclusive path; no fallback)
 
 ---
 

--- a/docs/dev/backend_reference.md
+++ b/docs/dev/backend_reference.md
@@ -157,7 +157,8 @@
   call via the Opal Backend proxy layer.
 - **Call Location:**
   [proxy-backed-client.ts](https://github.com/breadboard-ai/breadboard/tree/main/packages/visual-editor/src/mcp/proxy-backed-client.ts)
-- **Backend Client:** ❌ uses `fetchWithCreds`
+- **Backend Client:** ✅ uses `OpalBackendClient` when `ENABLE_BACKEND_CLIENT`
+  is on; falls back to `fetchWithCreds` otherwise.
 
 #### `POST /v1beta1/listMcpTools`
 
@@ -165,7 +166,8 @@
   all remote MCP tools available.
 - **Call Location:**
   [proxy-backed-client.ts](https://github.com/breadboard-ai/breadboard/tree/main/packages/visual-editor/src/mcp/proxy-backed-client.ts)
-- **Backend Client:** ❌ uses `fetchWithCreds`
+- **Backend Client:** ✅ uses `OpalBackendClient` when `ENABLE_BACKEND_CLIENT`
+  is on; falls back to `fetchWithCreds` otherwise.
 
 ---
 

--- a/packages/visual-editor/src/mcp/client-manager.ts
+++ b/packages/visual-editor/src/mcp/client-manager.ts
@@ -62,8 +62,6 @@ class McpClientManager {
           new ProxyBackedClient({
             name: serverInfo?.title || info.name,
             url,
-            fetchWithCreds: this.context.fetchWithCreds,
-            proxyUrl: this.proxyUrl,
             token: serverInfo?.authToken,
             backendClient: this.context.backendClient,
           }),

--- a/packages/visual-editor/src/mcp/client-manager.ts
+++ b/packages/visual-editor/src/mcp/client-manager.ts
@@ -65,6 +65,7 @@ class McpClientManager {
             fetchWithCreds: this.context.fetchWithCreds,
             proxyUrl: this.proxyUrl,
             token: serverInfo?.authToken,
+            backendClient: this.context.backendClient,
           }),
           this.#serverStore
         );

--- a/packages/visual-editor/src/mcp/proxy-backed-client.ts
+++ b/packages/visual-editor/src/mcp/proxy-backed-client.ts
@@ -12,6 +12,8 @@ import type {
 import { McpCallToolResult, McpClient, McpListToolResult } from "./types.js";
 import { err, ok } from "@breadboard-ai/utils";
 import { FunctionResponseCapabilityPart, Outcome } from "@breadboard-ai/types";
+import type { OpalBackendClient } from "@breadboard-ai/types/opal-backend-client.js";
+import { CLIENT_DEPLOYMENT_CONFIG } from "../ui/config/client-deployment-configuration.js";
 
 export { ProxyBackedClient };
 
@@ -34,6 +36,7 @@ type ProxyBackedClientArgs = {
    */
   readonly proxyUrl: string;
   readonly fetchWithCreds: typeof globalThis.fetch;
+  readonly backendClient?: Promise<OpalBackendClient>;
 };
 
 type ProxyListToolResponse = {
@@ -64,28 +67,41 @@ class ProxyBackedClient implements McpClient {
 
   async #call<T = unknown>(path: string, payload = {}): Promise<Outcome<T>> {
     try {
-      const url = new URL(path, this.args.proxyUrl);
-      let headers = {};
-      const token = this.args.token;
-      if (token) {
-        headers = {
-          headers: {
-            Authorization: `Bearer ${token}`,
+      let response: Response;
+      const methodName = path.replace(/^\/?(v1beta1\/)?/, "");
+
+      const bodyObj = {
+        mcpServerConfig: {
+          streamableHttp: {
+            url: this.args.url,
+            ...(this.args.token
+              ? {
+                  headers: {
+                    Authorization: `Bearer ${this.args.token}`,
+                  },
+                }
+              : {}),
           },
-        };
+        },
+        ...payload,
+      };
+
+      if (
+        CLIENT_DEPLOYMENT_CONFIG.ENABLE_BACKEND_CLIENT &&
+        this.args.backendClient
+      ) {
+        const backendClient = await this.args.backendClient;
+        response = await backendClient.sendHttpRequest(methodName, {
+          method: "POST",
+          body: bodyObj,
+        });
+      } else {
+        const url = new URL(path, this.args.proxyUrl);
+        response = await this.args.fetchWithCreds(url, {
+          method: "POST",
+          body: JSON.stringify(bodyObj),
+        });
       }
-      const response = await this.args.fetchWithCreds(url, {
-        method: "POST",
-        body: JSON.stringify({
-          mcpServerConfig: {
-            streamableHttp: {
-              url: this.args.url,
-              ...headers,
-            },
-          },
-          ...payload,
-        }),
-      });
       return response.json();
     } catch (e) {
       return err(`Calling MCP proxy failed: ${(e as Error).message}`);

--- a/packages/visual-editor/src/mcp/proxy-backed-client.ts
+++ b/packages/visual-editor/src/mcp/proxy-backed-client.ts
@@ -13,7 +13,6 @@ import { McpCallToolResult, McpClient, McpListToolResult } from "./types.js";
 import { err, ok } from "@breadboard-ai/utils";
 import { FunctionResponseCapabilityPart, Outcome } from "@breadboard-ai/types";
 import type { OpalBackendClient } from "@breadboard-ai/types/opal-backend-client.js";
-import { CLIENT_DEPLOYMENT_CONFIG } from "../ui/config/client-deployment-configuration.js";
 
 export { ProxyBackedClient };
 
@@ -31,12 +30,7 @@ type ProxyBackedClientArgs = {
    */
   readonly token?: string;
 
-  /**
-   * Proxy base URL
-   */
-  readonly proxyUrl: string;
-  readonly fetchWithCreds: typeof globalThis.fetch;
-  readonly backendClient?: Promise<OpalBackendClient>;
+  readonly backendClient: Promise<OpalBackendClient>;
 };
 
 type ProxyListToolResponse = {
@@ -67,7 +61,6 @@ class ProxyBackedClient implements McpClient {
 
   async #call<T = unknown>(path: string, payload = {}): Promise<Outcome<T>> {
     try {
-      let response: Response;
       const methodName = path.replace(/^\/?(v1beta1\/)?/, "");
 
       const bodyObj = {
@@ -86,22 +79,11 @@ class ProxyBackedClient implements McpClient {
         ...payload,
       };
 
-      if (
-        CLIENT_DEPLOYMENT_CONFIG.ENABLE_BACKEND_CLIENT &&
-        this.args.backendClient
-      ) {
-        const backendClient = await this.args.backendClient;
-        response = await backendClient.sendHttpRequest(methodName, {
-          method: "POST",
-          body: bodyObj,
-        });
-      } else {
-        const url = new URL(path, this.args.proxyUrl);
-        response = await this.args.fetchWithCreds(url, {
-          method: "POST",
-          body: JSON.stringify(bodyObj),
-        });
-      }
+      const backendClient = await this.args.backendClient;
+      const response = await backendClient.sendHttpRequest(methodName, {
+        method: "POST",
+        body: bodyObj,
+      });
       return response.json();
     } catch (e) {
       return err(`Calling MCP proxy failed: ${(e as Error).message}`);

--- a/packages/visual-editor/src/mcp/types.ts
+++ b/packages/visual-editor/src/mcp/types.ts
@@ -5,6 +5,7 @@
  */
 
 import { FunctionResponseCapabilityPart, Outcome } from "@breadboard-ai/types";
+import type { OpalBackendClient } from "@breadboard-ai/types/opal-backend-client.js";
 import { ToolCallback } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type {
@@ -148,6 +149,7 @@ export interface McpBuiltInClient extends McpClient {
 
 export type McpBuiltInClientFactoryContext = {
   fetchWithCreds: typeof fetch;
+  backendClient?: Promise<OpalBackendClient>;
 };
 
 export type McpBuiltInClientFactory = (

--- a/packages/visual-editor/src/mcp/types.ts
+++ b/packages/visual-editor/src/mcp/types.ts
@@ -149,7 +149,7 @@ export interface McpBuiltInClient extends McpClient {
 
 export type McpBuiltInClientFactoryContext = {
   fetchWithCreds: typeof fetch;
-  backendClient?: Promise<OpalBackendClient>;
+  backendClient: Promise<OpalBackendClient>;
 };
 
 export type McpBuiltInClientFactory = (

--- a/packages/visual-editor/src/sca/services/services.ts
+++ b/packages/visual-editor/src/sca/services/services.ts
@@ -120,6 +120,7 @@ export function services(
       builtInMcpClients,
       {
         fetchWithCreds: fetchWithCreds,
+        backendClient: config.shellHost.getOpalBackendClient(),
       },
       OPAL_BACKEND_API_PREFIX
     );

--- a/packages/visual-editor/tests/mcp/proxy-backed-client.test.ts
+++ b/packages/visual-editor/tests/mcp/proxy-backed-client.test.ts
@@ -1,0 +1,242 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, mock, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { ProxyBackedClient } from "../../src/mcp/proxy-backed-client.js";
+import { CLIENT_DEPLOYMENT_CONFIG } from "../../src/ui/config/client-deployment-configuration.js";
+
+describe("ProxyBackedClient", () => {
+  let savedFlag: boolean;
+
+  afterEach(() => {
+    if (savedFlag !== undefined) {
+      CLIENT_DEPLOYMENT_CONFIG.ENABLE_BACKEND_CLIENT = savedFlag;
+    }
+    mock.restoreAll();
+  });
+
+  it("uses fetchWithCreds when ENABLE_BACKEND_CLIENT is off (listTools)", async () => {
+    savedFlag = CLIENT_DEPLOYMENT_CONFIG.ENABLE_BACKEND_CLIENT;
+    CLIENT_DEPLOYMENT_CONFIG.ENABLE_BACKEND_CLIENT = false;
+
+    const fetchMock = mock.fn(
+      async (_url: URL | RequestInfo, _init?: RequestInit) => {
+        return new Response(
+          JSON.stringify({
+            functionDeclarations: [
+              {
+                name: "test_tool",
+                description: "A test tool",
+                parameters: { type: "object", properties: {} },
+              },
+            ],
+          }),
+          { status: 200 }
+        );
+      }
+    );
+
+    const client = new ProxyBackedClient({
+      name: "test-server",
+      url: "https://mcp.example.com",
+      proxyUrl: "https://proxy.example.com",
+      fetchWithCreds: fetchMock as unknown as typeof globalThis.fetch,
+    });
+
+    const result = await client.listTools();
+
+    assert.equal(fetchMock.mock.calls.length, 1);
+    const [url, init] = fetchMock.mock.calls[0].arguments;
+    assert.equal(
+      url.toString(),
+      "https://proxy.example.com/v1beta1/listMcpTools"
+    );
+    assert.equal(init?.method, "POST");
+
+    const bodyObj = JSON.parse(init?.body as string);
+    assert.deepStrictEqual(bodyObj, {
+      mcpServerConfig: {
+        streamableHttp: {
+          url: "https://mcp.example.com",
+        },
+      },
+    });
+
+    assert.equal(result.tools.length, 1);
+    assert.equal(result.tools[0].name, "test_tool");
+  });
+
+  it("uses fetchWithCreds when ENABLE_BACKEND_CLIENT is off (callTool)", async () => {
+    savedFlag = CLIENT_DEPLOYMENT_CONFIG.ENABLE_BACKEND_CLIENT;
+    CLIENT_DEPLOYMENT_CONFIG.ENABLE_BACKEND_CLIENT = false;
+
+    const fetchMock = mock.fn(
+      async (_url: URL | RequestInfo, _init?: RequestInit) => {
+        return new Response(
+          JSON.stringify({
+            content: [{ type: "text", text: "Tool response" }],
+          }),
+          { status: 200 }
+        );
+      }
+    );
+
+    const client = new ProxyBackedClient({
+      name: "test-server",
+      url: "https://mcp.example.com",
+      proxyUrl: "https://proxy.example.com",
+      token: "secret-token",
+      fetchWithCreds: fetchMock as unknown as typeof globalThis.fetch,
+    });
+
+    const result = await client.callTool({
+      name: "test_tool",
+      arguments: { arg1: "val" },
+    });
+
+    assert.equal(fetchMock.mock.calls.length, 1);
+    const [url, init] = fetchMock.mock.calls[0].arguments;
+    assert.equal(
+      url.toString(),
+      "https://proxy.example.com/v1beta1/callMcpTool"
+    );
+    assert.equal(init?.method, "POST");
+
+    const bodyObj = JSON.parse(init?.body as string);
+    assert.deepStrictEqual(bodyObj, {
+      mcpServerConfig: {
+        streamableHttp: {
+          url: "https://mcp.example.com",
+          headers: {
+            Authorization: "Bearer secret-token",
+          },
+        },
+      },
+      functionCall: {
+        id: "id",
+        name: "test_tool",
+        args: { arg1: "val" },
+      },
+    });
+
+    // McpCallToolResult returned
+    assert.deepStrictEqual(result, {
+      content: [{ type: "text", text: "Tool response" }],
+    });
+  });
+
+  it("uses sendHttpRequest when ENABLE_BACKEND_CLIENT is on (listTools)", async () => {
+    savedFlag = CLIENT_DEPLOYMENT_CONFIG.ENABLE_BACKEND_CLIENT;
+    CLIENT_DEPLOYMENT_CONFIG.ENABLE_BACKEND_CLIENT = true;
+
+    const backendClientMock = {
+      sendHttpRequest: mock.fn(async () => {
+        return new Response(
+          JSON.stringify({
+            functionDeclarations: [
+              {
+                name: "backend_tool",
+                description: "A backend tool",
+                parameters: { type: "object", properties: {} },
+              },
+            ],
+          }),
+          { status: 200 }
+        );
+      }),
+    };
+
+    const fetchMock = mock.fn();
+
+    const client = new ProxyBackedClient({
+      name: "test-server",
+      url: "https://mcp.example.com",
+      proxyUrl: "https://proxy.example.com",
+      fetchWithCreds: fetchMock as unknown as typeof globalThis.fetch,
+      backendClient: Promise.resolve(backendClientMock as any),
+    });
+
+    const result = await client.listTools();
+
+    assert.equal(backendClientMock.sendHttpRequest.mock.calls.length, 1);
+    assert.equal(fetchMock.mock.calls.length, 0);
+
+    const [methodName, options] = backendClientMock.sendHttpRequest.mock
+      .calls[0].arguments as unknown as [string, any];
+    assert.equal(methodName, "listMcpTools");
+    assert.equal(options.method, "POST");
+    assert.deepStrictEqual(options.body, {
+      mcpServerConfig: {
+        streamableHttp: {
+          url: "https://mcp.example.com",
+        },
+      },
+    });
+
+    assert.equal(result.tools.length, 1);
+    assert.equal(result.tools[0].name, "backend_tool");
+  });
+
+  it("uses sendHttpRequest when ENABLE_BACKEND_CLIENT is on (callTool)", async () => {
+    savedFlag = CLIENT_DEPLOYMENT_CONFIG.ENABLE_BACKEND_CLIENT;
+    CLIENT_DEPLOYMENT_CONFIG.ENABLE_BACKEND_CLIENT = true;
+
+    const backendClientMock = {
+      sendHttpRequest: mock.fn(async () => {
+        return new Response(
+          JSON.stringify({
+            content: [{ type: "text", text: "Backend tool response" }],
+          }),
+          { status: 200 }
+        );
+      }),
+    };
+
+    const fetchMock = mock.fn();
+
+    const client = new ProxyBackedClient({
+      name: "test-server",
+      url: "https://mcp.example.com",
+      proxyUrl: "https://proxy.example.com",
+      token: "secret-token",
+      fetchWithCreds: fetchMock as unknown as typeof globalThis.fetch,
+      backendClient: Promise.resolve(backendClientMock as any),
+    });
+
+    const result = await client.callTool({
+      name: "backend_tool",
+      arguments: { arg1: "val" },
+    });
+
+    assert.equal(backendClientMock.sendHttpRequest.mock.calls.length, 1);
+    assert.equal(fetchMock.mock.calls.length, 0);
+
+    const [methodName, options] = backendClientMock.sendHttpRequest.mock
+      .calls[0].arguments as unknown as [string, any];
+    assert.equal(methodName, "callMcpTool");
+    assert.equal(options.method, "POST");
+    assert.deepStrictEqual(options.body, {
+      mcpServerConfig: {
+        streamableHttp: {
+          url: "https://mcp.example.com",
+          headers: {
+            Authorization: "Bearer secret-token",
+          },
+        },
+      },
+      functionCall: {
+        id: "id",
+        name: "backend_tool",
+        args: { arg1: "val" },
+      },
+    });
+
+    assert.deepStrictEqual(result, {
+      content: [{ type: "text", text: "Backend tool response" }],
+    });
+  });
+});

--- a/packages/visual-editor/tests/mcp/proxy-backed-client.test.ts
+++ b/packages/visual-editor/tests/mcp/proxy-backed-client.test.ts
@@ -4,135 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, mock, afterEach } from "node:test";
+import { describe, it, mock } from "node:test";
 import assert from "node:assert/strict";
 import { ProxyBackedClient } from "../../src/mcp/proxy-backed-client.js";
-import { CLIENT_DEPLOYMENT_CONFIG } from "../../src/ui/config/client-deployment-configuration.js";
 
 describe("ProxyBackedClient", () => {
-  let savedFlag: boolean;
-
-  afterEach(() => {
-    if (savedFlag !== undefined) {
-      CLIENT_DEPLOYMENT_CONFIG.ENABLE_BACKEND_CLIENT = savedFlag;
-    }
-    mock.restoreAll();
-  });
-
-  it("uses fetchWithCreds when ENABLE_BACKEND_CLIENT is off (listTools)", async () => {
-    savedFlag = CLIENT_DEPLOYMENT_CONFIG.ENABLE_BACKEND_CLIENT;
-    CLIENT_DEPLOYMENT_CONFIG.ENABLE_BACKEND_CLIENT = false;
-
-    const fetchMock = mock.fn(
-      async (_url: URL | RequestInfo, _init?: RequestInit) => {
-        return new Response(
-          JSON.stringify({
-            functionDeclarations: [
-              {
-                name: "test_tool",
-                description: "A test tool",
-                parameters: { type: "object", properties: {} },
-              },
-            ],
-          }),
-          { status: 200 }
-        );
-      }
-    );
-
-    const client = new ProxyBackedClient({
-      name: "test-server",
-      url: "https://mcp.example.com",
-      proxyUrl: "https://proxy.example.com",
-      fetchWithCreds: fetchMock as unknown as typeof globalThis.fetch,
-    });
-
-    const result = await client.listTools();
-
-    assert.equal(fetchMock.mock.calls.length, 1);
-    const [url, init] = fetchMock.mock.calls[0].arguments;
-    assert.equal(
-      url.toString(),
-      "https://proxy.example.com/v1beta1/listMcpTools"
-    );
-    assert.equal(init?.method, "POST");
-
-    const bodyObj = JSON.parse(init?.body as string);
-    assert.deepStrictEqual(bodyObj, {
-      mcpServerConfig: {
-        streamableHttp: {
-          url: "https://mcp.example.com",
-        },
-      },
-    });
-
-    assert.equal(result.tools.length, 1);
-    assert.equal(result.tools[0].name, "test_tool");
-  });
-
-  it("uses fetchWithCreds when ENABLE_BACKEND_CLIENT is off (callTool)", async () => {
-    savedFlag = CLIENT_DEPLOYMENT_CONFIG.ENABLE_BACKEND_CLIENT;
-    CLIENT_DEPLOYMENT_CONFIG.ENABLE_BACKEND_CLIENT = false;
-
-    const fetchMock = mock.fn(
-      async (_url: URL | RequestInfo, _init?: RequestInit) => {
-        return new Response(
-          JSON.stringify({
-            content: [{ type: "text", text: "Tool response" }],
-          }),
-          { status: 200 }
-        );
-      }
-    );
-
-    const client = new ProxyBackedClient({
-      name: "test-server",
-      url: "https://mcp.example.com",
-      proxyUrl: "https://proxy.example.com",
-      token: "secret-token",
-      fetchWithCreds: fetchMock as unknown as typeof globalThis.fetch,
-    });
-
-    const result = await client.callTool({
-      name: "test_tool",
-      arguments: { arg1: "val" },
-    });
-
-    assert.equal(fetchMock.mock.calls.length, 1);
-    const [url, init] = fetchMock.mock.calls[0].arguments;
-    assert.equal(
-      url.toString(),
-      "https://proxy.example.com/v1beta1/callMcpTool"
-    );
-    assert.equal(init?.method, "POST");
-
-    const bodyObj = JSON.parse(init?.body as string);
-    assert.deepStrictEqual(bodyObj, {
-      mcpServerConfig: {
-        streamableHttp: {
-          url: "https://mcp.example.com",
-          headers: {
-            Authorization: "Bearer secret-token",
-          },
-        },
-      },
-      functionCall: {
-        id: "id",
-        name: "test_tool",
-        args: { arg1: "val" },
-      },
-    });
-
-    // McpCallToolResult returned
-    assert.deepStrictEqual(result, {
-      content: [{ type: "text", text: "Tool response" }],
-    });
-  });
-
-  it("uses sendHttpRequest when ENABLE_BACKEND_CLIENT is on (listTools)", async () => {
-    savedFlag = CLIENT_DEPLOYMENT_CONFIG.ENABLE_BACKEND_CLIENT;
-    CLIENT_DEPLOYMENT_CONFIG.ENABLE_BACKEND_CLIENT = true;
-
+  it("uses sendHttpRequest (listTools)", async () => {
     const backendClientMock = {
       sendHttpRequest: mock.fn(async () => {
         return new Response(
@@ -150,20 +27,15 @@ describe("ProxyBackedClient", () => {
       }),
     };
 
-    const fetchMock = mock.fn();
-
     const client = new ProxyBackedClient({
       name: "test-server",
       url: "https://mcp.example.com",
-      proxyUrl: "https://proxy.example.com",
-      fetchWithCreds: fetchMock as unknown as typeof globalThis.fetch,
       backendClient: Promise.resolve(backendClientMock as any),
     });
 
     const result = await client.listTools();
 
     assert.equal(backendClientMock.sendHttpRequest.mock.calls.length, 1);
-    assert.equal(fetchMock.mock.calls.length, 0);
 
     const [methodName, options] = backendClientMock.sendHttpRequest.mock
       .calls[0].arguments as unknown as [string, any];
@@ -181,10 +53,7 @@ describe("ProxyBackedClient", () => {
     assert.equal(result.tools[0].name, "backend_tool");
   });
 
-  it("uses sendHttpRequest when ENABLE_BACKEND_CLIENT is on (callTool)", async () => {
-    savedFlag = CLIENT_DEPLOYMENT_CONFIG.ENABLE_BACKEND_CLIENT;
-    CLIENT_DEPLOYMENT_CONFIG.ENABLE_BACKEND_CLIENT = true;
-
+  it("uses sendHttpRequest (callTool)", async () => {
     const backendClientMock = {
       sendHttpRequest: mock.fn(async () => {
         return new Response(
@@ -196,14 +65,10 @@ describe("ProxyBackedClient", () => {
       }),
     };
 
-    const fetchMock = mock.fn();
-
     const client = new ProxyBackedClient({
       name: "test-server",
       url: "https://mcp.example.com",
-      proxyUrl: "https://proxy.example.com",
       token: "secret-token",
-      fetchWithCreds: fetchMock as unknown as typeof globalThis.fetch,
       backendClient: Promise.resolve(backendClientMock as any),
     });
 
@@ -213,7 +78,6 @@ describe("ProxyBackedClient", () => {
     });
 
     assert.equal(backendClientMock.sendHttpRequest.mock.calls.length, 1);
-    assert.equal(fetchMock.mock.calls.length, 0);
 
     const [methodName, options] = backendClientMock.sendHttpRequest.mock
       .calls[0].arguments as unknown as [string, any];

--- a/projects/backend-client-migration/PROJECT.md
+++ b/projects/backend-client-migration/PROJECT.md
@@ -705,7 +705,7 @@ All 23 endpoints fall into 4 trigger categories for manual verification:
 | 2         | app-catalyst.ts SSE streams          | 3              | —          | ✅ Both flag paths + error + all 3 endpoints | ✅     |
 | 3.0       | A2ModuleArgs plumbing                | 0 (structural) | —          | N/A                                          | ✅     |
 | 3a        | A2 simple POSTs                      | 3              | 3.0        | ✅ Both flag paths + all 3 endpoints          | ✅     |
-| 3b        | MCP proxy-backed-client              | 2              | —          | 🔴 None                                      | ⬜     |
+| 3b        | MCP proxy-backed-client              | 2              | —          | ✅ Both flag paths + all 2 endpoints          | ✅     |
 | 3c        | NotebookLM api-client                | 1              | —          | 🔴 None (fake only)                          | ⬜     |
 | 4         | Token-in-body (data-transforms)      | 2              | 3.0        | 🔴 None                                      | ⬜     |
 | 5a        | A2 streaming                         | 2              | 3.0        | 🔴 None                                      | ⬜     |

--- a/projects/backend-client-migration/PROJECT.md
+++ b/projects/backend-client-migration/PROJECT.md
@@ -705,7 +705,7 @@ All 23 endpoints fall into 4 trigger categories for manual verification:
 | 2         | app-catalyst.ts SSE streams          | 3              | —          | ✅ Both flag paths + error + all 3 endpoints | ✅     |
 | 3.0       | A2ModuleArgs plumbing                | 0 (structural) | —          | N/A                                          | ✅     |
 | 3a        | A2 simple POSTs                      | 3              | 3.0        | ✅ Both flag paths + all 3 endpoints          | ✅     |
-| 3b        | MCP proxy-backed-client              | 2              | —          | ✅ Both flag paths + all 2 endpoints          | ✅     |
+| 3b        | MCP proxy-backed-client              | 2              | —          | ✅ Exclusive client path + all 2 endpoints    | ✅     |
 | 3c        | NotebookLM api-client                | 1              | —          | 🔴 None (fake only)                          | ⬜     |
 | 4         | Token-in-body (data-transforms)      | 2              | 3.0        | 🔴 None                                      | ⬜     |
 | 5a        | A2 streaming                         | 2              | 3.0        | 🔴 None                                      | ⬜     |


### PR DESCRIPTION
This particular path is not controlled by the ENABLE_BACKEND_CLIENT flag because it is only enabled in dev and experimental environments, so the additional safety of flag-gated migration is not necessary