### PR TITLE
[ve] Read-Only Graph Support in Agent Workbench

### DIFF
--- a/packages/visual-editor/src/sca/actions/board/board-actions.ts
+++ b/packages/visual-editor/src/sca/actions/board/board-actions.ts
@@ -733,6 +733,7 @@ export const onRename = asAction(
   },
   async (evt?: StateEvent<"board.rename">): Promise<void> => {
     const { controller } = bind;
+    if (controller.editor.graph.readOnly) return;
     const detail = evt!.detail;
     const { editor } = controller.editor.graph;
     if (!editor) return;

--- a/packages/visual-editor/src/sca/actions/workbench/workbench-actions.ts
+++ b/packages/visual-editor/src/sca/actions/workbench/workbench-actions.ts
@@ -49,6 +49,7 @@ async function applyPromptToGraph(
   newPrompt: string
 ): Promise<void> {
   const { controller } = bind;
+  if (controller.editor.graph.readOnly) return;
   const editor = controller.editor.graph.editor;
   if (!editor) return;
 
@@ -154,6 +155,8 @@ export const applyObjective = asAction(
   "Workbench.applyObjective",
   { mode: ActionMode.Immediate },
   async (blocks: LLMContent[]): Promise<void> => {
+    const { controller } = bind;
+    if (controller.editor.graph.readOnly) return;
     const agentNode = getAgentNode();
     if (!agentNode) return;
 
@@ -183,6 +186,8 @@ export const toggleTool = asAction(
     toolTitle: string,
     enabled: boolean
   ): Promise<void> => {
+    const { controller } = bind;
+    if (controller.editor.graph.readOnly) return;
     const agentNode = getAgentNode();
     if (!agentNode) return;
 

--- a/packages/visual-editor/src/ui/elements/agent-workbench/agent-config-column.ts
+++ b/packages/visual-editor/src/ui/elements/agent-workbench/agent-config-column.ts
@@ -398,6 +398,37 @@ export class AgentConfigColumn extends SignalWatcher(LitElement) {
           &:focus {
             border-color: var(--light-dark-n-90);
           }
+
+          &[contenteditable="false"] {
+            cursor: default;
+
+            &:hover,
+            &:focus {
+              border-color: transparent;
+            }
+          }
+        }
+      }
+
+      #remix-button {
+        display: flex;
+        align-items: center;
+        background: var(--light-dark-n-0);
+        border: none;
+        border-radius: 100px;
+        color: var(--light-dark-n-100);
+        height: var(--bb-grid-size-8);
+        padding: 0 var(--bb-grid-size-4) 0 var(--bb-grid-size-2);
+        font-size: 14px;
+        cursor: pointer;
+        transition: background 0.2s cubic-bezier(0, 0, 0.2, 1);
+
+        & .g-icon {
+          margin-right: var(--bb-grid-size-2);
+        }
+
+        &:hover {
+          background: light-dark(var(--n-25), var(--n-90));
         }
       }
 
@@ -527,6 +558,7 @@ export class AgentConfigColumn extends SignalWatcher(LitElement) {
   }
 
   #onHeadingBlur(evt: FocusEvent & { target: HTMLHeadingElement }) {
+    if (this.sca.controller.editor.graph.readOnly) return;
     const newTitle = evt.target.textContent?.trim() || "";
     const currentTitle = this.sca.controller.editor.graph.title;
     if (newTitle === "" || newTitle === currentTitle) {
@@ -550,11 +582,41 @@ export class AgentConfigColumn extends SignalWatcher(LitElement) {
 
   // ── Header render helpers ──
 
-  #renderPublishButton() {
+  #renderPublishOrRemixButton() {
+    const gc = this.sca.controller.editor.graph;
+    if (gc.readOnly) {
+      return this.#renderRemixButton();
+    }
     if (!this.isMine) {
       return nothing;
     }
     return html`<bb-publish-button id="publish-button"></bb-publish-button>`;
+  }
+
+  #renderRemixButton() {
+    const url = this.sca.controller.editor.graph.url;
+    if (!url) return nothing;
+
+    return html`<button
+      id="remix-button"
+      class="sans-flex round w-500"
+      @click=${() => {
+        this.sca?.services.actionTracker?.remixApp(url, "editor");
+        this.dispatchEvent(
+          new StateEvent({
+            eventType: "board.remix",
+            url,
+            messages: {
+              start: Strings.from("STATUS_REMIXING_PROJECT"),
+              end: Strings.from("STATUS_PROJECT_CREATED"),
+              error: Strings.from("ERROR_UNABLE_TO_CREATE_PROJECT"),
+            },
+          })
+        );
+      }}
+    >
+      <span class="g-icon">gesture</span>Remix
+    </button>`;
   }
 
   #renderSaveStatusLabel() {
@@ -657,7 +719,7 @@ export class AgentConfigColumn extends SignalWatcher(LitElement) {
         "sans-flex": true,
         round: true,
         "w-500": true,
-        owner: !!this.isMine,
+        owner: true,
         "sharing-v2": true,
       })}
       @mouseenter=${() => this.sca.actions.share.flushSave()}
@@ -940,7 +1002,7 @@ export class AgentConfigColumn extends SignalWatcher(LitElement) {
                     <span class="g-icon">play_arrow</span>Preview
                   </button>
                 `}
-            ${this.#renderPublishButton()} ${this.#renderShareButton()}
+            ${this.#renderPublishOrRemixButton()} ${this.#renderShareButton()}
             ${(() => {
               const hoverColor = showPreview
                 ? themeStyles["--s-95"]
@@ -997,7 +1059,9 @@ export class AgentConfigColumn extends SignalWatcher(LitElement) {
 
                   <div class="heading-section">
                     <h1
-                      contenteditable="true"
+                      contenteditable=${graphController.readOnly
+                        ? "false"
+                        : "true"}
                       @blur=${this.#onHeadingBlur}
                       @keydown=${this.#onHeadingKeyDown}
                       .innerText=${title}
@@ -1008,7 +1072,8 @@ export class AgentConfigColumn extends SignalWatcher(LitElement) {
                     <h3>Instructions</h3>
                     <bb-text-editor-remix
                       .value=${editorValue}
-                      .supportsFastAccess=${true}
+                      .readOnly=${graphController.readOnly}
+                      .supportsFastAccess=${!graphController.readOnly}
                       .fastAccessMode=${"browse-assets"}
                       @focus=${this.#onFocus}
                       @blur=${this.#onBlur}

--- a/packages/visual-editor/src/ui/elements/agent-workbench/asset-shelf/asset-shelf.ts
+++ b/packages/visual-editor/src/ui/elements/agent-workbench/asset-shelf/asset-shelf.ts
@@ -53,6 +53,13 @@ export class AgentAssetShelf extends SignalWatcher(LitElement) {
   @state()
   private accessor _playingAudioPath: string | null = null;
 
+  @state()
+  private accessor _pendingAssets: Array<{
+    id: string;
+    title: string;
+    badgeLabel: string;
+  }> = [];
+
   private _activeAudio: HTMLAudioElement | null = null;
 
   static styles = [
@@ -118,6 +125,25 @@ export class AgentAssetShelf extends SignalWatcher(LitElement) {
         justify-content: space-between;
         padding: var(--bb-grid-size-2) 0;
         position: relative;
+      }
+
+      .asset-row.pending {
+        opacity: 0.6;
+        pointer-events: none;
+      }
+
+      @keyframes spin {
+        from {
+          transform: rotate(0deg);
+        }
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      .spinning {
+        animation: spin 1s linear infinite;
+        display: inline-block;
       }
 
       .drag-handle {
@@ -497,131 +523,182 @@ export class AgentAssetShelf extends SignalWatcher(LitElement) {
       <div class="asset-shelf-wrapper">
         <div class="section-header">
           <h2>Assets</h2>
-          <bb-add-asset-button
-            .showGDrive=${true}
-            .showNotebookLm=${!!this.sca.env.flags.get("enableNotebookLm")}
-            .label=${"Add asset"}
-            @bbaddassetrequest=${(evt: AddAssetRequestEvent) => {
-              if (evt.assetType === "notebooklm") {
-                this.sca.actions.notebookLmPicker.open(async (notebooks) => {
-                  for (const notebook of notebooks) {
-                    const descriptor: GraphAssetDescriptor = {
-                      metadata: {
-                        title: notebook.preview || notebook.name || "Notebook",
-                        type: "content",
-                        subType: "notebooklm",
-                      },
-                      path: `asset-${globalThis.crypto.randomUUID().slice(0, 8)}.webp`,
-                      data: [
-                        {
-                          role: "user",
-                          parts: [
-                            {
-                              storedData: {
-                                handle: toNotebookLmUrl(notebook.id),
-                                mimeType: NOTEBOOKLM_MIMETYPE,
-                              },
+          ${graphController.readOnly
+            ? nothing
+            : html`<bb-add-asset-button
+                .showGDrive=${true}
+                .showNotebookLm=${!!this.sca.env.flags.get("enableNotebookLm")}
+                .label=${"Add asset"}
+                @bbaddassetrequest=${(evt: AddAssetRequestEvent) => {
+                  if (evt.assetType === "notebooklm") {
+                    this.sca.actions.notebookLmPicker.open(
+                      async (notebooks) => {
+                        const newPending = notebooks.map((notebook) => ({
+                          id: globalThis.crypto.randomUUID(),
+                          title:
+                            notebook.preview || notebook.name || "Notebook",
+                          badgeLabel: "NOTEBOOK",
+                        }));
+                        this._pendingAssets = [
+                          ...this._pendingAssets,
+                          ...newPending,
+                        ];
+                        this.requestUpdate();
+
+                        for (let i = 0; i < notebooks.length; i++) {
+                          const notebook = notebooks[i];
+                          const pendingItem = newPending[i];
+                          const descriptor: GraphAssetDescriptor = {
+                            metadata: {
+                              title: pendingItem.title,
+                              type: "content",
+                              subType: "notebooklm",
                             },
-                          ],
-                        },
-                      ],
-                    };
-                    await this.sca.actions.asset.addGraphAsset(descriptor);
+                            path: `asset-${globalThis.crypto.randomUUID().slice(0, 8)}.webp`,
+                            data: [
+                              {
+                                role: "user",
+                                parts: [
+                                  {
+                                    storedData: {
+                                      handle: toNotebookLmUrl(notebook.id),
+                                      mimeType: NOTEBOOKLM_MIMETYPE,
+                                    },
+                                  },
+                                ],
+                              },
+                            ],
+                          };
+                          await this.sca.actions.asset.addGraphAsset(
+                            descriptor
+                          );
+                          this._pendingAssets = this._pendingAssets.filter(
+                            (a) => a.id !== pendingItem.id
+                          );
+                          this.requestUpdate();
+                        }
+                      }
+                    );
+                    return;
                   }
