### PR TITLE
Change opt-in defaults based on regional requirements

### DIFF
--- a/packages/types/src/opal-shell-protocol.ts
+++ b/packages/types/src/opal-shell-protocol.ts
@@ -87,6 +87,13 @@ export declare interface OpalShellHostProtocol {
    * "Manage cookies" controls.
    */
   isCookieSettingsAvailable(): Promise<boolean>;
+
+  /**
+   * Returns the default opt-in status for marketing email preferences. In
+   * regions that require cookie consent (EEA, UK, etc.) this returns `false`
+   * so checkboxes default to unchecked. Elsewhere it returns `true`.
+   */
+  defaultMarketingOptinStatus(): Promise<boolean>;
 }
 
 export declare interface OpalShellGuestProtocol {

--- a/packages/visual-editor/eval/eval.ts
+++ b/packages/visual-editor/eval/eval.ts
@@ -378,6 +378,9 @@ class EvalRun implements EvalHarnessRuntimeArgs {
       isCookieSettingsAvailable: async function (): Promise<boolean> {
         return false;
       },
+      defaultMarketingOptinStatus: async function (): Promise<boolean> {
+        return true;
+      },
     } satisfies OpalShellHostProtocol,
   };
 }

--- a/packages/visual-editor/eval/graph-editing-eval.ts
+++ b/packages/visual-editor/eval/graph-editing-eval.ts
@@ -999,6 +999,9 @@ class GraphEditingEvalRun implements EvalLogger {
         isCookieSettingsAvailable: async function (): Promise<boolean> {
           return false;
         },
+        defaultMarketingOptinStatus: async function (): Promise<boolean> {
+          return true;
+        },
       } satisfies OpalShellHostProtocol,
     };
 

--- a/packages/visual-editor/fake/fake-mode-opal-shell.ts
+++ b/packages/visual-editor/fake/fake-mode-opal-shell.ts
@@ -175,4 +175,8 @@ class FakeModeOpalShell implements OpalShellHostProtocol {
   isCookieSettingsAvailable = async (): Promise<boolean> => {
     return false;
   };
+
+  defaultMarketingOptinStatus = async (): Promise<boolean> => {
+    return true;
+  };
 }