+                  this._showAddAssetModal = true;
+                  this._addAssetType = evt.assetType;
+                  this._allowedMimeTypes = evt.allowedMimeTypes;
                   this.requestUpdate();
-                });
-                return;
-              }
-              this._showAddAssetModal = true;
-              this._addAssetType = evt.assetType;
-              this._allowedMimeTypes = evt.allowedMimeTypes;
-              this.requestUpdate();
-            }}
-          ></bb-add-asset-button>
+                }}
+              ></bb-add-asset-button>`}
         </div>
         <div class="assets-list">
-          ${allAssets.length > 0
-            ? allAssets.map((asset) => {
-                const mimeType = this.#inferMimeType(asset);
-                const badgeLabel = this.#getAssetBadgeLabel(mimeType);
-                const isInUse = referencedAssetPaths.has(asset.path);
-                const isPlaying = this._playingAudioPath === asset.path;
-
-                return keyed(
-                  asset.path,
-                  html`
-                    <div class="asset-row">
-                      <span
-                        class="drag-handle g-icon"
-                        draggable="true"
-                        @dragstart=${(evt: DragEvent) =>
-                          this.#onDragStart(evt, asset)}
-                        @pointerover=${(evt: PointerEvent) => {
-                          this.dispatchEvent(
-                            new ShowTooltipEvent(
-                              "Drag to add to agent instructions",
-                              evt.clientX,
-                              evt.clientY
-                            )
-                          );
-                        }}
-                        @pointerout=${() => {
-                          this.dispatchEvent(new HideTooltipEvent());
-                        }}
-                        >drag_indicator</span
-                      >
-                      <div
-                        class="asset-info-wrapper"
-                        @click=${() => this.#onEditAsset(asset)}
-                      >
+          ${allAssets.length > 0 || this._pendingAssets.length > 0
+            ? html`
+                ${this._pendingAssets.map(
+                  (pending) => html`
+                    <div class="asset-row pending" .key=${pending.id}>
+                      <div class="asset-info-wrapper">
                         <div class="asset-icon-container">
-                          <bb-asset-thumbnail
-                            .asset=${asset}
-                            .mimeType=${mimeType || ""}
-                            .playing=${isPlaying}
-                            @bb-audio-toggle=${() => this.#onToggleAudio(asset)}
-                          ></bb-asset-thumbnail>
+                          <span class="g-icon spinning">sync</span>
                         </div>
                         <div class="asset-details">
-                          <div class="asset-title">
-                            ${asset.metadata?.title || asset.path}
-                          </div>
+                          <div class="asset-title">${pending.title}</div>
                           <div class="asset-meta">
-                            <span class="asset-badge">${badgeLabel}</span>
-                            ${isInUse
-                              ? html`<span class="in-use-pill">In use</span>`
-                              : nothing}
+                            <span class="asset-badge"
+                              >${pending.badgeLabel}</span
+                            >
                           </div>
                         </div>
                       </div>
-                      <button
-                        class="remove-button"
-                        @click=${() => this.#onRemoveAsset(asset.path)}
-                        @pointerover=${(evt: PointerEvent) => {
-                          this.dispatchEvent(
-                            new ShowTooltipEvent(
-                              "Remove asset",
-                              evt.clientX,
-                              evt.clientY
-                            )
-                          );
-                        }}
-                        @pointerout=${() => {
-                          this.dispatchEvent(new HideTooltipEvent());
-                        }}
-                      >
-                        <span class="g-icon">close</span>
-                      </button>
                     </div>
                   `
-                );
-              })
+                )}
+                ${allAssets.map((asset) => {
+                  const mimeType = this.#inferMimeType(asset);
+                  const badgeLabel = this.#getAssetBadgeLabel(mimeType);
+                  const isInUse = referencedAssetPaths.has(asset.path);
+                  const isPlaying = this._playingAudioPath === asset.path;
+
+                  return keyed(
+                    asset.path,
+                    html`
+                      <div class="asset-row">
+                        ${graphController.readOnly
+                          ? nothing
+                          : html`<span
+                              class="drag-handle g-icon"
+                              draggable="true"
+                              @dragstart=${(evt: DragEvent) =>
+                                this.#onDragStart(evt, asset)}
+                              @pointerover=${(evt: PointerEvent) => {
+                                this.dispatchEvent(
+                                  new ShowTooltipEvent(
+                                    "Drag to add to agent instructions",
+                                    evt.clientX,
+                                    evt.clientY
+                                  )
+                                );
+                              }}
+                              @pointerout=${() => {
+                                this.dispatchEvent(new HideTooltipEvent());
+                              }}
+                              >drag_indicator</span
+                            >`}
+                        <div
+                          class="asset-info-wrapper"
+                          @click=${() => this.#onEditAsset(asset)}
+                        >
+                          <div class="asset-icon-container">
+                            <bb-asset-thumbnail
+                              .asset=${asset}
+                              .mimeType=${mimeType || ""}
+                              .playing=${isPlaying}
+                              @bb-audio-toggle=${() =>
+                                this.#onToggleAudio(asset)}
+                            ></bb-asset-thumbnail>
+                          </div>
+                          <div class="asset-details">
+                            <div class="asset-title">
+                              ${asset.metadata?.title || asset.path}
+                            </div>
+                            <div class="asset-meta">
+                              <span class="asset-badge">${badgeLabel}</span>
+                              ${isInUse
+                                ? html`<span class="in-use-pill">In use</span>`
+                                : nothing}
+                            </div>
+                          </div>
+                        </div>
+                        ${graphController.readOnly
+                          ? nothing
+                          : html`<button
+                              class="remove-button"
+                              @click=${() => this.#onRemoveAsset(asset.path)}
+                              @pointerover=${(evt: PointerEvent) => {
+                                this.dispatchEvent(
+                                  new ShowTooltipEvent(
+                                    "Remove asset",
+                                    evt.clientX,
+                                    evt.clientY
+                                  )
+                                );
+                              }}
+                              @pointerout=${() => {
+                                this.dispatchEvent(new HideTooltipEvent());
+                              }}
+                            >
+                              <span class="g-icon">close</span>
+                            </button>`}
+                      </div>
+                    `
+                  );
+                })}
+              `
             : html`
                 <div class="empty-state">
                   <span class="g-icon filled heavy">attach_file_off</span>
                   <p>
-                    <span>No assets yet.</span> Click "Add asset" to upload
-                    images, audio, or PDFs.
+                    ${graphController.readOnly
+                      ? html`This agent has no assets.`
+                      : html`<span>No assets yet.</span> Click "Add asset" to
+                          upload images, audio, or PDFs.`}
                   </p>
                 </div>
               `}
@@ -686,7 +763,26 @@ export class AgentAssetShelf extends SignalWatcher(LitElement) {
                 data: [content],
               };
 
+              const tempId = globalThis.crypto.randomUUID();
+              const title = metadata?.title || "Asset";
+              const mimeType = this.#inferMimeType({
+                path,
+                data: [content],
+                metadata,
+              });
+              const badgeLabel = this.#getAssetBadgeLabel(mimeType);
+
+              this._pendingAssets = [
+                ...this._pendingAssets,
+                { id: tempId, title, badgeLabel },
+              ];
+              this.requestUpdate();
+
               await this.sca.actions.asset.addGraphAsset(assetDescriptor);
+
+              this._pendingAssets = this._pendingAssets.filter(
+                (a) => a.id !== tempId
+              );
               this.requestUpdate();
             }}
           ></bb-add-asset-modal>`

--- a/packages/visual-editor/src/ui/elements/agent-workbench/tool-shelf/tool-shelf.ts
+++ b/packages/visual-editor/src/ui/elements/agent-workbench/tool-shelf/tool-shelf.ts
@@ -214,6 +214,11 @@ export class ToolShelf extends SignalWatcher(LitElement) {
         transform: translateX(20px) scale(1.5);
         background-color: white;
       }
+
+      .switch.disabled {
+        opacity: 0.5;
+        pointer-events: none;
+      }
     `,
   ];
 
@@ -316,10 +321,13 @@ export class ToolShelf extends SignalWatcher(LitElement) {
                     <div class="tool-description">${tool.description}</div>
                   </div>
                 </div>
-                <label class="switch">
+                <label
+                  class="switch ${graphController.readOnly ? "disabled" : ""}"
+                >
                   <input
                     type="checkbox"
                     ?checked=${isEnabled}
+                    ?disabled=${graphController.readOnly}
                     @change=${(evt: Event & { target: HTMLInputElement }) => {
                       this.#onToggle(tool, evt.target.checked);
                     }}

--- a/projects/workbench/PROJECT.md
+++ b/projects/workbench/PROJECT.md
@@ -579,7 +579,43 @@ gallery.
 
 ---
 
-## Phase 5 — Polish & Responsive Layout
+## Phase 5 — Read-Only Graphs
+
+### 🎯 Objective
+
+When a user opens a read-only graph in the Agent Workbench:
+1. Opie is left as-is, allowing users to still chat.
+2. Users are prevented from editing the prompt/instructions (text editor is read-only).
+3. Users are prevented from adding or removing assets (no "Add asset" button, no remove buttons, no dragging from shelf).
+4. Users are prevented from toggling tools & skills (toggles are disabled).
+5. The publish button in the header is replaced with a prominent "Remix" button. The share button remains but is unified to always use the owner (black bg, white text) style regardless of ownership.
+6. A robust action-level guard prevents any accidental edits.
+
+**Observable proof:** Open a shared/read-only Opal in the workbench. The left column allows normal conversation with Opie. In the right column:
+- The agent name is static text, not editable.
+- The instructions editor is read-only and doesn't allow typing or dropping assets.
+- The asset shelf has no "Add asset" button next to "Assets", and individual assets have no "close/remove" button, nor can they be dragged.
+- The tool toggles are disabled and show a reduced-opacity/disabled visual style.
+- The header shows a "Remix" button where "Publish" would be, with the share button, settings cog, three-dot menu, and user avatar remaining.
+- Click "Remix" — a remix flow is triggered, creating an editable copy.
+
+### Changes
+
+#### packages/visual-editor — SCA Actions
+
+- [x] `applyPromptToGraph`, `applyObjective`, `toggleTool` (in `workbench-actions.ts`) — early exit if the graph is read-only.
+- [x] `onRename` (in `board-actions.ts`) — early exit if the graph is read-only.
+
+#### packages/visual-editor — UI
+
+- [x] `bb-agent-config-column` — heading `<h1>` is non-editable, and `bb-text-editor-remix` is readOnly when `graphController.readOnly` is true.
+- [x] `bb-agent-config-column` — publish button is replaced with a "Remix" button when the graph is read-only. Share button is unified to always use the owner (black) style.
+- [x] `bb-agent-asset-shelf` — hide drag handle, add asset button, and remove button when the graph is read-only.
+- [x] `bb-tool-shelf` — disable toggle switches and add disabled styling when the graph is read-only.
+
+---
+
+## Phase 6 — Polish & Responsive Layout
 
 ### 🎯 Objective
 
@@ -608,7 +644,7 @@ new, empty agent — each section shows an appropriate empty state.
 
 ---
 
-## Phase 6 — Contextualized History (Future)
+## Phase 7 — Contextualized History (Future)
 
 ### 🎯 Objective
 
@@ -641,7 +677,7 @@ current tip.
 
 ---
 
-## Phase 7 — Annotation System (Future)
+## Phase 8 — Annotation System (Future)
 
 ### 🎯 Objective
 


### PR DESCRIPTION
## What

Implements read-only graph visual and functional safeguards in the Agent Workbench. When viewing a read-only Opal, users are prevented from modifying configuration, name, assets, or tools, and the "Publish" button is replaced by a "Remix" action. Also adds a pending state in the asset shelf when adding new assets.

## Why

Allows users to view and interact (chat) with shared, read-only agents without accidentally modifying their configuration, while providing a premium, native "Remix" flow.

## Changes

### packages/visual-editor

#### SCA Actions
* **board-actions.ts**: Added a `readOnly` check in the `onRename` action to prevent renaming of read-only graphs.
* **workbench-actions.ts**: Guarded `applyPromptToGraph`, `applyObjective`, and `toggleTool` with `readOnly` checks to reject mutations early.

#### UI Components
* **agent-config-column.ts**:
  * Set `contenteditable="false"` on the agent title heading `<h1>` and styled it appropriately when read-only.
  * Passed the `readOnly` status to `<bb-text-editor-remix>` and disabled its fast access utility.
  * Swapped the `Publish` button for a `Remix` button that triggers the standard clone-and-navigate remix flow.
  * Unified the `Share` button style to always use the owner (black fill) presentation.
* **asset-shelf.ts**:
  * Added a `_pendingAssets` state array. Prepended pending items at the top of the shelf list with a spinning loading indicator and reduced opacity style.
  * Integrated the pending state transition into the NotebookLM and normal asset upload flows.
  * Hidden the "Add asset" button, individual drag handles, and remove buttons on read-only graphs. Show a custom "This agent has no assets." message for empty states.
* **tool-shelf.ts**: Disabled toggle switches and added a visual `.disabled` opacity styling when read-only.

### projects/workbench
* **PROJECT.md**: Checked off and completed Phase 5 ("Read-Only Graphs").

## Testing

1. Open a shared or read-only graph in the Agent Workbench.
2. Verify that Opie remains interactive in the left column.
3. Verify that the agent name is static text, the instructions editor is read-only, and the asset shelf has no controls or drag handles.
4. Verify that tool toggles are visually disabled and non-interactive.
5. Verify that the "Remix" button is visible instead of "Publish", and clicking it clones the graph.
6. Trigger an asset addition (e.g. upload an image or select a NotebookLM) and verify that a pending row appears instantly at the top of the asset shelf with a spinning loader, before being replaced by the loaded asset.