--- a/packages/visual-editor/src/index.ts
+++ b/packages/visual-editor/src/index.ts
@@ -554,6 +554,7 @@ class Main extends MainBase {
   #renderWarmWelcomeModal() {
     return html`<bb-warm-welcome-modal
       .emailPrefsManager=${this.sca.services.emailPrefsManager}
+      .defaultOptIn=${this.defaultMarketingOptIn}
       @bbmodaldismissed=${() => {
         this.sca.controller.global.main.show.delete("WarmWelcome");
       }}

--- a/packages/visual-editor/src/main-base.ts
+++ b/packages/visual-editor/src/main-base.ts
@@ -89,6 +89,13 @@ abstract class MainBase extends SignalWatcher(LitElement) {
   @state()
   protected accessor overflowMenuY = 0;
 
+  /**
+   * Default opt-in status for marketing email checkboxes. `true` means
+   * checked (non-consent regions), `false` means unchecked (EEA, UK, etc.).
+   */
+  @state()
+  protected accessor defaultMarketingOptIn = true;
+
   protected overflowMenuOnAction:
     | ((action: string, value: string | null) => void)
     | null = null;
@@ -174,7 +181,13 @@ abstract class MainBase extends SignalWatcher(LitElement) {
       }
     });
 
-    this.sca.services.emailPrefsManager.refreshPrefs().then(() => {
+    Promise.all([
+      this.sca.services.emailPrefsManager.refreshPrefs(),
+      this.sca.env.shellHost
+        .defaultMarketingOptinStatus()
+        .catch(() => true),
+    ]).then(([, optInDefault]) => {
+      this.defaultMarketingOptIn = optInDefault;
       if (
         this.sca.services.emailPrefsManager.prefsValid &&
         !this.sca.services.emailPrefsManager.hasStoredPreferences

--- a/packages/visual-editor/src/shell/opal-shell-host.ts
+++ b/packages/visual-editor/src/shell/opal-shell-host.ts
@@ -46,20 +46,27 @@ declare global {
 // miss the glueCookieNotificationBarLoaded callback fired by the cookie bar
 // script that loads before this module.
 //
-// Returns two promises:
-//   consentGranted — resolves when the user accepts cookies (or no bar).
-//   required       — resolves with whether the "Manage cookies" control
-//                    should be shown for the user's region.
+// Returns three promises:
+//   consentGranted  — resolves when the user accepts cookies (or no bar).
+//   required        — resolves with whether the "Manage cookies" control
+//                     should be shown for the user's region.
+//   isConsentRegion — resolves with whether the cookie bar is required at
+//                     all (EEA, UK, etc.), including regions where the
+//                     "Manage cookies" control is hidden.
 // ---------------------------------------------------------------------------
 
 type CookieBar = NonNullable<typeof window.glue>["CookieNotificationBar"];
 
-const { consentGranted: cookieConsentGranted, required: cookieBarRequired } =
-  setupCookieBar();
+const {
+  consentGranted: cookieConsentGranted,
+  required: cookieBarRequired,
+  isConsentRegion: cookieConsentRegion,
+} = setupCookieBar();
 
 function setupCookieBar(): {
   consentGranted: Promise<void>;
   required: Promise<boolean>;
+  isConsentRegion: Promise<boolean>;
 } {
   const cookieBar = window.glue?.CookieNotificationBar;
 
@@ -129,11 +136,43 @@ function setupCookieBar(): {
     });
   };
 
+  // Helper: determine whether cookie consent is required for this region
+  // (EEA, UK, etc.). Unlike shouldShowControl, this includes EEA countries
+  // where the cookie bar is shown but the "Manage cookies" button is hidden.
+  const checkConsentRegion = (cnb: CookieBar): Promise<boolean> => {
+    if (!cnb?.instance) return Promise.resolve(false);
+
+    return new Promise<boolean>((resolve) => {
+      let settled = false;
+      const settle = (v: boolean) => {
+        if (!settled) {
+          settled = true;
+          resolve(v);
+        }
+      };
+
+      cnb.instance!.listen("loaded", (event: CustomEvent) => {
+        settle(event.detail.required === true);
+      });
+
+      // Fallback: if loaded already fired, check whether the bar element
+      // exists and is visible (the library renders it for consent regions).
+      requestAnimationFrame(() => {
+        if (settled) return;
+        const bar = document.querySelector(".glue-cookie-notification-bar");
+        if (bar && !bar.hasAttribute("aria-hidden")) {
+          settle(true);
+        }
+      });
+    });
+  };
+
   // Case 1: Cookie bar already has an instance (script loaded before us).
   if (cookieBar?.instance) {
     return {
       consentGranted: watchForConsent(cookieBar),
       required: shouldShowControl(cookieBar),
+      isConsentRegion: checkConsentRegion(cookieBar),
     };
   }
 
@@ -142,6 +181,7 @@ function setupCookieBar(): {
   if (document.querySelector('script[src*="cookienotificationbar"]')) {
     let resolveConsent!: () => void;
     let resolveRequired!: (value: boolean) => void;
+    let resolveConsentRegion!: (value: boolean) => void;
 
     const consentGranted = new Promise<void>((r) => {
       resolveConsent = r;
@@ -149,25 +189,31 @@ function setupCookieBar(): {
     const required = new Promise<boolean>((r) => {
       resolveRequired = r;
     });
+    const isConsentRegion = new Promise<boolean>((r) => {
+      resolveConsentRegion = r;
+    });
 
     window.glueCookieNotificationBarLoaded = () => {
       const cnb = window.glue?.CookieNotificationBar;
       if (cnb) {
         watchForConsent(cnb).then(resolveConsent);
         shouldShowControl(cnb).then(resolveRequired);
+        checkConsentRegion(cnb).then(resolveConsentRegion);
       } else {
         resolveConsent();
         resolveRequired(false);
+        resolveConsentRegion(false);
       }
     };
 
-    return { consentGranted, required };
+    return { consentGranted, required, isConsentRegion };
   }
 
   // Case 3: No cookie bar present (e.g. local dev) — consent not required.
   return {
     consentGranted: Promise.resolve(),
     required: Promise.resolve(false),
+    isConsentRegion: Promise.resolve(false),
   };
 }
 
@@ -218,8 +264,9 @@ async function initializeOpalShellGuest() {
     // was set up at module scope so it's already listening.
     cookieConsentGranted.then(() => oauthShell.enableAnalytics());
 
-    // Tell the shell whether cookie management is needed for this region.
-    oauthShell.cookieBarRequired = cookieBarRequired;
+    // Tell the shell whether cookie settings management is needed for this region.
+    oauthShell.cookieSettingsRequired = cookieBarRequired;
+    oauthShell.cookieConsentRequired = cookieConsentRegion;
   }
 
   const boxedState: {

--- a/packages/visual-editor/src/ui/elements/shell/warm-welcome.ts
+++ b/packages/visual-editor/src/ui/elements/shell/warm-welcome.ts
@@ -60,11 +60,24 @@ export class VEWarmWelcomeModal extends LitElement {
   @property()
   accessor emailPrefsManager: EmailPrefsManager | null = null;
 
+  /**
+   * Default opt-in state for the email checkboxes. Set to `false` in regions
+   * that require cookie consent (EEA, UK, etc.) so checkboxes start unchecked.
+   */
+  @property({ type: Boolean })
+  accessor defaultOptIn = true;
+
   @state()
   accessor emailUpdates = true;
 
   @state()
   accessor userResearch = true;
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this.emailUpdates = this.defaultOptIn;
+    this.userResearch = this.defaultOptIn;
+  }
 
   #handleModalDismissed({ withSave }: ModalDismissedEvent) {
     // After first dismissal, we always save the prefs, but we only respect the

--- a/packages/visual-editor/src/ui/utils/oauth-based-opal-shell.ts
+++ b/packages/visual-editor/src/ui/utils/oauth-based-opal-shell.ts
@@ -972,11 +972,23 @@ export class OAuthBasedOpalShell implements OpalShellHostProtocol {
 
   /**
    * Set by the shell host after the cookie bar's `loaded` event resolves.
-   * Indicates whether cookie management is needed for this user's region.
+   * Indicates whether the "Manage cookies" control is needed for this
+   * user's region.
    */
-  cookieBarRequired: Promise<boolean> = Promise.resolve(false);
+  cookieSettingsRequired: Promise<boolean> = Promise.resolve(false);
 
   isCookieSettingsAvailable = async (): Promise<boolean> => {
-    return this.cookieBarRequired;
+    return this.cookieSettingsRequired;
+  };
+
+  /**
+   * Set by the shell host after the cookie bar's `loaded` event resolves.
+   * True when the user is in any cookie consent region (EEA, UK, etc.),
+   * including those where the "Manage cookies" control is hidden.
+   */
+  cookieConsentRequired: Promise<boolean> = Promise.resolve(false);
+
+  defaultMarketingOptinStatus = async (): Promise<boolean> => {
+    return !(await this.cookieConsentRequired);
   };
 }


### PR DESCRIPTION
## Functional changes

1. Regions requiring an informational cookie banner, should present unchecked opt-ins by default
<img width="2344" height="1774" alt="image" src="https://github.com/user-attachments/assets/f9b1166b-0d7f-4266-87ec-e1e910606d5b" />
1. Regions requiring a cookie banner with opt-out features, should present unchecked opt-ins by default
<img width="2348" height="1780" alt="image" src="https://github.com/user-attachments/assets/5b2e071e-0993-4875-be19-467ca690f411" />
1. Regions without cookie consent requirements, should present checked opt-ins by default 
  * **Note: the user must still confirm manually. Dismissing the dialog will opt-out ** 
<img width="2338" height="1772" alt="image" src="https://github.com/user-attachments/assets/bf0f270f-5030-4e74-b56e-f5c9443a17e9" />

b/517213171

## Changes

1. Using  the cookie bar library to detect the region and propagates the default state via comlink to the guest shell.